### PR TITLE
Remove redundant method for getting the remote cluster names

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
@@ -247,16 +247,16 @@ public final class RemoteClusterService extends RemoteClusterAware
     }
 
     public Map<String, OriginalIndices> groupIndices(IndicesOptions indicesOptions, String[] indices, boolean returnLocalAll) {
-        return groupIndices(getRemoteClusterNames(), indicesOptions, indices, returnLocalAll);
+        return groupIndices(getRegisteredRemoteClusterNames(), indicesOptions, indices, returnLocalAll);
     }
 
     public Map<String, OriginalIndices> groupIndices(IndicesOptions indicesOptions, String[] indices) {
-        return groupIndices(getRemoteClusterNames(), indicesOptions, indices, true);
+        return groupIndices(getRegisteredRemoteClusterNames(), indicesOptions, indices, true);
     }
 
     @Override
     public Set<String> getConfiguredClusters() {
-        return getRemoteClusterNames();
+        return getRegisteredRemoteClusterNames();
     }
 
     /**
@@ -270,7 +270,6 @@ public final class RemoteClusterService extends RemoteClusterAware
      * Returns the registered remote cluster names.
      */
     public Set<String> getRegisteredRemoteClusterNames() {
-        // remoteClusters is unmodifiable so its key set will be unmodifiable too
         return remoteClusters.keySet();
     }
 
@@ -353,10 +352,6 @@ public final class RemoteClusterService extends RemoteClusterAware
             throw new NoSuchRemoteClusterException(cluster);
         }
         return connection;
-    }
-
-    Set<String> getRemoteClusterNames() {
-        return this.remoteClusters.keySet();
     }
 
     @Override
@@ -648,7 +643,7 @@ public final class RemoteClusterService extends RemoteClusterAware
                 "this node does not have the " + DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE.roleName() + " role"
             );
         }
