### PR TITLE
Don't check TSDB end time in YAML test

### DIFF
--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/150_tsdb.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/150_tsdb.yml
@@ -108,7 +108,8 @@ created the data stream:
   - match: { data_streams.0.hidden: false }
   - match: { data_streams.0.system: false }
   - match: { data_streams.0.time_series.temporal_ranges.0.start: 2021-04-28T00:00:00.000Z }
-  - match: { data_streams.0.time_series.temporal_ranges.0.end: 2021-04-29T00:00:00.000Z }
+  # We can't match on time_series.temporal_ranges.0.end in this test because UpdateTimeSeriesRangeService updates it every 5 minutes, so every
+  # once in a while it is not what we expect it to be. See #124575.
   - set:  { data_streams.0.indices.0.index_name: backing_index }
 
   - do:

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -212,9 +212,6 @@ tests:
 - class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
   method: test {yaml=data_stream/190_failure_store_redirection/Redirect ingest failure in data stream to failure store}
   issue: https://github.com/elastic/elasticsearch/issues/124518
-- class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
-  method: test {yaml=data_stream/150_tsdb/created the data stream}
-  issue: https://github.com/elastic/elasticsearch/issues/124575
 - class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
   method: testDeploymentSurvivesRestart {cluster=OLD}
   issue: https://github.com/elastic/elasticsearch/issues/124160


### PR DESCRIPTION
The end time of a TSDB data stream is updated by
`UpdateTimeSeriesRangeService` every 5 minutes. This means that every once in a while the test fails if UpdateTimeSeriesRangeService happens to have run during the test. This PR gets rid of this check.

It's a bit odd that this failure hasn't shown up before (i.e. outside of the multi-project test suite), but I suspect it's related to the race condition we're seeing here - the MP test suite is likely a bit slower, making it slightly more likely to occur, perhaps.

Resolves #124575