### PR TITLE
[ML] Check old cluster version in ModelRegistry upgrade tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -411,12 +411,6 @@ tests:
   - class: org.elasticsearch.repositories.blobstore.testkit.analyze.GCSRepositoryAnalysisRestIT
     method: testRepositoryAnalysis
     issue: https://github.com/elastic/elasticsearch/issues/125668
-  - class: org.elasticsearch.xpack.application.ModelRegistryUpgradeIT
-    method: testUpgradeModels {upgradedNodes=0}
-    issue: https://github.com/elastic/elasticsearch/issues/125549
-  - class: org.elasticsearch.xpack.application.ModelRegistryUpgradeIT
-    method: testUpgradeModels {upgradedNodes=3}
-    issue: https://github.com/elastic/elasticsearch/issues/125535
   - class: org.elasticsearch.ingest.geoip.EnterpriseGeoIpDownloaderIT
     method: testEnterpriseDownloaderTask
     issue: https://github.com/elastic/elasticsearch/issues/126124

--- a/x-pack/plugin/inference/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/application/ModelRegistryUpgradeIT.java
+++ b/x-pack/plugin/inference/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/application/ModelRegistryUpgradeIT.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.xpack.application.HuggingFaceServiceUpgradeIT.HF_EMBEDDINGS_ADDED;
 import static org.elasticsearch.xpack.application.HuggingFaceServiceUpgradeIT.elserConfig;
 import static org.elasticsearch.xpack.application.HuggingFaceServiceUpgradeIT.elserResponse;
 import static org.elasticsearch.xpack.application.HuggingFaceServiceUpgradeIT.embeddingConfig;
@@ -27,6 +28,12 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 
 public class ModelRegistryUpgradeIT extends InferenceUpgradeTestCase {
+
+    // Hugging Face embeddings and ELSER was added in 8.12.0
+    // but in 8.15 the endpoints were renamed. For the sake of this
+    // test can can start at 8.15.0.
+    public static final String MIN_OLD_CLUSTER_VERSION = "8.15.0";
+
     private static MockWebServer embeddingsServer;
     private static MockWebServer elserServer;
 
@@ -50,6 +57,9 @@ public class ModelRegistryUpgradeIT extends InferenceUpgradeTestCase {
     }
 
     public void testUpgradeModels() throws Exception {
+        boolean oldClusterSupportsHF = oldClusterHasFeature("gte_v" + MIN_OLD_CLUSTER_VERSION);
+        assumeTrue("Test requires features added in " + MIN_OLD_CLUSTER_VERSION, oldClusterSupportsHF);
+
         if (isOldCluster()) {
             int numModels = randomIntBetween(5, 10);
             for (int i = 0; i < numModels; i++) {

--- a/x-pack/plugin/inference/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/application/ModelRegistryUpgradeIT.java
+++ b/x-pack/plugin/inference/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/application/ModelRegistryUpgradeIT.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.elasticsearch.xpack.application.HuggingFaceServiceUpgradeIT.HF_EMBEDDINGS_ADDED;
 import static org.elasticsearch.xpack.application.HuggingFaceServiceUpgradeIT.elserConfig;
 import static org.elasticsearch.xpack.application.HuggingFaceServiceUpgradeIT.elserResponse;
 import static org.elasticsearch.xpack.application.HuggingFaceServiceUpgradeIT.embeddingConfig;

--- a/x-pack/plugin/inference/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/application/ModelRegistryUpgradeIT.java
+++ b/x-pack/plugin/inference/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/application/ModelRegistryUpgradeIT.java
@@ -30,7 +30,7 @@ public class ModelRegistryUpgradeIT extends InferenceUpgradeTestCase {
 
     // Hugging Face embeddings and ELSER was added in 8.12.0
     // but in 8.15 the endpoints were renamed. For the sake of this
-    // test can can start at 8.15.0.
+    // test can start at 8.15.0.
     public static final String MIN_OLD_CLUSTER_VERSION = "8.15.0";
 
     private static MockWebServer embeddingsServer;


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch/issues/125549, https://github.com/elastic/elasticsearch/issues/125535
