### PR TITLE
ES|QL: add tests and fix docs for LOOKUP JOIN with index datemath

### DIFF
--- a/docs/reference/query-languages/esql/esql-lookup-join.md
+++ b/docs/reference/query-languages/esql/esql-lookup-join.md
@@ -181,6 +181,6 @@ The following are the current limitations with `LOOKUP JOIN`:
 * Indices in [`lookup` mode](/reference/elasticsearch/index-settings/index-modules.md#index-mode-setting) are always single-sharded.
 * Cross cluster search is unsupported initially. Both source and lookup indices must be local.
 * Currently, only matching on equality is supported.
-* `LOOKUP JOIN` can only use a single match field and a single index. Wildcards, aliases, datemath, and datastreams are not supported.
+* `LOOKUP JOIN` can only use a single match field and a single index. Wildcards, aliases, datemath, and datastreams are supported, as long as the index pattern matches a single concrete index {applies_to}`stack: ga 9.1.0`.
 * The name of the match field in `LOOKUP JOIN lu_idx ON match_field` must match an existing field in the query. This may require `RENAME`s or `EVAL`s to achieve.
 * The query will circuit break if there are too many matching documents in the lookup index, or if the documents are too large. More precisely, `LOOKUP JOIN` works in batches of, normally, about 10,000 rows; a large amount of heap space is needed if the matching documents from the lookup index for a batch are multiple megabytes or larger. This is roughly the same as for `ENRICH`.

--- a/docs/reference/query-languages/esql/esql-lookup-join.md
+++ b/docs/reference/query-languages/esql/esql-lookup-join.md
@@ -181,6 +181,7 @@ The following are the current limitations with `LOOKUP JOIN`:
 * Indices in [`lookup` mode](/reference/elasticsearch/index-settings/index-modules.md#index-mode-setting) are always single-sharded.
 * Cross cluster search is unsupported initially. Both source and lookup indices must be local.
 * Currently, only matching on equality is supported.
-* `LOOKUP JOIN` can only use a single match field and a single index. Wildcards, aliases, datemath, and datastreams are supported, as long as the index pattern matches a single concrete index {applies_to}`stack: ga 9.1.0`.
+* `LOOKUP JOIN` can only use a single match field and a single index. Wildcards are not supported.
+  * Aliases, datemath, and datastreams are supported, as long as the index pattern matches a single concrete index {applies_to}`stack: ga 9.1.0`.
 * The name of the match field in `LOOKUP JOIN lu_idx ON match_field` must match an existing field in the query. This may require `RENAME`s or `EVAL`s to achieve.
 * The query will circuit break if there are too many matching documents in the lookup index, or if the documents are too large. More precisely, `LOOKUP JOIN` works in batches of, normally, about 10,000 rows; a large amount of heap space is needed if the matching documents from the lookup index for a batch are multiple megabytes or larger. This is roughly the same as for `ENRICH`.

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/RestEsqlIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/RestEsqlIT.java
@@ -793,9 +793,9 @@ public class RestEsqlIT extends RestEsqlTestCase {
         ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
 
         String[] indices = {
-            "test-index-" + DateTimeFormatter.ofPattern("yyyy.MM.dd", Locale.ROOT).format(now),
-            "test-index-" + DateTimeFormatter.ofPattern("yyyy.MM.dd", Locale.ROOT).format(now.minusDays(1)),
-            "test-index-" + DateTimeFormatter.ofPattern("yyyy.MM.dd", Locale.ROOT).format(now.minusDays(2)) };
+            "test-index-" + DateTimeFormatter.ofPattern("yyyy", Locale.ROOT).format(now),
+            "test-index-" + DateTimeFormatter.ofPattern("yyyy", Locale.ROOT).format(now.minusYears(1)),
+            "test-index-" + DateTimeFormatter.ofPattern("yyyy", Locale.ROOT).format(now.minusYears(2)) };
 
         int idx = 0;
         for (String index : indices) {
@@ -810,7 +810,7 @@ public class RestEsqlIT extends RestEsqlTestCase {
 
         String query = """
             {
-                "query": "from <test-index-{now/d}> | sort f asc | limit 1 | keep f"
+                "query": "from <test-index-{now/d{yyyy}}> | sort f asc | limit 1 | keep f"
             }
             """;
         Request request = new Request("POST", "/_query");
@@ -824,7 +824,7 @@ public class RestEsqlIT extends RestEsqlTestCase {
 
         query = """
             {
-                "query": "from <test-index-{now/d-1d}> | sort f asc | limit 1 | keep f"
+                "query": "from <test-index-{now/d-1y{yyyy}}> | sort f asc | limit 1 | keep f"
             }
             """;
         request = new Request("POST", "/_query");
@@ -860,8 +860,8 @@ public class RestEsqlIT extends RestEsqlTestCase {
         assertOK(client().performRequest(request));
 
         String[] lookupIndices = {
-            "lookup-index-" + DateTimeFormatter.ofPattern("yyyy.MM.dd", Locale.ROOT).format(now),
-            "lookup-index-" + DateTimeFormatter.ofPattern("yyyy.MM.dd", Locale.ROOT).format(now.minusDays(1)) };
+            "lookup-index-" + DateTimeFormatter.ofPattern("yyyy", Locale.ROOT).format(now),
+            "lookup-index-" + DateTimeFormatter.ofPattern("yyyy", Locale.ROOT).format(now.minusYears(1)) };
 
         for (String index : lookupIndices) {
             createIndex(index, Settings.builder().put("mode", "lookup").build(), """
@@ -880,8 +880,8 @@ public class RestEsqlIT extends RestEsqlTestCase {
         }
 
         String[] queries = {
-            "from idx | lookup join <lookup-index-{now/d}> on key | limit 1",
-            "from idx | lookup join <lookup-index-{now/d-1d}> on key | limit 1" };
+            "from idx | lookup join <lookup-index-{now/d{yyyy}}> on key | limit 1",
+            "from idx | lookup join <lookup-index-{now/d-1y{yyyy}}> on key | limit 1" };
         for (int i = 0; i < queries.length; i++) {
             String queryPayload = "{\"query\": \"" + queries[i] + "\"}";
             request = new Request("POST", "/_query");


### PR DESCRIPTION
Adding tests and fixing docs for usage of date math in index patterns, especially in LOOKUP JOIN, that got recent support for aliases.