### PR TITLE
Add a simple query rewriter to support rewriting known match queries to semantic queries

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexModule.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexModule.java
@@ -63,6 +63,7 @@ import org.elasticsearch.indices.fielddata.cache.IndicesFieldDataCache;
 import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.plugins.IndexStorePlugin;
 import org.elasticsearch.plugins.internal.rewriter.QueryRewriteInterceptor;
+import org.elasticsearch.plugins.internal.rewriter.SimpleQueryRewriter;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -496,7 +497,8 @@ public final class IndexModule {
         ValuesSourceRegistry valuesSourceRegistry,
         IndexStorePlugin.IndexFoldersDeletionListener indexFoldersDeletionListener,
         Map<String, IndexStorePlugin.SnapshotCommitSupplier> snapshotCommitSuppliers,
-        QueryRewriteInterceptor queryRewriteInterceptor
+        QueryRewriteInterceptor queryRewriteInterceptor,
+        SimpleQueryRewriter simpleQueryRewriter
     ) throws IOException {
         final IndexEventListener eventListener = freeze();
         Function<IndexService, CheckedFunction<DirectoryReader, DirectoryReader, IOException>> readerWrapperFactory = indexReaderWrapper
@@ -561,6 +563,7 @@ public final class IndexModule {
                 indexCommitListener.get(),
                 mapperMetrics,
                 queryRewriteInterceptor,
+                simpleQueryRewriter,
                 indexingStatsSettings,
                 searchStatsSettings,
                 mergeMetrics

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -91,6 +91,7 @@ import org.elasticsearch.indices.fielddata.cache.IndicesFieldDataCache;
 import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.plugins.IndexStorePlugin;
 import org.elasticsearch.plugins.internal.rewriter.QueryRewriteInterceptor;
+import org.elasticsearch.plugins.internal.rewriter.SimpleQueryRewriter;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -171,6 +172,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
     private final ValuesSourceRegistry valuesSourceRegistry;
     private final MapperMetrics mapperMetrics;
     private final QueryRewriteInterceptor queryRewriteInterceptor;
+    private final SimpleQueryRewriter simpleQueryRewriter;
     private final IndexingStatsSettings indexingStatsSettings;
     private final SearchStatsSettings searchStatsSettings;
     private final MergeMetrics mergeMetrics;
@@ -211,6 +213,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         Engine.IndexCommitListener indexCommitListener,
         MapperMetrics mapperMetrics,
         QueryRewriteInterceptor queryRewriteInterceptor,
+        SimpleQueryRewriter simpleQueryRewriter,
         IndexingStatsSettings indexingStatsSettings,
         SearchStatsSettings searchStatsSettings,
         MergeMetrics mergeMetrics
@@ -291,6 +294,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         this.indexCommitListener = indexCommitListener;
         this.mapperMetrics = mapperMetrics;
         this.queryRewriteInterceptor = queryRewriteInterceptor;
+        this.simpleQueryRewriter = simpleQueryRewriter;
         try (var ignored = threadPool.getThreadContext().clearTraceContext()) {
             // kick off async ops for the first shard in this index
             this.refreshTask = new AsyncRefreshTask(this);

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -146,6 +146,7 @@ import org.elasticsearch.plugins.FieldPredicate;
 import org.elasticsearch.plugins.IndexStorePlugin;
 import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.plugins.internal.rewriter.QueryRewriteInterceptor;
+import org.elasticsearch.plugins.internal.rewriter.SimpleQueryRewriter;
 import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
@@ -281,7 +282,8 @@ public class IndicesService extends AbstractLifecycleComponent
     private final PostRecoveryMerger postRecoveryMerger;
     private final List<SearchOperationListener> searchOperationListeners;
     private final QueryRewriteInterceptor queryRewriteInterceptor;
-    final SlowLogFieldProvider slowLogFieldProvider; // pkg-private for testingå
+    private final SimpleQueryRewriter simpleQueryRewriter;
+    final SlowLogFieldProvider slowLogFieldProvider; // pkg-private for testing
     private final IndexingStatsSettings indexStatsSettings;
     private final SearchStatsSettings searchStatsSettings;
     private final MergeMetrics mergeMetrics;
@@ -359,6 +361,7 @@ public class IndicesService extends AbstractLifecycleComponent
         this.snapshotCommitSuppliers = builder.snapshotCommitSuppliers;
         this.requestCacheKeyDifferentiator = builder.requestCacheKeyDifferentiator;
         this.queryRewriteInterceptor = builder.queryRewriteInterceptor;
+        this.simpleQueryRewriter = builder.simpleQueryRewriter;
         this.mapperMetrics = builder.mapperMetrics;
         this.mergeMetrics = builder.mergeMetrics;
         // doClose() is called when shutting down a node, yet there might still be ongoing requests
@@ -834,7 +837,8 @@ public class IndicesService extends AbstractLifecycleComponent
             valuesSourceRegistry,
             indexFoldersDeletionListeners,
             snapshotCommitSuppliers,
-            queryRewriteInterceptor
+            queryRewriteInterceptor,
+            simpleQueryRewriter
         );
     }
 
@@ -1863,6 +1867,10 @@ public class IndicesService extends AbstractLifecycleComponent
             () -> clusterService.state().projectState(projectId),
             this::getTimestampFieldTypeInfo
         );
