### PR TITLE
[9.1] Unmute SearchWithRejectionsIT testOpenContextsAfterRejections

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -296,9 +296,6 @@ tests:
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test023InstallPluginUsingConfigFile
   issue: https://github.com/elastic/elasticsearch/issues/126145
-- class: org.elasticsearch.search.SearchWithRejectionsIT
-  method: testOpenContextsAfterRejections
-  issue: https://github.com/elastic/elasticsearch/issues/126340
 - class: org.elasticsearch.smoketest.MlWithSecurityIT
   method: test {yaml=ml/start_data_frame_analytics/Test start classification analysis when the dependent variable cardinality is too low}
   issue: https://github.com/elastic/elasticsearch/issues/123200

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/SearchWithRejectionsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/SearchWithRejectionsIT.java
@@ -58,7 +58,7 @@ public class SearchWithRejectionsIT extends ESIntegTestCase {
         }
         assertBusy(
             () -> assertThat(indicesAdmin().prepareStats().get().getTotal().getSearch().getOpenContexts(), equalTo(0L)),
-            1,
+            2,
             TimeUnit.SECONDS
         );
     }


### PR DESCRIPTION
Backports the following commits to 9.1:
 - Unmute SearchWithRejectionsIT testOpenContextsAfterRejections (#130628)
