### PR TITLE
@WithoutEntitlements on CommandTestCase

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/cli/CommandTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cli/CommandTestCase.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.cli;
 
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.ESTestCase.WithoutEntitlements;
 import org.hamcrest.Matcher;
 import org.junit.Before;
 
@@ -25,6 +26,7 @@ import static org.hamcrest.Matchers.emptyString;
 /**
  * A base test case for cli tools.
  */
+@WithoutEntitlements // CLI tools don't run with entitlements enforced
 public abstract class CommandTestCase extends ESTestCase {
 
     /** The terminal that execute uses */


### PR DESCRIPTION
CLI tools don't run with entitlements enforced, so there's no value in enforcing them during the tests.

Fixes #130550
Fixes #130551
Fixes #130552 