### PR TITLE
Add flat_settings and settings_filter to cluster.get_component_template

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_component_template.json
@@ -44,6 +44,14 @@
       "include_defaults":{
         "type":"boolean",
         "description":"Return all default configurations for the component template (default: false)"
+      },
+      "flat_settings":{
+        "type":"boolean",
+        "description":"Return settings in flat format (default: false)"
+      },
+      "settings_filter":{
+        "type":"string",
+        "description":"Filter out results, for example to filter out sensitive information. Supports wildcards or full settings keys"
       }
     }
   }


### PR DESCRIPTION
Those parameters are supported as [RestGetComponentTemplateAction.responseParams()](https://github.com/elastic/elasticsearch/blob/20ef9556d5e7b583e33ba70e3b0723e65ebed800/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetComponentTemplateAction.java#L72-L75) returns [Settings.FORMAT_PARAMS](https://github.com/elastic/elasticsearch/blob/a0d7d7e68416325b255b0c5991ca3879a64c70a7/server/src/main/java/org/elasticsearch/common/settings/Settings.java#L846). (It's not the only one, to be fair, [there are others too](https://github.com/search?q=repo%3Aelastic%2Felasticsearch+%22return+Settings.FORMAT_PARAMS%3B%22&type=code).)
