### PR TITLE
 Fix IllegalStateException when query match_only_text field with non keyword field type as parent #130845 

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
@@ -14,7 +14,6 @@ import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.StoredField;
-import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
@@ -48,6 +47,7 @@ import org.elasticsearch.index.mapper.BlockSourceReader;
 import org.elasticsearch.index.mapper.BlockStoredFieldsReader;
 import org.elasticsearch.index.mapper.DocumentParserContext;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperBuilderContext;
 import org.elasticsearch.index.mapper.SourceValueFetcher;
 import org.elasticsearch.index.mapper.StringFieldType;
@@ -254,7 +254,8 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
                 if (parent.isStored()) {
                     return storedFieldFetcher(parentField);
                 } else if (parent.hasDocValues()) {
-                    return docValuesFieldFetcher(parentField);
+                    var ifd = searchExecutionContext.getForField(parent, MappedFieldType.FielddataOperation.SEARCH);
+                    return docValuesFieldFetcher(ifd);
                 } else {
                     assert false : "parent field should either be stored or have doc values";
                 }
@@ -266,7 +267,8 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
                     if (fieldType.isStored()) {
                         return storedFieldFetcher(fieldType.name());
                     } else if (fieldType.hasDocValues()) {
-                        return docValuesFieldFetcher(fieldType.name());
+                        var ifd = searchExecutionContext.getForField(fieldType, MappedFieldType.FielddataOperation.SEARCH);
+                        return docValuesFieldFetcher(ifd);
                     } else {
                         assert false : "multi field should either be stored or have doc values";
                     }
@@ -291,15 +293,16 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
             };
         }
 
-        private static IOFunction<LeafReaderContext, CheckedIntFunction<List<Object>, IOException>> docValuesFieldFetcher(String name) {
+        private static IOFunction<LeafReaderContext, CheckedIntFunction<List<Object>, IOException>> docValuesFieldFetcher(
+            IndexFieldData<?> ifd
+        ) {
             return context -> {
-                var sortedDocValues = DocValues.getSortedSet(context.reader(), name);
+                var sortedBinaryDocValues = ifd.load(context).getBytesValues();
                 return docId -> {
-                    if (sortedDocValues.advanceExact(docId)) {
-                        var values = new ArrayList<>(sortedDocValues.docValueCount());
-                        for (int i = 0; i < sortedDocValues.docValueCount(); i++) {
-                            long ord = sortedDocValues.nextOrd();
-                            values.add(sortedDocValues.lookupOrd(ord).utf8ToString());
+                    if (sortedBinaryDocValues.advanceExact(docId)) {
+                        var values = new ArrayList<>(sortedBinaryDocValues.docValueCount());
+                        for (int i = 0; i < sortedBinaryDocValues.docValueCount(); i++) {
+                            values.add(sortedBinaryDocValues.nextValue().utf8ToString());
                         }
                         return values;
                     } else {

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/logsdb/20_synthetic_source.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/logsdb/20_synthetic_source.yml
@@ -1,0 +1,149 @@
+---
+synthetic_source match_only_text with wildcard as parent field:
+  - requires:
+      cluster_features: [ "mapper.source.mode_from_index_setting" ]
+      reason: "Source mode configured through index setting"
+
+  - do:
+      indices.create:
+        index: synthetic_source_test
+        body:
+          settings:
+            index:
+              mapping.source.mode: synthetic
+          mappings:
+            properties:
+              foo:
+                type: wildcard
+                fields:
+                  text:
+                    type: match_only_text
+
+  - do:
+      index:
+        index: synthetic_source_test
+        id:    "1"
+        refresh: true
+        body:
+          foo: "Apache Lucene powers Elasticsearch"
+
+  - do:
+      search:
+        index: synthetic_source_test
+        body:
+          query:
+            match_phrase:
+              foo.text: apache lucene
+
+  - match: { "hits.total.value": 1 }
+  - match:
+      hits.hits.0._source.foo: "Apache Lucene powers Elasticsearch"
+
+---
+synthetic_source match_only_text with number as parent field:
+  - requires:
+      cluster_features: [ "mapper.source.mode_from_index_setting" ]
+      reason: "Source mode configured through index setting"
+
+  - do:
+      indices.create:
+        index: synthetic_source_test
+        body:
+          settings:
+            index:
+              mapping.source.mode: synthetic
+          mappings:
+            properties:
+              foo:
+                type: long
+                fields:
+                  text:
+                    type: match_only_text
+
+  - do:
+      index:
+        index: synthetic_source_test
+        id:    "1"
+        refresh: true
+        body:
+          foo: [1, 5]
+
+  - do:
+      search:
+        index: synthetic_source_test
+        body:
+          query:
+            match_phrase:
+              foo.text: 1 5
+
+  - match: { "hits.total.value": 0 }
+
+  - do:
+      indices.create:
+        index: stored_source_test
+        body:
+          mappings:
+            properties:
+              foo:
+                type: long
+                fields:
+                  text:
+                    type: match_only_text
+
+  - do:
+      index:
+        index: stored_source_test
+        id:    "1"
+        refresh: true
+        body:
+          foo: [1, 5]
+
+  - do:
+      search:
+        index: stored_source_test
+        body:
+          query:
+            match_phrase:
+              foo.text: 1 5
+
+  - match: { "hits.total.value": 0 }
+
+---
+synthetic_source match_only_text with scaled_float as parent field:
+  - requires:
+      cluster_features: [ "mapper.source.mode_from_index_setting" ]
+      reason: "Source mode configured through index setting"
+
+  - do:
+      indices.create:
+        index: synthetic_source_test
+        body:
+          settings:
+            index:
+              mapping.source.mode: synthetic
+          mappings:
+            properties:
+              foo:
+                type: scaled_float
+                scaling_factor: 10
+                fields:
+                  text:
+                    type: match_only_text
+
+  - do:
+      index:
+        index: synthetic_source_test
+        id:    "1"
+        refresh: true
+        body:
+          foo: [1.1, 5.5]
+
+  - do:
+      search:
+        index: synthetic_source_test
+        body:
+          query:
+            match_phrase:
+              foo.text: 1.1 5.5
+
+  - match: { "hits.total.value": 0 }


### PR DESCRIPTION
This pulls https://github.com/elastic/elasticsearch/pull/130845 into the serverless fix branch for patch deployment.