### PR TITLE
* Native float type + proper QueryPragmas propagation

### DIFF
--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
@@ -653,8 +653,8 @@ public enum DataType {
      * If this is a "small" numeric type this contains the type ESQL will
      * widen it into, otherwise this returns {@code this}.
      */
-    public DataType widenSmallNumeric() {
-        return widenSmallNumeric == null ? this : widenSmallNumeric;
+    public DataType widenSmallNumeric(boolean supportNativeFloat) {
+        return widenSmallNumeric == null || supportNativeFloat ? this : widenSmallNumeric;
     }
 
     /**

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
@@ -475,7 +475,7 @@ public final class EsqlTestUtils {
     }
 
     public static Map<String, EsField> loadMapping(String name) {
-        return LoadMapping.loadMapping(name);
+        return new LoadMapping(QueryPragmas.EMPTY).loadMapping(name);
     }
 
     public static String loadUtf8TextFile(String name) {

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/floats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/floats.csv-spec
@@ -692,3 +692,11 @@ null
 null
 null
 ;
+
+
+foo
+row d = [3.141] | eval dd = to_double(d);
+
+d:double |dd:double
+[3.141]  |3.142
+;

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/LookupJoinTypesIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/LookupJoinTypesIT.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xpack.esql.expression.function.DocsV3Support;
 import org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry;
 import org.elasticsearch.xpack.esql.plan.logical.join.Join;
 import org.elasticsearch.xpack.esql.plugin.EsqlPlugin;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.elasticsearch.xpack.spatial.SpatialPlugin;
 import org.elasticsearch.xpack.unsignedlong.UnsignedLongMapperPlugin;
 import org.elasticsearch.xpack.versionfield.VersionFieldPlugin;
@@ -437,6 +438,10 @@ public class LookupJoinTypesIT extends ESIntegTestCase {
             this.configs = new LinkedHashMap<>();
         }
 
+        private QueryPragmas getPragmas() {
+            return QueryPragmas.EMPTY;
+        }
+
         public List<TestMapping> indices() {
             List<TestMapping> results = new ArrayList<>();
 
@@ -533,9 +538,9 @@ public class LookupJoinTypesIT extends ESIntegTestCase {
                 Locale.ROOT,
                 "JOIN left field [%s] of type [%s] is incompatible with right field [%s] of type [%s]",
                 fieldName,
-                mainType.widenSmallNumeric(),
+                mainType.widenSmallNumeric(getPragmas().native_float_type()),
                 fieldName,
-                lookupType.widenSmallNumeric()
+                lookupType.widenSmallNumeric(getPragmas().native_float_type())
             );
             add(
                 new TestConfigFails<>(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
@@ -181,6 +181,7 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.string.Trim;
 import org.elasticsearch.xpack.esql.expression.function.scalar.util.Delay;
 import org.elasticsearch.xpack.esql.expression.function.vector.Knn;
 import org.elasticsearch.xpack.esql.parser.ParsingException;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.elasticsearch.xpack.esql.session.Configuration;
 
 import java.lang.reflect.Constructor;
@@ -307,27 +308,28 @@ public class EsqlFunctionRegistry {
             // since they declare two public constructors - one with filter (for nested where) and one without
             // use casting to disambiguate between the two
             new FunctionDefinition[] {
-                def(Avg.class, uni(Avg::new), "avg"),
-                def(Count.class, uni(Count::new), "count"),
-                def(CountDistinct.class, bi(CountDistinct::new), "count_distinct"),
+                def(Avg.class, uniWithPragmas(Avg::new), "avg"),
+                def(Count.class, uniWithPragmas(Count::new), "count"),
+                def(CountDistinct.class, biWithPragmas(CountDistinct::new), "count_distinct"),
+                def(Sum.class, uniWithPragmas(Sum::new), "sum"),
+                def(Median.class, uniWithPragmas(Median::new), "median"),
+                def(WeightedAvg.class, biWithPragmas(WeightedAvg::new), "weighted_avg"),
+                def(Percentile.class, biWithPragmas(Percentile::new), "percentile") },
+            new FunctionDefinition[] {
                 def(Max.class, uni(Max::new), "max"),
-                def(Median.class, uni(Median::new), "median"),
-                def(MedianAbsoluteDeviation.class, uni(MedianAbsoluteDeviation::new), "median_absolute_deviation"),
+                def(MedianAbsoluteDeviation.class, uniWithPragmas(MedianAbsoluteDeviation::new), "median_absolute_deviation"),
                 def(Min.class, uni(Min::new), "min"),
-                def(Percentile.class, bi(Percentile::new), "percentile"),
                 def(Sample.class, bi(Sample::new), "sample"),
                 def(StdDev.class, uni(StdDev::new), "std_dev"),
-                def(Sum.class, uni(Sum::new), "sum"),
                 def(Top.class, tri(Top::new), "top"),
-                def(Values.class, uni(Values::new), "values"),
-                def(WeightedAvg.class, bi(WeightedAvg::new), "weighted_avg") },
+                def(Values.class, uni(Values::new), "values") },
             // math
             new FunctionDefinition[] {
                 def(Abs.class, Abs::new, "abs"),
                 def(Acos.class, Acos::new, "acos"),
                 def(Asin.class, Asin::new, "asin"),
                 def(Atan.class, Atan::new, "atan"),
-                def(Atan2.class, Atan2::new, "atan2"),
+                def(Atan2.class, bi(Atan2::new), "atan2"),
                 def(Cbrt.class, Cbrt::new, "cbrt"),
                 def(Ceil.class, Ceil::new, "ceil"),
                 def(Cos.class, Cos::new, "cos"),
@@ -342,10 +344,10 @@ public class EsqlFunctionRegistry {
                 def(Log10.class, Log10::new, "log10"),
                 def(Least.class, Least::new, "least"),
                 def(Pi.class, Pi::new, "pi"),
-                def(Pow.class, Pow::new, "pow"),
-                def(Round.class, Round::new, "round"),
+                def(Pow.class, bi(Pow::new), "pow"),
+                def(Round.class, bi(Round::new), "round"),
                 def(RoundTo.class, RoundTo::new, "round_to"),
-                def(Scalb.class, Scalb::new, "scalb"),
+                def(Scalb.class, bi(Scalb::new), "scalb"),
                 def(Signum.class, Signum::new, "signum"),
                 def(Sin.class, Sin::new, "sin"),
                 def(Sinh.class, Sinh::new, "sinh"),
@@ -358,18 +360,18 @@ public class EsqlFunctionRegistry {
                 def(BitLength.class, BitLength::new, "bit_length"),
                 def(ByteLength.class, ByteLength::new, "byte_length"),
                 def(Concat.class, Concat::new, "concat"),
-                def(EndsWith.class, EndsWith::new, "ends_with"),
-                def(Hash.class, Hash::new, "hash"),
+                def(EndsWith.class, bi(EndsWith::new), "ends_with"),
+                def(Hash.class, bi(Hash::new), "hash"),
                 def(LTrim.class, LTrim::new, "ltrim"),
-                def(Left.class, Left::new, "left"),
+                def(Left.class, bi(Left::new), "left"),
                 def(Length.class, Length::new, "length"),
                 def(Locate.class, Locate::new, "locate"),
                 def(Md5.class, Md5::new, "md5"),
                 def(RTrim.class, RTrim::new, "rtrim"),
-                def(Repeat.class, Repeat::new, "repeat"),
+                def(Repeat.class, bi(Repeat::new), "repeat"),
                 def(Replace.class, Replace::new, "replace"),
                 def(Reverse.class, Reverse::new, "reverse"),
-                def(Right.class, Right::new, "right"),
+                def(Right.class, bi(Right::new), "right"),
                 def(Sha1.class, Sha1::new, "sha1"),
                 def(Sha256.class, Sha256::new, "sha256"),
                 def(Space.class, Space::new, "space"),
@@ -421,16 +423,16 @@ public class EsqlFunctionRegistry {
                 def(ToDatetime.class, ToDatetime::new, "to_datetime", "to_dt"),
                 def(ToDateNanos.class, ToDateNanos::new, "to_date_nanos", "to_datenanos"),
                 def(ToDegrees.class, ToDegrees::new, "to_degrees"),
-                def(ToDouble.class, ToDouble::new, "to_double", "to_dbl"),
+                def(ToDouble.class, uniWithPragmas(ToDouble::new), "to_double", "to_dbl"),
                 def(ToGeoPoint.class, ToGeoPoint::new, "to_geopoint"),
                 def(ToGeoShape.class, ToGeoShape::new, "to_geoshape"),
-                def(ToIp.class, ToIp::new, "to_ip"),
-                def(ToInteger.class, ToInteger::new, "to_integer", "to_int"),
-                def(ToLong.class, ToLong::new, "to_long"),
+                def(ToIp.class, biWithPragmas(ToIp::new), "to_ip"),
+                def(ToInteger.class, uniWithPragmas(ToInteger::new), "to_integer", "to_int"),
+                def(ToLong.class, uniWithPragmas(ToLong::new), "to_long"),
                 def(ToRadians.class, ToRadians::new, "to_radians"),
                 def(ToString.class, ToString::new, "to_string", "to_str"),
                 def(ToTimeDuration.class, ToTimeDuration::new, "to_timeduration"),
-                def(ToUnsignedLong.class, ToUnsignedLong::new, "to_unsigned_long", "to_ulong", "to_ul"),
+                def(ToUnsignedLong.class, uniWithPragmas(ToUnsignedLong::new), "to_unsigned_long", "to_ulong", "to_ul"),
                 def(ToVersion.class, ToVersion::new, "to_version", "to_ver"), },
             // multivalue functions
             new FunctionDefinition[] {
@@ -471,10 +473,10 @@ public class EsqlFunctionRegistry {
                 def(Rate.class, uni(Rate::new), "rate"),
                 def(MaxOverTime.class, uni(MaxOverTime::new), "max_over_time"),
                 def(MinOverTime.class, uni(MinOverTime::new), "min_over_time"),
-                def(SumOverTime.class, uni(SumOverTime::new), "sum_over_time"),
-                def(CountOverTime.class, uni(CountOverTime::new), "count_over_time"),
-                def(CountDistinctOverTime.class, bi(CountDistinctOverTime::new), "count_distinct_over_time"),
-                def(AvgOverTime.class, uni(AvgOverTime::new), "avg_over_time"),
+                def(SumOverTime.class, uniWithPragmas(SumOverTime::new), "sum_over_time"),
+                def(CountOverTime.class, uniWithPragmas(CountOverTime::new), "count_over_time"),
+                def(CountDistinctOverTime.class, biWithPragmas(CountDistinctOverTime::new), "count_distinct_over_time"),
+                def(AvgOverTime.class, uniWithPragmas(AvgOverTime::new), "avg_over_time"),
                 def(LastOverTime.class, uni(LastOverTime::new), "last_over_time"),
                 def(FirstOverTime.class, uni(FirstOverTime::new), "first_over_time"),
                 def(Term.class, bi(Term::new), "term"),
@@ -1188,6 +1190,66 @@ public class EsqlFunctionRegistry {
         T build(Source source, Expression one, Expression two, Expression three, Configuration configuration);
     }
 
+    // Pragma aware builders and helpers: same as config aware, but for QueryPragmas additional parameter.
+
+    /**
+     * Build a {@linkplain FunctionDefinition} for a no-argument function that is configuration aware.
+     */
+    @SuppressWarnings("overloads")
+    protected static <T extends Function> FunctionDefinition def(Class<T> function, PragmasAwareBuilder<T> ctorRef, String... names) {
+        FunctionBuilder builder = (source, children, cfg) -> {
+            if (false == children.isEmpty()) {
+                throw new QlIllegalArgumentException("expects no arguments");
+            }
+            return ctorRef.build(source, cfg.pragmas());
+        };
+        return def(function, builder, names);
+    }
+
+    protected interface PragmasAwareBuilder<T> {
+        T build(Source source, QueryPragmas pragmas);
+    }
+
+    /**
+     * Build a {@linkplain FunctionDefinition} for a one-argument function that is pragmas aware.
+     */
+    @SuppressWarnings("overloads")
+    public static <T extends Function> FunctionDefinition def(Class<T> function, UnaryPragmasAwareBuilder<T> ctorRef, String... names) {
+        FunctionBuilder builder = (source, children, cfg) -> {
+            if (children.size() > 1) {
+                throw new QlIllegalArgumentException("expects exactly one argument");
+            }
+            Expression ex = children.size() == 1 ? children.get(0) : null;
+            return ctorRef.build(source, ex, cfg.pragmas());
+        };
+        return def(function, builder, names);
+    }
+
+    public interface UnaryPragmasAwareBuilder<T> {
+        T build(Source source, Expression exp, QueryPragmas pragmas);
+    }
+
+    /**
+     * Build a {@linkplain FunctionDefinition} for a binary function that is configuration aware.
+     */
+    @SuppressWarnings("overloads")
+    protected static <T extends Function> FunctionDefinition def(Class<T> function, BinaryPragmasAwareBuilder<T> ctorRef, String... names) {
+        FunctionBuilder builder = (source, children, cfg) -> {
+            boolean isBinaryOptionalParamFunction = OptionalArgument.class.isAssignableFrom(function);
+            if (isBinaryOptionalParamFunction && (children.size() > 2 || children.isEmpty())) {
+                throw new QlIllegalArgumentException("expects one or two arguments");
+            } else if (isBinaryOptionalParamFunction == false && children.size() != 2) {
+                throw new QlIllegalArgumentException("expects exactly two arguments");
+            }
+            return ctorRef.build(source, children.get(0), children.size() == 2 ? children.get(1) : null, cfg.pragmas());
+        };
+        return def(function, builder, names);
+    }
+
+    protected interface BinaryPragmasAwareBuilder<T> {
+        T build(Source source, Expression left, Expression right, QueryPragmas pragmas);
+    }
+
     //
     // Utility functions to help disambiguate the method handle passed in.
     // They work by providing additional method information to help the compiler know which method to pick.
@@ -1204,4 +1266,11 @@ public class EsqlFunctionRegistry {
         return function;
     }
 
+    private static <T extends Function> UnaryPragmasAwareBuilder<T> uniWithPragmas(UnaryPragmasAwareBuilder<T> function) {
+        return function;
+    }
+
+    private static <T extends Function> BinaryPragmasAwareBuilder<T> biWithPragmas(BinaryPragmasAwareBuilder<T> function) {
+        return function;
+    }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountOverTime.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountOverTime.java
@@ -20,6 +20,7 @@ import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesToLifecyc
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.FunctionType;
 import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.io.IOException;
 import java.util.List;
@@ -62,18 +63,23 @@ public class CountOverTime extends TimeSeriesAggregateFunction {
                 "text",
                 "unsigned_long",
                 "version" }
-        ) Expression field
+        ) Expression field,
+        QueryPragmas pragmas
     ) {
-        this(source, field, Literal.TRUE);
+        this(source, field, Literal.TRUE, pragmas);
     }
 
