### PR TITLE
ES|QL: Fix generative tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -539,18 +539,12 @@ tests:
 - class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
   method: test {yaml=indices.resolve_index/10_basic_resolve_index/Resolve index with hidden and closed indices}
   issue: https://github.com/elastic/elasticsearch/issues/130568
-- class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/130067
 - class: org.elasticsearch.xpack.monitoring.exporter.http.HttpExporterTests
   method: testExporterWithHostOnly
   issue: https://github.com/elastic/elasticsearch/issues/130599
 - class: org.elasticsearch.xpack.monitoring.exporter.http.HttpExporterTests
   method: testCreateRestClient
   issue: https://github.com/elastic/elasticsearch/issues/130600
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/130067
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=search.vectors/40_knn_search/Dimensions are dynamically set}
   issue: https://github.com/elastic/elasticsearch/issues/130626

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/EsqlQueryGenerator.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/EsqlQueryGenerator.java
@@ -107,6 +107,10 @@ public class EsqlQueryGenerator {
         return policies.stream().filter(x -> Set.of("languages_policy").contains(x.policyName())).toList();
     }
 
+    public static String randomNonVector(List<Column> previousOutput) {
+        return randomName(previousOutput.stream().filter(x -> x.type().contains("vector") == false).toList());
+    }
+
     public static String randomName(List<Column> previousOutput) {
         String result = randomRawName(previousOutput);
         if (result == null) {

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/command/pipe/MvExpandGenerator.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/command/pipe/MvExpandGenerator.java
@@ -25,7 +25,7 @@ public class MvExpandGenerator implements CommandGenerator {
         List<EsqlQueryGenerator.Column> previousOutput,
         QuerySchema schema
     ) {
-        String toExpand = EsqlQueryGenerator.randomName(previousOutput);
+        String toExpand = EsqlQueryGenerator.randomNonVector(previousOutput);
         if (toExpand == null) {
             return EMPTY_DESCRIPTION; // no columns to expand
         }


### PR DESCRIPTION
Fixes: https://github.com/elastic/elasticsearch/issues/130067

Dense vectors can't be used in mv_expand