### PR TITLE
ESQL: Ignore literal spaces in index patterns

### DIFF
--- a/docs/changelog/130802.yaml
+++ b/docs/changelog/130802.yaml
@@ -1,6 +1,6 @@
 pr: 130802
 summary: Ignore literal spaces in index patterns
 area: ES|QL
-type: bug
+type: enhancement
 issues:
  - 129768

--- a/docs/changelog/130802.yaml
+++ b/docs/changelog/130802.yaml
@@ -1,0 +1,6 @@
+pr: 130802
+summary: Ignore literal spaces in index patterns
+area: ES|QL
+type: bug
+issues:
+ - 129768


### PR DESCRIPTION
Resolves https://github.com/elastic/elasticsearch/issues/129768
