### PR TITLE
[9.1] add MS Graph third party tests to periodic tests job (#130380)

### DIFF
--- a/.buildkite/pipelines/periodic.template.yml
+++ b/.buildkite/pipelines/periodic.template.yml
@@ -204,6 +204,17 @@ steps:
           image: family/elasticsearch-ubuntu-2404
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+      - label: third-party / ms-graph
+        command: |
+          .ci/scripts/run-gradle.sh msGraphThirdPartyTest
+        env:
+          USE_3RD_PARTY_MS_GRAPH_CREDENTIALS: "true"
+        timeout_in_minutes: 30
+        agents:
+          provider: gcp
+          image: family/elasticsearch-ubuntu-2404
+          machineType: n2-standard-8
+          buildDirectory: /dev/shm/bk
   - group: lucene-compat
     steps:
       - label: "{{matrix.LUCENE_VERSION}} / lucene-compat"

--- a/.buildkite/pipelines/periodic.yml
+++ b/.buildkite/pipelines/periodic.yml
@@ -623,6 +623,17 @@ steps:
           image: family/elasticsearch-ubuntu-2404
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+      - label: third-party / ms-graph
+        command: |
+          .ci/scripts/run-gradle.sh msGraphThirdPartyTest
+        env:
+          USE_3RD_PARTY_MS_GRAPH_CREDENTIALS: "true"
+        timeout_in_minutes: 30
+        agents:
+          provider: gcp
+          image: family/elasticsearch-ubuntu-2404
+          machineType: n2-standard-8
+          buildDirectory: /dev/shm/bk
   - group: lucene-compat
     steps:
       - label: "{{matrix.LUCENE_VERSION}} / lucene-compat"

--- a/.buildkite/scripts/third-party-test-credentials.sh
+++ b/.buildkite/scripts/third-party-test-credentials.sh
@@ -48,6 +48,23 @@ if [[ "${USE_3RD_PARTY_GCS_CREDENTIALS:-}" == "true" ]]; then
   .buildkite/scripts/third-party-test-credentials.gcs.sh "$google_storage_service_account"
 fi
 
+if [[ "${USE_3RD_PARTY_MS_GRAPH_CREDENTIALS:-}" == "true" ]]; then
+  json=$(vault read -format=json secret/ci/elastic-elasticsearch/ms_graph_thirdparty_test_creds)
 
+  MS_GRAPH_TENANT_ID=$(echo "$json" | jq -r .data.tenant_id)
+  export ms_graph_tenant_id="$MS_GRAPH_TENANT_ID"
+
+  MS_GRAPH_CLIENT_ID=$(echo "$json" | jq -r .data.client_id)
+  export ms_graph_client_id="$MS_GRAPH_CLIENT_ID"
+
+  MS_GRAPH_CLIENT_SECRET=$(echo "$json" | jq -r .data.client_secret)
+  export ms_graph_client_secret="$MS_GRAPH_CLIENT_SECRET"
+
+  MS_GRAPH_USERNAME=$(echo "$json" | jq -r .data.username)
+  export ms_graph_username="$MS_GRAPH_USERNAME"
+
+  MS_GRAPH_GROUP_ID=$(echo "$json" | jq -r .data.group_id)
+  export ms_graph_group_id="$MS_GRAPH_GROUP_ID"
+fi
 
 unset json

--- a/x-pack/plugin/security/qa/microsoft-graph-authz-tests/build.gradle
+++ b/x-pack/plugin/security/qa/microsoft-graph-authz-tests/build.gradle
@@ -8,7 +8,34 @@ dependencies {
   clusterModules project(":modules:analysis-common")
 }
 
+boolean useFixture = false
+String msGraphTenantId = System.getenv("ms_graph_tenant_id")
+String msGraphClientId = System.getenv("ms_graph_client_id")
+String msGraphClientSecret = System.getenv("ms_graph_client_secret")
+String msGraphUsername = System.getenv("ms_graph_username")
+String msGraphGroupId = System.getenv("ms_graph_group_id")
+
+if (!msGraphTenantId || !msGraphClientId || !msGraphClientSecret || !msGraphUsername || !msGraphGroupId) {
+  msGraphTenantId = "tenant-id"
+  msGraphClientId = "client_id"
+  msGraphClientSecret = "client_secret"
+  msGraphUsername = "Thor"
+  msGraphGroupId = "test_group"
+  useFixture = true
+}
+
 tasks.named("javaRestTest").configure {
+  systemProperty "test.ms_graph.fixture", useFixture
+  systemProperty "test.ms_graph.tenant_id", msGraphTenantId
+  systemProperty "test.ms_graph.client_id", msGraphClientId
+  systemProperty "test.ms_graph.client_secret", msGraphClientSecret
+  systemProperty "test.ms_graph.username", msGraphUsername
+  systemProperty "test.ms_graph.group_id", msGraphGroupId
+
   // disable tests in FIPS mode as we need to use a custom truststore containing the certs used in MicrosoftGraphHttpFixture
   buildParams.withFipsEnabledOnly(it)
+}
+
+tasks.register("msGraphThirdPartyTest") {
+  dependsOn "javaRestTest"
 }


### PR DESCRIPTION
Backports the following commits to 9.1:
 - add MS Graph third party tests to periodic tests job (#130380)