### PR TITLE
[9.0] Fix tests involving getBestDowngradeVersion (#127646)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -204,9 +204,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/120816
 - class: org.elasticsearch.xpack.security.authc.ldap.ActiveDirectorySessionFactoryTests
   issue: https://github.com/elastic/elasticsearch/issues/121285
-- class: org.elasticsearch.env.NodeEnvironmentTests
-  method: testGetBestDowngradeVersion
-  issue: https://github.com/elastic/elasticsearch/issues/121316
 - class: org.elasticsearch.index.engine.ShuffleForcedMergePolicyTests
   method: testDiagnostics
   issue: https://github.com/elastic/elasticsearch/issues/121336
@@ -282,9 +279,6 @@ tests:
 - class: org.elasticsearch.action.admin.cluster.node.tasks.CancellableTasksIT
   method: testChildrenTasksCancelledOnTimeout
   issue: https://github.com/elastic/elasticsearch/issues/123568
-- class: org.elasticsearch.env.NodeEnvironmentTests
-  method: testIndexCompatibilityChecks
-  issue: https://github.com/elastic/elasticsearch/issues/130276
 
 # Examples:
 #

--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -1501,10 +1501,15 @@ public final class NodeEnvironment implements Closeable {
 
     /**
      * Get a useful version string to direct a user's downgrade operation
+     * <p>
+     * Assuming that the index was compatible with {@code previousNodeVersion},
+     * the user should downgrade to that {@code previousNodeVersion},
+     * unless it's prior to the minimum compatible version,
+     * in which case the user should downgrade to that instead.
+     * (If the index version is so old that the minimum compatible version is incompatible with the index,
+     * then the cluster was already borked before the node upgrade began,
+     * and we can't probably help them without more info than we have here.)
      *
-     * <p>If a user is trying to install current major N but has incompatible indices, the user should
-     * downgrade to last minor of the previous major (N-1).last. We return (N-1).last, unless the user is trying to upgrade from
-     * a (N-1).last.x release, in which case we return the last installed version.
      * @return Version to downgrade to
      */
     // visible for testing

--- a/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
@@ -42,7 +42,6 @@ import org.elasticsearch.test.IndexSettingsModule;
 import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.NodeRoles;
 import org.elasticsearch.test.junit.annotations.TestLogging;
-import org.hamcrest.Matchers;
 import org.junit.AssumptionViolatedException;
 
 import java.io.IOException;
@@ -581,9 +580,9 @@ public class NodeEnvironmentTests extends ESTestCase {
                     containsString("it holds metadata for indices with version [" + oldIndexVersion.toReleaseVersion() + "]"),
                     containsString(
                         "Revert this node to version ["
-                            + (previousNodeVersion.major == Version.CURRENT.major
-                                ? Version.CURRENT.minimumCompatibilityVersion()
-                                : previousNodeVersion)
+                            + (previousNodeVersion.onOrAfter(Version.CURRENT.minimumCompatibilityVersion())
+                                ? previousNodeVersion
+                                : Version.CURRENT.minimumCompatibilityVersion())
                             + "]"
                     )
                 )
@@ -638,29 +637,37 @@ public class NodeEnvironmentTests extends ESTestCase {
     }
 
     public void testGetBestDowngradeVersion() {
-        assertThat(
-            NodeEnvironment.getBestDowngradeVersion(BuildVersion.fromString("8.18.0")),
-            Matchers.equalTo(BuildVersion.fromString("8.18.0"))
+        int prev = Version.CURRENT.minimumCompatibilityVersion().major;
+        int last = Version.CURRENT.minimumCompatibilityVersion().minor;
+        int old = prev - 1;
+
+        assumeTrue("The current compatibility rules are active only from 8.x onward", prev >= 7);
+        assertEquals(Version.CURRENT.major - 1, prev);
+
+        assertEquals(
+            "From an old major, recommend prev.last",
+            NodeEnvironment.getBestDowngradeVersion(BuildVersion.fromString(old + ".0.0")),
+            BuildVersion.fromString(prev + "." + last + ".0")
         );
-        assertThat(
-            NodeEnvironment.getBestDowngradeVersion(BuildVersion.fromString("8.18.5")),
-            Matchers.equalTo(BuildVersion.fromString("8.18.5"))
+
+        if (last >= 1) {
+            assertEquals(
+                "From an old minor of the previous major, recommend prev.last",
+                NodeEnvironment.getBestDowngradeVersion(BuildVersion.fromString(prev + "." + (last - 1) + ".0")),
+                BuildVersion.fromString(prev + "." + last + ".0")
+            );
+        }
+
+        assertEquals(
+            "From an old patch of prev.last, return that version itself",
+            NodeEnvironment.getBestDowngradeVersion(BuildVersion.fromString(prev + "." + last + ".1")),
+            BuildVersion.fromString(prev + "." + last + ".1")
         );
-        assertThat(
-            NodeEnvironment.getBestDowngradeVersion(BuildVersion.fromString("8.18.12")),
-            Matchers.equalTo(BuildVersion.fromString("8.18.12"))
-        );
-        assertThat(
-            NodeEnvironment.getBestDowngradeVersion(BuildVersion.fromString("8.19.0")),
-            Matchers.equalTo(BuildVersion.fromString("8.19.0"))
-        );
-        assertThat(
-            NodeEnvironment.getBestDowngradeVersion(BuildVersion.fromString("8.17.0")),
-            Matchers.equalTo(BuildVersion.fromString("8.18.0"))
-        );
-        assertThat(
-            NodeEnvironment.getBestDowngradeVersion(BuildVersion.fromString("7.17.0")),
-            Matchers.equalTo(BuildVersion.fromString("8.18.0"))
+
+        assertEquals(
+            "From the first version of this major, return that version itself",
+            NodeEnvironment.getBestDowngradeVersion(BuildVersion.fromString(Version.CURRENT.major + ".0.0")),
+            BuildVersion.fromString(Version.CURRENT.major + ".0.0")
         );
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Fix tests involving getBestDowngradeVersion (#127646)](https://github.com/elastic/elasticsearch/pull/127646)

<!--- Backport version: 10.0.1 -->

Fixes https://github.com/elastic/elasticsearch/issues/130276
Fixes https://github.com/elastic/elasticsearch/issues/121316