### PR TITLE
[9.1] TEST Segregate test methods in ThreadPoolMergeExecutorServiceDiskSpaceTests wrt to the mocked filesystems (#130430)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -485,9 +485,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.ClassificationIT
   method: testWithDatastreams
   issue: https://github.com/elastic/elasticsearch/issues/129457
-- class: org.elasticsearch.index.engine.ThreadPoolMergeExecutorServiceDiskSpaceTests
-  method: testMergeTasksAreUnblockedWhenMoreDiskSpaceBecomesAvailable
-  issue: https://github.com/elastic/elasticsearch/issues/129296
 - class: org.elasticsearch.xpack.profiling.action.GetStatusActionIT
   method: testWaitsUntilResourcesAreCreated
   issue: https://github.com/elastic/elasticsearch/issues/129486

--- a/server/src/test/java/org/elasticsearch/index/engine/ThreadPoolMergeExecutorServiceDiskSpaceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/ThreadPoolMergeExecutorServiceDiskSpaceTests.java
@@ -27,8 +27,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.Before;
 
 import java.io.IOException;
 import java.nio.file.FileStore;
@@ -59,8 +58,8 @@ import static org.mockito.Mockito.when;
 
 public class ThreadPoolMergeExecutorServiceDiskSpaceTests extends ESTestCase {
 
-    private static TestMockFileStore aFileStore = new TestMockFileStore("mocka");
-    private static TestMockFileStore bFileStore = new TestMockFileStore("mockb");
+    private static TestMockFileStore aFileStore;
+    private static TestMockFileStore bFileStore;
     private static String aPathPart;
     private static String bPathPart;
     private static int mergeExecutorThreadCount;
@@ -69,8 +68,10 @@ public class ThreadPoolMergeExecutorServiceDiskSpaceTests extends ESTestCase {
     private static NodeEnvironment nodeEnvironment;
     private static boolean setThreadPoolMergeSchedulerSetting;
 
-    @BeforeClass
-    public static void installMockUsableSpaceFS() throws Exception {
+    @Before
+    public void setupTestEnv() throws Exception {
+        aFileStore = new TestMockFileStore("mocka");
+        bFileStore = new TestMockFileStore("mockb");
         FileSystem current = PathUtils.getDefaultFileSystem();
         aPathPart = "a-" + randomUUID();
         bPathPart = "b-" + randomUUID();
@@ -96,18 +97,19 @@ public class ThreadPoolMergeExecutorServiceDiskSpaceTests extends ESTestCase {
         nodeEnvironment = new NodeEnvironment(settings, TestEnvironment.newEnvironment(settings));
     }
 
-    @AfterClass
-    public static void removeMockUsableSpaceFS() {
+    @After
+    public void removeMockUsableSpaceFS() {
+        if (setThreadPoolMergeSchedulerSetting) {
+            assertWarnings(
+                "[indices.merge.scheduler.use_thread_pool] setting was deprecated in Elasticsearch "
+                    + "and will be removed in a future release. See the breaking changes documentation for the next major version."
+            );
+        }
         PathUtilsForTesting.teardown();
         aFileStore = null;
         bFileStore = null;
         testThreadPool.close();
         nodeEnvironment.close();
-    }
-
-    @After
-    public void cleanupThreadPool() {
-        testThreadPool.scheduledTasks.clear();
     }
 
     static class TestCapturingThreadPool extends TestThreadPool {
@@ -319,8 +321,6 @@ public class ThreadPoolMergeExecutorServiceDiskSpaceTests extends ESTestCase {
                 )
             );
         }
-        aFileStore.throwIoException = false;
-        bFileStore.throwIoException = false;
     }
 
     public void testAvailableDiskSpaceMonitorWhenFileSystemStatErrors() throws Exception {
@@ -406,8 +406,6 @@ public class ThreadPoolMergeExecutorServiceDiskSpaceTests extends ESTestCase {
                 }
             });
         }
-        aFileStore.throwIoException = false;
-        bFileStore.throwIoException = false;
     }
 
     public void testAvailableDiskSpaceMonitorSettingsUpdate() throws Exception {
@@ -516,12 +514,6 @@ public class ThreadPoolMergeExecutorServiceDiskSpaceTests extends ESTestCase {
                 }
             }, 5, TimeUnit.SECONDS);
         }
