### PR TITLE
[9.0] [Build] Fix maven-aggregation generation for shadowed artifacts (#130412)

### DIFF
--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/PublishPlugin.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/PublishPlugin.java
@@ -175,6 +175,8 @@ public class PublishPlugin implements Plugin<Project> {
     private static void configureWithShadowPlugin(Project project, MavenPublication publication) {
         var shadow = project.getExtensions().getByType(ShadowExtension.class);
         shadow.component(publication);
+        publication.artifact(project.getTasks().named("javadocJar"));
+        publication.artifact(project.getTasks().named("sourcesJar"));
     }
 
     private static void addScmInfo(XmlProvider xml, GitInfo gitInfo) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Build] Fix maven-aggregation generation for shadowed artifacts (#130412)](https://github.com/elastic/elasticsearch/pull/130412)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)