-    public CountOverTime(Source source, Expression field, Expression filter) {
+    public CountOverTime(Source source, Expression field, Expression filter, QueryPragmas pragmas) {
         super(source, field, filter, emptyList());
+        this.pragmas = pragmas;
     }
 
     private CountOverTime(StreamInput in) throws IOException {
         super(in);
+        this.pragmas = in.readNamedWriteable(QueryPragmas.class);
     }
+
+    private final QueryPragmas pragmas;
 
     @Override
     public String getWriteableName() {
@@ -82,17 +88,17 @@ public class CountOverTime extends TimeSeriesAggregateFunction {
 
     @Override
     public CountOverTime withFilter(Expression filter) {
-        return new CountOverTime(source(), field(), filter);
+        return new CountOverTime(source(), field(), filter, pragmas);
     }
 
     @Override
     protected NodeInfo<CountOverTime> info() {
-        return NodeInfo.create(this, CountOverTime::new, field(), filter());
+        return NodeInfo.create(this, CountOverTime::new, field(), filter(), pragmas);
     }
 
     @Override
     public CountOverTime replaceChildren(List<Expression> newChildren) {
-        return new CountOverTime(source(), newChildren.get(0), newChildren.get(1));
+        return new CountOverTime(source(), newChildren.get(0), newChildren.get(1), pragmas);
     }
 
     @Override
@@ -107,6 +113,6 @@ public class CountOverTime extends TimeSeriesAggregateFunction {
 
     @Override
     public Count perTimeSeriesAggregation() {
-        return new Count(source(), field(), filter());
+        return new Count(source(), field(), filter(), pragmas);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/AbstractConvertFunction.java.bak
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/AbstractConvertFunction.java.bak
@@ -1,0 +1,180 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import joptsimple.internal.Strings;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.data.Vector;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.compute.operator.EvalOperator.ExpressionEvaluator;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.scalar.UnaryScalarFunction;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+import org.elasticsearch.xpack.esql.session.Configuration;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isTypeOrUnionType;
+
+/**
+ * Base class for functions that converts a field into a function-specific type.
+ * <p>
+ *     We have a guide for writing these in the javadoc for
+ *     {@link org.elasticsearch.xpack.esql.expression.function.scalar}.
+ * </p>
+ */
+public abstract class AbstractConvertFunction extends UnaryScalarFunction implements ConvertFunction {
+
+    // the numeric types convert functions need to handle; the other numeric types are converted upstream to one of these
+    private static final List<DataType> NUMERIC_TYPES = List.of(DataType.INTEGER, DataType.LONG, DataType.UNSIGNED_LONG, DataType.DOUBLE);
+
+    protected AbstractConvertFunction(Source source, Expression field, Configuration config) {
+        super(source, field);
+        this.pragmas = config.pragmas();
+    }
+
+    private final QueryPragmas pragmas;
+
+    public QueryPragmas getPragmas() { return pragmas; }
+
+    protected AbstractConvertFunction(StreamInput in) throws IOException {
+        this(Source.readFrom((PlanStreamInput) in), in.readNamedWriteable(Expression.class), in.readNamedWriteable(QueryPragmas.class));
+    }
+
+    /**
+     * Build the evaluator given the evaluator a multivalued field.
+     */
+    protected final ExpressionEvaluator.Factory evaluator(ExpressionEvaluator.Factory fieldEval) {
+        DataType sourceType = field().dataType().widenSmallNumeric(pragmas.native_float_type());
+        var factory = factories().get(sourceType);
+        if (factory == null) {
+            throw EsqlIllegalArgumentException.illegalDataType(sourceType);
+        }
+        return factory.build(source(), fieldEval);
+    }
+
+    @Override
+    protected TypeResolution resolveType() {
+        if (childrenResolved() == false) {
+            return new TypeResolution("Unresolved children");
+        }
+        return isTypeOrUnionType(field(), factories()::containsKey, sourceText(), null, supportedTypesNames(supportedTypes()));
+    }
+
+    @Override
+    public Set<DataType> supportedTypes() {
+        return factories().keySet();
+    }
+
+    static String supportedTypesNames(Set<DataType> types) {
+        List<String> supportedTypesNames = new ArrayList<>(types.size());
+        HashSet<DataType> supportTypes = new HashSet<>(types);
+        if (supportTypes.containsAll(NUMERIC_TYPES)) {
+            supportedTypesNames.add("numeric");
+            NUMERIC_TYPES.forEach(supportTypes::remove);
+        }
+
+        if (types.containsAll(DataType.stringTypes())) {
+            supportedTypesNames.add("string");
+            DataType.stringTypes().forEach(supportTypes::remove);
+        }
+
+        supportTypes.forEach(t -> supportedTypesNames.add(t.nameUpper().toLowerCase(Locale.ROOT)));
+        supportedTypesNames.sort(String::compareTo);
+        return Strings.join(supportedTypesNames, " or ");
+    }
+
+    @FunctionalInterface
+    interface BuildFactory {
+        ExpressionEvaluator.Factory build(Source source, ExpressionEvaluator.Factory field);
+    }
+
+    /**
+     * A map from input type to {@link ExpressionEvaluator} ctor. Usually implemented like:
+     * <pre>{@code
+     *     private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
+     *         Map.entry(BOOLEAN, (field, source) -> field),
+     *         Map.entry(KEYWORD, ToBooleanFromStringEvaluator.Factory::new),
+     *         ...
+     *     );
+     *
+     *     @Override
+     *     protected Map<DataType, BuildFactory> factories() {
+     *         return EVALUATORS;
+     *     }
+     * }</pre>
+     */
+    protected abstract Map<DataType, BuildFactory> factories();
+
+    @Override
+    public ExpressionEvaluator.Factory toEvaluator(ToEvaluator toEvaluator) {
+        return evaluator(toEvaluator.apply(field()));
+    }
+
+    public abstract static class AbstractEvaluator implements EvalOperator.ExpressionEvaluator {
+
+        private static final Logger logger = LogManager.getLogger(AbstractEvaluator.class);
+
+        protected final DriverContext driverContext;
+        private final Warnings warnings;
+
+        protected AbstractEvaluator(DriverContext driverContext, Source source) {
+            this.driverContext = driverContext;
+            this.warnings = Warnings.createWarnings(
+                driverContext.warningsMode(),
+                source.source().getLineNumber(),
+                source.source().getColumnNumber(),
+                source.text()
+            );
+        }
+
+        protected abstract ExpressionEvaluator next();
+
+        /**
+         * Called when evaluating a {@link Block} that contains null values.
+         * @return the returned Block has its own reference and the caller is responsible for releasing it.
+         */
+        protected abstract Block evalBlock(Block b);
+
+        /**
+         * Called when evaluating a {@link Block} that does not contain null values.
+         * @return the returned Block has its own reference and the caller is responsible for releasing it.
+         */
+        protected abstract Block evalVector(Vector v);
+
+        @Override
+        public final Block eval(Page page) {
+            try (Block block = next().eval(page)) {
+                Vector vector = block.asVector();
+                return vector == null ? evalBlock(block) : evalVector(vector);
+            }
+        }
+
+        protected final void registerException(Exception exception) {
+            logger.trace("conversion failure", exception);
+            warnings.registerException(exception);
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ConvertFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ConvertFunction.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
 
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.util.Set;
 
@@ -25,4 +26,9 @@ public interface ConvertFunction {
      * The types that {@link #field()} can have.
      */
     Set<DataType> supportedTypes();
+
+    /**
+     * Convert functions tends to create new DataTypes, which makes them depend on pragmas.
+     */
+    QueryPragmas getPragmas();
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ConvertFunction.java.bak
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ConvertFunction.java.bak
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+
+import java.util.Set;
+
+/**
+ * A function that converts from one type to another.
+ */
+public interface ConvertFunction {
+    /**
+     * Expression containing the values to be converted.
+     */
+    Expression field();
+
+    /**
+     * The types that {@link #field()} can have.
+     */
+    Set<DataType> supportedTypes();
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FoldablesConvertFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FoldablesConvertFunction.java
@@ -14,6 +14,7 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.util.Locale;
 import java.util.Map;
@@ -29,8 +30,8 @@ import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.foldToTemp
  */
 public abstract class FoldablesConvertFunction extends AbstractConvertFunction implements PostOptimizationVerificationAware {
 
-    protected FoldablesConvertFunction(Source source, Expression field) {
-        super(source, field);
+    protected FoldablesConvertFunction(Source source, Expression field, QueryPragmas pragmas) {
+        super(source, field, pragmas);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FoldablesConvertFunction.java.bak
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FoldablesConvertFunction.java.bak
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xpack.esql.capabilities.PostOptimizationVerificationAware;
+import org.elasticsearch.xpack.esql.common.Failures;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.FoldContext;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.util.Locale;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isType;
+import static org.elasticsearch.xpack.esql.core.type.DataType.isString;
+import static org.elasticsearch.xpack.esql.expression.Validations.isFoldable;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.foldToTemporalAmount;
+
+/**
+ * Base class for functions that converts a constant into an interval type - DATE_PERIOD or TIME_DURATION.
+ * The functions will be folded at the end of LogicalPlanOptimizer by the coordinator, it does not reach data node.
+ */
+public abstract class FoldablesConvertFunction extends AbstractConvertFunction implements PostOptimizationVerificationAware {
+
+    protected FoldablesConvertFunction(Source source, Expression field, Configuration config) {
+        super(source, field, pragmas);
+    }
+
+    @Override
+    public final void writeTo(StreamOutput out) {
+        throw new UnsupportedOperationException("not serialized");
+    }
+
+    @Override
+    public final String getWriteableName() {
+        throw new UnsupportedOperationException("not serialized");
+    }
+
+    @Override
+    protected final TypeResolution resolveType() {
+        if (childrenResolved() == false) {
+            return new TypeResolution("Unresolved children");
+        }
+        return isType(
+            field(),
+            dt -> isString(dt) || dt == dataType(),
+            sourceText(),
+            null,
+            false,
+            dataType().typeName().toLowerCase(Locale.ROOT) + " or string"
+        );
+    }
+
+    @Override
+    protected final Map<DataType, BuildFactory> factories() {
+        // This is used by ResolveUnionTypes, which is expected to be applied to ES fields only
+        // FoldablesConvertFunction takes only constants as inputs, so this is empty
+        return Map.of();
+    }
+
+    @Override
+    public final Object fold(FoldContext ctx) {
+        return foldToTemporalAmount(ctx, field(), sourceText(), dataType());
+    }
+
+    @Override
+    public final void postOptimizationVerification(Failures failures) {
+        failures.add(isFoldable(field(), sourceText(), null));
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FromAggregateMetricDouble.java.bak
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FromAggregateMetricDouble.java.bak
@@ -1,0 +1,172 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.compute.data.AggregateMetricDoubleBlock;
+import org.elasticsearch.compute.data.AggregateMetricDoubleBlockBuilder;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Expressions;
+import org.elasticsearch.xpack.esql.core.expression.FoldContext;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
+import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.DEFAULT;
+import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isType;
+import static org.elasticsearch.xpack.esql.core.type.DataType.DOUBLE;
+import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
+import static org.elasticsearch.xpack.esql.core.type.DataType.NULL;
+
+public class FromAggregateMetricDouble extends EsqlScalarFunction {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        Expression.class,
+        "FromAggregateMetricDouble",
+        FromAggregateMetricDouble::new
+    );
+
+    private final Expression field;
+    private final Expression subfieldIndex;
+
+    @FunctionInfo(returnType = { "long", "double" }, description = "Convert aggregate double metric to a block of a single subfield.")
+    public FromAggregateMetricDouble(
+        Source source,
+        @Param(
+            name = "aggregate_metric_double",
+            type = { "aggregate_metric_double" },
+            description = "Aggregate double metric to convert."
+        ) Expression field,
+        @Param(name = "subfieldIndex", type = "int", description = "Index of subfield") Expression subfieldIndex
+    ) {
+        super(source, List.of(field, subfieldIndex));
+        this.field = field;
+        this.subfieldIndex = subfieldIndex;
+    }
+
+    public static FromAggregateMetricDouble withMetric(Source source, Expression field, AggregateMetricDoubleBlockBuilder.Metric metric) {
+        return new FromAggregateMetricDouble(source, field, new Literal(source, metric.getIndex(), INTEGER));
+    }
+
+    private FromAggregateMetricDouble(StreamInput in) throws IOException {
+        this(Source.readFrom((PlanStreamInput) in), in.readNamedWriteable(Expression.class), in.readNamedWriteable(Expression.class));
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        source().writeTo(out);
+        out.writeNamedWriteable(field);
+        out.writeNamedWriteable(subfieldIndex);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    @Override
+    public DataType dataType() {
+        if (subfieldIndex.foldable() == false) {
+            throw new EsqlIllegalArgumentException("Received a non-foldable value for subfield index");
+        }
+        var folded = subfieldIndex.fold(FoldContext.small());
+        if (folded == null) {
+            return NULL;
+        }
+        var subfield = ((Number) folded).intValue();
+        if (subfield == AggregateMetricDoubleBlockBuilder.Metric.COUNT.getIndex()) {
+            return INTEGER;
+        }
+        return DOUBLE;
+    }
+
+    @Override
+    public Expression replaceChildren(List<Expression> newChildren) {
+        return new FromAggregateMetricDouble(source(), newChildren.get(0), newChildren.get(1));
+    }
+
+    @Override
+    protected NodeInfo<? extends Expression> info() {
+        return NodeInfo.create(this, FromAggregateMetricDouble::new, field, subfieldIndex);
+    }
+
+    @Override
+    protected TypeResolution resolveType() {
+        if (childrenResolved() == false) {
+            return new TypeResolution("Unresolved children");
+        }
+        return isType(field, dt -> dt == DataType.AGGREGATE_METRIC_DOUBLE, sourceText(), DEFAULT, "aggregate_metric_double only");
+    }
+
+    @Override
+    public boolean foldable() {
+        return Expressions.foldable(children());
+    }
+
+    @Override
+    public EvalOperator.ExpressionEvaluator.Factory toEvaluator(ToEvaluator toEvaluator) {
+        var fieldEvaluator = toEvaluator.apply(field);
+        return new EvalOperator.ExpressionEvaluator.Factory() {
+
+            @Override
+            public String toString() {
+                return "FromAggregateMetricDoubleEvaluator[" + "field=" + fieldEvaluator + ",subfieldIndex=" + subfieldIndex + "]";
+            }
+
+            @Override
+            public EvalOperator.ExpressionEvaluator get(DriverContext context) {
+                final EvalOperator.ExpressionEvaluator eval = fieldEvaluator.get(context);
+
+                return new EvalOperator.ExpressionEvaluator() {
+                    @Override
+                    public Block eval(Page page) {
+                        Block block = eval.eval(page);
+                        if (block.areAllValuesNull()) {
+                            return block;
+                        }
+                        try {
+                            Block resultBlock = ((AggregateMetricDoubleBlock) block).getMetricBlock(
+                                ((Number) subfieldIndex.fold(FoldContext.small())).intValue()
+                            );
+                            resultBlock.incRef();
+                            return resultBlock;
+                        } finally {
+                            block.close();
+                        }
+                    }
+
+                    @Override
+                    public void close() {
+                        Releasables.closeExpectNoException(eval);
+                    }
+
+                    @Override
+                    public String toString() {
+                        return "FromAggregateMetricDoubleEvaluator[field=" + eval + ",subfieldIndex=" + subfieldIndex + "]";
+                    }
+                };
+
+            }
+        };
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FromBase64.java.bak
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FromBase64.java.bak
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.compute.ann.Evaluator;
+import org.elasticsearch.compute.ann.Fixed;
+import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.TypeResolutions;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.Example;
+import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
+import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.expression.function.scalar.UnaryScalarFunction;
+import org.elasticsearch.xpack.esql.planner.PlannerUtils;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.List;
+
+import static org.elasticsearch.compute.ann.Fixed.Scope.THREAD_LOCAL;
+import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isString;
+import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
+
+public class FromBase64 extends UnaryScalarFunction {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        Expression.class,
+        "FromBase64",
+        FromBase64::new
+    );
+
+    @FunctionInfo(
+        returnType = "keyword",
+        description = "Decode a base64 string.",
+        examples = @Example(file = "string", tag = "from_base64")
+    )
+    public FromBase64(
+        Source source,
+        @Param(name = "string", type = { "keyword", "text" }, description = "A base64 string.") Expression string
+    ) {
+        super(source, string);
+    }
+
+    @Override
+    protected TypeResolution resolveType() {
+        if (childrenResolved() == false) {
+            return new TypeResolution("Unresolved children");
+        }
+        return isString(field, sourceText(), TypeResolutions.ParamOrdinal.DEFAULT);
+    }
+
+    private FromBase64(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    @Override
+    public DataType dataType() {
+        return KEYWORD;
+    }
+
+    @Override
+    public Expression replaceChildren(List<Expression> newChildren) {
+        return new FromBase64(source(), newChildren.get(0));
+    }
+
+    @Override
+    protected NodeInfo<? extends Expression> info() {
+        return NodeInfo.create(this, FromBase64::new, field());
+    }
+
+    @Evaluator()
+    static BytesRef process(BytesRef field, @Fixed(includeInToString = false, scope = THREAD_LOCAL) BytesRefBuilder oScratch) {
+        byte[] bytes = new byte[field.length];
+        System.arraycopy(field.bytes, field.offset, bytes, 0, field.length);
+        oScratch.grow(field.length);
+        oScratch.clear();
+        int decodedSize = Base64.getDecoder().decode(bytes, oScratch.bytes());
+        return new BytesRef(oScratch.bytes(), 0, decodedSize);
+    }
+
+    @Override
+    public EvalOperator.ExpressionEvaluator.Factory toEvaluator(ToEvaluator toEvaluator) {
+        return switch (PlannerUtils.toElementType(field.dataType())) {
+            case BYTES_REF -> new FromBase64Evaluator.Factory(source(), toEvaluator.apply(field), context -> new BytesRefBuilder());
+            case NULL -> EvalOperator.CONSTANT_NULL_FACTORY;
+            default -> throw EsqlIllegalArgumentException.illegalDataType(field.dataType());
+        };
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ParseIp.java.bak
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ParseIp.java.bak
@@ -1,0 +1,240 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import org.apache.lucene.document.InetAddressPoint;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.compute.ann.ConvertEvaluator;
+import org.elasticsearch.compute.ann.Fixed;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
+import org.elasticsearch.compute.operator.EvalOperator;
+
+import java.net.InetAddress;
+
+/**
+ * Fast IP parsing suitable for embedding in an {@link EvalOperator.ExpressionEvaluator}
+ * because they don't allocate memory on every run. Instead, it converts directly from
+ * utf-8 encoded strings into {@link InetAddressPoint} encoded ips.
+ * <p>
+ *     This contains three parsing methods to handle the three ways ipv4 addresses
+ *     have historically handled leading 0s, namely, {@link #leadingZerosRejected reject} them,
+ *     treat them as {@link #leadingZerosAreDecimal decimal} numbers, and treat them as
+ *     {@link #leadingZerosAreOctal} numbers.
+ * </p>
+ * <p>
+ *     Note: We say "directly from utf-8" but, really, all of the digits in an ip are
+ *     in the traditional 7-bit ascii range where utf-8 overlaps. So we just treat everything
+ *     as 7-bit ascii. Anything that isn't in the range is an invalid ip anyway. Much love
+ *     for the designers of utf-8 for making it this way.
+ * </p>
+ */
+public class ParseIp {
+    private static final byte[] IPV4_PREFIX = new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, -1 };
+
+    static final AbstractConvertFunction.BuildFactory FROM_KEYWORD_LEADING_ZEROS_REJECTED = (source, field) -> {
+        return new ParseIpLeadingZerosRejectedEvaluator.Factory(source, field, driverContext -> buildScratch(driverContext.breaker()));
+    };
+
+    static final AbstractConvertFunction.BuildFactory FROM_KEYWORD_LEADING_ZEROS_DECIMAL = (source, field) -> {
+        return new ParseIpLeadingZerosAreDecimalEvaluator.Factory(source, field, driverContext -> buildScratch(driverContext.breaker()));
+    };
+
+    static final AbstractConvertFunction.BuildFactory FROM_KEYWORD_LEADING_ZEROS_OCTAL = (source, field) -> {
+        return new ParseIpLeadingZerosAreOctalEvaluator.Factory(source, field, driverContext -> buildScratch(driverContext.breaker()));
+    };
+
+    public static BreakingBytesRefBuilder buildScratch(CircuitBreaker breaker) {
+        BreakingBytesRefBuilder scratch = new BreakingBytesRefBuilder(breaker, "to_ip", 16);
+        scratch.setLength(InetAddressPoint.BYTES);
+        return scratch;
+    }
+
+    /**
+     * Parse an IP address, rejecting v4 addresses with leading 0s. This aligns
+     * exactly with {@link InetAddresses#forString(String)}.
+     * <ul>
+     *     <li>192.168.1.1 : valid</li>
+     *     <li>192.168.0.1 : valid</li>
+     *     <li>192.168.01.1 : invalid</li>
+     * </ul>
+     * @param scratch A "scratch" memory space build by {@link #buildScratch}
+     */
+    @ConvertEvaluator(extraName = "LeadingZerosRejected", warnExceptions = { IllegalArgumentException.class })
+    public static BytesRef leadingZerosRejected(
+        BytesRef string,
+        @Fixed(includeInToString = false, scope = Fixed.Scope.THREAD_LOCAL) BreakingBytesRefBuilder scratch
+    ) {
+        /*
+         * If this is an ipv6 address then delegate to InetAddresses.forString
+         * because we don't have anything nice for parsing those.
+         */
+        int end = string.offset + string.length;
+        if (isV6(string, end)) {
+            InetAddress inetAddress = InetAddresses.forString(string.utf8ToString());
+            return new BytesRef(InetAddressPoint.encode(inetAddress));
+        }
+
+        System.arraycopy(IPV4_PREFIX, 0, scratch.bytes(), 0, IPV4_PREFIX.length);
+        int offset = string.offset;
+        for (int dest = IPV4_PREFIX.length; dest < InetAddressPoint.BYTES; dest++) {
+            if (offset >= end) {
+                throw invalid(string);
+            }
+            if (string.bytes[offset] == '0') {
+                // Lone zeros are just 0, but a 0 with numbers after it are invalid
+                offset++;
+                if (offset == end || string.bytes[offset] == '.') {
+                    scratch.bytes()[dest] = (byte) 0;
+                    offset++;
+                    continue;
+                }
+                throw invalid(string);
+            }
+            int v = digit(string, offset++);
+            while (offset < end && string.bytes[offset] != '.') {
+                v = v * 10 + digit(string, offset++);
+            }
+            offset++;
+            if (v > 255) {
+                throw invalid(string);
+            }
+            scratch.bytes()[dest] = (byte) v;
+        }
+        return scratch.bytesRefView();
+    }
+
+    /**
+     * Parse an IP address, interpreting v4 addresses with leading 0s as
+     * <strong>decimal</strong> numbers.
+     * <ul>
+     *     <li>192.168.1.1 : valid</li>
+     *     <li>192.168.0.1 : valid</li>
+     *     <li>192.168.01.1 : valid</li>
+     *     <li>192.168.09.1 : valid</li>
+     *     <li>192.168.010.1 : valid</li>
+     * </ul>
+     * @param scratch A "scratch" memory space build by {@link #buildScratch}
+     */
+    @ConvertEvaluator(extraName = "LeadingZerosAreDecimal", warnExceptions = { IllegalArgumentException.class })
+    public static BytesRef leadingZerosAreDecimal(
+        BytesRef string,
+        @Fixed(includeInToString = false, scope = Fixed.Scope.THREAD_LOCAL) BreakingBytesRefBuilder scratch
+    ) {
+        /*
+         * If this is an ipv6 address then delegate to InetAddresses.forString
+         * because we don't have anything nice for parsing those.
+         */
+        int end = string.offset + string.length;
+        if (isV6(string, end)) {
+            InetAddress inetAddress = InetAddresses.forString(string.utf8ToString());
+            return new BytesRef(InetAddressPoint.encode(inetAddress));
+        }
+
+        System.arraycopy(IPV4_PREFIX, 0, scratch.bytes(), 0, IPV4_PREFIX.length);
+        int offset = string.offset;
+        for (int dest = IPV4_PREFIX.length; dest < InetAddressPoint.BYTES; dest++) {
+            if (offset >= end) {
+                throw invalid(string);
+            }
+            int v = digit(string, offset++);
+            while (offset < end && string.bytes[offset] != '.') {
+                v = v * 10 + digit(string, offset++);
+            }
+            offset++;
+            if (v > 255) {
+                throw invalid(string);
+            }
+            scratch.bytes()[dest] = (byte) v;
+        }
+        return scratch.bytesRefView();
+    }
+
+    /**
+     * Parse an IP address, interpreting v4 addresses with leading 0s as
+     * <strong>octal</strong> numbers.
+     * <ul>
+     *     <li>192.168.1.1 : valid</li>
+     *     <li>192.168.0.1 : valid</li>
+     *     <li>192.168.01.1 : valid</li>
+     *     <li>192.168.09.1 : invalid</li>
+     *     <li>192.168.010.1 : valid but would print as 192.168.8.1</li>
+     * </ul>
+     * @param scratch A "scratch" memory space build by {@link #buildScratch}
+     */
+    @ConvertEvaluator(extraName = "LeadingZerosAreOctal", warnExceptions = { IllegalArgumentException.class })
+    public static BytesRef leadingZerosAreOctal(
+        BytesRef string,
+        @Fixed(includeInToString = false, scope = Fixed.Scope.THREAD_LOCAL) BreakingBytesRefBuilder scratch
+    ) {
+        /*
+         * If this is an ipv6 address then delegate to InetAddresses.forString
+         * because we don't have anything nice for parsing those.
+         */
+        int end = string.offset + string.length;
+        if (isV6(string, end)) {
+            InetAddress inetAddress = InetAddresses.forString(string.utf8ToString());
+            return new BytesRef(InetAddressPoint.encode(inetAddress));
+        }
+
+        System.arraycopy(IPV4_PREFIX, 0, scratch.bytes(), 0, IPV4_PREFIX.length);
+        int offset = string.offset;
+        for (int dest = IPV4_PREFIX.length; dest < InetAddressPoint.BYTES; dest++) {
+            if (offset >= end) {
+                throw invalid(string);
+            }
+            int v;
+            if (string.bytes[offset] == '0') {
+                // Octal
+                offset++;
+                v = 0;
+                while (offset < end && string.bytes[offset] != '.') {
+                    v = v * 8 + octalDigit(string, offset++);
+                }
+                offset++;
+            } else {
+                // Decimal
+                v = digit(string, offset++);
+                while (offset < end && string.bytes[offset] != '.') {
+                    v = v * 10 + digit(string, offset++);
+                }
+                offset++;
+            }
+            scratch.bytes()[dest] = (byte) v;
+        }
+        return scratch.bytesRefView();
+    }
+
+    private static int digit(BytesRef string, int offset) {
+        if (string.bytes[offset] < '0' || '9' < string.bytes[offset]) {
+            throw invalid(string);
+        }
+        return string.bytes[offset] - '0';
+    }
+
+    private static int octalDigit(BytesRef string, int offset) {
+        if (string.bytes[offset] < '0' || '7' < string.bytes[offset]) {
+            throw invalid(string);
+        }
+        return string.bytes[offset] - '0';
+    }
+
+    private static IllegalArgumentException invalid(BytesRef string) {
+        return new IllegalArgumentException("'" + string.utf8ToString() + "' is not an IP string literal.");
+    }
+
+    private static boolean isV6(BytesRef string, int end) {
+        for (int i = string.offset; i < end; i++) {
+            if (string.bytes[i] == ':') {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToAggregateMetricDouble.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToAggregateMetricDouble.java
@@ -35,6 +35,7 @@ import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesTo;
 import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesToLifecycle;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter;
 
 import java.io.IOException;
@@ -79,9 +80,10 @@ public class ToAggregateMetricDouble extends AbstractConvertFunction {
             name = "number",
             type = { "double", "long", "unsigned_long", "integer", "aggregate_metric_double" },
             description = "Input value. The input can be a single- or multi-valued column or an expression."
-        ) Expression field
+        ) Expression field,
+        QueryPragmas pragmas
     ) {
-        super(source, field);
+        super(source, field, pragmas);
     }
 
     private ToAggregateMetricDouble(StreamInput in) throws IOException {
@@ -114,12 +116,12 @@ public class ToAggregateMetricDouble extends AbstractConvertFunction {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        return new ToAggregateMetricDouble(source(), newChildren.get(0));
+        return new ToAggregateMetricDouble(source(), newChildren.get(0), getPragmas());
     }
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, ToAggregateMetricDouble::new, field);
+        return NodeInfo.create(this, ToAggregateMetricDouble::new, field, getPragmas());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToAggregateMetricDouble.java.bak
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToAggregateMetricDouble.java.bak
@@ -1,0 +1,569 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.compute.data.AggregateMetricDoubleBlock;
+import org.elasticsearch.compute.data.AggregateMetricDoubleBlockBuilder;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.DoubleVector;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.data.Vector;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.search.aggregations.metrics.CompensatedSum;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.Example;
+import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesTo;
+import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesToLifecycle;
+import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
+import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+import org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.DEFAULT;
+import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isType;
+import static org.elasticsearch.xpack.esql.core.type.DataType.AGGREGATE_METRIC_DOUBLE;
+import static org.elasticsearch.xpack.esql.core.type.DataType.DOUBLE;
+import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
+import static org.elasticsearch.xpack.esql.core.type.DataType.LONG;
+import static org.elasticsearch.xpack.esql.core.type.DataType.UNSIGNED_LONG;
+
+public class ToAggregateMetricDouble extends AbstractConvertFunction {
+
+    private static final Map<DataType, AbstractConvertFunction.BuildFactory> EVALUATORS = Map.ofEntries(
+        Map.entry(AGGREGATE_METRIC_DOUBLE, (source, fieldEval) -> fieldEval),
+        Map.entry(DOUBLE, DoubleFactory::new),
+        Map.entry(INTEGER, IntFactory::new),
+        Map.entry(LONG, LongFactory::new),
+        Map.entry(UNSIGNED_LONG, UnsignedLongFactory::new)
+    );
+
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        Expression.class,
+        "ToAggregateMetricDouble",
+        ToAggregateMetricDouble::new
+    );
+
+    @FunctionInfo(
+        returnType = "aggregate_metric_double",
+        description = "Encode a numeric to an aggregate_metric_double.",
+        examples = {
+            @Example(file = "convert", tag = "toAggregateMetricDouble"),
+            @Example(description = "The expression also accepts multi-values", file = "convert", tag = "toAggregateMetricDoubleMv") },
+        appliesTo = { @FunctionAppliesTo(lifeCycle = FunctionAppliesToLifecycle.COMING) }
+    )
+    public ToAggregateMetricDouble(
+        Source source,
+        @Param(
+            name = "number",
+            type = { "double", "long", "unsigned_long", "integer", "aggregate_metric_double" },
+            description = "Input value. The input can be a single- or multi-valued column or an expression."
+        ) Expression field,
+        Configuration config
+    ) {
+        super(source, field, pragmas);
+    }
+
+    private ToAggregateMetricDouble(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    @Override
+    protected TypeResolution resolveType() {
+        if (childrenResolved() == false) {
+            return new TypeResolution("Unresolved children");
+        }
+        return isType(
+            field,
+            dt -> dt == DataType.AGGREGATE_METRIC_DOUBLE || dt == DataType.DOUBLE || dt == LONG || dt == INTEGER || dt == UNSIGNED_LONG,
+            sourceText(),
+            DEFAULT,
+            "numeric or aggregate_metric_double"
+        );
+    }
+
+    @Override
+    public DataType dataType() {
+        return AGGREGATE_METRIC_DOUBLE;
+    }
+
+    @Override
+    public Expression replaceChildren(List<Expression> newChildren) {
+        return new ToAggregateMetricDouble(source(), newChildren.get(0));
+    }
+
+    @Override
+    protected NodeInfo<? extends Expression> info() {
+        return NodeInfo.create(this, ToAggregateMetricDouble::new, field);
+    }
+
+    @Override
+    protected Map<DataType, AbstractConvertFunction.BuildFactory> factories() {
+        return EVALUATORS;
+    }
+
+    private static class AggregateMetricDoubleVectorBuilder implements Releasable {
+        private final DoubleVector.FixedBuilder valuesBuilder;
+        private final BlockFactory blockFactory;
+
+        private AggregateMetricDoubleVectorBuilder(int estimatedSize, BlockFactory blockFactory) {
+            this.blockFactory = blockFactory;
+            this.valuesBuilder = blockFactory.newDoubleVectorFixedBuilder(estimatedSize);
+        }
+
+        private void appendValue(double value) {
+            valuesBuilder.appendDouble(value);
+        }
+
+        private Block build() {
+            DoubleBlock doubleBlock = null;
+            IntBlock countBlock = null;
+            boolean success = false;
+            try {
+                doubleBlock = valuesBuilder.build().asBlock();
+                countBlock = blockFactory.newConstantIntBlockWith(1, doubleBlock.getPositionCount());
+                AggregateMetricDoubleBlock aggBlock = new AggregateMetricDoubleBlock(doubleBlock, doubleBlock, doubleBlock, countBlock);
+                doubleBlock.incRef();
+                doubleBlock.incRef();
+                success = true;
+                return aggBlock;
+            } finally {
+                if (success == false) {
+                    Releasables.closeExpectNoException(doubleBlock, countBlock);
+                }
+            }
+        }
+
+        @Override
+        public void close() {
+            Releasables.closeExpectNoException(valuesBuilder);
+        }
+    }
+
+    public static class DoubleFactory implements EvalOperator.ExpressionEvaluator.Factory {
+        private final Source source;
+
+        private final EvalOperator.ExpressionEvaluator.Factory fieldEvaluator;
+
+        public DoubleFactory(Source source, EvalOperator.ExpressionEvaluator.Factory fieldEvaluator) {
+            this.fieldEvaluator = fieldEvaluator;
+            this.source = source;
+        }
+
+        @Override
+        public String toString() {
+            return "ToAggregateMetricDoubleFromDoubleEvaluator[" + "field=" + fieldEvaluator + "]";
+        }
+
+        @Override
+        public EvalOperator.ExpressionEvaluator get(DriverContext context) {
+            final EvalOperator.ExpressionEvaluator eval = fieldEvaluator.get(context);
+
+            return new EvalOperator.ExpressionEvaluator() {
+                private Block evalBlock(Block block) {
+                    int positionCount = block.getPositionCount();
+                    DoubleBlock doubleBlock = (DoubleBlock) block;
+                    try (
+                        AggregateMetricDoubleBlockBuilder builder = context.blockFactory()
+                            .newAggregateMetricDoubleBlockBuilder(positionCount)
+                    ) {
+                        CompensatedSum compensatedSum = new CompensatedSum();
+                        for (int p = 0; p < positionCount; p++) {
+                            int valueCount = doubleBlock.getValueCount(p);
+                            if (valueCount == 0) {
+                                builder.appendNull();
+                                continue;
+                            }
+                            int start = doubleBlock.getFirstValueIndex(p);
+                            int end = start + valueCount;
+                            if (valueCount == 1) {
+                                double current = doubleBlock.getDouble(start);
+                                builder.min().appendDouble(current);
+                                builder.max().appendDouble(current);
+                                builder.sum().appendDouble(current);
+                                builder.count().appendInt(valueCount);
+                                continue;
+                            }
+                            double min = Double.POSITIVE_INFINITY;
+                            double max = Double.NEGATIVE_INFINITY;
+                            for (int i = start; i < end; i++) {
+                                double current = doubleBlock.getDouble(i);
+                                min = Math.min(min, current);
+                                max = Math.max(max, current);
+                                compensatedSum.add(current);
+                            }
+                            builder.min().appendDouble(min);
+                            builder.max().appendDouble(max);
+                            builder.sum().appendDouble(compensatedSum.value());
+                            builder.count().appendInt(valueCount);
+                            compensatedSum.reset(0, 0);
+                        }
+                        return builder.build();
+                    }
+                }
+
+                private Block evalVector(Vector vector) {
+                    int positionCount = vector.getPositionCount();
+                    DoubleVector doubleVector = (DoubleVector) vector;
+                    try (
+                        AggregateMetricDoubleVectorBuilder builder = new AggregateMetricDoubleVectorBuilder(
+                            positionCount,
+                            context.blockFactory()
+                        )
+                    ) {
+                        for (int p = 0; p < positionCount; p++) {
+                            double value = doubleVector.getDouble(p);
+                            builder.appendValue(value);
+                        }
+                        return builder.build();
+                    }
+                }
+
+                @Override
+                public Block eval(Page page) {
+                    try (Block block = eval.eval(page)) {
+                        Vector vector = block.asVector();
+                        return vector == null ? evalBlock(block) : evalVector(vector);
+                    }
+                }
+
+                @Override
+                public void close() {
+                    Releasables.closeExpectNoException(eval);
+                }
+
+                @Override
+                public String toString() {
+                    return "ToAggregateMetricDoubleFromDoubleEvaluator[field=" + eval + "]";
+                }
+            };
+        }
+    }
+
+    public static class IntFactory implements EvalOperator.ExpressionEvaluator.Factory {
+        private final Source source;
+
+        private final EvalOperator.ExpressionEvaluator.Factory fieldEvaluator;
+
+        public IntFactory(Source source, EvalOperator.ExpressionEvaluator.Factory fieldEvaluator) {
+            this.fieldEvaluator = fieldEvaluator;
+            this.source = source;
+        }
+
+        @Override
+        public String toString() {
+            return "ToAggregateMetricDoubleFromIntEvaluator[" + "field=" + fieldEvaluator + "]";
+        }
+
+        @Override
+        public EvalOperator.ExpressionEvaluator get(DriverContext context) {
+            final EvalOperator.ExpressionEvaluator eval = fieldEvaluator.get(context);
+
+            return new EvalOperator.ExpressionEvaluator() {
+                @Override
+                public Block eval(Page page) {
+                    try (Block block = eval.eval(page)) {
+                        Vector vector = block.asVector();
+                        return vector == null ? evalBlock(block) : evalVector(vector);
+                    }
+                }
+
+                private Block evalBlock(Block block) {
+                    int positionCount = block.getPositionCount();
+                    IntBlock intBlock = (IntBlock) block;
+                    try (
+                        AggregateMetricDoubleBlockBuilder builder = context.blockFactory()
+                            .newAggregateMetricDoubleBlockBuilder(positionCount)
+                    ) {
+                        CompensatedSum sum = new CompensatedSum();
+                        for (int p = 0; p < positionCount; p++) {
+                            int valueCount = intBlock.getValueCount(p);
+                            int start = intBlock.getFirstValueIndex(p);
+                            int end = start + valueCount;
+                            if (valueCount == 0) {
+                                builder.appendNull();
+                                continue;
+                            }
+                            if (valueCount == 1) {
+                                double current = intBlock.getInt(start);
+                                builder.min().appendDouble(current);
+                                builder.max().appendDouble(current);
+                                builder.sum().appendDouble(current);
+                                builder.count().appendInt(valueCount);
+                                continue;
+                            }
+                            double min = Double.POSITIVE_INFINITY;
+                            double max = Double.NEGATIVE_INFINITY;
+                            for (int i = start; i < end; i++) {
+                                double current = intBlock.getInt(i);
+                                min = Math.min(min, current);
+                                max = Math.max(max, current);
+                                sum.add(current);
+                            }
+                            builder.min().appendDouble(min);
+                            builder.max().appendDouble(max);
+                            builder.sum().appendDouble(sum.value());
+                            builder.count().appendInt(valueCount);
+                            sum.reset(0, 0);
+                        }
+                        return builder.build();
+                    }
+                }
+
+                private Block evalVector(Vector vector) {
+                    int positionCount = vector.getPositionCount();
+                    IntVector intVector = (IntVector) vector;
+                    try (
+                        AggregateMetricDoubleVectorBuilder builder = new AggregateMetricDoubleVectorBuilder(
+                            positionCount,
+                            context.blockFactory()
+                        )
+                    ) {
+                        for (int p = 0; p < positionCount; p++) {
+                            double value = intVector.getInt(p);
+                            builder.appendValue(value);
+                        }
+                        return builder.build();
+                    }
+                }
+
+                @Override
+                public void close() {
+                    Releasables.closeExpectNoException(eval);
+                }
+
+                @Override
+                public String toString() {
+                    return "ToAggregateMetricDoubleFromIntEvaluator[field=" + eval + "]";
+                }
+            };
+        }
+    }
+
+    public static class LongFactory implements EvalOperator.ExpressionEvaluator.Factory {
+        private final Source source;
+
+        private final EvalOperator.ExpressionEvaluator.Factory fieldEvaluator;
+
+        public LongFactory(Source source, EvalOperator.ExpressionEvaluator.Factory fieldEvaluator) {
+            this.fieldEvaluator = fieldEvaluator;
+            this.source = source;
+        }
+
+        @Override
+        public String toString() {
+            return "ToAggregateMetricDoubleFromLongEvaluator[" + "field=" + fieldEvaluator + "]";
+        }
+
+        @Override
+        public EvalOperator.ExpressionEvaluator get(DriverContext context) {
+            final EvalOperator.ExpressionEvaluator eval = fieldEvaluator.get(context);
+
+            return new EvalOperator.ExpressionEvaluator() {
+                private Block evalBlock(Block block) {
+                    int positionCount = block.getPositionCount();
+                    LongBlock longBlock = (LongBlock) block;
+                    try (
+                        AggregateMetricDoubleBlockBuilder builder = context.blockFactory()
+                            .newAggregateMetricDoubleBlockBuilder(positionCount)
+                    ) {
+                        CompensatedSum sum = new CompensatedSum();
+                        for (int p = 0; p < positionCount; p++) {
+                            int valueCount = longBlock.getValueCount(p);
+                            int start = longBlock.getFirstValueIndex(p);
+                            int end = start + valueCount;
+                            if (valueCount == 0) {
+                                builder.appendNull();
+                                continue;
+                            }
+                            if (valueCount == 1) {
+                                double current = longBlock.getLong(start);
+                                builder.min().appendDouble(current);
+                                builder.max().appendDouble(current);
+                                builder.sum().appendDouble(current);
+                                builder.count().appendInt(valueCount);
+                                continue;
+                            }
+                            double min = Double.POSITIVE_INFINITY;
+                            double max = Double.NEGATIVE_INFINITY;
+                            for (int i = start; i < end; i++) {
+                                double current = longBlock.getLong(i);
+                                min = Math.min(min, current);
+                                max = Math.max(max, current);
+                                sum.add(current);
+                            }
+                            builder.min().appendDouble(min);
+                            builder.max().appendDouble(max);
+                            builder.sum().appendDouble(sum.value());
+                            builder.count().appendInt(valueCount);
+                            sum.reset(0, 0);
+                        }
+                        return builder.build();
+                    }
+                }
+
+                private Block evalVector(Vector vector) {
+                    int positionCount = vector.getPositionCount();
+                    LongVector longVector = (LongVector) vector;
+                    try (
+                        AggregateMetricDoubleVectorBuilder builder = new AggregateMetricDoubleVectorBuilder(
+                            positionCount,
+                            context.blockFactory()
+                        )
+                    ) {
+                        for (int p = 0; p < positionCount; p++) {
+                            double value = longVector.getLong(p);
+                            builder.appendValue(value);
+                        }
+                        return builder.build();
+                    }
+                }
+
+                @Override
+                public Block eval(Page page) {
+                    try (Block block = eval.eval(page)) {
+                        Vector vector = block.asVector();
+                        return vector == null ? evalBlock(block) : evalVector(vector);
+                    }
+                }
+
+                @Override
+                public void close() {
+                    Releasables.closeExpectNoException(eval);
+                }
+
+                @Override
+                public String toString() {
+                    return "ToAggregateMetricDoubleFromLongEvaluator[field=" + eval + "]";
+                }
+            };
+        }
+    }
+
+    public static class UnsignedLongFactory implements EvalOperator.ExpressionEvaluator.Factory {
+        private final Source source;
+
+        private final EvalOperator.ExpressionEvaluator.Factory fieldEvaluator;
+
+        public UnsignedLongFactory(Source source, EvalOperator.ExpressionEvaluator.Factory fieldEvaluator) {
+            this.fieldEvaluator = fieldEvaluator;
+            this.source = source;
+        }
+
+        @Override
+        public String toString() {
+            return "ToAggregateMetricDoubleFromUnsignedLongEvaluator[" + "field=" + fieldEvaluator + "]";
+        }
+
+        @Override
+        public EvalOperator.ExpressionEvaluator get(DriverContext context) {
+            final EvalOperator.ExpressionEvaluator eval = fieldEvaluator.get(context);
+
+            return new EvalOperator.ExpressionEvaluator() {
+                private Block evalBlock(Block block) {
+                    int positionCount = block.getPositionCount();
+                    LongBlock longBlock = (LongBlock) block;
+                    try (
+                        AggregateMetricDoubleBlockBuilder builder = context.blockFactory()
+                            .newAggregateMetricDoubleBlockBuilder(positionCount)
+                    ) {
+                        CompensatedSum sum = new CompensatedSum();
+                        for (int p = 0; p < positionCount; p++) {
+                            int valueCount = longBlock.getValueCount(p);
+                            int start = longBlock.getFirstValueIndex(p);
+                            int end = start + valueCount;
+                            if (valueCount == 0) {
+                                builder.appendNull();
+                                continue;
+                            }
+                            if (valueCount == 1) {
+                                double current = EsqlDataTypeConverter.unsignedLongToDouble(longBlock.getLong(p));
+                                builder.min().appendDouble(current);
+                                builder.max().appendDouble(current);
+                                builder.sum().appendDouble(current);
+                                builder.count().appendInt(valueCount);
+                                continue;
+                            }
+                            double min = Double.POSITIVE_INFINITY;
+                            double max = Double.NEGATIVE_INFINITY;
+                            for (int i = start; i < end; i++) {
+                                double current = EsqlDataTypeConverter.unsignedLongToDouble(longBlock.getLong(p));
+                                min = Math.min(min, current);
+                                max = Math.max(max, current);
+                                sum.add(current);
+                            }
+                            builder.min().appendDouble(min);
+                            builder.max().appendDouble(max);
+                            builder.sum().appendDouble(sum.value());
+                            builder.count().appendInt(valueCount);
+                            sum.reset(0, 0);
+                        }
+                        return builder.build();
+                    }
+                }
+
+                private Block evalVector(Vector vector) {
+                    int positionCount = vector.getPositionCount();
+                    LongVector longVector = (LongVector) vector;
+                    try (
+                        AggregateMetricDoubleVectorBuilder builder = new AggregateMetricDoubleVectorBuilder(
+                            positionCount,
+                            context.blockFactory()
+                        )
+                    ) {
+                        for (int p = 0; p < positionCount; p++) {
+                            double value = EsqlDataTypeConverter.unsignedLongToDouble(longVector.getLong(p));
+                            builder.appendValue(value);
+                        }
+                        return builder.build();
+                    }
+                }
+
+                @Override
+                public Block eval(Page page) {
+                    try (Block block = eval.eval(page)) {
+                        Vector vector = block.asVector();
+                        return vector == null ? evalBlock(block) : evalVector(vector);
+                    }
+                }
+
+                @Override
+                public void close() {
+                    Releasables.closeExpectNoException(eval);
+                }
+
+                @Override
+                public String toString() {
+                    return "ToAggregateMetricDoubleFromUnsignedLongEvaluator[field=" + eval + "]";
+                }
+            };
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToBase64.java.bak
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToBase64.java.bak
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.compute.ann.Evaluator;
+import org.elasticsearch.compute.ann.Fixed;
+import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.TypeResolutions;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.Example;
+import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
+import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.expression.function.scalar.UnaryScalarFunction;
+import org.elasticsearch.xpack.esql.planner.PlannerUtils;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.List;
+
+import static org.elasticsearch.compute.ann.Fixed.Scope.THREAD_LOCAL;
+import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isString;
+import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
+
+public class ToBase64 extends UnaryScalarFunction {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "ToBase64", ToBase64::new);
+
+    @FunctionInfo(
+        returnType = "keyword",
+        description = "Encode a string to a base64 string.",
+        examples = @Example(file = "string", tag = "to_base64")
+    )
+    public ToBase64(Source source, @Param(name = "string", type = { "keyword", "text" }, description = "A string.") Expression string) {
+        super(source, string);
+    }
+
+    private ToBase64(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    @Override
+    protected TypeResolution resolveType() {
+        if (childrenResolved() == false) {
+            return new TypeResolution("Unresolved children");
+        }
+        return isString(field, sourceText(), TypeResolutions.ParamOrdinal.DEFAULT);
+    }
+
+    @Override
+    public DataType dataType() {
+        return KEYWORD;
+    }
+
+    @Override
+    public Expression replaceChildren(List<Expression> newChildren) {
+        return new ToBase64(source(), newChildren.get(0));
+    }
+
+    @Override
+    protected NodeInfo<? extends Expression> info() {
+        return NodeInfo.create(this, ToBase64::new, field);
+    }
+
+    @Evaluator(warnExceptions = { ArithmeticException.class })
+    static BytesRef process(BytesRef field, @Fixed(includeInToString = false, scope = THREAD_LOCAL) BytesRefBuilder oScratch) {
+        int outLength = Math.multiplyExact(4, (Math.addExact(field.length, 2) / 3));
+        byte[] bytes = new byte[field.length];
+        System.arraycopy(field.bytes, field.offset, bytes, 0, field.length);
+        oScratch.grow(outLength);
+        oScratch.clear();
+        int encodedSize = Base64.getEncoder().encode(bytes, oScratch.bytes());
+        return new BytesRef(oScratch.bytes(), 0, encodedSize);
+    }
+
+    @Override
+    public EvalOperator.ExpressionEvaluator.Factory toEvaluator(ToEvaluator toEvaluator) {
+        return switch (PlannerUtils.toElementType(field.dataType())) {
+            case BYTES_REF -> new ToBase64Evaluator.Factory(source(), toEvaluator.apply(field), context -> new BytesRefBuilder());
+            case NULL -> EvalOperator.CONSTANT_NULL_FACTORY;
+            default -> throw EsqlIllegalArgumentException.illegalDataType(field.dataType());
+        };
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToBoolean.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToBoolean.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.io.IOException;
 import java.util.List;
@@ -65,9 +66,10 @@ public class ToBoolean extends AbstractConvertFunction {
             name = "field",
             type = { "boolean", "keyword", "text", "double", "long", "unsigned_long", "integer" },
             description = "Input value. The input can be a single- or multi-valued column or an expression."
-        ) Expression field
+        ) Expression field,
+        QueryPragmas pragmas
     ) {
-        super(source, field);
+        super(source, field, pragmas);
     }
 
     private ToBoolean(StreamInput in) throws IOException {
@@ -91,12 +93,12 @@ public class ToBoolean extends AbstractConvertFunction {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        return new ToBoolean(source(), newChildren.get(0));
+        return new ToBoolean(source(), newChildren.getFirst(), getPragmas());
     }
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, ToBoolean::new, field());
+        return NodeInfo.create(this, ToBoolean::new, field(), getPragmas());
     }
 
     @ConvertEvaluator(extraName = "FromString")

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToBoolean.java.bak
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToBoolean.java.bak
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.compute.ann.ConvertEvaluator;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.Example;
+import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
+import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.core.type.DataType.BOOLEAN;
+import static org.elasticsearch.xpack.esql.core.type.DataType.DOUBLE;
+import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
+import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
+import static org.elasticsearch.xpack.esql.core.type.DataType.LONG;
+import static org.elasticsearch.xpack.esql.core.type.DataType.TEXT;
+import static org.elasticsearch.xpack.esql.core.type.DataType.UNSIGNED_LONG;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.stringToBoolean;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.unsignedLongToBoolean;
+
+public class ToBoolean extends AbstractConvertFunction {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        Expression.class,
+        "ToBoolean",
+        ToBoolean::new
+    );
+
+    private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
+        Map.entry(BOOLEAN, (source, field) -> field),
+        Map.entry(KEYWORD, ToBooleanFromStringEvaluator.Factory::new),
+        Map.entry(TEXT, ToBooleanFromStringEvaluator.Factory::new),
+        Map.entry(DOUBLE, ToBooleanFromDoubleEvaluator.Factory::new),
+        Map.entry(LONG, ToBooleanFromLongEvaluator.Factory::new),
+        Map.entry(UNSIGNED_LONG, ToBooleanFromUnsignedLongEvaluator.Factory::new),
+        Map.entry(INTEGER, ToBooleanFromIntEvaluator.Factory::new)
+    );
+
+    @FunctionInfo(
+        returnType = "boolean",
+        description = """
+            Converts an input value to a boolean value.
+            A string value of `true` will be case-insensitive converted to the Boolean `true`.
+            For anything else, including the empty string, the function will return `false`.
+            The numerical value of `0` will be converted to `false`, anything else will be converted to `true`.""",
+        examples = @Example(file = "boolean", tag = "to_boolean")
+    )
+    public ToBoolean(
+        Source source,
+        @Param(
+            name = "field",
+            type = { "boolean", "keyword", "text", "double", "long", "unsigned_long", "integer" },
+            description = "Input value. The input can be a single- or multi-valued column or an expression."
+        ) Expression field,
+        Configuration config
+    ) {
+        super(source, field, pragmas);
+    }
+
+    private ToBoolean(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    @Override
+    protected Map<DataType, BuildFactory> factories() {
+        return EVALUATORS;
+    }
+
+    @Override
+    public DataType dataType() {
+        return BOOLEAN;
+    }
+
+    @Override
+    public Expression replaceChildren(List<Expression> newChildren) {
+        return new ToBoolean(source(), newChildren.getFirst(), getPragmas());
+    }
+
+    @Override
+    protected NodeInfo<? extends Expression> info() {
+        return NodeInfo.create(this, ToBoolean::new, field(), getPragmas());
+    }
+
+    @ConvertEvaluator(extraName = "FromString")
+    static boolean fromKeyword(BytesRef keyword) {
+        return stringToBoolean(keyword.utf8ToString());
+    }
+
+    @ConvertEvaluator(extraName = "FromDouble")
+    static boolean fromDouble(double d) {
+        return d != 0;
+    }
+
+    @ConvertEvaluator(extraName = "FromLong")
+    static boolean fromLong(long l) {
+        return l != 0;
+    }
+
+    @ConvertEvaluator(extraName = "FromUnsignedLong")
+    static boolean fromUnsignedLong(long ul) {
+        return unsignedLongToBoolean(ul);
+    }
+
+    @ConvertEvaluator(extraName = "FromInt")
+    static boolean fromInt(int i) {
+        return fromLong(i);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianPoint.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianPoint.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.io.IOException;
 import java.util.List;
@@ -55,9 +56,10 @@ public class ToCartesianPoint extends AbstractConvertFunction {
             name = "field",
             type = { "cartesian_point", "keyword", "text" },
             description = "Input value. The input can be a single- or multi-valued column or an expression."
-        ) Expression field
+        ) Expression field,
+        QueryPragmas pragmas
     ) {
-        super(source, field);
+        super(source, field, pragmas);
     }
 
     private ToCartesianPoint(StreamInput in) throws IOException {
@@ -81,12 +83,12 @@ public class ToCartesianPoint extends AbstractConvertFunction {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        return new ToCartesianPoint(source(), newChildren.get(0));
+        return new ToCartesianPoint(source(), newChildren.getFirst(), getPragmas());
     }
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, ToCartesianPoint::new, field());
+        return NodeInfo.create(this, ToCartesianPoint::new, field(), getPragmas());
     }
 
     @ConvertEvaluator(extraName = "FromString", warnExceptions = { IllegalArgumentException.class })

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianPoint.java.bak
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianPoint.java.bak
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.compute.ann.ConvertEvaluator;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.Example;
+import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
+import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.core.type.DataType.CARTESIAN_POINT;
+import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
+import static org.elasticsearch.xpack.esql.core.type.DataType.TEXT;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.stringToSpatial;
+
+public class ToCartesianPoint extends AbstractConvertFunction {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        Expression.class,
+        "ToCartesianPoint",
+        ToCartesianPoint::new
+    );
+
+    private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
+        Map.entry(CARTESIAN_POINT, (source, fieldEval) -> fieldEval),
+        Map.entry(KEYWORD, ToCartesianPointFromStringEvaluator.Factory::new),
+        Map.entry(TEXT, ToCartesianPointFromStringEvaluator.Factory::new)
+    );
+
+    @FunctionInfo(
+        returnType = "cartesian_point",
+        description = """
+            Converts an input value to a `cartesian_point` value.
+            A string will only be successfully converted if it respects the
+            {wikipedia}/Well-known_text_representation_of_geometry[WKT Point] format.""",
+        examples = @Example(file = "spatial", tag = "to_cartesianpoint-str")
+    )
+    public ToCartesianPoint(
+        Source source,
+        @Param(
+            name = "field",
+            type = { "cartesian_point", "keyword", "text" },
+            description = "Input value. The input can be a single- or multi-valued column or an expression."
+        ) Expression field,
+        Configuration config
+    ) {
+        super(source, field, pragmas);
+    }
+
+    private ToCartesianPoint(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    @Override
+    protected Map<DataType, BuildFactory> factories() {
+        return EVALUATORS;
+    }
+
+    @Override
+    public DataType dataType() {
+        return CARTESIAN_POINT;
+    }
+
+    @Override
+    public Expression replaceChildren(List<Expression> newChildren) {
+        return new ToCartesianPoint(source(), newChildren.getFirst(), getPragmas());
+    }
+
+    @Override
+    protected NodeInfo<? extends Expression> info() {
+        return NodeInfo.create(this, ToCartesianPoint::new, field(), getPragmas());
+    }
+
+    @ConvertEvaluator(extraName = "FromString", warnExceptions = { IllegalArgumentException.class })
+    static BytesRef fromKeyword(BytesRef in) {
+        return stringToSpatial(in.utf8ToString());
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianShape.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianShape.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.io.IOException;
 import java.util.List;
@@ -57,9 +58,10 @@ public class ToCartesianShape extends AbstractConvertFunction {
             name = "field",
             type = { "cartesian_point", "cartesian_shape", "keyword", "text" },
             description = "Input value. The input can be a single- or multi-valued column or an expression."
-        ) Expression field
+        ) Expression field,
+        QueryPragmas pragmas
     ) {
-        super(source, field);
+        super(source, field, pragmas);
     }
 
     private ToCartesianShape(StreamInput in) throws IOException {
@@ -83,12 +85,12 @@ public class ToCartesianShape extends AbstractConvertFunction {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        return new ToCartesianShape(source(), newChildren.get(0));
+        return new ToCartesianShape(source(), newChildren.getFirst(), getPragmas());
     }
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, ToCartesianShape::new, field());
+        return NodeInfo.create(this, ToCartesianShape::new, field(), getPragmas());
     }
 
     @ConvertEvaluator(extraName = "FromString", warnExceptions = { IllegalArgumentException.class })

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianShape.java.bak
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianShape.java.bak
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.compute.ann.ConvertEvaluator;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.Example;
+import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
+import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.core.type.DataType.CARTESIAN_POINT;
+import static org.elasticsearch.xpack.esql.core.type.DataType.CARTESIAN_SHAPE;
+import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
+import static org.elasticsearch.xpack.esql.core.type.DataType.TEXT;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.stringToSpatial;
+
+public class ToCartesianShape extends AbstractConvertFunction {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        Expression.class,
+        "ToCartesianShape",
+        ToCartesianShape::new
+    );
+
+    private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
+        Map.entry(CARTESIAN_POINT, (source, fieldEval) -> fieldEval),
+        Map.entry(CARTESIAN_SHAPE, (source, fieldEval) -> fieldEval),
+        Map.entry(KEYWORD, ToCartesianShapeFromStringEvaluator.Factory::new),
+        Map.entry(TEXT, ToCartesianShapeFromStringEvaluator.Factory::new)
+    );
+
+    @FunctionInfo(
+        returnType = "cartesian_shape",
+        description = """
+            Converts an input value to a `cartesian_shape` value.
+            A string will only be successfully converted if it respects the
+            {wikipedia}/Well-known_text_representation_of_geometry[WKT] format.""",
+        examples = @Example(file = "spatial_shapes", tag = "to_cartesianshape-str")
+    )
+    public ToCartesianShape(
+        Source source,
+        @Param(
+            name = "field",
+            type = { "cartesian_point", "cartesian_shape", "keyword", "text" },
+            description = "Input value. The input can be a single- or multi-valued column or an expression."
+        ) Expression field,
+        Configuration config
+    ) {
+        super(source, field, pragmas);
+    }
+
+    private ToCartesianShape(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    @Override
+    protected Map<DataType, BuildFactory> factories() {
+        return EVALUATORS;
+    }
+
+    @Override
+    public DataType dataType() {
+        return CARTESIAN_SHAPE;
+    }
+
+    @Override
+    public Expression replaceChildren(List<Expression> newChildren) {
+        return new ToCartesianShape(source(), newChildren.getFirst(), getPragmas());
+    }
+
+    @Override
+    protected NodeInfo<? extends Expression> info() {
+        return NodeInfo.create(this, ToCartesianShape::new, field(), getPragmas());
+    }
+
+    @ConvertEvaluator(extraName = "FromString", warnExceptions = { IllegalArgumentException.class })
+    static BytesRef fromKeyword(BytesRef in) {
+        return stringToSpatial(in.utf8ToString());
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDateNanos.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDateNanos.java
@@ -22,6 +22,7 @@ import org.elasticsearch.xpack.esql.core.type.DataTypeConverter;
 import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -73,9 +74,10 @@ public class ToDateNanos extends AbstractConvertFunction {
             name = "field",
             type = { "date", "date_nanos", "keyword", "text", "double", "long", "unsigned_long" },
             description = "Input value. The input can be a single- or multi-valued column or an expression."
-        ) Expression field
+        ) Expression field,
+        QueryPragmas pragmas
     ) {
-        super(source, field);
+        super(source, field, pragmas);
     }
 
     protected ToDateNanos(StreamInput in) throws IOException {
@@ -94,12 +96,12 @@ public class ToDateNanos extends AbstractConvertFunction {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        return new ToDateNanos(source(), newChildren.get(0));
+        return new ToDateNanos(source(), newChildren.getFirst(), getPragmas());
     }
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, ToDateNanos::new, field());
+        return NodeInfo.create(this, ToDateNanos::new, field(), getPragmas());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDateNanos.java.bak
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDateNanos.java.bak
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.time.DateFormatters;
+import org.elasticsearch.common.time.DateUtils;
+import org.elasticsearch.compute.ann.ConvertEvaluator;
+import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.DataTypeConverter;
+import org.elasticsearch.xpack.esql.expression.function.Example;
+import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
+import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.core.type.DataType.DATETIME;
+import static org.elasticsearch.xpack.esql.core.type.DataType.DATE_NANOS;
+import static org.elasticsearch.xpack.esql.core.type.DataType.DOUBLE;
+import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
+import static org.elasticsearch.xpack.esql.core.type.DataType.LONG;
+import static org.elasticsearch.xpack.esql.core.type.DataType.TEXT;
+import static org.elasticsearch.xpack.esql.core.type.DataType.UNSIGNED_LONG;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.DEFAULT_DATE_NANOS_FORMATTER;
+
+public class ToDateNanos extends AbstractConvertFunction {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        Expression.class,
+        "ToDateNanos",
+        ToDateNanos::new
+    );
+
+    private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
+        Map.entry(DATETIME, ToDateNanosFromDatetimeEvaluator.Factory::new),
+        Map.entry(DATE_NANOS, (source, field) -> field),
+        Map.entry(LONG, ToDateNanosFromLongEvaluator.Factory::new),
+        Map.entry(KEYWORD, ToDateNanosFromStringEvaluator.Factory::new),
+        Map.entry(TEXT, ToDateNanosFromStringEvaluator.Factory::new),
+        Map.entry(DOUBLE, ToDateNanosFromDoubleEvaluator.Factory::new),
+        Map.entry(UNSIGNED_LONG, ToLongFromUnsignedLongEvaluator.Factory::new)
+        /*
+         NB: not including an integer conversion, because max int in nanoseconds is like 2 seconds after epoch, and it seems more likely
+         a user who tries to convert an int to a nanosecond date has made a mistake that we should catch that at parse time.
+         TO_DATE_NANOS(TO_LONG(intVal)) is still possible if someone really needs to do this.
+         */
+    );
+
+    @FunctionInfo(
+        returnType = "date_nanos",
+        description = "Converts an input to a nanosecond-resolution date value (aka date_nanos).",
+        note = "The range for date nanos is 1970-01-01T00:00:00.000000000Z to 2262-04-11T23:47:16.854775807Z, attempting to convert "
+            + "values outside of that range will result in null with a warning.  Additionally, integers cannot be converted into date "
+            + "nanos, as the range of integer nanoseconds only covers about 2 seconds after epoch.",
+        examples = { @Example(file = "date_nanos", tag = "to_date_nanos") }
+    )
+    public ToDateNanos(
+        Source source,
+        @Param(
+            name = "field",
+            type = { "date", "date_nanos", "keyword", "text", "double", "long", "unsigned_long" },
+            description = "Input value. The input can be a single- or multi-valued column or an expression."
+        ) Expression field,
+        Configuration config
+    ) {
+        super(source, field, pragmas);
+    }
+
+    protected ToDateNanos(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public DataType dataType() {
+        return DATE_NANOS;
+    }
+
+    @Override
+    protected Map<DataType, BuildFactory> factories() {
+        return EVALUATORS;
+    }
+
+    @Override
+    public Expression replaceChildren(List<Expression> newChildren) {
+        return new ToDateNanos(source(), newChildren.getFirst(), getPragmas());
+    }
+
+    @Override
+    protected NodeInfo<? extends Expression> info() {
+        return NodeInfo.create(this, ToDateNanos::new, field(), getPragmas());
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    @ConvertEvaluator(extraName = "FromLong", warnExceptions = { IllegalArgumentException.class })
+    static long fromLong(long in) {
+        if (in < 0L) {
+            throw new IllegalArgumentException("Nanosecond dates before 1970-01-01T00:00:00.000Z are not supported.");
+        }
+        return in;
+    }
+
+    @ConvertEvaluator(extraName = "FromDouble", warnExceptions = { IllegalArgumentException.class, InvalidArgumentException.class })
+    static long fromDouble(double in) {
+        if (in < 0d) {
+            throw new IllegalArgumentException("Nanosecond dates before 1970-01-01T00:00:00.000Z are not supported.");
+        }
+        return DataTypeConverter.safeDoubleToLong(in);
+    }
+
+    @ConvertEvaluator(extraName = "FromString", warnExceptions = { IllegalArgumentException.class })
+    static long fromKeyword(BytesRef in) {
+        Instant parsed = DateFormatters.from(DEFAULT_DATE_NANOS_FORMATTER.parse(in.utf8ToString())).toInstant();
+        return DateUtils.toLong(parsed);
+    }
+
+    @ConvertEvaluator(extraName = "FromDatetime", warnExceptions = { IllegalArgumentException.class })
+    static long fromDatetime(long in) {
+        return DateUtils.toNanoSeconds(in);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDatePeriod.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDatePeriod.java
@@ -14,6 +14,7 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.util.List;
 
@@ -32,9 +33,10 @@ public class ToDatePeriod extends FoldablesConvertFunction {
             name = "field",
             type = { "date_period", "keyword", "text" },
             description = "Input value. The input is a valid constant date period expression."
-        ) Expression v
+        ) Expression v,
+        QueryPragmas pragmas
     ) {
-        super(source, v);
+        super(source, v, pragmas);
     }
 
     @Override
@@ -44,11 +46,11 @@ public class ToDatePeriod extends FoldablesConvertFunction {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        return new ToDatePeriod(source(), newChildren.get(0));
+        return new ToDatePeriod(source(), newChildren.getFirst(), getPragmas());
     }
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, ToDatePeriod::new, field());
+        return NodeInfo.create(this, ToDatePeriod::new, field(), getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDatePeriod.java.bak
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDatePeriod.java.bak
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.Example;
+import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
+import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.session.Configuration;
+
+import java.util.List;
+
+import static org.elasticsearch.xpack.esql.core.type.DataType.DATE_PERIOD;
+
+public class ToDatePeriod extends FoldablesConvertFunction {
+
+    @FunctionInfo(
+        returnType = "date_period",
+        description = "Converts an input value into a `date_period` value.",
+        examples = @Example(file = "convert", tag = "castToDatePeriod")
+    )
+    public ToDatePeriod(
+        Source source,
+        @Param(
+            name = "field",
+            type = { "date_period", "keyword", "text" },
+            description = "Input value. The input is a valid constant date period expression."
+        ) Expression v,
+        Configuration config
+    ) {
+        super(source, v, config);
+    }
+
+    @Override
+    public DataType dataType() {
+        return DATE_PERIOD;
+    }
+
+    @Override
+    public Expression replaceChildren(List<Expression> newChildren) {
+        return new ToDatePeriod(source(), newChildren.getFirst(), getPragmas());
+    }
+
+    @Override
+    protected NodeInfo<? extends Expression> info() {
+        return NodeInfo.create(this, ToDatePeriod::new, field(), getP);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDatetime.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDatetime.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.io.IOException;
 import java.util.List;
@@ -88,9 +89,10 @@ public class ToDatetime extends AbstractConvertFunction {
             name = "field",
             type = { "date", "date_nanos", "keyword", "text", "double", "long", "unsigned_long", "integer" },
             description = "Input value. The input can be a single- or multi-valued column or an expression."
-        ) Expression field
+        ) Expression field,
+        QueryPragmas pragmas
     ) {
-        super(source, field);
+        super(source, field, pragmas);
     }
 
     private ToDatetime(StreamInput in) throws IOException {
@@ -114,12 +116,12 @@ public class ToDatetime extends AbstractConvertFunction {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        return new ToDatetime(source(), newChildren.get(0));
+        return new ToDatetime(source(), newChildren.getFirst(), getPragmas());
     }
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, ToDatetime::new, field());
+        return NodeInfo.create(this, ToDatetime::new, field(), getPragmas());
     }
 
     @ConvertEvaluator(extraName = "FromString", warnExceptions = { IllegalArgumentException.class })

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDatetime.java.bak
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDatetime.java.bak
@@ -1,0 +1,136 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.time.DateUtils;
+import org.elasticsearch.compute.ann.ConvertEvaluator;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.Example;
+import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
+import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.core.type.DataType.DATETIME;
+import static org.elasticsearch.xpack.esql.core.type.DataType.DATE_NANOS;
+import static org.elasticsearch.xpack.esql.core.type.DataType.DOUBLE;
+import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
+import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
+import static org.elasticsearch.xpack.esql.core.type.DataType.LONG;
+import static org.elasticsearch.xpack.esql.core.type.DataType.TEXT;
+import static org.elasticsearch.xpack.esql.core.type.DataType.UNSIGNED_LONG;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.dateTimeToLong;
+
+public class ToDatetime extends AbstractConvertFunction {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        Expression.class,
+        "ToDatetime",
+        ToDatetime::new
+    );
+
+    private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
+        Map.entry(DATETIME, (source, field) -> field),
+        Map.entry(DATE_NANOS, ToDatetimeFromDateNanosEvaluator.Factory::new),
+        Map.entry(LONG, (source, field) -> field),
+        Map.entry(KEYWORD, ToDatetimeFromStringEvaluator.Factory::new),
+        Map.entry(TEXT, ToDatetimeFromStringEvaluator.Factory::new),
+        Map.entry(DOUBLE, ToLongFromDoubleEvaluator.Factory::new),
+        Map.entry(UNSIGNED_LONG, ToLongFromUnsignedLongEvaluator.Factory::new),
+        Map.entry(INTEGER, ToLongFromIntEvaluator.Factory::new) // CastIntToLongEvaluator would be a candidate, but not MV'd
+    );
+
+    @FunctionInfo(
+        returnType = "date",
+        description = """
+            Converts an input value to a date value.
+            A string will only be successfully converted if it’s respecting the format `yyyy-MM-dd'T'HH:mm:ss.SSS'Z'`.
+            To convert dates in other formats, use <<esql-date_parse>>.""",
+        note = "Note that when converting from nanosecond resolution to millisecond resolution with this function, the nanosecond date is "
+            + "truncated, not rounded.",
+        examples = {
+            @Example(file = "date", tag = "to_datetime-str", explanation = """
+                Note that in this example, the last value in the source multi-valued field has not been converted.
+                The reason being that if the date format is not respected, the conversion will result in a `null` value.
+                When this happens a _Warning_ header is added to the response.
+                The header will provide information on the source of the failure:
+
+                `"Line 1:112: evaluation of [TO_DATETIME(string)] failed, treating result as null. "Only first 20 failures recorded."`
+
+                A following header will contain the failure reason and the offending value:
+
+                `"java.lang.IllegalArgumentException: failed to parse date field [1964-06-02 00:00:00]
+                with format [yyyy-MM-dd'T'HH:mm:ss.SSS'Z']"`
+                """),
+            @Example(
+                description = """
+                    If the input parameter is of a numeric type,
+                    its value will be interpreted as milliseconds since the {wikipedia}/Unix_time[Unix epoch]. For example:""",
+                file = "date",
+                tag = "to_datetime-int"
+            ) }
+    )
+    public ToDatetime(
+        Source source,
+        @Param(
+            name = "field",
+            type = { "date", "date_nanos", "keyword", "text", "double", "long", "unsigned_long", "integer" },
+            description = "Input value. The input can be a single- or multi-valued column or an expression."
+        ) Expression field,
+        Configuration config
+    ) {
+        super(source, field, pragmas);
+    }
+
+    private ToDatetime(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    @Override
+    protected Map<DataType, BuildFactory> factories() {
+        return EVALUATORS;
+    }
+
+    @Override
+    public DataType dataType() {
+        return DATETIME;
+    }
+
+    @Override
+    public Expression replaceChildren(List<Expression> newChildren) {
+        return new ToDatetime(source(), newChildren.getFirst(), getPragmas());
+    }
+
+    @Override
+    protected NodeInfo<? extends Expression> info() {
+        return NodeInfo.create(this, ToDatetime::new, field(), getPragmas());
+    }
+
+    @ConvertEvaluator(extraName = "FromString", warnExceptions = { IllegalArgumentException.class })
+    static long fromKeyword(BytesRef in) {
+        return dateTimeToLong(in.utf8ToString());
+    }
+
+    @ConvertEvaluator(extraName = "FromDateNanos", warnExceptions = { IllegalArgumentException.class })
+    static long fromDatenanos(long in) {
+        return DateUtils.toMilliSeconds(in);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDegrees.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDegrees.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xpack.esql.evaluator.mapper.EvaluatorMapper;
 import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.io.IOException;
 import java.util.List;
@@ -61,9 +62,10 @@ public class ToDegrees extends AbstractConvertFunction implements EvaluatorMappe
             name = "number",
             type = { "double", "integer", "long", "unsigned_long" },
             description = "Input value. The input can be a single- or multi-valued column or an expression."
-        ) Expression field
+        ) Expression field,
+        QueryPragmas pragmas
     ) {
-        super(source, field);
+        super(source, field, pragmas);
     }
 
     private ToDegrees(StreamInput in) throws IOException {
@@ -82,12 +84,12 @@ public class ToDegrees extends AbstractConvertFunction implements EvaluatorMappe
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        return new ToDegrees(source(), newChildren.get(0));
+        return new ToDegrees(source(), newChildren.getFirst(), getPragmas());
     }
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, ToDegrees::new, field());
+        return NodeInfo.create(this, ToDegrees::new, field(), getPragmas());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDegrees.java.bak
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDegrees.java.bak
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.compute.ann.ConvertEvaluator;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.util.NumericUtils;
+import org.elasticsearch.xpack.esql.evaluator.mapper.EvaluatorMapper;
+import org.elasticsearch.xpack.esql.expression.function.Example;
+import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
+import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.core.type.DataType.DOUBLE;
+import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
+import static org.elasticsearch.xpack.esql.core.type.DataType.LONG;
+import static org.elasticsearch.xpack.esql.core.type.DataType.UNSIGNED_LONG;
+
+/**
+ * Converts from <a href="https://en.wikipedia.org/wiki/Radian">radians</a>
+ * to <a href="https://en.wikipedia.org/wiki/Degree_(angle)">degrees</a>.
+ */
+public class ToDegrees extends AbstractConvertFunction implements EvaluatorMapper {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        Expression.class,
+        "ToDegrees",
+        ToDegrees::new
+    );
+
+    private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
+        Map.entry(DOUBLE, ToDegreesEvaluator.Factory::new),
+        Map.entry(INTEGER, (source, field) -> new ToDegreesEvaluator.Factory(source, new ToDoubleFromIntEvaluator.Factory(source, field))),
+        Map.entry(LONG, (source, field) -> new ToDegreesEvaluator.Factory(source, new ToDoubleFromLongEvaluator.Factory(source, field))),
+        Map.entry(
+            UNSIGNED_LONG,
+            (source, field) -> new ToDegreesEvaluator.Factory(source, new ToDoubleFromUnsignedLongEvaluator.Factory(source, field))
+        )
+    );
+
+    @FunctionInfo(
+        returnType = "double",
+        description = "Converts a number in {wikipedia}/Radian[radians] to {wikipedia}/Degree_(angle)[degrees].",
+        examples = @Example(file = "floats", tag = "to_degrees")
+    )
+    public ToDegrees(
+        Source source,
+        @Param(
+            name = "number",
+            type = { "double", "integer", "long", "unsigned_long" },
+            description = "Input value. The input can be a single- or multi-valued column or an expression."
+        ) Expression field,
+        Configuration config
+    ) {
+        super(source, field, pragmas);
+    }
+
+    private ToDegrees(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    @Override
+    protected Map<DataType, BuildFactory> factories() {
+        return EVALUATORS;
+    }
+
+    @Override
+    public Expression replaceChildren(List<Expression> newChildren) {
+        return new ToDegrees(source(), newChildren.getFirst(), getPragmas());
+    }
+
+    @Override
+    protected NodeInfo<? extends Expression> info() {
+        return NodeInfo.create(this, ToDegrees::new, field(), getPragmas());
+    }
+
+    @Override
+    public DataType dataType() {
+        return DOUBLE;
+    }
+
+    @ConvertEvaluator(warnExceptions = { ArithmeticException.class })
+    static double process(double deg) {
+        return NumericUtils.asFiniteNumber(Math.toDegrees(deg));
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDouble.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDouble.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.io.IOException;
 import java.util.List;
@@ -85,9 +86,10 @@ public class ToDouble extends AbstractConvertFunction {
                 "counter_integer",
                 "counter_long" },
             description = "Input value. The input can be a single- or multi-valued column or an expression."
-        ) Expression field
+        ) Expression field,
+        QueryPragmas pragmas
     ) {
-        super(source, field);
+        super(source, field, pragmas);
     }
 
     private ToDouble(StreamInput in) throws IOException {
@@ -111,12 +113,12 @@ public class ToDouble extends AbstractConvertFunction {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        return new ToDouble(source(), newChildren.get(0));
+        return new ToDouble(source(), newChildren.getFirst(), getPragmas());
     }
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, ToDouble::new, field());
+        return NodeInfo.create(this, ToDouble::new, field(), getPragmas());
     }
 
     @ConvertEvaluator(extraName = "FromBoolean")

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDouble.java.bak
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDouble.java.bak
@@ -1,0 +1,148 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.compute.ann.ConvertEvaluator;
+import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.Example;
+import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
+import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.core.type.DataType.BOOLEAN;
+import static org.elasticsearch.xpack.esql.core.type.DataType.DATETIME;
+import static org.elasticsearch.xpack.esql.core.type.DataType.DOUBLE;
+import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
+import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
+import static org.elasticsearch.xpack.esql.core.type.DataType.LONG;
+import static org.elasticsearch.xpack.esql.core.type.DataType.TEXT;
+import static org.elasticsearch.xpack.esql.core.type.DataType.UNSIGNED_LONG;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.stringToDouble;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.unsignedLongToDouble;
+
+public class ToDouble extends AbstractConvertFunction {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "ToDouble", ToDouble::new);
+
+    private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
+        Map.entry(DOUBLE, (source, fieldEval) -> fieldEval),
+        Map.entry(BOOLEAN, ToDoubleFromBooleanEvaluator.Factory::new),
+        Map.entry(DATETIME, ToDoubleFromLongEvaluator.Factory::new), // CastLongToDoubleEvaluator would be a candidate, but not MV'd
+        Map.entry(KEYWORD, ToDoubleFromStringEvaluator.Factory::new),
+        Map.entry(TEXT, ToDoubleFromStringEvaluator.Factory::new),
+        Map.entry(UNSIGNED_LONG, ToDoubleFromUnsignedLongEvaluator.Factory::new),
+        Map.entry(LONG, ToDoubleFromLongEvaluator.Factory::new), // CastLongToDoubleEvaluator would be a candidate, but not MV'd
+        Map.entry(INTEGER, ToDoubleFromIntEvaluator.Factory::new), // CastIntToDoubleEvaluator would be a candidate, but not MV'd
+        Map.entry(DataType.COUNTER_DOUBLE, (source, field) -> field),
+        Map.entry(DataType.COUNTER_INTEGER, ToDoubleFromIntEvaluator.Factory::new),
+        Map.entry(DataType.COUNTER_LONG, ToDoubleFromLongEvaluator.Factory::new)
+    );
+
+    @FunctionInfo(
+        returnType = "double",
+        description = """
+            Converts an input value to a double value. If the input parameter is of a date type,
+            its value will be interpreted as milliseconds since the {wikipedia}/Unix_time[Unix epoch],
+            converted to double. Boolean `true` will be converted to double `1.0`, `false` to `0.0`.""",
+        examples = @Example(file = "floats", tag = "to_double-str", explanation = """
+            Note that in this example, the last conversion of the string isn’t possible.
+            When this happens, the result is a `null` value. In this case a _Warning_ header is added to the response.
+            The header will provide information on the source of the failure:
+
+            `"Line 1:115: evaluation of [TO_DOUBLE(str2)] failed, treating result as null. Only first 20 failures recorded."`
+
+            A following header will contain the failure reason and the offending value:
+            `"java.lang.NumberFormatException: For input string: \"foo\""`""")
+    )
+    public ToDouble(
+        Source source,
+        @Param(
+            name = "field",
+            type = {
+                "boolean",
+                "date",
+                "keyword",
+                "text",
+                "double",
+                "long",
+                "unsigned_long",
+                "integer",
+                "counter_double",
+                "counter_integer",
+                "counter_long" },
+            description = "Input value. The input can be a single- or multi-valued column or an expression."
+        ) Expression field,
+        Configuration config
+    ) {
+        super(source, field, pragmas);
+    }
+
+    private ToDouble(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    @Override
+    protected Map<DataType, BuildFactory> factories() {
+        return EVALUATORS;
+    }
+
+    @Override
+    public DataType dataType() {
+        return DOUBLE;
+    }
+
+    @Override
+    public Expression replaceChildren(List<Expression> newChildren) {
+        return new ToDouble(source(), newChildren.getFirst(), getPragmas());
+    }
+
+    @Override
+    protected NodeInfo<? extends Expression> info() {
+        return NodeInfo.create(this, ToDouble::new, field(), getPragmas());
+    }
+
+    @ConvertEvaluator(extraName = "FromBoolean")
+    static double fromBoolean(boolean bool) {
+        return bool ? 1d : 0d;
+    }
+
+    @ConvertEvaluator(extraName = "FromString", warnExceptions = { InvalidArgumentException.class })
+    static double fromKeyword(BytesRef in) {
+        return stringToDouble(in.utf8ToString());
+    }
+
+    @ConvertEvaluator(extraName = "FromUnsignedLong")
+    static double fromUnsignedLong(long l) {
+        return unsignedLongToDouble(l);
+    }
+
+    @ConvertEvaluator(extraName = "FromLong")
+    static double fromLong(long l) {
+        return l;
+    }
+
+    @ConvertEvaluator(extraName = "FromInt")
+    static double fromInt(int i) {
+        return i;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoPoint.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoPoint.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.io.IOException;
 import java.util.List;
@@ -55,9 +56,10 @@ public class ToGeoPoint extends AbstractConvertFunction {
             name = "field",
             type = { "geo_point", "keyword", "text" },
             description = "Input value. The input can be a single- or multi-valued column or an expression."
-        ) Expression field
+        ) Expression field,
+        QueryPragmas pragmas
     ) {
-        super(source, field);
+        super(source, field, pragmas);
     }
 
     private ToGeoPoint(StreamInput in) throws IOException {
@@ -81,12 +83,12 @@ public class ToGeoPoint extends AbstractConvertFunction {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        return new ToGeoPoint(source(), newChildren.get(0));
+        return new ToGeoPoint(source(), newChildren.getFirst(), getPragmas());
     }
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, ToGeoPoint::new, field());
+        return NodeInfo.create(this, ToGeoPoint::new, field(), getPragmas());
     }
 
     @ConvertEvaluator(extraName = "FromString", warnExceptions = { IllegalArgumentException.class })

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoPoint.java.bak
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoPoint.java.bak
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.compute.ann.ConvertEvaluator;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.Example;
+import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
+import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.core.type.DataType.GEO_POINT;
+import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
+import static org.elasticsearch.xpack.esql.core.type.DataType.TEXT;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.stringToGeo;
+
+public class ToGeoPoint extends AbstractConvertFunction {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        Expression.class,
+        "ToGeoPoint",
+        ToGeoPoint::new
+    );
+
+    private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
+        Map.entry(GEO_POINT, (source, fieldEval) -> fieldEval),
+        Map.entry(KEYWORD, ToGeoPointFromStringEvaluator.Factory::new),
+        Map.entry(TEXT, ToGeoPointFromStringEvaluator.Factory::new)
+    );
+
+    @FunctionInfo(
+        returnType = "geo_point",
+        description = """
+            Converts an input value to a `geo_point` value.
+            A string will only be successfully converted if it respects the
+            {wikipedia}/Well-known_text_representation_of_geometry[WKT Point] format.""",
+        examples = @Example(file = "spatial", tag = "to_geopoint-str")
+    )
+    public ToGeoPoint(
+        Source source,
+        @Param(
+            name = "field",
+            type = { "geo_point", "keyword", "text" },
+            description = "Input value. The input can be a single- or multi-valued column or an expression."
+        ) Expression field,
+        Configuration config
+    ) {
+        super(source, field, pragmas);
+    }
+
+    private ToGeoPoint(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    @Override
+    protected Map<DataType, BuildFactory> factories() {
+        return EVALUATORS;
+    }
+
+    @Override
+    public DataType dataType() {
+        return GEO_POINT;
+    }
+
+    @Override
+    public Expression replaceChildren(List<Expression> newChildren) {
+        return new ToGeoPoint(source(), newChildren.getFirst(), getPragmas());
+    }
+
+    @Override
+    protected NodeInfo<? extends Expression> info() {
+        return NodeInfo.create(this, ToGeoPoint::new, field(), getPragmas());
+    }
+
+    @ConvertEvaluator(extraName = "FromString", warnExceptions = { IllegalArgumentException.class })
+    static BytesRef fromKeyword(BytesRef in) {
+        return stringToGeo(in.utf8ToString());
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoShape.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoShape.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.io.IOException;
 import java.util.List;
@@ -57,9 +58,10 @@ public class ToGeoShape extends AbstractConvertFunction {
             name = "field",
             type = { "geo_point", "geo_shape", "keyword", "text" },
             description = "Input value. The input can be a single- or multi-valued column or an expression."
-        ) Expression field
+        ) Expression field,
+        QueryPragmas pragmas
     ) {
-        super(source, field);
+        super(source, field, pragmas);
     }
 
     private ToGeoShape(StreamInput in) throws IOException {
@@ -83,12 +85,12 @@ public class ToGeoShape extends AbstractConvertFunction {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        return new ToGeoShape(source(), newChildren.get(0));
+        return new ToGeoShape(source(), newChildren.getFirst(), getPragmas());
     }
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, ToGeoShape::new, field());
+        return NodeInfo.create(this, ToGeoShape::new, field(), getPragmas());
     }
 
     @ConvertEvaluator(extraName = "FromString", warnExceptions = { IllegalArgumentException.class })

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoShape.java.bak
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoShape.java.bak
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.compute.ann.ConvertEvaluator;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.Example;
+import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
+import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.core.type.DataType.GEO_POINT;
+import static org.elasticsearch.xpack.esql.core.type.DataType.GEO_SHAPE;
+import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
+import static org.elasticsearch.xpack.esql.core.type.DataType.TEXT;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.stringToGeo;
+
+public class ToGeoShape extends AbstractConvertFunction {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        Expression.class,
+        "ToGeoShape",
+        ToGeoShape::new
+    );
+
+    private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
+        Map.entry(GEO_POINT, (source, fieldEval) -> fieldEval),
+        Map.entry(GEO_SHAPE, (source, fieldEval) -> fieldEval),
+        Map.entry(KEYWORD, ToGeoShapeFromStringEvaluator.Factory::new),
+        Map.entry(TEXT, ToGeoShapeFromStringEvaluator.Factory::new)
+    );
+
+    @FunctionInfo(
+        returnType = "geo_shape",
+        description = """
+            Converts an input value to a `geo_shape` value.
+            A string will only be successfully converted if it respects the
+            {wikipedia}/Well-known_text_representation_of_geometry[WKT] format.""",
+        examples = @Example(file = "spatial_shapes", tag = "to_geoshape-str")
+    )
+    public ToGeoShape(
+        Source source,
+        @Param(
+            name = "field",
+            type = { "geo_point", "geo_shape", "keyword", "text" },
+            description = "Input value. The input can be a single- or multi-valued column or an expression."
+        ) Expression field,
+        Configuration config
+    ) {
+        super(source, field, pragmas);
+    }
+
+    private ToGeoShape(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    @Override
+    protected Map<DataType, BuildFactory> factories() {
+        return EVALUATORS;
+    }
+
+    @Override
+    public DataType dataType() {
+        return GEO_SHAPE;
+    }
+
+    @Override
+    public Expression replaceChildren(List<Expression> newChildren) {
+        return new ToGeoShape(source(), newChildren.getFirst(), getPragmas());
+    }
+
+    @Override
+    protected NodeInfo<? extends Expression> info() {
+        return NodeInfo.create(this, ToGeoShape::new, field(), getPragmas());
+    }
+
+    @ConvertEvaluator(extraName = "FromString", warnExceptions = { IllegalArgumentException.class })
+    static BytesRef fromKeyword(BytesRef in) {
+        return stringToGeo(in.utf8ToString());
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToInteger.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToInteger.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.io.IOException;
 import java.util.List;
@@ -80,9 +81,10 @@ public class ToInteger extends AbstractConvertFunction {
             name = "field",
             type = { "boolean", "date", "keyword", "text", "double", "long", "unsigned_long", "integer", "counter_integer" },
             description = "Input value. The input can be a single- or multi-valued column or an expression."
-        ) Expression field
+        ) Expression field,
+        QueryPragmas pragmas
     ) {
-        super(source, field);
+        super(source, field, pragmas);
     }
 
     private ToInteger(StreamInput in) throws IOException {
@@ -106,12 +108,12 @@ public class ToInteger extends AbstractConvertFunction {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        return new ToInteger(source(), newChildren.get(0));
+        return new ToInteger(source(), newChildren.getFirst(), getPragmas());
     }
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, ToInteger::new, field());
+        return NodeInfo.create(this, ToInteger::new, field(), getPragmas());
     }
 
     @ConvertEvaluator(extraName = "FromBoolean")

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToInteger.java.bak
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToInteger.java.bak
@@ -1,0 +1,143 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.compute.ann.ConvertEvaluator;
+import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.Example;
+import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
+import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.core.type.DataType.BOOLEAN;
+import static org.elasticsearch.xpack.esql.core.type.DataType.COUNTER_INTEGER;
+import static org.elasticsearch.xpack.esql.core.type.DataType.DATETIME;
+import static org.elasticsearch.xpack.esql.core.type.DataType.DOUBLE;
+import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
+import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
+import static org.elasticsearch.xpack.esql.core.type.DataType.LONG;
+import static org.elasticsearch.xpack.esql.core.type.DataType.TEXT;
+import static org.elasticsearch.xpack.esql.core.type.DataType.UNSIGNED_LONG;
+import static org.elasticsearch.xpack.esql.core.type.DataTypeConverter.safeToInt;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.stringToInt;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.unsignedLongToInt;
+
+public class ToInteger extends AbstractConvertFunction {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        Expression.class,
+        "ToInteger",
+        ToInteger::new
+    );
+
+    private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
+        Map.entry(INTEGER, (source, fieldEval) -> fieldEval),
+        Map.entry(BOOLEAN, ToIntegerFromBooleanEvaluator.Factory::new),
+        Map.entry(DATETIME, ToIntegerFromLongEvaluator.Factory::new),
+        Map.entry(KEYWORD, ToIntegerFromStringEvaluator.Factory::new),
+        Map.entry(TEXT, ToIntegerFromStringEvaluator.Factory::new),
+        Map.entry(DOUBLE, ToIntegerFromDoubleEvaluator.Factory::new),
+        Map.entry(UNSIGNED_LONG, ToIntegerFromUnsignedLongEvaluator.Factory::new),
+        Map.entry(LONG, ToIntegerFromLongEvaluator.Factory::new),
+        Map.entry(COUNTER_INTEGER, (source, fieldEval) -> fieldEval)
+    );
+
+    @FunctionInfo(
+        returnType = "integer",
+        description = """
+            Converts an input value to an integer value.
+            If the input parameter is of a date type, its value will be interpreted as milliseconds
+            since the {wikipedia}/Unix_time[Unix epoch], converted to integer.
+            Boolean `true` will be converted to integer `1`, `false` to `0`.""",
+        examples = @Example(file = "ints", tag = "to_int-long", explanation = """
+            Note that in this example, the last value of the multi-valued field cannot be converted as an integer.
+            When this happens, the result is a `null` value. In this case a _Warning_ header is added to the response.
+            The header will provide information on the source of the failure:
+
+            `"Line 1:61: evaluation of [TO_INTEGER(long)] failed, treating result as null. Only first 20 failures recorded."`
+
+            A following header will contain the failure reason and the offending value:
+
+            `"org.elasticsearch.xpack.esql.core.InvalidArgumentException: [501379200000] out of [integer] range"`""")
+    )
+    public ToInteger(
+        Source source,
+        @Param(
+            name = "field",
+            type = { "boolean", "date", "keyword", "text", "double", "long", "unsigned_long", "integer", "counter_integer" },
+            description = "Input value. The input can be a single- or multi-valued column or an expression."
+        ) Expression field,
+        Configuration config
+    ) {
+        super(source, field, pragmas);
+    }
+
+    private ToInteger(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    @Override
+    protected Map<DataType, BuildFactory> factories() {
+        return EVALUATORS;
+    }
+
+    @Override
+    public DataType dataType() {
+        return INTEGER;
+    }
+
+    @Override
+    public Expression replaceChildren(List<Expression> newChildren) {
+        return new ToInteger(source(), newChildren.getFirst(), getPragmas());
+    }
+
+    @Override
+    protected NodeInfo<? extends Expression> info() {
+        return NodeInfo.create(this, ToInteger::new, field(), getPragmas());
+    }
+
+    @ConvertEvaluator(extraName = "FromBoolean")
+    static int fromBoolean(boolean bool) {
+        return bool ? 1 : 0;
+    }
+
+    @ConvertEvaluator(extraName = "FromString", warnExceptions = { InvalidArgumentException.class })
+    static int fromKeyword(BytesRef in) {
+        return stringToInt(in.utf8ToString());
+    }
+
+    @ConvertEvaluator(extraName = "FromDouble", warnExceptions = { InvalidArgumentException.class })
+    static int fromDouble(double dbl) {
+        return safeToInt(dbl);
+    }
+
+    @ConvertEvaluator(extraName = "FromUnsignedLong", warnExceptions = { InvalidArgumentException.class })
+    static int fromUnsignedLong(long ul) {
+        return unsignedLongToInt(ul);
+    }
+
+    @ConvertEvaluator(extraName = "FromLong", warnExceptions = { InvalidArgumentException.class })
+    static int fromLong(long lng) {
+        return safeToInt(lng);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIp.java.bak
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIp.java.bak
@@ -1,0 +1,259 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.esql.core.expression.EntryExpression;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.MapExpression;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.SurrogateExpression;
+import org.elasticsearch.xpack.esql.expression.function.Example;
+import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
+import org.elasticsearch.xpack.esql.expression.function.MapParam;
+import org.elasticsearch.xpack.esql.expression.function.OptionalArgument;
+import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.SECOND;
+import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isMapExpression;
+import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isTypeOrUnionType;
+import static org.elasticsearch.xpack.esql.core.type.DataType.IP;
+import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
+import static org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractConvertFunction.supportedTypesNames;
+
+/**
+ * Converts strings to IPs.
+ * <p>
+ *     IPv4 addresses have traditionally parsed quads with leading zeros in three
+ *     mutually exclusive ways:
+ * </p>
+ * <ul>
+ *     <li>As octal numbers. So {@code 1.1.010.1} becomes {@code 1.1.8.1}.</li>
+ *     <li>As decimal numbers. So {@code 1.1.010.1} becomes {@code 1.1.10.1}.</li>
+ *     <li>Rejects them entirely. So {@code 1.1.010.1} becomes {@code null} with a warning.</li>
+ * </ul>
+ * <p>
+ *     These three ways of handling leading zeros are available with the optional
+ *     {@code leading_zeros} named parameter. Set to {@code octal}, {@code decimal},
+ *     or {@code reject}. If not sent this defaults to {@code reject} which has
+ *     been Elasticsearch's traditional way of handling leading zeros for years.
+ * </p>
+ * <p>
+ *     This doesn't extend from {@link AbstractConvertFunction} so that it can
+ *     support a named parameter for the leading zeros behavior. Instead, it rewrites
+ *     itself into either {@link ToIpLeadingZerosOctal}, {@link ToIpLeadingZerosDecimal},
+ *     or {@link ToIpLeadingZerosRejected} which are all {@link AbstractConvertFunction}
+ *     subclasses. This keeps the conversion code happy while still allowing us to
+ *     expose a single method to users.
+ * </p>
+ */
+public class ToIp extends EsqlScalarFunction implements SurrogateExpression, OptionalArgument, ConvertFunction {
+    private static final String LEADING_ZEROS = "leading_zeros";
+    public static final Map<String, DataType> ALLOWED_OPTIONS = Map.ofEntries(Map.entry(LEADING_ZEROS, KEYWORD));
+
+    private final Expression field;
+    private final Expression options;
+    private final QueryPragmas pragmas;
+
+    @FunctionInfo(
+        returnType = "ip",
+        description = "Converts an input string to an IP value.",
+        examples = {
+            @Example(file = "ip", tag = "to_ip", explanation = """
+                Note that in this example, the last conversion of the string isn’t possible.
+                When this happens, the result is a `null` value. In this case a _Warning_ header is added to the response.
+                The header will provide information on the source of the failure:
+
+                `"Line 1:68: evaluation of [TO_IP(str2)] failed, treating result as null. Only first 20 failures recorded."`
+
+                A following header will contain the failure reason and the offending value:
+
+                `"java.lang.IllegalArgumentException: 'foo' is not an IP string literal."`"""),
+            @Example(file = "ip", tag = "to_ip_leading_zeros_octal", explanation = """
+                Parse v4 addresses with leading zeros as octal. Like `ping` or `ftp`.
+                """),
+            @Example(file = "ip", tag = "to_ip_leading_zeros_decimal", explanation = """
+                Parse v4 addresses with leading zeros as decimal. Java's `InetAddress.getByName`.
+                """) }
+    )
+    public ToIp(
+        Source source,
+        @Param(
+            name = "field",
+            type = { "ip", "keyword", "text" },
+            description = "Input value. The input can be a single- or multi-valued column or an expression."
+        ) Expression field,
+        @MapParam(
+            name = "options",
+            params = {
+                @MapParam.MapParamEntry(
+                    name = "leading_zeros",
+                    type = "keyword",
+                    valueHint = { "reject", "octal", "decimal" },
+                    description = "What to do with leading 0s in IPv4 addresses."
+                ) },
+            description = "(Optional) Additional options.",
+            optional = true
+        ) Expression options,
+        Configuration config
+    ) {
+        super(source, options == null ? List.of(field) : List.of(field, options));
+        this.field = field;
+        this.options = options;
+        this.pragmas = pragmas;
+    }
+
+    @Override
+    public String getWriteableName() {
+        throw new UnsupportedOperationException("not serialized");
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        throw new UnsupportedOperationException("not serialized");
+    }
+
+    @Override
+    public DataType dataType() {
+        return IP;
+    }
+
+    @Override
+    public Expression replaceChildren(List<Expression> newChildren) {
+        return new ToIp(source(), newChildren.get(0), newChildren.size() == 1 ? null : newChildren.get(1), pragmas);
+    }
+
+    @Override
+    protected NodeInfo<? extends Expression> info() {
+        return NodeInfo.create(this, ToIp::new, field, options, pragmas);
+    }
+
+    @Override
+    public EvalOperator.ExpressionEvaluator.Factory toEvaluator(ToEvaluator toEvaluator) {
+        throw new UnsupportedOperationException("should be rewritten");
+    }
+
+    @Override
+    public Expression surrogate() {
+        return LeadingZeros.from((MapExpression) options).surrogate(source(), field, pragmas);
+    }
+
+    @Override
+    public Expression field() {
+        return field;
+    }
+
+    @Override
+    public Set<DataType> supportedTypes() {
+        // All ToIpLeadingZeros* functions support the same input set. So we just pick one.
+        return ToIpLeadingZerosRejected.EVALUATORS.keySet();
+    }
+
+    @Override
+    protected TypeResolution resolveType() {
+        if (childrenResolved() == false) {
+            return new TypeResolution("Unresolved children");
+        }
+        TypeResolution resolution = isTypeOrUnionType(
+            field,
+            ToIpLeadingZerosRejected.EVALUATORS::containsKey,
+            sourceText(),
+            null,
+            supportedTypesNames(supportedTypes())
+        );
+        if (resolution.unresolved()) {
+            return resolution;
+        }
+        if (options == null) {
+            return resolution;
+        }
+        resolution = isMapExpression(options, sourceText(), SECOND);
+        if (resolution.unresolved()) {
+            return resolution;
+        }
+        for (EntryExpression e : ((MapExpression) options).entryExpressions()) {
+            String key;
+            if (e.key().dataType() != KEYWORD) {
+                return new TypeResolution("map keys must be strings");
+            }
+            if (e.key() instanceof Literal keyl) {
+                key = (String) keyl.value();
+            } else {
+                return new TypeResolution("map keys must be literals");
+            }
+            DataType expected = ALLOWED_OPTIONS.get(key);
+            if (expected == null) {
+                return new TypeResolution("[" + key + "] is not a supported option");
+            }
+
+            if (e.value().dataType() != expected) {
+                return new TypeResolution("[" + key + "] expects [" + expected + "] but was [" + e.value().dataType() + "]");
+            }
+            if (e.value() instanceof Literal == false) {
+                return new TypeResolution("map values must be literals");
+            }
+        }
+        try {
+            LeadingZeros.from((MapExpression) options);
+        } catch (IllegalArgumentException e) {
+            return new TypeResolution(e.getMessage());
+        }
+        return TypeResolution.TYPE_RESOLVED;
+    }
+
+    public enum LeadingZeros {
+        REJECT {
+            @Override
+            public Expression surrogate(Source source, Expression field, Configuration config) {
+                return new ToIpLeadingZerosRejected(source, field, pragmas);
+            }
+        },
+        DECIMAL {
+            @Override
+            public Expression surrogate(Source source, Expression field, Configuration config) {
+                return new ToIpLeadingZerosDecimal(source, field, pragmas);
+            }
+        },
+        OCTAL {
+            @Override
+            public Expression surrogate(Source source, Expression field, Configuration config) {
+                return new ToIpLeadingZerosOctal(source, field, pragmas);
+            }
+        };
+
+        public static LeadingZeros from(MapExpression exp) {
+            if (exp == null) {
+                return REJECT;
+            }
+            Expression e = exp.keyFoldedMap().get(LEADING_ZEROS);
+            return e == null ? REJECT : from((String) ((Literal) e).value());
+        }
+
+        public static LeadingZeros from(String str) {
+            return switch (str) {
+                case "reject" -> REJECT;
+                case "octal" -> OCTAL;
+                case "decimal" -> DECIMAL;
+                default -> throw new IllegalArgumentException("Illegal leading_zeros [" + str + "]");
+            };
+        }
+
+        public abstract Expression surrogate(Source source, Expression field, Configuration config);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIpLeadingZerosDecimal.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIpLeadingZerosDecimal.java
@@ -13,6 +13,7 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.io.IOException;
 import java.util.List;
@@ -36,8 +37,8 @@ public class ToIpLeadingZerosDecimal extends AbstractConvertFunction {
         Map.entry(TEXT, FROM_KEYWORD_LEADING_ZEROS_DECIMAL)
     );
 
-    public ToIpLeadingZerosDecimal(Source source, Expression field) {
-        super(source, field);
+    public ToIpLeadingZerosDecimal(Source source, Expression field, QueryPragmas pragmas) {
+        super(source, field, pragmas);
     }
 
     private ToIpLeadingZerosDecimal(StreamInput in) throws IOException {
@@ -61,11 +62,11 @@ public class ToIpLeadingZerosDecimal extends AbstractConvertFunction {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        return new ToIpLeadingZerosDecimal(source(), newChildren.get(0));
+        return new ToIpLeadingZerosDecimal(source(), newChildren.getFirst(), getPragmas());
     }
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, ToIpLeadingZerosDecimal::new, field());
+        return NodeInfo.create(this, ToIpLeadingZerosDecimal::new, field(), getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIpLeadingZerosDecimal.java.bak
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIpLeadingZerosDecimal.java.bak
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.core.type.DataType.IP;
+import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
+import static org.elasticsearch.xpack.esql.core.type.DataType.TEXT;
+import static org.elasticsearch.xpack.esql.expression.function.scalar.convert.ParseIp.FROM_KEYWORD_LEADING_ZEROS_DECIMAL;
+
+public class ToIpLeadingZerosDecimal extends AbstractConvertFunction {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        Expression.class,
+        "ToIpLeadingZerosDecimal",
+        ToIpLeadingZerosDecimal::new
+    );
+
+    static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
+        Map.entry(IP, (source, field) -> field),
+        Map.entry(KEYWORD, FROM_KEYWORD_LEADING_ZEROS_DECIMAL),
+        Map.entry(TEXT, FROM_KEYWORD_LEADING_ZEROS_DECIMAL)
+    );
+
+    public ToIpLeadingZerosDecimal(Source source, Expression field, Configuration config) {
+        super(source, field, pragmas);
+    }
+
+    private ToIpLeadingZerosDecimal(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    @Override
+    protected Map<DataType, BuildFactory> factories() {
+        return EVALUATORS;
+    }
+
+    @Override
+    public DataType dataType() {
+        return IP;
+    }
+
+    @Override
+    public Expression replaceChildren(List<Expression> newChildren) {
+        return new ToIpLeadingZerosDecimal(source(), newChildren.getFirst(), getPragmas());
+    }
+
+    @Override
+    protected NodeInfo<? extends Expression> info() {
+        return NodeInfo.create(this, ToIpLeadingZerosDecimal::new, field(), getPragmas());
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIpLeadingZerosOctal.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIpLeadingZerosOctal.java
@@ -13,6 +13,7 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.io.IOException;
 import java.util.List;
@@ -36,8 +37,8 @@ public class ToIpLeadingZerosOctal extends AbstractConvertFunction {
         Map.entry(TEXT, FROM_KEYWORD_LEADING_ZEROS_OCTAL)
     );
 
-    public ToIpLeadingZerosOctal(Source source, Expression field) {
-        super(source, field);
+    public ToIpLeadingZerosOctal(Source source, Expression field, QueryPragmas pragmas) {
+        super(source, field, pragmas);
     }
 
     private ToIpLeadingZerosOctal(StreamInput in) throws IOException {
@@ -61,11 +62,11 @@ public class ToIpLeadingZerosOctal extends AbstractConvertFunction {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        return new ToIpLeadingZerosOctal(source(), newChildren.get(0));
+        return new ToIpLeadingZerosOctal(source(), newChildren.getFirst(), getPragmas());
     }
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, ToIpLeadingZerosOctal::new, field());
+        return NodeInfo.create(this, ToIpLeadingZerosOctal::new, field(), getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIpLeadingZerosOctal.java.bak
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIpLeadingZerosOctal.java.bak
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.core.type.DataType.IP;
+import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
+import static org.elasticsearch.xpack.esql.core.type.DataType.TEXT;
+import static org.elasticsearch.xpack.esql.expression.function.scalar.convert.ParseIp.FROM_KEYWORD_LEADING_ZEROS_OCTAL;
+
+public class ToIpLeadingZerosOctal extends AbstractConvertFunction {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        Expression.class,
+        "ToIpLeadingZerosOctal",
+        ToIpLeadingZerosOctal::new
+    );
+
+    static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
+        Map.entry(IP, (source, field) -> field),
+        Map.entry(KEYWORD, FROM_KEYWORD_LEADING_ZEROS_OCTAL),
+        Map.entry(TEXT, FROM_KEYWORD_LEADING_ZEROS_OCTAL)
+    );
+
+    public ToIpLeadingZerosOctal(Source source, Expression field, Configuration config) {
+        super(source, field, pragmas);
+    }
+
+    private ToIpLeadingZerosOctal(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    @Override
+    protected Map<DataType, BuildFactory> factories() {
+        return EVALUATORS;
+    }
+
+    @Override
+    public DataType dataType() {
+        return IP;
+    }
+
+    @Override
+    public Expression replaceChildren(List<Expression> newChildren) {
+        return new ToIpLeadingZerosOctal(source(), newChildren.get(0), getPragmas());
+    }
+
+    @Override
+    protected NodeInfo<? extends Expression> info() {
+        return NodeInfo.create(this, ToIpLeadingZerosOctal::new, field(), getPragmas());
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIpLeadingZerosRejected.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIpLeadingZerosRejected.java
@@ -13,6 +13,8 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+import org.elasticsearch.xpack.esql.session.Configuration;
 
 import java.io.IOException;
 import java.util.List;
@@ -40,8 +42,12 @@ public class ToIpLeadingZerosRejected extends AbstractConvertFunction {
         Map.entry(TEXT, FROM_KEYWORD_LEADING_ZEROS_REJECTED)
     );
 
-    public ToIpLeadingZerosRejected(Source source, Expression field) {
-        super(source, field);
+    public ToIpLeadingZerosRejected(Source source, Expression field, Configuration config) {
+        this(source, field, config.pragmas());
+    }
+
+    public ToIpLeadingZerosRejected(Source source, Expression field, QueryPragmas pragmas) {
+        super(source, field, pragmas);
     }
 
     private ToIpLeadingZerosRejected(StreamInput in) throws IOException {
@@ -65,11 +71,11 @@ public class ToIpLeadingZerosRejected extends AbstractConvertFunction {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        return new ToIpLeadingZerosRejected(source(), newChildren.get(0));
+        return new ToIpLeadingZerosRejected(source(), newChildren.getFirst(), getPragmas());
     }
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, ToIpLeadingZerosRejected::new, field());
+        return NodeInfo.create(this, ToIpLeadingZerosRejected::new, field(), getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIpLeadingZerosRejected.java.bak
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIpLeadingZerosRejected.java.bak
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.core.type.DataType.IP;
+import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
+import static org.elasticsearch.xpack.esql.core.type.DataType.TEXT;
+import static org.elasticsearch.xpack.esql.expression.function.scalar.convert.ParseIp.FROM_KEYWORD_LEADING_ZEROS_REJECTED;
+
+public class ToIpLeadingZerosRejected extends AbstractConvertFunction {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        Expression.class,
+        /*
+         * This is the name a function with this behavior has had since the
+         * dawn of ESQL. The ToIp function that exists now is not serialized.
+         */
+        "ToIP",
+        ToIpLeadingZerosRejected::new
+    );
+
+    static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
+        Map.entry(IP, (source, field) -> field),
+        Map.entry(KEYWORD, FROM_KEYWORD_LEADING_ZEROS_REJECTED),
+        Map.entry(TEXT, FROM_KEYWORD_LEADING_ZEROS_REJECTED)
+    );
+
+    public ToIpLeadingZerosRejected(Source source, Expression field, Configuration config) {
+        super(source, field, pragmas);
+    }
+
+    private ToIpLeadingZerosRejected(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    @Override
+    protected Map<DataType, BuildFactory> factories() {
+        return EVALUATORS;
+    }
+
+    @Override
+    public DataType dataType() {
+        return IP;
+    }
+
+    @Override
+    public Expression replaceChildren(List<Expression> newChildren) {
+        return new ToIpLeadingZerosRejected(source(), newChildren.getFirst(), getPragmas());
+    }
+
+    @Override
+    protected NodeInfo<? extends Expression> info() {
+        return NodeInfo.create(this, ToIpLeadingZerosRejected::new, field(), getPragmas());
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLong.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLong.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.io.IOException;
 import java.util.List;
@@ -69,7 +70,7 @@ public class ToLong extends AbstractConvertFunction {
 
             A following header will contain the failure reason and the offending value:
 
-            `"java.lang.NumberFormatException: For input string: \"foo\""`""")
+            `"java.lang.NumberFormatException: For input string: "foo""`""")
     )
     public ToLong(
         Source source,
@@ -88,9 +89,11 @@ public class ToLong extends AbstractConvertFunction {
                 "counter_integer",
                 "counter_long" },
             description = "Input value. The input can be a single- or multi-valued column or an expression."
-        ) Expression field
+        ) Expression field,
+        QueryPragmas pragmas
+
     ) {
-        super(source, field);
+        super(source, field, pragmas);
     }
 
     private ToLong(StreamInput in) throws IOException {
@@ -114,12 +117,12 @@ public class ToLong extends AbstractConvertFunction {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        return new ToLong(source(), newChildren.get(0));
+        return new ToLong(source(), newChildren.getFirst(), getPragmas());
     }
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, ToLong::new, field());
+        return NodeInfo.create(this, ToLong::new, field(), getPragmas());
     }
 
     @ConvertEvaluator(extraName = "FromBoolean")

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLong.java.bak
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLong.java.bak
@@ -1,0 +1,152 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.compute.ann.ConvertEvaluator;
+import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.Example;
+import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
+import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.core.type.DataType.BOOLEAN;
+import static org.elasticsearch.xpack.esql.core.type.DataType.DATETIME;
+import static org.elasticsearch.xpack.esql.core.type.DataType.DATE_NANOS;
+import static org.elasticsearch.xpack.esql.core.type.DataType.DOUBLE;
+import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
+import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
+import static org.elasticsearch.xpack.esql.core.type.DataType.LONG;
+import static org.elasticsearch.xpack.esql.core.type.DataType.TEXT;
+import static org.elasticsearch.xpack.esql.core.type.DataType.UNSIGNED_LONG;
+import static org.elasticsearch.xpack.esql.core.type.DataTypeConverter.safeDoubleToLong;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.stringToLong;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.unsignedLongToLong;
+
+public class ToLong extends AbstractConvertFunction {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "ToLong", ToLong::new);
+
+    private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
+        Map.entry(LONG, (source, fieldEval) -> fieldEval),
+        Map.entry(DATETIME, (source, fieldEval) -> fieldEval),
+        Map.entry(DATE_NANOS, (source, fieldEval) -> fieldEval),
+        Map.entry(BOOLEAN, ToLongFromBooleanEvaluator.Factory::new),
+        Map.entry(KEYWORD, ToLongFromStringEvaluator.Factory::new),
+        Map.entry(TEXT, ToLongFromStringEvaluator.Factory::new),
+        Map.entry(DOUBLE, ToLongFromDoubleEvaluator.Factory::new),
+        Map.entry(UNSIGNED_LONG, ToLongFromUnsignedLongEvaluator.Factory::new),
+        Map.entry(INTEGER, ToLongFromIntEvaluator.Factory::new), // CastIntToLongEvaluator would be a candidate, but not MV'd
+        Map.entry(DataType.COUNTER_LONG, (source, field) -> field),
+        Map.entry(DataType.COUNTER_INTEGER, ToLongFromIntEvaluator.Factory::new)
+    );
+
+    @FunctionInfo(
+        returnType = "long",
+        description = """
+            Converts an input value to a long value. If the input parameter is of a date type,
+            its value will be interpreted as milliseconds since the {wikipedia}/Unix_time[Unix epoch], converted to long.
+            Boolean `true` will be converted to long `1`, `false` to `0`.""",
+        examples = @Example(file = "ints", tag = "to_long-str", explanation = """
+            Note that in this example, the last conversion of the string isn’t possible.
+            When this happens, the result is a `null` value. In this case a _Warning_ header is added to the response.
+            The header will provide information on the source of the failure:
+
+            `"Line 1:113: evaluation of [TO_LONG(str3)] failed, treating result as null. Only first 20 failures recorded."`
+
+            A following header will contain the failure reason and the offending value:
+
+            `"java.lang.NumberFormatException: For input string: "foo""`""")
+    )
+    public ToLong(
+        Source source,
+        @Param(
+            name = "field",
+            type = {
+                "boolean",
+                "date",
+                "date_nanos",
+                "keyword",
+                "text",
+                "double",
+                "long",
+                "unsigned_long",
+                "integer",
+                "counter_integer",
+                "counter_long" },
+            description = "Input value. The input can be a single- or multi-valued column or an expression."
+        ) Expression field,
+        Configuration config
+
+    ) {
+        super(source, field, pragmas);
+    }
+
+    private ToLong(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    @Override
+    protected Map<DataType, BuildFactory> factories() {
+        return EVALUATORS;
+    }
+
+    @Override
+    public DataType dataType() {
+        return LONG;
+    }
+
+    @Override
+    public Expression replaceChildren(List<Expression> newChildren) {
+        return new ToLong(source(), newChildren.getFirst(), getPragmas());
+    }
+
+    @Override
+    protected NodeInfo<? extends Expression> info() {
+        return NodeInfo.create(this, ToLong::new, field(), getPragmas());
+    }
+
+    @ConvertEvaluator(extraName = "FromBoolean")
+    static long fromBoolean(boolean bool) {
+        return bool ? 1L : 0L;
+    }
+
+    @ConvertEvaluator(extraName = "FromString", warnExceptions = { InvalidArgumentException.class })
+    static long fromKeyword(BytesRef in) {
+        return stringToLong(in.utf8ToString());
+    }
+
+    @ConvertEvaluator(extraName = "FromDouble", warnExceptions = { InvalidArgumentException.class })
+    static long fromDouble(double dbl) {
+        return safeDoubleToLong(dbl);
+    }
+
+    @ConvertEvaluator(extraName = "FromUnsignedLong", warnExceptions = { InvalidArgumentException.class })
+    static long fromUnsignedLong(long ul) {
+        return unsignedLongToLong(ul);
+    }
+
+    @ConvertEvaluator(extraName = "FromInt")
+    static long fromInt(int i) {
+        return i;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToRadians.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToRadians.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.esql.evaluator.mapper.EvaluatorMapper;
 import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.io.IOException;
 import java.util.List;
@@ -60,9 +61,10 @@ public class ToRadians extends AbstractConvertFunction implements EvaluatorMappe
             name = "number",
             type = { "double", "integer", "long", "unsigned_long" },
             description = "Input value. The input can be a single- or multi-valued column or an expression."
-        ) Expression field
+        ) Expression field,
+        QueryPragmas pragmas
     ) {
-        super(source, field);
+        super(source, field, pragmas);
     }
 
     private ToRadians(StreamInput in) throws IOException {
@@ -81,12 +83,12 @@ public class ToRadians extends AbstractConvertFunction implements EvaluatorMappe
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        return new ToRadians(source(), newChildren.get(0));
+        return new ToRadians(source(), newChildren.getFirst(), getPragmas());
     }
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, ToRadians::new, field());
+        return NodeInfo.create(this, ToRadians::new, field(), getPragmas());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToRadians.java.bak
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToRadians.java.bak
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.compute.ann.ConvertEvaluator;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.evaluator.mapper.EvaluatorMapper;
+import org.elasticsearch.xpack.esql.expression.function.Example;
+import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
+import org.elasticsearch.xpack.esql.expression.function.Param;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.core.type.DataType.DOUBLE;
+import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
+import static org.elasticsearch.xpack.esql.core.type.DataType.LONG;
+import static org.elasticsearch.xpack.esql.core.type.DataType.UNSIGNED_LONG;
+
+/**
+ * Converts from <a href="https://en.wikipedia.org/wiki/Degree_(angle)">degrees</a>
+ * to <a href="https://en.wikipedia.org/wiki/Radian">radians</a>.
+ */
+public class ToRadians extends AbstractConvertFunction implements EvaluatorMapper {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        Expression.class,
+        "ToRadians",
+        ToRadians::new
+    );
+
+    private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
+        Map.entry(DOUBLE, ToRadiansEvaluator.Factory::new),
+        Map.entry(INTEGER, (source, field) -> new ToRadiansEvaluator.Factory(source, new ToDoubleFromIntEvaluator.Factory(source, field))),
+        Map.entry(LONG, (source, field) -> new ToRadiansEvaluator.Factory(source, new ToDoubleFromLongEvaluator.Factory(source, field))),
+        Map.entry(
+            UNSIGNED_LONG,
+            (source, field) -> new ToRadiansEvaluator.Factory(source, new ToDoubleFromUnsignedLongEvaluator.Factory(source, field))
+        )
+    );
+
+    @FunctionInfo(
+        returnType = "double",
+        description = "Converts a number in {wikipedia}/Degree_(angle)[degrees] to {wikipedia}/Radian[radians].",
+        examples = @Example(file = "floats", tag = "to_radians")
+    )
+    public ToRadians(
+        Source source,
+        @Param(
+            name = "number",
+            type = { "double", "integer", "long", "unsigned_long" },
+            description = "Input value. The input can be a single- or multi-valued column or an expression."
+        ) Expression field
+    ) {
+        super(source, field);
+    }
+
+    private ToRadians(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    @Override
+    protected Map<DataType, BuildFactory> factories() {
+        return EVALUATORS;
+    }
+
+    @Override
+    public Expression replaceChildren(List<Expression> newChildren) {
+        return new ToRadians(source(), newChildren.get(0));
+    }
+
+    @Override
+    protected NodeInfo<? extends Expression> info() {
+        return NodeInfo.create(this, ToRadians::new, field());
+    }
+
+    @Override
+    public DataType dataType() {
+        return DOUBLE;
+    }
+
+    @ConvertEvaluator
+    static double process(double deg) {
+        return Math.toRadians(deg);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToString.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToString.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xpack.esql.evaluator.mapper.EvaluatorMapper;
 import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.io.IOException;
 import java.util.List;
@@ -99,9 +100,10 @@ public class ToString extends AbstractConvertFunction implements EvaluatorMapper
                 "unsigned_long",
                 "version" },
             description = "Input value. The input can be a single- or multi-valued column or an expression."
-        ) Expression v
+        ) Expression v,
+        QueryPragmas pragmas
     ) {
-        super(source, v);
+        super(source, v, pragmas);
     }
 
     private ToString(StreamInput in) throws IOException {
@@ -125,12 +127,12 @@ public class ToString extends AbstractConvertFunction implements EvaluatorMapper
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        return new ToString(source(), newChildren.get(0));
+        return new ToString(source(), newChildren.getFirst(), getPragmas());
     }
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, ToString::new, field());
+        return NodeInfo.create(this, ToString::new, field(), getPragmas());
     }
 
     @ConvertEvaluator(extraName = "FromBoolean")

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToString.java.bak
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToString.java.bak
@@ -1,0 +1,202 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.compute.ann.ConvertEvaluator;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.evaluator.mapper.EvaluatorMapper;
+import org.elasticsearch.xpack.esql.expression.function.Example;
+import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
+import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.core.type.DataType.AGGREGATE_METRIC_DOUBLE;
+import static org.elasticsearch.xpack.esql.core.type.DataType.BOOLEAN;
+import static org.elasticsearch.xpack.esql.core.type.DataType.CARTESIAN_POINT;
+import static org.elasticsearch.xpack.esql.core.type.DataType.CARTESIAN_SHAPE;
+import static org.elasticsearch.xpack.esql.core.type.DataType.DATETIME;
+import static org.elasticsearch.xpack.esql.core.type.DataType.DATE_NANOS;
+import static org.elasticsearch.xpack.esql.core.type.DataType.DOUBLE;
+import static org.elasticsearch.xpack.esql.core.type.DataType.GEO_POINT;
+import static org.elasticsearch.xpack.esql.core.type.DataType.GEO_SHAPE;
+import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
+import static org.elasticsearch.xpack.esql.core.type.DataType.IP;
+import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
+import static org.elasticsearch.xpack.esql.core.type.DataType.LONG;
+import static org.elasticsearch.xpack.esql.core.type.DataType.TEXT;
+import static org.elasticsearch.xpack.esql.core.type.DataType.UNSIGNED_LONG;
+import static org.elasticsearch.xpack.esql.core.type.DataType.VERSION;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.dateTimeToString;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.ipToString;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.nanoTimeToString;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.numericBooleanToString;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.spatialToString;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.unsignedLongToString;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.versionToString;
+
+public class ToString extends AbstractConvertFunction implements EvaluatorMapper {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "ToString", ToString::new);
+
+    private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
+        Map.entry(KEYWORD, (source, fieldEval) -> fieldEval),
+        Map.entry(BOOLEAN, ToStringFromBooleanEvaluator.Factory::new),
+        Map.entry(DATETIME, ToStringFromDatetimeEvaluator.Factory::new),
+        Map.entry(DATE_NANOS, ToStringFromDateNanosEvaluator.Factory::new),
+        Map.entry(IP, ToStringFromIPEvaluator.Factory::new),
+        Map.entry(DOUBLE, ToStringFromDoubleEvaluator.Factory::new),
+        Map.entry(LONG, ToStringFromLongEvaluator.Factory::new),
+        Map.entry(INTEGER, ToStringFromIntEvaluator.Factory::new),
+        Map.entry(TEXT, (source, fieldEval) -> fieldEval),
+        Map.entry(VERSION, ToStringFromVersionEvaluator.Factory::new),
+        Map.entry(UNSIGNED_LONG, ToStringFromUnsignedLongEvaluator.Factory::new),
+        Map.entry(GEO_POINT, ToStringFromGeoPointEvaluator.Factory::new),
+        Map.entry(CARTESIAN_POINT, ToStringFromCartesianPointEvaluator.Factory::new),
+        Map.entry(CARTESIAN_SHAPE, ToStringFromCartesianShapeEvaluator.Factory::new),
+        Map.entry(GEO_SHAPE, ToStringFromGeoShapeEvaluator.Factory::new),
+        Map.entry(AGGREGATE_METRIC_DOUBLE, ToStringFromAggregateMetricDoubleEvaluator.Factory::new)
+    );
+
+    @FunctionInfo(
+        returnType = "keyword",
+        description = "Converts an input value into a string.",
+        examples = {
+            @Example(file = "string", tag = "to_string"),
+            @Example(description = "It also works fine on multivalued fields:", file = "string", tag = "to_string_multivalue") }
+    )
+    public ToString(
+        Source source,
+        @Param(
+            name = "field",
+            type = {
+                "aggregate_metric_double",
+                "boolean",
+                "cartesian_point",
+                "cartesian_shape",
+                "date",
+                "date_nanos",
+                "double",
+                "geo_point",
+                "geo_shape",
+                "integer",
+                "ip",
+                "keyword",
+                "long",
+                "text",
+                "unsigned_long",
+                "version" },
+            description = "Input value. The input can be a single- or multi-valued column or an expression."
+        ) Expression v,
+        Configuration config
+    ) {
+        super(source, v, config);
+    }
+
+    private ToString(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    @Override
+    protected Map<DataType, BuildFactory> factories() {
+        return EVALUATORS;
+    }
+
+    @Override
+    public DataType dataType() {
+        return KEYWORD;
+    }
+
+    @Override
+    public Expression replaceChildren(List<Expression> newChildren) {
+        return new ToString(source(), newChildren.getFirst(), getPragmas());
+    }
+
+    @Override
+    protected NodeInfo<? extends Expression> info() {
+        return NodeInfo.create(this, ToString::new, field(), getPragmas());
+    }
+
+    @ConvertEvaluator(extraName = "FromBoolean")
+    static BytesRef fromBoolean(boolean bool) {
+        return numericBooleanToString(bool);
+    }
+
+    @ConvertEvaluator(extraName = "FromIP")
+    static BytesRef fromIP(BytesRef ip) {
+        return new BytesRef(ipToString(ip));
+    }
+
+    @ConvertEvaluator(extraName = "FromDatetime")
+    static BytesRef fromDatetime(long datetime) {
+        return new BytesRef(dateTimeToString(datetime));
+    }
+
+    @ConvertEvaluator(extraName = "FromDateNanos")
+    static BytesRef fromDateNanos(long datetime) {
+        return new BytesRef(nanoTimeToString(datetime));
+    }
+
+    @ConvertEvaluator(extraName = "FromDouble")
+    static BytesRef fromDouble(double dbl) {
+        return numericBooleanToString(dbl);
+    }
+
+    @ConvertEvaluator(extraName = "FromLong")
+    static BytesRef fromDouble(long lng) {
+        return numericBooleanToString(lng);
+    }
+
+    @ConvertEvaluator(extraName = "FromInt")
+    static BytesRef fromDouble(int integer) {
+        return numericBooleanToString(integer);
+    }
+
+    @ConvertEvaluator(extraName = "FromVersion")
+    static BytesRef fromVersion(BytesRef version) {
+        return new BytesRef(versionToString(version));
+    }
+
+    @ConvertEvaluator(extraName = "FromUnsignedLong")
+    static BytesRef fromUnsignedLong(long lng) {
+        return unsignedLongToString(lng);
+    }
+
+    @ConvertEvaluator(extraName = "FromGeoPoint")
+    static BytesRef fromGeoPoint(BytesRef wkb) {
+        return new BytesRef(spatialToString(wkb));
+    }
+
+    @ConvertEvaluator(extraName = "FromCartesianPoint")
+    static BytesRef fromCartesianPoint(BytesRef wkb) {
+        return new BytesRef(spatialToString(wkb));
+    }
+
+    @ConvertEvaluator(extraName = "FromCartesianShape")
+    static BytesRef fromCartesianShape(BytesRef wkb) {
+        return new BytesRef(spatialToString(wkb));
+    }
+
+    @ConvertEvaluator(extraName = "FromGeoShape")
+    static BytesRef fromGeoShape(BytesRef wkb) {
+        return new BytesRef(spatialToString(wkb));
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromAggregateMetricDoubleEvaluator.java.bak
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromAggregateMetricDoubleEvaluator.java.bak
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.AggregateMetricDoubleBlock;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.Vector;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.aggregateMetricDoubleBlockToString;
+
+public class ToStringFromAggregateMetricDoubleEvaluator extends AbstractConvertFunction.AbstractEvaluator {
+    private final EvalOperator.ExpressionEvaluator field;
+
+    public ToStringFromAggregateMetricDoubleEvaluator(Source source, EvalOperator.ExpressionEvaluator field, DriverContext driverContext) {
+        super(driverContext, source);
+        this.field = field;
+    }
+
+    @Override
+    protected EvalOperator.ExpressionEvaluator next() {
+        return field;
+    }
+
+    @Override
+    protected Block evalVector(Vector v) {
+        return evalBlock(v.asBlock());
+    }
+
+    private static BytesRef evalValue(AggregateMetricDoubleBlock aggBlock, int index) {
+        return new BytesRef(aggregateMetricDoubleBlockToString(aggBlock, index));
+    }
+
+    @Override
+    public Block evalBlock(Block b) {
+        AggregateMetricDoubleBlock block = (AggregateMetricDoubleBlock) b;
+        int positionCount = block.getPositionCount();
+        try (BytesRefBlock.Builder builder = driverContext.blockFactory().newBytesRefBlockBuilder(positionCount)) {
+            for (int p = 0; p < positionCount; p++) {
+                if (block.isNull(p)) {
+                    builder.appendNull();
+                } else {
+                    builder.appendBytesRef(evalValue(block, p));
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "ToStringFromAggregateMetricDoubleEvaluator[field=" + field + ']';
+    }
+
+    @Override
+    public void close() {
+        Releasables.closeExpectNoException(field);
+    }
+
+    public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
+        private final Source source;
+        private final EvalOperator.ExpressionEvaluator.Factory field;
+
+        public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory field) {
+            this.source = source;
+            this.field = field;
+        }
+
+        @Override
+        public EvalOperator.ExpressionEvaluator get(DriverContext context) {
+            return new ToStringFromAggregateMetricDoubleEvaluator(source, field.get(context), context);
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToTimeDuration.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToTimeDuration.java
@@ -14,6 +14,7 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.util.List;
 
@@ -32,9 +33,10 @@ public class ToTimeDuration extends FoldablesConvertFunction {
             name = "field",
             type = { "time_duration", "keyword", "text" },
             description = "Input value. The input is a valid constant time duration expression."
-        ) Expression v
+        ) Expression v,
+        QueryPragmas pragmas
     ) {
-        super(source, v);
+        super(source, v, pragmas);
     }
 
     @Override
@@ -44,11 +46,11 @@ public class ToTimeDuration extends FoldablesConvertFunction {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        return new ToTimeDuration(source(), newChildren.get(0));
+        return new ToTimeDuration(source(), newChildren.getFirst(), getPragmas());
     }
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, ToTimeDuration::new, field());
+        return NodeInfo.create(this, ToTimeDuration::new, field(), getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToTimeDuration.java.bak
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToTimeDuration.java.bak
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.Example;
+import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
+import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.util.List;
+
+import static org.elasticsearch.xpack.esql.core.type.DataType.TIME_DURATION;
+
+public class ToTimeDuration extends FoldablesConvertFunction {
+
+    @FunctionInfo(
+        returnType = "time_duration",
+        description = "Converts an input value into a `time_duration` value.",
+        examples = @Example(file = "convert", tag = "castToTimeDuration")
+    )
+    public ToTimeDuration(
+        Source source,
+        @Param(
+            name = "field",
+            type = { "time_duration", "keyword", "text" },
+            description = "Input value. The input is a valid constant time duration expression."
+        ) Expression v,
+        Configuration config
+    ) {
+        super(source, v, config);
+    }
+
+    @Override
+    public DataType dataType() {
+        return TIME_DURATION;
+    }
+
+    @Override
+    public Expression replaceChildren(List<Expression> newChildren) {
+        return new ToTimeDuration(source(), newChildren.getFirst(), getPragmas());
+    }
+
+    @Override
+    protected NodeInfo<? extends Expression> info() {
+        return NodeInfo.create(this, ToTimeDuration::new, field(), getPragmas());
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToUnsignedLong.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToUnsignedLong.java
@@ -21,6 +21,7 @@ import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesTo;
 import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesToLifecycle;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.io.IOException;
 import java.util.List;
@@ -84,9 +85,10 @@ public class ToUnsignedLong extends AbstractConvertFunction {
             name = "field",
             type = { "boolean", "date", "keyword", "text", "double", "long", "unsigned_long", "integer" },
             description = "Input value. The input can be a single- or multi-valued column or an expression."
-        ) Expression field
+        ) Expression field,
+        QueryPragmas pragmas
     ) {
-        super(source, field);
+        super(source, field, pragmas);
     }
 
     private ToUnsignedLong(StreamInput in) throws IOException {
@@ -110,12 +112,12 @@ public class ToUnsignedLong extends AbstractConvertFunction {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        return new ToUnsignedLong(source(), newChildren.get(0));
+        return new ToUnsignedLong(source(), newChildren.getFirst(), getPragmas());
     }
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, ToUnsignedLong::new, field());
+        return NodeInfo.create(this, ToUnsignedLong::new, field(), getPragmas());
     }
 
     @ConvertEvaluator(extraName = "FromBoolean")

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToUnsignedLong.java.bak
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToUnsignedLong.java.bak
@@ -1,0 +1,143 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.compute.ann.ConvertEvaluator;
+import org.elasticsearch.xpack.esql.core.InvalidArgumentException;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.Example;
+import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
+import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.core.type.DataType.BOOLEAN;
+import static org.elasticsearch.xpack.esql.core.type.DataType.DATETIME;
+import static org.elasticsearch.xpack.esql.core.type.DataType.DOUBLE;
+import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
+import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
+import static org.elasticsearch.xpack.esql.core.type.DataType.LONG;
+import static org.elasticsearch.xpack.esql.core.type.DataType.TEXT;
+import static org.elasticsearch.xpack.esql.core.type.DataType.UNSIGNED_LONG;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.booleanToUnsignedLong;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.doubleToUnsignedLong;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.intToUnsignedLong;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.longToUnsignedLong;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.stringToUnsignedLong;
+
+public class ToUnsignedLong extends AbstractConvertFunction {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        Expression.class,
+        "ToUnsignedLong",
+        ToUnsignedLong::new
+    );
+
+    private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
+        Map.entry(UNSIGNED_LONG, (source, fieldEval) -> fieldEval),
+        Map.entry(DATETIME, ToUnsignedLongFromLongEvaluator.Factory::new),
+        Map.entry(BOOLEAN, ToUnsignedLongFromBooleanEvaluator.Factory::new),
+        Map.entry(KEYWORD, ToUnsignedLongFromStringEvaluator.Factory::new),
+        Map.entry(TEXT, ToUnsignedLongFromStringEvaluator.Factory::new),
+        Map.entry(DOUBLE, ToUnsignedLongFromDoubleEvaluator.Factory::new),
+        Map.entry(LONG, ToUnsignedLongFromLongEvaluator.Factory::new),
+        Map.entry(INTEGER, ToUnsignedLongFromIntEvaluator.Factory::new)
+    );
+
+    @FunctionInfo(
+        returnType = "unsigned_long",
+        description = """
+            Converts an input value to an unsigned long value. If the input parameter is of a date type,
+            its value will be interpreted as milliseconds since the {wikipedia}/Unix_time[Unix epoch], converted to unsigned long.
+            Boolean `true` will be converted to unsigned long `1`, `false` to `0`.""",
+        examples = @Example(file = "ints", tag = "to_unsigned_long-str", explanation = """
+            Note that in this example, the last conversion of the string isn’t possible.
+            When this happens, the result is a `null` value. In this case a _Warning_ header is added to the response.
+            The header will provide information on the source of the failure:
+
+            `"Line 1:133: evaluation of [TO_UL(str3)] failed, treating result as null. Only first 20 failures recorded."`
+
+            A following header will contain the failure reason and the offending value:
+
+            `"java.lang.NumberFormatException: Character f is neither a decimal digit number, decimal point,
+            + "nor \"e\" notation exponential mark."`""")
+    )
+    public ToUnsignedLong(
+        Source source,
+        @Param(
+            name = "field",
+            type = { "boolean", "date", "keyword", "text", "double", "long", "unsigned_long", "integer" },
+            description = "Input value. The input can be a single- or multi-valued column or an expression."
+        ) Expression field,
+        Configuration config
+    ) {
+        super(source, field, pragmas);
+    }
+
+    private ToUnsignedLong(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    @Override
+    protected Map<DataType, BuildFactory> factories() {
+        return EVALUATORS;
+    }
+
+    @Override
+    public DataType dataType() {
+        return UNSIGNED_LONG;
+    }
+
+    @Override
+    public Expression replaceChildren(List<Expression> newChildren) {
+        return new ToUnsignedLong(source(), newChildren.getFirst(), getPragmas());
+    }
+
+    @Override
+    protected NodeInfo<? extends Expression> info() {
+        return NodeInfo.create(this, ToUnsignedLong::new, field(), getPragmas());
+    }
+
+    @ConvertEvaluator(extraName = "FromBoolean")
+    static long fromBoolean(boolean bool) {
+        return booleanToUnsignedLong(bool);
+    }
+
+    @ConvertEvaluator(extraName = "FromString", warnExceptions = { InvalidArgumentException.class, NumberFormatException.class })
+    static long fromKeyword(BytesRef in) {
+        return stringToUnsignedLong(in.utf8ToString());
+    }
+
+    @ConvertEvaluator(extraName = "FromDouble", warnExceptions = { InvalidArgumentException.class })
+    static long fromDouble(double dbl) {
+        return doubleToUnsignedLong(dbl);
+    }
+
+    @ConvertEvaluator(extraName = "FromLong", warnExceptions = { InvalidArgumentException.class })
+    static long fromLong(long lng) {
+        return longToUnsignedLong(lng, false);
+    }
+
+    @ConvertEvaluator(extraName = "FromInt", warnExceptions = { InvalidArgumentException.class })
+    static long fromInt(int i) {
+        return intToUnsignedLong(i);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToVersion.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToVersion.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.io.IOException;
 import java.util.List;
@@ -52,9 +53,10 @@ public class ToVersion extends AbstractConvertFunction {
             name = "field",
             type = { "keyword", "text", "version" },
             description = "Input value. The input can be a single- or multi-valued column or an expression."
-        ) Expression v
+        ) Expression v,
+        QueryPragmas pragmas
     ) {
-        super(source, v);
+        super(source, v, pragmas);
     }
 
     private ToVersion(StreamInput in) throws IOException {
@@ -78,12 +80,12 @@ public class ToVersion extends AbstractConvertFunction {
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        return new ToVersion(source(), newChildren.get(0));
+        return new ToVersion(source(), newChildren.getFirst(), getPragmas());
     }
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, ToVersion::new, field());
+        return NodeInfo.create(this, ToVersion::new, field(), getPragmas());
     }
 
     @ConvertEvaluator(extraName = "FromString")

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToVersion.java.bak
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToVersion.java.bak
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.compute.ann.ConvertEvaluator;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.Example;
+import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
+import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
+import static org.elasticsearch.xpack.esql.core.type.DataType.TEXT;
+import static org.elasticsearch.xpack.esql.core.type.DataType.VERSION;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.stringToVersion;
+
+public class ToVersion extends AbstractConvertFunction {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        Expression.class,
+        "ToVersion",
+        ToVersion::new
+    );
+
+    private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
+        Map.entry(VERSION, (source, fieldEval) -> fieldEval),
+        Map.entry(KEYWORD, ToVersionFromStringEvaluator.Factory::new),
+        Map.entry(TEXT, ToVersionFromStringEvaluator.Factory::new)
+    );
+
+    @FunctionInfo(
+        returnType = "version",
+        description = "Converts an input string to a version value.",
+        examples = @Example(file = "version", tag = "to_version")
+    )
+    public ToVersion(
+        Source source,
+        @Param(
+            name = "field",
+            type = { "keyword", "text", "version" },
+            description = "Input value. The input can be a single- or multi-valued column or an expression."
+        ) Expression v,
+        Configuration config
+    ) {
+        super(source, v, config);
+    }
+
+    private ToVersion(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    @Override
+    protected Map<DataType, BuildFactory> factories() {
+        return EVALUATORS;
+    }
+
+    @Override
+    public DataType dataType() {
+        return VERSION;
+    }
+
+    @Override
+    public Expression replaceChildren(List<Expression> newChildren) {
+        return new ToVersion(source(), newChildren.getFirst(), getPragmas());
+    }
+
+    @Override
+    protected NodeInfo<? extends Expression> info() {
+        return NodeInfo.create(this, ToVersion::new, field(), getPragmas());
+    }
+
+    @ConvertEvaluator(extraName = "FromString")
+    static BytesRef fromKeyword(BytesRef asString) {
+        return stringToVersion(asString);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeohashToLong.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeohashToLong.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesToLifecyc
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractConvertFunction;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.io.IOException;
 import java.util.List;
@@ -57,9 +58,10 @@ public class StGeohashToLong extends AbstractConvertFunction implements Evaluato
             name = "grid_id",
             type = { "keyword", "long" },
             description = "Input geohash grid-id. The input can be a single- or multi-valued column or an expression."
-        ) Expression v
+        ) Expression v,
+        QueryPragmas pragmas
     ) {
-        super(source, v);
+        super(source, v, pragmas);
     }
 
     private StGeohashToLong(StreamInput in) throws IOException {
@@ -83,12 +85,12 @@ public class StGeohashToLong extends AbstractConvertFunction implements Evaluato
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        return new StGeohashToLong(source(), newChildren.get(0));
+        return new StGeohashToLong(source(), newChildren.getFirst(), getPragmas());
     }
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, StGeohashToLong::new, field());
+        return NodeInfo.create(this, StGeohashToLong::new, field(), getPragmas());
     }
 
     @ConvertEvaluator(extraName = "FromString")

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeohashToString.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeohashToString.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesToLifecyc
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractConvertFunction;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.io.IOException;
 import java.util.List;
@@ -57,9 +58,10 @@ public class StGeohashToString extends AbstractConvertFunction implements Evalua
             name = "grid_id",
             type = { "keyword", "long" },
             description = "Input geohash grid-id. The input can be a single- or multi-valued column or an expression."
-        ) Expression v
+        ) Expression v,
+        QueryPragmas pragmas
     ) {
-        super(source, v);
+        super(source, v, pragmas);
     }
 
     private StGeohashToString(StreamInput in) throws IOException {
@@ -83,12 +85,12 @@ public class StGeohashToString extends AbstractConvertFunction implements Evalua
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        return new StGeohashToString(source(), newChildren.get(0));
+        return new StGeohashToString(source(), newChildren.getFirst(), getPragmas());
     }
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, StGeohashToString::new, field());
+        return NodeInfo.create(this, StGeohashToString::new, field(), getPragmas());
     }
 
     @ConvertEvaluator(extraName = "FromLong")

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeohexToLong.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeohexToLong.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesToLifecyc
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractConvertFunction;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.io.IOException;
 import java.util.List;
