### PR TITLE
Use `isSearchable` instead of checking if a shard can be promoted.

### DIFF
--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DownsampleShardPersistentTaskExecutor.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DownsampleShardPersistentTaskExecutor.java
@@ -161,11 +161,10 @@ public class DownsampleShardPersistentTaskExecutor extends PersistentTasksExecut
 
     /**
      * Only shards that can be searched can be used as the source of a downsampling task.
-     * In stateless deployment, this means that shards that CANNOT be promoted to primary can be used.
      * For simplicity, in non-stateless deployments we use the primary shard.
      */
     private boolean isEligible(ShardRouting shardRouting) {
-        return shardRouting.started() && (isStateless ? shardRouting.isPromotableToPrimary() == false : shardRouting.primary());
+        return shardRouting.started() && (isStateless ? shardRouting.isSearchable() : shardRouting.primary());
     }
 
     private boolean isCandidateNode(Collection<DiscoveryNode> candidateNodes, String nodeId) {

--- a/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/DownsampleShardPersistentTaskExecutorTests.java
+++ b/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/DownsampleShardPersistentTaskExecutorTests.java
@@ -144,16 +144,14 @@ public class DownsampleShardPersistentTaskExecutorTests extends ESTestCase {
         var searchNode = newNode(Set.of(DiscoveryNodeRole.SEARCH_ROLE));
         var indexNode = newNode(Set.of(DiscoveryNodeRole.INDEX_ROLE));
         var shardId = new ShardId(backingIndex, 0);
+        ShardRouting indexOnlyShard = shardRoutingBuilder(shardId, indexNode.getId(), true, STARTED).withRecoverySource(null)
+            .withRole(ShardRouting.Role.INDEX_ONLY)
+            .build();
         var clusterState = ClusterState.builder(initialClusterState)
             .nodes(new DiscoveryNodes.Builder().add(indexNode).add(searchNode).build())
             .putRoutingTable(
                 projectId,
-                RoutingTable.builder()
-                    .add(
-                        IndexRoutingTable.builder(backingIndex)
-                            .addShard(shardRoutingBuilder(shardId, indexNode.getId(), true, STARTED).withRecoverySource(null).build())
-                    )
-                    .build()
+                RoutingTable.builder().add(IndexRoutingTable.builder(backingIndex).addShard(indexOnlyShard)).build()
             )
             .build();
 
@@ -177,7 +175,7 @@ public class DownsampleShardPersistentTaskExecutorTests extends ESTestCase {
                 RoutingTable.builder()
                     .add(
                         IndexRoutingTable.builder(backingIndex)
-                            .addShard(shardRoutingBuilder(shardId, indexNode.getId(), true, STARTED).withRecoverySource(null).build())
+                            .addShard(indexOnlyShard)
                             .addShard(
                                 shardRoutingBuilder(shardId, searchNode.getId(), false, STARTED).withRecoverySource(null)
                                     .withRole(ShardRouting.Role.SEARCH_ONLY)


### PR DESCRIPTION
Follow up from #130160 .

Use `isSearchable` instead of negating `isPromotableToPrimary` because it better captures what we need.

For non stateless deployments, we preserve the current logic to downsample the primary. This can change in the future but we should think through if there are any implications.