### PR TITLE
Fix LogsdbTestSuiteIT 9.1 release test failures 

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -548,6 +548,9 @@ tests:
 - class: org.elasticsearch.index.engine.ThreadPoolMergeExecutorServiceDiskSpaceTests
   method: testUnavailableBudgetBlocksNewMergeTasksFromStartingExecution
   issue: https://github.com/elastic/elasticsearch/issues/130205
+- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlClientYamlIT
+  method: test {p0=esql/60_usage/Basic ESQL usage output (telemetry) non-snapshot version}
+  issue: https://github.com/elastic/elasticsearch/issues/129888
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlClientYamlIT
   method: test {p0=esql/60_usage/Basic ESQL usage output (telemetry) non-snapshot version}
   issue: https://github.com/elastic/elasticsearch/issues/129888

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -551,6 +551,9 @@ tests:
 - class: org.elasticsearch.index.engine.ThreadPoolMergeExecutorServiceDiskSpaceTests
   method: testUnavailableBudgetBlocksNewMergeTasksFromStartingExecution
   issue: https://github.com/elastic/elasticsearch/issues/130205
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=esql/60_usage/Basic ESQL usage output (telemetry) non-snapshot version}
+  issue: https://github.com/elastic/elasticsearch/issues/129888
 
 # Examples:
 #

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -548,12 +548,6 @@ tests:
 - class: org.elasticsearch.index.engine.ThreadPoolMergeExecutorServiceDiskSpaceTests
   method: testUnavailableBudgetBlocksNewMergeTasksFromStartingExecution
   issue: https://github.com/elastic/elasticsearch/issues/130205
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlClientYamlIT
-  method: test {p0=esql/60_usage/Basic ESQL usage output (telemetry) non-snapshot version}
-  issue: https://github.com/elastic/elasticsearch/issues/129888
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlClientYamlIT
-  method: test {p0=esql/60_usage/Basic ESQL usage output (telemetry) non-snapshot version}
-  issue: https://github.com/elastic/elasticsearch/issues/129888
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=search.vectors/40_knn_search/Dimensions are dynamically set}
   issue: https://github.com/elastic/elasticsearch/issues/130626

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -548,7 +548,7 @@ tests:
 - class: org.elasticsearch.index.engine.ThreadPoolMergeExecutorServiceDiskSpaceTests
   method: testUnavailableBudgetBlocksNewMergeTasksFromStartingExecution
   issue: https://github.com/elastic/elasticsearch/issues/130205
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlClientYamlI
   method: test {p0=esql/60_usage/Basic ESQL usage output (telemetry) non-snapshot version}
   issue: https://github.com/elastic/elasticsearch/issues/129888
 

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -548,7 +548,7 @@ tests:
 - class: org.elasticsearch.index.engine.ThreadPoolMergeExecutorServiceDiskSpaceTests
   method: testUnavailableBudgetBlocksNewMergeTasksFromStartingExecution
   issue: https://github.com/elastic/elasticsearch/issues/130205
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlClientYamlI
+- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlClientYamlIT
   method: test {p0=esql/60_usage/Basic ESQL usage output (telemetry) non-snapshot version}
   issue: https://github.com/elastic/elasticsearch/issues/129888
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/FeatureFlag.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/FeatureFlag.java
@@ -22,7 +22,7 @@ public enum FeatureFlag {
     USE_LUCENE101_POSTINGS_FORMAT("es.use_lucene101_postings_format_feature_flag_enabled=true", Version.fromString("9.1.0"), null),
     IVF_FORMAT("es.ivf_format_feature_flag_enabled=true", Version.fromString("9.1.0"), null),
     LOGS_STREAM("es.logs_stream_feature_flag_enabled=true", Version.fromString("9.1.0"), null),
-    PATTERNED_TEXT("es.patterned_text_feature_flag_enabled=true", Version.fromString("9.2.0"), null);
+    PATTERNED_TEXT("es.patterned_text_feature_flag_enabled=true", Version.fromString("9.1.0"), null);
 
     public final String systemProperty;
     public final Version from;

--- a/x-pack/plugin/logsdb/src/yamlRestTest/java/org/elasticsearch/xpack/logsdb/LogsdbTestSuiteIT.java
+++ b/x-pack/plugin/logsdb/src/yamlRestTest/java/org/elasticsearch/xpack/logsdb/LogsdbTestSuiteIT.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.logsdb;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.elasticsearch.Build;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -19,6 +20,9 @@ import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
 import org.junit.ClassRule;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class LogsdbTestSuiteIT extends ESClientYamlSuiteTestCase {
 
@@ -43,7 +47,19 @@ public class LogsdbTestSuiteIT extends ESClientYamlSuiteTestCase {
 
     @ParametersFactory
     public static Iterable<Object[]> parameters() throws Exception {
-        return ESClientYamlSuiteTestCase.createParameters();
+        // Filter out 52_esql_insist_operator_synthetic_source.yml suite for snapshot builds:
+        // (esql doesn't use feature flags and all experimental features are just enabled if build is snapshot)
+
+        List<Object[]> filtered = new ArrayList<>();
+        for (Object[] params : ESClientYamlSuiteTestCase.createParameters()) {
+            ClientYamlTestCandidate candidate = (ClientYamlTestCandidate) params[0];
+            if (candidate.getRestTestSuite().getName().equals("52_esql_insist_operator_synthetic_source")
+                && Build.current().isSnapshot() == false) {
+                continue;
+            }
+            filtered.add(new Object[] { candidate });
+        }
+        return filtered;
     }
 
     @Override


### PR DESCRIPTION
Backport https://github.com/elastic/elasticsearch/pull/130528 and tweak feature flag version.

Closes #130592