### PR TITLE
[8.19] Specify master timeout when submitting alias tasks (#130733)

### DIFF
--- a/docs/changelog/130733.yaml
+++ b/docs/changelog/130733.yaml
@@ -1,0 +1,6 @@
+pr: 130733
+summary: Specify master timeout when submitting alias tasks
+area: Indices APIs
+type: bug
+issues:
+ - 120389

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexAliasesService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexAliasesService.java
@@ -85,7 +85,7 @@ public class MetadataIndexAliasesService {
         final IndicesAliasesClusterStateUpdateRequest request,
         final ActionListener<IndicesAliasesResponse> listener
     ) {
-        taskQueue.submitTask("index-aliases", new ApplyAliasesTask(request, listener), null); // TODO use request.masterNodeTimeout() here?
+        taskQueue.submitTask("index-aliases", new ApplyAliasesTask(request, listener), request.masterNodeTimeout());
     }
 
     /**


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Specify master timeout when submitting alias tasks (#130733)