### PR TITLE
Fix bad merge done in commit 315aba6

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -492,11 +492,6 @@ tests:
   method: "builds distribution from branches via archives extractedAssemble [bwcDistVersion: 8.2.1, bwcProject: bugfix, expectedAssembleTaskName:
     extractedAssemble, #2]"
   issue: https://github.com/elastic/elasticsearch/issues/119871
-- class: geoip.GeoIpMultiProjectIT
-  issue: https://github.com/elastic/elasticsearch/issues/130073
-- class: org.elasticsearch.xpack.esql.action.EnrichIT
-  method: testTopN
-  issue: https://github.com/elastic/elasticsearch/issues/130122
 - class: org.elasticsearch.action.support.ThreadedActionListenerTests
   method: testRejectionHandling
   issue: https://github.com/elastic/elasticsearch/issues/130129


### PR DESCRIPTION
Follow up to #130523 and #129763

Fix bad merge in #129763 - there were two tests that should have been removed as well. Again, sorry for the trouble.