### PR TITLE
Replace `_remote_access` with `REMOTE_CLUSTER_PROFILE` in comment

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterPortSettings.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterPortSettings.java
@@ -158,7 +158,7 @@ public class RemoteClusterPortSettings {
     public static TcpTransport.ProfileSettings buildRemoteAccessProfileSettings(Settings settings) {
         validateRemoteAccessSettings(settings);
 
-        // Build a synthetic settings object with the `_remote_access` profile properly configured per the friendlier settings,
+        // Build a synthetic settings object with the REMOTE_CLUSTER_PROFILE properly configured per the friendlier settings,
         Settings syntheticRemoteAccessProfile = Settings.builder()
             .put(settings)
             .put(TCP_KEEP_ALIVE_PROFILE.getConcreteSettingForNamespace(REMOTE_CLUSTER_PROFILE).getKey(), TCP_KEEP_ALIVE.get(settings))


### PR DESCRIPTION
There isn't a `_remote_access` profile, it looks like the author meant to write `_remote_cluster`.  This commit changes it to `REMOTE_CLUSTER_PROFILE` to match the code below and avoid confusing the reader with a profile name that doesn't exist.