### PR TITLE
[9.1] Re-enable entitlements for various ingest tests (#130708)

### DIFF
--- a/modules/ingest-attachment/src/test/java/org/elasticsearch/ingest/attachment/AttachmentProcessorTests.java
+++ b/modules/ingest-attachment/src/test/java/org/elasticsearch/ingest/attachment/AttachmentProcessorTests.java
@@ -15,7 +15,6 @@ import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.Processor;
 import org.elasticsearch.ingest.RandomDocumentPicks;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.ESTestCase.WithoutEntitlements;
 import org.junit.Before;
 
 import java.io.InputStream;
@@ -39,7 +38,6 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
-@WithoutEntitlements // ES-12084
 public class AttachmentProcessorTests extends ESTestCase {
 
     private Processor processor;

--- a/modules/ingest-attachment/src/test/java/org/elasticsearch/ingest/attachment/TikaDocTests.java
+++ b/modules/ingest-attachment/src/test/java/org/elasticsearch/ingest/attachment/TikaDocTests.java
@@ -14,7 +14,6 @@ import org.apache.lucene.tests.util.TestUtil;
 import org.apache.tika.metadata.Metadata;
 import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.ESTestCase.WithoutEntitlements;
 
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
@@ -26,7 +25,6 @@ import java.nio.file.Path;
  * comes back and no exception.
  */
 @SuppressFileSystems("ExtrasFS") // don't try to parse extraN
-@WithoutEntitlements // ES-12084
 public class TikaDocTests extends ESTestCase {
 
     /** some test files from tika test suite, zipped up */

--- a/modules/ingest-attachment/src/test/java/org/elasticsearch/ingest/attachment/TikaImplTests.java
+++ b/modules/ingest-attachment/src/test/java/org/elasticsearch/ingest/attachment/TikaImplTests.java
@@ -9,9 +9,7 @@
 package org.elasticsearch.ingest.attachment;
 
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.ESTestCase.WithoutEntitlements;
 
-@WithoutEntitlements // ES-12084
 public class TikaImplTests extends ESTestCase {
 
     public void testTikaLoads() throws Exception {

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RegisteredDomainProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RegisteredDomainProcessorFactoryTests.java
@@ -11,7 +11,6 @@ package org.elasticsearch.ingest.common;
 
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.ESTestCase.WithoutEntitlements;
 import org.junit.Before;
 
 import java.util.HashMap;
@@ -19,7 +18,6 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
 
-@WithoutEntitlements // ES-12084
 public class RegisteredDomainProcessorFactoryTests extends ESTestCase {
 
     private RegisteredDomainProcessor.Factory factory;

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RegisteredDomainProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/RegisteredDomainProcessorTests.java
@@ -13,7 +13,6 @@ import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.TestIngestDocument;
 import org.elasticsearch.ingest.common.RegisteredDomainProcessor.DomainInfo;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.ESTestCase.WithoutEntitlements;
 
 import java.util.Collections;
 import java.util.Map;
@@ -31,7 +30,6 @@ import static org.hamcrest.Matchers.nullValue;
  * Effective TLDs (eTLDs) are not the same as DNS TLDs. Uses for eTLDs are listed here:
  *   https://publicsuffix.org/learn/
  */
-@WithoutEntitlements // ES-12084
 public class RegisteredDomainProcessorTests extends ESTestCase {
 
     public void testGetRegisteredDomain() {


### PR DESCRIPTION
Backports the following commits to 9.1:
 - Re-enable entitlements for various ingest tests (#130708)