@@ -57,9 +58,10 @@ public class StGeohexToLong extends AbstractConvertFunction implements Evaluator
             name = "grid_id",
             type = { "keyword", "long" },
             description = "Input geohex grid-id. The input can be a single- or multi-valued column or an expression."
-        ) Expression v
+        ) Expression v,
+        QueryPragmas pragmas
     ) {
-        super(source, v);
+        super(source, v, pragmas);
     }
 
     private StGeohexToLong(StreamInput in) throws IOException {
@@ -83,12 +85,12 @@ public class StGeohexToLong extends AbstractConvertFunction implements Evaluator
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        return new StGeohexToLong(source(), newChildren.get(0));
+        return new StGeohexToLong(source(), newChildren.getFirst(), getPragmas());
     }
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, StGeohexToLong::new, field());
+        return NodeInfo.create(this, StGeohexToLong::new, field(), getPragmas());
     }
 
     @ConvertEvaluator(extraName = "FromString")

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeohexToString.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeohexToString.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesToLifecyc
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractConvertFunction;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.io.IOException;
 import java.util.List;
@@ -57,9 +58,10 @@ public class StGeohexToString extends AbstractConvertFunction implements Evaluat
             name = "grid_id",
             type = { "keyword", "long" },
             description = "Input Geohex grid-id. The input can be a single- or multi-valued column or an expression."
