### PR TITLE
Prevent trace context propagation for self-rescheduling operations

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedRunner.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedRunner.java
@@ -338,7 +338,11 @@ public class DatafeedRunner {
                     }
                     holder.problemTracker.finishReport();
                     if (nextDelayInMsSinceEpoch >= 0) {
-                        doDatafeedRealtime(nextDelayInMsSinceEpoch, jobId, holder);
+                        // Prevent the propagation of the trace context here to not create everlasting APM transactions.
+                        // Such a trace context is created when executing any transport action.
+                        try (var ignored = threadPool.getThreadContext().clearTraceContext()) {
+                            doDatafeedRealtime(nextDelayInMsSinceEpoch, jobId, holder);
+                        }
                     }
                 }
             }, delay, threadPool.executor(MachineLearning.DATAFEED_THREAD_POOL_NAME));


### PR DESCRIPTION
Prevent trace context propagation for self-rescheduling operations to not create everlasting APM transactions.

Relates to ES-10969