### PR TITLE
remove limitation of rollover during snapshot

### DIFF
--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamsSnapshotsIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamsSnapshotsIT.java
@@ -1149,12 +1149,7 @@ public class DataStreamsSnapshotsIT extends AbstractSnapshotIntegTestCase {
         awaitNumberOfSnapshotsInProgress(1);
         final ActionFuture<RolloverResponse> rolloverResponse = indicesAdmin().rolloverIndex(new RolloverRequest("ds", null));
 
-        if (partial) {
-            assertTrue(rolloverResponse.get().isRolledOver());
-        } else {
-            SnapshotInProgressException e = expectThrows(SnapshotInProgressException.class, rolloverResponse);
-            assertThat(e.getMessage(), containsString("Cannot roll over data stream that is being snapshotted:"));
-        }
+        assertTrue(rolloverResponse.get().isRolledOver());
         unblockAllDataNodes(repoName);
         final SnapshotInfo snapshotInfo = assertSuccessful(snapshotFuture);
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverService.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverService.java
@@ -47,14 +47,11 @@ import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.indices.SystemDataStreamDescriptor;
 import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.injection.guice.Inject;
-import org.elasticsearch.snapshots.SnapshotInProgressException;
-import org.elasticsearch.snapshots.SnapshotsService;
 import org.elasticsearch.telemetry.TelemetryProvider;
 import org.elasticsearch.telemetry.metric.MeterRegistry;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.time.Instant;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -294,18 +291,6 @@ public class MetadataRolloverService {
         @Nullable AutoShardingResult autoShardingResult,
         boolean isFailureStoreRollover
     ) throws Exception {
-
-        if (SnapshotsService.snapshottingDataStreams(currentState, Collections.singleton(dataStream.getName())).isEmpty() == false) {
-            // we can't roll over the snapshot concurrently because the snapshot contains the indices that existed when it was started but
-            // the cluster metadata of when it completes so the new write index would not exist in the snapshot if there was a concurrent
-            // rollover
-            throw new SnapshotInProgressException(
-                "Cannot roll over data stream that is being snapshotted: "
-                    + dataStream.getName()
-                    + ". Try again after snapshot finishes or cancel the currently running snapshot."
-            );
-        }
-
         final Metadata metadata = currentState.getMetadata();
         final ComposableIndexTemplate templateV2;
         final SystemDataStreamDescriptor systemDataStreamDescriptor;


### PR DESCRIPTION
our cluster performs scheduled full snapshot backups daily. Due to high throughput, we have many new indices created each day, causing snapshot to take ​1–2 hours​ to complete. During this period, the restriction that prevents rolling over datastreams while snapshots are in progress make some trouble:
1. Some index become way bigger then expected but ilm can't rollover because snapshot is running.
2. Changes to shard nums for datastreams are deferred until snapshot finish.

Is the current restriction exists to ​preserve datastream integrity​ by ensuring the write index is included in the snapshot?
The new write index can be captured in the ​next scheduled snapshot​ without compromising data consistency.
Immediate rollover capability is essential for real-time configuration updates. So removing this limitation would resolve operational bottlenecks while maintaining data reliability long-term.

