### PR TITLE
Fix bwc tests failures introduced in #130254

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/SearchFeatures.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchFeatures.java
@@ -27,7 +27,7 @@ public final class SearchFeatures implements FeatureSpecification {
     );
     public static final NodeFeature INT_SORT_FOR_INT_SHORT_BYTE_FIELDS = new NodeFeature("search.sort.int_sort_for_int_short_byte_fields");
     static final NodeFeature MULTI_MATCH_CHECKS_POSITIONS = new NodeFeature("search.multi.match.checks.positions");
-    private static final NodeFeature KNN_QUERY_BUGFIX_130254 = new NodeFeature("search.knn.query.bugfix.130254");
+    private static final NodeFeature KNN_QUERY_BUGFIX_130254 = new NodeFeature("search.knn.query.bugfix.130254", true);
 
     @Override
     public Set<NodeFeature> getTestFeatures() {


### PR DESCRIPTION
#130254 introduced a new test cluster feature to check that https://github.com/elastic/elasticsearch/issues/130239 was fixed.

However, rolling upgrade tests cannot work due to upgraded nodes unable to join the cluster, as 9.x does not have this feature.

This PR marks the test feature as assumed for next compatibility boundary, effectively assuming new versions have that feature.

Relates to #130254