### PR TITLE
Disable entitlements on OverrideNodeVersionCommandTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/env/OverrideNodeVersionCommandTests.java
+++ b/server/src/test/java/org/elasticsearch/env/OverrideNodeVersionCommandTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.gateway.PersistedClusterStateService;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.ESTestCase.WithoutEntitlements;
 import org.junit.After;
 import org.junit.Before;
 
@@ -31,6 +32,7 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
+@WithoutEntitlements
 public class OverrideNodeVersionCommandTests extends ESTestCase {
 
     private Environment environment;


### PR DESCRIPTION
Disable entitlements on this test since it's testing a CLI tool, in which we'll never run with entitlements enabled.

Resolves https://github.com/elastic/elasticsearch/issues/130654