### PR TITLE
[9.1] Add flat_settings and settings_filter to cluster.get_component_template (#130684)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_component_template.json
@@ -44,6 +44,14 @@
       "include_defaults":{
         "type":"boolean",
         "description":"Return all default configurations for the component template (default: false)"
+      },
+      "flat_settings":{
+        "type":"boolean",
+        "description":"Return settings in flat format (default: false)"
+      },
+      "settings_filter":{
+        "type":"string",
+        "description":"Filter out results, for example to filter out sensitive information. Supports wildcards or full settings keys"
       }
     }
   }


### PR DESCRIPTION
Backports the following commits to 9.1:
 - Add flat_settings and settings_filter to cluster.get_component_template (#130684)