### PR TITLE
Add pattern_text feature flag to logsdb yaml tests

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -45,6 +45,7 @@ public class MapperFeatures implements FeatureSpecification {
     static final NodeFeature IVF_FORMAT_CLUSTER_FEATURE = new NodeFeature("mapper.ivf_format_cluster_feature");
     static final NodeFeature IVF_NESTED_SUPPORT = new NodeFeature("mapper.ivf_nested_support");
     static final NodeFeature SEARCH_LOAD_PER_SHARD = new NodeFeature("mapper.search_load_per_shard");
+    static final NodeFeature PATTERNED_TEXT = new NodeFeature("mapper.patterned_text");
 
     @Override
     public Set<NodeFeature> getTestFeatures() {
@@ -76,7 +77,8 @@ public class MapperFeatures implements FeatureSpecification {
             IVF_FORMAT_CLUSTER_FEATURE,
             IVF_NESTED_SUPPORT,
             SEARCH_LOAD_PER_SHARD,
-            SPARSE_VECTOR_INDEX_OPTIONS_FEATURE
+            SPARSE_VECTOR_INDEX_OPTIONS_FEATURE,
+            PATTERNED_TEXT
         );
     }
 }

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/FeatureFlag.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/FeatureFlag.java
@@ -21,7 +21,8 @@ public enum FeatureFlag {
     DOC_VALUES_SKIPPER("es.doc_values_skipper_feature_flag_enabled=true", Version.fromString("8.18.1"), null),
     USE_LUCENE101_POSTINGS_FORMAT("es.use_lucene101_postings_format_feature_flag_enabled=true", Version.fromString("9.1.0"), null),
     IVF_FORMAT("es.ivf_format_feature_flag_enabled=true", Version.fromString("9.1.0"), null),
-    LOGS_STREAM("es.logs_stream_feature_flag_enabled=true", Version.fromString("9.1.0"), null);
+    LOGS_STREAM("es.logs_stream_feature_flag_enabled=true", Version.fromString("9.1.0"), null),
+    PATTERNED_TEXT("es.patterned_text_feature_flag_enabled=true", Version.fromString("9.1.1"), null);
 
     public final String systemProperty;
     public final Version from;

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/FeatureFlag.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/FeatureFlag.java
@@ -22,7 +22,7 @@ public enum FeatureFlag {
     USE_LUCENE101_POSTINGS_FORMAT("es.use_lucene101_postings_format_feature_flag_enabled=true", Version.fromString("9.1.0"), null),
     IVF_FORMAT("es.ivf_format_feature_flag_enabled=true", Version.fromString("9.1.0"), null),
     LOGS_STREAM("es.logs_stream_feature_flag_enabled=true", Version.fromString("9.1.0"), null),
-    PATTERNED_TEXT("es.patterned_text_feature_flag_enabled=true", Version.fromString("9.1.1"), null);
+    PATTERNED_TEXT("es.patterned_text_feature_flag_enabled=true", Version.fromString("9.2.0"), null);
 
     public final String systemProperty;
     public final Version from;

--- a/x-pack/plugin/logsdb/src/yamlRestTest/java/org/elasticsearch/xpack/logsdb/LogsdbTestSuiteIT.java
+++ b/x-pack/plugin/logsdb/src/yamlRestTest/java/org/elasticsearch/xpack/logsdb/LogsdbTestSuiteIT.java
@@ -34,6 +34,7 @@ public class LogsdbTestSuiteIT extends ESClientYamlSuiteTestCase {
         .setting("xpack.license.self_generated.type", "trial")
         .feature(FeatureFlag.DOC_VALUES_SKIPPER)
         .feature(FeatureFlag.USE_LUCENE101_POSTINGS_FORMAT)
+        .feature(FeatureFlag.PATTERNED_TEXT)
         .build();
 
     public LogsdbTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {

--- a/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/patternedtext/10_basic.yml
+++ b/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/patternedtext/10_basic.yml
@@ -41,9 +41,6 @@ setup:
 
 ---
 Field caps:
-  - requires:
-      cluster_features: [ "mapper.patterned_text" ]
-      reason: "patterned_text mappings are used in this test"
 
   - do:
       field_caps:
@@ -55,9 +52,6 @@ Field caps:
 
 ---
 Exist query:
-  - requires:
-      cluster_features: [ "mapper.patterned_text" ]
-      reason: "patterned_text mappings are used in this test"
 
   - do:
       search:
@@ -72,9 +66,6 @@ Exist query:
 
 ---
 Match query:
-  - requires:
-      cluster_features: [ "mapper.patterned_text" ]
-      reason: "patterned_text mappings are used in this test"
 
   - do:
       search:
@@ -89,9 +80,6 @@ Match query:
 
 ---
 Match Phrase query:
-  - requires:
-      cluster_features: [ "mapper.patterned_text" ]
-      reason: "patterned_text mappings are used in this test"
 
   - do:
       search:
@@ -106,9 +94,6 @@ Match Phrase query:
 
 ---
 Match Phrase Prefix query:
-  - requires:
-      cluster_features: [ "mapper.patterned_text" ]
-      reason: "patterned_text mappings are used in this test"
 
   - do:
       search:
@@ -124,9 +109,6 @@ Match Phrase Prefix query:
 
 ---
 Query String query with phrase:
-  - requires:
-      cluster_features: [ "mapper.patterned_text" ]
-      reason: "patterned_text mappings are used in this test"
 
   - do:
       search:
@@ -143,9 +125,6 @@ Query String query with phrase:
 
 ---
 Regexp query:
-  - requires:
-      cluster_features: [ "mapper.patterned_text" ]
-      reason: "patterned_text mappings are used in this test"
 
   - do:
       search:
@@ -160,9 +139,6 @@ Regexp query:
 
 ---
 Wildcard query:
-  - requires:
-      cluster_features: [ "mapper.patterned_text" ]
-      reason: "patterned_text mappings are used in this test"
 
   - do:
       search:
@@ -177,9 +153,6 @@ Wildcard query:
 
 ---
 Prefix query:
-  - requires:
-      cluster_features: [ "mapper.patterned_text" ]
-      reason: "patterned_text mappings are used in this test"
 
   - do:
       search:
@@ -194,9 +167,6 @@ Prefix query:
 
 ---
 Fuzzy query:
-  - requires:
-      cluster_features: [ "mapper.patterned_text" ]
-      reason: "patterned_text mappings are used in this test"
 
   - do:
       search:
@@ -211,9 +181,6 @@ Fuzzy query:
 
 ---
 Span query:
-  - requires:
-      cluster_features: [ "mapper.patterned_text" ]
-      reason: "patterned_text mappings are used in this test"
 
   - do:
       catch: bad_request
@@ -226,9 +193,6 @@ Span query:
 
 ---
 Term intervals query:
-  - requires:
-      cluster_features: [ "mapper.patterned_text" ]
-      reason: "patterned_text mappings are used in this test"
 
   - do:
       search:
@@ -245,9 +209,6 @@ Term intervals query:
 
 ---
 Prefix intervals query:
-  - requires:
-      cluster_features: [ "mapper.patterned_text" ]
-      reason: "patterned_text mappings are used in this test"
 
   - do:
       search:
@@ -263,9 +224,6 @@ Prefix intervals query:
 
 ---
 Wildcard intervals query:
-  - requires:
-      cluster_features: [ "mapper.patterned_text" ]
-      reason: "patterned_text mappings are used in this test"
 
   - do:
       search:
@@ -281,9 +239,6 @@ Wildcard intervals query:
 
 ---
 Fuzzy intervals query:
-  - requires:
-      cluster_features: [ "mapper.patterned_text" ]
-      reason: "patterned_text mappings are used in this test"
 
   - do:
       search:
@@ -299,9 +254,6 @@ Fuzzy intervals query:
 
 ---
 Wildcard highlighting:
-  - requires:
-      cluster_features: [ "mapper.patterned_text" ]
-      reason: "patterned_text mappings are used in this test"
 
   - do:
       search:
@@ -320,9 +272,6 @@ Wildcard highlighting:
 
 ---
 tsdb:
-  - requires:
-      cluster_features: [ "mapper.patterned_text" ]
-      reason: "patterned_text mappings are used in this test"
 
   - do:
       indices.create:
@@ -364,10 +313,6 @@ tsdb:
 
 ---
 Multiple values:
-  - requires:
-      cluster_features: [ "mapper.patterned_text" ]
-      reason: "patterned_text mappings are used in this test"
-
   - do:
       indices.create:
         index: test1

--- a/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/patternedtext/10_basic.yml
+++ b/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/patternedtext/10_basic.yml
@@ -1,4 +1,7 @@
 setup:
+  - requires:
+      cluster_features: [ "mapper.patterned_text" ]
+      reason: "patterned_text mappings are used in this test"
 
   - do:
       indices.create:
@@ -38,6 +41,9 @@ setup:
 
 ---
 Field caps:
+  - requires:
+      cluster_features: [ "mapper.patterned_text" ]
+      reason: "patterned_text mappings are used in this test"
 
   - do:
       field_caps:
@@ -49,6 +55,9 @@ Field caps:
 
 ---
 Exist query:
+  - requires:
+      cluster_features: [ "mapper.patterned_text" ]
+      reason: "patterned_text mappings are used in this test"
 
   - do:
       search:
@@ -63,6 +72,9 @@ Exist query:
 
 ---
 Match query:
+  - requires:
+      cluster_features: [ "mapper.patterned_text" ]
+      reason: "patterned_text mappings are used in this test"
 
   - do:
       search:
@@ -77,6 +89,9 @@ Match query:
 
 ---
 Match Phrase query:
+  - requires:
+      cluster_features: [ "mapper.patterned_text" ]
+      reason: "patterned_text mappings are used in this test"
 
   - do:
       search:
@@ -91,6 +106,9 @@ Match Phrase query:
 
 ---
 Match Phrase Prefix query:
+  - requires:
+      cluster_features: [ "mapper.patterned_text" ]
+      reason: "patterned_text mappings are used in this test"
 
   - do:
       search:
@@ -106,6 +124,9 @@ Match Phrase Prefix query:
 
 ---
 Query String query with phrase:
+  - requires:
+      cluster_features: [ "mapper.patterned_text" ]
+      reason: "patterned_text mappings are used in this test"
 
   - do:
       search:
@@ -122,6 +143,9 @@ Query String query with phrase:
 
 ---
 Regexp query:
+  - requires:
+      cluster_features: [ "mapper.patterned_text" ]
+      reason: "patterned_text mappings are used in this test"
 
   - do:
       search:
@@ -136,6 +160,9 @@ Regexp query:
 
 ---
 Wildcard query:
+  - requires:
+      cluster_features: [ "mapper.patterned_text" ]
+      reason: "patterned_text mappings are used in this test"
 
   - do:
       search:
@@ -150,6 +177,9 @@ Wildcard query:
 
 ---
 Prefix query:
+  - requires:
+      cluster_features: [ "mapper.patterned_text" ]
+      reason: "patterned_text mappings are used in this test"
 
   - do:
       search:
@@ -164,6 +194,9 @@ Prefix query:
 
 ---
 Fuzzy query:
+  - requires:
+      cluster_features: [ "mapper.patterned_text" ]
+      reason: "patterned_text mappings are used in this test"
 
   - do:
       search:
@@ -178,6 +211,9 @@ Fuzzy query:
 
 ---
 Span query:
+  - requires:
+      cluster_features: [ "mapper.patterned_text" ]
+      reason: "patterned_text mappings are used in this test"
 
   - do:
       catch: bad_request
@@ -190,6 +226,9 @@ Span query:
 
 ---
 Term intervals query:
+  - requires:
+      cluster_features: [ "mapper.patterned_text" ]
+      reason: "patterned_text mappings are used in this test"
 
   - do:
       search:
@@ -206,6 +245,9 @@ Term intervals query:
 
 ---
 Prefix intervals query:
+  - requires:
+      cluster_features: [ "mapper.patterned_text" ]
+      reason: "patterned_text mappings are used in this test"
 
   - do:
       search:
@@ -221,6 +263,9 @@ Prefix intervals query:
 
 ---
 Wildcard intervals query:
+  - requires:
+      cluster_features: [ "mapper.patterned_text" ]
+      reason: "patterned_text mappings are used in this test"
 
   - do:
       search:
@@ -236,6 +281,9 @@ Wildcard intervals query:
 
 ---
 Fuzzy intervals query:
+  - requires:
+      cluster_features: [ "mapper.patterned_text" ]
+      reason: "patterned_text mappings are used in this test"
 
   - do:
       search:
@@ -251,6 +299,9 @@ Fuzzy intervals query:
 
 ---
 Wildcard highlighting:
+  - requires:
+      cluster_features: [ "mapper.patterned_text" ]
+      reason: "patterned_text mappings are used in this test"
 
   - do:
       search:
@@ -269,6 +320,9 @@ Wildcard highlighting:
 
 ---
 tsdb:
+  - requires:
+      cluster_features: [ "mapper.patterned_text" ]
+      reason: "patterned_text mappings are used in this test"
 
   - do:
       indices.create:
@@ -310,6 +364,10 @@ tsdb:
 
 ---
 Multiple values:
+  - requires:
+      cluster_features: [ "mapper.patterned_text" ]
+      reason: "patterned_text mappings are used in this test"
+
   - do:
       indices.create:
         index: test1

--- a/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/patternedtext/20_synthetic_source.yml
+++ b/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/patternedtext/20_synthetic_source.yml
@@ -1,8 +1,10 @@
-simple:
+setup:
   - requires:
       cluster_features: [ "mapper.patterned_text" ]
       reason: "patterned_text mappings are used in this test"
 
+---
+simple:
   - do:
       indices.create:
         index: test

--- a/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/patternedtext/20_synthetic_source.yml
+++ b/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/patternedtext/20_synthetic_source.yml
@@ -1,4 +1,8 @@
 simple:
+  - requires:
+      cluster_features: [ "mapper.patterned_text" ]
+      reason: "patterned_text mappings are used in this test"
+
   - do:
       indices.create:
         index: test
@@ -39,6 +43,9 @@ simple:
 
 ---
 synthetic_source with copy_to:
+  - requires:
+      cluster_features: [ "mapper.patterned_text" ]
+      reason: "patterned_text mappings are used in this test"
 
   - do:
       indices.create:

--- a/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/patternedtext/20_synthetic_source.yml
+++ b/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/patternedtext/20_synthetic_source.yml
@@ -43,9 +43,6 @@ simple:
 
 ---
 synthetic_source with copy_to:
-  - requires:
-      cluster_features: [ "mapper.patterned_text" ]
-      reason: "patterned_text mappings are used in this test"
 
   - do:
       indices.create:


### PR DESCRIPTION
Patterned text yaml tests in logsdb plugin are failing as they assume the presence of the pattern_text type. Enable the feature flag for the tests.

Fixes https://github.com/elastic/elasticsearch/issues/130376#event-18403762232