### PR TITLE
[9.1] Add pattern_text feature flag to logsdb yaml tests (#130399)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -45,6 +45,7 @@ public class MapperFeatures implements FeatureSpecification {
     static final NodeFeature IVF_FORMAT_CLUSTER_FEATURE = new NodeFeature("mapper.ivf_format_cluster_feature");
     static final NodeFeature IVF_NESTED_SUPPORT = new NodeFeature("mapper.ivf_nested_support");
     static final NodeFeature SEARCH_LOAD_PER_SHARD = new NodeFeature("mapper.search_load_per_shard");
+    static final NodeFeature PATTERNED_TEXT = new NodeFeature("mapper.patterned_text");
 
     @Override
     public Set<NodeFeature> getTestFeatures() {
@@ -76,7 +77,8 @@ public class MapperFeatures implements FeatureSpecification {
             IVF_FORMAT_CLUSTER_FEATURE,
             IVF_NESTED_SUPPORT,
             SEARCH_LOAD_PER_SHARD,
-            SPARSE_VECTOR_INDEX_OPTIONS_FEATURE
+            SPARSE_VECTOR_INDEX_OPTIONS_FEATURE,
+            PATTERNED_TEXT
         );
     }
 }

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/FeatureFlag.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/FeatureFlag.java
@@ -21,7 +21,8 @@ public enum FeatureFlag {
     DOC_VALUES_SKIPPER("es.doc_values_skipper_feature_flag_enabled=true", Version.fromString("8.18.1"), null),
     USE_LUCENE101_POSTINGS_FORMAT("es.use_lucene101_postings_format_feature_flag_enabled=true", Version.fromString("9.1.0"), null),
     IVF_FORMAT("es.ivf_format_feature_flag_enabled=true", Version.fromString("9.1.0"), null),
-    LOGS_STREAM("es.logs_stream_feature_flag_enabled=true", Version.fromString("9.1.0"), null);
+    LOGS_STREAM("es.logs_stream_feature_flag_enabled=true", Version.fromString("9.1.0"), null),
+    PATTERNED_TEXT("es.patterned_text_feature_flag_enabled=true", Version.fromString("9.2.0"), null);
 
     public final String systemProperty;
     public final Version from;

--- a/x-pack/plugin/logsdb/src/yamlRestTest/java/org/elasticsearch/xpack/logsdb/LogsdbTestSuiteIT.java
+++ b/x-pack/plugin/logsdb/src/yamlRestTest/java/org/elasticsearch/xpack/logsdb/LogsdbTestSuiteIT.java
@@ -34,6 +34,7 @@ public class LogsdbTestSuiteIT extends ESClientYamlSuiteTestCase {
         .setting("xpack.license.self_generated.type", "trial")
         .feature(FeatureFlag.DOC_VALUES_SKIPPER)
         .feature(FeatureFlag.USE_LUCENE101_POSTINGS_FORMAT)
+        .feature(FeatureFlag.PATTERNED_TEXT)
         .build();
 
     public LogsdbTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {

--- a/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/patternedtext/10_basic.yml
+++ b/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/patternedtext/10_basic.yml
@@ -1,4 +1,7 @@
 setup:
+  - requires:
+      cluster_features: [ "mapper.patterned_text" ]
+      reason: "patterned_text mappings are used in this test"
 
   - do:
       indices.create:

--- a/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/patternedtext/20_synthetic_source.yml
+++ b/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/patternedtext/20_synthetic_source.yml
@@ -1,3 +1,9 @@
+setup:
+  - requires:
+      cluster_features: [ "mapper.patterned_text" ]
+      reason: "patterned_text mappings are used in this test"
+
+---
 simple:
   - do:
       indices.create:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Add pattern_text feature flag to logsdb yaml tests (#130399)](https://github.com/elastic/elasticsearch/pull/130399)

<!--- Backport version: 9.6.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)