### PR TITLE
[9.1] Trim to size lists created in source fetchers (#130521)

### DIFF
--- a/docs/changelog/130521.yaml
+++ b/docs/changelog/130521.yaml
@@ -1,0 +1,5 @@
+pr: 130521
+summary: Trim to size lists created in source fetchers
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/mapper/ArraySourceValueFetcher.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ArraySourceValueFetcher.java
@@ -56,7 +56,7 @@ public abstract class ArraySourceValueFetcher implements ValueFetcher {
 
     @Override
     public List<Object> fetchValues(Source source, int doc, List<Object> ignoredValues) {
-        List<Object> values = new ArrayList<>();
+        ArrayList<Object> values = new ArrayList<>();
         for (String path : sourcePaths) {
             Object sourceValue = source.extractValue(path, nullValue);
             if (sourceValue == null) {
@@ -70,6 +70,7 @@ public abstract class ArraySourceValueFetcher implements ValueFetcher {
                 ignoredValues.add(sourceValue);
             }
         }
+        values.trimToSize();
         return values;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/NestedValueFetcher.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NestedValueFetcher.java
@@ -42,7 +42,7 @@ public class NestedValueFetcher implements ValueFetcher {
 
     @Override
     public List<Object> fetchValues(Source source, int doc, List<Object> includedValues) throws IOException {
-        List<Object> nestedEntriesToReturn = new ArrayList<>();
+        ArrayList<Object> nestedEntriesToReturn = new ArrayList<>();
         Map<String, Object> filteredSource = new HashMap<>();
         Map<String, Object> stub = createSourceMapStub(filteredSource);
         List<?> nestedValues = XContentMapValues.extractNestedSources(nestedFieldPath, source.source());
@@ -69,6 +69,7 @@ public class NestedValueFetcher implements ValueFetcher {
                 nestedEntriesToReturn.add(nestedEntry);
             }
         }
+        nestedEntriesToReturn.trimToSize();
         return nestedEntriesToReturn;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceValueFetcher.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceValueFetcher.java
@@ -55,7 +55,7 @@ public abstract class SourceValueFetcher implements ValueFetcher {
 
     @Override
     public List<Object> fetchValues(Source source, int doc, List<Object> ignoredValues) {
-        List<Object> values = new ArrayList<>();
+        ArrayList<Object> values = new ArrayList<>();
         for (String path : sourcePaths) {
             Object sourceValue = source.extractValue(path, nullValue);
             if (sourceValue == null) {
@@ -92,6 +92,7 @@ public abstract class SourceValueFetcher implements ValueFetcher {
                 }
             }
         }
+        values.trimToSize();
         return values;
     }
 


### PR DESCRIPTION
Backports the following commits to 9.1:
 - Trim to size lists created in source fetchers (#130521)