### PR TITLE
Improve reading ignored source in esql

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/fieldvisitor/IgnoredSourceFieldLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/fieldvisitor/IgnoredSourceFieldLoader.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.fieldvisitor;
+
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.StoredFieldVisitor;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.CheckedBiConsumer;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.lucene.index.SequentialStoredFieldsLeafReader;
+import org.elasticsearch.index.mapper.IgnoredSourceFieldMapper;
+import org.elasticsearch.search.fetch.StoredFieldsSpec;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+class IgnoredSourceFieldLoader extends StoredFieldLoader {
+
+    @Override
+    public LeafStoredFieldLoader getLoader(LeafReaderContext ctx, int[] docs) throws IOException {
+        var reader = sequentialReader(ctx);
+        var visitor = new SFV();
+        return new LeafStoredFieldLoader() {
+
+            private int doc = -1;
+
+            @Override
+            public void advanceTo(int doc) throws IOException {
+                if (doc != this.doc) {
+                    visitor.reset();
+                    reader.accept(doc, visitor);
+                    this.doc = doc;
+                }
+            }
+
+            @Override
+            public BytesReference source() {
+                return null;
+            }
+
+            @Override
+            public String id() {
+                return null;
+            }
+
+            @Override
+            public String routing() {
+                return null;
+            }
+
+            @Override
+            public Map<String, List<Object>> storedFields() {
+                return Map.of(IgnoredSourceFieldMapper.NAME, visitor.values);
+            }
+        };
+    }
+
+    @Override
+    public List<String> fieldsToLoad() {
+        return List.of(IgnoredSourceFieldMapper.NAME);
+    }
+
+    static class SFV extends StoredFieldVisitor {
+
+        boolean processing;
+        final List<Object> values = new ArrayList<>();
+
+        @Override
+        public Status needsField(FieldInfo fieldInfo) throws IOException {
+            if (IgnoredSourceFieldMapper.NAME.equals(fieldInfo.name)) {
+                processing = true;
+                return Status.YES;
+            } else if (processing) {
+                return Status.STOP;
+            }
+
+            return Status.NO;
+        }
+
+        @Override
+        public void binaryField(FieldInfo fieldInfo, byte[] value) throws IOException {
+            values.add(new BytesRef(value));
+        }
+
+        void reset() {
+            values.clear();
+            processing = false;
+        }
+
+    }
+
+    static boolean supports(StoredFieldsSpec spec) {
+        return spec.requiresSource() == false
+            && spec.requiresMetadata() == false
+            && spec.requiredStoredFields().size() == 1
+            && spec.requiredStoredFields().contains(IgnoredSourceFieldMapper.NAME);
+    }
+
+    // TODO: use provided one
+    private static CheckedBiConsumer<Integer, StoredFieldVisitor, IOException> sequentialReader(LeafReaderContext ctx) throws IOException {
+        LeafReader leafReader = ctx.reader();
+        if (leafReader instanceof SequentialStoredFieldsLeafReader lf) {
+            return lf.getSequentialStoredFieldsReader()::document;
+        }
+        return leafReader.storedFields()::document;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/fieldvisitor/IgnoredSourceFieldLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/fieldvisitor/IgnoredSourceFieldLoader.java
@@ -112,7 +112,7 @@ class IgnoredSourceFieldLoader extends StoredFieldLoader {
             var result = IgnoredSourceFieldMapper.decodeIfMatch(value, potentialFieldsInIgnoreSource);
             if (result != null) {
                 // TODO: can't do this in case multiple entries for the same field name. (objects, arrays etc.)
-//                done = true;
+                // done = true;
                 values.add(result);
             }
         }

--- a/server/src/main/java/org/elasticsearch/index/fieldvisitor/IgnoredSourceFieldLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/fieldvisitor/IgnoredSourceFieldLoader.java
@@ -111,7 +111,8 @@ class IgnoredSourceFieldLoader extends StoredFieldLoader {
         public void binaryField(FieldInfo fieldInfo, byte[] value) throws IOException {
             var result = IgnoredSourceFieldMapper.decodeIfMatch(value, potentialFieldsInIgnoreSource);
             if (result != null) {
-                done = true;
+                // TODO: can't do this in case multiple entries for the same field name. (objects, arrays etc.)
+//                done = true;
                 values.add(result);
             }
         }

--- a/server/src/main/java/org/elasticsearch/index/fieldvisitor/StoredFieldLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/fieldvisitor/StoredFieldLoader.java
@@ -51,7 +51,7 @@ public abstract class StoredFieldLoader {
             return StoredFieldLoader.empty();
         }
         if (IgnoredSourceFieldLoader.supports(spec)) {
-            return new IgnoredSourceFieldLoader();
+            return new IgnoredSourceFieldLoader(spec);
         }
         return create(spec.requiresSource(), spec.requiredStoredFields());
     }
@@ -95,7 +95,7 @@ public abstract class StoredFieldLoader {
             return StoredFieldLoader.empty();
         }
         if (IgnoredSourceFieldLoader.supports(spec)) {
-            return new IgnoredSourceFieldLoader();
+            return new IgnoredSourceFieldLoader(spec);
         }
 
         List<String> fieldsToLoad = fieldsToLoad(spec.requiresSource(), spec.requiredStoredFields());

--- a/server/src/main/java/org/elasticsearch/index/fieldvisitor/StoredFieldLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/fieldvisitor/StoredFieldLoader.java
@@ -50,6 +50,9 @@ public abstract class StoredFieldLoader {
         if (spec.noRequirements()) {
             return StoredFieldLoader.empty();
         }
+        if (IgnoredSourceFieldLoader.supports(spec)) {
+            return new IgnoredSourceFieldLoader();
+        }
         return create(spec.requiresSource(), spec.requiredStoredFields());
     }
 
@@ -91,6 +94,10 @@ public abstract class StoredFieldLoader {
         if (spec.noRequirements()) {
             return StoredFieldLoader.empty();
         }
+        if (IgnoredSourceFieldLoader.supports(spec)) {
+            return new IgnoredSourceFieldLoader();
+        }
+
         List<String> fieldsToLoad = fieldsToLoad(spec.requiresSource(), spec.requiredStoredFields());
         return new StoredFieldLoader() {
             @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/FallbackSyntheticSourceBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FallbackSyntheticSourceBlockLoader.java
@@ -59,7 +59,7 @@ public abstract class FallbackSyntheticSourceBlockLoader implements BlockLoader 
 
     @Override
     public StoredFieldsSpec rowStrideStoredFieldSpec() {
-        return new StoredFieldsSpec(false, false, Set.of(IgnoredSourceFieldMapper.NAME));
+        return new StoredFieldsSpec(false, false, Set.of(IgnoredSourceFieldMapper.NAME + "." + fieldName));
     }
 
     @Override
@@ -72,7 +72,7 @@ public abstract class FallbackSyntheticSourceBlockLoader implements BlockLoader 
         throw new UnsupportedOperationException();
     }
 
-    static Set<String> splitIntoFieldPaths(String fieldName) {
+    public static Set<String> splitIntoFieldPaths(String fieldName) {
         var paths = new HashSet<String>();
         paths.add("_doc");
         var current = new StringBuilder();
@@ -107,7 +107,7 @@ public abstract class FallbackSyntheticSourceBlockLoader implements BlockLoader 
 
             Map<String, List<IgnoredSourceFieldMapper.NameValue>> valuesForFieldAndParents = new HashMap<>();
             for (Object value : ignoredSource) {
-                IgnoredSourceFieldMapper.NameValue nameValue = IgnoredSourceFieldMapper.decode(value);
+                IgnoredSourceFieldMapper.NameValue nameValue = (IgnoredSourceFieldMapper.NameValue) value;
                 if (fieldPaths.contains(nameValue.name())) {
                     valuesForFieldAndParents.computeIfAbsent(nameValue.name(), k -> new ArrayList<>()).add(nameValue);
                 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapper.java
@@ -186,6 +186,20 @@ public class IgnoredSourceFieldMapper extends MetadataFieldMapper {
         return new NameValue(name, parentOffset, value, null);
     }
 
+    public static NameValue decodeIfMatch(byte[] bytes, Set<String> potentialFieldsInIgnoreSource) {
+        int encodedSize = ByteUtils.readIntLE(bytes, 0);
+        int nameSize = encodedSize % PARENT_OFFSET_IN_NAME_OFFSET;
+        int parentOffset = encodedSize / PARENT_OFFSET_IN_NAME_OFFSET;
+
+        String name = new String(bytes, 4, nameSize, StandardCharsets.UTF_8);
+        if (potentialFieldsInIgnoreSource.contains(name)) {
+            BytesRef value = new BytesRef(bytes, 4 + nameSize, bytes.length - nameSize - 4);
+            return new NameValue(name, parentOffset, value, null);
+        } else {
+            return null;
+        }
+    }
+
     // In rare cases decoding values stored in this field can fail leading to entire source
     // not being available.
     // We would like to have an option to lose some values in synthetic source


### PR DESCRIPTION
* Parse sub field fields once in IgnoredSourceRowStrideReader instead of for each doc that gets read.
* Introduce a dedicated StoredFieldLoader for ignored source (IgnoredSourceFieldLoader). Which optimizes reading stored fields just for ignored source by avoiding relatively expensive set stuff (see CustomFieldsVisitor) and make use aborting loading stored fields (`Status.STOP`) when ignored source is read.