-        if (setThreadPoolMergeSchedulerSetting) {
-            assertWarnings(
-                "[indices.merge.scheduler.use_thread_pool] setting was deprecated in Elasticsearch "
-                    + "and will be removed in a future release. See the breaking changes documentation for the next major version."
-            );
-        }
     }
 
     public void testAbortingOrRunningMergeTaskHoldsUpBudget() throws Exception {
@@ -564,7 +556,7 @@ public class ThreadPoolMergeExecutorServiceDiskSpaceTests extends ESTestCase {
                 testDoneLatch.await();
                 return null;
             }).when(stallingMergeTask).abort();
-            threadPoolMergeExecutorService.submitMergeTask(stallingMergeTask);
+            assertTrue(threadPoolMergeExecutorService.submitMergeTask(stallingMergeTask));
             // assert the merge task is holding up disk space budget
             expectedAvailableBudget.set(expectedAvailableBudget.get() - taskBudget);
             assertBusy(
@@ -574,7 +566,7 @@ public class ThreadPoolMergeExecutorServiceDiskSpaceTests extends ESTestCase {
             ThreadPoolMergeScheduler.MergeTask mergeTask = mock(ThreadPoolMergeScheduler.MergeTask.class);
             when(mergeTask.estimatedRemainingMergeSize()).thenReturn(randomLongBetween(0L, expectedAvailableBudget.get()));
             when(mergeTask.schedule()).thenReturn(RUN);
-            threadPoolMergeExecutorService.submitMergeTask(mergeTask);
+            assertTrue(threadPoolMergeExecutorService.submitMergeTask(mergeTask));
             assertBusy(() -> {
                 verify(mergeTask).schedule();
                 verify(mergeTask).run();
@@ -594,12 +586,6 @@ public class ThreadPoolMergeExecutorServiceDiskSpaceTests extends ESTestCase {
                 }
                 assertThat(threadPoolMergeExecutorService.allDone(), is(true));
             });
-        }
-        if (setThreadPoolMergeSchedulerSetting) {
-            assertWarnings(
-                "[indices.merge.scheduler.use_thread_pool] setting was deprecated in Elasticsearch "
-                    + "and will be removed in a future release. See the breaking changes documentation for the next major version."
-            );
         }
     }
 
@@ -654,7 +640,7 @@ public class ThreadPoolMergeExecutorServiceDiskSpaceTests extends ESTestCase {
                     testDoneLatch.await();
                     return null;
                 }).when(mergeTask).abort();
-                threadPoolMergeExecutorService.submitMergeTask(mergeTask);
+                assertTrue(threadPoolMergeExecutorService.submitMergeTask(mergeTask));
                 if (mergeTask.schedule() == RUN) {
                     runningMergeTasks.add(mergeTask);
                 } else {
@@ -679,7 +665,7 @@ public class ThreadPoolMergeExecutorServiceDiskSpaceTests extends ESTestCase {
                         return RUN;
                     }
                 }).when(mergeTask).schedule();
-                threadPoolMergeExecutorService.submitMergeTask(mergeTask);
+                assertTrue(threadPoolMergeExecutorService.submitMergeTask(mergeTask));
                 backloggingMergeTasksScheduleCountMap.put(mergeTask, 1);
             }
             int checkRounds = randomIntBetween(1, 10);
@@ -712,7 +698,7 @@ public class ThreadPoolMergeExecutorServiceDiskSpaceTests extends ESTestCase {
                 long taskBudget = randomLongBetween(1L, backloggedMergeTaskDiskSpaceBudget);
                 when(mergeTask.estimatedRemainingMergeSize()).thenReturn(taskBudget);
                 when(mergeTask.schedule()).thenReturn(RUN);
-                threadPoolMergeExecutorService.submitMergeTask(mergeTask);
+                assertTrue(threadPoolMergeExecutorService.submitMergeTask(mergeTask));
                 assertBusy(() -> {
                     verify(mergeTask).schedule();
                     verify(mergeTask).run();
@@ -738,12 +724,6 @@ public class ThreadPoolMergeExecutorServiceDiskSpaceTests extends ESTestCase {
                 assertThat(threadPoolMergeExecutorService.getDiskSpaceAvailableForNewMergeTasks(), is(availableInitialBudget));
                 assertThat(threadPoolMergeExecutorService.allDone(), is(true));
             });
-        }
-        if (setThreadPoolMergeSchedulerSetting) {
-            assertWarnings(
-                "[indices.merge.scheduler.use_thread_pool] setting was deprecated in Elasticsearch "
-                    + "and will be removed in a future release. See the breaking changes documentation for the next major version."
-            );
         }
     }
 
@@ -823,7 +803,7 @@ public class ThreadPoolMergeExecutorServiceDiskSpaceTests extends ESTestCase {
                     runningOrAbortingMergeTasksList.add(mergeTask);
                     latchesBlockingMergeTasksList.add(blockMergeTaskLatch);
                 }
