### PR TITLE
[8.19] Add data-streams tests to restResourcesZip (#130424)

### DIFF
--- a/modules/data-streams/build.gradle
+++ b/modules/data-streams/build.gradle
@@ -81,3 +81,7 @@ tasks.named("yamlRestTestV7CompatTransform").configure({ task ->
   task.skipTest("data_stream/210_rollover_failure_store/Roll over a data stream's failure store without conditions", "Rolling over a data stream using target_failure_store is no longer supported.")
   task.skipTest("data_stream/240_failure_store_info/Get failure store info from explicitly enabled failure store and disabled lifecycle", "failure store lifecycle is not using anymore the data stream lifecycle")
 })
+
+artifacts {
+  restTests(new File(projectDir, "src/yamlRestTest/resources/rest-api-spec/test"))
+}

--- a/x-pack/rest-resources-zip/build.gradle
+++ b/x-pack/rest-resources-zip/build.gradle
@@ -20,6 +20,7 @@ dependencies {
   freeTests project(path: ':rest-api-spec', configuration: 'restTests')
   freeTests project(path: ':modules:aggregations', configuration: 'restTests')
   freeTests project(path: ':modules:analysis-common', configuration: 'restTests')
+  freeTests project(path: ':modules:data-streams', configuration: 'restTests')
   freeTests project(path: ':modules:ingest-geoip', configuration: 'restTests')
   compatApis project(path: ':rest-api-spec', configuration: 'restCompatSpecs')
   compatApis project(path: ':x-pack:plugin', configuration: 'restCompatSpecs')


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Add data-streams tests to restResourcesZip (#130424)](https://github.com/elastic/elasticsearch/pull/130424)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)