### PR TITLE
Transport action changes for streams write restrictions

### DIFF
--- a/modules/streams/build.gradle
+++ b/modules/streams/build.gradle
@@ -20,7 +20,7 @@ esplugin {
 
 restResources {
   restApi {
-    include '_common', 'streams'
+    include '_common', 'streams', "bulk", "index", "ingest", "indices"
   }
 }
 
@@ -38,4 +38,5 @@ artifacts {
 
 dependencies {
   testImplementation project(path: ':test:test-clusters')
+  clusterModules project(':modules:ingest-common')
 }

--- a/modules/streams/build.gradle
+++ b/modules/streams/build.gradle
@@ -20,7 +20,7 @@ esplugin {
 
 restResources {
   restApi {
-    include '_common', 'streams', "bulk", "index", "ingest", "indices"
+    include '_common', 'streams', "bulk", "index", "ingest", "indices", "delete_by_query", "search"
   }
 }
 
@@ -39,4 +39,5 @@ artifacts {
 dependencies {
   testImplementation project(path: ':test:test-clusters')
   clusterModules project(':modules:ingest-common')
+  clusterModules project(':modules:reindex')
 }

--- a/modules/streams/src/yamlRestTest/java/org/elasticsearch/streams/StreamsYamlTestSuiteIT.java
+++ b/modules/streams/src/yamlRestTest/java/org/elasticsearch/streams/StreamsYamlTestSuiteIT.java
@@ -29,7 +29,11 @@ public class StreamsYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
     }
 
     @ClassRule
-    public static ElasticsearchCluster cluster = ElasticsearchCluster.local().module("streams").feature(FeatureFlag.LOGS_STREAM).build();
+    public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .module("streams")
+        .module("ingest-common")
+        .feature(FeatureFlag.LOGS_STREAM)
+        .build();
 
     @Override
     protected String getTestRestCluster() {

--- a/modules/streams/src/yamlRestTest/java/org/elasticsearch/streams/StreamsYamlTestSuiteIT.java
+++ b/modules/streams/src/yamlRestTest/java/org/elasticsearch/streams/StreamsYamlTestSuiteIT.java
@@ -32,6 +32,7 @@ public class StreamsYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
         .module("streams")
         .module("ingest-common")
+        .module("reindex")
         .feature(FeatureFlag.LOGS_STREAM)
         .build();
 

--- a/modules/streams/src/yamlRestTest/resources/rest-api-spec/test/streams/logs/20_substream_restrictions.yml
+++ b/modules/streams/src/yamlRestTest/resources/rest-api-spec/test/streams/logs/20_substream_restrictions.yml
@@ -1,0 +1,72 @@
+---
+"Check User Can't Write To Substream Directly":
+  - do:
+      streams.logs_enable: { }
+  - is_true: acknowledged
+
+  - do:
+      streams.status: { }
+  - is_true: logs.enabled
+
+  - do:
+      bulk:
+        body: |
+          { "index": { "_index": "logs.foo" } }
+          { "foo": "bar" }
+  - match: { errors: true }
+  - match: { items.0.index.status: 400 }
+  - match: { items.0.index.error.type: "illegal_argument_exception" }
+  - match: { items.0.index.error.reason: "Writes to child stream [logs.foo] are not allowed, use the parent stream instead: [logs]" }
+
+---
+"Check User Can't Write To Substream Directly With Single Doc":
+  - do:
+      streams.logs_enable: { }
+  - is_true: acknowledged
+
+  - do:
+      streams.status: { }
+  - is_true: logs.enabled
+
+  - do:
+      catch: bad_request
+      index:
+        index: logs.foo
+        id: "1"
+        body:
+          foo: bar
+  - match: { error.type: "illegal_argument_exception" }
+  - match: { error.reason: "Writes to child stream [logs.foo] are not allowed, use the parent stream instead: [logs]" }
+
+---
+"Check Bulk Index With Reroute Processor To Substream Is Rejected":
+  - do:
+      streams.logs_enable: { }
+  - is_true: acknowledged
+
+  - do:
+      streams.status: { }
+  - is_true: logs.enabled
+
+  - do:
+      ingest.put_pipeline:
+        id: "reroute-to-logs-foo"
+        body:
+          processors:
+            - reroute:
+                destination: "logs.foo"
+  - do:
+      indices.create:
+        index: "bad-index"
+        body:
+          settings:
+            index.default_pipeline: "reroute-to-logs-foo"
+  - do:
+      bulk:
+        body: |
+          { "index": { "_index": "bad-index" } }
+          { "foo": "bar" }
+  - match: { errors: true }
+  - match: { items.0.index.status: 400 }
+  - match: { items.0.index.error.type: "illegal_argument_exception" }
+  - match: { items.0.index.error.reason: "Cannot reroute to substream [logs.foo] as only the stream itself can reroute to substreams. Please reroute to the stream [logs] instead." }

--- a/modules/streams/src/yamlRestTest/resources/rest-api-spec/test/streams/logs/20_substream_restrictions.yml
+++ b/modules/streams/src/yamlRestTest/resources/rest-api-spec/test/streams/logs/20_substream_restrictions.yml
@@ -16,7 +16,7 @@
   - match: { errors: true }
   - match: { items.0.index.status: 400 }
   - match: { items.0.index.error.type: "illegal_argument_exception" }
-  - match: { items.0.index.error.reason: "Writes to child stream [logs.foo] are not allowed, use the parent stream instead: [logs]" }
+  - match: { items.0.index.error.reason: "Direct writes to child streams are prohibited. Index directly into the [logs] stream instead" }
 
 ---
 "Check User Can't Write To Substream Directly With Single Doc":
@@ -36,7 +36,7 @@
         body:
           foo: bar
   - match: { error.type: "illegal_argument_exception" }
-  - match: { error.reason: "Writes to child stream [logs.foo] are not allowed, use the parent stream instead: [logs]" }
+  - match: { error.reason: "Direct writes to child streams are prohibited. Index directly into the [logs] stream instead" }
 
 ---
 "Check Bulk Index With Reroute Processor To Substream Is Rejected":
@@ -69,4 +69,4 @@
   - match: { errors: true }
   - match: { items.0.index.status: 400 }
   - match: { items.0.index.error.type: "illegal_argument_exception" }
-  - match: { items.0.index.error.reason: "Cannot reroute to substream [logs.foo] as only the stream itself can reroute to substreams. Please reroute to the stream [logs] instead." }
+  - match: { items.0.index.error.reason: "Pipelines can't re-route documents to child streams, but pipeline [reroute-to-logs-foo] tried to reroute this document from index [bad-index] to index [logs.foo]. Reroute history: bad-index" }

--- a/modules/streams/src/yamlRestTest/resources/rest-api-spec/test/streams/logs/20_substream_restrictions.yml
+++ b/modules/streams/src/yamlRestTest/resources/rest-api-spec/test/streams/logs/20_substream_restrictions.yml
@@ -70,3 +70,87 @@
   - match: { items.0.index.status: 400 }
   - match: { items.0.index.error.type: "illegal_argument_exception" }
   - match: { items.0.index.error.reason: "Pipelines can't re-route documents to child streams, but pipeline [reroute-to-logs-foo] tried to reroute this document from index [bad-index] to index [logs.foo]. Reroute history: bad-index" }
+
+---
+"Check Bulk Index With Script Processor To Substream Is Rejected":
+  - do:
+      streams.logs_enable: { }
+  - is_true: acknowledged
+
+  - do:
+      streams.status: { }
+  - is_true: logs.enabled
+
+  - do:
+      ingest.put_pipeline:
+        id: "script-to-logs-foo"
+        body:
+          processors:
+            - script:
+                source: "ctx._index = 'logs.foo'"
+  - do:
+      indices.create:
+        index: "bad-index-script"
+        body:
+          settings:
+            index.default_pipeline: "script-to-logs-foo"
+  - do:
+      bulk:
+        body: |
+          { "index": { "_index": "bad-index-script" } }
+          { "foo": "bar" }
+  - match: { errors: true }
+  - match: { items.0.index.status: 400 }
+  - match: { items.0.index.error.type: "illegal_argument_exception" }
+  - match: { items.0.index.error.reason: "Pipelines can't re-route documents to child streams, but pipeline [script-to-logs-foo] tried to reroute this document from index [bad-index-script] to index [logs.foo]. Reroute history: bad-index-script" }
+
+---
+"Check Delete By Query Directly On Substream After Reroute Succeeds":
+  - do:
+      streams.logs_enable: { }
+  - is_true: acknowledged
+
+  - do:
+      streams.status: { }
+  - is_true: logs.enabled
+
+  - do:
+      ingest.put_pipeline:
+        id: "reroute-to-logs-foo-success"
+        body:
+          processors:
+            - reroute:
+                destination: "logs.foo"
+  - do:
+      indices.create:
+        index: "logs"
+        body:
+          settings:
+            index.default_pipeline: "reroute-to-logs-foo-success"
+  - do:
+      bulk:
+        refresh: true
+        body: |
+          { "index": { "_index": "logs" } }
+          { "foo": "bar", "baz": "qux" }
+  - match: { errors: false }
+  - match: { items.0.index.status: 201 }
+
+  - do:
+      delete_by_query:
+        index: logs.foo
+        refresh: true
+        body:
+          query:
+            match:
+              foo: "bar"
+  - match: { deleted: 1 }
+  - match: { total: 1 }
+
+  - do:
+      search:
+        index: logs.foo
+        body:
+          query:
+            match_all: {}
+  - match: { hits.total.value: 0 }

--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -213,6 +213,7 @@ module org.elasticsearch.server {
     exports org.elasticsearch.common.regex;
     exports org.elasticsearch.common.scheduler;
     exports org.elasticsearch.common.settings;
+    exports org.elasticsearch.common.streams;
     exports org.elasticsearch.common.text;
     exports org.elasticsearch.common.time;
     exports org.elasticsearch.common.transport;

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkRequestModifier.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkRequestModifier.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicIntegerArray;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -101,22 +102,33 @@ final class BulkRequestModifier implements Iterator<DocWriteRequest<?>> {
         }
     }
 
+    ActionListener<BulkResponse> wrapActionListenerIfNeeded(ActionListener<BulkResponse> actionListener) {
+        return doWrapActionListenerIfNeeded(BulkResponse::getIngestTookInMillis, actionListener);
+    }
+
+    ActionListener<BulkResponse> wrapActionListenerIfNeeded(long ingestTookInMillis, ActionListener<BulkResponse> actionListener) {
+        return doWrapActionListenerIfNeeded(ignoredResponse -> ingestTookInMillis, actionListener);
+    }
+
     /**
      * If documents were dropped or failed in ingest, this method wraps the action listener that will be notified when the
      * updated bulk operation is completed. The wrapped listener combines the dropped and failed document results from the ingest
      * service with the results returned from running the remaining write operations.
      *
-     * @param ingestTookInMillis Time elapsed for ingestion to be passed to final result.
+     * @param ingestTimeProviderFunction A function to provide the ingest time taken for this response
      * @param actionListener The action listener that expects the final bulk response.
      * @return An action listener that combines ingest failure results with the results from writing the remaining documents.
      */
-    ActionListener<BulkResponse> wrapActionListenerIfNeeded(long ingestTookInMillis, ActionListener<BulkResponse> actionListener) {
+    private ActionListener<BulkResponse> doWrapActionListenerIfNeeded(
+        Function<BulkResponse, Long> ingestTimeProviderFunction,
+        ActionListener<BulkResponse> actionListener
+    ) {
         if (itemResponses.isEmpty()) {
             return actionListener.map(
                 response -> new BulkResponse(
                     response.getItems(),
                     response.getTook().getMillis(),
-                    ingestTookInMillis,
+                    ingestTimeProviderFunction.apply(response),
                     response.getIncrementalState()
                 )
             );
@@ -142,6 +154,8 @@ final class BulkRequestModifier implements Iterator<DocWriteRequest<?>> {
                 if (Assertions.ENABLED) {
                     assertResponsesAreCorrect(bulkResponses, allResponses);
                 }
+
+                var ingestTookInMillis = ingestTimeProviderFunction.apply(response);
 
                 return new BulkResponse(allResponses, response.getTook().getMillis(), ingestTookInMillis, response.getIncrementalState());
             });

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkRequestModifier.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkRequestModifier.java
@@ -127,7 +127,7 @@ final class BulkRequestModifier implements Iterator<DocWriteRequest<?>> {
             return actionListener.map(
                 response -> new BulkResponse(
                     response.getItems(),
-                    response.getTook().getMillis(),
+                    response.getTookInMillis(),
                     ingestTimeProviderFunction.apply(response),
                     response.getIncrementalState()
                 )

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkResponse.java
@@ -19,7 +19,9 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xcontent.ToXContent;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Iterator;
+import java.util.Objects;
 
 /**
  * A response of a bulk execution. Holding a response for each item responding (in order) of the
@@ -165,5 +167,22 @@ public class BulkResponse extends ActionResponse implements Iterable<BulkItemRes
             }
             return builder.startArray(ITEMS);
         }), Iterators.forArray(responses), Iterators.<ToXContent>single((builder, p) -> builder.endArray().endObject()));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof BulkResponse that) {
+            return tookInMillis == that.tookInMillis
+                && ingestTookInMillis == that.ingestTookInMillis
+                && Objects.deepEquals(responses, that.responses)
+                && Objects.equals(incrementalState, that.incrementalState);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(Arrays.hashCode(responses), tookInMillis, ingestTookInMillis, incrementalState);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportAbstractBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportAbstractBulkAction.java
@@ -415,12 +415,7 @@ public abstract class TransportAbstractBulkAction extends HandledTransportAction
                 DocWriteRequest<?> req = bulkRequestModifier.bulkRequest.requests.get(i);
                 String prefix = streamType.getStreamName() + ".";
 
-                boolean prePipeline = true;
-                if (req instanceof IndexRequest ir) {
-                    prePipeline = ir.isPipelineResolved() == false;
-                }
-
-                if (req != null && req.index() != null && req.index().startsWith(prefix) && prePipeline) {
+                if (req instanceof IndexRequest ir && ir.index().startsWith(prefix) && ir.isPipelineResolved() == false) {
                     IllegalArgumentException e = new IllegalArgumentException(
                         "Direct writes to child streams are prohibited. Index directly into the ["
                             + streamType.getStreamName()

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportAbstractBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportAbstractBulkAction.java
@@ -405,7 +405,7 @@ public abstract class TransportAbstractBulkAction extends HandledTransportAction
         // Validate child stream writes before processing pipelines
         ProjectMetadata projectMetadata = projectResolver.getProjectMetadata(clusterService.state());
         Set<StreamType> enabledStreamTypes = Arrays.stream(StreamType.values())
-            .filter(t -> StreamType.streamTypeIsEnabled(t, projectMetadata))
+            .filter(t -> t.streamTypeIsEnabled(projectMetadata))
             .collect(Collectors.toCollection(() -> EnumSet.noneOf(StreamType.class)));
 
         BulkRequestModifier bulkRequestModifier = new BulkRequestModifier(bulkRequest);

--- a/server/src/main/java/org/elasticsearch/common/streams/StreamType.java
+++ b/server/src/main/java/org/elasticsearch/common/streams/StreamType.java
@@ -26,9 +26,9 @@ public enum StreamType {
         return streamName;
     }
 
-    public static boolean streamTypeIsEnabled(StreamType streamType, ProjectMetadata projectMetadata) {
+    public boolean streamTypeIsEnabled(ProjectMetadata projectMetadata) {
         StreamsMetadata metadata = projectMetadata.custom(StreamsMetadata.TYPE, StreamsMetadata.EMPTY);
-        return switch (streamType) {
+        return switch (this) {
             case LOGS -> metadata.isLogsEnabled();
         };
     }

--- a/server/src/main/java/org/elasticsearch/common/streams/StreamType.java
+++ b/server/src/main/java/org/elasticsearch/common/streams/StreamType.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.common.streams;
+
+import org.elasticsearch.cluster.metadata.ProjectMetadata;
+import org.elasticsearch.cluster.metadata.StreamsMetadata;
+
+public enum StreamType {
+
+    LOGS("logs");
+
+    private final String streamName;
+
+    StreamType(String streamName) {
+        this.streamName = streamName;
+    }
+
+    public String getStreamName() {
+        return streamName;
+    }
+
+    public static boolean streamTypeIsEnabled(StreamType streamType, ProjectMetadata projectMetadata) {
+        StreamsMetadata metadata = projectMetadata.custom(StreamsMetadata.TYPE, StreamsMetadata.EMPTY);
+        return switch (streamType) {
+            case LOGS -> metadata.isLogsEnabled();
+        };
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -1200,7 +1200,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
                     }
 
                     for (StreamType streamType : StreamType.values()) {
-                        if (StreamType.streamTypeIsEnabled(streamType, project)) {
+                        if (streamType.streamTypeIsEnabled(project)) {
                             if (newIndex.startsWith(streamType.getStreamName() + ".")
                                 && ingestDocument.getIndexHistory().stream().noneMatch(s -> s.equals(streamType.getStreamName()))) {
                                 exceptionHandler.accept(

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionIngestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionIngestTests.java
@@ -80,6 +80,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -544,11 +545,11 @@ public class TransportBulkActionIngestTests extends ESTestCase {
         indexRequest.source(Collections.emptyMap());
         indexRequest.setPipeline("testpipeline");
         bulkRequest.add(indexRequest);
-        BulkResponse bulkResponse = mock(BulkResponse.class);
+        BulkResponse bulkResponse = new BulkResponse(new BulkItemResponse[0], 1234);
         AtomicBoolean responseCalled = new AtomicBoolean(false);
         ActionListener<BulkResponse> listener = ActionTestUtils.assertNoFailureListener(response -> {
             responseCalled.set(true);
-            assertSame(bulkResponse, response);
+            assertThat(bulkResponse, equalTo(bulkResponse));
         });
         ActionTestUtils.execute(action, null, bulkRequest, listener);
 


### PR DESCRIPTION
Very early PR for restricting writes to substreams (`<streamName>.*`) via the single document, bulk document and reroute pipeline processors.

Discussion to be had with product on if additional restrictions (Such as changing routing in painless scripts) also needs to be restricted and the additional cost of that.

Fixes ES-11941