### PR TITLE
Disable ILM history in core MP test suite

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -567,12 +567,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/130067
-- class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
-  method: test {yaml=nodes.stats/11_indices_metrics/Metric - blank for indices mappings}
-  issue: https://github.com/elastic/elasticsearch/issues/130772
-- class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
-  method: test {yaml=search.vectors/70_dense_vector_telemetry/Field mapping stats with field details}
-  issue: https://github.com/elastic/elasticsearch/issues/130777
 
 # Examples:
 #

--- a/x-pack/qa/multi-project/core-rest-tests-with-multiple-projects/src/yamlRestTest/java/org/elasticsearch/multiproject/test/CoreWithMultipleProjectsClientYamlTestSuiteIT.java
+++ b/x-pack/qa/multi-project/core-rest-tests-with-multiple-projects/src/yamlRestTest/java/org/elasticsearch/multiproject/test/CoreWithMultipleProjectsClientYamlTestSuiteIT.java
@@ -44,6 +44,8 @@ public class CoreWithMultipleProjectsClientYamlTestSuiteIT extends MultipleProje
         .setting("xpack.ml.enabled", "false")
         .setting("xpack.license.self_generated.type", "trial")
         .setting("xpack.security.autoconfiguration.enabled", "false")
+        // disable ILM history, since it disturbs tests using _all
+        .setting("indices.lifecycle.history_index_enabled", "false")
         .user(USER, PASS)
         .systemProperty("es.queryable_built_in_roles_enabled", "false")
         .feature(FeatureFlag.TIME_SERIES_MODE)


### PR DESCRIPTION
#130729 disabled the history store in the x-pack MP suite, now we also disable it in the core MP suite.

Fixes #130772
Fixes #130777