### PR TITLE
Refactor custom API key authenticator interface

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/apikey/CustomApiKeyAuthenticator.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/apikey/CustomApiKeyAuthenticator.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.core.security.authc.apikey;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationResult;
@@ -22,7 +23,7 @@ import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
 public interface CustomApiKeyAuthenticator {
     String name();
 
-    AuthenticationToken extractCredentials(@Nullable SecureString apiKeyCredentials);
+    AuthenticationToken extractCredentials(ThreadContext threadContext,  @Nullable SecureString apiKeyCredentials);
 
     void authenticate(@Nullable AuthenticationToken authenticationToken, ActionListener<AuthenticationResult<Authentication>> listener);
 
@@ -36,7 +37,7 @@ public interface CustomApiKeyAuthenticator {
         }
 
         @Override
-        public AuthenticationToken extractCredentials(@Nullable SecureString apiKeyCredentials) {
+        public AuthenticationToken extractCredentials(ThreadContext threadContext,  @Nullable SecureString apiKeyCredentials) {
             return null;
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/apikey/CustomApiKeyAuthenticator.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/apikey/CustomApiKeyAuthenticator.java
@@ -23,7 +23,7 @@ import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
 public interface CustomApiKeyAuthenticator {
     String name();
 
-    AuthenticationToken extractCredentials(ThreadContext threadContext,  @Nullable SecureString apiKeyCredentials);
+    AuthenticationToken extractCredentials(ThreadContext threadContext, @Nullable SecureString apiKeyCredentials);
 
     void authenticate(@Nullable AuthenticationToken authenticationToken, ActionListener<AuthenticationResult<Authentication>> listener);
 
@@ -37,7 +37,7 @@ public interface CustomApiKeyAuthenticator {
         }
 
         @Override
-        public AuthenticationToken extractCredentials(ThreadContext threadContext,  @Nullable SecureString apiKeyCredentials) {
+        public AuthenticationToken extractCredentials(ThreadContext threadContext, @Nullable SecureString apiKeyCredentials) {
             return null;
         }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/PluggableApiKeyAuthenticator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/PluggableApiKeyAuthenticator.java
@@ -32,7 +32,7 @@ public class PluggableApiKeyAuthenticator implements Authenticator {
 
     @Override
     public AuthenticationToken extractCredentials(Context context) {
-        return authenticator.extractCredentials(context.getApiKeyString());
+        return authenticator.extractCredentials(context.getThreadContext(), context.getApiKeyString());
     }
 
     @Override


### PR DESCRIPTION
Extending `extractCredentials` method to accept `ThreadContext` 
in order to allow associating any additional request headers with 
the authentication token.
