### PR TITLE
Backport - ESQL: Unmute test (#127065)

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/10_basic.yml
@@ -197,8 +197,8 @@ basic with documents_found:
           query: 'from test | keep data | sort data | limit 2'
           columnar: true
 
-  - match: {documents_found: 10}   # two documents per shard
-  - match: {values_loaded: 10}     # one per document
+  - gte:   {documents_found: 2}   # we might early terminate, so the most we can assume is >=2
+  - gte:   {values_loaded: 2}     # same as above
   - match: {columns.0.name: "data"}
   - match: {columns.0.type: "long"}
   - match: {values.0: [1, 1]}


### PR DESCRIPTION
backport of #127065 related to https://github.com/elastic/elasticsearch/issues/130256

test got muted on main - but the test failed on 8.19