+    }
+
+    public SimpleQueryRewriter getSimpleQueryRewriter() {
+        return simpleQueryRewriter;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/plugins/internal/InternalSearchPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/internal/InternalSearchPlugin.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.plugins.internal;
 
 import org.elasticsearch.plugins.internal.rewriter.QueryRewriteInterceptor;
+import org.elasticsearch.plugins.internal.rewriter.SimpleQueryRewriter;
 
 import java.util.List;
 
@@ -22,6 +23,10 @@ public interface InternalSearchPlugin {
      * Note: This is internal to Elasticsearch's API and not extensible by external plugins.
      */
     default List<QueryRewriteInterceptor> getQueryRewriteInterceptors() {
+        return emptyList();
+    }
+
+    default List<SimpleQueryRewriter> getSimpleQueryRewriters() {
         return emptyList();
     }
 }

--- a/server/src/main/java/org/elasticsearch/plugins/internal/rewriter/SimpleQueryRewriter.java
+++ b/server/src/main/java/org/elasticsearch/plugins/internal/rewriter/SimpleQueryRewriter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.plugins.internal.rewriter;
+
+import org.elasticsearch.index.query.QueryBuilder;
+
+import java.util.Map;
+
+public interface SimpleQueryRewriter {
+
+    String getName();
+
+    QueryBuilder rewrite(QueryBuilder queryBuilder);
+
+    static SimpleQueryRewriter multi(Map<String, SimpleQueryRewriter> rewriters) {
+        return rewriters.isEmpty() ? new NoOpSimpleQueryRewriter() : new CompositeSimpleQueryRewriter(rewriters);
+    }
+
+    class CompositeSimpleQueryRewriter implements SimpleQueryRewriter {
+        final String NAME = "composite";
+        private final Map<String, SimpleQueryRewriter> simpleQueryRewriters;
+
+        private CompositeSimpleQueryRewriter(Map<String, SimpleQueryRewriter> simpleQueryRewriters) {
+            this.simpleQueryRewriters = simpleQueryRewriters;
+        }
+
+        @Override
+        public String getName() {
+            return NAME;
+        }
+
+        @Override
+        public QueryBuilder rewrite(QueryBuilder queryBuilder) {
+            SimpleQueryRewriter rewriter = simpleQueryRewriters.get(queryBuilder.getName());
+            if (rewriter != null) {
+                return rewriter.rewrite(queryBuilder);
+            }
+            return queryBuilder;
+        }
+    }
+
+    class NoOpSimpleQueryRewriter implements SimpleQueryRewriter {
+        @Override
+        public QueryBuilder rewrite(QueryBuilder queryBuilder) {
+            return queryBuilder;
+        }
+
+        @Override
+        public String getName() {
+            return null;
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
@@ -51,6 +51,7 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.search.NestedHelper;
 import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.plugins.internal.rewriter.SimpleQueryRewriter;
 import org.elasticsearch.search.aggregations.SearchContextAggregations;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -161,6 +162,7 @@ final class DefaultSearchContext extends SearchContext {
     private final Map<String, SearchExtBuilder> searchExtBuilders = new HashMap<>();
     private final SearchExecutionContext searchExecutionContext;
     private final FetchPhase fetchPhase;
+    private final SimpleQueryRewriter simpleQueryRewriter;
 
     DefaultSearchContext(
         ReaderContext readerContext,
@@ -174,7 +176,8 @@ final class DefaultSearchContext extends SearchContext {
         SearchService.ResultsType resultsType,
         boolean enableQueryPhaseParallelCollection,
         int minimumDocsPerSlice,
-        long memoryAccountingBufferSize
+        long memoryAccountingBufferSize,
+        SimpleQueryRewriter simpleQueryRewriter
     ) throws IOException {
         this.readerContext = readerContext;
         this.request = request;
@@ -186,6 +189,7 @@ final class DefaultSearchContext extends SearchContext {
             this.indexService = readerContext.indexService();
             this.indexShard = readerContext.indexShard();
             this.memoryAccountingBufferSize = memoryAccountingBufferSize;
+            this.simpleQueryRewriter = simpleQueryRewriter;
 
             Engine.Searcher engineSearcher = readerContext.acquireSearcher("search");
             int maximumNumberOfSlices = determineMaximumNumberOfSlices(
@@ -975,5 +979,10 @@ final class DefaultSearchContext extends SearchContext {
         } else {
             return IdLoader.fromLeafStoredFieldLoader();
         }
+    }
+
+    @Override
+    public SimpleQueryRewriter simpleQueryRewriter() {
+        return simpleQueryRewriter;
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -1402,7 +1402,8 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                 resultsType,
                 enableQueryPhaseParallelCollection,
                 minimumDocsPerSlice,
-                memoryAccountingBufferSize
+                memoryAccountingBufferSize,
+                indicesService.getSimpleQueryRewriter()
             );
             // we clone the query shard context here just for rewriting otherwise we
             // might end up with incorrect state since we are using now() or script services

--- a/server/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -26,6 +26,7 @@ import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.plugins.internal.rewriter.SimpleQueryRewriter;
 import org.elasticsearch.search.RescoreDocIds;
 import org.elasticsearch.search.SearchExtBuilder;
 import org.elasticsearch.search.SearchShardTarget;
@@ -449,4 +450,6 @@ public abstract class SearchContext implements Releasable {
     public abstract SourceLoader newSourceLoader(@Nullable SourceFilter sourceFilter);
 
     public abstract IdLoader newIdLoader();
+
+    public abstract SimpleQueryRewriter simpleQueryRewriter();
 }

--- a/server/src/main/java/org/elasticsearch/search/internal/SubSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/SubSearchContext.java
@@ -11,6 +11,7 @@ package org.elasticsearch.search.internal;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.index.query.ParsedQuery;
+import org.elasticsearch.plugins.internal.rewriter.SimpleQueryRewriter;
 import org.elasticsearch.search.aggregations.SearchContextAggregations;
 import org.elasticsearch.search.collapse.CollapseContext;
 import org.elasticsearch.search.fetch.FetchSearchResult;
@@ -304,5 +305,10 @@ public class SubSearchContext extends FilteredSearchContext {
     @Override
     public float getMaxScore() {
         return querySearchResult.getMaxScore();
+    }
+
+    @Override
+    public SimpleQueryRewriter simpleQueryRewriter() {
+        throw new UnsupportedOperationException("Not supported");
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/rank/RankSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/rank/RankSearchContext.java
@@ -22,6 +22,7 @@ import org.elasticsearch.index.mapper.SourceLoader;
 import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.plugins.internal.rewriter.SimpleQueryRewriter;
 import org.elasticsearch.search.SearchExtBuilder;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.aggregations.SearchContextAggregations;
@@ -545,5 +546,10 @@ public class RankSearchContext extends SearchContext {
     @Override
     public IdLoader newIdLoader() {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SimpleQueryRewriter simpleQueryRewriter() {
+        return parent.simpleQueryRewriter();
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
@@ -239,7 +239,8 @@ public class IndexModuleTests extends ESTestCase {
             null,
             indexDeletionListener,
             emptyMap(),
-            new MockQueryRewriteInterceptor()
+            new MockQueryRewriteInterceptor(),
+            null
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/search/DefaultSearchContextTests.java
+++ b/server/src/test/java/org/elasticsearch/search/DefaultSearchContextTests.java
@@ -190,7 +190,8 @@ public class DefaultSearchContextTests extends MapperServiceTestCase {
                 randomFrom(SearchService.ResultsType.values()),
                 randomBoolean(),
                 randomInt(),
-                MEMORY_ACCOUNTING_BUFFER_SIZE
+                MEMORY_ACCOUNTING_BUFFER_SIZE,
+                null
             );
             contextWithoutScroll.from(300);
             contextWithoutScroll.close();
@@ -233,7 +234,8 @@ public class DefaultSearchContextTests extends MapperServiceTestCase {
                     randomFrom(SearchService.ResultsType.values()),
                     randomBoolean(),
                     randomInt(),
-                    MEMORY_ACCOUNTING_BUFFER_SIZE
+                    MEMORY_ACCOUNTING_BUFFER_SIZE,
+                    null
 
                 )
             ) {
@@ -317,7 +319,8 @@ public class DefaultSearchContextTests extends MapperServiceTestCase {
                     randomFrom(SearchService.ResultsType.values()),
                     randomBoolean(),
                     randomInt(),
-                    MEMORY_ACCOUNTING_BUFFER_SIZE
+                    MEMORY_ACCOUNTING_BUFFER_SIZE,
+                    null
                 )
             ) {
 
@@ -360,7 +363,8 @@ public class DefaultSearchContextTests extends MapperServiceTestCase {
                     randomFrom(SearchService.ResultsType.values()),
                     randomBoolean(),
                     randomInt(),
-                    MEMORY_ACCOUNTING_BUFFER_SIZE
+                    MEMORY_ACCOUNTING_BUFFER_SIZE,
+                    null
                 )
             ) {
                 context3.sliceBuilder(null).parsedQuery(parsedQuery).preProcess();
@@ -392,7 +396,8 @@ public class DefaultSearchContextTests extends MapperServiceTestCase {
                     randomFrom(SearchService.ResultsType.values()),
                     randomBoolean(),
                     randomInt(),
-                    MEMORY_ACCOUNTING_BUFFER_SIZE
+                    MEMORY_ACCOUNTING_BUFFER_SIZE,
+                    null
                 )
             ) {
                 context4.sliceBuilder(new SliceBuilder(1, 2)).parsedQuery(parsedQuery).preProcess();
@@ -464,7 +469,8 @@ public class DefaultSearchContextTests extends MapperServiceTestCase {
                 randomFrom(SearchService.ResultsType.values()),
                 randomBoolean(),
                 randomInt(),
-                MEMORY_ACCOUNTING_BUFFER_SIZE
+                MEMORY_ACCOUNTING_BUFFER_SIZE,
+                null
             );
 
             assertThat(context.searcher().hasCancellations(), is(false));
@@ -1084,7 +1090,8 @@ public class DefaultSearchContextTests extends MapperServiceTestCase {
                 randomFrom(SearchService.ResultsType.values()),
                 randomBoolean(),
                 randomInt(),
-                MEMORY_ACCOUNTING_BUFFER_SIZE
+                MEMORY_ACCOUNTING_BUFFER_SIZE,
+                null
             );
         }
     }

--- a/server/src/test/java/org/elasticsearch/search/rescore/RescorePhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/rescore/RescorePhaseTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.action.search.SearchShardTask;
 import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.IndexShardTestCase;
+import org.elasticsearch.plugins.internal.rewriter.SimpleQueryRewriter;
 import org.elasticsearch.search.fetch.subphase.FetchDocValuesContext;
 import org.elasticsearch.search.fetch.subphase.FetchFieldsContext;
 import org.elasticsearch.search.internal.ContextIndexSearcher;
@@ -76,6 +77,11 @@ public class RescorePhaseTests extends IndexShardTestCase {
                         @Override
                         public boolean lowLevelCancellation() {
                             return true;
+                        }
+
+                        @Override
+                        public SimpleQueryRewriter simpleQueryRewriter() {
+                            return null;
                         }
 
                         @Override

--- a/test/framework/src/main/java/org/elasticsearch/test/TestSearchContext.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TestSearchContext.java
@@ -23,6 +23,7 @@ import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.plugins.internal.rewriter.SimpleQueryRewriter;
 import org.elasticsearch.search.SearchExtBuilder;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.aggregations.SearchContextAggregations;
@@ -561,5 +562,10 @@ public class TestSearchContext extends SearchContext {
     @Override
     public IdLoader newIdLoader() {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SimpleQueryRewriter simpleQueryRewriter() {
+        return new SimpleQueryRewriter.NoOpSimpleQueryRewriter();
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
@@ -43,6 +43,7 @@ import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.plugins.SystemIndexPlugin;
 import org.elasticsearch.plugins.internal.InternalSearchPlugin;
 import org.elasticsearch.plugins.internal.rewriter.QueryRewriteInterceptor;
+import org.elasticsearch.plugins.internal.rewriter.SimpleQueryRewriter;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestHandler;
 import org.elasticsearch.rest.RestHeaderDefinition;
@@ -96,6 +97,7 @@ import org.elasticsearch.xpack.inference.queries.SemanticKnnVectorQueryRewriteIn
 import org.elasticsearch.xpack.inference.queries.SemanticMatchQueryRewriteInterceptor;
 import org.elasticsearch.xpack.inference.queries.SemanticQueryBuilder;
 import org.elasticsearch.xpack.inference.queries.SemanticSparseVectorQueryRewriteInterceptor;
+import org.elasticsearch.xpack.inference.queries.SimpleSemanticQueryRewriter;
 import org.elasticsearch.xpack.inference.rank.random.RandomRankBuilder;
 import org.elasticsearch.xpack.inference.rank.random.RandomRankRetrieverBuilder;
 import org.elasticsearch.xpack.inference.rank.textsimilarity.TextSimilarityRankBuilder;
@@ -150,6 +152,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.elasticsearch.xpack.inference.action.filter.ShardBulkInferenceActionFilter.INDICES_INFERENCE_BATCH_SIZE;
 import static org.elasticsearch.xpack.inference.common.InferenceAPIClusterAwareRateLimitingFeature.INFERENCE_API_CLUSTER_AWARE_RATE_LIMITING_FEATURE_FLAG;
@@ -553,6 +556,11 @@ public class InferencePlugin extends Plugin
             new SemanticMatchQueryRewriteInterceptor(),
             new SemanticSparseVectorQueryRewriteInterceptor()
         );
+    }
+
+    @Override
+    public List<SimpleQueryRewriter> getSimpleQueryRewriters() {
+        return List.of(new SimpleSemanticQueryRewriter());
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
@@ -152,7 +152,6 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
-import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.elasticsearch.xpack.inference.action.filter.ShardBulkInferenceActionFilter.INDICES_INFERENCE_BATCH_SIZE;
 import static org.elasticsearch.xpack.inference.common.InferenceAPIClusterAwareRateLimitingFeature.INFERENCE_API_CLUSTER_AWARE_RATE_LIMITING_FEATURE_FLAG;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/queries/SimpleSemanticQueryRewriter.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/queries/SimpleSemanticQueryRewriter.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.queries;
+
+import org.elasticsearch.index.query.MatchQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.plugins.internal.rewriter.SimpleQueryRewriter;
+
+public class SimpleSemanticQueryRewriter implements SimpleQueryRewriter {
+
+    public SimpleSemanticQueryRewriter() {
+
+    }
+
+    public String getName() {
+        return MatchQueryBuilder.NAME;
+    }
+
+    @Override
+    public QueryBuilder rewrite(QueryBuilder queryBuilder) {
+
+        if (queryBuilder instanceof MatchQueryBuilder == false) {
+            // no-op
+            return queryBuilder;
+        }
+
+        MatchQueryBuilder matchQueryBuilder = (MatchQueryBuilder) queryBuilder;
+        return new SemanticQueryBuilder(matchQueryBuilder.fieldName(), matchQueryBuilder.value().toString());
+    }
+}

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/index/query/SimpleSemanticQueryRewriterTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/index/query/SimpleSemanticQueryRewriterTests.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.index.query;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.inference.queries.SemanticQueryBuilder;
+import org.elasticsearch.xpack.inference.queries.SimpleSemanticQueryRewriter;
+
+public class SimpleSemanticQueryRewriterTests extends ESTestCase {
+
+    public void testMatchQueryRewrite() {
+        MatchQueryBuilder matchQuery = QueryBuilders.matchQuery("field", "value");
+        SimpleSemanticQueryRewriter rewriter = new SimpleSemanticQueryRewriter();
+        QueryBuilder expected = new SemanticQueryBuilder("field", "value");
+        QueryBuilder rewritten = rewriter.rewrite(matchQuery);
+        assertEquals(rewritten, expected);
+    }
+
+    public void testNoOpRewrite() {
+        TermQueryBuilder termQuery = QueryBuilders.termQuery("field", "value");
+        SimpleSemanticQueryRewriter rewriter = new SimpleSemanticQueryRewriter();
+        QueryBuilder rewritten = rewriter.rewrite(termQuery);
+        assertEquals(rewritten, termQuery);
+    }
+}


### PR DESCRIPTION
This provides a simple query rewriter to support rewriting `match` queries under certain known circumstances to `semantic` queries. In practice, this is planned to be used internally in the `RankFeatureShardPhase` during query rewrite time, when we want to manually create a `semantic` query to correctly extract snippets in this phase where no rewrite context is accessible. 