### PR TITLE
Unmute SearchWithRejectionsIT testOpenContextsAfterRejections

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -290,9 +290,6 @@ tests:
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test023InstallPluginUsingConfigFile
   issue: https://github.com/elastic/elasticsearch/issues/126145
-- class: org.elasticsearch.search.SearchWithRejectionsIT
-  method: testOpenContextsAfterRejections
-  issue: https://github.com/elastic/elasticsearch/issues/126340
 - class: org.elasticsearch.smoketest.MlWithSecurityIT
   method: test {yaml=ml/start_data_frame_analytics/Test start classification analysis when the dependent variable cardinality is too low}
   issue: https://github.com/elastic/elasticsearch/issues/123200

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/SearchWithRejectionsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/SearchWithRejectionsIT.java
@@ -58,7 +58,7 @@ public class SearchWithRejectionsIT extends ESIntegTestCase {
         }
         assertBusy(
             () -> assertThat(indicesAdmin().prepareStats().get().getTotal().getSearch().getOpenContexts(), equalTo(0L)),
-            1,
+            2,
             TimeUnit.SECONDS
         );
     }


### PR DESCRIPTION
I have thoroughly investigated this issue, including extensive debugging, but have been unable to identify any underlying problem. The failure cannot be reproduced locally, and it appears to be muted on the main and 9.1 branches, not 8.19 as reported [here](https://github.com/elastic/elasticsearch/issues/126340).

As a precaution, I have increased the assertBusy timeout, although I do not believe this change will have a significant impact.

I am unmuting the test to allow it to run again in CI for further evaluation and will revisit if the issue persists.