### PR TITLE
[8.19] Bootstrap entitlements for testing (#129268)

### DIFF
--- a/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/release/ReleaseNotesGeneratorTest.java
+++ b/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/release/ReleaseNotesGeneratorTest.java
@@ -105,6 +105,6 @@ public class ReleaseNotesGeneratorTest {
     }
 
     private String getResource(String name) throws Exception {
-        return Files.readString(Paths.get(Objects.requireNonNull(this.getClass().getResource(name)).toURI()), StandardCharsets.UTF_8);
+        return Files.readString(Paths.get(Objects.requireNonNull(this.getClass().getResource(name)).toURI()), StandardCharsets.UTF_8).replace("\r", "");
     }
 }

--- a/build-tools/src/main/java/org/elasticsearch/gradle/test/TestBuildInfoPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/test/TestBuildInfoPlugin.java
@@ -18,7 +18,10 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
+import org.gradle.api.tasks.testing.Test;
 import org.gradle.language.jvm.tasks.ProcessResources;
+
+import java.util.List;
 
 import javax.inject.Inject;
 
@@ -53,5 +56,11 @@ public class TestBuildInfoPlugin implements Plugin<Project> {
         project.getTasks().withType(ProcessResources.class).named("processResources").configure(task -> {
             task.into("META-INF", copy -> copy.from(testBuildInfoTask));
         });
+
+        if (project.getRootProject().getName().equals("elasticsearch")) {
+            project.getTasks().withType(Test.class).matching(test -> List.of("test").contains(test.getName())).configureEach(test -> {
+                test.systemProperty("es.entitlement.enableForTests", "true");
+            });
+        }
     }
 }

--- a/libs/build.gradle
+++ b/libs/build.gradle
@@ -45,4 +45,14 @@ configure(childProjects.values()) {
      */
     apply plugin: 'elasticsearch.build'
   }
