### PR TITLE
Unmute FieldSortIT testSortMixedFieldTypes

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -558,9 +558,6 @@ tests:
 - class: org.elasticsearch.indices.stats.IndexStatsIT
   method: testFilterCacheStats
   issue: https://github.com/elastic/elasticsearch/issues/124447
-- class: org.elasticsearch.search.sort.FieldSortIT
-  method: testSortMixedFieldTypes
-  issue: https://github.com/elastic/elasticsearch/issues/129445
 - class: org.elasticsearch.xpack.esql.action.CrossClusterAsyncQueryStopIT
   method: testStopQueryLocal
   issue: https://github.com/elastic/elasticsearch/issues/121672


### PR DESCRIPTION
I would like to unmute this test again since it fails [rarely enough](https://es-delivery-stats.elastic.dev/app/r/s/ZipTG) and we would
still like to collect more information on its variants and different scenarios in which
it happens for better reproduction.