-        ) Expression v
+        ) Expression v,
+        QueryPragmas pragmas
     ) {
-        super(source, v);
+        super(source, v, pragmas);
     }
 
     private StGeohexToString(StreamInput in) throws IOException {
@@ -83,12 +85,12 @@ public class StGeohexToString extends AbstractConvertFunction implements Evaluat
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        return new StGeohexToString(source(), newChildren.get(0));
+        return new StGeohexToString(source(), newChildren.getFirst(), getPragmas());
     }
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, StGeohexToString::new, field());
+        return NodeInfo.create(this, StGeohexToString::new, field(), getPragmas());
     }
 
     @ConvertEvaluator(extraName = "FromLong")

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeotileToLong.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeotileToLong.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesToLifecyc
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractConvertFunction;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.io.IOException;
 import java.util.List;
@@ -57,9 +58,10 @@ public class StGeotileToLong extends AbstractConvertFunction implements Evaluato
             name = "grid_id",
             type = { "keyword", "long" },
             description = "Input geotile grid-id. The input can be a single- or multi-valued column or an expression."
-        ) Expression v
+        ) Expression v,
+        QueryPragmas pragmas
     ) {
-        super(source, v);
+        super(source, v, pragmas);
     }
 
     private StGeotileToLong(StreamInput in) throws IOException {
@@ -83,12 +85,12 @@ public class StGeotileToLong extends AbstractConvertFunction implements Evaluato
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        return new StGeotileToLong(source(), newChildren.get(0));
+        return new StGeotileToLong(source(), newChildren.getFirst(), getPragmas());
     }
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, StGeotileToLong::new, field());
+        return NodeInfo.create(this, StGeotileToLong::new, field(), getPragmas());
     }
 
     @ConvertEvaluator(extraName = "FromString")

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeotileToString.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeotileToString.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xpack.esql.expression.function.FunctionAppliesToLifecyc
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractConvertFunction;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.io.IOException;
 import java.util.List;
