### PR TITLE
Simplified Linear and RRF Retrievers Docs

### DIFF
--- a/docs/reference/elasticsearch/rest-apis/retrievers.md
+++ b/docs/reference/elasticsearch/rest-apis/retrievers.md
@@ -1042,7 +1042,7 @@ In the `linear` retriever, this grouping relies on using a normalizer other than
 If you use the `none` normalizer, the scores across field groups will not be normalized and the results may be biased towards lexical field matches.
 ::::
 
-### Field boosting
+### Field boosting [multi-field-field-boosting]
 
 ::::{note}
 This section applies only to the `linear` retriever.

--- a/docs/reference/elasticsearch/rest-apis/retrievers.md
+++ b/docs/reference/elasticsearch/rest-apis/retrievers.md
@@ -1130,7 +1130,8 @@ Note, however, that wildcard field patterns will only resolve to fields that eit
 
 ### Examples
 
-TODO: Link to examples
+- [RRF with the multi-field query format](docs-content://solutions/search/retrievers-examples.md#retrievers-examples-rrf-multi-field-query-format)
+- [Linear retriever with the multi-field query format](docs-content://solutions/search/retrievers-examples.md#retrievers-examples-linear-multi-field-query-format)
 
 ## Common usage guidelines [retriever-common-parameters]
 

--- a/docs/reference/elasticsearch/rest-apis/retrievers.md
+++ b/docs/reference/elasticsearch/rest-apis/retrievers.md
@@ -259,7 +259,7 @@ A retriever that normalizes and linearly combines the scores of other retrievers
 #### Parameters [linear-retriever-parameters]
 
 ::::{note}
-Either `query` or `retrievers` must exclusively be specified.
+Either `query` or `retrievers` must be specified.
 Combining `query` and `retrievers` is not supported.
 ::::
 
@@ -341,7 +341,7 @@ Reciprocal rank fusion (RRF) is a method for combining multiple result sets with
 #### Parameters [rrf-retriever-parameters]
 
 ::::{note}
-Either `query` or `retrievers` must exclusively be specified.
+Either `query` or `retrievers` must be specified.
 Combining `query` and `retrievers` is not supported.
 ::::
 

--- a/docs/reference/elasticsearch/rest-apis/retrievers.md
+++ b/docs/reference/elasticsearch/rest-apis/retrievers.md
@@ -263,19 +263,19 @@ Either `query` or `retrievers` must exclusively be specified.
 Combining `query` and `retrievers` is not supported.
 ::::
 
-`query`
+`query` {applies_to}`stack: ga 9.1`
 :   (Optional, String)
 
     The query to use when using the [multi-field query format](#multi-field-query-format).
 
-`fields`
+`fields` {applies_to}`stack: ga 9.1`
 :   (Optional, array of strings)
 
     The fields to query when using the [multi-field query format](#multi-field-query-format).
     Fields can include boost values using the `^` notation (e.g., `"field^2"`).
     If not specified, uses the index's default fields from the `index.query.default_field` index setting, which is `*` by default.
 
-`normalizer`
+`normalizer` {applies_to}`stack: ga 9.1`
 :   (Optional, String)
 
     The normalizer to use when using the [multi-field query format](#multi-field-query-format).
@@ -345,12 +345,12 @@ Either `query` or `retrievers` must exclusively be specified.
 Combining `query` and `retrievers` is not supported.
 ::::
 
-`query`
+`query` {applies_to}`stack: ga 9.1`
 :   (Optional, String)
 
     The query to use when using the [multi-field query format](#multi-field-query-format).
 
-`fields`
+`fields` {applies_to}`stack: ga 9.1`
 :   (Optional, array of strings)
 
     The fields to query when using the [multi-field query format](#multi-field-query-format).
@@ -1021,6 +1021,9 @@ GET /restaurants/_search
 ```
 
 ## Multi-field query format [multi-field-query-format]
+```yaml {applies_to}
+stack: ga 9.1
+```
 
 The `linear` and `rrf` retrievers support a multi-field query format that provides a simplified way to define searches across multiple fields without explicitly specifying inner retrievers.
 This format automatically generates appropriate inner retrievers based on the field types and query parameters.

--- a/docs/reference/elasticsearch/rest-apis/retrievers.md
+++ b/docs/reference/elasticsearch/rest-apis/retrievers.md
@@ -1200,8 +1200,8 @@ Note, however, that wildcard field patterns will only resolve to fields that eit
 
 ### Examples
 
-- [RRF with the multi-field query format](docs-content://solutions/search/retrievers-examples.md#retrievers-examples-rrf-multi-field-query-format)
-- [Linear retriever with the multi-field query format](docs-content://solutions/search/retrievers-examples.md#retrievers-examples-linear-multi-field-query-format)
+<!-- - [RRF with the multi-field query format](docs-content://solutions/search/retrievers-examples.md#retrievers-examples-rrf-multi-field-query-format) -->
+<!-- - [Linear retriever with the multi-field query format](docs-content://solutions/search/retrievers-examples.md#retrievers-examples-linear-multi-field-query-format) -->
 
 ## Common usage guidelines [retriever-common-parameters]
 

--- a/docs/reference/elasticsearch/rest-apis/retrievers.md
+++ b/docs/reference/elasticsearch/rest-apis/retrievers.md
@@ -1053,13 +1053,9 @@ In the `linear` retriever, this grouping relies on using a normalizer other than
 If you use the `none` normalizer, the scores across field groups will not be normalized and the results may be biased towards lexical field matches.
 ::::
 
-### Field boosting [multi-field-field-boosting]
+### Linear retriever field boosting [multi-field-field-boosting]
 
-::::{note}
-This section applies only to the `linear` retriever.
-::::
-
-Fields can be boosted using the `^` notation:
+When using the `linear` retriever, fields can be boosted using the `^` notation:
 
 ```console
 GET books/_search

--- a/docs/reference/elasticsearch/rest-apis/retrievers.md
+++ b/docs/reference/elasticsearch/rest-apis/retrievers.md
@@ -279,10 +279,13 @@ Combining `query` and `retrievers` is not supported.
 :   (Optional, String)
 
     The normalizer to use when using the [multi-field query format](#multi-field-query-format).
+    See [normalizers](#linear-retriever-normalizers) for supported values.
     Required when `query` is specified.
 
-    Use `minmax` or `l2_norm` for proper result relevance.
-    Avoid using `none` as that will disable normalization, which will compromise result relevance.
+    ::::{warning}
+    Avoid using `none` as that will disable normalization and may bias the result set towards lexical matches.
+    See [field grouping](#multi-field-field-grouping) for more information.
+    ::::
 
 `retrievers`
 :   (Optional, array of objects)
@@ -318,18 +321,23 @@ Each entry in the `retrievers` array specifies the following parameters:
 `normalizer`
 :   (Optional, String)
 
-    - Specifies how we will normalize the retriever’s scores, before applying the specified `weight`. Available values are: `minmax`, `l2_norm`, and `none`. Defaults to `none`.
-
-    * `none`
-    * `minmax` : A `MinMaxScoreNormalizer` that normalizes scores based on the following formula
-
-        ```
-        score = (score - min) / (max - min)
-        ```
-
-    * `l2_norm` : An `L2ScoreNormalizer` that normalizes scores using the L2 norm of the score values.
+    Specifies how the retriever’s score will be normalized before applying the specified `weight`.
+    See [normalizers](#linear-retriever-normalizers) for supported values.
+    Defaults to `none`.
 
 See also [this hybrid search example](docs-content://solutions/search/retrievers-examples.md#retrievers-examples-linear-retriever) using a linear retriever on how to independently configure and apply normalizers to retrievers.
+
+#### Normalizers [linear-retriever-normalizers]
+
+The `linear` retriever supports the following normalizers:
+
+* `none`: No normalization
+* `minmax`: Normalizes scores based on the following formula:
+
+    ```
+    score = (score - min) / (max - min)
+    ```
+* `l2_norm`: Normalizes scores using the L2 norm of the score values
 
 
 ## RRF Retriever [rrf-retriever]

--- a/docs/reference/elasticsearch/rest-apis/retrievers.md
+++ b/docs/reference/elasticsearch/rest-apis/retrievers.md
@@ -1045,7 +1045,7 @@ The multi-field query format groups queried fields into two categories:
 - **Semantic fields**: [`semantic_text` fields](/reference/elasticsearch/mapping-reference/semantic-text.md).
 
 Each field group is queried separately and the scores/ranks are normalized such that each contributes 50% to the final score/rank.
-This is done to balance the importance of lexical and semantic fields.
+This balances the importance of lexical and semantic fields.
 Most indices contain more lexical than semantic fields, and without this grouping the results would often bias towards lexical field matches.
 
 ::::{warning}

--- a/docs/reference/elasticsearch/rest-apis/retrievers.md
+++ b/docs/reference/elasticsearch/rest-apis/retrievers.md
@@ -1166,7 +1166,7 @@ The score breakdown would change to:
     * `title_semantic`: 33% of semantic fields group score, 16.5% of final score
     * `description_semantic`: 66% of semantic fields group score, 33% of final score
 
-### Wildcard field patterns
+### Wildcard field patterns [multi-field-wildcard-field-patterns]
 
 Field names support the `*` wildcard character to match multiple fields:
 


### PR DESCRIPTION
Adds documentation for the simplified `linear` and `rrf` retriever query syntax. Sibling PR to https://github.com/elastic/docs-content/pull/2026.

Will spin up a separate pr for 8.19 once these changes are approved.
