### PR TITLE
[9.1] [ESQL] Ensure date/date_nanos implicit casting rule behind snapshot (#130026)

### DIFF
--- a/docs/changelog/127797.yaml
+++ b/docs/changelog/127797.yaml
@@ -1,6 +1,0 @@
-pr: 127797
-summary: "Date nanos implicit casting in union types option #2"
-area: ES|QL
-type: enhancement
-issues:
- - 110009


### PR DESCRIPTION
Backports the following commits to 9.1:
 - [ESQL] Ensure date/date_nanos implicit casting rule behind snapshot (#130026)