### PR TITLE
[9.1] Only run patterned_text mapper test if feature flag enabled (#130214)

### DIFF
--- a/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/patternedtext/PatternedTextFieldMapperTests.java
+++ b/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/patternedtext/PatternedTextFieldMapperTests.java
@@ -40,6 +40,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xpack.logsdb.LogsDBPlugin;
 import org.junit.AssumptionViolatedException;
+import org.junit.Before;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -70,6 +71,11 @@ public class PatternedTextFieldMapperTests extends MapperTestCase {
         FieldExistsQuery fieldExistsQuery = (FieldExistsQuery) query;
         assertThat(fieldExistsQuery.getField(), startsWith("field"));
         assertNoFieldNamesField(fields);
+    }
+
+    @Before
+    public void setup() {
+        assumeTrue("Only when patterned_text feature flag is enabled", PatternedTextFieldMapper.PATTERNED_TEXT_MAPPER.isEnabled());
     }
 
     public void testExistsStandardSource() throws IOException {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Only run patterned_text mapper test if feature flag enabled (#130214)](https://github.com/elastic/elasticsearch/pull/130214)

<!--- Backport version: 9.6.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)