### PR TITLE
[DOCS] Update applies_to tags in Docs for Sparse Vector Mapping / Index Options

### DIFF
--- a/docs/reference/elasticsearch/mapping-reference/sparse-vector.md
+++ b/docs/reference/elasticsearch/mapping-reference/sparse-vector.md
@@ -25,9 +25,6 @@ PUT my-index
 ```
 
 ## Token pruning
-```{applies_to}
-stack: preview 9.1
-```
 
 With any new indices created, token pruning will be turned on by default with appropriate defaults. You can control this behaviour using the optional `index_options` parameters for the field:
 
@@ -63,23 +60,23 @@ The following parameters are accepted by `sparse_vector` fields:
     * Exclude the field from [_source](/reference/elasticsearch/rest-apis/retrieve-selected-fields.md#source-filtering).
     * Use [synthetic `_source`](/reference/elasticsearch/mapping-reference/mapping-source-field.md#synthetic-source).
 
-index_options {applies_to}`stack: preview 9.1`
+index_options
 :   (Optional, object) You can set index options for your  `sparse_vector` field to determine if you should prune tokens, and the parameter configurations for the token pruning. If pruning options are not set in your [`sparse_vector` query](/reference/query-languages/query-dsl/query-dsl-sparse-vector-query.md), Elasticsearch will use the default options configured for the field, if any.
 
 Parameters for `index_options` are:
 
-`prune` {applies_to}`stack: preview 9.1`
+`prune`
 :   (Optional, boolean) Whether to perform pruning, omitting the non-significant tokens from the query to improve query performance. If `prune` is true but the `pruning_config` is not specified, pruning will occur but default values will be used. Default: true.
 
-`pruning_config` {applies_to}`stack: preview 9.1`
+`pruning_config`
 :   (Optional, object) Optional pruning configuration. If enabled, this will omit non-significant tokens from the query in order to improve query performance. This is only used if `prune` is set to `true`. If `prune` is set to `true` but `pruning_config` is not specified, default values will be used. If `prune` is set to false but `pruning_config` is specified, an exception will occur.
 
     Parameters for `pruning_config` include:
 
-    `tokens_freq_ratio_threshold` {applies_to}`stack: preview 9.1`
+    `tokens_freq_ratio_threshold`
     :   (Optional, integer) Tokens whose frequency is more than `tokens_freq_ratio_threshold` times the average frequency of all tokens in the specified field are considered outliers and pruned. This value must between 1 and 100. Default: `5`.
 
-    `tokens_weight_threshold` {applies_to}`stack: preview 9.1`
+    `tokens_weight_threshold`
     :   (Optional, float) Tokens whose weight is less than `tokens_weight_threshold` are considered insignificant and pruned. This value must be between 0 and 1. Default: `0.4`.
 
     ::::{note}

--- a/docs/reference/elasticsearch/mapping-reference/sparse-vector.md
+++ b/docs/reference/elasticsearch/mapping-reference/sparse-vector.md
@@ -25,6 +25,9 @@ PUT my-index
 ```
 
 ## Token pruning
+```{applies_to}
+stack: ga 9.1
+```
 
 With any new indices created, token pruning will be turned on by default with appropriate defaults. You can control this behaviour using the optional `index_options` parameters for the field:
 
@@ -60,23 +63,23 @@ The following parameters are accepted by `sparse_vector` fields:
     * Exclude the field from [_source](/reference/elasticsearch/rest-apis/retrieve-selected-fields.md#source-filtering).
     * Use [synthetic `_source`](/reference/elasticsearch/mapping-reference/mapping-source-field.md#synthetic-source).
 
-index_options
+index_options {applies_to}`stack: ga 9.1`
 :   (Optional, object) You can set index options for your  `sparse_vector` field to determine if you should prune tokens, and the parameter configurations for the token pruning. If pruning options are not set in your [`sparse_vector` query](/reference/query-languages/query-dsl/query-dsl-sparse-vector-query.md), Elasticsearch will use the default options configured for the field, if any.
 
 Parameters for `index_options` are:
 
-`prune`
+`prune` {applies_to}`stack: ga 9.1`
 :   (Optional, boolean) Whether to perform pruning, omitting the non-significant tokens from the query to improve query performance. If `prune` is true but the `pruning_config` is not specified, pruning will occur but default values will be used. Default: true.
 
-`pruning_config`
+`pruning_config` {applies_to}`stack: ga 9.1`
 :   (Optional, object) Optional pruning configuration. If enabled, this will omit non-significant tokens from the query in order to improve query performance. This is only used if `prune` is set to `true`. If `prune` is set to `true` but `pruning_config` is not specified, default values will be used. If `prune` is set to false but `pruning_config` is specified, an exception will occur.
 
     Parameters for `pruning_config` include:
 
-    `tokens_freq_ratio_threshold`
+    `tokens_freq_ratio_threshold` {applies_to}`stack: ga 9.1`
     :   (Optional, integer) Tokens whose frequency is more than `tokens_freq_ratio_threshold` times the average frequency of all tokens in the specified field are considered outliers and pruned. This value must between 1 and 100. Default: `5`.
 
-    `tokens_weight_threshold`
+    `tokens_weight_threshold` {applies_to}`stack: ga 9.1`
     :   (Optional, float) Tokens whose weight is less than `tokens_weight_threshold` are considered insignificant and pruned. This value must be between 0 and 1. Default: `0.4`.
 
     ::::{note}


### PR DESCRIPTION
Follow on to https://github.com/elastic/elasticsearch/pull/129089

Updates the applies_to labels in the docs for the sparse vector index options / token pruning configurations as these features are in GA, not preview. 