### PR TITLE
Handle more edge cases in HierarchicalKMeans

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -1,619 +1,619 @@
 tests:
-  - class: "org.elasticsearch.client.RestClientSingleHostIntegTests"
-    issue: "https://github.com/elastic/elasticsearch/issues/102717"
-    method: "testRequestResetAndAbort"
-  - class: org.elasticsearch.packaging.test.PackagesSecurityAutoConfigurationTests
-    method: test20SecurityNotAutoConfiguredOnReInstallation
-    issue: https://github.com/elastic/elasticsearch/issues/112635
-  - class: org.elasticsearch.xpack.sql.qa.single_node.JdbcSqlSpecIT
-    method: test {case-functions.testSelectInsertWithLcaseAndLengthWithOrderBy}
-    issue: https://github.com/elastic/elasticsearch/issues/112642
-  - class: org.elasticsearch.xpack.sql.qa.single_node.JdbcSqlSpecIT
-    method: test {case-functions.testUcaseInline1}
-    issue: https://github.com/elastic/elasticsearch/issues/112641
-  - class: org.elasticsearch.xpack.sql.qa.single_node.JdbcSqlSpecIT
-    method: test {case-functions.testUpperCasingTheSecondLetterFromTheRightFromFirstName}
-    issue: https://github.com/elastic/elasticsearch/issues/112640
-  - class: org.elasticsearch.xpack.sql.qa.single_node.JdbcSqlSpecIT
-    method: test {case-functions.testUcaseInline3}
-    issue: https://github.com/elastic/elasticsearch/issues/112643
-  - class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT
-    method: test {case-functions.testUcaseInline1}
-    issue: https://github.com/elastic/elasticsearch/issues/112641
-  - class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT
-    method: test {case-functions.testUcaseInline3}
-    issue: https://github.com/elastic/elasticsearch/issues/112643
-  - class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT
-    method: test {case-functions.testUpperCasingTheSecondLetterFromTheRightFromFirstName}
-    issue: https://github.com/elastic/elasticsearch/issues/112640
-  - class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT
-    method: test {case-functions.testSelectInsertWithLcaseAndLengthWithOrderBy}
-    issue: https://github.com/elastic/elasticsearch/issues/112642
-  - class: org.elasticsearch.packaging.test.WindowsServiceTests
-    method: test30StartStop
-    issue: https://github.com/elastic/elasticsearch/issues/113160
-  - class: org.elasticsearch.packaging.test.WindowsServiceTests
-    method: test33JavaChanged
-    issue: https://github.com/elastic/elasticsearch/issues/113177
-  - class: org.elasticsearch.packaging.test.WindowsServiceTests
-    method: test80JavaOptsInEnvVar
-    issue: https://github.com/elastic/elasticsearch/issues/113219
-  - class: org.elasticsearch.packaging.test.WindowsServiceTests
-    method: test81JavaOptsInJvmOptions
-    issue: https://github.com/elastic/elasticsearch/issues/113313
-  - class: org.elasticsearch.xpack.transform.integration.TransformIT
-    method: testStopWaitForCheckpoint
-    issue: https://github.com/elastic/elasticsearch/issues/106113
-  - class: org.elasticsearch.xpack.remotecluster.RemoteClusterSecurityWithApmTracingRestIT
-    method: testTracingCrossCluster
-    issue: https://github.com/elastic/elasticsearch/issues/112731
-  - class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
-    method: testDeploymentSurvivesRestart {cluster=UPGRADED}
-    issue: https://github.com/elastic/elasticsearch/issues/115528
-  - class: org.elasticsearch.xpack.shutdown.NodeShutdownIT
-    method: testStalledShardMigrationProperlyDetected
-    issue: https://github.com/elastic/elasticsearch/issues/115697
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_start_stop/Verify start transform reuses destination index}
-    issue: https://github.com/elastic/elasticsearch/issues/115808
-  - class: org.elasticsearch.xpack.application.connector.ConnectorIndexServiceTests
-    issue: https://github.com/elastic/elasticsearch/issues/116087
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_start_stop/Test start already started transform}
-    issue: https://github.com/elastic/elasticsearch/issues/98802
-  - class: org.elasticsearch.xpack.shutdown.NodeShutdownIT
-    method: testAllocationPreventedForRemoval
-    issue: https://github.com/elastic/elasticsearch/issues/116363
-  - class: org.elasticsearch.xpack.security.authc.ldap.ActiveDirectoryGroupsResolverTests
-    issue: https://github.com/elastic/elasticsearch/issues/116182
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=snapshot/20_operator_privileges_disabled/Operator only settings can be set and restored by non-operator user when operator privileges is disabled}
-    issue: https://github.com/elastic/elasticsearch/issues/116775
-  - class: org.elasticsearch.search.basic.SearchWithRandomIOExceptionsIT
-    method: testRandomDirectoryIOExceptions
-    issue: https://github.com/elastic/elasticsearch/issues/114824
-  - class: org.elasticsearch.xpack.apmdata.APMYamlTestSuiteIT
-    method: test {yaml=/10_apm/Test template reinstallation}
-    issue: https://github.com/elastic/elasticsearch/issues/116445
-  - class: org.elasticsearch.versioning.ConcurrentSeqNoVersioningIT
-    method: testSeqNoCASLinearizability
-    issue: https://github.com/elastic/elasticsearch/issues/117249
-  - class: org.elasticsearch.discovery.ClusterDisruptionIT
-    method: testAckedIndexing
-    issue: https://github.com/elastic/elasticsearch/issues/117024
-  - class: org.elasticsearch.xpack.inference.InferenceRestIT
-    method: test {p0=inference/40_semantic_text_query/Query a field that uses the default ELSER 2 endpoint}
-    issue: https://github.com/elastic/elasticsearch/issues/117027
-  - class: org.elasticsearch.xpack.inference.InferenceRestIT
-    method: test {p0=inference/30_semantic_text_inference/Calculates embeddings using the default ELSER 2 endpoint}
-    issue: https://github.com/elastic/elasticsearch/issues/117349
-  - class: org.elasticsearch.xpack.inference.InferenceRestIT
-    method: test {p0=inference/30_semantic_text_inference_bwc/Calculates embeddings using the default ELSER 2 endpoint}
-    issue: https://github.com/elastic/elasticsearch/issues/117349
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_reset/Test reset running transform}
-    issue: https://github.com/elastic/elasticsearch/issues/117473
-  - class: org.elasticsearch.xpack.ml.integration.RegressionIT
-    method: testTwoJobsWithSameRandomizeSeedUseSameTrainingSet
-    issue: https://github.com/elastic/elasticsearch/issues/117805
-  - class: org.elasticsearch.packaging.test.ArchiveTests
-    method: test44AutoConfigurationNotTriggeredOnNotWriteableConfDir
-    issue: https://github.com/elastic/elasticsearch/issues/118208
-  - class: org.elasticsearch.packaging.test.ArchiveTests
-    method: test51AutoConfigurationWithPasswordProtectedKeystore
-    issue: https://github.com/elastic/elasticsearch/issues/118212
-  - class: org.elasticsearch.xpack.ccr.rest.ShardChangesRestIT
-    method: testShardChangesNoOperation
-    issue: https://github.com/elastic/elasticsearch/issues/118800
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_start_stop/Test start/stop/start transform}
-    issue: https://github.com/elastic/elasticsearch/issues/119508
-  - class: org.elasticsearch.smoketest.MlWithSecurityIT
-    method: test {yaml=ml/sparse_vector_search/Test sparse_vector search with query vector and pruning config}
-    issue: https://github.com/elastic/elasticsearch/issues/119548
-  - class: org.elasticsearch.xpack.ml.integration.ForecastIT
-    method: testOverflowToDisk
-    issue: https://github.com/elastic/elasticsearch/issues/117740
-  - class: org.elasticsearch.xpack.security.authc.ldap.MultiGroupMappingIT
-    issue: https://github.com/elastic/elasticsearch/issues/119599
-  - class: org.elasticsearch.multi_cluster.MultiClusterYamlTestSuiteIT
-    issue: https://github.com/elastic/elasticsearch/issues/119983
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_unattended/Test unattended put and start}
-    issue: https://github.com/elastic/elasticsearch/issues/120019
-  - class: org.elasticsearch.xpack.security.QueryableReservedRolesIT
-    method: testConfiguredReservedRolesAfterClosingAndOpeningIndex
-    issue: https://github.com/elastic/elasticsearch/issues/120127
-  - class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
-    method: testOldRepoAccess
-    issue: https://github.com/elastic/elasticsearch/issues/120148
-  - class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
-    method: testOldSourceOnlyRepoAccess
-    issue: https://github.com/elastic/elasticsearch/issues/120080
-  - class: org.elasticsearch.xpack.ccr.FollowIndexSecurityIT
-    method: testCleanShardFollowTaskAfterDeleteFollower
-    issue: https://github.com/elastic/elasticsearch/issues/120339
-  - class: org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeToCharProcessorTests
-    issue: https://github.com/elastic/elasticsearch/issues/120575
-  - class: org.elasticsearch.xpack.inference.DefaultEndPointsIT
-    method: testMultipleInferencesTriggeringDownloadAndDeploy
-    issue: https://github.com/elastic/elasticsearch/issues/120668
-  - class: org.elasticsearch.xpack.security.authc.ldap.ADLdapUserSearchSessionFactoryTests
-    issue: https://github.com/elastic/elasticsearch/issues/119882
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=ml/3rd_party_deployment/Test start deployment fails while model download in progress}
-    issue: https://github.com/elastic/elasticsearch/issues/120810
-  - class: org.elasticsearch.xpack.security.authc.service.ServiceAccountIT
-    method: testAuthenticateShouldNotFallThroughInCaseOfFailure
-    issue: https://github.com/elastic/elasticsearch/issues/120902
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test050BasicApiTests
-    issue: https://github.com/elastic/elasticsearch/issues/120911
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test140CgroupOsStatsAreAvailable
-    issue: https://github.com/elastic/elasticsearch/issues/120914
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test070BindMountCustomPathConfAndJvmOptions
-    issue: https://github.com/elastic/elasticsearch/issues/120910
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test071BindMountCustomPathWithDifferentUID
-    issue: https://github.com/elastic/elasticsearch/issues/120918
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test171AdditionalCliOptionsAreForwarded
-    issue: https://github.com/elastic/elasticsearch/issues/120925
-  - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-    method: test {p0=nodes.stats/11_indices_metrics/indices mappings exact count test for indices level}
-    issue: https://github.com/elastic/elasticsearch/issues/120950
-  - class: org.elasticsearch.xpack.ml.integration.PyTorchModelIT
-    issue: https://github.com/elastic/elasticsearch/issues/121165
-  - class: org.elasticsearch.xpack.security.authc.ldap.ActiveDirectorySessionFactoryTests
-    issue: https://github.com/elastic/elasticsearch/issues/121285
-  - class: org.elasticsearch.test.rest.yaml.CcsCommonYamlTestSuiteIT
-    issue: https://github.com/elastic/elasticsearch/issues/121407
-  - class: org.elasticsearch.analysis.common.CommonAnalysisClientYamlTestSuiteIT
-    method: test {yaml=analysis-common/40_token_filters/stemmer_override file access}
-    issue: https://github.com/elastic/elasticsearch/issues/121625
-  - class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
-    method: test {yaml=snapshot.delete/10_basic/Delete a snapshot asynchronously}
-    issue: https://github.com/elastic/elasticsearch/issues/122102
-  - class: org.elasticsearch.smoketest.SmokeTestMonitoringWithSecurityIT
-    method: testHTTPExporterWithSSL
-    issue: https://github.com/elastic/elasticsearch/issues/122220
-  - class: org.elasticsearch.blocks.SimpleBlocksIT
-    method: testConcurrentAddBlock
-    issue: https://github.com/elastic/elasticsearch/issues/122324
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test151MachineDependentHeapWithSizeOverride
-    issue: https://github.com/elastic/elasticsearch/issues/123437
-  - class: org.elasticsearch.action.admin.cluster.node.tasks.CancellableTasksIT
-    method: testChildrenTasksCancelledOnTimeout
-    issue: https://github.com/elastic/elasticsearch/issues/123568
-  - class: org.elasticsearch.xpack.searchablesnapshots.FrozenSearchableSnapshotsIntegTests
-    method: testCreateAndRestorePartialSearchableSnapshot
-    issue: https://github.com/elastic/elasticsearch/issues/123773
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=snapshot/10_basic/Create a source only snapshot and then restore it}
-    issue: https://github.com/elastic/elasticsearch/issues/122755
-  - class: org.elasticsearch.smoketest.MlWithSecurityIT
-    method: test {yaml=ml/data_frame_analytics_crud/Test get stats given multiple analytics}
-    issue: https://github.com/elastic/elasticsearch/issues/123034
-  - class: org.elasticsearch.indices.recovery.IndexRecoveryIT
-    method: testSourceThrottling
-    issue: https://github.com/elastic/elasticsearch/issues/123680
-  - class: org.elasticsearch.smoketest.MlWithSecurityIT
-    method: test {yaml=ml/3rd_party_deployment/Test start deployment fails while model download in progress}
-    issue: https://github.com/elastic/elasticsearch/issues/120814
-  - class: org.elasticsearch.smoketest.MlWithSecurityIT
-    method: test {yaml=ml/start_data_frame_analytics/Test start classification analysis when the dependent variable is missing}
-    issue: https://github.com/elastic/elasticsearch/issues/124168
-  - class: org.elasticsearch.smoketest.MlWithSecurityIT
-    method: test {yaml=ml/3rd_party_deployment/Test start and stop multiple deployments}
-    issue: https://github.com/elastic/elasticsearch/issues/124315
-  - class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
-    method: test {yaml=data_stream/190_failure_store_redirection/Redirect ingest failure in data stream to failure store}
-    issue: https://github.com/elastic/elasticsearch/issues/124518
-  - class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
-    method: test {yaml=data_stream/150_tsdb/created the data stream}
-    issue: https://github.com/elastic/elasticsearch/issues/124575
-  - class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
-    method: testDeploymentSurvivesRestart {cluster=OLD}
-    issue: https://github.com/elastic/elasticsearch/issues/124160
-  - class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
-    method: test {yaml=search.vectors/41_knn_search_byte_quantized/kNN search plus query}
-    issue: https://github.com/elastic/elasticsearch/issues/124687
-  - class: org.elasticsearch.packaging.test.BootstrapCheckTests
-    method: test20RunWithBootstrapChecks
-    issue: https://github.com/elastic/elasticsearch/issues/124940
-  - class: org.elasticsearch.packaging.test.BootstrapCheckTests
-    method: test10Install
-    issue: https://github.com/elastic/elasticsearch/issues/124957
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test011SecurityEnabledStatus
-    issue: https://github.com/elastic/elasticsearch/issues/124990
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test012SecurityCanBeDisabled
-    issue: https://github.com/elastic/elasticsearch/issues/116636
-  - class: org.elasticsearch.index.shard.StoreRecoveryTests
-    method: testAddIndices
-    issue: https://github.com/elastic/elasticsearch/issues/124104
-  - class: org.elasticsearch.smoketest.MlWithSecurityIT
-    method: test {yaml=ml/data_frame_analytics_crud/Test get stats on newly created config}
-    issue: https://github.com/elastic/elasticsearch/issues/121726
-  - class: org.elasticsearch.smoketest.MlWithSecurityIT
-    method: test {yaml=ml/data_frame_analytics_cat_apis/Test cat data frame analytics all jobs with header and column selection}
-    issue: https://github.com/elastic/elasticsearch/issues/125641
-  - class: org.elasticsearch.smoketest.MlWithSecurityIT
-    method: test {yaml=ml/data_frame_analytics_cat_apis/Test cat data frame analytics single job with header}
-    issue: https://github.com/elastic/elasticsearch/issues/125642
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test010Install
-    issue: https://github.com/elastic/elasticsearch/issues/125680
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_start_stop/Test schedule_now on an already started transform}
-    issue: https://github.com/elastic/elasticsearch/issues/120720
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_start_stop/Verify start transform creates destination index with appropriate mapping}
-    issue: https://github.com/elastic/elasticsearch/issues/125854
-  - class: org.elasticsearch.xpack.core.common.notifications.AbstractAuditorTests
-    method: testRecreateTemplateWhenDeleted
-    issue: https://github.com/elastic/elasticsearch/issues/123232
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=ml/start_data_frame_analytics/Test start given dest index is not empty}
-    issue: https://github.com/elastic/elasticsearch/issues/125909
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_stats/Test get transform stats with timeout}
-    issue: https://github.com/elastic/elasticsearch/issues/125975
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test021InstallPlugin
-    issue: https://github.com/elastic/elasticsearch/issues/116147
-  - class: org.elasticsearch.action.RejectionActionIT
-    method: testSimulatedSearchRejectionLoad
-    issue: https://github.com/elastic/elasticsearch/issues/125901
-  - class: org.elasticsearch.search.CCSDuelIT
-    method: testTerminateAfter
-    issue: https://github.com/elastic/elasticsearch/issues/126085
-  - class: org.elasticsearch.search.basic.SearchWithRandomDisconnectsIT
-    method: testSearchWithRandomDisconnects
-    issue: https://github.com/elastic/elasticsearch/issues/122707
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test020PluginsListWithNoPlugins
-    issue: https://github.com/elastic/elasticsearch/issues/126232
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_reset/Test force reseting a running transform}
-    issue: https://github.com/elastic/elasticsearch/issues/126240
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_stats/Test get transform stats}
-    issue: https://github.com/elastic/elasticsearch/issues/126270
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=ml/start_data_frame_analytics/Test start classification analysis when the dependent variable cardinality is too low}
-    issue: https://github.com/elastic/elasticsearch/issues/126299
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test023InstallPluginUsingConfigFile
-    issue: https://github.com/elastic/elasticsearch/issues/126145
-  - class: org.elasticsearch.smoketest.MlWithSecurityIT
-    method: test {yaml=ml/start_data_frame_analytics/Test start classification analysis when the dependent variable cardinality is too low}
-    issue: https://github.com/elastic/elasticsearch/issues/123200
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test022InstallPluginsFromLocalArchive
-    issue: https://github.com/elastic/elasticsearch/issues/116866
-  - class: org.elasticsearch.smoketest.MlWithSecurityIT
-    method: test {yaml=ml/trained_model_cat_apis/Test cat trained models}
-    issue: https://github.com/elastic/elasticsearch/issues/125750
-  - class: org.elasticsearch.ingest.geoip.EnterpriseGeoIpDownloaderIT
-    method: testEnterpriseDownloaderTask
-    issue: https://github.com/elastic/elasticsearch/issues/126124
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_start_stop/Test start/stop only starts/stops specified transform}
-    issue: https://github.com/elastic/elasticsearch/issues/126466
-  - class: org.elasticsearch.smoketest.MlWithSecurityIT
-    method: test {yaml=ml/get_trained_model_stats/Test get stats given trained models}
-    issue: https://github.com/elastic/elasticsearch/issues/126510
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_stats/Test get multiple transform stats}
-    issue: https://github.com/elastic/elasticsearch/issues/126567
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_stats/Test get single transform stats when it does not have a task}
-    issue: https://github.com/elastic/elasticsearch/issues/126568
-  - class: org.elasticsearch.repositories.blobstore.testkit.rest.SnapshotRepoTestKitClientYamlTestSuiteIT
-    method: test {p0=/10_analyze/Analysis without details}
-    issue: https://github.com/elastic/elasticsearch/issues/126569
-  - class: org.elasticsearch.xpack.esql.action.EsqlActionIT
-    method: testQueryOnEmptyDataIndex
-    issue: https://github.com/elastic/elasticsearch/issues/126580
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_start_stop/Test start/stop/start continuous transform}
-    issue: https://github.com/elastic/elasticsearch/issues/126755
-  - class: org.elasticsearch.search.SearchServiceSingleNodeTests
-    method: testBeforeShardLockDuringShardCreate
-    issue: https://github.com/elastic/elasticsearch/issues/126812
-  - class: org.elasticsearch.search.SearchServiceSingleNodeTests
-    method: testLookUpSearchContext
-    issue: https://github.com/elastic/elasticsearch/issues/126813
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_stats/Test get multiple transform stats where one does not have a task}
-    issue: https://github.com/elastic/elasticsearch/issues/126863
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=ml/inference_crud/Test delete given unused trained model}
-    issue: https://github.com/elastic/elasticsearch/issues/126881
-  - class: org.elasticsearch.index.engine.CompletionStatsCacheTests
-    method: testCompletionStatsCache
-    issue: https://github.com/elastic/elasticsearch/issues/126910
-  - class: org.elasticsearch.xpack.ml.integration.ClassificationHousePricingIT
-    method: testFeatureImportanceValues
-    issue: https://github.com/elastic/elasticsearch/issues/124341
-  - class: org.elasticsearch.cli.keystore.AddStringKeyStoreCommandTests
-    method: testStdinWithMultipleValues
-    issue: https://github.com/elastic/elasticsearch/issues/126882
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test024InstallPluginFromArchiveUsingConfigFile
-    issue: https://github.com/elastic/elasticsearch/issues/126936
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test026InstallBundledRepositoryPlugins
-    issue: https://github.com/elastic/elasticsearch/issues/127081
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test026InstallBundledRepositoryPluginsViaConfigFile
-    issue: https://github.com/elastic/elasticsearch/issues/127158
-  - class: org.elasticsearch.xpack.remotecluster.CrossClusterEsqlRCS2EnrichUnavailableRemotesIT
-    method: testEsqlEnrichWithSkipUnavailable
-    issue: https://github.com/elastic/elasticsearch/issues/127368
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=ml/data_frame_analytics_cat_apis/Test cat data frame analytics all jobs with header}
-    issue: https://github.com/elastic/elasticsearch/issues/127625
-  - class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
-    method: testCancellationViaTimeoutWithAllowPartialResultsSetToFalse
-    issue: https://github.com/elastic/elasticsearch/issues/127096
-  - class: org.elasticsearch.xpack.ccr.action.ShardFollowTaskReplicationTests
-    method: testChangeFollowerHistoryUUID
-    issue: https://github.com/elastic/elasticsearch/issues/127680
-  - class: org.elasticsearch.action.admin.indices.diskusage.IndexDiskUsageAnalyzerTests
-    method: testKnnVectors
-    issue: https://github.com/elastic/elasticsearch/issues/127689
-  - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-    method: test {p0=search/350_point_in_time/point-in-time with index filter}
-    issue: https://github.com/elastic/elasticsearch/issues/127741
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test025SyncPluginsUsingProxy
-    issue: https://github.com/elastic/elasticsearch/issues/127138
-  - class: org.elasticsearch.xpack.esql.action.CrossClusterQueryWithPartialResultsIT
-    method: testOneRemoteClusterPartial
-    issue: https://github.com/elastic/elasticsearch/issues/124055
-  - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-    method: test {lookup-join.MvJoinKeyOnTheLookupIndex ASYNC}
-    issue: https://github.com/elastic/elasticsearch/issues/128030
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test042KeystorePermissionsAreCorrect
-    issue: https://github.com/elastic/elasticsearch/issues/128018
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test072RunEsAsDifferentUserAndGroup
-    issue: https://github.com/elastic/elasticsearch/issues/128031
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test122CanUseDockerLoggingConfig
-    issue: https://github.com/elastic/elasticsearch/issues/128110
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test041AmazonCaCertsAreInTheKeystore
-    issue: https://github.com/elastic/elasticsearch/issues/128006
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test130JavaHasCorrectOwnership
-    issue: https://github.com/elastic/elasticsearch/issues/128174
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test600Interrupt
-    issue: https://github.com/elastic/elasticsearch/issues/128144
-  - class: org.elasticsearch.packaging.test.EnrollmentProcessTests
-    method: test20DockerAutoFormCluster
-    issue: https://github.com/elastic/elasticsearch/issues/128113
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test121CanUseStackLoggingConfig
-    issue: https://github.com/elastic/elasticsearch/issues/128165
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test080ConfigurePasswordThroughEnvironmentVariableFile
-    issue: https://github.com/elastic/elasticsearch/issues/128075
-  - class: org.elasticsearch.ingest.geoip.GeoIpDownloaderCliIT
-    method: testInvalidTimestamp
-    issue: https://github.com/elastic/elasticsearch/issues/128284
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test120DockerLogsIncludeElasticsearchLogs
-    issue: https://github.com/elastic/elasticsearch/issues/128117
-  - class: org.elasticsearch.packaging.test.TemporaryDirectoryConfigTests
-    method: test21AcceptsCustomPathInDocker
-    issue: https://github.com/elastic/elasticsearch/issues/128114
-  - class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
-    method: testCCSClusterDetailsWhereAllShardsSkippedInCanMatch
-    issue: https://github.com/elastic/elasticsearch/issues/128418
-  - class: org.elasticsearch.xpack.esql.action.CrossClusterQueryWithFiltersIT
-    method: testTimestampFilterFromQuery
-    issue: https://github.com/elastic/elasticsearch/issues/127332
-  - class: org.elasticsearch.xpack.esql.plugin.DataNodeRequestSenderIT
-    method: testSearchWhileRelocating
-    issue: https://github.com/elastic/elasticsearch/issues/128500
-  - class: org.elasticsearch.xpack.esql.action.CrossClusterQueryWithPartialResultsIT
-    method: testFailToStartRequestOnRemoteCluster
-    issue: https://github.com/elastic/elasticsearch/issues/128545
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test124CanRestartContainerWithStackLoggingConfig
-    issue: https://github.com/elastic/elasticsearch/issues/128121
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test085EnvironmentVariablesAreRespectedUnderDockerExec
-    issue: https://github.com/elastic/elasticsearch/issues/128115
-  - class: org.elasticsearch.compute.operator.LimitOperatorTests
-    method: testEarlyTermination
-    issue: https://github.com/elastic/elasticsearch/issues/128721
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test040JavaUsesTheOsProvidedKeystore
-    issue: https://github.com/elastic/elasticsearch/issues/128230
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test150MachineDependentHeap
-    issue: https://github.com/elastic/elasticsearch/issues/128120
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test073RunEsAsDifferentUserAndGroupWithoutBindMounting
-    issue: https://github.com/elastic/elasticsearch/issues/128996
-  - class: org.elasticsearch.upgrades.UpgradeClusterClientYamlTestSuiteIT
-    method: test {p0=upgraded_cluster/70_ilm/Test Lifecycle Still There And Indices Are Still Managed}
-    issue: https://github.com/elastic/elasticsearch/issues/129097
-  - class: org.elasticsearch.upgrades.UpgradeClusterClientYamlTestSuiteIT
-    method: test {p0=upgraded_cluster/90_ml_data_frame_analytics_crud/Get mixed cluster outlier_detection job}
-    issue: https://github.com/elastic/elasticsearch/issues/129098
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test081SymlinksAreFollowedWithEnvironmentVariableFiles
-    issue: https://github.com/elastic/elasticsearch/issues/128867
-  - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeForkIT
-    method: test {lookup-join.EnrichLookupStatsBug ASYNC}
-    issue: https://github.com/elastic/elasticsearch/issues/129228
-  - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeForkIT
-    method: test {lookup-join.EnrichLookupStatsBug SYNC}
-    issue: https://github.com/elastic/elasticsearch/issues/129229
-  - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeForkIT
-    method: test {lookup-join.MultipleBatches*
-    issue: https://github.com/elastic/elasticsearch/issues/129210
-  - class: org.elasticsearch.entitlement.runtime.policy.FileAccessTreeTests
-    method: testWindowsMixedCaseAccess
-    issue: https://github.com/elastic/elasticsearch/issues/129167
-  - class: org.elasticsearch.entitlement.runtime.policy.FileAccessTreeTests
-    method: testWindowsAbsolutPathAccess
-    issue: https://github.com/elastic/elasticsearch/issues/129168
-  - class: org.elasticsearch.xpack.ml.integration.ClassificationIT
-    method: testWithDatastreams
-    issue: https://github.com/elastic/elasticsearch/issues/129457
-  - class: org.elasticsearch.xpack.security.PermissionsIT
-    method: testCanManageIndexWithNoPermissions
-    issue: https://github.com/elastic/elasticsearch/issues/129471
-  - class: org.elasticsearch.xpack.security.PermissionsIT
-    method: testCanManageIndexAndPolicyDifferentUsers
-    issue: https://github.com/elastic/elasticsearch/issues/129479
-  - class: org.elasticsearch.xpack.security.PermissionsIT
-    method: testCanViewExplainOnUnmanagedIndex
-    issue: https://github.com/elastic/elasticsearch/issues/129480
-  - class: org.elasticsearch.xpack.profiling.action.GetStatusActionIT
-    method: testWaitsUntilResourcesAreCreated
-    issue: https://github.com/elastic/elasticsearch/issues/129486
-  - class: org.elasticsearch.xpack.security.PermissionsIT
-    method: testWhenUserLimitedByOnlyAliasOfIndexCanWriteToIndexWhichWasRolledoverByILMPolicy
-    issue: https://github.com/elastic/elasticsearch/issues/129481
-  - class: org.elasticsearch.upgrades.IndexingIT
-    method: testIndexing
-    issue: https://github.com/elastic/elasticsearch/issues/129533
-  - class: org.elasticsearch.upgrades.MlJobSnapshotUpgradeIT
-    method: testSnapshotUpgrader
-    issue: https://github.com/elastic/elasticsearch/issues/98560
-  - class: org.elasticsearch.upgrades.QueryableBuiltInRolesUpgradeIT
-    method: testBuiltInRolesSyncedOnClusterUpgrade
-    issue: https://github.com/elastic/elasticsearch/issues/129534
-  - class: org.elasticsearch.search.query.VectorIT
-    method: testFilteredQueryStrategy
-    issue: https://github.com/elastic/elasticsearch/issues/129517
-  - class: org.elasticsearch.snapshots.SnapshotShutdownIT
-    method: testSnapshotShutdownProgressTracker
-    issue: https://github.com/elastic/elasticsearch/issues/129752
-  - class: org.elasticsearch.xpack.security.SecurityRolesMultiProjectIT
-    method: testUpdatingFileBasedRoleAffectsAllProjects
-    issue: https://github.com/elastic/elasticsearch/issues/129775
-  - class: org.elasticsearch.qa.verify_version_constants.VerifyVersionConstantsIT
-    method: testLuceneVersionConstant
-    issue: https://github.com/elastic/elasticsearch/issues/125638
-  - class: org.elasticsearch.index.store.FsDirectoryFactoryTests
-    method: testPreload
-    issue: https://github.com/elastic/elasticsearch/issues/129852
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=esql/60_usage/Basic ESQL usage output (telemetry) non-snapshot version}
-    issue: https://github.com/elastic/elasticsearch/issues/129888
-  - class: org.elasticsearch.gradle.internal.InternalDistributionBwcSetupPluginFuncTest
-    method: "builds distribution from branches via archives extractedAssemble [bwcDistVersion: 8.2.1, bwcProject: bugfix, expectedAssembleTaskName:
+- class: "org.elasticsearch.client.RestClientSingleHostIntegTests"
+  issue: "https://github.com/elastic/elasticsearch/issues/102717"
+  method: "testRequestResetAndAbort"
+- class: org.elasticsearch.packaging.test.PackagesSecurityAutoConfigurationTests
+  method: test20SecurityNotAutoConfiguredOnReInstallation
+  issue: https://github.com/elastic/elasticsearch/issues/112635
+- class: org.elasticsearch.xpack.sql.qa.single_node.JdbcSqlSpecIT
+  method: test {case-functions.testSelectInsertWithLcaseAndLengthWithOrderBy}
+  issue: https://github.com/elastic/elasticsearch/issues/112642
+- class: org.elasticsearch.xpack.sql.qa.single_node.JdbcSqlSpecIT
+  method: test {case-functions.testUcaseInline1}
+  issue: https://github.com/elastic/elasticsearch/issues/112641
+- class: org.elasticsearch.xpack.sql.qa.single_node.JdbcSqlSpecIT
+  method: test {case-functions.testUpperCasingTheSecondLetterFromTheRightFromFirstName}
+  issue: https://github.com/elastic/elasticsearch/issues/112640
+- class: org.elasticsearch.xpack.sql.qa.single_node.JdbcSqlSpecIT
+  method: test {case-functions.testUcaseInline3}
+  issue: https://github.com/elastic/elasticsearch/issues/112643
+- class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT
+  method: test {case-functions.testUcaseInline1}
+  issue: https://github.com/elastic/elasticsearch/issues/112641
+- class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT
+  method: test {case-functions.testUcaseInline3}
+  issue: https://github.com/elastic/elasticsearch/issues/112643
+- class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT
+  method: test {case-functions.testUpperCasingTheSecondLetterFromTheRightFromFirstName}
+  issue: https://github.com/elastic/elasticsearch/issues/112640
+- class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT
+  method: test {case-functions.testSelectInsertWithLcaseAndLengthWithOrderBy}
+  issue: https://github.com/elastic/elasticsearch/issues/112642
+- class: org.elasticsearch.packaging.test.WindowsServiceTests
+  method: test30StartStop
+  issue: https://github.com/elastic/elasticsearch/issues/113160
+- class: org.elasticsearch.packaging.test.WindowsServiceTests
+  method: test33JavaChanged
+  issue: https://github.com/elastic/elasticsearch/issues/113177
+- class: org.elasticsearch.packaging.test.WindowsServiceTests
+  method: test80JavaOptsInEnvVar
+  issue: https://github.com/elastic/elasticsearch/issues/113219
+- class: org.elasticsearch.packaging.test.WindowsServiceTests
+  method: test81JavaOptsInJvmOptions
+  issue: https://github.com/elastic/elasticsearch/issues/113313
+- class: org.elasticsearch.xpack.transform.integration.TransformIT
+  method: testStopWaitForCheckpoint
+  issue: https://github.com/elastic/elasticsearch/issues/106113
+- class: org.elasticsearch.xpack.remotecluster.RemoteClusterSecurityWithApmTracingRestIT
+  method: testTracingCrossCluster
+  issue: https://github.com/elastic/elasticsearch/issues/112731
+- class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
+  method: testDeploymentSurvivesRestart {cluster=UPGRADED}
+  issue: https://github.com/elastic/elasticsearch/issues/115528
+- class: org.elasticsearch.xpack.shutdown.NodeShutdownIT
+  method: testStalledShardMigrationProperlyDetected
+  issue: https://github.com/elastic/elasticsearch/issues/115697
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_start_stop/Verify start transform reuses destination index}
+  issue: https://github.com/elastic/elasticsearch/issues/115808
+- class: org.elasticsearch.xpack.application.connector.ConnectorIndexServiceTests
+  issue: https://github.com/elastic/elasticsearch/issues/116087
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_start_stop/Test start already started transform}
+  issue: https://github.com/elastic/elasticsearch/issues/98802
+- class: org.elasticsearch.xpack.shutdown.NodeShutdownIT
+  method: testAllocationPreventedForRemoval
+  issue: https://github.com/elastic/elasticsearch/issues/116363
+- class: org.elasticsearch.xpack.security.authc.ldap.ActiveDirectoryGroupsResolverTests
+  issue: https://github.com/elastic/elasticsearch/issues/116182
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=snapshot/20_operator_privileges_disabled/Operator only settings can be set and restored by non-operator user when operator privileges is disabled}
+  issue: https://github.com/elastic/elasticsearch/issues/116775
+- class: org.elasticsearch.search.basic.SearchWithRandomIOExceptionsIT
+  method: testRandomDirectoryIOExceptions
+  issue: https://github.com/elastic/elasticsearch/issues/114824
+- class: org.elasticsearch.xpack.apmdata.APMYamlTestSuiteIT
+  method: test {yaml=/10_apm/Test template reinstallation}
+  issue: https://github.com/elastic/elasticsearch/issues/116445
+- class: org.elasticsearch.versioning.ConcurrentSeqNoVersioningIT
+  method: testSeqNoCASLinearizability
+  issue: https://github.com/elastic/elasticsearch/issues/117249
+- class: org.elasticsearch.discovery.ClusterDisruptionIT
+  method: testAckedIndexing
+  issue: https://github.com/elastic/elasticsearch/issues/117024
+- class: org.elasticsearch.xpack.inference.InferenceRestIT
+  method: test {p0=inference/40_semantic_text_query/Query a field that uses the default ELSER 2 endpoint}
+  issue: https://github.com/elastic/elasticsearch/issues/117027
+- class: org.elasticsearch.xpack.inference.InferenceRestIT
+  method: test {p0=inference/30_semantic_text_inference/Calculates embeddings using the default ELSER 2 endpoint}
+  issue: https://github.com/elastic/elasticsearch/issues/117349
+- class: org.elasticsearch.xpack.inference.InferenceRestIT
+  method: test {p0=inference/30_semantic_text_inference_bwc/Calculates embeddings using the default ELSER 2 endpoint}
+  issue: https://github.com/elastic/elasticsearch/issues/117349
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_reset/Test reset running transform}
+  issue: https://github.com/elastic/elasticsearch/issues/117473
+- class: org.elasticsearch.xpack.ml.integration.RegressionIT
+  method: testTwoJobsWithSameRandomizeSeedUseSameTrainingSet
+  issue: https://github.com/elastic/elasticsearch/issues/117805
+- class: org.elasticsearch.packaging.test.ArchiveTests
+  method: test44AutoConfigurationNotTriggeredOnNotWriteableConfDir
+  issue: https://github.com/elastic/elasticsearch/issues/118208
+- class: org.elasticsearch.packaging.test.ArchiveTests
+  method: test51AutoConfigurationWithPasswordProtectedKeystore
+  issue: https://github.com/elastic/elasticsearch/issues/118212
+- class: org.elasticsearch.xpack.ccr.rest.ShardChangesRestIT
+  method: testShardChangesNoOperation
+  issue: https://github.com/elastic/elasticsearch/issues/118800
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_start_stop/Test start/stop/start transform}
+  issue: https://github.com/elastic/elasticsearch/issues/119508
+- class: org.elasticsearch.smoketest.MlWithSecurityIT
+  method: test {yaml=ml/sparse_vector_search/Test sparse_vector search with query vector and pruning config}
+  issue: https://github.com/elastic/elasticsearch/issues/119548
+- class: org.elasticsearch.xpack.ml.integration.ForecastIT
+  method: testOverflowToDisk
+  issue: https://github.com/elastic/elasticsearch/issues/117740
+- class: org.elasticsearch.xpack.security.authc.ldap.MultiGroupMappingIT
+  issue: https://github.com/elastic/elasticsearch/issues/119599
+- class: org.elasticsearch.multi_cluster.MultiClusterYamlTestSuiteIT
+  issue: https://github.com/elastic/elasticsearch/issues/119983
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_unattended/Test unattended put and start}
+  issue: https://github.com/elastic/elasticsearch/issues/120019
+- class: org.elasticsearch.xpack.security.QueryableReservedRolesIT
+  method: testConfiguredReservedRolesAfterClosingAndOpeningIndex
+  issue: https://github.com/elastic/elasticsearch/issues/120127
+- class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
+  method: testOldRepoAccess
+  issue: https://github.com/elastic/elasticsearch/issues/120148
+- class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
+  method: testOldSourceOnlyRepoAccess
+  issue: https://github.com/elastic/elasticsearch/issues/120080
+- class: org.elasticsearch.xpack.ccr.FollowIndexSecurityIT
+  method: testCleanShardFollowTaskAfterDeleteFollower
+  issue: https://github.com/elastic/elasticsearch/issues/120339
+- class: org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeToCharProcessorTests
+  issue: https://github.com/elastic/elasticsearch/issues/120575
+- class: org.elasticsearch.xpack.inference.DefaultEndPointsIT
+  method: testMultipleInferencesTriggeringDownloadAndDeploy
+  issue: https://github.com/elastic/elasticsearch/issues/120668
+- class: org.elasticsearch.xpack.security.authc.ldap.ADLdapUserSearchSessionFactoryTests
+  issue: https://github.com/elastic/elasticsearch/issues/119882
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=ml/3rd_party_deployment/Test start deployment fails while model download in progress}
+  issue: https://github.com/elastic/elasticsearch/issues/120810
+- class: org.elasticsearch.xpack.security.authc.service.ServiceAccountIT
+  method: testAuthenticateShouldNotFallThroughInCaseOfFailure
+  issue: https://github.com/elastic/elasticsearch/issues/120902
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test050BasicApiTests
+  issue: https://github.com/elastic/elasticsearch/issues/120911
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test140CgroupOsStatsAreAvailable
+  issue: https://github.com/elastic/elasticsearch/issues/120914
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test070BindMountCustomPathConfAndJvmOptions
+  issue: https://github.com/elastic/elasticsearch/issues/120910
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test071BindMountCustomPathWithDifferentUID
+  issue: https://github.com/elastic/elasticsearch/issues/120918
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test171AdditionalCliOptionsAreForwarded
+  issue: https://github.com/elastic/elasticsearch/issues/120925
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  method: test {p0=nodes.stats/11_indices_metrics/indices mappings exact count test for indices level}
+  issue: https://github.com/elastic/elasticsearch/issues/120950
+- class: org.elasticsearch.xpack.ml.integration.PyTorchModelIT
+  issue: https://github.com/elastic/elasticsearch/issues/121165
+- class: org.elasticsearch.xpack.security.authc.ldap.ActiveDirectorySessionFactoryTests
+  issue: https://github.com/elastic/elasticsearch/issues/121285
+- class: org.elasticsearch.test.rest.yaml.CcsCommonYamlTestSuiteIT
+  issue: https://github.com/elastic/elasticsearch/issues/121407
+- class: org.elasticsearch.analysis.common.CommonAnalysisClientYamlTestSuiteIT
+  method: test {yaml=analysis-common/40_token_filters/stemmer_override file access}
+  issue: https://github.com/elastic/elasticsearch/issues/121625
+- class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
+  method: test {yaml=snapshot.delete/10_basic/Delete a snapshot asynchronously}
+  issue: https://github.com/elastic/elasticsearch/issues/122102
+- class: org.elasticsearch.smoketest.SmokeTestMonitoringWithSecurityIT
+  method: testHTTPExporterWithSSL
+  issue: https://github.com/elastic/elasticsearch/issues/122220
+- class: org.elasticsearch.blocks.SimpleBlocksIT
+  method: testConcurrentAddBlock
+  issue: https://github.com/elastic/elasticsearch/issues/122324
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test151MachineDependentHeapWithSizeOverride
+  issue: https://github.com/elastic/elasticsearch/issues/123437
+- class: org.elasticsearch.action.admin.cluster.node.tasks.CancellableTasksIT
+  method: testChildrenTasksCancelledOnTimeout
+  issue: https://github.com/elastic/elasticsearch/issues/123568
+- class: org.elasticsearch.xpack.searchablesnapshots.FrozenSearchableSnapshotsIntegTests
+  method: testCreateAndRestorePartialSearchableSnapshot
+  issue: https://github.com/elastic/elasticsearch/issues/123773
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=snapshot/10_basic/Create a source only snapshot and then restore it}
+  issue: https://github.com/elastic/elasticsearch/issues/122755
+- class: org.elasticsearch.smoketest.MlWithSecurityIT
+  method: test {yaml=ml/data_frame_analytics_crud/Test get stats given multiple analytics}
+  issue: https://github.com/elastic/elasticsearch/issues/123034
+- class: org.elasticsearch.indices.recovery.IndexRecoveryIT
+  method: testSourceThrottling
+  issue: https://github.com/elastic/elasticsearch/issues/123680
+- class: org.elasticsearch.smoketest.MlWithSecurityIT
+  method: test {yaml=ml/3rd_party_deployment/Test start deployment fails while model download in progress}
+  issue: https://github.com/elastic/elasticsearch/issues/120814
+- class: org.elasticsearch.smoketest.MlWithSecurityIT
+  method: test {yaml=ml/start_data_frame_analytics/Test start classification analysis when the dependent variable is missing}
+  issue: https://github.com/elastic/elasticsearch/issues/124168
+- class: org.elasticsearch.smoketest.MlWithSecurityIT
+  method: test {yaml=ml/3rd_party_deployment/Test start and stop multiple deployments}
+  issue: https://github.com/elastic/elasticsearch/issues/124315
+- class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
+  method: test {yaml=data_stream/190_failure_store_redirection/Redirect ingest failure in data stream to failure store}
+  issue: https://github.com/elastic/elasticsearch/issues/124518
+- class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
+  method: test {yaml=data_stream/150_tsdb/created the data stream}
+  issue: https://github.com/elastic/elasticsearch/issues/124575
+- class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
+  method: testDeploymentSurvivesRestart {cluster=OLD}
+  issue: https://github.com/elastic/elasticsearch/issues/124160
+- class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
+  method: test {yaml=search.vectors/41_knn_search_byte_quantized/kNN search plus query}
+  issue: https://github.com/elastic/elasticsearch/issues/124687
+- class: org.elasticsearch.packaging.test.BootstrapCheckTests
+  method: test20RunWithBootstrapChecks
+  issue: https://github.com/elastic/elasticsearch/issues/124940
+- class: org.elasticsearch.packaging.test.BootstrapCheckTests
+  method: test10Install
+  issue: https://github.com/elastic/elasticsearch/issues/124957
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test011SecurityEnabledStatus
+  issue: https://github.com/elastic/elasticsearch/issues/124990
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test012SecurityCanBeDisabled
+  issue: https://github.com/elastic/elasticsearch/issues/116636
+- class: org.elasticsearch.index.shard.StoreRecoveryTests
+  method: testAddIndices
+  issue: https://github.com/elastic/elasticsearch/issues/124104
+- class: org.elasticsearch.smoketest.MlWithSecurityIT
+  method: test {yaml=ml/data_frame_analytics_crud/Test get stats on newly created config}
+  issue: https://github.com/elastic/elasticsearch/issues/121726
+- class: org.elasticsearch.smoketest.MlWithSecurityIT
+  method: test {yaml=ml/data_frame_analytics_cat_apis/Test cat data frame analytics all jobs with header and column selection}
+  issue: https://github.com/elastic/elasticsearch/issues/125641
+- class: org.elasticsearch.smoketest.MlWithSecurityIT
+  method: test {yaml=ml/data_frame_analytics_cat_apis/Test cat data frame analytics single job with header}
+  issue: https://github.com/elastic/elasticsearch/issues/125642
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test010Install
+  issue: https://github.com/elastic/elasticsearch/issues/125680
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_start_stop/Test schedule_now on an already started transform}
+  issue: https://github.com/elastic/elasticsearch/issues/120720
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_start_stop/Verify start transform creates destination index with appropriate mapping}
+  issue: https://github.com/elastic/elasticsearch/issues/125854
+- class: org.elasticsearch.xpack.core.common.notifications.AbstractAuditorTests
+  method: testRecreateTemplateWhenDeleted
+  issue: https://github.com/elastic/elasticsearch/issues/123232
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=ml/start_data_frame_analytics/Test start given dest index is not empty}
+  issue: https://github.com/elastic/elasticsearch/issues/125909
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_stats/Test get transform stats with timeout}
+  issue: https://github.com/elastic/elasticsearch/issues/125975
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test021InstallPlugin
+  issue: https://github.com/elastic/elasticsearch/issues/116147
+- class: org.elasticsearch.action.RejectionActionIT
+  method: testSimulatedSearchRejectionLoad
+  issue: https://github.com/elastic/elasticsearch/issues/125901
+- class: org.elasticsearch.search.CCSDuelIT
+  method: testTerminateAfter
+  issue: https://github.com/elastic/elasticsearch/issues/126085
+- class: org.elasticsearch.search.basic.SearchWithRandomDisconnectsIT
+  method: testSearchWithRandomDisconnects
+  issue: https://github.com/elastic/elasticsearch/issues/122707
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test020PluginsListWithNoPlugins
+  issue: https://github.com/elastic/elasticsearch/issues/126232
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_reset/Test force reseting a running transform}
+  issue: https://github.com/elastic/elasticsearch/issues/126240
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_stats/Test get transform stats}
+  issue: https://github.com/elastic/elasticsearch/issues/126270
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=ml/start_data_frame_analytics/Test start classification analysis when the dependent variable cardinality is too low}
+  issue: https://github.com/elastic/elasticsearch/issues/126299
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test023InstallPluginUsingConfigFile
+  issue: https://github.com/elastic/elasticsearch/issues/126145
+- class: org.elasticsearch.smoketest.MlWithSecurityIT
+  method: test {yaml=ml/start_data_frame_analytics/Test start classification analysis when the dependent variable cardinality is too low}
+  issue: https://github.com/elastic/elasticsearch/issues/123200
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test022InstallPluginsFromLocalArchive
+  issue: https://github.com/elastic/elasticsearch/issues/116866
+- class: org.elasticsearch.smoketest.MlWithSecurityIT
+  method: test {yaml=ml/trained_model_cat_apis/Test cat trained models}
+  issue: https://github.com/elastic/elasticsearch/issues/125750
+- class: org.elasticsearch.ingest.geoip.EnterpriseGeoIpDownloaderIT
+  method: testEnterpriseDownloaderTask
+  issue: https://github.com/elastic/elasticsearch/issues/126124
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_start_stop/Test start/stop only starts/stops specified transform}
+  issue: https://github.com/elastic/elasticsearch/issues/126466
+- class: org.elasticsearch.smoketest.MlWithSecurityIT
+  method: test {yaml=ml/get_trained_model_stats/Test get stats given trained models}
+  issue: https://github.com/elastic/elasticsearch/issues/126510
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_stats/Test get multiple transform stats}
+  issue: https://github.com/elastic/elasticsearch/issues/126567
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_stats/Test get single transform stats when it does not have a task}
+  issue: https://github.com/elastic/elasticsearch/issues/126568
+- class: org.elasticsearch.repositories.blobstore.testkit.rest.SnapshotRepoTestKitClientYamlTestSuiteIT
+  method: test {p0=/10_analyze/Analysis without details}
+  issue: https://github.com/elastic/elasticsearch/issues/126569
+- class: org.elasticsearch.xpack.esql.action.EsqlActionIT
+  method: testQueryOnEmptyDataIndex
+  issue: https://github.com/elastic/elasticsearch/issues/126580
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_start_stop/Test start/stop/start continuous transform}
+  issue: https://github.com/elastic/elasticsearch/issues/126755
+- class: org.elasticsearch.search.SearchServiceSingleNodeTests
+  method: testBeforeShardLockDuringShardCreate
+  issue: https://github.com/elastic/elasticsearch/issues/126812
+- class: org.elasticsearch.search.SearchServiceSingleNodeTests
+  method: testLookUpSearchContext
+  issue: https://github.com/elastic/elasticsearch/issues/126813
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_stats/Test get multiple transform stats where one does not have a task}
+  issue: https://github.com/elastic/elasticsearch/issues/126863
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=ml/inference_crud/Test delete given unused trained model}
+  issue: https://github.com/elastic/elasticsearch/issues/126881
+- class: org.elasticsearch.index.engine.CompletionStatsCacheTests
+  method: testCompletionStatsCache
+  issue: https://github.com/elastic/elasticsearch/issues/126910
+- class: org.elasticsearch.xpack.ml.integration.ClassificationHousePricingIT
+  method: testFeatureImportanceValues
+  issue: https://github.com/elastic/elasticsearch/issues/124341
+- class: org.elasticsearch.cli.keystore.AddStringKeyStoreCommandTests
+  method: testStdinWithMultipleValues
+  issue: https://github.com/elastic/elasticsearch/issues/126882
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test024InstallPluginFromArchiveUsingConfigFile
+  issue: https://github.com/elastic/elasticsearch/issues/126936
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test026InstallBundledRepositoryPlugins
+  issue: https://github.com/elastic/elasticsearch/issues/127081
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test026InstallBundledRepositoryPluginsViaConfigFile
+  issue: https://github.com/elastic/elasticsearch/issues/127158
+- class: org.elasticsearch.xpack.remotecluster.CrossClusterEsqlRCS2EnrichUnavailableRemotesIT
+  method: testEsqlEnrichWithSkipUnavailable
+  issue: https://github.com/elastic/elasticsearch/issues/127368
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=ml/data_frame_analytics_cat_apis/Test cat data frame analytics all jobs with header}
+  issue: https://github.com/elastic/elasticsearch/issues/127625
+- class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
+  method: testCancellationViaTimeoutWithAllowPartialResultsSetToFalse
+  issue: https://github.com/elastic/elasticsearch/issues/127096
+- class: org.elasticsearch.xpack.ccr.action.ShardFollowTaskReplicationTests
+  method: testChangeFollowerHistoryUUID
+  issue: https://github.com/elastic/elasticsearch/issues/127680
+- class: org.elasticsearch.action.admin.indices.diskusage.IndexDiskUsageAnalyzerTests
+  method: testKnnVectors
+  issue: https://github.com/elastic/elasticsearch/issues/127689
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  method: test {p0=search/350_point_in_time/point-in-time with index filter}
+  issue: https://github.com/elastic/elasticsearch/issues/127741
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test025SyncPluginsUsingProxy
+  issue: https://github.com/elastic/elasticsearch/issues/127138
+- class: org.elasticsearch.xpack.esql.action.CrossClusterQueryWithPartialResultsIT
+  method: testOneRemoteClusterPartial
+  issue: https://github.com/elastic/elasticsearch/issues/124055
+- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
+  method: test {lookup-join.MvJoinKeyOnTheLookupIndex ASYNC}
+  issue: https://github.com/elastic/elasticsearch/issues/128030
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test042KeystorePermissionsAreCorrect
+  issue: https://github.com/elastic/elasticsearch/issues/128018
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test072RunEsAsDifferentUserAndGroup
+  issue: https://github.com/elastic/elasticsearch/issues/128031
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test122CanUseDockerLoggingConfig
+  issue: https://github.com/elastic/elasticsearch/issues/128110
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test041AmazonCaCertsAreInTheKeystore
+  issue: https://github.com/elastic/elasticsearch/issues/128006
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test130JavaHasCorrectOwnership
+  issue: https://github.com/elastic/elasticsearch/issues/128174
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test600Interrupt
+  issue: https://github.com/elastic/elasticsearch/issues/128144
+- class: org.elasticsearch.packaging.test.EnrollmentProcessTests
+  method: test20DockerAutoFormCluster
+  issue: https://github.com/elastic/elasticsearch/issues/128113
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test121CanUseStackLoggingConfig
+  issue: https://github.com/elastic/elasticsearch/issues/128165
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test080ConfigurePasswordThroughEnvironmentVariableFile
+  issue: https://github.com/elastic/elasticsearch/issues/128075
+- class: org.elasticsearch.ingest.geoip.GeoIpDownloaderCliIT
+  method: testInvalidTimestamp
+  issue: https://github.com/elastic/elasticsearch/issues/128284
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test120DockerLogsIncludeElasticsearchLogs
+  issue: https://github.com/elastic/elasticsearch/issues/128117
+- class: org.elasticsearch.packaging.test.TemporaryDirectoryConfigTests
+  method: test21AcceptsCustomPathInDocker
+  issue: https://github.com/elastic/elasticsearch/issues/128114
+- class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
+  method: testCCSClusterDetailsWhereAllShardsSkippedInCanMatch
+  issue: https://github.com/elastic/elasticsearch/issues/128418
+- class: org.elasticsearch.xpack.esql.action.CrossClusterQueryWithFiltersIT
+  method: testTimestampFilterFromQuery
+  issue: https://github.com/elastic/elasticsearch/issues/127332
+- class: org.elasticsearch.xpack.esql.plugin.DataNodeRequestSenderIT
+  method: testSearchWhileRelocating
+  issue: https://github.com/elastic/elasticsearch/issues/128500
+- class: org.elasticsearch.xpack.esql.action.CrossClusterQueryWithPartialResultsIT
+  method: testFailToStartRequestOnRemoteCluster
+  issue: https://github.com/elastic/elasticsearch/issues/128545
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test124CanRestartContainerWithStackLoggingConfig
+  issue: https://github.com/elastic/elasticsearch/issues/128121
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test085EnvironmentVariablesAreRespectedUnderDockerExec
+  issue: https://github.com/elastic/elasticsearch/issues/128115
+- class: org.elasticsearch.compute.operator.LimitOperatorTests
+  method: testEarlyTermination
+  issue: https://github.com/elastic/elasticsearch/issues/128721
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test040JavaUsesTheOsProvidedKeystore
+  issue: https://github.com/elastic/elasticsearch/issues/128230
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test150MachineDependentHeap
+  issue: https://github.com/elastic/elasticsearch/issues/128120
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test073RunEsAsDifferentUserAndGroupWithoutBindMounting
+  issue: https://github.com/elastic/elasticsearch/issues/128996
+- class: org.elasticsearch.upgrades.UpgradeClusterClientYamlTestSuiteIT
+  method: test {p0=upgraded_cluster/70_ilm/Test Lifecycle Still There And Indices Are Still Managed}
+  issue: https://github.com/elastic/elasticsearch/issues/129097
+- class: org.elasticsearch.upgrades.UpgradeClusterClientYamlTestSuiteIT
+  method: test {p0=upgraded_cluster/90_ml_data_frame_analytics_crud/Get mixed cluster outlier_detection job}
+  issue: https://github.com/elastic/elasticsearch/issues/129098
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test081SymlinksAreFollowedWithEnvironmentVariableFiles
+  issue: https://github.com/elastic/elasticsearch/issues/128867
+- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeForkIT
+  method: test {lookup-join.EnrichLookupStatsBug ASYNC}
+  issue: https://github.com/elastic/elasticsearch/issues/129228
+- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeForkIT
+  method: test {lookup-join.EnrichLookupStatsBug SYNC}
+  issue: https://github.com/elastic/elasticsearch/issues/129229
+- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeForkIT
+  method: test {lookup-join.MultipleBatches*
+  issue: https://github.com/elastic/elasticsearch/issues/129210
+- class: org.elasticsearch.entitlement.runtime.policy.FileAccessTreeTests
+  method: testWindowsMixedCaseAccess
+  issue: https://github.com/elastic/elasticsearch/issues/129167
+- class: org.elasticsearch.entitlement.runtime.policy.FileAccessTreeTests
+  method: testWindowsAbsolutPathAccess
+  issue: https://github.com/elastic/elasticsearch/issues/129168
+- class: org.elasticsearch.xpack.ml.integration.ClassificationIT
+  method: testWithDatastreams
+  issue: https://github.com/elastic/elasticsearch/issues/129457
+- class: org.elasticsearch.xpack.security.PermissionsIT
+  method: testCanManageIndexWithNoPermissions
+  issue: https://github.com/elastic/elasticsearch/issues/129471
+- class: org.elasticsearch.xpack.security.PermissionsIT
+  method: testCanManageIndexAndPolicyDifferentUsers
+  issue: https://github.com/elastic/elasticsearch/issues/129479
+- class: org.elasticsearch.xpack.security.PermissionsIT
+  method: testCanViewExplainOnUnmanagedIndex
+  issue: https://github.com/elastic/elasticsearch/issues/129480
+- class: org.elasticsearch.xpack.profiling.action.GetStatusActionIT
+  method: testWaitsUntilResourcesAreCreated
+  issue: https://github.com/elastic/elasticsearch/issues/129486
+- class: org.elasticsearch.xpack.security.PermissionsIT
+  method: testWhenUserLimitedByOnlyAliasOfIndexCanWriteToIndexWhichWasRolledoverByILMPolicy
+  issue: https://github.com/elastic/elasticsearch/issues/129481
+- class: org.elasticsearch.upgrades.IndexingIT
+  method: testIndexing
+  issue: https://github.com/elastic/elasticsearch/issues/129533
+- class: org.elasticsearch.upgrades.MlJobSnapshotUpgradeIT
+  method: testSnapshotUpgrader
+  issue: https://github.com/elastic/elasticsearch/issues/98560
+- class: org.elasticsearch.upgrades.QueryableBuiltInRolesUpgradeIT
+  method: testBuiltInRolesSyncedOnClusterUpgrade
+  issue: https://github.com/elastic/elasticsearch/issues/129534
+- class: org.elasticsearch.search.query.VectorIT
+  method: testFilteredQueryStrategy
+  issue: https://github.com/elastic/elasticsearch/issues/129517
+- class: org.elasticsearch.snapshots.SnapshotShutdownIT
+  method: testSnapshotShutdownProgressTracker
+  issue: https://github.com/elastic/elasticsearch/issues/129752
+- class: org.elasticsearch.xpack.security.SecurityRolesMultiProjectIT
+  method: testUpdatingFileBasedRoleAffectsAllProjects
+  issue: https://github.com/elastic/elasticsearch/issues/129775
+- class: org.elasticsearch.qa.verify_version_constants.VerifyVersionConstantsIT
+  method: testLuceneVersionConstant
+  issue: https://github.com/elastic/elasticsearch/issues/125638
+- class: org.elasticsearch.index.store.FsDirectoryFactoryTests
+  method: testPreload
+  issue: https://github.com/elastic/elasticsearch/issues/129852
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=esql/60_usage/Basic ESQL usage output (telemetry) non-snapshot version}
+  issue: https://github.com/elastic/elasticsearch/issues/129888
+- class: org.elasticsearch.gradle.internal.InternalDistributionBwcSetupPluginFuncTest
+  method: "builds distribution from branches via archives extractedAssemble [bwcDistVersion: 8.2.1, bwcProject: bugfix, expectedAssembleTaskName:
     extractedAssemble, #2]"