@@ -57,9 +58,10 @@ public class StGeotileToString extends AbstractConvertFunction implements Evalua
             name = "grid_id",
             type = { "keyword", "long" },
             description = "Input geotile grid-id. The input can be a single- or multi-valued column or an expression."
-        ) Expression v
+        ) Expression v,
+        QueryPragmas pragmas
     ) {
-        super(source, v);
+        super(source, v, pragmas);
     }
 
     private StGeotileToString(StreamInput in) throws IOException {
@@ -83,12 +85,12 @@ public class StGeotileToString extends AbstractConvertFunction implements Evalua
 
     @Override
     public Expression replaceChildren(List<Expression> newChildren) {
-        return new StGeotileToString(source(), newChildren.get(0));
+        return new StGeotileToString(source(), newChildren.getFirst(), getPragmas());
     }
 
     @Override
     protected NodeInfo<? extends Expression> info() {
-        return NodeInfo.create(this, StGeotileToString::new, field());
+        return NodeInfo.create(this, StGeotileToString::new, field(), getPragmas());
     }
 
     @ConvertEvaluator(extraName = "FromLong")

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/EsqlParser.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/EsqlParser.java
@@ -153,7 +153,7 @@ public class EsqlParser {
                 log.trace("Parse tree: {}", tree.toStringTree());
             }
 
-            return result.apply(new AstBuilder(new ExpressionBuilder.ParsingContext(params, metrics)), tree);
+            return result.apply(new AstBuilder(new ExpressionBuilder.ParsingContext(params, metrics, configuration.pragmas())), tree);
         } catch (StackOverflowError e) {
             throw new ParsingException("ESQL statement is too large, causing stack overflow when generating the parsing tree: [{}]", query);
             // likely thrown by an invalid popMode (such as extra closing parenthesis)

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/ExpressionBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/ExpressionBuilder.java
@@ -64,6 +64,7 @@ import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.InsensitiveEquals;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThanOrEqual;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.elasticsearch.xpack.esql.telemetry.PlanTelemetry;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter;
 
@@ -121,7 +122,7 @@ public abstract class ExpressionBuilder extends IdentifierBuilder {
 
     protected final ParsingContext context;
 
-    public record ParsingContext(QueryParams params, PlanTelemetry telemetry) {}
+    public record ParsingContext(QueryParams params, PlanTelemetry telemetry, QueryPragmas pragmas) {}
 
     ExpressionBuilder(ParsingContext context) {
         this.context = context;
@@ -697,7 +698,7 @@ public abstract class ExpressionBuilder extends IdentifierBuilder {
             throw new ParsingException(source, "Unsupported conversion to type [{}]", dataType);
         }
         Expression expr = expression(parseTree);
-        var convertFunction = converterToFactory.apply(source, expr);
+        var convertFunction = converterToFactory.apply(source, expr, context.pragmas());
         context.telemetry().function(convertFunction.getClass());
         return convertFunction;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
@@ -183,7 +183,7 @@ public class LogicalPlanBuilder extends ExpressionBuilder {
             String pattern = BytesRefs.toString(visitString(ctx.string()).fold(FoldContext.small() /* TODO remove me */));
             Grok.Parser grokParser;
             try {
-                grokParser = Grok.pattern(source, pattern);
+                grokParser = Grok.pattern(source, pattern, context.pragmas());
             } catch (SyntaxException e) {
                 throw new ParsingException(source, "Invalid grok pattern [{}]: [{}]", pattern, e.getMessage());
             }
@@ -742,7 +742,11 @@ public class LogicalPlanBuilder extends ExpressionBuilder {
             Attribute idAttr = new UnresolvedAttribute(source, IdFieldMapper.NAME);
             Attribute indexAttr = new UnresolvedAttribute(source, MetadataAttribute.INDEX);
             List<NamedExpression> aggregates = List.of(
-                new Alias(source, MetadataAttribute.SCORE, new Sum(source, scoreAttr, new Literal(source, true, DataType.BOOLEAN)))
+                new Alias(
+                    source,
+                    MetadataAttribute.SCORE,
+                    new Sum(source, scoreAttr, new Literal(source, true, DataType.BOOLEAN), context.pragmas())
+                )
             );
             List<Attribute> groupings = List.of(idAttr, indexAttr);
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/GrokExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/GrokExec.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 import org.elasticsearch.xpack.esql.plan.logical.Grok;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.io.IOException;
 import java.util.List;
@@ -47,7 +48,7 @@ public class GrokExec extends RegexExtractExec {
             source,
             in.readNamedWriteable(PhysicalPlan.class),
             in.readNamedWriteable(Expression.class),
-            Grok.pattern(source, in.readString()),
+            Grok.pattern(source, in.readString(), in.readNamedWriteable(QueryPragmas.class)),
             in.readNamedWriteableCollectionAsList(Attribute.class)
         );
     }
@@ -57,7 +58,7 @@ public class GrokExec extends RegexExtractExec {
         Source.EMPTY.writeTo(out);
         out.writeNamedWriteable(child());
         out.writeNamedWriteable(inputExpression());
-        out.writeString(pattern().pattern());
+        out.writeString(getParser().getPattern());
         out.writeNamedWriteableCollection(extractedFields());
     }
 
@@ -90,7 +91,7 @@ public class GrokExec extends RegexExtractExec {
         return Objects.hash(super.hashCode(), parser);
     }
 
-    public Grok.Parser pattern() {
+    public Grok.Parser getParser() {
         return parser;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -565,7 +565,7 @@ public class LocalExecutionPlanner {
         Map<String, Integer> fieldToPos = Maps.newHashMapWithExpectedSize(extractedFields.size());
         Map<String, ElementType> fieldToType = Maps.newHashMapWithExpectedSize(extractedFields.size());
         ElementType[] types = new ElementType[extractedFields.size()];
-        List<Attribute> extractedFieldsFromPattern = grok.pattern().extractedFields();
+        List<Attribute> extractedFieldsFromPattern = grok.getParser().extractedFields();
         for (int i = 0; i < extractedFields.size(); i++) {
             DataType extractedFieldType = extractedFields.get(i).dataType();
             // Names in pattern and layout can differ.
@@ -582,7 +582,7 @@ public class LocalExecutionPlanner {
             new ColumnExtractOperator.Factory(
                 types,
                 EvalMapper.toEvaluator(context.foldCtx(), grok.inputExpression(), layout),
-                () -> new GrokEvaluatorExtracter(grok.pattern().grok(), grok.pattern().pattern(), fieldToPos, fieldToType)
+                () -> new GrokEvaluatorExtracter(grok.getParser().getGrok(), grok.getParser().getPattern(), fieldToPos, fieldToType)
             ),
             layout
         );

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/QueryPragmas.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/QueryPragmas.java
@@ -7,9 +7,9 @@
 
 package org.elasticsearch.xpack.esql.plugin;
 
+import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -30,7 +30,7 @@ import java.util.Objects;
 /**
  * Holds the pragmas for an ESQL query. Just a wrapper of settings for now.
  */
-public final class QueryPragmas implements Writeable {
+public final class QueryPragmas implements NamedWriteable {
     public static final Setting<Integer> EXCHANGE_BUFFER_SIZE = Setting.intSetting("exchange_buffer_size", 10);
     public static final Setting<Integer> EXCHANGE_CONCURRENT_CLIENTS = Setting.intSetting("exchange_concurrent_clients", 2);
     public static final Setting<Integer> ENRICH_MAX_WORKERS = Setting.intSetting("enrich_max_workers", 1);
@@ -78,6 +78,8 @@ public final class QueryPragmas implements Writeable {
         "field_extract_preference",
         MappedFieldType.FieldExtractPreference.NONE
     );
+
+    public static final Setting<Boolean> NATIVE_FLOAT_TYPE = Setting.boolSetting("native_float_type", false);
 
     public static final QueryPragmas EMPTY = new QueryPragmas(Settings.EMPTY);
 
@@ -196,6 +198,13 @@ public final class QueryPragmas implements Writeable {
         return FIELD_EXTRACT_PREFERENCE.get(settings);
     }
 
+    /**
+     * Returns true if we let float type get pass type resolution
+     */
+    public boolean native_float_type() {
+        return NATIVE_FLOAT_TYPE.get(settings);
+    }
+
     public boolean isEmpty() {
         return settings.isEmpty();
     }
@@ -216,5 +225,10 @@ public final class QueryPragmas implements Writeable {
     @Override
     public String toString() {
         return settings.toString();
+    }
+
+    @Override
+    public String getWriteableName() {
+        return "query_params";
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeConverter.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeConverter.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.type;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.TriFunction;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
@@ -55,6 +56,7 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToTimeDur
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToUnsignedLong;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToVersion;
 import org.elasticsearch.xpack.esql.parser.ParsingException;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.elasticsearch.xpack.versionfield.Version;
 
 import java.io.IOException;
@@ -68,7 +70,6 @@ import java.time.temporal.TemporalAmount;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import static java.util.Map.entry;
@@ -115,27 +116,28 @@ public class EsqlDataTypeConverter {
 
     public static final DateFormatter HOUR_MINUTE_SECOND = DateFormatter.forPattern("strict_hour_minute_second_fraction");
 
-    private static final Map<DataType, BiFunction<Source, Expression, AbstractConvertFunction>> TYPE_TO_CONVERTER_FUNCTION = Map.ofEntries(
-        entry(AGGREGATE_METRIC_DOUBLE, ToAggregateMetricDouble::new),
-        entry(BOOLEAN, ToBoolean::new),
-        entry(CARTESIAN_POINT, ToCartesianPoint::new),
-        entry(CARTESIAN_SHAPE, ToCartesianShape::new),
-        entry(DATETIME, ToDatetime::new),
-        entry(DATE_NANOS, ToDateNanos::new),
-        // ToDegrees, typeless
-        entry(DOUBLE, ToDouble::new),
-        entry(GEO_POINT, ToGeoPoint::new),
-        entry(GEO_SHAPE, ToGeoShape::new),
-        entry(INTEGER, ToInteger::new),
-        entry(IP, ToIpLeadingZerosRejected::new),
-        entry(LONG, ToLong::new),
-        // ToRadians, typeless
-        entry(KEYWORD, ToString::new),
-        entry(UNSIGNED_LONG, ToUnsignedLong::new),
-        entry(VERSION, ToVersion::new),
-        entry(DATE_PERIOD, ToDatePeriod::new),
-        entry(TIME_DURATION, ToTimeDuration::new)
-    );
+    private static final Map<DataType, TriFunction<Source, Expression, QueryPragmas, AbstractConvertFunction>> TYPE_TO_CONVERTER_FUNCTION =
+        Map.ofEntries(
+            entry(AGGREGATE_METRIC_DOUBLE, ToAggregateMetricDouble::new),
+            entry(BOOLEAN, ToBoolean::new),
+            entry(CARTESIAN_POINT, ToCartesianPoint::new),
+            entry(CARTESIAN_SHAPE, ToCartesianShape::new),
+            entry(DATETIME, ToDatetime::new),
+            entry(DATE_NANOS, ToDateNanos::new),
+            // ToDegrees, typeless
+            entry(DOUBLE, ToDouble::new),
+            entry(GEO_POINT, ToGeoPoint::new),
+            entry(GEO_SHAPE, ToGeoShape::new),
+            entry(INTEGER, ToInteger::new),
+            entry(IP, ToIpLeadingZerosRejected::new),
+            entry(LONG, ToLong::new),
+            // ToRadians, typeless
+            entry(KEYWORD, ToString::new),
+            entry(UNSIGNED_LONG, ToUnsignedLong::new),
+            entry(VERSION, ToVersion::new),
+            entry(DATE_PERIOD, ToDatePeriod::new),
+            entry(TIME_DURATION, ToTimeDuration::new)
+        );
 
     public enum INTERVALS {
         // TIME_DURATION,
@@ -814,7 +816,7 @@ public class EsqlDataTypeConverter {
         }
     }
 
-    public static BiFunction<Source, Expression, AbstractConvertFunction> converterFunctionFactory(DataType toType) {
+    public static TriFunction<Source, Expression, QueryPragmas, AbstractConvertFunction> converterFunctionFactory(DataType toType) {
         return TYPE_TO_CONVERTER_FUNCTION.get(toType);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeRegistry.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.type;
 
 import org.elasticsearch.index.mapper.TimeSeriesParams;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 public class EsqlDataTypeRegistry {
 
@@ -16,7 +17,7 @@ public class EsqlDataTypeRegistry {
 
     private EsqlDataTypeRegistry() {}
 
-    public DataType fromEs(String typeName, TimeSeriesParams.MetricType metricType) {
+    public DataType fromEs(String typeName, TimeSeriesParams.MetricType metricType, QueryPragmas pragmas) {
         DataType type = DataType.fromEs(typeName);
         /*
          * If we're handling a time series COUNTER type field then convert it
@@ -24,6 +25,6 @@ public class EsqlDataTypeRegistry {
          * have time series counters for `double`, `long` and `int`, not `float`
          * and `half_float`, etc.
          */
-        return metricType == TimeSeriesParams.MetricType.COUNTER ? type.widenSmallNumeric().counter() : type;
+        return metricType == TimeSeriesParams.MetricType.COUNTER ? type.widenSmallNumeric(pragmas.native_float_type()).counter() : type;
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponseTests.java
@@ -56,6 +56,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.planner.PlannerUtils;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.elasticsearch.xpack.esql.type.UnsupportedEsFieldTests;
 import org.elasticsearch.xpack.versionfield.Version;
 import org.junit.After;
@@ -190,7 +191,7 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
                 || t == DataType.PARTIAL_AGG
                 || t == DataType.AGGREGATE_METRIC_DOUBLE,
             () -> randomFrom(DataType.types())
-        ).widenSmallNumeric();
+        ).widenSmallNumeric(QueryPragmas.EMPTY.native_float_type());
         return new ColumnInfoImpl(randomAlphaOfLength(10), type.esType(), randomOriginalTypes());
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTestUtils.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTestUtils.java
@@ -116,6 +116,12 @@ public final class AnalyzerTestUtils {
         );
     }
 
+    // TODO:
+    // 1) Add QueryPragmas as an additional "optional" argument here
+    // 2) Consider replacing with a builder. Even without the pragmas that's already too
+    // complex and error prone. Default values which magically getting threaded into tests
+    // may hide bugs.
+
     public static LogicalPlan analyze(String query) {
         return analyze(query, "mapping-basic.json");
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -86,6 +86,7 @@ import org.elasticsearch.xpack.esql.plan.logical.inference.Completion;
 import org.elasticsearch.xpack.esql.plan.logical.inference.Rerank;
 import org.elasticsearch.xpack.esql.plan.logical.local.EsqlProject;
 import org.elasticsearch.xpack.esql.plugin.EsqlPlugin;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.elasticsearch.xpack.esql.session.IndexResolver;
 
 import java.io.IOException;
@@ -184,7 +185,7 @@ public class AnalyzerTests extends ESTestCase {
     }
 
     public void testAttributeResolution() {
-        EsIndex idx = new EsIndex("idx", LoadMapping.loadMapping("mapping-one-field.json"));
+        EsIndex idx = new EsIndex("idx", new LoadMapping(QueryPragmas.EMPTY).loadMapping("mapping-one-field.json"));
         Analyzer analyzer = analyzer(IndexResolution.valid(idx));
 
         var plan = analyzer.analyze(
@@ -2927,7 +2928,8 @@ public class AnalyzerTests extends ESTestCase {
                     fieldCapabilitiesIndexResponse("bar", Map.of())
                 ),
                 List.of()
-            )
+            ),
+            QueryPragmas.EMPTY
         );
 
         String query = "FROM foo, bar | INSIST_🐔 message";
@@ -2947,7 +2949,8 @@ public class AnalyzerTests extends ESTestCase {
             new FieldCapabilitiesResponse(
                 List.of(fieldCapabilitiesIndexResponse("foo", messageResponseMap("long")), fieldCapabilitiesIndexResponse("bar", Map.of())),
                 List.of()
-            )
+            ),
+            QueryPragmas.EMPTY
         );
         var plan = analyze("FROM foo, bar | INSIST_🐔 message", analyzer(resolution, TEST_VERIFIER));
         var limit = as(plan, Limit.class);
@@ -2972,7 +2975,8 @@ public class AnalyzerTests extends ESTestCase {
                     fieldCapabilitiesIndexResponse("bazz", Map.of())
                 ),
                 List.of()
-            )
+            ),
+            QueryPragmas.EMPTY
         );
         var plan = analyze("FROM foo, bar | INSIST_🐔 message", analyzer(resolution, TEST_VERIFIER));
         var limit = as(plan, Limit.class);
@@ -2997,7 +3001,8 @@ public class AnalyzerTests extends ESTestCase {
                     fieldCapabilitiesIndexResponse("qux", Map.of())
                 ),
                 List.of()
-            )
+            ),
+            QueryPragmas.EMPTY
         );
         var plan = analyze("FROM foo, bar | INSIST_🐔 message", analyzer(resolution, TEST_VERIFIER));
         var limit = as(plan, Limit.class);
@@ -3021,7 +3026,8 @@ public class AnalyzerTests extends ESTestCase {
                     fieldCapabilitiesIndexResponse("bazz", Map.of())
                 ),
                 List.of()
-            )
+            ),
+            QueryPragmas.EMPTY
         );
         VerificationException e = expectThrows(
             VerificationException.class,
@@ -3472,7 +3478,7 @@ public class AnalyzerTests extends ESTestCase {
             new FieldCapabilitiesIndexResponse("idx", "idx", Map.of(), true, IndexMode.STANDARD)
         );
         FieldCapabilitiesResponse caps = new FieldCapabilitiesResponse(idxResponses, List.of());
-        IndexResolution resolution = IndexResolver.mergedMappings("test*", caps);
+        IndexResolution resolution = IndexResolver.mergedMappings("test*", caps, QueryPragmas.EMPTY);
         var analyzer = analyzer(resolution, TEST_VERIFIER, configuration(query));
         return analyze(query, analyzer);
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/ParsingTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/ParsingTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.xpack.esql.parser.QueryParam;
 import org.elasticsearch.xpack.esql.parser.QueryParams;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Row;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter;
 
 import java.io.IOException;
@@ -224,6 +225,6 @@ public class ParsingTests extends ESTestCase {
     }
 
     private static IndexResolution loadIndexResolution(String name) {
-        return IndexResolution.valid(new EsIndex(INDEX_NAME, LoadMapping.loadMapping(name)));
+        return IndexResolution.valid(new EsIndex(INDEX_NAME, new LoadMapping(QueryPragmas.EMPTY).loadMapping(name)));
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/enrich/EnrichPolicyResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/enrich/EnrichPolicyResolverTests.java
@@ -44,6 +44,7 @@ import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
 import org.elasticsearch.xpack.esql.action.EsqlExecutionInfo;
 import org.elasticsearch.xpack.esql.analysis.EnrichResolution;
 import org.elasticsearch.xpack.esql.plan.logical.Enrich;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.elasticsearch.xpack.esql.session.IndexResolver;
 import org.junit.After;
 import org.junit.Before;
@@ -71,6 +72,9 @@ public class EnrichPolicyResolverTests extends ESTestCase {
     private TestEnrichPolicyResolver localCluster;
     private TestEnrichPolicyResolver clusterA;
     private TestEnrichPolicyResolver clusterB;
+
+    // TODO inject from Gradle command
+    private QueryPragmas pragmas;
 
     @After
     public void stopClusters() {
@@ -170,7 +174,11 @@ public class EnrichPolicyResolverTests extends ESTestCase {
     public void testLocalHosts() {
         for (Enrich.Mode mode : Enrich.Mode.values()) {
             Set<String> clusters = Set.of(LOCAL_CLUSTER_GROUP_KEY);
-            var resolution = localCluster.resolvePolicies(clusters, List.of(new EnrichPolicyResolver.UnresolvedPolicy("hosts", mode)));
+            var resolution = localCluster.resolvePolicies(
+                clusters,
+                List.of(new EnrichPolicyResolver.UnresolvedPolicy("hosts", mode)),
+                QueryPragmas.EMPTY
+            );
             ResolvedEnrichPolicy resolved = resolution.getResolvedPolicy("hosts", mode);
             assertHostPolicies(resolved);
             assertThat(resolved.concreteIndices(), equalTo(Map.of("", ".enrich-hosts-123")));
@@ -180,7 +188,11 @@ public class EnrichPolicyResolverTests extends ESTestCase {
     public void testRemoteHosts() {
         Set<String> clusters = Set.of("cluster_a", "cluster_b");
         for (Enrich.Mode mode : Enrich.Mode.values()) {
-            var resolution = localCluster.resolvePolicies(clusters, List.of(new EnrichPolicyResolver.UnresolvedPolicy("hosts", mode)));
+            var resolution = localCluster.resolvePolicies(
+                clusters,
+                List.of(new EnrichPolicyResolver.UnresolvedPolicy("hosts", mode)),
+                QueryPragmas.EMPTY
+            );
             ResolvedEnrichPolicy resolved = resolution.getResolvedPolicy("hosts", mode);
             assertHostPolicies(resolved);
             var expectedIndices = switch (mode) {
@@ -195,7 +207,11 @@ public class EnrichPolicyResolverTests extends ESTestCase {
     public void testMixedHosts() {
         Set<String> clusters = Set.of(LOCAL_CLUSTER_GROUP_KEY, "cluster_a", "cluster_b");
         for (Enrich.Mode mode : Enrich.Mode.values()) {
-            var resolution = localCluster.resolvePolicies(clusters, List.of(new EnrichPolicyResolver.UnresolvedPolicy("hosts", mode)));
+            var resolution = localCluster.resolvePolicies(
+                clusters,
+                List.of(new EnrichPolicyResolver.UnresolvedPolicy("hosts", mode)),
+                QueryPragmas.EMPTY
+            );
             ResolvedEnrichPolicy resolved = resolution.getResolvedPolicy("hosts", mode);
             assertHostPolicies(resolved);
             var expectedIndices = switch (mode) {
@@ -209,7 +225,11 @@ public class EnrichPolicyResolverTests extends ESTestCase {
     public void testLocalAddress() {
         for (Enrich.Mode mode : Enrich.Mode.values()) {
             Set<String> clusters = Set.of(LOCAL_CLUSTER_GROUP_KEY);
-            var resolution = localCluster.resolvePolicies(clusters, List.of(new EnrichPolicyResolver.UnresolvedPolicy("address", mode)));
+            var resolution = localCluster.resolvePolicies(
+                clusters,
+                List.of(new EnrichPolicyResolver.UnresolvedPolicy("address", mode)),
+                QueryPragmas.EMPTY
+            );
             ResolvedEnrichPolicy resolved = resolution.getResolvedPolicy("address", mode);
             assertNotNull(resolved);
             assertThat(resolved.matchField(), equalTo("emp_id"));
@@ -220,7 +240,11 @@ public class EnrichPolicyResolverTests extends ESTestCase {
         {
             List<String> clusters = randomSubsetOf(between(1, 3), List.of("", "cluster_a", "cluster_a"));
             var mode = Enrich.Mode.COORDINATOR;
-            var resolution = localCluster.resolvePolicies(clusters, List.of(new EnrichPolicyResolver.UnresolvedPolicy("address", mode)));
+            var resolution = localCluster.resolvePolicies(
+                clusters,
+                List.of(new EnrichPolicyResolver.UnresolvedPolicy("address", mode)),
+                QueryPragmas.EMPTY
+            );
             ResolvedEnrichPolicy resolved = resolution.getResolvedPolicy("address", mode);
             assertNotNull(resolved);
             assertThat(resolved.matchField(), equalTo("emp_id"));
@@ -233,7 +257,11 @@ public class EnrichPolicyResolverTests extends ESTestCase {
     public void testRemoteAddress() {
         Set<String> clusters = Set.of("cluster_a", "cluster_b");
         for (Enrich.Mode mode : List.of(Enrich.Mode.ANY, Enrich.Mode.REMOTE)) {
-            var resolution = localCluster.resolvePolicies(clusters, List.of(new EnrichPolicyResolver.UnresolvedPolicy("address", mode)));
+            var resolution = localCluster.resolvePolicies(
+                clusters,
+                List.of(new EnrichPolicyResolver.UnresolvedPolicy("address", mode)),
+                QueryPragmas.EMPTY
+            );
             assertNull(resolution.getResolvedPolicy("address", mode));
             var msg = "enrich policy [address] has different enrich fields across clusters; "
                 + "these fields are missing in some policies: [state]";
@@ -244,7 +272,11 @@ public class EnrichPolicyResolverTests extends ESTestCase {
     public void testMixedAddress() {
         Set<String> clusters = Set.of(LOCAL_CLUSTER_GROUP_KEY, "cluster_a", "cluster_b");
         for (Enrich.Mode mode : List.of(Enrich.Mode.ANY, Enrich.Mode.REMOTE)) {
-            var resolution = localCluster.resolvePolicies(clusters, List.of(new EnrichPolicyResolver.UnresolvedPolicy("hosts", mode)));
+            var resolution = localCluster.resolvePolicies(
+                clusters,
+                List.of(new EnrichPolicyResolver.UnresolvedPolicy("hosts", mode)),
+                QueryPragmas.EMPTY
+            );
             ResolvedEnrichPolicy resolved = resolution.getResolvedPolicy("hosts", mode);
             assertHostPolicies(resolved);
             assertThat(
@@ -258,7 +290,11 @@ public class EnrichPolicyResolverTests extends ESTestCase {
     public void testLocalAuthor() {
         for (Enrich.Mode mode : Enrich.Mode.values()) {
             Set<String> clusters = Set.of(LOCAL_CLUSTER_GROUP_KEY);
-            var resolution = localCluster.resolvePolicies(clusters, List.of(new EnrichPolicyResolver.UnresolvedPolicy("author", mode)));
+            var resolution = localCluster.resolvePolicies(
+                clusters,
+                List.of(new EnrichPolicyResolver.UnresolvedPolicy("author", mode)),
+                QueryPragmas.EMPTY
+            );
             ResolvedEnrichPolicy resolved = resolution.getResolvedPolicy("author", mode);
             assertNotNull(resolved);
             assertThat(resolved.matchField(), equalTo("author"));
@@ -269,7 +305,11 @@ public class EnrichPolicyResolverTests extends ESTestCase {
         {
             var mode = Enrich.Mode.COORDINATOR;
             var clusters = randomSubsetOf(between(1, 3), Set.of("", "cluster_a", "cluster_b"));
-            var resolution = localCluster.resolvePolicies(clusters, List.of(new EnrichPolicyResolver.UnresolvedPolicy("author", mode)));
+            var resolution = localCluster.resolvePolicies(
+                clusters,
+                List.of(new EnrichPolicyResolver.UnresolvedPolicy("author", mode)),
+                QueryPragmas.EMPTY
+            );
             ResolvedEnrichPolicy resolved = resolution.getResolvedPolicy("author", mode);
             assertNotNull(resolved);
             assertThat(resolved.matchField(), equalTo("author"));
@@ -284,7 +324,11 @@ public class EnrichPolicyResolverTests extends ESTestCase {
         Set<String> clusters = Set.of("cluster_a");
         {
             var mode = Enrich.Mode.ANY;
-            var resolution = localCluster.resolvePolicies(clusters, List.of(new EnrichPolicyResolver.UnresolvedPolicy("author", mode)));
+            var resolution = localCluster.resolvePolicies(
+                clusters,
+                List.of(new EnrichPolicyResolver.UnresolvedPolicy("author", mode)),
+                QueryPragmas.EMPTY
+            );
             assertNull(resolution.getResolvedPolicy("author", mode));
             assertThat(
                 resolution.getError("author", mode),
@@ -293,7 +337,11 @@ public class EnrichPolicyResolverTests extends ESTestCase {
         }
         {
             var mode = Enrich.Mode.REMOTE;
-            var resolution = localCluster.resolvePolicies(clusters, List.of(new EnrichPolicyResolver.UnresolvedPolicy("author", mode)));
+            var resolution = localCluster.resolvePolicies(
+                clusters,
+                List.of(new EnrichPolicyResolver.UnresolvedPolicy("author", mode)),
+                pragmas
+            );
             ResolvedEnrichPolicy resolved = resolution.getResolvedPolicy("author", mode);
             assertNotNull(resolved);
             assertThat(resolved.matchType(), equalTo("range"));
@@ -308,7 +356,11 @@ public class EnrichPolicyResolverTests extends ESTestCase {
         Set<String> clusters = Set.of("cluster_b");
         {
             var mode = Enrich.Mode.ANY;
-            var resolution = localCluster.resolvePolicies(clusters, List.of(new EnrichPolicyResolver.UnresolvedPolicy("author", mode)));
+            var resolution = localCluster.resolvePolicies(
+                clusters,
+                List.of(new EnrichPolicyResolver.UnresolvedPolicy("author", mode)),
+                pragmas
+            );
             assertNull(resolution.getResolvedPolicy("author", mode));
             assertThat(
                 resolution.getError("author", mode),
@@ -317,7 +369,11 @@ public class EnrichPolicyResolverTests extends ESTestCase {
         }
         {
             var mode = Enrich.Mode.REMOTE;
-            var resolution = localCluster.resolvePolicies(clusters, List.of(new EnrichPolicyResolver.UnresolvedPolicy("author", mode)));
+            var resolution = localCluster.resolvePolicies(
+                clusters,
+                List.of(new EnrichPolicyResolver.UnresolvedPolicy("author", mode)),
+                pragmas
+            );
             ResolvedEnrichPolicy resolved = resolution.getResolvedPolicy("author", mode);
             assertNotNull(resolved);
             assertThat(resolved.matchType(), equalTo("match"));
@@ -332,7 +388,11 @@ public class EnrichPolicyResolverTests extends ESTestCase {
         Set<String> clusters = Set.of("cluster_a", "cluster_b");
         {
             var mode = Enrich.Mode.ANY;
-            var resolution = localCluster.resolvePolicies(clusters, List.of(new EnrichPolicyResolver.UnresolvedPolicy("author", mode)));
+            var resolution = localCluster.resolvePolicies(
+                clusters,
+                List.of(new EnrichPolicyResolver.UnresolvedPolicy("author", mode)),
+                pragmas
+            );
             assertNull(resolution.getResolvedPolicy("author", mode));
             assertThat(
                 resolution.getError("author", mode),
@@ -341,7 +401,11 @@ public class EnrichPolicyResolverTests extends ESTestCase {
         }
         {
             var mode = Enrich.Mode.REMOTE;
-            var resolution = localCluster.resolvePolicies(clusters, List.of(new EnrichPolicyResolver.UnresolvedPolicy("author", mode)));
+            var resolution = localCluster.resolvePolicies(
+                clusters,
+                List.of(new EnrichPolicyResolver.UnresolvedPolicy("author", mode)),
+                pragmas
+            );
             assertNull(resolution.getResolvedPolicy("author", mode));
             assertThat(
                 resolution.getError("author", mode),
@@ -354,7 +418,11 @@ public class EnrichPolicyResolverTests extends ESTestCase {
         Set<String> clusters = Set.of("", "cluster_b");
         {
             var mode = Enrich.Mode.ANY;
-            var resolution = localCluster.resolvePolicies(clusters, List.of(new EnrichPolicyResolver.UnresolvedPolicy("author", mode)));
+            var resolution = localCluster.resolvePolicies(
+                clusters,
+                List.of(new EnrichPolicyResolver.UnresolvedPolicy("author", mode)),
+                pragmas
+            );
             assertNull(resolution.getResolvedPolicy("author", mode));
             assertThat(
                 resolution.getError("author", mode),
@@ -363,7 +431,11 @@ public class EnrichPolicyResolverTests extends ESTestCase {
         }
         {
             var mode = Enrich.Mode.REMOTE;
-            var resolution = localCluster.resolvePolicies(clusters, List.of(new EnrichPolicyResolver.UnresolvedPolicy("author", mode)));
+            var resolution = localCluster.resolvePolicies(
+                clusters,
+                List.of(new EnrichPolicyResolver.UnresolvedPolicy("author", mode)),
+                pragmas
+            );
             assertNull(resolution.getResolvedPolicy("author", mode));
             assertThat(
                 resolution.getError("author", mode),
@@ -374,7 +446,11 @@ public class EnrichPolicyResolverTests extends ESTestCase {
 
     public void testMissingLocalPolicy() {
         for (Enrich.Mode mode : Enrich.Mode.values()) {
-            var resolution = localCluster.resolvePolicies(Set.of(""), List.of(new EnrichPolicyResolver.UnresolvedPolicy("authoz", mode)));
+            var resolution = localCluster.resolvePolicies(
+                Set.of(""),
+                List.of(new EnrichPolicyResolver.UnresolvedPolicy("authoz", mode)),
+                pragmas
+            );
             assertNull(resolution.getResolvedPolicy("authoz", mode));
             assertThat(resolution.getError("authoz", mode), equalTo("cannot find enrich policy [authoz], did you mean [author]?"));
         }
@@ -385,7 +461,8 @@ public class EnrichPolicyResolverTests extends ESTestCase {
             var mode = Enrich.Mode.REMOTE;
             var resolution = localCluster.resolvePolicies(
                 Set.of("cluster_a"),
-                List.of(new EnrichPolicyResolver.UnresolvedPolicy("addrezz", mode))
+                List.of(new EnrichPolicyResolver.UnresolvedPolicy("addrezz", mode)),
+                pragmas
             );
             assertNull(resolution.getResolvedPolicy("addrezz", mode));
             assertThat(resolution.getError("addrezz", mode), equalTo("cannot find enrich policy [addrezz] on clusters [cluster_a]"));
@@ -394,7 +471,8 @@ public class EnrichPolicyResolverTests extends ESTestCase {
             var mode = Enrich.Mode.ANY;
             var resolution = localCluster.resolvePolicies(
                 Set.of("cluster_a"),
-                List.of(new EnrichPolicyResolver.UnresolvedPolicy("addrezz", mode))
+                List.of(new EnrichPolicyResolver.UnresolvedPolicy("addrezz", mode)),
+                pragmas
             );
             assertNull(resolution.getResolvedPolicy("addrezz", mode));
             assertThat(
@@ -433,7 +511,11 @@ public class EnrichPolicyResolverTests extends ESTestCase {
             this.mappings = mappings;
         }
 
-        EnrichResolution resolvePolicies(Collection<String> clusters, Collection<UnresolvedPolicy> unresolvedPolicies) {
+        EnrichResolution resolvePolicies(
+            Collection<String> clusters,
+            Collection<UnresolvedPolicy> unresolvedPolicies,
+            QueryPragmas pragmas
+        ) {
             PlainActionFuture<EnrichResolution> future = new PlainActionFuture<>();
             EsqlExecutionInfo esqlExecutionInfo = new EsqlExecutionInfo(true);
             for (String cluster : clusters) {
@@ -452,7 +534,7 @@ public class EnrichPolicyResolverTests extends ESTestCase {
                     unresolvedPolicies.add(new UnresolvedPolicy("legacy-policy-1", randomFrom(Enrich.Mode.values())));
                 }
             }
-            super.resolvePolicies(unresolvedPolicies, esqlExecutionInfo, future);
+            super.resolvePolicies(unresolvedPolicies, esqlExecutionInfo, pragmas, future);
             return future.actionGet(30, TimeUnit.SECONDS);
         }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/AbstractExpressionSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/AbstractExpressionSerializationTests.java
@@ -12,8 +12,15 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Node;
 import org.elasticsearch.xpack.esql.expression.function.ReferenceAttributeTests;
 import org.elasticsearch.xpack.esql.plan.AbstractNodeSerializationTests;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 public abstract class AbstractExpressionSerializationTests<T extends Expression> extends AbstractNodeSerializationTests<T> {
+    // TODO:
+    // - move to `ESQLTestCase` (unify with ErrorsForCasesWithoutExampleTestCase and more)
+    // - Provide better implementation, maybe fetch the pragmas from gradle parameters.
+    protected QueryPragmas getPragmas() {
+        return QueryPragmas.EMPTY;
+    }
 
     public static Expression randomChild() {
         return ReferenceAttributeTests.randomReferenceAttribute(false);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractScalarFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractScalarFunctionTestCase.java
@@ -409,11 +409,14 @@ public abstract class AbstractScalarFunctionTestCase extends AbstractFunctionTes
 
         Set<List<DataType>> valid = testCaseSuppliers.stream().map(TestCaseSupplier::types).collect(Collectors.toSet());
 
+        // Assume that the whole suite runs with the same query pragmas.
+        var pragmas = testCaseSuppliers.getFirst().get().getConfiguration().pragmas();
+
         testCaseSuppliers.stream()
             .map(s -> s.types().size())
             .collect(Collectors.toSet())
             .stream()
-            .flatMap(count -> allPermutations(count))
+            .flatMap(count -> allPermutations(count, pragmas))
             .filter(types -> valid.contains(types) == false)
             .map(types -> new TestCaseSupplier("type error for " + TestCaseSupplier.nameFromTypes(types), types, () -> {
                 throw new IllegalStateException("must implement a case for " + types);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/ErrorsForCasesWithoutExamplesTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/ErrorsForCasesWithoutExamplesTestCase.java
@@ -13,6 +13,7 @@ import org.elasticsearch.xpack.esql.core.expression.TypeResolutions;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvCountErrorTests;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.hamcrest.Matcher;
 
 import java.util.ArrayList;
@@ -102,7 +103,7 @@ public abstract class ErrorsForCasesWithoutExamplesTestCase extends ESTestCase {
             .map(s -> s.types().size())
             .collect(Collectors.toSet())
             .stream()
-            .flatMap(AbstractFunctionTestCase::allPermutations)
+            .flatMap(x -> AbstractFunctionTestCase.allPermutations(x, QueryPragmas.EMPTY))
             .filter(types -> valid.contains(types) == false)
             /*
              * Skip any cases with more than one null. Our tests don't generate
@@ -188,5 +189,12 @@ public abstract class ErrorsForCasesWithoutExamplesTestCase extends ESTestCase {
                 + "]";
 
         }
+    }
+
+    // TODO:
+    // - move to `ESQLTestCase`
+    // - Provide real implementation, maybe fetch the pragmas from gradle parameters.
+    protected QueryPragmas getPragmas() {
+        return QueryPragmas.EMPTY;
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AvgErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AvgErrorTests.java
@@ -27,7 +27,7 @@ public class AvgErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new Avg(source, args.get(0));
+        return new Avg(source, args.get(0), getPragmas());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AvgOverTimeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AvgOverTimeTests.java
@@ -30,6 +30,6 @@ public class AvgOverTimeTests extends AbstractFunctionTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new AvgOverTime(source, args.get(0));
+        return new AvgOverTime(source, args.getFirst(), getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AvgSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AvgSerializationTests.java
@@ -14,11 +14,15 @@ import java.io.IOException;
 public class AvgSerializationTests extends AbstractExpressionSerializationTests<Avg> {
     @Override
     protected Avg createTestInstance() {
-        return new Avg(randomSource(), randomChild());
+        return new Avg(randomSource(), randomChild(), getPragmas());
     }
 
     @Override
     protected Avg mutateInstance(Avg instance) throws IOException {
-        return new Avg(instance.source(), randomValueOtherThan(instance.field(), AbstractExpressionSerializationTests::randomChild));
+        return new Avg(
+            instance.source(),
+            randomValueOtherThan(instance.field(), AbstractExpressionSerializationTests::randomChild),
+            getPragmas()
+        );
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AvgTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AvgTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.AbstractAggregationTestCase;
 import org.elasticsearch.xpack.esql.expression.function.MultiRowTestCaseSupplier;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -58,7 +59,7 @@ public class AvgTests extends AbstractAggregationTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new Avg(source, args.get(0));
+        return new Avg(source, args.getFirst(), getPragmas());
     }
 
     private static TestCaseSupplier makeSupplier(TestCaseSupplier.TypedDataSupplier fieldSupplier) {
@@ -72,7 +73,7 @@ public class AvgTests extends AbstractAggregationTestCase {
                 // For single elements, we directly return them to avoid precision issues
                 expected = ((Number) fieldData.get(0)).doubleValue();
             } else if (fieldData.size() > 1) {
-                expected = switch (fieldTypedData.type().widenSmallNumeric()) {
+                expected = switch (fieldTypedData.type().widenSmallNumeric(QueryPragmas.EMPTY.native_float_type())) {
                     case INTEGER -> fieldData.stream()
                         .map(v -> (Integer) v)
                         .collect(Collectors.summarizingInt(Integer::intValue))

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinctOverTimeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinctOverTimeTests.java
@@ -30,6 +30,6 @@ public class CountDistinctOverTimeTests extends AbstractFunctionTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new CountDistinctOverTime(source, args.get(0), args.size() > 1 ? args.get(1) : null);
+        return new CountDistinctOverTime(source, args.get(0), args.size() > 1 ? args.get(1) : null, getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinctSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinctSerializationTests.java
@@ -19,7 +19,7 @@ public class CountDistinctSerializationTests extends AbstractExpressionSerializa
         Source source = randomSource();
         Expression field = randomChild();
         Expression precision = randomBoolean() ? null : randomChild();
-        return new CountDistinct(source, field, precision);
+        return new CountDistinct(source, field, precision, getPragmas());
     }
 
     @Override
@@ -32,6 +32,6 @@ public class CountDistinctSerializationTests extends AbstractExpressionSerializa
         } else {
             precision = randomValueOtherThan(precision, () -> randomBoolean() ? null : randomChild());
         }
-        return new CountDistinct(source, field, precision);
+        return new CountDistinct(source, field, precision, getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinctTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinctTests.java
@@ -97,7 +97,7 @@ public class CountDistinctTests extends AbstractAggregationTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new CountDistinct(source, args.get(0), args.size() > 1 ? args.get(1) : null);
+        return new CountDistinct(source, args.get(0), args.size() > 1 ? args.get(1) : null, getPragmas());
     }
 
     private static TestCaseSupplier makeSupplier(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountOverTimeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountOverTimeTests.java
@@ -30,6 +30,6 @@ public class CountOverTimeTests extends AbstractFunctionTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new CountOverTime(source, args.get(0));
+        return new CountOverTime(source, args.getFirst(), getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountSerializationTests.java
@@ -14,11 +14,15 @@ import java.io.IOException;
 public class CountSerializationTests extends AbstractExpressionSerializationTests<Count> {
     @Override
     protected Count createTestInstance() {
-        return new Count(randomSource(), randomChild());
+        return new Count(randomSource(), randomChild(), getPragmas());
     }
 
     @Override
     protected Count mutateInstance(Count instance) throws IOException {
-        return new Count(instance.source(), randomValueOtherThan(instance.field(), AbstractExpressionSerializationTests::randomChild));
+        return new Count(
+            instance.source(),
+            randomValueOtherThan(instance.field(), AbstractExpressionSerializationTests::randomChild),
+            getPragmas()
+        );
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountTests.java
@@ -86,7 +86,7 @@ public class CountTests extends AbstractAggregationTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new Count(source, args.get(0));
+        return new Count(source, args.getFirst(), getPragmas());
     }
 
     private static TestCaseSupplier makeSupplier(TestCaseSupplier.TypedDataSupplier fieldSupplier) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/MedianAbsoluteDeviationSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/MedianAbsoluteDeviationSerializationTests.java
@@ -14,14 +14,15 @@ import java.io.IOException;
 public class MedianAbsoluteDeviationSerializationTests extends AbstractExpressionSerializationTests<MedianAbsoluteDeviation> {
     @Override
     protected MedianAbsoluteDeviation createTestInstance() {
-        return new MedianAbsoluteDeviation(randomSource(), randomChild());
+        return new MedianAbsoluteDeviation(randomSource(), randomChild(), getPragmas());
     }
 
     @Override
     protected MedianAbsoluteDeviation mutateInstance(MedianAbsoluteDeviation instance) throws IOException {
         return new MedianAbsoluteDeviation(
             instance.source(),
-            randomValueOtherThan(instance.field(), AbstractExpressionSerializationTests::randomChild)
+            randomValueOtherThan(instance.field(), AbstractExpressionSerializationTests::randomChild),
+            getPragmas()
         );
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/MedianAbsoluteDeviationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/MedianAbsoluteDeviationTests.java
@@ -44,7 +44,7 @@ public class MedianAbsoluteDeviationTests extends AbstractAggregationTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new MedianAbsoluteDeviation(source, args.get(0));
+        return new MedianAbsoluteDeviation(source, args.getFirst(), getPragmas());
     }
 
     private static TestCaseSupplier makeSupplier(TestCaseSupplier.TypedDataSupplier fieldSupplier) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/MedianSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/MedianSerializationTests.java
@@ -14,11 +14,15 @@ import java.io.IOException;
 public class MedianSerializationTests extends AbstractExpressionSerializationTests<Median> {
     @Override
     protected Median createTestInstance() {
-        return new Median(randomSource(), randomChild());
+        return new Median(randomSource(), randomChild(), getPragmas());
     }
 
     @Override
     protected Median mutateInstance(Median instance) throws IOException {
-        return new Median(instance.source(), randomValueOtherThan(instance.field(), AbstractExpressionSerializationTests::randomChild));
+        return new Median(
+            instance.source(),
+            randomValueOtherThan(instance.field(), AbstractExpressionSerializationTests::randomChild),
+            getPragmas()
+        );
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/MedianTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/MedianTests.java
@@ -78,7 +78,7 @@ public class MedianTests extends AbstractAggregationTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new Median(source, args.get(0));
+        return new Median(source, args.getFirst(), getPragmas());
     }
 
     private static TestCaseSupplier makeSupplier(TestCaseSupplier.TypedDataSupplier fieldSupplier) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/PercentileErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/PercentileErrorTests.java
@@ -27,7 +27,7 @@ public class PercentileErrorTests extends ErrorsForCasesWithoutExamplesTestCase 
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new Percentile(source, args.get(0), args.get(1));
+        return new Percentile(source, args.get(0), args.get(1), getPragmas());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/PercentileSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/PercentileSerializationTests.java
@@ -19,7 +19,7 @@ public class PercentileSerializationTests extends AbstractExpressionSerializatio
         Source source = randomSource();
         Expression field = randomChild();
         Expression percentile = randomChild();
-        return new Percentile(source, field, percentile);
+        return new Percentile(source, field, percentile, getPragmas());
     }
 
     @Override
@@ -32,6 +32,6 @@ public class PercentileSerializationTests extends AbstractExpressionSerializatio
         } else {
             percentile = randomValueOtherThan(percentile, AbstractExpressionSerializationTests::randomChild);
         }
-        return new Percentile(source, field, percentile);
+        return new Percentile(source, field, percentile, getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/PercentileTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/PercentileTests.java
@@ -58,7 +58,7 @@ public class PercentileTests extends AbstractAggregationTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new Percentile(source, args.get(0), args.get(1));
+        return new Percentile(source, args.get(0), args.get(1), getPragmas());
     }
 
     private static TestCaseSupplier makeSupplier(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SumSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SumSerializationTests.java
@@ -14,11 +14,15 @@ import java.io.IOException;
 public class SumSerializationTests extends AbstractExpressionSerializationTests<Sum> {
     @Override
     protected Sum createTestInstance() {
-        return new Sum(randomSource(), randomChild());
+        return new Sum(randomSource(), randomChild(), getPragmas());
     }
 
     @Override
     protected Sum mutateInstance(Sum instance) throws IOException {
-        return new Sum(instance.source(), randomValueOtherThan(instance.field(), AbstractExpressionSerializationTests::randomChild));
+        return new Sum(
+            instance.source(),
+            randomValueOtherThan(instance.field(), AbstractExpressionSerializationTests::randomChild),
+            getPragmas()
+        );
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SumTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SumTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.AbstractAggregationTestCase;
 import org.elasticsearch.xpack.esql.expression.function.MultiRowTestCaseSupplier;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -82,7 +83,7 @@ public class SumTests extends AbstractAggregationTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new Sum(source, args.get(0));
+        return new Sum(source, args.getFirst(), getPragmas());
     }
 
     private static TestCaseSupplier makeSupplier(TestCaseSupplier.TypedDataSupplier fieldSupplier) {
@@ -92,7 +93,7 @@ public class SumTests extends AbstractAggregationTestCase {
             Object expected;
 
             try {
-                expected = switch (fieldTypedData.type().widenSmallNumeric()) {
+                expected = switch (fieldTypedData.type().widenSmallNumeric(QueryPragmas.EMPTY.native_float_type())) {
                     case INTEGER -> fieldTypedData.multiRowData()
                         .stream()
                         .map(v -> (Integer) v)

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/WeightedAvgTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/WeightedAvgTests.java
@@ -95,7 +95,7 @@ public class WeightedAvgTests extends AbstractAggregationTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new WeightedAvg(source, args.get(0), args.get(1));
+        return new WeightedAvg(source, args.get(0), args.get(1), getPragmas());
     }
 
     private static TestCaseSupplier makeSupplier(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToAggregateMetricDoubleTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToAggregateMetricDoubleTests.java
@@ -36,7 +36,7 @@ public class ToAggregateMetricDoubleTests extends AbstractScalarFunctionTestCase
         if (args.get(0).dataType() == DataType.AGGREGATE_METRIC_DOUBLE) {
             assumeTrue("Test sometimes wraps literals as fields", args.get(0).foldable());
         }
-        return new ToAggregateMetricDouble(source, args.get(0));
+        return new ToAggregateMetricDouble(source, args.getFirst(), getPragmas());
     }
 
     @ParametersFactory

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToBooleanErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToBooleanErrorTests.java
@@ -27,7 +27,7 @@ public class ToBooleanErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToBoolean(source, args.get(0));
+        return new ToBoolean(source, args.getFirst(), getPragmas());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToBooleanSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToBooleanSerializationTests.java
@@ -14,6 +14,6 @@ import org.elasticsearch.xpack.esql.expression.AbstractUnaryScalarSerializationT
 public class ToBooleanSerializationTests extends AbstractUnaryScalarSerializationTests<ToBoolean> {
     @Override
     protected ToBoolean create(Source source, Expression child) {
-        return new ToBoolean(source, child);
+        return new ToBoolean(source, child, getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToBooleanTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToBooleanTests.java
@@ -85,6 +85,6 @@ public class ToBooleanTests extends AbstractScalarFunctionTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToBoolean(source, args.get(0));
+        return new ToBoolean(source, args.getFirst(), getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianPointErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianPointErrorTests.java
@@ -27,7 +27,7 @@ public class ToCartesianPointErrorTests extends ErrorsForCasesWithoutExamplesTes
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToCartesianPoint(source, args.get(0));
+        return new ToCartesianPoint(source, args.getFirst(), getPragmas());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianPointSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianPointSerializationTests.java
@@ -14,6 +14,6 @@ import org.elasticsearch.xpack.esql.expression.AbstractUnaryScalarSerializationT
 public class ToCartesianPointSerializationTests extends AbstractUnaryScalarSerializationTests<ToCartesianPoint> {
     @Override
     protected ToCartesianPoint create(Source source, Expression child) {
-        return new ToCartesianPoint(source, child);
+        return new ToCartesianPoint(source, child, getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianPointTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianPointTests.java
@@ -77,6 +77,6 @@ public class ToCartesianPointTests extends AbstractScalarFunctionTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToCartesianPoint(source, args.get(0));
+        return new ToCartesianPoint(source, args.getFirst(), getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianShapeErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianShapeErrorTests.java
@@ -27,7 +27,7 @@ public class ToCartesianShapeErrorTests extends ErrorsForCasesWithoutExamplesTes
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToCartesianShape(source, args.get(0));
+        return new ToCartesianShape(source, args.getFirst(), getPragmas());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianShapeSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianShapeSerializationTests.java
@@ -14,6 +14,6 @@ import org.elasticsearch.xpack.esql.expression.AbstractUnaryScalarSerializationT
 public class ToCartesianShapeSerializationTests extends AbstractUnaryScalarSerializationTests<ToCartesianShape> {
     @Override
     protected ToCartesianShape create(Source source, Expression child) {
-        return new ToCartesianShape(source, child);
+        return new ToCartesianShape(source, child, getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianShapeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianShapeTests.java
@@ -78,6 +78,6 @@ public class ToCartesianShapeTests extends AbstractScalarFunctionTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToCartesianShape(source, args.get(0));
+        return new ToCartesianShape(source, args.getFirst(), getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDateNanosErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDateNanosErrorTests.java
@@ -27,7 +27,7 @@ public class ToDateNanosErrorTests extends ErrorsForCasesWithoutExamplesTestCase
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToDateNanos(source, args.get(0));
+        return new ToDateNanos(source, args.getFirst(), getPragmas());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDateNanosSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDateNanosSerializationTests.java
@@ -14,6 +14,6 @@ import org.elasticsearch.xpack.esql.expression.AbstractUnaryScalarSerializationT
 public class ToDateNanosSerializationTests extends AbstractUnaryScalarSerializationTests<ToDateNanos> {
     @Override
     protected ToDateNanos create(Source source, Expression child) {
-        return new ToDateNanos(source, child);
+        return new ToDateNanos(source, child, getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDateNanosTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDateNanosTests.java
@@ -137,6 +137,6 @@ public class ToDateNanosTests extends AbstractScalarFunctionTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToDateNanos(source, args.get(0));
+        return new ToDateNanos(source, args.getFirst(), getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDatePeriodErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDatePeriodErrorTests.java
@@ -27,7 +27,7 @@ public class ToDatePeriodErrorTests extends ErrorsForCasesWithoutExamplesTestCas
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToDatePeriod(source, args.get(0));
+        return new ToDatePeriod(source, args.getFirst(), getPragmas());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDatePeriodTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDatePeriodTests.java
@@ -76,7 +76,7 @@ public class ToDatePeriodTests extends AbstractScalarFunctionTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToDatePeriod(source, args.get(0));
+        return new ToDatePeriod(source, args.getFirst(), getPragmas());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDatetimeErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDatetimeErrorTests.java
@@ -27,7 +27,7 @@ public class ToDatetimeErrorTests extends ErrorsForCasesWithoutExamplesTestCase 
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToDatetime(source, args.get(0));
+        return new ToDatetime(source, args.getFirst(), getPragmas());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDatetimeSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDatetimeSerializationTests.java
@@ -14,6 +14,6 @@ import org.elasticsearch.xpack.esql.expression.AbstractUnaryScalarSerializationT
 public class ToDatetimeSerializationTests extends AbstractUnaryScalarSerializationTests<ToDatetime> {
     @Override
     protected ToDatetime create(Source source, Expression child) {
-        return new ToDatetime(source, child);
+        return new ToDatetime(source, child, getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDatetimeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDatetimeTests.java
@@ -187,6 +187,6 @@ public class ToDatetimeTests extends AbstractScalarFunctionTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToDatetime(source, args.get(0));
+        return new ToDatetime(source, args.getFirst(), getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDegreesErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDegreesErrorTests.java
@@ -27,7 +27,7 @@ public class ToDegreesErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToDegrees(source, args.get(0));
+        return new ToDegrees(source, args.getFirst(), getPragmas());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDegreesSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDegreesSerializationTests.java
@@ -14,6 +14,6 @@ import org.elasticsearch.xpack.esql.expression.AbstractUnaryScalarSerializationT
 public class ToDegreesSerializationTests extends AbstractUnaryScalarSerializationTests<ToDegrees> {
     @Override
     protected ToDegrees create(Source source, Expression child) {
-        return new ToDegrees(source, child);
+        return new ToDegrees(source, child, getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDegreesTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDegreesTests.java
@@ -95,6 +95,6 @@ public class ToDegreesTests extends AbstractScalarFunctionTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToDegrees(source, args.get(0));
+        return new ToDegrees(source, args.getFirst(), getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDoubleErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDoubleErrorTests.java
@@ -27,7 +27,7 @@ public class ToDoubleErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToDouble(source, args.get(0));
+        return new ToDouble(source, args.getFirst(), getPragmas());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDoubleSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDoubleSerializationTests.java
@@ -14,6 +14,6 @@ import org.elasticsearch.xpack.esql.expression.AbstractUnaryScalarSerializationT
 public class ToDoubleSerializationTests extends AbstractUnaryScalarSerializationTests<ToDouble> {
     @Override
     protected ToDouble create(Source source, Expression child) {
-        return new ToDouble(source, child);
+        return new ToDouble(source, child, getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDoubleTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDoubleTests.java
@@ -149,6 +149,6 @@ public class ToDoubleTests extends AbstractScalarFunctionTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToDouble(source, args.get(0));
+        return new ToDouble(source, args.getFirst(), getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoPointErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoPointErrorTests.java
@@ -27,7 +27,7 @@ public class ToGeoPointErrorTests extends ErrorsForCasesWithoutExamplesTestCase 
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToGeoPoint(source, args.get(0));
+        return new ToGeoPoint(source, args.getFirst(), getPragmas());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoPointSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoPointSerializationTests.java
@@ -14,6 +14,6 @@ import org.elasticsearch.xpack.esql.expression.AbstractUnaryScalarSerializationT
 public class ToGeoPointSerializationTests extends AbstractUnaryScalarSerializationTests<ToGeoPoint> {
     @Override
     protected ToGeoPoint create(Source source, Expression child) {
-        return new ToGeoPoint(source, child);
+        return new ToGeoPoint(source, child, getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoPointTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoPointTests.java
@@ -71,6 +71,6 @@ public class ToGeoPointTests extends AbstractScalarFunctionTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToGeoPoint(source, args.get(0));
+        return new ToGeoPoint(source, args.getFirst(), getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoShapeErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoShapeErrorTests.java
@@ -27,7 +27,7 @@ public class ToGeoShapeErrorTests extends ErrorsForCasesWithoutExamplesTestCase 
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToGeoShape(source, args.get(0));
+        return new ToGeoShape(source, args.getFirst(), getPragmas());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoShapeSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoShapeSerializationTests.java
@@ -14,6 +14,6 @@ import org.elasticsearch.xpack.esql.expression.AbstractUnaryScalarSerializationT
 public class ToGeoShapeSerializationTests extends AbstractUnaryScalarSerializationTests<ToGeoShape> {
     @Override
     protected ToGeoShape create(Source source, Expression child) {
-        return new ToGeoShape(source, child);
+        return new ToGeoShape(source, child, getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoShapeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoShapeTests.java
@@ -71,6 +71,6 @@ public class ToGeoShapeTests extends AbstractScalarFunctionTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToGeoShape(source, args.get(0));
+        return new ToGeoShape(source, args.getFirst(), getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIntegerErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIntegerErrorTests.java
@@ -27,7 +27,7 @@ public class ToIntegerErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToInteger(source, args.get(0));
+        return new ToInteger(source, args.getFirst(), getPragmas());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIntegerSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIntegerSerializationTests.java
@@ -14,6 +14,6 @@ import org.elasticsearch.xpack.esql.expression.AbstractUnaryScalarSerializationT
 public class ToIntegerSerializationTests extends AbstractUnaryScalarSerializationTests<ToInteger> {
     @Override
     protected ToInteger create(Source source, Expression child) {
-        return new ToInteger(source, child);
+        return new ToInteger(source, child, getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIntegerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIntegerTests.java
@@ -279,7 +279,7 @@ public class ToIntegerTests extends AbstractScalarFunctionTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToInteger(source, args.get(0));
+        return new ToInteger(source, args.getFirst(), getPragmas());
     }
 
     private static List<TestCaseSupplier.TypedDataSupplier> dateCases(long min, long max) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIpErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIpErrorTests.java
@@ -28,7 +28,7 @@ public class ToIpErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToIp(source, args.getFirst(), null);
+        return new ToIp(source, args.getFirst(), null, getPragmas());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIpLeadingZerosDecimalSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIpLeadingZerosDecimalSerializationTests.java
@@ -14,6 +14,6 @@ import org.elasticsearch.xpack.esql.expression.AbstractUnaryScalarSerializationT
 public class ToIpLeadingZerosDecimalSerializationTests extends AbstractUnaryScalarSerializationTests<ToIpLeadingZerosDecimal> {
     @Override
     protected ToIpLeadingZerosDecimal create(Source source, Expression child) {
-        return new ToIpLeadingZerosDecimal(source, child);
+        return new ToIpLeadingZerosDecimal(source, child, getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIpLeadingZerosOctalSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIpLeadingZerosOctalSerializationTests.java
@@ -14,6 +14,6 @@ import org.elasticsearch.xpack.esql.expression.AbstractUnaryScalarSerializationT
 public class ToIpLeadingZerosOctalSerializationTests extends AbstractUnaryScalarSerializationTests<ToIpLeadingZerosOctal> {
     @Override
     protected ToIpLeadingZerosOctal create(Source source, Expression child) {
-        return new ToIpLeadingZerosOctal(source, child);
+        return new ToIpLeadingZerosOctal(source, child, getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIpLeadingZerosRejectedSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIpLeadingZerosRejectedSerializationTests.java
@@ -14,6 +14,6 @@ import org.elasticsearch.xpack.esql.expression.AbstractUnaryScalarSerializationT
 public class ToIpLeadingZerosRejectedSerializationTests extends AbstractUnaryScalarSerializationTests<ToIpLeadingZerosRejected> {
     @Override
     protected ToIpLeadingZerosRejected create(Source source, Expression child) {
-        return new ToIpLeadingZerosRejected(source, child);
+        return new ToIpLeadingZerosRejected(source, child, getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIpTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToIpTests.java
@@ -133,7 +133,7 @@ public class ToIpTests extends AbstractScalarFunctionTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToIp(source, args.getFirst(), options());
+        return new ToIp(source, args.getFirst(), options(), getPragmas());
     }
 
     private MapExpression options() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongErrorTests.java
@@ -27,7 +27,7 @@ public class ToLongErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToLong(source, args.get(0));
+        return new ToLong(source, args.getFirst(), getPragmas());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongSerializationTests.java
@@ -14,6 +14,6 @@ import org.elasticsearch.xpack.esql.expression.AbstractUnaryScalarSerializationT
 public class ToLongSerializationTests extends AbstractUnaryScalarSerializationTests<ToLong> {
     @Override
     protected ToLong create(Source source, Expression child) {
-        return new ToLong(source, child);
+        return new ToLong(source, child, getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongTests.java
@@ -251,6 +251,6 @@ public class ToLongTests extends AbstractScalarFunctionTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToLong(source, args.get(0));
+        return new ToLong(source, args.getFirst(), getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToRadiansErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToRadiansErrorTests.java
@@ -27,7 +27,7 @@ public class ToRadiansErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToRadians(source, args.get(0));
+        return new ToRadians(source, args.getFirst(), getPragmas());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToRadiansSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToRadiansSerializationTests.java
@@ -14,6 +14,6 @@ import org.elasticsearch.xpack.esql.expression.AbstractUnaryScalarSerializationT
 public class ToRadiansSerializationTests extends AbstractUnaryScalarSerializationTests<ToRadians> {
     @Override
     protected ToRadians create(Source source, Expression child) {
-        return new ToRadians(source, child);
+        return new ToRadians(source, child, getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToRadiansTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToRadiansTests.java
@@ -77,6 +77,6 @@ public class ToRadiansTests extends AbstractScalarFunctionTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToRadians(source, args.get(0));
+        return new ToRadians(source, args.getFirst(), getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringErrorTests.java
@@ -27,7 +27,7 @@ public class ToStringErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToString(source, args.get(0));
+        return new ToString(source, args.getFirst(), getPragmas());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringSerializationTests.java
@@ -14,6 +14,6 @@ import org.elasticsearch.xpack.esql.expression.AbstractUnaryScalarSerializationT
 public class ToStringSerializationTests extends AbstractUnaryScalarSerializationTests<ToString> {
     @Override
     protected ToString create(Source source, Expression child) {
-        return new ToString(source, child);
+        return new ToString(source, child, getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringTests.java
@@ -146,6 +146,6 @@ public class ToStringTests extends AbstractScalarFunctionTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToString(source, args.get(0));
+        return new ToString(source, args.getFirst(), getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToTimeDurationErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToTimeDurationErrorTests.java
@@ -27,7 +27,7 @@ public class ToTimeDurationErrorTests extends ErrorsForCasesWithoutExamplesTestC
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToTimeDuration(source, args.get(0));
+        return new ToTimeDuration(source, args.getFirst(), getPragmas());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToTimeDurationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToTimeDurationTests.java
@@ -75,7 +75,7 @@ public class ToTimeDurationTests extends AbstractScalarFunctionTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToTimeDuration(source, args.get(0));
+        return new ToTimeDuration(source, args.getFirst(), getPragmas());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToUnsignedLongErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToUnsignedLongErrorTests.java
@@ -27,7 +27,7 @@ public class ToUnsignedLongErrorTests extends ErrorsForCasesWithoutExamplesTestC
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToUnsignedLong(source, args.get(0));
+        return new ToUnsignedLong(source, args.getFirst(), getPragmas());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToUnsignedLongSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToUnsignedLongSerializationTests.java
@@ -14,6 +14,6 @@ import org.elasticsearch.xpack.esql.expression.AbstractUnaryScalarSerializationT
 public class ToUnsignedLongSerializationTests extends AbstractUnaryScalarSerializationTests<ToUnsignedLong> {
     @Override
     protected ToUnsignedLong create(Source source, Expression child) {
-        return new ToUnsignedLong(source, child);
+        return new ToUnsignedLong(source, child, getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToUnsignedLongTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToUnsignedLongTests.java
@@ -254,6 +254,6 @@ public class ToUnsignedLongTests extends AbstractScalarFunctionTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToUnsignedLong(source, args.get(0));
+        return new ToUnsignedLong(source, args.getFirst(), getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToVersionLongErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToVersionLongErrorTests.java
@@ -27,7 +27,7 @@ public class ToVersionLongErrorTests extends ErrorsForCasesWithoutExamplesTestCa
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToVersion(source, args.get(0));
+        return new ToVersion(source, args.get(0), getPragmas());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToVersionSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToVersionSerializationTests.java
@@ -14,6 +14,6 @@ import org.elasticsearch.xpack.esql.expression.AbstractUnaryScalarSerializationT
 public class ToVersionSerializationTests extends AbstractUnaryScalarSerializationTests<ToVersion> {
     @Override
     protected ToVersion create(Source source, Expression child) {
-        return new ToVersion(source, child);
+        return new ToVersion(source, child, getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToVersionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToVersionTests.java
@@ -65,6 +65,6 @@ public class ToVersionTests extends AbstractScalarFunctionTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new ToVersion(source, args.get(0));
+        return new ToVersion(source, args.getFirst(), getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeohashToLongTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeohashToLongTests.java
@@ -58,6 +58,6 @@ public class StGeohashToLongTests extends SpatialGridTypeConversionTestCases {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new StGeohashToLong(source, args.get(0));
+        return new StGeohashToLong(source, args.getFirst(), getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeohashToStringTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeohashToStringTests.java
@@ -59,6 +59,6 @@ public class StGeohashToStringTests extends SpatialGridTypeConversionTestCases {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new StGeohashToString(source, args.get(0));
+        return new StGeohashToString(source, args.getFirst(), getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeohexToLongTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeohexToLongTests.java
@@ -58,6 +58,6 @@ public class StGeohexToLongTests extends SpatialGridTypeConversionTestCases {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new StGeohexToLong(source, args.get(0));
+        return new StGeohexToLong(source, args.getFirst(), getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeohexToStringTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeohexToStringTests.java
@@ -59,6 +59,6 @@ public class StGeohexToStringTests extends SpatialGridTypeConversionTestCases {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new StGeohexToString(source, args.get(0));
+        return new StGeohexToString(source, args.getFirst(), getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeotileToLongTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeotileToLongTests.java
@@ -58,6 +58,6 @@ public class StGeotileToLongTests extends SpatialGridTypeConversionTestCases {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new StGeotileToLong(source, args.get(0));
+        return new StGeotileToLong(source, args.getFirst(), getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeotileToStringTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StGeotileToStringTests.java
@@ -59,6 +59,6 @@ public class StGeotileToStringTests extends SpatialGridTypeConversionTestCases {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new StGeotileToString(source, args.get(0));
+        return new StGeotileToString(source, args.getFirst(), getPragmas());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
@@ -272,11 +272,12 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
         allFieldRowSize = testData.mapping.values()
             .stream()
             .mapToInt(
-                f -> (EstimatesRowSize.estimateSize(f.getDataType().widenSmallNumeric()) + f.getProperties()
+                f -> (EstimatesRowSize.estimateSize(f.getDataType().widenSmallNumeric(QueryPragmas.EMPTY.native_float_type())) + f
+                    .getProperties()
                     .values()
                     .stream()
                     // check one more level since the mapping contains TEXT fields with KEYWORD multi-fields
-                    .mapToInt(x -> EstimatesRowSize.estimateSize(x.getDataType().widenSmallNumeric()))
+                    .mapToInt(x -> EstimatesRowSize.estimateSize(x.getDataType().widenSmallNumeric(QueryPragmas.EMPTY.native_float_type())))
                     .sum())
             )
             .sum();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/FoldNullTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/FoldNullTests.java
@@ -63,6 +63,7 @@ import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Gre
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThanOrEqual;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.NotEquals;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.lang.reflect.Constructor;
 import java.util.List;
@@ -91,6 +92,9 @@ public class FoldNullTests extends ESTestCase {
     private Expression foldNull(Expression e) {
         return new FoldNull().rule(e, unboundLogicalOptimizerContext());
     }
+
+    // TODO inject from Gradle command
+    private QueryPragmas pragmas = QueryPragmas.EMPTY;
 
     public void testBasicNullFolding() {
         assertNullLiteral(foldNull(new Add(EMPTY, L(randomInt()), Literal.NULL)));
@@ -163,7 +167,7 @@ public class FoldNullTests extends ESTestCase {
         // ip
         assertNullLiteral(foldNull(new CIDRMatch(EMPTY, NULL, List.of(NULL))));
         // conversion
-        assertNullLiteral(foldNull(new ToString(EMPTY, NULL)));
+        assertNullLiteral(foldNull(new ToString(EMPTY, NULL, QueryPragmas.EMPTY)));
     }
 
     public void testNullFoldingDoesNotApplyOnLogicalExpressions() {
@@ -190,39 +194,39 @@ public class FoldNullTests extends ESTestCase {
             assertEquals(NULL, foldNull(conditionalFunction));
         }
 
-        Avg avg = new Avg(EMPTY, getFieldAttribute("a"));
+        Avg avg = new Avg(EMPTY, getFieldAttribute("a"), pragmas);
         assertEquals(avg, foldNull(avg));
-        avg = new Avg(EMPTY, NULL);
+        avg = new Avg(EMPTY, NULL, pragmas);
         assertEquals(new Literal(EMPTY, null, DOUBLE), foldNull(avg));
 
-        Count count = new Count(EMPTY, getFieldAttribute("a"));
+        Count count = new Count(EMPTY, getFieldAttribute("a"), pragmas);
         assertEquals(count, foldNull(count));
-        count = new Count(EMPTY, NULL);
+        count = new Count(EMPTY, NULL, pragmas);
         assertEquals(count, foldNull(count));
 
-        CountDistinct countd = new CountDistinct(EMPTY, getFieldAttribute("a"), getFieldAttribute("a"));
+        CountDistinct countd = new CountDistinct(EMPTY, getFieldAttribute("a"), getFieldAttribute("a"), pragmas);
         assertEquals(countd, foldNull(countd));
-        countd = new CountDistinct(EMPTY, NULL, NULL);
+        countd = new CountDistinct(EMPTY, NULL, NULL, pragmas);
         assertEquals(new Literal(EMPTY, null, LONG), foldNull(countd));
 
-        Median median = new Median(EMPTY, getFieldAttribute("a"));
+        Median median = new Median(EMPTY, getFieldAttribute("a"), pragmas);
         assertEquals(median, foldNull(median));
-        median = new Median(EMPTY, NULL);
+        median = new Median(EMPTY, NULL, pragmas);
         assertEquals(new Literal(EMPTY, null, DOUBLE), foldNull(median));
 
-        MedianAbsoluteDeviation medianad = new MedianAbsoluteDeviation(EMPTY, getFieldAttribute("a"));
+        MedianAbsoluteDeviation medianad = new MedianAbsoluteDeviation(EMPTY, getFieldAttribute("a"), pragmas);
         assertEquals(medianad, foldNull(medianad));
-        medianad = new MedianAbsoluteDeviation(EMPTY, NULL);
+        medianad = new MedianAbsoluteDeviation(EMPTY, NULL, pragmas);
         assertEquals(new Literal(EMPTY, null, DOUBLE), foldNull(medianad));
 
-        Percentile percentile = new Percentile(EMPTY, getFieldAttribute("a"), getFieldAttribute("a"));
+        Percentile percentile = new Percentile(EMPTY, getFieldAttribute("a"), getFieldAttribute("a"), pragmas);
         assertEquals(percentile, foldNull(percentile));
-        percentile = new Percentile(EMPTY, NULL, NULL);
+        percentile = new Percentile(EMPTY, NULL, NULL, pragmas);
         assertEquals(new Literal(EMPTY, null, DOUBLE), foldNull(percentile));
 
-        Sum sum = new Sum(EMPTY, getFieldAttribute("a"));
+        Sum sum = new Sum(EMPTY, getFieldAttribute("a"), pragmas);
         assertEquals(sum, foldNull(sum));
-        sum = new Sum(EMPTY, NULL);
+        sum = new Sum(EMPTY, NULL, pragmas);
         assertEquals(new Literal(EMPTY, null, DOUBLE), foldNull(sum));
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineFiltersTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineFiltersTests.java
@@ -35,6 +35,7 @@ import org.elasticsearch.xpack.esql.plan.logical.Project;
 import org.elasticsearch.xpack.esql.plan.logical.inference.Completion;
 import org.elasticsearch.xpack.esql.plan.logical.inference.Rerank;
 import org.elasticsearch.xpack.esql.plan.logical.local.EsqlProject;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -59,6 +60,8 @@ import static org.elasticsearch.xpack.esql.core.tree.Source.EMPTY;
 import static org.mockito.Mockito.mock;
 
 public class PushDownAndCombineFiltersTests extends ESTestCase {
+    // TODO inject from Gradle command
+    private QueryPragmas pragmas = QueryPragmas.EMPTY;
 
     public void testCombineFilters() {
         EsRelation relation = relation();
@@ -226,7 +229,7 @@ public class PushDownAndCombineFiltersTests extends ESTestCase {
         EsRelation relation = relation();
         GreaterThan conditionA = greaterThanOf(getFieldAttribute("a"), ONE);
         LessThan conditionB = lessThanOf(getFieldAttribute("b"), TWO);
-        GreaterThanOrEqual aggregateCondition = greaterThanOrEqualOf(new Count(EMPTY, ONE), THREE);
+        GreaterThanOrEqual aggregateCondition = greaterThanOrEqualOf(new Count(EMPTY, ONE, pragmas), THREE);
 
         Filter fa = new Filter(EMPTY, relation, conditionA);
         // invalid aggregate but that's fine cause its properties are not used by this rule

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineLimitsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineLimitsTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.xpack.esql.plan.logical.OrderBy;
 import org.elasticsearch.xpack.esql.plan.logical.UnaryPlan;
 import org.elasticsearch.xpack.esql.plan.logical.inference.Completion;
 import org.elasticsearch.xpack.esql.plan.logical.inference.Rerank;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.util.List;
 import java.util.function.BiConsumer;
@@ -66,10 +67,11 @@ public class PushDownAndCombineLimitsTests extends ESTestCase {
         }
     }
 
+    // TODO pragma threading
     private static final List<PushDownLimitTestCase<? extends UnaryPlan>> PUSHABLE_LIMIT_TEST_CASES = List.of(
         new PushDownLimitTestCase<>(
             Eval.class,
-            (plan, attr) -> new Eval(EMPTY, plan, List.of(new Alias(EMPTY, "y", new ToInteger(EMPTY, attr)))),
+            (plan, attr) -> new Eval(EMPTY, plan, List.of(new Alias(EMPTY, "y", new ToInteger(EMPTY, attr, QueryPragmas.EMPTY)))),
             (basePlan, optimizedPlan) -> {
                 assertEquals(basePlan.source(), optimizedPlan.source());
                 assertEquals(basePlan.fields(), optimizedPlan.fields());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
@@ -1184,7 +1184,7 @@ public class StatementParserTests extends AbstractStatementParserTests {
         LogicalPlan cmd = processingCommand("grok a \"%{WORD:foo}\"");
         assertEquals(Grok.class, cmd.getClass());
         Grok grok = (Grok) cmd;
-        assertEquals("%{WORD:foo}", grok.parser().pattern());
+        assertEquals("%{WORD:foo}", grok.parser().getPattern());
         assertEquals(List.of(referenceAttribute("foo", KEYWORD)), grok.extractedFields());
 
         expectThrows(
@@ -1196,7 +1196,7 @@ public class StatementParserTests extends AbstractStatementParserTests {
         cmd = processingCommand("grok a \"%{WORD:foo} %{WORD:foo}\"");
         assertEquals(Grok.class, cmd.getClass());
         grok = (Grok) cmd;
-        assertEquals("%{WORD:foo} %{WORD:foo}", grok.parser().pattern());
+        assertEquals("%{WORD:foo} %{WORD:foo}", grok.parser().getPattern());
         assertEquals(List.of(referenceAttribute("foo", KEYWORD)), grok.extractedFields());
 
         expectError(
@@ -1980,7 +1980,7 @@ public class StatementParserTests extends AbstractStatementParserTests {
         assertEquals(rename.renamings(), List.of(new Alias(EMPTY, "f.8", attribute("f7*."))));
         Grok grok = as(rename.child(), Grok.class);
         assertEquals(grok.input(), attribute("f.6."));
-        assertEquals("%{WORD:foo}", grok.parser().pattern());
+        assertEquals("%{WORD:foo}", grok.parser().getPattern());
         assertEquals(List.of(referenceAttribute("foo", KEYWORD)), grok.extractedFields());
         Dissect dissect = as(grok.child(), Dissect.class);
         assertEquals(dissect.input(), attribute("f.5*"));
@@ -2021,7 +2021,7 @@ public class StatementParserTests extends AbstractStatementParserTests {
         assertEquals(rename.renamings(), List.of(new Alias(EMPTY, "f11*..f.12", attribute("f.9*.f.10."))));
         grok = as(rename.child(), Grok.class);
         assertEquals(grok.input(), attribute("f7*..f.8"));
-        assertEquals("%{WORD:foo}", grok.parser().pattern());
+        assertEquals("%{WORD:foo}", grok.parser().getPattern());
         assertEquals(List.of(referenceAttribute("foo", KEYWORD)), grok.extractedFields());
         dissect = as(grok.child(), Dissect.class);
         assertEquals(dissect.input(), attribute("f.5*.f.6."));
@@ -2696,7 +2696,7 @@ public class StatementParserTests extends AbstractStatementParserTests {
             """);
         Grok grok = as(plan, Grok.class);
         assertEquals(function("fn2", List.of(attribute("f3"), mapExpression(expectedMap2))), grok.input());
-        assertEquals("%{WORD:foo}", grok.parser().pattern());
+        assertEquals("%{WORD:foo}", grok.parser().getPattern());
         assertEquals(List.of(referenceAttribute("foo", KEYWORD)), grok.extractedFields());
         Dissect dissect = as(grok.child(), Dissect.class);
         assertEquals(function("fn1", List.of(attribute("f1"), attribute("f2"), mapExpression(expectedMap1))), dissect.input());
@@ -2839,7 +2839,7 @@ public class StatementParserTests extends AbstractStatementParserTests {
         );
         Grok grok = as(plan, Grok.class);
         assertEquals(function("fn2", List.of(attribute("f3"), mapExpression(expectedMap2))), grok.input());
-        assertEquals("%{WORD:foo}", grok.parser().pattern());
+        assertEquals("%{WORD:foo}", grok.parser().getPattern());
         assertEquals(List.of(referenceAttribute("foo", KEYWORD)), grok.extractedFields());
         Dissect dissect = as(grok.child(), Dissect.class);
         assertEquals(function("fn1", List.of(attribute("f1"), attribute("f2"), mapExpression(expectedMap1))), dissect.input());
@@ -4259,7 +4259,7 @@ public class StatementParserTests extends AbstractStatementParserTests {
             assertEquals(rename.renamings(), List.of(new Alias(EMPTY, "f.8", attribute("f7*."))));
             Grok grok = as(rename.child(), Grok.class);
             assertEquals(grok.input(), attribute("f.6."));
-            assertEquals("%{WORD:foo}", grok.parser().pattern());
+            assertEquals("%{WORD:foo}", grok.parser().getPattern());
             assertEquals(List.of(referenceAttribute("foo", KEYWORD)), grok.extractedFields());
             Dissect dissect = as(grok.child(), Dissect.class);
             assertEquals(dissect.input(), attribute("f.5*"));
@@ -4369,7 +4369,7 @@ public class StatementParserTests extends AbstractStatementParserTests {
             assertEquals(rename.renamings(), List.of(new Alias(EMPTY, "f11*..f.12", attribute("f.9*.f.10."))));
             Grok grok = as(rename.child(), Grok.class);
             assertEquals(grok.input(), attribute("f7*..f.8"));
-            assertEquals("%{WORD:foo}", grok.parser().pattern());
+            assertEquals("%{WORD:foo}", grok.parser().getPattern());
             assertEquals(List.of(referenceAttribute("foo", KEYWORD)), grok.extractedFields());
             Dissect dissect = as(grok.child(), Dissect.class);
             assertEquals(dissect.input(), attribute("f.5*.f.6."));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/AggregateSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/AggregateSerializationTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.xpack.esql.expression.function.aggregate.Min;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Sum;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Top;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Values;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -42,7 +43,7 @@ public class AggregateSerializationTests extends AbstractLogicalPlanSerializatio
             Expression agg = switch (between(0, 5)) {
                 case 0 -> new Max(randomSource(), FieldAttributeTests.createFieldAttribute(1, true));
                 case 1 -> new Min(randomSource(), FieldAttributeTests.createFieldAttribute(1, true));
-                case 2 -> new Count(randomSource(), FieldAttributeTests.createFieldAttribute(1, true));
+                case 2 -> new Count(randomSource(), FieldAttributeTests.createFieldAttribute(1, true), QueryPragmas.EMPTY);
                 case 3 -> new Top(
                     randomSource(),
                     FieldAttributeTests.createFieldAttribute(1, true),
@@ -50,7 +51,7 @@ public class AggregateSerializationTests extends AbstractLogicalPlanSerializatio
                     Literal.keyword(randomSource(), randomFrom("ASC", "DESC"))
                 );
                 case 4 -> new Values(randomSource(), FieldAttributeTests.createFieldAttribute(1, true));
-                case 5 -> new Sum(randomSource(), FieldAttributeTests.createFieldAttribute(1, true));
+                case 5 -> new Sum(randomSource(), FieldAttributeTests.createFieldAttribute(1, true), QueryPragmas.EMPTY);
                 default -> throw new IllegalArgumentException();
             };
             result.add(new Alias(randomSource(), randomAlphaOfLength(5), agg));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/GrokSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/logical/GrokSerializationTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.expression.function.FieldAttributeTests;
 import org.elasticsearch.xpack.esql.expression.function.ReferenceAttributeTests;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.io.IOException;
 import java.util.List;
@@ -24,21 +25,27 @@ public class GrokSerializationTests extends AbstractLogicalPlanSerializationTest
         Expression inputExpr = FieldAttributeTests.createFieldAttribute(3, false);
         String pattern = randomAlphaOfLength(5);
         List<Attribute> extracted = randomList(1, 10, () -> ReferenceAttributeTests.randomReferenceAttribute(false));
-        return new Grok(source, child, inputExpr, Grok.pattern(source, pattern), extracted);
+        return new Grok(source, child, inputExpr, Grok.pattern(source, pattern, QueryPragmas.EMPTY), extracted);
     }
 
     @Override
     protected Grok mutateInstance(Grok instance) throws IOException {
         LogicalPlan child = instance.child();
         Expression inputExpr = instance.input();
-        String pattern = instance.parser().pattern();
+        String pattern = instance.parser().getPattern();
         List<Attribute> extracted = instance.extractedFields();
         switch (between(0, 2)) {
             case 0 -> child = randomValueOtherThan(child, () -> randomChild(0));
             case 1 -> inputExpr = randomValueOtherThan(inputExpr, () -> FieldAttributeTests.createFieldAttribute(0, false));
             case 2 -> pattern = randomValueOtherThan(pattern, () -> randomAlphaOfLength(5));
         }
-        return new Grok(instance.source(), child, inputExpr, Grok.pattern(instance.source(), pattern), extracted);
+        return new Grok(
+            instance.source(),
+            child,
+            inputExpr,
+            Grok.pattern(instance.source(), pattern, instance.parser().getPragmas()),
+            extracted
+        );
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/ExchangeSinkExecSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/ExchangeSinkExecSerializationTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
 import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Limit;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.io.IOException;
 import java.util.List;
@@ -198,7 +199,7 @@ public class ExchangeSinkExecSerializationTests extends AbstractPhysicalPlanSeri
     }
 
     private void testSerializePlanWithIndex(EsIndex index, ByteSizeValue expected, boolean keepAllFields) throws IOException {
-        List<Attribute> allAttributes = Analyzer.mappingAsAttributes(randomSource(), index.mapping());
+        List<Attribute> allAttributes = Analyzer.mappingAsAttributes(randomSource(), index.mapping(), QueryPragmas.EMPTY);
         List<Attribute> keepAttributes = keepAllFields || allAttributes.isEmpty() ? allAttributes : List.of(allAttributes.getFirst());
         EsRelation relation = new EsRelation(randomSource(), index.name(), IndexMode.STANDARD, index.indexNameWithModes(), keepAttributes);
         Limit limit = new Limit(randomSource(), new Literal(randomSource(), 10, DataType.INTEGER), relation);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/GrokExecSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/GrokExecSerializationTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.expression.function.FieldAttributeTests;
 import org.elasticsearch.xpack.esql.plan.logical.Grok;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.elasticsearch.xpack.esql.tree.EsqlNodeSubclassTests;
 
 import java.io.IOException;
@@ -20,7 +21,7 @@ public class GrokExecSerializationTests extends AbstractPhysicalPlanSerializatio
         Source source = randomSource();
         PhysicalPlan child = randomChild(depth);
         Expression inputExpression = FieldAttributeTests.createFieldAttribute(0, false);
-        Grok.Parser parser = Grok.pattern(source, EsqlNodeSubclassTests.randomGrokPattern());
+        Grok.Parser parser = Grok.pattern(source, EsqlNodeSubclassTests.randomGrokPattern(), QueryPragmas.EMPTY);
         return new GrokExec(source, child, inputExpression, parser, parser.extractedFields());
     }
 
@@ -33,13 +34,14 @@ public class GrokExecSerializationTests extends AbstractPhysicalPlanSerializatio
     protected GrokExec mutateInstance(GrokExec instance) throws IOException {
         PhysicalPlan child = instance.child();
         Expression inputExpression = instance.inputExpression();
-        Grok.Parser parser = instance.pattern();
+        Grok.Parser parser = instance.getParser();
         switch (between(0, 2)) {
             case 0 -> child = randomValueOtherThan(child, () -> randomChild(0));
             case 1 -> inputExpression = randomValueOtherThan(inputExpression, () -> FieldAttributeTests.createFieldAttribute(0, false));
             case 2 -> parser = Grok.pattern(
                 instance.source(),
-                randomValueOtherThan(parser.pattern(), EsqlNodeSubclassTests::randomGrokPattern)
+                randomValueOtherThan(parser.getPattern(), EsqlNodeSubclassTests::randomGrokPattern),
+                QueryPragmas.EMPTY
             );
         }
         return new GrokExec(instance.source(), child, inputExpression, parser, parser.extractedFields());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/telemetry/PlanExecutorMetricsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/telemetry/PlanExecutorMetricsTests.java
@@ -38,6 +38,7 @@ import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.enrich.EnrichPolicyResolver;
 import org.elasticsearch.xpack.esql.execution.PlanExecutor;
 import org.elasticsearch.xpack.esql.plugin.EsqlPlugin;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.elasticsearch.xpack.esql.querylog.EsqlQueryLog;
 import org.elasticsearch.xpack.esql.session.EsqlSession;
 import org.elasticsearch.xpack.esql.session.IndexResolver;
@@ -83,7 +84,7 @@ public class PlanExecutorMetricsTests extends ESTestCase {
             ActionListener<EnrichResolution> listener = (ActionListener<EnrichResolution>) arguments[arguments.length - 1];
             listener.onResponse(new EnrichResolution());
             return null;
-        }).when(enrichResolver).resolvePolicies(any(), any(), any());
+        }).when(enrichResolver).resolvePolicies(any(), any(), QueryPragmas.EMPTY, any());
         return enrichResolver;
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java
@@ -56,6 +56,7 @@ import org.elasticsearch.xpack.esql.plan.physical.EsStatsQueryExec.StatsType;
 import org.elasticsearch.xpack.esql.plan.physical.MergeExec;
 import org.elasticsearch.xpack.esql.plan.physical.OutputExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.elasticsearch.xpack.esql.session.Configuration;
 import org.elasticsearch.xpack.esql.type.EsFieldTests;
 import org.mockito.exceptions.base.MockitoException;
@@ -430,7 +431,7 @@ public class EsqlNodeSubclassTests<T extends B, B extends Node<B>> extends NodeS
             return new Dissect.Parser(pattern, appendSeparator, new DissectParser(pattern, appendSeparator));
         } else if (argClass == Grok.Parser.class) {
             // Grok.Parser is a record / final, cannot be mocked
-            return Grok.pattern(Source.EMPTY, randomGrokPattern());
+            return Grok.pattern(Source.EMPTY, randomGrokPattern(), QueryPragmas.EMPTY);
         } else if (argClass == EsQueryExec.FieldSort.class) {
             // TODO: It appears neither FieldSort nor GeoDistanceSort are ever actually tested
             return randomFieldSort();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeRegistryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeRegistryTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.index.IndexResolution;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.elasticsearch.xpack.esql.session.IndexResolver;
 
 import java.util.List;
@@ -54,7 +55,7 @@ public class EsqlDataTypeRegistryTests extends ESTestCase {
 
         FieldCapabilitiesResponse caps = new FieldCapabilitiesResponse(idxResponses, List.of());
         // IndexResolver uses EsqlDataTypeRegistry directly
-        IndexResolution resolution = IndexResolver.mergedMappings("idx-*", caps);
+        IndexResolution resolution = IndexResolver.mergedMappings("idx-*", caps, QueryPragmas.EMPTY);
         EsField f = resolution.get().mapping().get(field);
         assertThat(f.getDataType(), equalTo(expected));
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/MultiTypeEsFieldTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/type/MultiTypeEsFieldTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToString;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToVersion;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.elasticsearch.xpack.esql.session.Configuration;
 import org.junit.Before;
 
@@ -107,8 +108,14 @@ public class MultiTypeEsFieldTests extends AbstractWireTestCase<MultiTypeEsField
     private static Map<String, Expression> randomConvertExpressions(String name, boolean toString, DataType dataType) {
         Map<String, Expression> indexToConvertExpressions = new HashMap<>();
         if (toString) {
-            indexToConvertExpressions.put(randomAlphaOfLength(4), new ToString(Source.EMPTY, fieldAttribute(name, dataType)));
-            indexToConvertExpressions.put(randomAlphaOfLength(4), new ToString(Source.EMPTY, fieldAttribute(name, DataType.KEYWORD)));
+            indexToConvertExpressions.put(
+                randomAlphaOfLength(4),
+                new ToString(Source.EMPTY, fieldAttribute(name, dataType), QueryPragmas.EMPTY)
+            );
+            indexToConvertExpressions.put(
+                randomAlphaOfLength(4),
+                new ToString(Source.EMPTY, fieldAttribute(name, DataType.KEYWORD), QueryPragmas.EMPTY)
+            );
         } else {
             indexToConvertExpressions.put(randomAlphaOfLength(4), testConvertExpression(name, DataType.KEYWORD, dataType));
             indexToConvertExpressions.put(randomAlphaOfLength(4), testConvertExpression(name, dataType, dataType));
@@ -148,21 +155,21 @@ public class MultiTypeEsFieldTests extends AbstractWireTestCase<MultiTypeEsField
     private static Expression testConvertExpression(String name, DataType fromType, DataType toType) {
         FieldAttribute fromField = fieldAttribute(name, fromType);
         if (isString(toType)) {
-            return new ToString(Source.EMPTY, fromField);
+            return new ToString(Source.EMPTY, fromField, QueryPragmas.EMPTY);
         } else {
             return switch (toType) {
-                case BOOLEAN -> new ToBoolean(Source.EMPTY, fromField);
-                case DATETIME -> new ToDatetime(Source.EMPTY, fromField);
-                case DOUBLE, FLOAT -> new ToDouble(Source.EMPTY, fromField);
-                case INTEGER -> new ToInteger(Source.EMPTY, fromField);
-                case LONG -> new ToLong(Source.EMPTY, fromField);
-                case IP -> new ToIpLeadingZerosRejected(Source.EMPTY, fromField);
-                case KEYWORD -> new ToString(Source.EMPTY, fromField);
-                case GEO_POINT -> new ToGeoPoint(Source.EMPTY, fromField);
-                case GEO_SHAPE -> new ToGeoShape(Source.EMPTY, fromField);
-                case CARTESIAN_POINT -> new ToCartesianPoint(Source.EMPTY, fromField);
-                case CARTESIAN_SHAPE -> new ToCartesianShape(Source.EMPTY, fromField);
-                case VERSION -> new ToVersion(Source.EMPTY, fromField);
+                case BOOLEAN -> new ToBoolean(Source.EMPTY, fromField, QueryPragmas.EMPTY);
+                case DATETIME -> new ToDatetime(Source.EMPTY, fromField, QueryPragmas.EMPTY);
+                case DOUBLE, FLOAT -> new ToDouble(Source.EMPTY, fromField, QueryPragmas.EMPTY);
+                case INTEGER -> new ToInteger(Source.EMPTY, fromField, QueryPragmas.EMPTY);
+                case LONG -> new ToLong(Source.EMPTY, fromField, QueryPragmas.EMPTY);
+                case IP -> new ToIpLeadingZerosRejected(Source.EMPTY, fromField, QueryPragmas.EMPTY);
+                case KEYWORD -> new ToString(Source.EMPTY, fromField, QueryPragmas.EMPTY);
+                case GEO_POINT -> new ToGeoPoint(Source.EMPTY, fromField, QueryPragmas.EMPTY);
+                case GEO_SHAPE -> new ToGeoShape(Source.EMPTY, fromField, QueryPragmas.EMPTY);
+                case CARTESIAN_POINT -> new ToCartesianPoint(Source.EMPTY, fromField, QueryPragmas.EMPTY);
+                case CARTESIAN_SHAPE -> new ToCartesianShape(Source.EMPTY, fromField, QueryPragmas.EMPTY);
+                case VERSION -> new ToVersion(Source.EMPTY, fromField, QueryPragmas.EMPTY);
                 default -> throw new UnsupportedOperationException("Conversion from " + fromType + " to " + toType + " is not supported");
             };
         }


### PR DESCRIPTION
* Added a flag for ESQL's DataType's `widenSmallType`, to control to widening of floats

* Threaded QueryPragmas into any place in theh code which eventually calls `widenSmallType`, to allow conditioning the float widening on the session / query specific pragmas.

* For now, provided `QueryPragmas.EMPTY` as a hard coded argument for all the tests that now needs pragmas because of those changes. Ideally, next thing should be to inject pragmas into the tests from a single place, and using a Gradle command parameter. This will make sure that all the tests are running with the same pragmas values, and ` avoid redyndant degrees of freedom where each test manually pass its own value.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
