### PR TITLE
Add http-only headers to ElasticsearchException

### DIFF
--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexFromRemoteWithAuthTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexFromRemoteWithAuthTests.java
@@ -209,7 +209,7 @@ public class ReindexFromRemoteWithAuthTests extends ESSingleNodeTestCase {
             String auth = context.getHeader(AUTHORIZATION_HEADER);
             if (auth == null) {
                 ElasticsearchSecurityException e = new ElasticsearchSecurityException("Authentication required", RestStatus.UNAUTHORIZED);
-                e.addHeader("WWW-Authenticate", "Basic realm=auth-realm");
+                e.addBodyHeader("WWW-Authenticate", "Basic realm=auth-realm");
                 throw e;
             }
             if (false == REQUIRED_AUTH.equals(auth)) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/ingest/IngestClientIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/ingest/IngestClientIT.java
@@ -322,8 +322,8 @@ public class IngestClientIT extends ESIntegTestCase {
             client().index(indexRequest).get();
         });
         IngestProcessorException ingestException = (IngestProcessorException) e.getCause();
-        assertThat(ingestException.getHeader("processor_type"), equalTo(List.of("fail")));
-        assertThat(ingestException.getHeader("pipeline_origin"), equalTo(List.of("3", "2", "1")));
+        assertThat(ingestException.getBodyHeader("processor_type"), equalTo(List.of("fail")));
+        assertThat(ingestException.getBodyHeader("pipeline_origin"), equalTo(List.of("3", "2", "1")));
     }
 
     public void testPipelineProcessorOnFailure() throws Exception {

--- a/server/src/main/java/org/elasticsearch/action/bulk/FailureStoreDocumentConverter.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/FailureStoreDocumentConverter.java
@@ -115,22 +115,23 @@ public class FailureStoreDocumentConverter {
                 // we can't instantiate it in tests, so we'll have to check for the headers directly.
                 var ingestException = ExceptionsHelper.<ElasticsearchException>unwrapCausesAndSuppressed(
                     exception,
-                    t -> t instanceof ElasticsearchException e && Sets.haveNonEmptyIntersection(e.getHeaderKeys(), INGEST_EXCEPTION_HEADERS)
+                    t -> t instanceof ElasticsearchException e
+                        && Sets.haveNonEmptyIntersection(e.getBodyHeaderKeys(), INGEST_EXCEPTION_HEADERS)
                 ).orElse(null);
                 if (ingestException != null) {
-                    if (ingestException.getHeaderKeys().contains(PIPELINE_ORIGIN_EXCEPTION_HEADER)) {
-                        List<String> pipelineOrigin = ingestException.getHeader(PIPELINE_ORIGIN_EXCEPTION_HEADER);
+                    if (ingestException.getBodyHeaderKeys().contains(PIPELINE_ORIGIN_EXCEPTION_HEADER)) {
+                        List<String> pipelineOrigin = ingestException.getBodyHeader(PIPELINE_ORIGIN_EXCEPTION_HEADER);
                         Collections.reverse(pipelineOrigin);
                         if (pipelineOrigin.isEmpty() == false) {
                             builder.field("pipeline_trace", pipelineOrigin);
                             builder.field("pipeline", pipelineOrigin.get(pipelineOrigin.size() - 1));
                         }
                     }
-                    if (ingestException.getHeaderKeys().contains(PROCESSOR_TAG_EXCEPTION_HEADER)) {
-                        builder.field("processor_tag", ingestException.getHeader(PROCESSOR_TAG_EXCEPTION_HEADER).get(0));
+                    if (ingestException.getBodyHeaderKeys().contains(PROCESSOR_TAG_EXCEPTION_HEADER)) {
+                        builder.field("processor_tag", ingestException.getBodyHeader(PROCESSOR_TAG_EXCEPTION_HEADER).get(0));
                     }
-                    if (ingestException.getHeaderKeys().contains(PROCESSOR_TYPE_EXCEPTION_HEADER)) {
-                        builder.field("processor_type", ingestException.getHeader(PROCESSOR_TYPE_EXCEPTION_HEADER).get(0));
+                    if (ingestException.getBodyHeaderKeys().contains(PROCESSOR_TYPE_EXCEPTION_HEADER)) {
+                        builder.field("processor_type", ingestException.getBodyHeader(PROCESSOR_TYPE_EXCEPTION_HEADER).get(0));
                     }
                 }
             }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchPhaseExecutionException.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchPhaseExecutionException.java
@@ -128,7 +128,7 @@ public class SearchPhaseExecutionException extends ElasticsearchException {
             // We don't have a cause when all shards failed, but we do have shards failures so we can "guess" a cause
             // (see {@link #getCause()}). Here, we use super.getCause() because we don't want the guessed exception to
             // be rendered twice (one in the "cause" field, one in "failed_shards")
-            innerToXContent(builder, params, this, getHeaders(), getMetadata(), super.getCause(), nestedLevel);
+            innerToXContent(builder, params, this, getBodyHeaders(), getMetadata(), super.getCause(), nestedLevel);
         }
         return builder;
     }

--- a/server/src/main/java/org/elasticsearch/common/io/stream/NotSerializableExceptionWrapper.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/NotSerializableExceptionWrapper.java
@@ -36,8 +36,8 @@ public final class NotSerializableExceptionWrapper extends ElasticsearchExceptio
             addSuppressed(otherSuppressed);
         }
         if (other instanceof ElasticsearchException ex) {
-            for (String key : ex.getHeaderKeys()) {
-                this.addHeader(key, ex.getHeader(key));
+            for (String key : ex.getBodyHeaderKeys()) {
+                this.addBodyHeader(key, ex.getBodyHeader(key));
             }
             for (String key : ex.getMetadataKeys()) {
                 this.addMetadata(key, ex.getMetadata(key));

--- a/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
@@ -292,9 +292,9 @@ public class CompoundProcessor implements Processor {
     }
 
     private static void putFailureMetadata(IngestDocument ingestDocument, ElasticsearchException cause) {
-        List<String> processorTypeHeader = cause.getHeader(PROCESSOR_TYPE_EXCEPTION_HEADER);
-        List<String> processorTagHeader = cause.getHeader(PROCESSOR_TAG_EXCEPTION_HEADER);
-        List<String> processorOriginHeader = cause.getHeader(PIPELINE_ORIGIN_EXCEPTION_HEADER);
+        List<String> processorTypeHeader = cause.getBodyHeader(PROCESSOR_TYPE_EXCEPTION_HEADER);
+        List<String> processorTagHeader = cause.getBodyHeader(PROCESSOR_TAG_EXCEPTION_HEADER);
+        List<String> processorOriginHeader = cause.getBodyHeader(PIPELINE_ORIGIN_EXCEPTION_HEADER);
         String failedProcessorType = (processorTypeHeader != null) ? processorTypeHeader.get(0) : null;
         String failedProcessorTag = (processorTagHeader != null) ? processorTagHeader.get(0) : null;
         String failedPipelineId = (processorOriginHeader != null) ? processorOriginHeader.get(0) : null;
@@ -316,7 +316,7 @@ public class CompoundProcessor implements Processor {
     }
 
     static IngestProcessorException newCompoundProcessorException(Exception e, Processor processor, IngestDocument document) {
-        if (e instanceof IngestProcessorException ipe && ipe.getHeader(PROCESSOR_TYPE_EXCEPTION_HEADER) != null) {
+        if (e instanceof IngestProcessorException ipe && ipe.getBodyHeader(PROCESSOR_TYPE_EXCEPTION_HEADER) != null) {
             return ipe;
         }
 
@@ -324,16 +324,16 @@ public class CompoundProcessor implements Processor {
 
         String processorType = processor.getType();
         if (processorType != null) {
-            exception.addHeader(PROCESSOR_TYPE_EXCEPTION_HEADER, processorType);
+            exception.addBodyHeader(PROCESSOR_TYPE_EXCEPTION_HEADER, processorType);
         }
         String processorTag = processor.getTag();
         if (processorTag != null) {
-            exception.addHeader(PROCESSOR_TAG_EXCEPTION_HEADER, processorTag);
+            exception.addBodyHeader(PROCESSOR_TAG_EXCEPTION_HEADER, processorTag);
         }
         if (document != null) {
             List<String> pipelineStack = document.getPipelineStack();
             if (pipelineStack.isEmpty() == false) {
-                exception.addHeader(PIPELINE_ORIGIN_EXCEPTION_HEADER, pipelineStack);
+                exception.addBodyHeader(PIPELINE_ORIGIN_EXCEPTION_HEADER, pipelineStack);
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/ingest/IngestPipelineException.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestPipelineException.java
@@ -28,7 +28,7 @@ public class IngestPipelineException extends ElasticsearchException implements E
 
     IngestPipelineException(final String pipeline, final Exception cause) {
         super(cause);
-        this.addHeader(PIPELINE_ORIGIN_EXCEPTION_HEADER, List.of(pipeline));
+        this.addBodyHeader(PIPELINE_ORIGIN_EXCEPTION_HEADER, List.of(pipeline));
     }
 
     public IngestPipelineException(final StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -1565,8 +1565,8 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
     }
 
     private static Pipeline substitutePipeline(String id, ElasticsearchParseException e) {
-        String tag = e.getHeaderKeys().contains("processor_tag") ? e.getHeader("processor_tag").get(0) : null;
-        String type = e.getHeaderKeys().contains("processor_type") ? e.getHeader("processor_type").get(0) : "unknown";
+        String tag = e.getBodyHeaderKeys().contains("processor_tag") ? e.getBodyHeader("processor_tag").get(0) : null;
+        String type = e.getBodyHeaderKeys().contains("processor_type") ? e.getBodyHeader("processor_type").get(0) : "unknown";
         String errorMessage = "pipeline with id [" + id + "] could not be loaded, caused by [" + e.getDetailedMessage() + "]";
         Processor failureProcessor = new AbstractProcessor(tag, "this is a placeholder processor") {
             @Override

--- a/server/src/main/java/org/elasticsearch/rest/RestResponse.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestResponse.java
@@ -212,12 +212,16 @@ public final class RestResponse implements Releasable {
     }
 
     public void copyHeaders(ElasticsearchException ex) {
-        Set<String> headerKeySet = ex.getHeaderKeys();
+        Set<String> bodyHeaderKeySet = ex.getBodyHeaderKeys();
+        Set<String> httpHeaderKeySet = ex.getHttpHeaderKeys();
         if (customHeaders == null) {
-            customHeaders = Maps.newMapWithExpectedSize(headerKeySet.size());
+            customHeaders = Maps.newMapWithExpectedSize(bodyHeaderKeySet.size() + httpHeaderKeySet.size());
         }
-        for (String key : headerKeySet) {
-            customHeaders.computeIfAbsent(key, k -> new ArrayList<>()).addAll(ex.getHeader(key));
+        for (String key : bodyHeaderKeySet) {
+            customHeaders.computeIfAbsent(key, k -> new ArrayList<>()).addAll(ex.getBodyHeader(key));
+        }
+        for (String key : httpHeaderKeySet) {
+            customHeaders.computeIfAbsent(key, k -> new ArrayList<>()).addAll(ex.getHttpHeader(key));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
+++ b/server/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
@@ -622,8 +622,8 @@ public class ElasticsearchExceptionTests extends ESTestCase {
             ParsingException ex = new ParsingException(1, 2, "foobar", null);
             ex.addMetadata("es.test1", "value1");
             ex.addMetadata("es.test2", "value2");
-            ex.addHeader("test", "some value");
-            ex.addHeader("test_multi", "some value", "another value");
+            ex.addBodyHeader("test", "some value");
+            ex.addBodyHeader("test_multi", "some value", "another value");
 
             String expected = """
                 {"error":{"type": "parsing_exception","reason": "foobar"}}""";
@@ -652,8 +652,8 @@ public class ElasticsearchExceptionTests extends ESTestCase {
             ParsingException ex = new ParsingException(1, 2, "foobar", null);
             ex.addMetadata("es.test1", "value1");
             ex.addMetadata("es.test2", "value2");
-            ex.addHeader("test", "some value");
-            ex.addHeader("test_multi", "some value", "another value");
+            ex.addBodyHeader("test", "some value");
+            ex.addBodyHeader("test_multi", "some value", "another value");
 
             String expectedFragment = """
                 {
@@ -708,8 +708,8 @@ public class ElasticsearchExceptionTests extends ESTestCase {
             ParsingException ex = new ParsingException(1, 2, "foobar", null);
             ex.addMetadata("es.test1", "value1");
             ex.addMetadata("es.test2", "value2");
-            ex.addHeader("test", "some value");
-            ex.addHeader("test_multi", "some value", "another value");
+            ex.addBodyHeader("test", "some value");
+            ex.addBodyHeader("test_multi", "some value", "another value");
 
             String expected = """
                 {
@@ -739,8 +739,8 @@ public class ElasticsearchExceptionTests extends ESTestCase {
                 new ElasticsearchException("baz", new ClusterBlockException(singleton(NoMasterBlockService.NO_MASTER_BLOCK_WRITES)))
             )
         );
-        e.addHeader("foo_0", "0");
-        e.addHeader("foo_1", "1");
+        e.addBodyHeader("foo_0", "0");
+        e.addBodyHeader("foo_1", "1");
         e.addMetadata("es.metadata_foo_0", "foo_0");
         e.addMetadata("es.metadata_foo_1", "foo_1");
 
@@ -780,9 +780,9 @@ public class ElasticsearchExceptionTests extends ESTestCase {
 
         assertNotNull(parsed);
         assertEquals(parsed.getMessage(), "Elasticsearch exception [type=exception, reason=foo]");
-        assertThat(parsed.getHeaderKeys(), hasSize(2));
-        assertEquals(parsed.getHeader("foo_0").get(0), "0");
-        assertEquals(parsed.getHeader("foo_1").get(0), "1");
+        assertThat(parsed.getBodyHeaderKeys(), hasSize(2));
+        assertEquals(parsed.getBodyHeader("foo_0").get(0), "0");
+        assertEquals(parsed.getBodyHeader("foo_1").get(0), "1");
         assertThat(parsed.getMetadataKeys(), hasSize(2));
         assertEquals(parsed.getMetadata("es.metadata_foo_0").get(0), "foo_0");
         assertEquals(parsed.getMetadata("es.metadata_foo_1").get(0), "foo_1");
@@ -896,7 +896,7 @@ public class ElasticsearchExceptionTests extends ESTestCase {
             cause.getMessage(),
             "Elasticsearch exception [type=routing_missing_exception, reason=routing is required for [_test]/[_id]]"
         );
-        assertThat(cause.getHeaderKeys(), hasSize(0));
+        assertThat(cause.getBodyHeaderKeys(), hasSize(0));
         assertThat(cause.getMetadataKeys(), hasSize(2));
         assertThat(cause.getMetadata("es.index"), hasItem("_test"));
         assertThat(cause.getMetadata("es.index_uuid"), hasItem("_na_"));
@@ -905,17 +905,17 @@ public class ElasticsearchExceptionTests extends ESTestCase {
     public void testFromXContentWithHeadersAndMetadata() throws IOException {
         RoutingMissingException routing = new RoutingMissingException("_test", "_id");
         ElasticsearchException baz = new ElasticsearchException("baz", routing);
-        baz.addHeader("baz_0", "baz0");
+        baz.addBodyHeader("baz_0", "baz0");
         baz.addMetadata("es.baz_1", "baz1");
-        baz.addHeader("baz_2", "baz2");
+        baz.addBodyHeader("baz_2", "baz2");
         baz.addMetadata("es.baz_3", "baz3");
         ElasticsearchException bar = new ElasticsearchException("bar", baz);
         bar.addMetadata("es.bar_0", "bar0");
-        bar.addHeader("bar_1", "bar1");
+        bar.addBodyHeader("bar_1", "bar1");
         bar.addMetadata("es.bar_2", "bar2");
         ElasticsearchException foo = new ElasticsearchException("foo", bar);
         foo.addMetadata("es.foo_0", "foo0");
-        foo.addHeader("foo_1", "foo1");
+        foo.addBodyHeader("foo_1", "foo1");
 
         final XContent xContent = randomFrom(XContentType.values()).xContent();
         XContentBuilder builder = XContentBuilder.builder(xContent).startObject().value(foo).endObject();
@@ -931,24 +931,24 @@ public class ElasticsearchExceptionTests extends ESTestCase {
 
         assertNotNull(parsed);
         assertEquals("Elasticsearch exception [type=exception, reason=foo]", parsed.getMessage());
-        assertThat(parsed.getHeaderKeys(), hasSize(1));
-        assertThat(parsed.getHeader("foo_1"), hasItem("foo1"));
+        assertThat(parsed.getBodyHeaderKeys(), hasSize(1));
+        assertThat(parsed.getBodyHeader("foo_1"), hasItem("foo1"));
         assertThat(parsed.getMetadataKeys(), hasSize(1));
         assertThat(parsed.getMetadata("es.foo_0"), hasItem("foo0"));
 
         ElasticsearchException cause = (ElasticsearchException) parsed.getCause();
         assertEquals(cause.getMessage(), "Elasticsearch exception [type=exception, reason=bar]");
-        assertThat(cause.getHeaderKeys(), hasSize(1));
-        assertThat(cause.getHeader("bar_1"), hasItem("bar1"));
+        assertThat(cause.getBodyHeaderKeys(), hasSize(1));
+        assertThat(cause.getBodyHeader("bar_1"), hasItem("bar1"));
         assertThat(cause.getMetadataKeys(), hasSize(2));
         assertThat(cause.getMetadata("es.bar_0"), hasItem("bar0"));
         assertThat(cause.getMetadata("es.bar_2"), hasItem("bar2"));
 
         cause = (ElasticsearchException) cause.getCause();
         assertEquals(cause.getMessage(), "Elasticsearch exception [type=exception, reason=baz]");
-        assertThat(cause.getHeaderKeys(), hasSize(2));
-        assertThat(cause.getHeader("baz_0"), hasItem("baz0"));
-        assertThat(cause.getHeader("baz_2"), hasItem("baz2"));
+        assertThat(cause.getBodyHeaderKeys(), hasSize(2));
+        assertThat(cause.getBodyHeader("baz_0"), hasItem("baz0"));
+        assertThat(cause.getBodyHeader("baz_2"), hasItem("baz2"));
         assertThat(cause.getMetadataKeys(), hasSize(2));
         assertThat(cause.getMetadata("es.baz_1"), hasItem("baz1"));
         assertThat(cause.getMetadata("es.baz_3"), hasItem("baz3"));
@@ -958,7 +958,7 @@ public class ElasticsearchExceptionTests extends ESTestCase {
             cause.getMessage(),
             "Elasticsearch exception [type=routing_missing_exception, reason=routing is required for [_test]/[_id]]"
         );
-        assertThat(cause.getHeaderKeys(), hasSize(0));
+        assertThat(cause.getBodyHeaderKeys(), hasSize(0));
         assertThat(cause.getMetadataKeys(), hasSize(2));
         assertThat(cause.getMetadata("es.index"), hasItem("_test"));
         assertThat(cause.getMetadata("es.index_uuid"), hasItem("_na_"));
@@ -1016,9 +1016,9 @@ public class ElasticsearchExceptionTests extends ESTestCase {
 
         assertNotNull(parsedException);
         assertEquals("Elasticsearch exception [type=custom_exception, reason=Custom reason]", parsedException.getMessage());
-        assertEquals(2, parsedException.getHeaderKeys().size());
-        assertThat(parsedException.getHeader("header_string"), hasItem("some header"));
-        assertThat(parsedException.getHeader("header_array_of_strings"), hasItems("foo", "bar", "baz"));
+        assertEquals(2, parsedException.getBodyHeaderKeys().size());
+        assertThat(parsedException.getBodyHeader("header_string"), hasItem("some header"));
+        assertThat(parsedException.getBodyHeader("header_array_of_strings"), hasItems("foo", "bar", "baz"));
         assertEquals(1, parsedException.getMetadataKeys().size());
         assertThat(parsedException.getMetadata("es.metadata_other"), hasItem("some metadata"));
     }
@@ -1086,7 +1086,7 @@ public class ElasticsearchExceptionTests extends ESTestCase {
 
         // Failure was null, expecting a "unknown" reason
         assertEquals("Elasticsearch exception [type=unknown, reason=unknown]", parsedFailure.getMessage());
-        assertEquals(0, parsedFailure.getHeaders().size());
+        assertEquals(0, parsedFailure.getBodyHeaders().size());
         assertEquals(0, parsedFailure.getMetadata().size());
     }
 
@@ -1113,7 +1113,7 @@ public class ElasticsearchExceptionTests extends ESTestCase {
 
         // Failure was null, expecting a "unknown" reason
         assertEquals("Elasticsearch exception [type=exception, reason=unknown]", parsedFailure.getMessage());
-        assertEquals(0, parsedFailure.getHeaders().size());
+        assertEquals(0, parsedFailure.getBodyHeaders().size());
         assertEquals(0, parsedFailure.getMetadata().size());
     }
 
@@ -1145,7 +1145,7 @@ public class ElasticsearchExceptionTests extends ESTestCase {
         String type = ElasticsearchException.getExceptionName(failure);
         String reason = failure.getMessage();
         assertEquals(ElasticsearchException.buildMessage(type, reason, null), parsedFailure.getMessage());
-        assertEquals(0, parsedFailure.getHeaders().size());
+        assertEquals(0, parsedFailure.getBodyHeaders().size());
         assertEquals(0, parsedFailure.getMetadata().size());
         assertNull(parsedFailure.getCause());
     }
@@ -1183,7 +1183,7 @@ public class ElasticsearchExceptionTests extends ESTestCase {
             reason = "No ElasticsearchException found";
         }
         assertEquals(ElasticsearchException.buildMessage("exception", reason, null), parsedFailure.getMessage());
-        assertEquals(0, parsedFailure.getHeaders().size());
+        assertEquals(0, parsedFailure.getBodyHeaders().size());
         assertEquals(0, parsedFailure.getMetadata().size());
         assertNull(parsedFailure.getCause());
     }
@@ -1205,25 +1205,25 @@ public class ElasticsearchExceptionTests extends ESTestCase {
             }
             case 1 -> { // Simple elasticsearch exception with headers (other metadata of type number are not parsed)
                 failure = new ParsingException(3, 2, "B", null);
-                ((ElasticsearchException) failure).addHeader("header_name", "0", "1");
+                ((ElasticsearchException) failure).addBodyHeader("header_name", "0", "1");
                 expected = new ElasticsearchException("Elasticsearch exception [type=parsing_exception, reason=B]");
-                expected.addHeader("header_name", "0", "1");
+                expected.addBodyHeader("header_name", "0", "1");
                 suppressed = new ElasticsearchException("Elasticsearch exception [type=parsing_exception, reason=B]");
-                suppressed.addHeader("header_name", "0", "1");
+                suppressed.addBodyHeader("header_name", "0", "1");
                 expected.addSuppressed(suppressed);
             }
             case 2 -> { // Elasticsearch exception with a cause, headers and parsable metadata
                 failureCause = new NullPointerException("var is null");
                 failure = new ScriptException("C", failureCause, singletonList("stack"), "test", "painless");
-                ((ElasticsearchException) failure).addHeader("script_name", "my_script");
+                ((ElasticsearchException) failure).addBodyHeader("script_name", "my_script");
                 expectedCause = new ElasticsearchException("Elasticsearch exception [type=null_pointer_exception, reason=var is null]");
                 expected = new ElasticsearchException("Elasticsearch exception [type=script_exception, reason=C]", expectedCause);
-                expected.addHeader("script_name", "my_script");
+                expected.addBodyHeader("script_name", "my_script");
                 expected.addMetadata("es.lang", "painless");
                 expected.addMetadata("es.script", "test");
                 expected.addMetadata("es.script_stack", "stack");
                 suppressed = new ElasticsearchException("Elasticsearch exception [type=script_exception, reason=C]");
-                suppressed.addHeader("script_name", "my_script");
+                suppressed.addBodyHeader("script_name", "my_script");
                 suppressed.addMetadata("es.lang", "painless");
                 suppressed.addMetadata("es.script", "test");
                 suppressed.addMetadata("es.script_stack", "stack");
@@ -1358,7 +1358,7 @@ public class ElasticsearchExceptionTests extends ESTestCase {
             }
 
             assertEquals(expected.getMessage(), actual.getMessage());
-            assertEquals(expected.getHeaders(), actual.getHeaders());
+            assertEquals(expected.getBodyHeaders(), actual.getBodyHeaders());
             assertEquals(expected.getMetadata(), actual.getMetadata());
             assertEquals(expected.getResourceType(), actual.getResourceType());
             assertEquals(expected.getResourceId(), actual.getResourceId());
@@ -1452,13 +1452,13 @@ public class ElasticsearchExceptionTests extends ESTestCase {
                 }
 
                 for (Map.Entry<String, List<String>> entry : randomHeaders.entrySet()) {
-                    actualException.addHeader(entry.getKey(), entry.getValue());
-                    expected.addHeader(entry.getKey(), entry.getValue());
+                    actualException.addBodyHeader(entry.getKey(), entry.getValue());
+                    expected.addBodyHeader(entry.getKey(), entry.getValue());
                 }
 
                 if (rarely()) {
                     // Empty or null headers are not printed out by the toXContent method
-                    actualException.addHeader("ignored", randomBoolean() ? emptyList() : null);
+                    actualException.addBodyHeader("ignored", randomBoolean() ? emptyList() : null);
                 }
             }
 
@@ -1566,7 +1566,7 @@ public class ElasticsearchExceptionTests extends ESTestCase {
 
     public void testTimeout() throws IOException {
         var e = new ExceptionSubclass("some timeout");
-        assertThat(e.getHeaderKeys(), hasItem(ElasticsearchException.TIMED_OUT_HEADER));
+        assertThat(e.getBodyHeaderKeys(), hasItem(ElasticsearchException.TIMED_OUT_HEADER));
 
         XContentBuilder builder = XContentFactory.jsonBuilder();
         builder.startObject();
@@ -1580,6 +1580,26 @@ public class ElasticsearchExceptionTests extends ESTestCase {
               "header": {
                 "X-Timed-Out": "?1"
               }
+            }""";
+        assertEquals(XContentHelper.stripWhitespace(expected), Strings.toString(builder));
+    }
+
+    public void testHttpHeaders() throws IOException {
+        var e = new ElasticsearchException("some exception");
+        e.addHttpHeader("My-Header", "value");
+        assertThat(e.getHttpHeaderKeys(), hasItem("My-Header"));
+        assertThat(e.getHttpHeader("My-Header"), equalTo(List.of("value")));
+        assertThat(e.getHttpHeaders(), hasEntry("My-Header", List.of("value")));
+
+        // ensure http headers are not written to response body
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        e.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+        String expected = """
+            {
+              "type": "exception",
+              "reason": "some exception"
             }""";
         assertEquals(XContentHelper.stripWhitespace(expected), Strings.toString(builder));
     }

--- a/server/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
@@ -578,13 +578,13 @@ public class ExceptionSerializationTests extends ESTestCase {
     public void testWithRestHeadersException() throws IOException {
         {
             ElasticsearchException ex = new ElasticsearchException("msg");
-            ex.addHeader("foo", "foo", "bar");
+            ex.addBodyHeader("foo", "foo", "bar");
             ex.addMetadata("es.foo_metadata", "value1", "value2");
             ex = serialize(ex);
             assertEquals("msg", ex.getMessage());
-            assertEquals(2, ex.getHeader("foo").size());
-            assertEquals("foo", ex.getHeader("foo").get(0));
-            assertEquals("bar", ex.getHeader("foo").get(1));
+            assertEquals(2, ex.getBodyHeader("foo").size());
+            assertEquals("foo", ex.getBodyHeader("foo").get(0));
+            assertEquals("bar", ex.getBodyHeader("foo").get(1));
             assertEquals(2, ex.getMetadata("es.foo_metadata").size());
             assertEquals("value1", ex.getMetadata("es.foo_metadata").get(0));
             assertEquals("value2", ex.getMetadata("es.foo_metadata").get(1));
@@ -593,16 +593,16 @@ public class ExceptionSerializationTests extends ESTestCase {
             RestStatus status = randomFrom(RestStatus.values());
             // ensure we are carrying over the headers and metadata even if not serialized
             UnknownHeaderException uhe = new UnknownHeaderException("msg", status);
-            uhe.addHeader("foo", "foo", "bar");
+            uhe.addBodyHeader("foo", "foo", "bar");
             uhe.addMetadata("es.foo_metadata", "value1", "value2");
 
             ElasticsearchException serialize = serialize((ElasticsearchException) uhe);
             assertTrue(serialize instanceof NotSerializableExceptionWrapper);
             NotSerializableExceptionWrapper e = (NotSerializableExceptionWrapper) serialize;
             assertEquals("unknown_header_exception: msg", e.getMessage());
-            assertEquals(2, e.getHeader("foo").size());
-            assertEquals("foo", e.getHeader("foo").get(0));
-            assertEquals("bar", e.getHeader("foo").get(1));
+            assertEquals(2, e.getBodyHeader("foo").size());
+            assertEquals("foo", e.getBodyHeader("foo").get(0));
+            assertEquals("bar", e.getBodyHeader("foo").get(1));
             assertEquals(2, e.getMetadata("es.foo_metadata").size());
             assertEquals("value1", e.getMetadata("es.foo_metadata").get(0));
             assertEquals("value2", e.getMetadata("es.foo_metadata").get(1));

--- a/server/src/test/java/org/elasticsearch/action/bulk/FailureStoreDocumentConverterTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/FailureStoreDocumentConverterTests.java
@@ -43,18 +43,18 @@ public class FailureStoreDocumentConverterTests extends ESTestCase {
         }
         boolean withPipelineOrigin = randomBoolean();
         if (withPipelineOrigin) {
-            ingestException.addHeader(
+            ingestException.addBodyHeader(
                 CompoundProcessor.PIPELINE_ORIGIN_EXCEPTION_HEADER,
                 Arrays.asList("some-failing-pipeline", "some-pipeline")
             );
         }
         boolean withProcessorTag = randomBoolean();
         if (withProcessorTag) {
-            ingestException.addHeader(CompoundProcessor.PROCESSOR_TAG_EXCEPTION_HEADER, "foo-tag");
+            ingestException.addBodyHeader(CompoundProcessor.PROCESSOR_TAG_EXCEPTION_HEADER, "foo-tag");
         }
         boolean withProcessorType = randomBoolean();
         if (withProcessorType) {
-            ingestException.addHeader(CompoundProcessor.PROCESSOR_TYPE_EXCEPTION_HEADER, "bar-type");
+            ingestException.addBodyHeader(CompoundProcessor.PROCESSOR_TYPE_EXCEPTION_HEADER, "bar-type");
         }
         if (randomBoolean()) {
             exception = new RemoteTransportException("Test exception wrapper, please ignore", exception);

--- a/server/src/test/java/org/elasticsearch/action/search/SearchPhaseExecutionExceptionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchPhaseExecutionExceptionTests.java
@@ -122,7 +122,7 @@ public class SearchPhaseExecutionExceptionTests extends ESTestCase {
         }
 
         assertNotNull(parsedException);
-        assertThat(parsedException.getHeaderKeys(), hasSize(0));
+        assertThat(parsedException.getBodyHeaderKeys(), hasSize(0));
         assertThat(parsedException.getMetadataKeys(), hasSize(1));
         assertThat(parsedException.getMetadata("es.phase"), hasItem(phase));
         // SearchPhaseExecutionException has no cause field

--- a/server/src/test/java/org/elasticsearch/action/support/master/TransportMasterNodeActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/master/TransportMasterNodeActionTests.java
@@ -596,7 +596,7 @@ public class TransportMasterNodeActionTests extends ESTestCase {
             listener.get();
         } else {
             ElasticsearchException t = new ElasticsearchException("test");
-            t.addHeader("header", "is here");
+            t.addBodyHeader("header", "is here");
             transport.handleRemoteError(capturedRequest.requestId(), t);
             assertTrue(listener.isDone());
             try {
@@ -607,7 +607,7 @@ public class TransportMasterNodeActionTests extends ESTestCase {
                 assertThat(cause, instanceOf(ElasticsearchException.class));
                 final ElasticsearchException es = (ElasticsearchException) cause;
                 assertThat(es.getMessage(), equalTo(t.getMessage()));
-                assertThat(es.getHeader("header"), equalTo(t.getHeader("header")));
+                assertThat(es.getBodyHeader("header"), equalTo(t.getBodyHeader("header")));
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/ingest/CompoundProcessorTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/CompoundProcessorTests.java
@@ -408,9 +408,9 @@ public class CompoundProcessorTests extends ESTestCase {
             processor,
             ingestDocument
         );
-        assertThat(ingestProcessorException1.getHeader("processor_tag"), equalTo(List.of("my_tag")));
-        assertThat(ingestProcessorException1.getHeader("processor_type"), equalTo(List.of("my_type")));
-        assertThat(ingestProcessorException1.getHeader("pipeline_origin"), nullValue());
+        assertThat(ingestProcessorException1.getBodyHeader("processor_tag"), equalTo(List.of("my_tag")));
+        assertThat(ingestProcessorException1.getBodyHeader("processor_type"), equalTo(List.of("my_type")));
+        assertThat(ingestProcessorException1.getBodyHeader("pipeline_origin"), nullValue());
 
         IngestProcessorException ingestProcessorException2 = CompoundProcessor.newCompoundProcessorException(
             ingestProcessorException1,
@@ -459,9 +459,9 @@ public class CompoundProcessorTests extends ESTestCase {
         Exception[] holder = new Exception[1];
         ingestDocument.executePipeline(pipeline1, (document, e) -> holder[0] = e);
         IngestProcessorException ingestProcessorException = (IngestProcessorException) holder[0];
-        assertThat(ingestProcessorException.getHeader("processor_tag"), equalTo(List.of("my_tag")));
-        assertThat(ingestProcessorException.getHeader("processor_type"), equalTo(List.of("my_type")));
-        assertThat(ingestProcessorException.getHeader("pipeline_origin"), equalTo(List.of("2", "1")));
+        assertThat(ingestProcessorException.getBodyHeader("processor_tag"), equalTo(List.of("my_tag")));
+        assertThat(ingestProcessorException.getBodyHeader("processor_type"), equalTo(List.of("my_type")));
+        assertThat(ingestProcessorException.getBodyHeader("pipeline_origin"), equalTo(List.of("2", "1")));
     }
 
     public void testMultipleProcessors() {

--- a/server/src/test/java/org/elasticsearch/rest/RestResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestResponseTests.java
@@ -89,11 +89,13 @@ public class RestResponseTests extends ESTestCase {
         RestChannel channel = randomBoolean() ? new DetailedExceptionRestChannel(request) : new SimpleExceptionRestChannel(request);
 
         RestResponse response = new RestResponse(channel, new WithHeadersException());
-        assertEquals(2, response.getHeaders().size());
+        assertEquals(3, response.getHeaders().size());
         assertThat(response.getHeaders().get("n1"), notNullValue());
         assertThat(response.getHeaders().get("n1"), contains("v11", "v12"));
         assertThat(response.getHeaders().get("n2"), notNullValue());
         assertThat(response.getHeaders().get("n2"), contains("v21", "v22"));
+        assertThat(response.getHeaders().get("My-Header"), notNullValue());
+        assertThat(response.getHeaders().get("My-Header"), contains("v1"));
     }
 
     public void testEmptyChunkedBody() {
@@ -368,8 +370,8 @@ public class RestResponseTests extends ESTestCase {
         if (addHeadersOrMetadata) {
             ElasticsearchException originalException = ((ElasticsearchException) original);
             if (randomBoolean()) {
-                originalException.addHeader("foo", "bar", "baz");
-                expected.addHeader("foo", "bar", "baz");
+                originalException.addBodyHeader("foo", "bar", "baz");
+                expected.addBodyHeader("foo", "bar", "baz");
             }
             if (randomBoolean()) {
                 originalException.addMetadata("es.metadata_0", "0");
@@ -447,8 +449,8 @@ public class RestResponseTests extends ESTestCase {
         }
 
         ElasticsearchStatusException result = new ElasticsearchStatusException(exception.getMessage(), status, exception.getCause());
-        for (String header : exception.getHeaderKeys()) {
-            result.addHeader(header, exception.getHeader(header));
+        for (String header : exception.getBodyHeaderKeys()) {
+            result.addBodyHeader(header, exception.getBodyHeader(header));
         }
         for (String metadata : exception.getMetadataKeys()) {
             result.addMetadata(metadata, exception.getMetadata(metadata));
@@ -532,8 +534,9 @@ public class RestResponseTests extends ESTestCase {
 
         WithHeadersException() {
             super("");
-            this.addHeader("n1", "v11", "v12");
-            this.addHeader("n2", "v21", "v22");
+            this.addBodyHeader("n1", "v11", "v12");
+            this.addBodyHeader("n2", "v21", "v22");
+            this.addHttpHeader("My-Header", "v1");
             this.addMetadata("es.test", "value1", "value2");
         }
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/DefaultAuthenticationFailureHandler.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/DefaultAuthenticationFailureHandler.java
@@ -170,13 +170,13 @@ public class DefaultAuthenticationFailureHandler implements AuthenticationFailur
         if (t instanceof ElasticsearchSecurityException) {
             assert ((ElasticsearchSecurityException) t).status() == RestStatus.UNAUTHORIZED;
             ese = (ElasticsearchSecurityException) t;
-            if (ese.getHeader("WWW-Authenticate") != null && ese.getHeader("WWW-Authenticate").isEmpty() == false) {
+            if (ese.getBodyHeader("WWW-Authenticate") != null && ese.getBodyHeader("WWW-Authenticate").isEmpty() == false) {
                 /**
                  * If 'WWW-Authenticate' header is present with 'Negotiate ' then do not
                  * replace. In case of kerberos spnego mechanism, we use
                  * 'WWW-Authenticate' header value to communicate outToken to peer.
                  */
-                containsNegotiateWithToken = ese.getHeader("WWW-Authenticate")
+                containsNegotiateWithToken = ese.getBodyHeader("WWW-Authenticate")
                     .stream()
                     .anyMatch(s -> s != null && s.regionMatches(true, 0, "Negotiate ", 0, "Negotiate ".length()));
             } else {
@@ -191,7 +191,7 @@ public class DefaultAuthenticationFailureHandler implements AuthenticationFailur
                 return;
             }
             // If it is already present then it will replace the existing header.
-            ese.addHeader(key, value);
+            ese.addBodyHeader(key, value);
         });
         return ese;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/support/Exceptions.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/support/Exceptions.java
@@ -18,13 +18,13 @@ public class Exceptions {
 
     public static ElasticsearchSecurityException authenticationError(String msg, Throwable cause, Object... args) {
         ElasticsearchSecurityException e = new ElasticsearchSecurityException(msg, RestStatus.UNAUTHORIZED, cause, args);
-        e.addHeader("WWW-Authenticate", "Basic realm=\"" + XPackField.SECURITY + "\", charset=\"UTF-8\"");
+        e.addBodyHeader("WWW-Authenticate", "Basic realm=\"" + XPackField.SECURITY + "\", charset=\"UTF-8\"");
         return e;
     }
 
     public static ElasticsearchSecurityException authenticationError(String msg, Object... args) {
         ElasticsearchSecurityException e = new ElasticsearchSecurityException(msg, RestStatus.UNAUTHORIZED, args);
-        e.addHeader("WWW-Authenticate", "Basic realm=\"" + XPackField.SECURITY + "\", charset=\"UTF-8\"");
+        e.addBodyHeader("WWW-Authenticate", "Basic realm=\"" + XPackField.SECURITY + "\", charset=\"UTF-8\"");
         return e;
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/DefaultAuthenticationFailureHandlerTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/DefaultAuthenticationFailureHandlerTests.java
@@ -50,7 +50,7 @@ public class DefaultAuthenticationFailureHandlerTests extends ESTestCase {
         );
         assertThat(ese, is(notNullValue()));
         assertThat(ese.getMessage(), equalTo("action [someaction] requires authentication"));
-        assertThat(ese.getHeader("WWW-Authenticate"), is(notNullValue()));
+        assertThat(ese.getBodyHeader("WWW-Authenticate"), is(notNullValue()));
         if (testDefault) {
             assertWWWAuthenticateWithSchemes(ese, basicAuthScheme);
         } else {
@@ -86,7 +86,7 @@ public class DefaultAuthenticationFailureHandlerTests extends ESTestCase {
         final boolean withAuthenticateHeader = randomBoolean();
         final String selectedScheme = randomFrom(bearerAuthScheme, basicAuthScheme, negotiateAuthScheme);
         if (withAuthenticateHeader) {
-            eseCause.addHeader("WWW-Authenticate", Collections.singletonList(selectedScheme));
+            eseCause.addBodyHeader("WWW-Authenticate", Collections.singletonList(selectedScheme));
         }
 
         if (causeIsElasticsearchSecurityException) {
@@ -97,7 +97,7 @@ public class DefaultAuthenticationFailureHandlerTests extends ESTestCase {
                     new ThreadContext(Settings.builder().build())
                 );
                 assertThat(ese, is(notNullValue()));
-                assertThat(ese.getHeader("WWW-Authenticate"), is(notNullValue()));
+                assertThat(ese.getBodyHeader("WWW-Authenticate"), is(notNullValue()));
                 assertThat(ese, is(sameInstance(cause)));
                 if (withAuthenticateHeader == false) {
                     assertWWWAuthenticateWithSchemes(ese, negotiateAuthScheme, bearerAuthScheme, basicAuthScheme);
@@ -126,7 +126,7 @@ public class DefaultAuthenticationFailureHandlerTests extends ESTestCase {
                 new ThreadContext(Settings.builder().build())
             );
             assertThat(ese, is(notNullValue()));
-            assertThat(ese.getHeader("WWW-Authenticate"), is(notNullValue()));
+            assertThat(ese.getBodyHeader("WWW-Authenticate"), is(notNullValue()));
             assertThat(ese.getMessage(), equalTo("error attempting to authenticate request"));
             assertWWWAuthenticateWithSchemes(ese, negotiateAuthScheme, bearerAuthScheme, basicAuthScheme);
         }
@@ -151,13 +151,13 @@ public class DefaultAuthenticationFailureHandlerTests extends ESTestCase {
         );
 
         assertThat(ese, is(notNullValue()));
-        assertThat(ese.getHeader("WWW-Authenticate"), is(notNullValue()));
+        assertThat(ese.getBodyHeader("WWW-Authenticate"), is(notNullValue()));
         assertThat(ese.getMessage(), equalTo("error attempting to authenticate request"));
         assertWWWAuthenticateWithSchemes(ese, negotiateAuthScheme, bearerAuthScheme, apiKeyAuthScheme, basicAuthScheme);
     }
 
     private void assertWWWAuthenticateWithSchemes(final ElasticsearchSecurityException ese, final String... schemes) {
-        assertThat(ese.getHeader("WWW-Authenticate").size(), is(schemes.length));
-        assertThat(ese.getHeader("WWW-Authenticate"), contains(schemes));
+        assertThat(ese.getBodyHeader("WWW-Authenticate").size(), is(schemes.length));
+        assertThat(ese.getBodyHeader("WWW-Authenticate"), contains(schemes));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/test/SecurityAssertions.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/test/SecurityAssertions.java
@@ -20,8 +20,8 @@ public class SecurityAssertions {
 
     public static void assertContainsWWWAuthenticateHeader(ElasticsearchSecurityException e) {
         assertThat(e.status(), is(RestStatus.UNAUTHORIZED));
-        assertThat(e.getHeaderKeys(), hasSize(1));
-        assertThat(e.getHeader("WWW-Authenticate"), notNullValue());
-        assertThat(e.getHeader("WWW-Authenticate"), contains("Basic realm=\"" + XPackField.SECURITY + "\", charset=\"UTF-8\""));
+        assertThat(e.getBodyHeaderKeys(), hasSize(1));
+        assertThat(e.getBodyHeader("WWW-Authenticate"), notNullValue());
+        assertThat(e.getBodyHeader("WWW-Authenticate"), contains("Basic realm=\"" + XPackField.SECURITY + "\", charset=\"UTF-8\""));
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -2153,7 +2153,7 @@ public class ApiKeyService implements Closeable {
     private static <E extends Throwable> E traceLog(String action, String identifier, E exception) {
         if (logger.isTraceEnabled()) {
             if (exception instanceof final ElasticsearchException esEx) {
-                final Object detail = esEx.getHeader("error_description");
+                final Object detail = esEx.getBodyHeader("error_description");
                 if (detail != null) {
                     logger.trace(() -> format("Failure in [%s] for id [%s] - [%s]", action, identifier, detail), esEx);
                 } else {
@@ -2172,7 +2172,7 @@ public class ApiKeyService implements Closeable {
     private static <E extends Throwable> E traceLog(String action, E exception) {
         if (logger.isTraceEnabled()) {
             if (exception instanceof final ElasticsearchException esEx) {
-                final Object detail = esEx.getHeader("error_description");
+                final Object detail = esEx.getBodyHeader("error_description");
                 if (detail != null) {
                     logger.trace(() -> format("Failure in [%s] - [%s]", action, detail), esEx);
                 } else {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/AuthenticatorChain.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/AuthenticatorChain.java
@@ -295,7 +295,7 @@ class AuthenticatorChain {
                     ese.status(),
                     ese.getCause()
                 );
-                ese.getHeaderKeys().forEach(k -> eseWithPreviousCredentials.addHeader(k, ese.getHeader(k)));
+                ese.getBodyHeaderKeys().forEach(k -> eseWithPreviousCredentials.addBodyHeader(k, ese.getBodyHeader(k)));
                 addMetadata(context, eseWithPreviousCredentials);
                 listener.onFailure(eseWithPreviousCredentials);
             } else {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
@@ -2222,7 +2222,7 @@ public class TokenService {
      */
     private static ElasticsearchSecurityException expiredTokenException() {
         ElasticsearchSecurityException e = new ElasticsearchSecurityException("token expired", RestStatus.UNAUTHORIZED);
-        e.addHeader("WWW-Authenticate", EXPIRED_TOKEN_WWW_AUTH_VALUE);
+        e.addBodyHeader("WWW-Authenticate", EXPIRED_TOKEN_WWW_AUTH_VALUE);
         return e;
     }
 
@@ -2231,7 +2231,7 @@ public class TokenService {
      */
     private static ElasticsearchSecurityException invalidGrantException(String detail) {
         ElasticsearchSecurityException e = new ElasticsearchSecurityException("invalid_grant", RestStatus.BAD_REQUEST);
-        e.addHeader("error_description", detail);
+        e.addBodyHeader("error_description", detail);
         return e;
     }
 
@@ -2245,7 +2245,7 @@ public class TokenService {
     private static <E extends Throwable> E traceLog(String action, String identifier, E exception) {
         if (logger.isTraceEnabled()) {
             if (exception instanceof final ElasticsearchException esEx) {
-                final Object detail = esEx.getHeader("error_description");
+                final Object detail = esEx.getBodyHeader("error_description");
                 if (detail != null) {
                     logger.trace(() -> format("Failure in [%s] for id [%s] - [%s]", action, identifier, detail), esEx);
                 } else {
@@ -2264,7 +2264,7 @@ public class TokenService {
     private static <E extends Throwable> E traceLog(String action, E exception) {
         if (logger.isTraceEnabled()) {
             if (exception instanceof final ElasticsearchException esEx) {
-                final Object detail = esEx.getHeader("error_description");
+                final Object detail = esEx.getBodyHeader("error_description");
                 if (detail != null) {
                     logger.trace(() -> format("Failure in [%s] - [%s]", action, detail), esEx);
                 } else {
@@ -2278,7 +2278,7 @@ public class TokenService {
     }
 
     static boolean isExpiredTokenException(ElasticsearchSecurityException e) {
-        final List<String> headers = e.getHeader("WWW-Authenticate");
+        final List<String> headers = e.getBodyHeader("WWW-Authenticate");
         return headers != null && headers.stream().anyMatch(EXPIRED_TOKEN_WWW_AUTH_VALUE::equals);
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosAuthenticationToken.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosAuthenticationToken.java
@@ -124,7 +124,7 @@ public final class KerberosAuthenticationToken implements AuthenticationToken {
      */
     static ElasticsearchSecurityException unauthorized(final String message, final Throwable cause, final Object... args) {
         ElasticsearchSecurityException ese = new ElasticsearchSecurityException(message, RestStatus.UNAUTHORIZED, cause, args);
-        ese.addHeader(WWW_AUTHENTICATE, NEGOTIATE_SCHEME_NAME);
+        ese.addBodyHeader(WWW_AUTHENTICATE, NEGOTIATE_SCHEME_NAME);
         return ese;
     }
 
@@ -146,7 +146,7 @@ public final class KerberosAuthenticationToken implements AuthenticationToken {
     static ElasticsearchSecurityException unauthorizedWithOutputToken(final ElasticsearchSecurityException ese, final String outToken) {
         assert ese.status() == RestStatus.UNAUTHORIZED;
         if (Strings.hasText(outToken)) {
-            ese.addHeader(WWW_AUTHENTICATE, NEGOTIATE_AUTH_HEADER_PREFIX + outToken);
+            ese.addBodyHeader(WWW_AUTHENTICATE, NEGOTIATE_AUTH_HEADER_PREFIX + outToken);
         }
         return ese;
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/oauth2/RestGetTokenAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/oauth2/RestGetTokenAction.java
@@ -144,10 +144,10 @@ public final class RestGetTokenAction extends TokenBaseRestHandler implements Re
                 sendTokenErrorResponse(error, validationException.getMessage(), e);
             } else if (e instanceof ElasticsearchSecurityException
                 && "invalid_grant".equals(e.getMessage())
-                && ((ElasticsearchSecurityException) e).getHeader("error_description").size() == 1) {
+                && ((ElasticsearchSecurityException) e).getBodyHeader("error_description").size() == 1) {
                     sendTokenErrorResponse(
                         TokenRequestError.INVALID_GRANT,
-                        ((ElasticsearchSecurityException) e).getHeader("error_description").get(0),
+                        ((ElasticsearchSecurityException) e).getBodyHeader("error_description").get(0),
                         e
                     );
                 } else if (e instanceof ElasticsearchSecurityException
@@ -164,7 +164,7 @@ public final class RestGetTokenAction extends TokenBaseRestHandler implements Re
 
         private static String extractBase64EncodedToken(ElasticsearchSecurityException e) {
             String base64EncodedToken = null;
-            List<String> values = e.getHeader(KerberosAuthenticationToken.WWW_AUTHENTICATE);
+            List<String> values = e.getBodyHeader(KerberosAuthenticationToken.WWW_AUTHENTICATE);
             if (values != null && values.size() == 1) {
                 final String wwwAuthenticateHeaderValue = values.get(0);
                 // it may contain base64 encoded token that needs to be sent to client if Spnego GSS context negotiation failed

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
@@ -1235,9 +1235,9 @@ public class SecurityTests extends ESTestCase {
 
     private void verifyHasAuthenticationHeaderValue(Exception e, String... expectedValues) {
         assertThat(e, instanceOf(ElasticsearchSecurityException.class));
-        assertThat(((ElasticsearchSecurityException) e).getHeader("WWW-Authenticate"), notNullValue());
-        assertThat(((ElasticsearchSecurityException) e).getHeader("WWW-Authenticate"), hasSize(expectedValues.length));
-        assertThat(((ElasticsearchSecurityException) e).getHeader("WWW-Authenticate"), containsInAnyOrder(expectedValues));
+        assertThat(((ElasticsearchSecurityException) e).getBodyHeader("WWW-Authenticate"), notNullValue());
+        assertThat(((ElasticsearchSecurityException) e).getBodyHeader("WWW-Authenticate"), hasSize(expectedValues.length));
+        assertThat(((ElasticsearchSecurityException) e).getBodyHeader("WWW-Authenticate"), containsInAnyOrder(expectedValues));
     }
 
     private String randomCacheHashSetting() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenActionTests.java
@@ -171,7 +171,7 @@ public class TransportCreateTokenActionTests extends ESTestCase {
                     && new String((byte[]) token.credentials(), StandardCharsets.UTF_8).equals("fail")) {
                     String errorMessage = "failed to authenticate user, gss context negotiation not complete";
                     ElasticsearchSecurityException ese = new ElasticsearchSecurityException(errorMessage, RestStatus.UNAUTHORIZED);
-                    ese.addHeader(KerberosAuthenticationToken.WWW_AUTHENTICATE, "Negotiate FAIL");
+                    ese.addBodyHeader(KerberosAuthenticationToken.WWW_AUTHENTICATE, "Negotiate FAIL");
                     authListener.onFailure(ese);
                     return Void.TYPE;
                 }
@@ -320,9 +320,9 @@ public class TransportCreateTokenActionTests extends ESTestCase {
         action.doExecute(null, createTokenRequest, tokenResponseFuture);
         if (failOrSuccess.equals("fail")) {
             ElasticsearchSecurityException ese = expectThrows(ElasticsearchSecurityException.class, () -> tokenResponseFuture.actionGet());
-            assertNotNull(ese.getHeader(KerberosAuthenticationToken.WWW_AUTHENTICATE));
-            assertThat(ese.getHeader(KerberosAuthenticationToken.WWW_AUTHENTICATE).size(), is(1));
-            assertThat(ese.getHeader(KerberosAuthenticationToken.WWW_AUTHENTICATE).get(0), is("Negotiate FAIL"));
+            assertNotNull(ese.getBodyHeader(KerberosAuthenticationToken.WWW_AUTHENTICATE));
+            assertThat(ese.getBodyHeader(KerberosAuthenticationToken.WWW_AUTHENTICATE).size(), is(1));
+            assertThat(ese.getBodyHeader(KerberosAuthenticationToken.WWW_AUTHENTICATE).get(0), is("Negotiate FAIL"));
         } else {
             CreateTokenResponse createTokenResponse = tokenResponseFuture.get();
             assertNotNull(createTokenResponse.getRefreshToken());

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
@@ -1523,7 +1523,7 @@ public class AuthenticationServiceTests extends ESTestCase {
         if (throwElasticsearchSecurityException) {
             throwE = new ElasticsearchSecurityException("authentication error", RestStatus.UNAUTHORIZED);
             if (withAuthenticateHeader) {
-                ((ElasticsearchSecurityException) throwE).addHeader("WWW-Authenticate", selectedScheme);
+                ((ElasticsearchSecurityException) throwE).addBodyHeader("WWW-Authenticate", selectedScheme);
             }
         }
         mockAuthenticate(secondRealm, token, throwE, true);
@@ -1535,13 +1535,13 @@ public class AuthenticationServiceTests extends ESTestCase {
         if (throwElasticsearchSecurityException) {
             assertThat(e.getMessage(), is("authentication error"));
             if (withAuthenticateHeader) {
-                assertThat(e.getHeader("WWW-Authenticate"), contains(selectedScheme));
+                assertThat(e.getBodyHeader("WWW-Authenticate"), contains(selectedScheme));
             } else {
-                assertThat(e.getHeader("WWW-Authenticate"), contains(basicScheme));
+                assertThat(e.getBodyHeader("WWW-Authenticate"), contains(basicScheme));
             }
         } else {
             assertThat(e.getMessage(), is("error attempting to authenticate request"));
-            assertThat(e.getHeader("WWW-Authenticate"), contains(basicScheme));
+            assertThat(e.getBodyHeader("WWW-Authenticate"), contains(basicScheme));
         }
         if (requestIdAlreadyPresent) {
             assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
@@ -1573,7 +1573,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             () -> authenticateBlocking("_action", transportRequest, null, null)
         );
         assertThat(e.getMessage(), is("unable to authenticate user [" + principal + "] for action [_action]"));
-        assertThat(e.getHeader("WWW-Authenticate"), contains(basicScheme));
+        assertThat(e.getBodyHeader("WWW-Authenticate"), contains(basicScheme));
         if (requestIdAlreadyPresent) {
             assertThat(expectAuditRequestId(threadContext), is(reqId.get()));
         } else {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
@@ -473,7 +473,7 @@ public class TokenServiceTests extends ESTestCase {
             final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(requestContext);
             tokenService.tryAuthenticateToken(bearerToken, future);
             ElasticsearchSecurityException e = expectThrows(ElasticsearchSecurityException.class, future::actionGet);
-            final String headerValue = e.getHeader("WWW-Authenticate").get(0);
+            final String headerValue = e.getBodyHeader("WWW-Authenticate").get(0);
             assertThat(headerValue, containsString("Bearer realm="));
             assertThat(headerValue, containsString("expired"));
         }
@@ -674,7 +674,7 @@ public class TokenServiceTests extends ESTestCase {
             final SecureString bearerToken = Authenticator.extractBearerTokenFromHeader(requestContext);
             tokenService.tryAuthenticateToken(bearerToken, future);
             ElasticsearchSecurityException e = expectThrows(ElasticsearchSecurityException.class, future::actionGet);
-            final String headerValue = e.getHeader("WWW-Authenticate").get(0);
+            final String headerValue = e.getBodyHeader("WWW-Authenticate").get(0);
             assertThat(headerValue, containsString("Bearer realm="));
             assertThat(headerValue, containsString("expired"));
         }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosAuthenticationTokenTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosAuthenticationTokenTests.java
@@ -110,8 +110,11 @@ public class KerberosAuthenticationTokenTests extends ESTestCase {
 
     private static void assertContainsAuthenticateHeader(ElasticsearchSecurityException e) {
         assertThat(e.status(), is(RestStatus.UNAUTHORIZED));
-        assertThat(e.getHeaderKeys(), hasSize(1));
-        assertThat(e.getHeader(KerberosAuthenticationToken.WWW_AUTHENTICATE), notNullValue());
-        assertThat(e.getHeader(KerberosAuthenticationToken.WWW_AUTHENTICATE), contains(KerberosAuthenticationToken.NEGOTIATE_SCHEME_NAME));
+        assertThat(e.getBodyHeaderKeys(), hasSize(1));
+        assertThat(e.getBodyHeader(KerberosAuthenticationToken.WWW_AUTHENTICATE), notNullValue());
+        assertThat(
+            e.getBodyHeader(KerberosAuthenticationToken.WWW_AUTHENTICATE),
+            contains(KerberosAuthenticationToken.NEGOTIATE_SCHEME_NAME)
+        );
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosRealmAuthenticateFailedTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosRealmAuthenticateFailedTests.java
@@ -100,7 +100,7 @@ public class KerberosRealmAuthenticateFailedTests extends KerberosRealmTestCase 
                 assertThat(result.getStatus(), is(equalTo(AuthenticationResult.Status.TERMINATE)));
                 if (throwExceptionForInvalidTicket == false) {
                     assertThat(result.getException(), is(instanceOf(ElasticsearchSecurityException.class)));
-                    final List<String> wwwAuthnHeader = ((ElasticsearchSecurityException) result.getException()).getHeader(
+                    final List<String> wwwAuthnHeader = ((ElasticsearchSecurityException) result.getException()).getBodyHeader(
                         KerberosAuthenticationToken.WWW_AUTHENTICATE
                     );
                     assertThat(wwwAuthnHeader, is(notNullValue()));
@@ -113,7 +113,7 @@ public class KerberosRealmAuthenticateFailedTests extends KerberosRealmTestCase 
                         assertThat(result.getMessage(), is(equalTo("failed to authenticate user, gss context negotiation failure")));
                     }
                     assertThat(result.getException(), is(instanceOf(ElasticsearchSecurityException.class)));
-                    final List<String> wwwAuthnHeader = ((ElasticsearchSecurityException) result.getException()).getHeader(
+                    final List<String> wwwAuthnHeader = ((ElasticsearchSecurityException) result.getException()).getBodyHeader(
                         KerberosAuthenticationToken.WWW_AUTHENTICATE
                     );
                     assertThat(wwwAuthnHeader, is(notNullValue()));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/oauth2/RestGetTokenActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/oauth2/RestGetTokenActionTests.java
@@ -124,7 +124,7 @@ public class RestGetTokenActionTests extends ESTestCase {
         String errorMessage = "failed to authenticate user, gss context negotiation not complete";
         ElasticsearchSecurityException ese = new ElasticsearchSecurityException(errorMessage, RestStatus.UNAUTHORIZED);
         boolean addBase64EncodedToken = randomBoolean();
-        ese.addHeader(KerberosAuthenticationToken.WWW_AUTHENTICATE, "Negotiate" + ((addBase64EncodedToken) ? " FAIL" : ""));
+        ese.addBodyHeader(KerberosAuthenticationToken.WWW_AUTHENTICATE, "Negotiate" + ((addBase64EncodedToken) ? " FAIL" : ""));
         listener.onFailure(ese);
 
         RestResponse response = responseSetOnce.get();

--- a/x-pack/qa/security-example-spi-extension/src/main/java/org/elasticsearch/example/realm/CustomAuthenticationFailureHandler.java
+++ b/x-pack/qa/security-example-spi-extension/src/main/java/org/elasticsearch/example/realm/CustomAuthenticationFailureHandler.java
@@ -25,7 +25,7 @@ public class CustomAuthenticationFailureHandler extends DefaultAuthenticationFai
     public ElasticsearchSecurityException failedAuthentication(HttpPreRequest request, AuthenticationToken token, ThreadContext context) {
         ElasticsearchSecurityException e = super.failedAuthentication(request, token, context);
         // set a custom header
-        e.addHeader("WWW-Authenticate", "custom-challenge");
+        e.addBodyHeader("WWW-Authenticate", "custom-challenge");
         return e;
     }
 
@@ -38,7 +38,7 @@ public class CustomAuthenticationFailureHandler extends DefaultAuthenticationFai
     ) {
         ElasticsearchSecurityException e = super.failedAuthentication(message, token, action, context);
         // set a custom header
-        e.addHeader("WWW-Authenticate", "custom-challenge");
+        e.addBodyHeader("WWW-Authenticate", "custom-challenge");
         return e;
     }
 
@@ -46,7 +46,7 @@ public class CustomAuthenticationFailureHandler extends DefaultAuthenticationFai
     public ElasticsearchSecurityException missingToken(HttpPreRequest request, ThreadContext context) {
         ElasticsearchSecurityException e = super.missingToken(request, context);
         // set a custom header
-        e.addHeader("WWW-Authenticate", "custom-challenge");
+        e.addBodyHeader("WWW-Authenticate", "custom-challenge");
         return e;
     }
 
@@ -54,7 +54,7 @@ public class CustomAuthenticationFailureHandler extends DefaultAuthenticationFai
     public ElasticsearchSecurityException missingToken(TransportRequest message, String action, ThreadContext context) {
         ElasticsearchSecurityException e = super.missingToken(message, action, context);
         // set a custom header
-        e.addHeader("WWW-Authenticate", "custom-challenge");
+        e.addBodyHeader("WWW-Authenticate", "custom-challenge");
         return e;
     }
 }


### PR DESCRIPTION
When return an error from Elasticsearch exceptions may contain values written as http response headers. ElasticsearchException contains a map of headers that are added to the response. But these values are also written to a special "header" section of the response body.

This commit renames the existing "headers" in ElasticsearchException to "body headers", which are both http headers and written to the response body. A new "http headers" is added for headers that should only be written as response headers.