### PR TITLE
Refactor acquireHistoryRetentionLock to Use Releasable instead of Closeable

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/RetentionLeaseIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/RetentionLeaseIT.java
@@ -18,6 +18,7 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.Maps;
+import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.IndexSettings;
@@ -96,7 +97,7 @@ public class RetentionLeaseIT extends ESIntegTestCase {
             final CountDownLatch latch = new CountDownLatch(1);
             final ActionListener<ReplicationResponse> listener = countDownLatchListener(latch);
             // simulate a peer recovery which locks the soft deletes policy on the primary
-            final Closeable retentionLock = randomBoolean() ? primary.acquireHistoryRetentionLock() : () -> {};
+            final Releasable retentionLock = randomBoolean() ? primary.acquireHistoryRetentionLock() : () -> {};
             currentRetentionLeases.put(id, primary.addRetentionLease(id, retainingSequenceNumber, source, listener));
             latch.await();
             retentionLock.close();
@@ -145,7 +146,7 @@ public class RetentionLeaseIT extends ESIntegTestCase {
             final CountDownLatch latch = new CountDownLatch(1);
             final ActionListener<ReplicationResponse> listener = countDownLatchListener(latch);
             // simulate a peer recovery which locks the soft deletes policy on the primary
-            final Closeable retentionLock = randomBoolean() ? primary.acquireHistoryRetentionLock() : () -> {};
+            final Releasable retentionLock = randomBoolean() ? primary.acquireHistoryRetentionLock() : () -> {};
             currentRetentionLeases.put(id, primary.addRetentionLease(id, retainingSequenceNumber, source, listener));
             latch.await();
             retentionLock.close();
@@ -156,7 +157,7 @@ public class RetentionLeaseIT extends ESIntegTestCase {
             final CountDownLatch latch = new CountDownLatch(1);
             primary.removeRetentionLease(id, countDownLatchListener(latch));
             // simulate a peer recovery which locks the soft deletes policy on the primary
-            final Closeable retentionLock = randomBoolean() ? primary.acquireHistoryRetentionLock() : () -> {};
+            final Releasable retentionLock = randomBoolean() ? primary.acquireHistoryRetentionLock() : () -> {};
             currentRetentionLeases.remove(id);
             latch.await();
             retentionLock.close();

--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -1050,7 +1050,7 @@ public abstract class Engine implements Closeable {
     /**
      * Acquires a lock on Lucene soft-deleted documents to prevent them from being trimmed
      */
-    public abstract Closeable acquireHistoryRetentionLock();
+    public abstract Releasable acquireHistoryRetentionLock();
 
     /**
      * Counts the number of operations in the range of the given sequence numbers.

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -3318,7 +3318,7 @@ public class InternalEngine extends Engine {
     }
 
     @Override
-    public Closeable acquireHistoryRetentionLock() {
+    public Releasable acquireHistoryRetentionLock() {
         return softDeletesPolicy.acquireRetentionLock();
     }
 

--- a/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Releasable;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.mapper.DocumentParser;
@@ -345,7 +346,7 @@ public class ReadOnlyEngine extends Engine {
     public void syncTranslog() {}
 
     @Override
-    public Closeable acquireHistoryRetentionLock() {
+    public Releasable acquireHistoryRetentionLock() {
         return () -> {};
     }
 

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -2669,7 +2669,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     /**
      * Acquires a lock on Lucene soft-deleted documents to prevent them from being trimmed
      */
-    public Closeable acquireHistoryRetentionLock() {
+    public Releasable acquireHistoryRetentionLock() {
         return getEngine().acquireHistoryRetentionLock();
     }
 
@@ -2900,13 +2900,11 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         assert assertPrimaryMode();
         verifyNotClosed();
         ensureSoftDeletesEnabled();
-        try (Closeable ignore = acquireHistoryRetentionLock()) {
+        try (Releasable ignore = acquireHistoryRetentionLock()) {
             final long actualRetainingSequenceNumber = retainingSequenceNumber == RETAIN_ALL
                 ? getMinRetainedSeqNo()
                 : retainingSequenceNumber;
             return replicationTracker.addRetentionLease(id, actualRetainingSequenceNumber, source, listener);
-        } catch (final IOException e) {
-            throw new AssertionError(e);
         }
     }
 
@@ -2923,13 +2921,11 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         assert assertPrimaryMode();
         verifyNotClosed();
         ensureSoftDeletesEnabled();
-        try (Closeable ignore = acquireHistoryRetentionLock()) {
+        try (Releasable ignore = acquireHistoryRetentionLock()) {
             final long actualRetainingSequenceNumber = retainingSequenceNumber == RETAIN_ALL
                 ? getMinRetainedSeqNo()
                 : retainingSequenceNumber;
             return replicationTracker.renewRetentionLease(id, actualRetainingSequenceNumber, source);
-        } catch (final IOException e) {
-            throw new AssertionError(e);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -204,7 +204,7 @@ public class RecoverySourceHandler {
     }
 
     private void recoverToTarget(RetentionLease retentionLease, Consumer<Exception> onFailure) throws IOException {
-        final Closeable retentionLock = shard.acquireHistoryRetentionLock();
+        final Releasable retentionLock = shard.acquireHistoryRetentionLock();
         resources.add(retentionLock);
         final long startingSeqNo;
         final boolean isSequenceNumberBasedRecovery = request.startingSeqNo() != SequenceNumbers.UNASSIGNED_SEQ_NO
@@ -1234,7 +1234,7 @@ public class RecoverySourceHandler {
                 );
                 /*
                  * if the recovery process fails after disabling primary mode on the source shard, both relocation source and
-                 * target are failed (see {@link IndexShard#updateRoutingEntry}).
+                 * target are failed (see {@link IndexShard#updateShardState}).
                  */
             }));
         } else {


### PR DESCRIPTION
Replaces `Closeable` with `Releasable` for history retention locks. The `Closeable` interface forces unnecessary `IOException` handling despite the history retention lock implementation never throwing IO exceptions. This change simplifies resource management by aligning the API with actual behavior.  