### PR TITLE
Test for duplicate transport versions (#130494)

### DIFF
--- a/server/src/test/java/org/elasticsearch/TransportVersionTests.java
+++ b/server/src/test/java/org/elasticsearch/TransportVersionTests.java
@@ -14,8 +14,8 @@ import org.elasticsearch.test.TransportVersionUtils;
 
 import java.lang.reflect.Modifier;
 import java.util.Collections;
-import java.util.Map;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
@@ -259,7 +259,6 @@ public class TransportVersionTests extends ESTestCase {
             fail(msg.toString());
         }
     }
-
 
     public void testDuplicateConstants() {
         List<TransportVersion> tvs = TransportVersions.getAllVersions().stream().sorted().toList();

--- a/server/src/test/java/org/elasticsearch/TransportVersionTests.java
+++ b/server/src/test/java/org/elasticsearch/TransportVersionTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.test.TransportVersionUtils;
 import java.lang.reflect.Modifier;
 import java.util.Collections;
 import java.util.Map;
+import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
@@ -256,6 +257,19 @@ public class TransportVersionTests extends ESTestCase {
                 msg.append("  " + id + "\n");
             }
             fail(msg.toString());
+        }
+    }
+
+
+    public void testDuplicateConstants() {
+        List<TransportVersion> tvs = TransportVersions.getAllVersions().stream().sorted().toList();
+        TransportVersion previous = tvs.get(0);
+        for (int i = 1; i < tvs.size(); i++) {
+            TransportVersion next = tvs.get(i);
+            if (next.id() == previous.id()) {
+                throw new AssertionError("Duplicate transport version id: " + next.id());
+            }
+            previous = next;
         }
     }
 }


### PR DESCRIPTION
We used to have an assertion during transport version loading that duplicate ids were not found, but it appears to have been lost in refactorings. This commit adds a test to ensure duplicate ids do not occur.

relates #130486