### PR TITLE
Handle newlines in release notes test (#130134)

### DIFF
--- a/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/release/ReleaseNotesGeneratorTest.java
+++ b/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/release/ReleaseNotesGeneratorTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Objects;
 
 import static org.elasticsearch.gradle.internal.release.GenerateReleaseNotesTask.getSortedBundlesWithUniqueChangelogs;
+import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -100,7 +101,10 @@ public class ReleaseNotesGeneratorTest {
             writeResource(outputFile, actualOutput);
             assertFalse("UPDATE_EXPECTED_OUTPUT should be set back to false after updating output", UPDATE_EXPECTED_OUTPUT);
         } else {
-            assertThat(actualOutput, equalTo(expectedOutput));
+            String[] expectedLines = expectedOutput.replace("\r", "").split("\n");
+            String[] actualLines = actualOutput.split("\n");
+
+            assertThat(actualLines, arrayContaining(expectedLines));
         }
     }
 


### PR DESCRIPTION
Newlines are system dependent. The release notes generator uses groovy's template engine, which produces system dependent newlines. This commit adjusts the test to account for newlines on both windows and nix systems.