### PR TITLE
[9.1] rest-api-spec: fix esql.get_query accept header (#130377)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/esql.get_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/esql.get_query.json
@@ -7,10 +7,8 @@
     "stability": "experimental",
     "visibility": "public",
     "headers": {
-      "accept": [],
-      "content_type": [
-        "application/json"
-      ]
+      "accept": ["application/json"],
+      "content_type": ["application/json"]
     },
     "url": {
       "paths": [


### PR DESCRIPTION
Backports the following commits to 9.1:
 - rest-api-spec: fix esql.get_query accept header (#130377)