### PR TITLE
Tweak patterned_text_feature_flag_enabled ff.

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/FeatureFlag.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/FeatureFlag.java
@@ -22,7 +22,7 @@ public enum FeatureFlag {
     USE_LUCENE101_POSTINGS_FORMAT("es.use_lucene101_postings_format_feature_flag_enabled=true", Version.fromString("9.1.0"), null),
     IVF_FORMAT("es.ivf_format_feature_flag_enabled=true", Version.fromString("9.1.0"), null),
     LOGS_STREAM("es.logs_stream_feature_flag_enabled=true", Version.fromString("9.1.0"), null),
-    PATTERNED_TEXT("es.patterned_text_feature_flag_enabled=true", Version.fromString("9.2.0"), null);
+    PATTERNED_TEXT("es.patterned_text_feature_flag_enabled=true", Version.fromString("9.1.0"), null);
 
     public final String systemProperty;
     public final Version from;


### PR DESCRIPTION
 Adjusted version from 9.2.0 to 9.1.0, given that it has been backported to the 9.1 branch.

 Relates to #130633