### PR TITLE
Disable ILM history in MP test suite

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -518,12 +518,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.inference.bulk.BulkInferenceExecutorTests
   method: testSuccessfulExecution
   issue: https://github.com/elastic/elasticsearch/issues/130306
-- class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
-  method: test {yaml=cluster.stats/10_basic/Dense vector stats}
-  issue: https://github.com/elastic/elasticsearch/issues/130307
-- class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
-  method: test {yaml=nodes.stats/11_indices_metrics/Lucene segment level fields stats}
-  issue: https://github.com/elastic/elasticsearch/issues/130360
 - class: org.elasticsearch.ingest.PipelineFactoryTests
   method: testCreateUnsupportedFieldAccessPattern
   issue: https://github.com/elastic/elasticsearch/issues/130422
@@ -536,9 +530,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.action.EsqlActionBreakerIT
   method: testTopNPushedToLucene
   issue: https://github.com/elastic/elasticsearch/issues/130505
-- class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
-  method: test {yaml=indices.resolve_index/10_basic_resolve_index/Resolve index with hidden and closed indices}
-  issue: https://github.com/elastic/elasticsearch/issues/130568
 - class: org.elasticsearch.xpack.monitoring.exporter.http.HttpExporterTests
   method: testExporterWithHostOnly
   issue: https://github.com/elastic/elasticsearch/issues/130599
@@ -569,18 +560,12 @@ tests:
 - class: org.elasticsearch.test.rest.yaml.RcsCcsCommonYamlTestSuiteIT
   method: test {p0=search.vectors/41_knn_search_half_byte_quantized/Test create, merge, and search cosine}
   issue: https://github.com/elastic/elasticsearch/issues/130663
-- class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
-  method: test {yaml=search.vectors/70_dense_vector_telemetry/Field mapping stats}
-  issue: https://github.com/elastic/elasticsearch/issues/130672
 - class: org.elasticsearch.indices.stats.IndexStatsIT
   method: testFilterCacheStats
   issue: https://github.com/elastic/elasticsearch/issues/124447
 - class: org.elasticsearch.search.sort.FieldSortIT
   method: testSortMixedFieldTypes
   issue: https://github.com/elastic/elasticsearch/issues/129445
-- class: org.elasticsearch.multiproject.test.XpackWithMultipleProjectsClientYamlTestSuiteIT
-  method: test {yaml=dlm/10_usage/Test data stream lifecycle usage stats}
-  issue: https://github.com/elastic/elasticsearch/issues/130677
 - class: org.elasticsearch.xpack.esql.action.CrossClusterAsyncQueryStopIT
   method: testStopQueryLocal
   issue: https://github.com/elastic/elasticsearch/issues/121672

--- a/x-pack/qa/multi-project/xpack-rest-tests-with-multiple-projects/src/yamlRestTest/java/org/elasticsearch/multiproject/test/XpackWithMultipleProjectsClientYamlTestSuiteIT.java
+++ b/x-pack/qa/multi-project/xpack-rest-tests-with-multiple-projects/src/yamlRestTest/java/org/elasticsearch/multiproject/test/XpackWithMultipleProjectsClientYamlTestSuiteIT.java
@@ -20,6 +20,8 @@ import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
 import org.junit.ClassRule;
 
+import java.util.Objects;
+
 @TimeoutSuite(millis = 60 * TimeUnits.MINUTE)
 public class XpackWithMultipleProjectsClientYamlTestSuiteIT extends MultipleProjectsClientYamlSuiteTestCase {
     @ClassRule
@@ -30,7 +32,7 @@ public class XpackWithMultipleProjectsClientYamlTestSuiteIT extends MultipleProj
         .setting("xpack.ml.enabled", "true")
         .setting("xpack.security.enabled", "true")
         .setting("xpack.watcher.enabled", "false")
-        .setting("xpack.license.self_generated.type", "trial")
+        // Integration tests are supposed to enable/disable exporters before/after each test
         .setting("xpack.security.authc.token.enabled", "true")
         .setting("xpack.security.authc.api_key.enabled", "true")
         .setting("xpack.security.transport.ssl.enabled", "true")
@@ -38,12 +40,20 @@ public class XpackWithMultipleProjectsClientYamlTestSuiteIT extends MultipleProj
         .setting("xpack.security.transport.ssl.certificate", "testnode.crt")
         .setting("xpack.security.transport.ssl.verification_mode", "certificate")
         .setting("xpack.security.audit.enabled", "true")
+        .setting("xpack.license.self_generated.type", "trial")
+        // disable ILM history, since it disturbs tests using _all
+        .setting("indices.lifecycle.history_index_enabled", "false")
         .keystore("xpack.security.transport.ssl.secure_key_passphrase", "testnode")
         .configFile("testnode.pem", Resource.fromClasspath("/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.pem"))
         .configFile("testnode.crt", Resource.fromClasspath("/org/elasticsearch/xpack/security/transport/ssl/certs/simple/testnode.crt"))
         .configFile("service_tokens", Resource.fromClasspath("service_tokens"))
         .user(USER, PASS)
         .feature(FeatureFlag.TIME_SERIES_MODE)
+        .feature(FeatureFlag.SUB_OBJECTS_AUTO_ENABLED)
+        .systemProperty("es.queryable_built_in_roles_enabled", () -> {
+            final String enabled = System.getProperty("es.queryable_built_in_roles_enabled");
+            return Objects.requireNonNullElse(enabled, "");
+        })
         .build();
 
     public XpackWithMultipleProjectsClientYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {


### PR DESCRIPTION
The ILM history store disturbs tests and was already disabled in the original `XPackRestIT`. We sync the cluster configuration of the multi-project test suite with the original one.

Closes #130307
Closes #130360
Closes #130568
Closes #130672
Closes #130677