### PR TITLE
[9.1] Fix various test to run with FIPS and entitlements (#130616)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/entitlement/runtime/policy/TestPolicyManager.java
+++ b/test/framework/src/main/java/org/elasticsearch/entitlement/runtime/policy/TestPolicyManager.java
@@ -159,6 +159,8 @@ public class TestPolicyManager extends PolicyManager {
         "org.junit",
         "org.mockito",
         "net.bytebuddy", // Mockito uses this
+
+        "org.bouncycastle.jsse.provider" // Used in test code if FIPS is enabled, support more fine-grained config in ES-12128
     };
 
     @Override


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Fix various test to run with FIPS and entitlements (#130616)](https://github.com/elastic/elasticsearch/pull/130616)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)