### PR TITLE
[IVF] Simplify how we build CentroidAssignments

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/CentroidAssignments.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/CentroidAssignments.java
@@ -9,36 +9,10 @@
 
 package org.elasticsearch.index.codec.vectors;
 
-final class CentroidAssignments {
-
-    private final int numCentroids;
-    private final float[][] cachedCentroids;
-    private final int[][] assignmentsByCluster;
-
-    private CentroidAssignments(int numCentroids, float[][] cachedCentroids, int[][] assignmentsByCluster) {
-        this.numCentroids = numCentroids;
-        this.cachedCentroids = cachedCentroids;
-        this.assignmentsByCluster = assignmentsByCluster;
-    }
+record CentroidAssignments(int numCentroids, float[][] centroids, int[][] assignmentsByCluster) {
 
     CentroidAssignments(float[][] centroids, int[][] assignmentsByCluster) {
         this(centroids.length, centroids, assignmentsByCluster);
-    }
-
-    CentroidAssignments(int numCentroids, int[][] assignmentsByCluster) {
-        this(numCentroids, null, assignmentsByCluster);
-    }
-
-    // Getters and setters
-    public int numCentroids() {
-        return numCentroids;
-    }
-
-    public float[][] cachedCentroids() {
-        return cachedCentroids;
-    }
-
-    public int[][] assignmentsByCluster() {
-        return assignmentsByCluster;
+        assert centroids.length == assignmentsByCluster.length;
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/DefaultIVFVectorsWriter.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/DefaultIVFVectorsWriter.java
@@ -177,7 +177,7 @@ public class DefaultIVFVectorsWriter extends IVFVectorsWriter {
         FloatVectorValues floatVectorValues,
         IndexOutput centroidOutput,
         float[] globalCentroid
-    )       throws IOException {
+    ) throws IOException {
 
         long nanoTime = System.nanoTime();
 

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/IVFVectorsWriter.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/IVFVectorsWriter.java
@@ -166,7 +166,7 @@ public abstract class IVFVectorsWriter extends KnnVectorsWriter {
                 globalCentroid
             );
 
-            CentroidSupplier centroidSupplier = new OnHeapCentroidSupplier(centroidAssignments.cachedCentroids());
+            CentroidSupplier centroidSupplier = new OnHeapCentroidSupplier(centroidAssignments.centroids());
 
             long centroidLength = ivfCentroids.getFilePointer() - centroidOffset;
             final long[] offsets = buildAndWritePostingsLists(
@@ -280,26 +280,27 @@ public abstract class IVFVectorsWriter extends KnnVectorsWriter {
             IndexInput docs = docsFileName == null ? null : mergeState.segmentInfo.dir.openInput(docsFileName, IOContext.DEFAULT)
         ) {
             final FloatVectorValues floatVectorValues = getFloatVectorValues(fieldInfo, docs, vectors, numVectors);
-            success = false;
-            long centroidOffset;
-            long centroidLength;
+
+            final long centroidOffset;
+            final long centroidLength;
+            final int numCentroids;
+            final int[][] assignmentsByCluster;
+            final float[] calculatedGlobalCentroid = new float[fieldInfo.getVectorDimension()];
             String centroidTempName = null;
-            int numCentroids;
             IndexOutput centroidTemp = null;
-            CentroidAssignments centroidAssignments;
-            float[] calculatedGlobalCentroid = new float[fieldInfo.getVectorDimension()];
+            success = false;
             try {
                 centroidTemp = mergeState.segmentInfo.dir.createTempOutput(mergeState.segmentInfo.name, "civf_", IOContext.DEFAULT);
                 centroidTempName = centroidTemp.getName();
-                centroidAssignments = calculateAndWriteCentroids(
+                CentroidAssignments centroidAssignments = calculateAndWriteCentroids(
                     fieldInfo,
-                    floatVectorValues,
+                    getFloatVectorValues(fieldInfo, docs, vectors, numVectors),
                     centroidTemp,
                     mergeState,
                     calculatedGlobalCentroid
                 );
                 numCentroids = centroidAssignments.numCentroids();
-
+                assignmentsByCluster = centroidAssignments.assignmentsByCluster();
                 success = true;
             } finally {
                 if (success == false && centroidTempName != null) {
@@ -336,7 +337,7 @@ public abstract class IVFVectorsWriter extends KnnVectorsWriter {
                         centroidSupplier,
                         floatVectorValues,
                         ivfClusters,
-                        centroidAssignments.assignmentsByCluster()
+                        assignmentsByCluster
                     );
                     assert offsets.length == centroidSupplier.size();
                     writeMeta(fieldInfo, centroidOffset, centroidLength, offsets, calculatedGlobalCentroid);


### PR DESCRIPTION
This commit removes the flag for cache centroids when building cetroid assigments as I don't think is needed. It makes CentroidAssignments a record too.