### PR TITLE
Simplified Linear and RRF Retrievers Docs - Add Links to Examples

### DIFF
--- a/docs/reference/elasticsearch/rest-apis/retrievers.md
+++ b/docs/reference/elasticsearch/rest-apis/retrievers.md
@@ -1200,8 +1200,8 @@ Note, however, that wildcard field patterns will only resolve to fields that eit
 
 ### Examples
 
-<!-- - [RRF with the multi-field query format](docs-content://solutions/search/retrievers-examples.md#retrievers-examples-rrf-multi-field-query-format) -->
-<!-- - [Linear retriever with the multi-field query format](docs-content://solutions/search/retrievers-examples.md#retrievers-examples-linear-multi-field-query-format) -->
+- [RRF with the multi-field query format](docs-content://solutions/search/retrievers-examples.md#retrievers-examples-rrf-multi-field-query-format)
+- [Linear retriever with the multi-field query format](docs-content://solutions/search/retrievers-examples.md#retrievers-examples-linear-multi-field-query-format)
 
 ## Common usage guidelines [retriever-common-parameters]
 


### PR DESCRIPTION
Follow-up to https://github.com/elastic/elasticsearch/pull/130559. Adds links to retriever examples. To be merged after https://github.com/elastic/docs-content/pull/2026.