-        if (transportService.getRemoteClusterService().getRemoteClusterNames().contains(clusterAlias) == false) {
+        if (transportService.getRemoteClusterService().getRegisteredRemoteClusterNames().contains(clusterAlias) == false) {
             throw new NoSuchRemoteClusterException(clusterAlias);
         }
         return new RemoteClusterAwareClient(transportService, clusterAlias, responseExecutor, switch (disconnectedStrategy) {

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
@@ -170,7 +170,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
                     assertFalse(service.isRemoteClusterRegistered("foo"));
                     {
                         Map<String, List<String>> perClusterIndices = service.groupClusterIndices(
-                            service.getRemoteClusterNames(),
+                            service.getRegisteredRemoteClusterNames(),
                             new String[] {
                                 "cluster_1:bar",
                                 "cluster_2:foo:bar",
@@ -191,7 +191,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
                     expectThrows(
                         NoSuchRemoteClusterException.class,
                         () -> service.groupClusterIndices(
-                            service.getRemoteClusterNames(),
+                            service.getRegisteredRemoteClusterNames(),
                             new String[] { "foo:bar", "cluster_1:bar", "cluster_2:foo:bar", "cluster_1:test", "cluster_2:foo*", "foo" }
                         )
                     );
@@ -199,7 +199,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
                     expectThrows(
                         NoSuchRemoteClusterException.class,
                         () -> service.groupClusterIndices(
-                            service.getRemoteClusterNames(),
+                            service.getRegisteredRemoteClusterNames(),
                             new String[] { "cluster_1:bar", "cluster_2:foo:bar", "cluster_1:test", "cluster_2:foo*", "does_not_exist:*" }
                         )
                     );
@@ -208,7 +208,10 @@ public class RemoteClusterServiceTests extends ESTestCase {
                     {
                         String[] indices = shuffledList(List.of("cluster*:foo*", "foo", "-cluster_1:*", "*:boo")).toArray(new String[0]);
 
-                        Map<String, List<String>> perClusterIndices = service.groupClusterIndices(service.getRemoteClusterNames(), indices);
+                        Map<String, List<String>> perClusterIndices = service.groupClusterIndices(
+                            service.getRegisteredRemoteClusterNames(),
+                            indices
+                        );
                         assertEquals(2, perClusterIndices.size());
                         List<String> localIndexes = perClusterIndices.get(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
                         assertNotNull(localIndexes);
@@ -223,7 +226,10 @@ public class RemoteClusterServiceTests extends ESTestCase {
                     {
                         String[] indices = shuffledList(List.of("*:*", "-clu*_1:*", "*:boo")).toArray(new String[0]);
 
-                        Map<String, List<String>> perClusterIndices = service.groupClusterIndices(service.getRemoteClusterNames(), indices);
+                        Map<String, List<String>> perClusterIndices = service.groupClusterIndices(
+                            service.getRegisteredRemoteClusterNames(),
+                            indices
+                        );
                         assertEquals(1, perClusterIndices.size());
 
                         List<String> cluster2 = perClusterIndices.get("cluster_2");
@@ -236,7 +242,10 @@ public class RemoteClusterServiceTests extends ESTestCase {
                             new String[0]
                         );
 
-                        Map<String, List<String>> perClusterIndices = service.groupClusterIndices(service.getRemoteClusterNames(), indices);
+                        Map<String, List<String>> perClusterIndices = service.groupClusterIndices(
+                            service.getRegisteredRemoteClusterNames(),
+                            indices
+                        );
                         assertEquals(1, perClusterIndices.size());
                         List<String> localIndexes = perClusterIndices.get(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
                         assertNotNull(localIndexes);
@@ -246,7 +255,10 @@ public class RemoteClusterServiceTests extends ESTestCase {
                     {
                         String[] indices = shuffledList(List.of("cluster*:*", "foo", "-*:*")).toArray(new String[0]);
 
-                        Map<String, List<String>> perClusterIndices = service.groupClusterIndices(service.getRemoteClusterNames(), indices);
+                        Map<String, List<String>> perClusterIndices = service.groupClusterIndices(
+                            service.getRegisteredRemoteClusterNames(),
+                            indices
+                        );
                         assertEquals(1, perClusterIndices.size());
                         List<String> localIndexes = perClusterIndices.get(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
                         assertNotNull(localIndexes);
@@ -257,7 +269,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
                         IllegalArgumentException e = expectThrows(
                             IllegalArgumentException.class,
                             () -> service.groupClusterIndices(
-                                service.getRemoteClusterNames(),
+                                service.getRegisteredRemoteClusterNames(),
                                 // -cluster_1:foo* is not allowed, only -cluster_1:*
                                 new String[] { "cluster_1:bar", "-cluster_2:foo*", "cluster_1:test", "cluster_2:foo*", "foo" }
                             )
@@ -271,7 +283,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
                         IllegalArgumentException e = expectThrows(
                             IllegalArgumentException.class,
                             () -> service.groupClusterIndices(
-                                service.getRemoteClusterNames(),
+                                service.getRegisteredRemoteClusterNames(),
                                 // -cluster_1:* will fail since cluster_1 was never included in order to qualify to be excluded
                                 new String[] { "-cluster_1:*", "cluster_2:foo*", "foo" }
                             )
@@ -287,7 +299,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
                     {
                         IllegalArgumentException e = expectThrows(
                             IllegalArgumentException.class,
-                            () -> service.groupClusterIndices(service.getRemoteClusterNames(), new String[] { "-cluster_1:*" })
+                            () -> service.groupClusterIndices(service.getRegisteredRemoteClusterNames(), new String[] { "-cluster_1:*" })
                         );
                         assertThat(
                             e.getMessage(),
@@ -300,7 +312,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
                     {
                         IllegalArgumentException e = expectThrows(
                             IllegalArgumentException.class,
-                            () -> service.groupClusterIndices(service.getRemoteClusterNames(), new String[] { "-*:*" })
+                            () -> service.groupClusterIndices(service.getRegisteredRemoteClusterNames(), new String[] { "-*:*" })
                         );
                         assertThat(
                             e.getMessage(),
@@ -315,7 +327,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
 
                         IllegalArgumentException e = expectThrows(
                             IllegalArgumentException.class,
-                            () -> service.groupClusterIndices(service.getRemoteClusterNames(), indices)
+                            () -> service.groupClusterIndices(service.getRegisteredRemoteClusterNames(), indices)
                         );
                         assertThat(
                             e.getMessage(),
@@ -394,7 +406,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
                         expectThrows(
                             NoSuchRemoteClusterException.class,
                             () -> service.groupClusterIndices(
-                                service.getRemoteClusterNames(),
+                                service.getRegisteredRemoteClusterNames(),
                                 new String[] { "foo:bar", "cluster_1:bar", "cluster_2:foo:bar", "cluster_1:test", "cluster_2:foo*", "foo" }
                             )
                         );


### PR DESCRIPTION
This change removes `RemoteClusterService.getRemoteClusterNames()` since `getRegisteredRemoteClusterNames()` provides the same functionality. The comment in `getRegisteredRemoteClusterNames()` was removed since it is no longer accurate after the change in PR #47891.