### PR TITLE
Fix Netty4HttpServerTransportTests if run with FIPS and entitlements

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -572,12 +572,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.action.EsqlActionBreakerIT
   method: testTopNPushedToLucene
   issue: https://github.com/elastic/elasticsearch/issues/130505
-- class: org.elasticsearch.common.ssl.DefaultJdkTrustConfigTests
-  method: testGetSystemTrustStoreWithNoSystemProperties
-  issue: https://github.com/elastic/elasticsearch/issues/130517
-- class: org.elasticsearch.common.ssl.DefaultJdkTrustConfigTests
-  method: testGetNonPKCS11TrustStoreWithPasswordSet
-  issue: https://github.com/elastic/elasticsearch/issues/130519
 - class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
   method: test {yaml=indices.resolve_index/10_basic_resolve_index/Resolve index with hidden and closed indices}
   issue: https://github.com/elastic/elasticsearch/issues/130568

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -605,12 +605,6 @@ tests:
 - class: org.elasticsearch.reindex.ReindexFromRemoteBuildRestClientTests
   method: testBuildRestClient
   issue: https://github.com/elastic/elasticsearch/issues/130588
-- class: org.elasticsearch.http.netty4.Netty4HttpServerTransportTests
-  method: testRespondAfterServiceCloseWithClientCancel
-  issue: https://github.com/elastic/elasticsearch/issues/130590
-- class: org.elasticsearch.http.netty4.Netty4HttpServerTransportTests
-  method: testRespondAfterServiceCloseWithServerCancel
-  issue: https://github.com/elastic/elasticsearch/issues/130591
 - class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/130067

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -590,15 +590,6 @@ tests:
 - class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
   method: test {yaml=indices.resolve_index/10_basic_resolve_index/Resolve index with hidden and closed indices}
   issue: https://github.com/elastic/elasticsearch/issues/130568
-- class: org.elasticsearch.reindex.ReindexRestClientSslTests
-  method: testClientPassesClientCertificate
-  issue: https://github.com/elastic/elasticsearch/issues/130584
-- class: org.elasticsearch.reindex.ReindexRestClientSslTests
-  method: testClientFailsWithUntrustedCertificate
-  issue: https://github.com/elastic/elasticsearch/issues/130585
-- class: org.elasticsearch.reindex.ReindexRestClientSslTests
-  method: testClientSucceedsWithCertificateAuthorities
-  issue: https://github.com/elastic/elasticsearch/issues/130586
 - class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/130067

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -599,12 +599,6 @@ tests:
 - class: org.elasticsearch.reindex.ReindexRestClientSslTests
   method: testClientSucceedsWithCertificateAuthorities
   issue: https://github.com/elastic/elasticsearch/issues/130586
-- class: org.elasticsearch.reindex.ReindexFromRemoteBuildRestClientTests
-  method: testHeaders
-  issue: https://github.com/elastic/elasticsearch/issues/130587
-- class: org.elasticsearch.reindex.ReindexFromRemoteBuildRestClientTests
-  method: testBuildRestClient
-  issue: https://github.com/elastic/elasticsearch/issues/130588
 - class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/130067

--- a/test/framework/src/main/java/org/elasticsearch/entitlement/runtime/policy/TestPolicyManager.java
+++ b/test/framework/src/main/java/org/elasticsearch/entitlement/runtime/policy/TestPolicyManager.java
@@ -159,6 +159,8 @@ public class TestPolicyManager extends PolicyManager {
         "org.junit",
         "org.mockito",
         "net.bytebuddy", // Mockito uses this
+
+        "org.bouncycastle.jsse.provider" // Used in test code if FIPS is enabled, support more fine-grained config in ES-12128
     };
 
     @Override


### PR DESCRIPTION
In this case `org.bouncycastle.jsse.provider` needs to be considered a test library so we can create the appropriate request.
Configuring test libraries in a better way needs to be looked at in ES-12128.

Fixes #130591
Fixes #130590
Fixes #130589
Fixes #130588
Fixes #130587
Fixes #130586
Fixes #130585
Fixes #130584
Fixes #130517
Fixes #130519

