### PR TITLE
ES|QL: Unmute esql/10_basic/basic with documents_found

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -503,9 +503,6 @@ tests:
 - class: org.elasticsearch.compute.aggregation.TopIntAggregatorFunctionTests
   method: testManyInitialManyPartialFinalRunnerThrowing
   issue: https://github.com/elastic/elasticsearch/issues/130145
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=esql/10_basic/basic with documents_found}
-  issue: https://github.com/elastic/elasticsearch/issues/130256
 - class: org.elasticsearch.xpack.searchablesnapshots.cache.shared.NodesCachesStatsIntegTests
   method: testNodesCachesStats
   issue: https://github.com/elastic/elasticsearch/issues/129863


### PR DESCRIPTION
close https://github.com/elastic/elasticsearch/issues/130256

the failures happened on the 8.19 branch and have been fixed with https://github.com/elastic/elasticsearch/pull/130689