### PR TITLE
[8.19] Fix ThreadPoolMergeSchedulerTests testSchedulerCloseWaitsForRunningMerge

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -453,6 +453,3 @@ tests:
   - class: org.elasticsearch.search.CCSDuelIT
     method: testTerminateAfter
     issue: https://github.com/elastic/elasticsearch/issues/126085
-  - class: org.elasticsearch.index.engine.ThreadPoolMergeSchedulerTests
-    method: testSchedulerCloseWaitsForRunningMerge
-    issue: https://github.com/elastic/elasticsearch/issues/125236

--- a/server/src/test/java/org/elasticsearch/index/engine/ThreadPoolMergeSchedulerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/ThreadPoolMergeSchedulerTests.java
@@ -566,11 +566,12 @@ public class ThreadPoolMergeSchedulerTests extends ESTestCase {
                         fail(e);
                     }
                 });
+                // test expects that there definitely is a running merge before closing the merge scheduler
+                mergeRunningLatch.await();
+                // closes the merge scheduler
                 t.start();
                 try {
                     assertTrue(t.isAlive());
-                    // wait for the merge to actually run
-                    mergeRunningLatch.await();
                     // ensure the merge scheduler is effectively "closed"
                     assertBusy(() -> {
                         MergeSource mergeSource2 = mock(MergeSource.class);


### PR DESCRIPTION
This fixes a race condition in the test scenario, between the merge scheduler closing and the merge task being scheduled to run. The test scenario expects that the merge task runs when the scheduler is closed. If the merge scheduler is closed before the merge task is scheduled, the merge task will instead be scheduled as aborted.

Fixes: https://github.com/elastic/elasticsearch/issues/125236
Backport of https://github.com/elastic/elasticsearch/pull/130078