-                threadPoolMergeExecutorService.submitMergeTask(mergeTask);
+                assertTrue(threadPoolMergeExecutorService.submitMergeTask(mergeTask));
             }
             // currently running (or aborting) merge tasks have consumed some of the available budget
             while (runningOrAbortingMergeTasksList.isEmpty() == false) {
@@ -855,8 +835,8 @@ public class ThreadPoolMergeExecutorServiceDiskSpaceTests extends ESTestCase {
                     // merge task 2 can run because it is under budget
                     when(mergeTask2.estimatedRemainingMergeSize()).thenReturn(underBudget);
                 }
-                threadPoolMergeExecutorService.submitMergeTask(mergeTask1);
-                threadPoolMergeExecutorService.submitMergeTask(mergeTask2);
+                assertTrue(threadPoolMergeExecutorService.submitMergeTask(mergeTask1));
+                assertTrue(threadPoolMergeExecutorService.submitMergeTask(mergeTask2));
                 assertBusy(() -> {
                     if (task1Runs) {
                         verify(mergeTask1).schedule();
@@ -889,12 +869,6 @@ public class ThreadPoolMergeExecutorServiceDiskSpaceTests extends ESTestCase {
             aFileStore.usableSpace = Long.MAX_VALUE;
             bFileStore.usableSpace = Long.MAX_VALUE;
             assertBusy(() -> assertThat(threadPoolMergeExecutorService.allDone(), is(true)));
-        }
-        if (setThreadPoolMergeSchedulerSetting) {
-            assertWarnings(
-                "[indices.merge.scheduler.use_thread_pool] setting was deprecated in Elasticsearch "
-                    + "and will be removed in a future release. See the breaking changes documentation for the next major version."
-            );
         }
     }
 
@@ -990,12 +964,6 @@ public class ThreadPoolMergeExecutorServiceDiskSpaceTests extends ESTestCase {
                 }
             });
         }
-        if (setThreadPoolMergeSchedulerSetting) {
-            assertWarnings(
-                "[indices.merge.scheduler.use_thread_pool] setting was deprecated in Elasticsearch "
-                    + "and will be removed in a future release. See the breaking changes documentation for the next major version."
-            );
-        }
     }
 
     public void testMergeTasksAreUnblockedWhenMoreDiskSpaceBecomesAvailable() throws Exception {
@@ -1058,7 +1026,7 @@ public class ThreadPoolMergeExecutorServiceDiskSpaceTests extends ESTestCase {
                     testDoneLatch.await();
                     return null;
                 }).when(mergeTask).abort();
-                threadPoolMergeExecutorService.submitMergeTask(mergeTask);
+                assertTrue(threadPoolMergeExecutorService.submitMergeTask(mergeTask));
                 if (mergeTask.schedule() == RUN) {
                     runningMergeTasks.add(mergeTask);
                 } else {
@@ -1083,7 +1051,7 @@ public class ThreadPoolMergeExecutorServiceDiskSpaceTests extends ESTestCase {
                 when(mergeTask.estimatedRemainingMergeSize()).thenReturn(taskBudget);
                 Schedule schedule = randomFrom(RUN, ABORT);
                 when(mergeTask.schedule()).thenReturn(schedule);
-                threadPoolMergeExecutorService.submitMergeTask(mergeTask);
+                assertTrue(threadPoolMergeExecutorService.submitMergeTask(mergeTask));
                 if (schedule == RUN) {
                     overBudgetTasksToRunList.add(mergeTask);
                 } else {
@@ -1149,12 +1117,6 @@ public class ThreadPoolMergeExecutorServiceDiskSpaceTests extends ESTestCase {
                     is(availableInitialBudget + grantedUsableSpaceBuffer)
                 );
             });
-        }
-        if (setThreadPoolMergeSchedulerSetting) {
-            assertWarnings(
-                "[indices.merge.scheduler.use_thread_pool] setting was deprecated in Elasticsearch "
-                    + "and will be removed in a future release. See the breaking changes documentation for the next major version."
-            );
         }
     }
 }


### PR DESCRIPTION
Previously, out of zealousness for testing efficiency, the mocked filesystems were reused across the test suite class. But this makes tests liable to interference wrt to filesystem stats calls. Moreover, if one test fails, it can trigger failures in other test methods.

This PR recreates the mocked filesystems for every test method.

Backport of https://github.com/elastic/elasticsearch/pull/130430
Fixes #129296 #130205