### PR TITLE
[9.1] [ML] Removing custom service from service api (#130739)

### DIFF
--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceGetServicesIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceGetServicesIT.java
@@ -20,7 +20,6 @@ import java.util.Map;
 
 import static org.elasticsearch.xpack.inference.InferenceBaseRestTest.assertStatusOkOrCreated;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.equalTo;
 
 public class InferenceGetServicesIT extends BaseMockEISAuthServerTest {
 
@@ -41,7 +40,6 @@ public class InferenceGetServicesIT extends BaseMockEISAuthServerTest {
                     "azureaistudio",
                     "azureopenai",
                     "cohere",
-                    "custom",
                     "deepseek",
                     "elastic",
                     "elasticsearch",
@@ -77,9 +75,6 @@ public class InferenceGetServicesIT extends BaseMockEISAuthServerTest {
     }
 
     public void testGetServicesWithTextEmbeddingTaskType() throws IOException {
-        List<Object> services = getServices(TaskType.TEXT_EMBEDDING);
-        assertThat(services.size(), equalTo(18));
-
         assertThat(
             providersFor(TaskType.TEXT_EMBEDDING),
             containsInAnyOrder(
@@ -90,7 +85,6 @@ public class InferenceGetServicesIT extends BaseMockEISAuthServerTest {
                     "azureaistudio",
                     "azureopenai",
                     "cohere",
-                    "custom",
                     "elastic",
                     "elasticsearch",
                     "googleaistudio",
@@ -118,7 +112,6 @@ public class InferenceGetServicesIT extends BaseMockEISAuthServerTest {
                 List.of(
                     "alibabacloud-ai-search",
                     "cohere",
-                    "custom",
                     "elasticsearch",
                     "googlevertexai",
                     "jinaai",
@@ -143,7 +136,6 @@ public class InferenceGetServicesIT extends BaseMockEISAuthServerTest {
                     "azureaistudio",
                     "azureopenai",
                     "cohere",
-                    "custom",
                     "deepseek",
                     "googleaistudio",
                     "openai",
@@ -181,7 +173,6 @@ public class InferenceGetServicesIT extends BaseMockEISAuthServerTest {
             containsInAnyOrder(
                 List.of(
                     "alibabacloud-ai-search",
-                    "custom",
                     "elastic",
                     "elasticsearch",
                     "hugging_face",

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/custom/CustomService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/custom/CustomService.java
@@ -355,6 +355,12 @@ public class CustomService extends SenderService {
         return TransportVersions.INFERENCE_CUSTOM_SERVICE_ADDED;
     }
 
+    @Override
+    public boolean hideFromConfigurationApi() {
+        // The Custom service is very configurable so we're going to hide it from being exposed in the service API.
+        return true;
+    }
+
     public static class Configuration {
         public static InferenceServiceConfiguration get() {
             return configuration.getOrCompute();


### PR DESCRIPTION
Backports the following commits to 9.1:
 - [ML] Removing custom service from service api (#130739)