### PR TITLE
Fix cluster.put_component_template rest-api-spec

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_component_template.json
@@ -33,9 +33,10 @@
         "description":"Whether the index template should only be added if new or can also replace an existing one",
         "default":false
       },
-      "timeout":{
-        "type":"time",
-        "description":"Explicit operation timeout"
+      "cause": {
+        "type": "string",
+        "description": "User defined reason for create the component template",
+        "default": "api"
       },
       "master_timeout":{
         "type":"time",


### PR DESCRIPTION
The query parameters are parsed in https://github.com/elastic/elasticsearch/blob/e2bc52e662d4fe46e58c8027fcd25b722e6554a5/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutComponentTemplateAction.java#L49-L52.