### PR TITLE
[9.1] Add data-streams tests to restResourcesZip (#130424)

### DIFF
--- a/modules/data-streams/build.gradle
+++ b/modules/data-streams/build.gradle
@@ -83,7 +83,7 @@ tasks.named("yamlRestCompatTestTransform").configure({ task ->
 })
 
 configurations {
-  basicRestSpecs {
+  restTests {
     attributes {
       attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.DIRECTORY_TYPE)
     }
@@ -91,5 +91,5 @@ configurations {
 }
 
 artifacts {
-  basicRestSpecs(new File(projectDir, "src/yamlRestTest/resources/rest-api-spec/test"))
+  restTests(new File(projectDir, "src/yamlRestTest/resources/rest-api-spec/test"))
 }

--- a/x-pack/qa/multi-project/core-rest-tests-with-multiple-projects/build.gradle
+++ b/x-pack/qa/multi-project/core-rest-tests-with-multiple-projects/build.gradle
@@ -28,7 +28,7 @@ dependencies {
   clusterModules project(xpackModule('mapper-constant-keyword'))
   clusterModules project(xpackModule('wildcard'))
   clusterModules project(':test:external-modules:test-multi-project')
-  restTestConfig project(path: ':modules:data-streams', configuration: "basicRestSpecs")
+  restTestConfig project(path: ':modules:data-streams', configuration: "restTests")
   restTestConfig project(path: ':modules:ingest-common', configuration: "basicRestSpecs")
   restTestConfig project(path: ':modules:reindex', configuration: "basicRestSpecs")
   restTestConfig project(path: ':modules:streams', configuration: "basicRestSpecs")

--- a/x-pack/rest-resources-zip/build.gradle
+++ b/x-pack/rest-resources-zip/build.gradle
@@ -20,6 +20,7 @@ dependencies {
   freeTests project(path: ':rest-api-spec', configuration: 'restTests')
   freeTests project(path: ':modules:aggregations', configuration: 'restTests')
   freeTests project(path: ':modules:analysis-common', configuration: 'restTests')
+  freeTests project(path: ':modules:data-streams', configuration: 'restTests')
   freeTests project(path: ':modules:ingest-geoip', configuration: 'restTests')
   compatApis project(path: ':rest-api-spec', configuration: 'restCompatSpecs')
   compatApis project(path: ':x-pack:plugin', configuration: 'restCompatSpecs')


### PR DESCRIPTION
Backports the following commits to 9.1:
 - Add data-streams tests to restResourcesZip (#130424)