### PR TITLE
[ES|QL] Fix suggested_cast yaml test

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1215,12 +1215,7 @@ public class EsqlCapabilities {
         /**
          * (Re)Added EXPLAIN command
          */
-        EXPLAIN(Build.current().isSnapshot()),
-
-        /**
-         * Enable yaml test for suggested cast properly
-         */
-        SUGGESTED_CAST_YAML_TEST;
+        EXPLAIN(Build.current().isSnapshot());
 
         private final boolean enabled;
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1215,7 +1215,12 @@ public class EsqlCapabilities {
         /**
          * (Re)Added EXPLAIN command
          */
-        EXPLAIN(Build.current().isSnapshot());
+        EXPLAIN(Build.current().isSnapshot()),
+
+        /**
+         * Enable yaml test for suggested cast properly
+         */
+        SUGGESTED_CAST_YAML_TEST;
 
         private final boolean enabled;
 

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/160_union_types.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/160_union_types.yml
@@ -913,8 +913,8 @@ suggested_type:
         - method: POST
           path: /_query
           parameters: []
-          capabilities: [recommended_cast]
-      reason: "uses recommended_cast"
+          capabilities: [suggested_cast_yaml_test]
+      reason: "was using incorrect capabilities name and being skipped before"
 
   - do:
       indices.create:
@@ -969,9 +969,7 @@ suggested_type:
   - match: { columns.0.original_types: ["aggregate_metric_double", "long"] }
   - match: { columns.0.suggested_cast: "aggregate_metric_double" }
   - match: { columns.1.name: "my_date" }
-  - match: { columns.1.type: "unsupported" }
-  - match: { columns.1.original_types: ["date_nanos", "datetime"] }
-  - match: { columns.1.suggested_cast: "date_nanos" }
+  - match: { columns.1.type: "date_nanos" }
   - match: { columns.2.name: "my_double" }
   - match: { columns.2.type: "double" }
   - is_false: columns.2.original_types

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/160_union_types.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/160_union_types.yml
@@ -913,7 +913,7 @@ suggested_type:
         - method: POST
           path: /_query
           parameters: []
-          capabilities: [implicit_casting_date_and_date_nanos]
+          capabilities: [suggested_cast, implicit_casting_date_and_date_nanos]
       reason: "date and date_nanos should no longer produce suggested_cast column"
 
   - do:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/160_union_types.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/160_union_types.yml
@@ -913,8 +913,8 @@ suggested_type:
         - method: POST
           path: /_query
           parameters: []
-          capabilities: [suggested_cast_yaml_test]
-      reason: "was using incorrect capabilities name and being skipped before"
+          capabilities: [implicit_casting_date_and_date_nanos]
+      reason: "date and date_nanos should no longer produce suggested_cast column"
 
   - do:
       indices.create:


### PR DESCRIPTION
The wrong capability name was being used in this yaml test
causing it to be skipped. This commit fixes that.