+
+  // This is for any code potentially included in the server at runtime.
+  // Omit oddball libraries that aren't in server.
+  def nonServerLibs = ['plugin-scanner']
+  if (false == nonServerLibs.contains(project.name)) {
+    project.getTasks().withType(Test.class).matching(test -> ['test'].contains(test.name)).configureEach(test -> {
+      test.systemProperty('es.entitlement.enableForTests', 'true')
+    })
+  }
+
 }

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyCheckerImpl.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyCheckerImpl.java
@@ -135,7 +135,7 @@ public class PolicyCheckerImpl implements PolicyChecker {
             Strings.format(
                 "component [%s], module [%s], class [%s], operation [%s]",
                 entitlements.componentName(),
-                PolicyCheckerImpl.getModuleName(requestingClass),
+                entitlements.moduleName(),
                 requestingClass,
                 operationDescription.get()
             ),
@@ -247,7 +247,7 @@ public class PolicyCheckerImpl implements PolicyChecker {
                 Strings.format(
                     "component [%s], module [%s], class [%s], entitlement [file], operation [read], path [%s]",
                     entitlements.componentName(),
-                    PolicyCheckerImpl.getModuleName(requestingClass),
+                    entitlements.moduleName(),
                     requestingClass,
                     realPath == null ? path : Strings.format("%s -> %s", path, realPath)
                 ),
@@ -279,7 +279,7 @@ public class PolicyCheckerImpl implements PolicyChecker {
                 Strings.format(
                     "component [%s], module [%s], class [%s], entitlement [file], operation [write], path [%s]",
                     entitlements.componentName(),
-                    PolicyCheckerImpl.getModuleName(requestingClass),
+                    entitlements.moduleName(),
                     requestingClass,
                     path
                 ),
@@ -383,7 +383,7 @@ public class PolicyCheckerImpl implements PolicyChecker {
                     () -> Strings.format(
                         "Entitled: component [%s], module [%s], class [%s], entitlement [write_system_properties], property [%s]",
                         entitlements.componentName(),
-                        PolicyCheckerImpl.getModuleName(requestingClass),
+                        entitlements.moduleName(),
                         requestingClass,
                         property
                     )
@@ -394,7 +394,7 @@ public class PolicyCheckerImpl implements PolicyChecker {
             Strings.format(
                 "component [%s], module [%s], class [%s], entitlement [write_system_properties], property [%s]",
                 entitlements.componentName(),
-                PolicyCheckerImpl.getModuleName(requestingClass),
+                entitlements.moduleName(),
                 requestingClass,
                 property
             ),
@@ -447,7 +447,7 @@ public class PolicyCheckerImpl implements PolicyChecker {
                 Strings.format(
                     "component [%s], module [%s], class [%s], entitlement [%s]",
                     classEntitlements.componentName(),
-                    PolicyCheckerImpl.getModuleName(requestingClass),
+                    classEntitlements.moduleName(),
                     requestingClass,
                     PolicyParser.buildEntitlementNameFromClass(entitlementClass)
                 ),
@@ -460,7 +460,7 @@ public class PolicyCheckerImpl implements PolicyChecker {
                 () -> Strings.format(
                     "Entitled: component [%s], module [%s], class [%s], entitlement [%s]",
                     classEntitlements.componentName(),
-                    PolicyCheckerImpl.getModuleName(requestingClass),
+                    classEntitlements.moduleName(),
                     requestingClass,
                     PolicyParser.buildEntitlementNameFromClass(entitlementClass)
                 )

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
@@ -118,8 +118,9 @@ public class PolicyManager {
      *
      * @param componentName the plugin name or else one of the special component names like "(server)".
      */
-    record ModuleEntitlements(
+    protected record ModuleEntitlements(
         String componentName,
+        String moduleName,
         Map<Class<? extends Entitlement>, List<Entitlement>> entitlementsByType,
         FileAccessTree fileAccess,
         Logger logger
@@ -148,7 +149,13 @@ public class PolicyManager {
 
     // pkg private for testing
     ModuleEntitlements defaultEntitlements(String componentName, Collection<Path> componentPaths, String moduleName) {
-        return new ModuleEntitlements(componentName, Map.of(), getDefaultFileAccess(componentPaths), getLogger(componentName, moduleName));
+        return new ModuleEntitlements(
+            componentName,
+            moduleName,
+            Map.of(),
+            getDefaultFileAccess(componentPaths),
+            getLogger(componentName, moduleName)
+        );
     }
 
     // pkg private for testing
@@ -166,6 +173,7 @@ public class PolicyManager {
         }
         return new ModuleEntitlements(
             componentName,
+            moduleName,
             entitlements.stream().collect(groupingBy(Entitlement::getClass)),
             FileAccessTree.of(componentName, moduleName, filesEntitlement, pathLookup, componentPaths, exclusivePaths),
             getLogger(componentName, moduleName)
@@ -293,11 +301,11 @@ public class PolicyManager {
      */
     private static final ConcurrentHashMap<String, Logger> MODULE_LOGGERS = new ConcurrentHashMap<>();
 
-    ModuleEntitlements getEntitlements(Class<?> requestingClass) {
+    protected ModuleEntitlements getEntitlements(Class<?> requestingClass) {
         return moduleEntitlementsMap.computeIfAbsent(requestingClass.getModule(), m -> computeEntitlements(requestingClass));
     }
 
-    private ModuleEntitlements computeEntitlements(Class<?> requestingClass) {
+    protected final ModuleEntitlements computeEntitlements(Class<?> requestingClass) {
         var policyScope = scopeResolver.apply(requestingClass);
         var componentName = policyScope.componentName();
         var moduleName = policyScope.moduleName();
@@ -336,8 +344,7 @@ public class PolicyManager {
         }
     }
 
-    // pkg private for testing
-    static Collection<Path> getComponentPathsFromClass(Class<?> requestingClass) {
+    protected Collection<Path> getComponentPathsFromClass(Class<?> requestingClass) {
         var codeSource = requestingClass.getProtectionDomain().getCodeSource();
         if (codeSource == null) {
             return List.of();

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyManagerTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyManagerTests.java
@@ -89,7 +89,6 @@ public class PolicyManagerTests extends ESTestCase {
         AtomicReference<PolicyScope> policyScope = new AtomicReference<>();
 
         // A common policy with a variety of entitlements to test
-        Collection<Path> thisSourcePaths = PolicyManager.getComponentPathsFromClass(getClass());
         var plugin1SourcePaths = List.of(Path.of("modules", "plugin1"));
         var policyManager = new PolicyManager(
             new Policy("server", List.of(new Scope("org.example.httpclient", List.of(new OutboundNetworkEntitlement())))),
@@ -99,6 +98,7 @@ public class PolicyManagerTests extends ESTestCase {
             Map.of("plugin1", plugin1SourcePaths),
             TEST_PATH_LOOKUP
         );
+        Collection<Path> thisSourcePaths = policyManager.getComponentPathsFromClass(getClass());
 
         // "Unspecified" below means that the module is not named in the policy
 

--- a/modules/ingest-attachment/src/test/java/org/elasticsearch/ingest/attachment/AttachmentProcessorTests.java
+++ b/modules/ingest-attachment/src/test/java/org/elasticsearch/ingest/attachment/AttachmentProcessorTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.Processor;
 import org.elasticsearch.ingest.RandomDocumentPicks;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.ESTestCase.WithoutEntitlements;
 import org.junit.Before;
 
 import java.io.InputStream;
@@ -38,6 +39,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
+@WithoutEntitlements // ES-12084
 public class AttachmentProcessorTests extends ESTestCase {
 
     private Processor processor;

--- a/modules/ingest-attachment/src/test/java/org/elasticsearch/ingest/attachment/TikaDocTests.java
+++ b/modules/ingest-attachment/src/test/java/org/elasticsearch/ingest/attachment/TikaDocTests.java
@@ -14,6 +14,7 @@ import org.apache.lucene.tests.util.TestUtil;
 import org.apache.tika.metadata.Metadata;
 import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.ESTestCase.WithoutEntitlements;
 
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
@@ -25,6 +26,7 @@ import java.nio.file.Path;
  * comes back and no exception.
  */
 @SuppressFileSystems("ExtrasFS") // don't try to parse extraN
+@WithoutEntitlements // ES-12084
 public class TikaDocTests extends ESTestCase {
 
     /** some test files from tika test suite, zipped up */

--- a/modules/ingest-attachment/src/test/java/org/elasticsearch/ingest/attachment/TikaImplTests.java
+++ b/modules/ingest-attachment/src/test/java/org/elasticsearch/ingest/attachment/TikaImplTests.java
@@ -9,7 +9,9 @@
 package org.elasticsearch.ingest.attachment;
 
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.ESTestCase.WithoutEntitlements;
 
+@WithoutEntitlements // ES-12084
 public class TikaImplTests extends ESTestCase {
 
     public void testTikaLoads() throws Exception {

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RegisteredDomainProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RegisteredDomainProcessorFactoryTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.ingest.common;
 
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.ESTestCase.WithoutEntitlements;
 import org.junit.Before;
 
 import java.util.HashMap;
@@ -18,6 +19,7 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
 
+@WithoutEntitlements // ES-12084
 public class RegisteredDomainProcessorFactoryTests extends ESTestCase {
 
     private RegisteredDomainProcessor.Factory factory;

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RegisteredDomainProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RegisteredDomainProcessorTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.TestIngestDocument;
 import org.elasticsearch.ingest.common.RegisteredDomainProcessor.DomainInfo;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.ESTestCase.WithoutEntitlements;
 
 import java.util.Collections;
 import java.util.Map;
@@ -30,6 +31,7 @@ import static org.hamcrest.Matchers.nullValue;
  * Effective TLDs (eTLDs) are not the same as DNS TLDs. Uses for eTLDs are listed here:
  *   https://publicsuffix.org/learn/
  */
+@WithoutEntitlements // ES-12084
 public class RegisteredDomainProcessorTests extends ESTestCase {
 
     public void testGetRegisteredDomain() {

--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -252,9 +252,16 @@ class Elasticsearch {
             args.pidFile(),
             Set.of(EntitlementSelfTester.class.getPackage())
         );
-        EntitlementSelfTester.entitlementSelfTest();
+        entitlementSelfTest();
 
         bootstrap.setPluginsLoader(pluginsLoader);
+    }
+
+    /**
+     * @throws IllegalStateException if entitlements aren't functioning properly.
+     */
+    static void entitlementSelfTest() {
+        EntitlementSelfTester.entitlementSelfTest();
     }
 
     private static Map<String, String> collectPluginPolicyPatches(

--- a/server/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
@@ -217,7 +217,9 @@ public class ExceptionSerializationTests extends ESTestCase {
         };
 
         Files.walkFileTree(startPath, visitor);
-        final Path testStartPath = PathUtils.get(ExceptionSerializationTests.class.getResource(path).toURI());
+        final Path testStartPath = PathUtils.get(
+            ElasticsearchExceptionTests.class.getProtectionDomain().getCodeSource().getLocation().toURI()
+        ).resolve("org").resolve("elasticsearch");
         Files.walkFileTree(testStartPath, visitor);
         assertTrue(notRegistered.remove(TestException.class));
         assertTrue(notRegistered.remove(UnknownHeaderException.class));

--- a/server/src/test/java/org/elasticsearch/bootstrap/EntitlementMetaTests.java
+++ b/server/src/test/java/org/elasticsearch/bootstrap/EntitlementMetaTests.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.bootstrap;
+
+import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.entitlement.bootstrap.TestEntitlementBootstrap;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.ESTestCase.WithEntitlementsOnTestCode;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Ensures that unit tests are subject to entitlement checks.
+ * This is a "meta test" because it tests that the tests are working:
+ * if these tests fail, it means other tests won't be correctly detecting
+ * entitlement enforcement errors.
+ * <p>
+ * It may seem strange to have this test where it is, rather than in the entitlement library.
+ * There's a reason for that.
+ * <p>
+ * To exercise entitlement enforcement, we must attempt an operation that should be denied.
+ * This necessitates some operation that fails the entitlement check,
+ * and it must be in production code (or else we'd also need {@link WithEntitlementsOnTestCode},
+ * and we don't want to require that here).
+ * Naturally, there are very few candidates, because most code doesn't fail entitlement checks:
+ * really just the entitlement self-test we do at startup. Hence, that's what we use here.
+ * <p>
+ * Since we want to call the self-test, which is in the server, we can't call it
+ * from a place like the entitlement library tests, because those deliberately do not
+ * have a dependency on the server code. Hence, this test lives here in the server tests.
+ *
+ * @see WithoutEntitlementsMetaTests
+ * @see WithEntitlementsOnTestCodeMetaTests
+ */
+public class EntitlementMetaTests extends ESTestCase {
+    public void testSelfTestPasses() {
+        assumeTrue("Not yet working in serverless", TestEntitlementBootstrap.isEnabledForTest());
+        Elasticsearch.entitlementSelfTest();
+    }
+
+    /**
+     * Unless {@link WithEntitlementsOnTestCode} is specified, sensitive methods <em>can</em>
+     * be called from test code.
+     */
+    @SuppressForbidden(reason = "Testing that a forbidden API is allowed under these circumstances")
+    public void testForbiddenActionAllowedInTestCode() throws IOException {
+        // If entitlements were enforced, this would throw.
+        Path.of(".").toRealPath();
+    }
+}

--- a/server/src/test/java/org/elasticsearch/bootstrap/WithEntitlementsOnTestCodeMetaTests.java
+++ b/server/src/test/java/org/elasticsearch/bootstrap/WithEntitlementsOnTestCodeMetaTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.bootstrap;
+
+import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.entitlement.bootstrap.TestEntitlementBootstrap;
+import org.elasticsearch.entitlement.runtime.api.NotEntitledException;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.ESTestCase.WithEntitlementsOnTestCode;
+
+import java.nio.file.Path;
+
+/**
+ * A version of {@link EntitlementMetaTests} that tests {@link WithEntitlementsOnTestCode}.
+ *
+ * @see EntitlementMetaTests
+ * @see WithoutEntitlementsMetaTests
+ */
+@WithEntitlementsOnTestCode
+public class WithEntitlementsOnTestCodeMetaTests extends ESTestCase {
+    /**
+     * {@link WithEntitlementsOnTestCode} should not affect this, since the sensitive method
+     * is called from server code. The self-test should pass as usual.
+     */
+    public void testSelfTestPasses() {
+        assumeTrue("Not yet working in serverless", TestEntitlementBootstrap.isEnabledForTest());
+        Elasticsearch.entitlementSelfTest();
+    }
+
+    @SuppressForbidden(reason = "Testing that a forbidden API is disallowed")
+    public void testForbiddenActionDenied() {
+        assumeTrue("Not yet working in serverless", TestEntitlementBootstrap.isEnabledForTest());
+        assertThrows(NotEntitledException.class, () -> Path.of(".").toRealPath());
+    }
+}

--- a/server/src/test/java/org/elasticsearch/bootstrap/WithoutEntitlementsMetaTests.java
+++ b/server/src/test/java/org/elasticsearch/bootstrap/WithoutEntitlementsMetaTests.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.bootstrap;
+
+import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.ESTestCase.WithoutEntitlements;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * A version of {@link EntitlementMetaTests} that tests {@link WithoutEntitlements}.
+ *
+ * @see EntitlementMetaTests
+ * @see WithEntitlementsOnTestCodeMetaTests
+ */
+@WithoutEntitlements
+public class WithoutEntitlementsMetaTests extends ESTestCase {
+    /**
+     * Without enforcement of entitlements, {@link Elasticsearch#entitlementSelfTest} will fail and throw.
+     */
+    public void testSelfTestFails() {
+        assertThrows(IllegalStateException.class, Elasticsearch::entitlementSelfTest);
+    }
+
+    /**
+     * A forbidden action called from test code should be allowed,
+     * with or without {@link WithoutEntitlements}.
+     */
+    @SuppressForbidden(reason = "Testing that a forbidden API is allowed under these circumstances")
+    public void testForbiddenActionAllowed() throws IOException {
+        // If entitlements were enforced, this would throw
+        Path.of(".").toRealPath();
+    }
+}

--- a/server/src/test/java/org/elasticsearch/common/settings/ScopedSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/ScopedSettingsTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.ESTestCase.WithoutEntitlements;
 import org.elasticsearch.transport.TransportSettings;
 import org.mockito.Mockito;
 
@@ -48,6 +49,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+@WithoutEntitlements // Entitlement logging interferes
 public class ScopedSettingsTests extends ESTestCase {
 
     public void testResetSetting() {

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -2536,11 +2536,11 @@ public class InternalEngineTests extends EngineTestCase {
         MockAppender mockAppender = new MockAppender("testIndexWriterInfoStream");
         mockAppender.start();
 
-        Logger rootLogger = LogManager.getRootLogger();
-        Level savedLevel = rootLogger.getLevel();
-        Loggers.addAppender(rootLogger, mockAppender);
-        Loggers.setLevel(rootLogger, Level.DEBUG);
-        rootLogger = LogManager.getRootLogger();
+        Logger theLogger = LogManager.getLogger("org.elasticsearch.index");
+        Level savedLevel = theLogger.getLevel();
+        Loggers.addAppender(theLogger, mockAppender);
+        Loggers.setLevel(theLogger, Level.DEBUG);
+        theLogger = LogManager.getLogger("org.elasticsearch.index");
 
         try {
             // First, with DEBUG, which should NOT log IndexWriter output:
@@ -2550,15 +2550,15 @@ public class InternalEngineTests extends EngineTestCase {
             assertFalse(mockAppender.sawIndexWriterMessage);
 
             // Again, with TRACE, which should log IndexWriter output:
-            Loggers.setLevel(rootLogger, Level.TRACE);
+            Loggers.setLevel(theLogger, Level.TRACE);
             engine.index(indexForDoc(doc));
             engine.flush();
             assertTrue(mockAppender.sawIndexWriterMessage);
             engine.close();
         } finally {
-            Loggers.removeAppender(rootLogger, mockAppender);
+            Loggers.removeAppender(theLogger, mockAppender);
             mockAppender.stop();
-            Loggers.setLevel(rootLogger, savedLevel);
+            Loggers.setLevel(theLogger, savedLevel);
         }
     }
 
@@ -2598,10 +2598,10 @@ public class InternalEngineTests extends EngineTestCase {
         final MockMergeThreadAppender mockAppender = new MockMergeThreadAppender("testMergeThreadLogging");
         mockAppender.start();
 
-        Logger rootLogger = LogManager.getRootLogger();
-        Level savedLevel = rootLogger.getLevel();
-        Loggers.addAppender(rootLogger, mockAppender);
-        Loggers.setLevel(rootLogger, Level.TRACE);
+        Logger theLogger = LogManager.getLogger("org.elasticsearch.index");
+        Level savedLevel = theLogger.getLevel();
+        Loggers.addAppender(theLogger, mockAppender);
+        Loggers.setLevel(theLogger, Level.TRACE);
         try {
             LogMergePolicy lmp = newLogMergePolicy();
             lmp.setMergeFactor(2);
@@ -2634,12 +2634,12 @@ public class InternalEngineTests extends EngineTestCase {
                     assertThat(mockAppender.mergeCompleted(), is(true));
                 });
 
-                Loggers.setLevel(rootLogger, savedLevel);
+                Loggers.setLevel(theLogger, savedLevel);
                 engine.close();
             }
         } finally {
-            Loggers.setLevel(rootLogger, savedLevel);
-            Loggers.removeAppender(rootLogger, mockAppender);
+            Loggers.setLevel(theLogger, savedLevel);
+            Loggers.removeAppender(theLogger, mockAppender);
             mockAppender.stop();
         }
     }

--- a/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -14,7 +14,9 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.network.IfConfig;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Booleans;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.PathUtils;
+import org.elasticsearch.entitlement.bootstrap.TestEntitlementBootstrap;
 import org.elasticsearch.jdk.JarHell;
 
 import java.io.IOException;
@@ -71,6 +73,21 @@ public class BootstrapForTesting {
 
         // Log ifconfig output before SecurityManager is installed
         IfConfig.logIfNecessary();
+
+        // Fire up entitlements
+        try {
+            TestEntitlementBootstrap.bootstrap(javaTmpDir, maybePath(System.getProperty("tests.config")));
+        } catch (IOException e) {
+            throw new IllegalStateException(e.getClass().getSimpleName() + " while initializing entitlements for tests", e);
+        }
+    }
+
+    private static @Nullable Path maybePath(String str) {
+        if (str == null) {
+            return null;
+        } else {
+            return PathUtils.get(str);
+        }
     }
 
     // does nothing, just easy way to make sure the class is loaded.

--- a/test/framework/src/main/java/org/elasticsearch/entitlement/bootstrap/TestEntitlementBootstrap.java
+++ b/test/framework/src/main/java/org/elasticsearch/entitlement/bootstrap/TestEntitlementBootstrap.java
@@ -12,13 +12,16 @@ package org.elasticsearch.entitlement.bootstrap;
 import org.elasticsearch.bootstrap.TestBuildInfo;
 import org.elasticsearch.bootstrap.TestBuildInfoParser;
 import org.elasticsearch.bootstrap.TestScopeResolver;
+import org.elasticsearch.core.Booleans;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.entitlement.initialization.EntitlementInitialization;
 import org.elasticsearch.entitlement.runtime.policy.PathLookup;
 import org.elasticsearch.entitlement.runtime.policy.Policy;
-import org.elasticsearch.entitlement.runtime.policy.PolicyManager;
 import org.elasticsearch.entitlement.runtime.policy.PolicyParser;
+import org.elasticsearch.entitlement.runtime.policy.TestPathLookup;
 import org.elasticsearch.entitlement.runtime.policy.TestPolicyManager;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -26,77 +29,126 @@ import org.elasticsearch.plugins.PluginDescriptor;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Stream;
+import java.util.TreeSet;
+
+import static java.util.stream.Collectors.toCollection;
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
+import static org.elasticsearch.entitlement.runtime.policy.PathLookup.BaseDir.CONFIG;
+import static org.elasticsearch.entitlement.runtime.policy.PathLookup.BaseDir.TEMP;
 
 public class TestEntitlementBootstrap {
 
     private static final Logger logger = LogManager.getLogger(TestEntitlementBootstrap.class);
 
+    private static TestPolicyManager policyManager;
+
     /**
      * Activates entitlement checking in tests.
      */
-    public static void bootstrap() throws IOException {
-        TestPathLookup pathLookup = new TestPathLookup();
-        EntitlementInitialization.initializeArgs = new EntitlementInitialization.InitializeArgs(
-            pathLookup,
-            Set.of(),
-            createPolicyManager(pathLookup)
-        );
+    public static void bootstrap(@Nullable Path tempDir, @Nullable Path configDir) throws IOException {
+        if (isEnabledForTest() == false) {
+            return;
+        }
+        TestPathLookup pathLookup = new TestPathLookup(Map.of(TEMP, zeroOrOne(tempDir), CONFIG, zeroOrOne(configDir)));
+        policyManager = createPolicyManager(pathLookup);
+        EntitlementInitialization.initializeArgs = new EntitlementInitialization.InitializeArgs(pathLookup, Set.of(), policyManager);
         logger.debug("Loading entitlement agent");
         EntitlementBootstrap.loadAgent(EntitlementBootstrap.findAgentJar(), EntitlementInitialization.class.getName());
     }
 
-    private record TestPathLookup() implements PathLookup {
-        @Override
-        public Path pidFile() {
-            return null;
+    private static <T> List<T> zeroOrOne(T item) {
+        if (item == null) {
+            return List.of();
+        } else {
+            return List.of(item);
         }
-
-        @Override
-        public Stream<Path> getBaseDirPaths(BaseDir baseDir) {
-            return Stream.empty();
-        }
-
-        @Override
-        public Stream<Path> resolveSettingPaths(BaseDir baseDir, String settingName) {
-            return Stream.empty();
-        }
-
     }
 
-    private static PolicyManager createPolicyManager(PathLookup pathLookup) throws IOException {
+    public static boolean isEnabledForTest() {
+        return Booleans.parseBoolean(System.getProperty("es.entitlement.enableForTests", "false"));
+    }
 
+    public static void setActive(boolean newValue) {
+        policyManager.setActive(newValue);
+    }
+
+    public static void setTriviallyAllowingTestCode(boolean newValue) {
+        policyManager.setTriviallyAllowingTestCode(newValue);
+    }
+
+    public static void reset() {
+        if (policyManager != null) {
+            policyManager.reset();
+        }
+    }
+
+    private static TestPolicyManager createPolicyManager(PathLookup pathLookup) throws IOException {
         var pluginsTestBuildInfo = TestBuildInfoParser.parseAllPluginTestBuildInfo();
         var serverTestBuildInfo = TestBuildInfoParser.parseServerTestBuildInfo();
-        var scopeResolver = TestScopeResolver.createScopeResolver(serverTestBuildInfo, pluginsTestBuildInfo);
         List<String> pluginNames = pluginsTestBuildInfo.stream().map(TestBuildInfo::component).toList();
 
         var pluginDescriptors = parsePluginsDescriptors(pluginNames);
+        Set<String> modularPlugins = pluginDescriptors.stream()
+            .filter(PluginDescriptor::isModular)
+            .map(PluginDescriptor::getName)
+            .collect(toSet());
+        var scopeResolver = TestScopeResolver.createScopeResolver(serverTestBuildInfo, pluginsTestBuildInfo, modularPlugins);
         var pluginsData = pluginDescriptors.stream()
             .map(descriptor -> new TestPluginData(descriptor.getName(), descriptor.isModular(), false))
             .toList();
         Map<String, Policy> pluginPolicies = parsePluginsPolicies(pluginsData);
 
+        String separator = System.getProperty("path.separator");
+
+        // In productions, plugins would have access to their respective bundle directories,
+        // and so they'd be able to read from their jars. In testing, we approximate this
+        // by considering the entire classpath to be "source paths" of all plugins. This
+        // also has the effect of granting read access to everything on the test-only classpath,
+        // which is fine, because any entitlement errors there could only be false positives.
+        String classPathProperty = System.getProperty("java.class.path");
+
+        Set<Path> classPathEntries;
+        if (classPathProperty == null) {
+            classPathEntries = Set.of();
+        } else {
+            classPathEntries = Arrays.stream(classPathProperty.split(separator)).map(PathUtils::get).collect(toCollection(TreeSet::new));
+        }
+        Map<String, Collection<Path>> pluginSourcePaths = pluginNames.stream().collect(toMap(n -> n, n -> classPathEntries));
+
         FilesEntitlementsValidation.validate(pluginPolicies, pathLookup);
+
+        String testOnlyPathString = System.getenv("es.entitlement.testOnlyPath");
+        Set<URI> testOnlyClassPath;
+        if (testOnlyPathString == null) {
+            testOnlyClassPath = Set.of();
+        } else {
+            testOnlyClassPath = Arrays.stream(testOnlyPathString.split(separator))
+                .map(PathUtils::get)
+                .map(Path::toUri)
+                .collect(toCollection(TreeSet::new));
+        }
 
         return new TestPolicyManager(
             HardcodedEntitlements.serverPolicy(null, null),
             HardcodedEntitlements.agentEntitlements(),
             pluginPolicies,
             scopeResolver,
-            Map.of(),
-            pathLookup
+            pluginSourcePaths,
+            pathLookup,
+            testOnlyClassPath
         );
     }
-
-    private record TestPluginData(String pluginName, boolean isModular, boolean isExternalPlugin) {}
 
     private static Map<String, Policy> parsePluginsPolicies(List<TestPluginData> pluginsData) {
         Map<String, Policy> policies = new HashMap<>();
@@ -136,5 +188,7 @@ public class TestEntitlementBootstrap {
     private static InputStream getStream(URL resource) throws IOException {
         return resource.openStream();
     }
+
+    private record TestPluginData(String pluginName, boolean isModular, boolean isExternalPlugin) {}
 
 }

--- a/test/framework/src/main/java/org/elasticsearch/entitlement/runtime/policy/TestPathLookup.java
+++ b/test/framework/src/main/java/org/elasticsearch/entitlement/runtime/policy/TestPathLookup.java
@@ -10,9 +10,18 @@
 package org.elasticsearch.entitlement.runtime.policy;
 
 import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 public class TestPathLookup implements PathLookup {
+    final Map<BaseDir, Collection<Path>> baseDirPaths;
+
+    public TestPathLookup(Map<BaseDir, Collection<Path>> baseDirPaths) {
+        this.baseDirPaths = baseDirPaths;
+    }
+
     @Override
     public Path pidFile() {
         return null;
@@ -20,7 +29,7 @@ public class TestPathLookup implements PathLookup {
 
     @Override
     public Stream<Path> getBaseDirPaths(BaseDir baseDir) {
-        return Stream.empty();
+        return baseDirPaths.getOrDefault(baseDir, List.of()).stream();
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/entitlement/runtime/policy/TestPolicyManager.java
+++ b/test/framework/src/main/java/org/elasticsearch/entitlement/runtime/policy/TestPolicyManager.java
@@ -10,30 +10,64 @@
 package org.elasticsearch.entitlement.runtime.policy;
 
 import org.elasticsearch.entitlement.runtime.policy.entitlements.Entitlement;
+import org.elasticsearch.test.ESTestCase;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Path;
+import java.security.CodeSource;
+import java.security.ProtectionDomain;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
+import static java.util.Objects.requireNonNull;
+
 public class TestPolicyManager extends PolicyManager {
+
+    boolean isActive;
+    boolean isTriviallyAllowingTestCode;
+
+    /**
+     * We don't have modules in tests, so we can't use the inherited map of entitlements per module.
+     * We need this larger map per class instead.
+     */
+    final Map<Class<?>, ModuleEntitlements> classEntitlementsMap = new ConcurrentHashMap<>();
+
+    final Collection<URI> testOnlyClasspath;
+
     public TestPolicyManager(
         Policy serverPolicy,
         List<Entitlement> apmAgentEntitlements,
         Map<String, Policy> pluginPolicies,
         Function<Class<?>, PolicyScope> scopeResolver,
         Map<String, Collection<Path>> pluginSourcePaths,
-        PathLookup pathLookup
+        PathLookup pathLookup,
+        Collection<URI> testOnlyClasspath
     ) {
         super(serverPolicy, apmAgentEntitlements, pluginPolicies, scopeResolver, pluginSourcePaths, pathLookup);
+        this.testOnlyClasspath = testOnlyClasspath;
+        reset();
+    }
+
+    public void setActive(boolean newValue) {
+        this.isActive = newValue;
+    }
+
+    public void setTriviallyAllowingTestCode(boolean newValue) {
+        this.isTriviallyAllowingTestCode = newValue;
     }
 
     /**
      * Called between tests so each test is not affected by prior tests
      */
-    public void reset() {
-        super.moduleEntitlementsMap.clear();
+    public final void reset() {
+        assert moduleEntitlementsMap.isEmpty() : "We're not supposed to be using moduleEntitlementsMap in tests";
+        classEntitlementsMap.clear();
+        isActive = false;
+        isTriviallyAllowingTestCode = true;
     }
 
     @Override
@@ -44,7 +78,31 @@ public class TestPolicyManager extends PolicyManager {
 
     @Override
     boolean isTriviallyAllowed(Class<?> requestingClass) {
-        return isTestFrameworkClass(requestingClass) || isEntitlementClass(requestingClass) || super.isTriviallyAllowed(requestingClass);
+        if (isActive == false) {
+            return true;
+        }
+        if (isEntitlementClass(requestingClass)) {
+            return true;
+        }
+        if (isTestFrameworkClass(requestingClass)) {
+            return true;
+        }
+        if ("org.elasticsearch.jdk".equals(requestingClass.getPackageName())) {
+            // PluginsLoaderTests, PluginsServiceTests, PluginsUtilsTests
+            return true;
+        }
+        if ("org.elasticsearch.nativeaccess".equals(requestingClass.getPackageName())) {
+            // UberModuleClassLoaderTests
+            return true;
+        }
+        if (requestingClass.getPackageName().startsWith("org.elasticsearch.plugins")) {
+            // PluginsServiceTests, NamedComponentReaderTests
+            return true;
+        }
+        if (isTriviallyAllowingTestCode && isTestCode(requestingClass)) {
+            return true;
+        }
+        return super.isTriviallyAllowed(requestingClass);
     }
 
     private boolean isEntitlementClass(Class<?> requestingClass) {
@@ -52,8 +110,59 @@ public class TestPolicyManager extends PolicyManager {
             && (requestingClass.getName().contains("Test") == false);
     }
 
+    @Deprecated // TODO: reevaluate whether we want this.
+    // If we can simply check for dependencies the gradle worker has that aren't
+    // declared in the gradle config (namely org.gradle) that would be simpler.
     private boolean isTestFrameworkClass(Class<?> requestingClass) {
         String packageName = requestingClass.getPackageName();
-        return packageName.startsWith("org.junit") || packageName.startsWith("org.gradle");
+        for (String prefix : TEST_FRAMEWORK_PACKAGE_PREFIXES) {
+            if (packageName.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isTestCode(Class<?> requestingClass) {
+        // TODO: Cache this? It's expensive
+        for (Class<?> candidate = requireNonNull(requestingClass); candidate != null; candidate = candidate.getDeclaringClass()) {
+            if (ESTestCase.class.isAssignableFrom(candidate)) {
+                return true;
+            }
+        }
+        ProtectionDomain protectionDomain = requestingClass.getProtectionDomain();
+        CodeSource codeSource = protectionDomain.getCodeSource();
+        if (codeSource == null) {
+            // This can happen for JDK classes
+            return false;
+        }
+        URI needle;
+        try {
+            needle = codeSource.getLocation().toURI();
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException(e);
+        }
+        boolean result = testOnlyClasspath.contains(needle);
+        return result;
+    }
+
+    private static final String[] TEST_FRAMEWORK_PACKAGE_PREFIXES = {
+        "org.gradle",
+
+        "org.jcodings", // A library loaded with SPI that tries to create a CharsetProvider
+        "com.google.common.jimfs", // Used on Windows
+
+        // We shouldn't really need the rest of these. They should be discovered on the testOnlyClasspath.
+        "com.carrotsearch.randomizedtesting",
+        "com.sun.tools.javac",
+        "org.apache.lucene.tests", // Interferes with SSLErrorMessageFileTests.testMessageForPemCertificateOutsideConfigDir
+        "org.junit",
+        "org.mockito",
+        "net.bytebuddy", // Mockito uses this
+    };
+
+    @Override
+    protected ModuleEntitlements getEntitlements(Class<?> requestingClass) {
+        return classEntitlementsMap.computeIfAbsent(requestingClass, this::computeEntitlements);
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -266,6 +266,7 @@ import static org.hamcrest.Matchers.startsWith;
  * </ul>
  */
 @LuceneTestCase.SuppressFileSystems("ExtrasFS") // doesn't work with potential multi data path from test cluster yet
+@ESTestCase.WithoutEntitlements // ES-12042
 public abstract class ESIntegTestCase extends ESTestCase {
 
     /** node names of the corresponding clusters will start with these prefixes */

--- a/test/framework/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
@@ -85,6 +85,7 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
  * A test that keep a singleton node started for all tests that can be used to get
  * references to Guice injectors in unit tests.
  */
+@ESTestCase.WithoutEntitlements // ES-12042
 public abstract class ESSingleNodeTestCase extends ESTestCase {
 
     private static Node NODE = null;

--- a/test/framework/src/test/java/org/elasticsearch/bootstrap/TestScopeResolverTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/bootstrap/TestScopeResolverTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.hamcrest.Matchers.is;
 
@@ -23,7 +24,7 @@ public class TestScopeResolverTests extends ESTestCase {
             "server",
             List.of(new TestBuildInfoLocation("org/elasticsearch/Build.class", "org.elasticsearch.server"))
         );
-        var resolver = TestScopeResolver.createScopeResolver(testBuildInfo, List.of());
+        var resolver = TestScopeResolver.createScopeResolver(testBuildInfo, List.of(), Set.of());
 
         var scope = resolver.apply(Plugin.class);
         assertThat(scope.componentName(), is("(server)"));
@@ -39,7 +40,7 @@ public class TestScopeResolverTests extends ESTestCase {
             "test-component",
             List.of(new TestBuildInfoLocation("org/elasticsearch/bootstrap/TestBuildInfoParserTests.class", "test-module-name"))
         );
-        var resolver = TestScopeResolver.createScopeResolver(testBuildInfo, List.of(testOwnBuildInfo));
+        var resolver = TestScopeResolver.createScopeResolver(testBuildInfo, List.of(testOwnBuildInfo), Set.of("test-component"));
 
         var scope = resolver.apply(this.getClass());
         assertThat(scope.componentName(), is("test-component"));

--- a/test/framework/src/test/java/org/elasticsearch/entitlement/runtime/policy/TestPolicyManagerTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/entitlement/runtime/policy/TestPolicyManagerTests.java
@@ -31,22 +31,24 @@ public class TestPolicyManagerTests extends ESTestCase {
             Map.of(),
             c -> new PolicyScope(PLUGIN, "example-plugin" + scopeCounter.incrementAndGet(), "org.example.module"),
             Map.of(),
-            new TestPathLookup()
+            new TestPathLookup(Map.of()),
+            List.of()
         );
+        policyManager.setActive(true);
     }
 
     public void testReset() {
-        assertTrue(policyManager.moduleEntitlementsMap.isEmpty());
+        assertTrue(policyManager.classEntitlementsMap.isEmpty());
         assertEquals("example-plugin1", policyManager.getEntitlements(getClass()).componentName());
         assertEquals("example-plugin1", policyManager.getEntitlements(getClass()).componentName());
-        assertFalse(policyManager.moduleEntitlementsMap.isEmpty());
+        assertFalse(policyManager.classEntitlementsMap.isEmpty());
 
         policyManager.reset();
 
-        assertTrue(policyManager.moduleEntitlementsMap.isEmpty());
+        assertTrue(policyManager.classEntitlementsMap.isEmpty());
         assertEquals("example-plugin2", policyManager.getEntitlements(getClass()).componentName());
         assertEquals("example-plugin2", policyManager.getEntitlements(getClass()).componentName());
-        assertFalse(policyManager.moduleEntitlementsMap.isEmpty());
+        assertFalse(policyManager.classEntitlementsMap.isEmpty());
     }
 
     public void testIsTriviallyAllowed() {
@@ -54,6 +56,8 @@ public class TestPolicyManagerTests extends ESTestCase {
         assertTrue(policyManager.isTriviallyAllowed(org.junit.Before.class));
         assertTrue(policyManager.isTriviallyAllowed(PolicyManager.class));
 
+        assertTrue(policyManager.isTriviallyAllowed(getClass()));
+        policyManager.setTriviallyAllowingTestCode(false);
         assertFalse(policyManager.isTriviallyAllowed(getClass()));
     }
 }

--- a/x-pack/plugin/core/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/x-pack/plugin/core/src/main/plugin-metadata/entitlement-policy.yaml
@@ -18,6 +18,7 @@ org.apache.httpcomponents.httpasyncclient:
   - manage_threads
 unboundid.ldapsdk:
   - set_https_connection_properties # TODO: review if we need this once we have proper test coverage
+  - inbound_network # For com.unboundid.ldap.listener.LDAPListener
   - outbound_network
   - manage_threads
   - write_system_properties:

--- a/x-pack/plugin/monitoring/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/x-pack/plugin/monitoring/src/main/plugin-metadata/entitlement-policy.yaml
@@ -1,5 +1,6 @@
 ALL-UNNAMED:
   - set_https_connection_properties # potentially required by apache.httpcomponents
+  - manage_threads # For org.elasticsearch.client.snif.Sniffer
   # the original policy has java.net.SocketPermission "*", "accept,connect"
   # but a comment stating it was "needed for multiple server implementations used in tests"
   # TODO: this is likely not needed, but including here to be on the safe side until


### PR DESCRIPTION
Enables entitlement enforcement on ordinary unit tests.

See ES-11597.