### PR TITLE
[8.19] Fix cluster.put_component_template rest-api-spec (#130634)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_component_template.json
@@ -33,9 +33,10 @@
         "description":"Whether the index template should only be added if new or can also replace an existing one",
         "default":false
       },
-      "timeout":{
-        "type":"time",
-        "description":"Explicit operation timeout"
+      "cause": {
+        "type": "string",
+        "description": "User defined reason for create the component template",
+        "default": "api"
       },
       "master_timeout":{
         "type":"time",


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Fix cluster.put_component_template rest-api-spec (#130634)