-    issue: https://github.com/elastic/elasticsearch/issues/119871
-  - class: geoip.GeoIpMultiProjectIT
-    issue: https://github.com/elastic/elasticsearch/issues/130073
-  - class: org.elasticsearch.xpack.esql.action.EnrichIT
-    method: testTopN
-    issue: https://github.com/elastic/elasticsearch/issues/130122
-  - class: org.elasticsearch.action.support.ThreadedActionListenerTests
-    method: testRejectionHandling
-    issue: https://github.com/elastic/elasticsearch/issues/130129
-  - class: org.elasticsearch.compute.aggregation.TopIntAggregatorFunctionTests
-    method: testManyInitialManyPartialFinalRunnerThrowing
-    issue: https://github.com/elastic/elasticsearch/issues/130145
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=esql/10_basic/basic with documents_found}
-    issue: https://github.com/elastic/elasticsearch/issues/130256
-  - class: org.elasticsearch.xpack.searchablesnapshots.cache.shared.NodesCachesStatsIntegTests
-    method: testNodesCachesStats
-    issue: https://github.com/elastic/elasticsearch/issues/129863
-  - class: org.elasticsearch.index.IndexingPressureIT
-    method: testWriteCanRejectOnPrimaryBasedOnMaxOperationSize
-    issue: https://github.com/elastic/elasticsearch/issues/130281
-  - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-    method: test {lookup-join.MvJoinKeyOnFrom SYNC}
-    issue: https://github.com/elastic/elasticsearch/issues/130296
-  - class: org.elasticsearch.xpack.esql.inference.bulk.BulkInferenceExecutorTests
-    method: testSuccessfulExecution
-    issue: https://github.com/elastic/elasticsearch/issues/130306
-  - class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
-    method: test {yaml=cluster.stats/10_basic/Dense vector stats}
-    issue: https://github.com/elastic/elasticsearch/issues/130307
-  - class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
-    method: test {yaml=nodes.stats/11_indices_metrics/Lucene segment level fields stats}
-    issue: https://github.com/elastic/elasticsearch/issues/130360
-  - class: org.elasticsearch.ingest.PipelineFactoryTests
-    method: testCreateUnsupportedFieldAccessPattern
-    issue: https://github.com/elastic/elasticsearch/issues/130422
-  - class: org.elasticsearch.test.rest.yaml.RcsCcsCommonYamlTestSuiteIT
-    method: test {p0=msearch/20_typed_keys/Multisearch test with typed_keys parameter for sampler and significant terms}
-    issue: https://github.com/elastic/elasticsearch/issues/130472
-  - class: org.elasticsearch.xpack.esql.action.EsqlActionBreakerIT
-    method: testProjectWhere
-    issue: https://github.com/elastic/elasticsearch/issues/130504
-  - class: org.elasticsearch.xpack.esql.action.EsqlActionBreakerIT
-    method: testTopNPushedToLucene
-    issue: https://github.com/elastic/elasticsearch/issues/130505
-  - class: org.elasticsearch.common.ssl.DefaultJdkTrustConfigTests
-    method: testGetSystemTrustStoreWithNoSystemProperties
-    issue: https://github.com/elastic/elasticsearch/issues/130517
-  - class: org.elasticsearch.common.ssl.DefaultJdkTrustConfigTests
-    method: testGetNonPKCS11TrustStoreWithPasswordSet
-    issue: https://github.com/elastic/elasticsearch/issues/130519
-  - class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
-    method: test {yaml=indices.resolve_index/10_basic_resolve_index/Resolve index with hidden and closed indices}
-    issue: https://github.com/elastic/elasticsearch/issues/130568
-  - class: org.elasticsearch.reindex.ReindexRestClientSslTests
-    method: testClientPassesClientCertificate
-    issue: https://github.com/elastic/elasticsearch/issues/130584
-  - class: org.elasticsearch.reindex.ReindexRestClientSslTests
-    method: testClientFailsWithUntrustedCertificate
-    issue: https://github.com/elastic/elasticsearch/issues/130585
-  - class: org.elasticsearch.reindex.ReindexRestClientSslTests
-    method: testClientSucceedsWithCertificateAuthorities
-    issue: https://github.com/elastic/elasticsearch/issues/130586
-  - class: org.elasticsearch.reindex.ReindexFromRemoteBuildRestClientTests
-    method: testHeaders
-    issue: https://github.com/elastic/elasticsearch/issues/130587
-  - class: org.elasticsearch.reindex.ReindexFromRemoteBuildRestClientTests
-    method: testBuildRestClient
-    issue: https://github.com/elastic/elasticsearch/issues/130588
-  - class: org.elasticsearch.http.netty4.Netty4HttpServerTransportTests
-    method: testRespondAfterServiceCloseWithClientCancel
-    issue: https://github.com/elastic/elasticsearch/issues/130590
-  - class: org.elasticsearch.http.netty4.Netty4HttpServerTransportTests
-    method: testRespondAfterServiceCloseWithServerCancel
-    issue: https://github.com/elastic/elasticsearch/issues/130591
-  - class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
-    method: test
-    issue: https://github.com/elastic/elasticsearch/issues/130067
-  - class: org.elasticsearch.xpack.monitoring.exporter.http.HttpExporterTests
-    method: testExporterWithHostOnly
-    issue: https://github.com/elastic/elasticsearch/issues/130599
-  - class: org.elasticsearch.xpack.monitoring.exporter.http.HttpExporterTests
-    method: testCreateRestClient
-    issue: https://github.com/elastic/elasticsearch/issues/130600
-  - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
-    method: test
-    issue: https://github.com/elastic/elasticsearch/issues/130067
-  - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-    method: test {p0=search.vectors/40_knn_search/Dimensions are dynamically set}
-    issue: https://github.com/elastic/elasticsearch/issues/130626
-  - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-    method: test {match-operator.MatchWithMoreComplexDisjunctionAndConjunction SYNC}
-    issue: https://github.com/elastic/elasticsearch/issues/130640
-  - class: org.elasticsearch.gradle.LoggedExecFuncTest
-    method: failed tasks output logged to console when spooling true
-    issue: https://github.com/elastic/elasticsearch/issues/119509
+  issue: https://github.com/elastic/elasticsearch/issues/119871
+- class: geoip.GeoIpMultiProjectIT
+  issue: https://github.com/elastic/elasticsearch/issues/130073
+- class: org.elasticsearch.xpack.esql.action.EnrichIT
+  method: testTopN
+  issue: https://github.com/elastic/elasticsearch/issues/130122
+- class: org.elasticsearch.action.support.ThreadedActionListenerTests
+  method: testRejectionHandling
+  issue: https://github.com/elastic/elasticsearch/issues/130129
+- class: org.elasticsearch.compute.aggregation.TopIntAggregatorFunctionTests
+  method: testManyInitialManyPartialFinalRunnerThrowing
+  issue: https://github.com/elastic/elasticsearch/issues/130145
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=esql/10_basic/basic with documents_found}
+  issue: https://github.com/elastic/elasticsearch/issues/130256
+- class: org.elasticsearch.xpack.searchablesnapshots.cache.shared.NodesCachesStatsIntegTests
+  method: testNodesCachesStats
+  issue: https://github.com/elastic/elasticsearch/issues/129863
+- class: org.elasticsearch.index.IndexingPressureIT
+  method: testWriteCanRejectOnPrimaryBasedOnMaxOperationSize
+  issue: https://github.com/elastic/elasticsearch/issues/130281
+- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
+  method: test {lookup-join.MvJoinKeyOnFrom SYNC}
+  issue: https://github.com/elastic/elasticsearch/issues/130296
+- class: org.elasticsearch.xpack.esql.inference.bulk.BulkInferenceExecutorTests
+  method: testSuccessfulExecution
+  issue: https://github.com/elastic/elasticsearch/issues/130306
+- class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
+  method: test {yaml=cluster.stats/10_basic/Dense vector stats}
+  issue: https://github.com/elastic/elasticsearch/issues/130307
+- class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
+  method: test {yaml=nodes.stats/11_indices_metrics/Lucene segment level fields stats}
+  issue: https://github.com/elastic/elasticsearch/issues/130360
+- class: org.elasticsearch.ingest.PipelineFactoryTests
+  method: testCreateUnsupportedFieldAccessPattern
+  issue: https://github.com/elastic/elasticsearch/issues/130422
+- class: org.elasticsearch.test.rest.yaml.RcsCcsCommonYamlTestSuiteIT
+  method: test {p0=msearch/20_typed_keys/Multisearch test with typed_keys parameter for sampler and significant terms}
+  issue: https://github.com/elastic/elasticsearch/issues/130472
+- class: org.elasticsearch.xpack.esql.action.EsqlActionBreakerIT
+  method: testProjectWhere
+  issue: https://github.com/elastic/elasticsearch/issues/130504
+- class: org.elasticsearch.xpack.esql.action.EsqlActionBreakerIT
+  method: testTopNPushedToLucene
+  issue: https://github.com/elastic/elasticsearch/issues/130505
+- class: org.elasticsearch.common.ssl.DefaultJdkTrustConfigTests
+  method: testGetSystemTrustStoreWithNoSystemProperties
+  issue: https://github.com/elastic/elasticsearch/issues/130517
+- class: org.elasticsearch.common.ssl.DefaultJdkTrustConfigTests
+  method: testGetNonPKCS11TrustStoreWithPasswordSet
+  issue: https://github.com/elastic/elasticsearch/issues/130519
+- class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
+  method: test {yaml=indices.resolve_index/10_basic_resolve_index/Resolve index with hidden and closed indices}
+  issue: https://github.com/elastic/elasticsearch/issues/130568
+- class: org.elasticsearch.reindex.ReindexRestClientSslTests
+  method: testClientPassesClientCertificate
+  issue: https://github.com/elastic/elasticsearch/issues/130584
+- class: org.elasticsearch.reindex.ReindexRestClientSslTests
+  method: testClientFailsWithUntrustedCertificate
+  issue: https://github.com/elastic/elasticsearch/issues/130585
+- class: org.elasticsearch.reindex.ReindexRestClientSslTests
+  method: testClientSucceedsWithCertificateAuthorities
+  issue: https://github.com/elastic/elasticsearch/issues/130586
+- class: org.elasticsearch.reindex.ReindexFromRemoteBuildRestClientTests
+  method: testHeaders
+  issue: https://github.com/elastic/elasticsearch/issues/130587
+- class: org.elasticsearch.reindex.ReindexFromRemoteBuildRestClientTests
+  method: testBuildRestClient
+  issue: https://github.com/elastic/elasticsearch/issues/130588
+- class: org.elasticsearch.http.netty4.Netty4HttpServerTransportTests
+  method: testRespondAfterServiceCloseWithClientCancel
+  issue: https://github.com/elastic/elasticsearch/issues/130590
+- class: org.elasticsearch.http.netty4.Netty4HttpServerTransportTests
+  method: testRespondAfterServiceCloseWithServerCancel
+  issue: https://github.com/elastic/elasticsearch/issues/130591
+- class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
+  method: test
+  issue: https://github.com/elastic/elasticsearch/issues/130067
+- class: org.elasticsearch.xpack.monitoring.exporter.http.HttpExporterTests
+  method: testExporterWithHostOnly
+  issue: https://github.com/elastic/elasticsearch/issues/130599
+- class: org.elasticsearch.xpack.monitoring.exporter.http.HttpExporterTests
+  method: testCreateRestClient
+  issue: https://github.com/elastic/elasticsearch/issues/130600
+- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
+  method: test
+  issue: https://github.com/elastic/elasticsearch/issues/130067
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  method: test {p0=search.vectors/40_knn_search/Dimensions are dynamically set}
+  issue: https://github.com/elastic/elasticsearch/issues/130626
+- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
+  method: test {match-operator.MatchWithMoreComplexDisjunctionAndConjunction SYNC}
+  issue: https://github.com/elastic/elasticsearch/issues/130640
+- class: org.elasticsearch.gradle.LoggedExecFuncTest
+  method: failed tasks output logged to console when spooling true
+  issue: https://github.com/elastic/elasticsearch/issues/119509
 
 # Examples:
 #

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -614,9 +614,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/130067
-- class: org.elasticsearch.index.codec.vectors.cluster.HierarchicalKMeansTests
-  method: testHKmeans
-  issue: https://github.com/elastic/elasticsearch/issues/130497
 
 # Examples:
 #

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/KMeansLocal.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/KMeansLocal.java
@@ -329,8 +329,10 @@ class KMeansLocal {
         float[][] centroids = kMeansIntermediate.centroids();
         int k = centroids.length;
         int n = vectors.size();
+        int[] assignments = kMeansIntermediate.assignments();
 
-        if (k == 1 || k >= n) {
+        if (k == 1) {
+            Arrays.fill(assignments, 0);
             return;
         }
         IntToIntFunction translateOrd = i -> i;
@@ -339,7 +341,7 @@ class KMeansLocal {
             sampledVectors = SampleReader.createSampleReader(vectors, sampleSize, 42L);
             translateOrd = sampledVectors::ordToDoc;
         }
-        int[] assignments = kMeansIntermediate.assignments();
+
         assert assignments.length == n;
         float[][] nextCentroids = new float[centroids.length][vectors.dimension()];
         for (int i = 0; i < maxIterations; i++) {
@@ -349,7 +351,7 @@ class KMeansLocal {
             }
         }
         // If we were sampled, do a once over the full set of vectors to finalize the centroids
-        if (sampleSize < n) {
+        if (sampleSize < n || maxIterations == 0) {
             // No ordinal translation needed here, we are using the full set of vectors
             stepLloyd(vectors, i -> i, centroids, nextCentroids, assignments, neighborhoods);
         }

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/cluster/HierarchicalKMeansTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/cluster/HierarchicalKMeansTests.java
@@ -19,10 +19,10 @@ public class HierarchicalKMeansTests extends ESTestCase {
 
     public void testHKmeans() throws IOException {
         int nClusters = random().nextInt(1, 10);
-        int nVectors = random().nextInt(nClusters * 100, nClusters * 200);
+        int nVectors = random().nextInt(1, nClusters * 200);
         int dims = random().nextInt(2, 20);
-        int sampleSize = random().nextInt(100, nVectors + 1);
-        int maxIterations = random().nextInt(0, 100);
+        int sampleSize = random().nextInt(Math.min(nVectors, 100), nVectors + 1);
+        int maxIterations = random().nextInt(1, 100);
         int clustersPerNeighborhood = random().nextInt(2, 512);
         float soarLambda = random().nextFloat(0.5f, 1.5f);
         FloatVectorValues vectors = generateData(nVectors, dims, nClusters);
@@ -36,14 +36,16 @@ public class HierarchicalKMeansTests extends ESTestCase {
         int[] assignments = result.assignments();
         int[] soarAssignments = result.soarAssignments();
 
-        assertEquals(nClusters, centroids.length, 6);
+        assertEquals(Math.min(nClusters, nVectors), centroids.length, 8);
         assertEquals(nVectors, assignments.length);
-        if (centroids.length > 1 && clustersPerNeighborhood > 0) {
+        if (centroids.length > 1 && centroids.length < nVectors) {
             assertEquals(nVectors, soarAssignments.length);
             // verify no duplicates exist
             for (int i = 0; i < assignments.length; i++) {
                 assert assignments[i] != soarAssignments[i];
             }
+        } else {
+            assertEquals(0, soarAssignments.length);
         }
     }
 


### PR DESCRIPTION
This commit handle the following cases:

1) When the number of centroids is one (and better checks when number of centroids < number of vectors).

2) when number of maxIterations is equal to 0 (no sampling)

fixes https://github.com/elastic/elasticsearch/issues/130497