### PR TITLE
Specify master timeout when submitting alias tasks

### DIFF
--- a/docs/changelog/130733.yaml
+++ b/docs/changelog/130733.yaml
@@ -1,0 +1,6 @@
+pr: 130733
+summary: Specify master timeout when submitting alias tasks
+area: Indices APIs
+type: bug
+issues:
+ - 120389

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexAliasesService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexAliasesService.java
@@ -92,7 +92,7 @@ public class MetadataIndexAliasesService {
         final IndicesAliasesClusterStateUpdateRequest request,
         final ActionListener<IndicesAliasesResponse> listener
     ) {
-        taskQueue.submitTask("index-aliases", new ApplyAliasesTask(request, listener), null); // TODO use request.masterNodeTimeout() here?
+        taskQueue.submitTask("index-aliases", new ApplyAliasesTask(request, listener), request.masterNodeTimeout());
     }
 
     /**


### PR DESCRIPTION
We specify the master node timeout from the REST request to avoid waiting for the task indefinitely.

Resolves #120389