### PR TITLE
Split AllocationDecider into sub-interfaces and group deciders

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/ShardRoutingRoleIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/ShardRoutingRoleIT.java
@@ -35,6 +35,7 @@ import org.elasticsearch.cluster.routing.allocation.command.AllocationCommand;
 import org.elasticsearch.cluster.routing.allocation.command.CancelAllocationCommand;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.cluster.routing.allocation.decider.DefaultAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -179,7 +180,7 @@ public class ShardRoutingRoleIT extends ESIntegTestCase {
 
         @Override
         public Collection<AllocationDecider> createAllocationDeciders(Settings settings, ClusterSettings clusterSettings) {
-            return List.of(new AllocationDecider() {
+            return List.of(new DefaultAllocationDecider() {
                 @Override
                 public Decision canForceAllocatePrimary(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
                     // once a primary is cancelled it _stays_ cancelled

--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/GatewayServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/GatewayServiceIT.java
@@ -15,6 +15,7 @@ import org.elasticsearch.cluster.routing.allocation.ExistingShardsAllocator;
 import org.elasticsearch.cluster.routing.allocation.FailedShard;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.DefaultAllocationDecider;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
@@ -104,7 +105,7 @@ public class GatewayServiceIT extends ESIntegTestCase {
         }
     }
 
-    private static class TestAllocationDecider extends AllocationDecider {
+    private static class TestAllocationDecider extends DefaultAllocationDecider {
         TestAllocationDecider(Settings settings, ClusterSettings clusterSettings, AtomicBoolean settingApplied) {
             if (TEST_SETTING.get(settings)) {
                 settingApplied.set(true);

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AwarenessAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AwarenessAllocationDecider.java
@@ -69,7 +69,11 @@ import static java.util.stream.Collectors.toList;
  * node.zone: zone1
  * </pre>
  */
-public class AwarenessAllocationDecider extends AllocationDecider {
+public class AwarenessAllocationDecider
+    implements
+        AllocationDecider.ShardToNode,
+        AllocationDecider.ForceDuringReplace,
+        AllocationDecider.ShardRemain {
 
     public static final String NAME = "awareness";
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ClusterRebalanceAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ClusterRebalanceAllocationDecider.java
@@ -38,7 +38,7 @@ import java.util.Locale;
  * is active</li>
  * </ul>
  */
-public class ClusterRebalanceAllocationDecider extends AllocationDecider {
+public class ClusterRebalanceAllocationDecider implements AllocationDecider.ShardRebalance, AllocationDecider.ClusterRebalance {
 
     private static final Logger logger = LogManager.getLogger(ClusterRebalanceAllocationDecider.class);
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ConcurrentRebalanceAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ConcurrentRebalanceAllocationDecider.java
@@ -29,7 +29,7 @@ import org.elasticsearch.common.settings.Setting.Property;
  * setting is set to {@code -1} the number of concurrent re-balance operations
  * are unlimited.
  */
-public class ConcurrentRebalanceAllocationDecider extends AllocationDecider {
+public class ConcurrentRebalanceAllocationDecider implements AllocationDecider.ShardRebalance, AllocationDecider.ClusterRebalance {
 
     private static final Logger logger = LogManager.getLogger(ConcurrentRebalanceAllocationDecider.class);
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DefaultAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DefaultAllocationDecider.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.cluster.routing.allocation.decider;
+
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+
+import java.util.Optional;
+import java.util.Set;
+
+public class DefaultAllocationDecider
+    implements
+        AllocationDecider.ShardToNode,
+        AllocationDecider.ShardToCluster,
+        AllocationDecider.IndexToNode,
+        AllocationDecider.ShardRemain,
+        AllocationDecider.ShardRebalance,
+        AllocationDecider.ClusterRebalance,
+        AllocationDecider.ForceDuringReplace,
+        AllocationDecider.ForcedInitialShardAllocation,
+        AllocationDecider.AutoExpandToNode {
+    @Override
+    public Decision shouldAutoExpandToNode(IndexMetadata indexMetadata, DiscoveryNode node, RoutingAllocation allocation) {
+        return Decision.ALWAYS;
+    }
+
+    @Override
+    public Decision canRebalance(RoutingAllocation allocation) {
+        return Decision.ALWAYS;
+    }
+
+    @Override
+    public Decision canForceAllocateDuringReplace(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+        return Decision.ALWAYS;
+    }
+
+    @Override
+    public Optional<Set<String>> getForcedInitialShardAllocationToNodes(ShardRouting shardRouting, RoutingAllocation allocation) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Decision canAllocate(IndexMetadata indexMetadata, RoutingNode node, RoutingAllocation allocation) {
+        return Decision.ALWAYS;
+    }
+
+    @Override
+    public Decision canRebalance(ShardRouting shardRouting, RoutingAllocation allocation) {
+        return Decision.ALWAYS;
+    }
+
+    @Override
+    public Decision canRemain(IndexMetadata indexMetadata, ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+        return Decision.ALWAYS;
+    }
+
+    @Override
+    public Decision canAllocate(ShardRouting shardRouting, RoutingAllocation allocation) {
+        return Decision.ALWAYS;
+    }
+
+    @Override
+    public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+        return Decision.ALWAYS;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
@@ -65,7 +65,11 @@ import static org.elasticsearch.cluster.routing.ExpectedShardSizeEstimator.shoul
  * <code>cluster.routing.allocation.disk.threshold_enabled</code> is used to
  * enable or disable this decider. It defaults to true (enabled).
  */
-public class DiskThresholdDecider extends AllocationDecider {
+public class DiskThresholdDecider
+    implements
+        AllocationDecider.ShardToNode,
+        AllocationDecider.ForceDuringReplace,
+        AllocationDecider.ShardRemain {
 
     private static final Logger logger = LogManager.getLogger(DiskThresholdDecider.class);
 
@@ -352,7 +356,7 @@ public class DiskThresholdDecider extends AllocationDecider {
                 -freeBytesAfterShard
             );
         } else {
-            return super.canForceAllocateDuringReplace(shardRouting, node, allocation);
+            return Decision.ALWAYS;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationDecider.java
@@ -49,7 +49,12 @@ import java.util.Locale;
  * @see Rebalance
  * @see Allocation
  */
-public class EnableAllocationDecider extends AllocationDecider {
+public class EnableAllocationDecider
+    implements
+        AllocationDecider.ShardToNode,
+        AllocationDecider.ShardToCluster,
+        AllocationDecider.ShardRebalance,
+        AllocationDecider.ClusterRebalance {
 
     public static final String NAME = "enable";
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/FilterAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/FilterAllocationDecider.java
@@ -58,7 +58,13 @@ import static org.elasticsearch.cluster.node.DiscoveryNodeFilters.validateIpValu
  * filtered node</li>
  * </ol>
  */
-public class FilterAllocationDecider extends AllocationDecider {
+public class FilterAllocationDecider
+    implements
+        AllocationDecider.ShardToNode,
+        AllocationDecider.IndexToNode,
+        AllocationDecider.ShardRemain,
+        AllocationDecider.AutoExpandToNode,
+        AllocationDecider.ForcedInitialShardAllocation {
 
     public static final String NAME = "filter";
 
@@ -242,6 +248,6 @@ public class FilterAllocationDecider extends AllocationDecider {
                 );
             }
         }
-        return super.getForcedInitialShardAllocationToNodes(shardRouting, allocation);
+        return Optional.empty();
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/IndexVersionAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/IndexVersionAllocationDecider.java
@@ -23,7 +23,7 @@ import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
  * on the lowest level since it might have already written segments that use a new postings format or codec that is not
  * available on the target node.
  */
-public class IndexVersionAllocationDecider extends AllocationDecider {
+public class IndexVersionAllocationDecider implements AllocationDecider.ShardToNode, AllocationDecider.ForceDuringReplace {
 
     public static final String NAME = "index_version";
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/MaxRetryAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/MaxRetryAllocationDecider.java
@@ -25,7 +25,11 @@ import org.elasticsearch.common.settings.Setting;
  * API is manually invoked. This allows single retries without raising the limits.
  *
  */
-public class MaxRetryAllocationDecider extends AllocationDecider {
+public class MaxRetryAllocationDecider
+    implements
+        AllocationDecider.ShardToCluster,
+        AllocationDecider.ShardToNode,
+        AllocationDecider.ForceDuringReplace {
 
     public static final Setting<Integer> SETTING_ALLOCATION_MAX_RETRY = Setting.intSetting(
         "index.allocation.max_retries",

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/NodeReplacementAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/NodeReplacementAllocationDecider.java
@@ -21,7 +21,12 @@ import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
  * It also ensures that auto-expands replicas are expanded to only the replacement source or target (not both at the same time)
  * and only of the shards that were already present on the source node.
  */
-public class NodeReplacementAllocationDecider extends AllocationDecider {
+public class NodeReplacementAllocationDecider
+    implements
+        AllocationDecider.ShardToNode,
+        AllocationDecider.AutoExpandToNode,
+        AllocationDecider.ShardRemain,
+        AllocationDecider.ForceDuringReplace {
 
     public static final String NAME = "node_replacement";
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/NodeShutdownAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/NodeShutdownAllocationDecider.java
@@ -22,7 +22,11 @@ import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
  * No shards can be allocated to or remain on a node which is shutting down for removal.
  * Shards can be allocated to or remain on a node scheduled for a restart.
  */
-public class NodeShutdownAllocationDecider extends AllocationDecider {
+public class NodeShutdownAllocationDecider
+    implements
+        AllocationDecider.ShardToNode,
+        AllocationDecider.ShardRemain,
+        AllocationDecider.AutoExpandToNode {
 
     private static final String NAME = "node_shutdown";
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/NodeVersionAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/NodeVersionAllocationDecider.java
@@ -23,7 +23,7 @@ import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
  * on the lowest level since it might have already written segments that use a new postings format or codec that is not
  * available on the target node.
  */
-public class NodeVersionAllocationDecider extends AllocationDecider {
+public class NodeVersionAllocationDecider implements AllocationDecider.ShardToNode, AllocationDecider.ForceDuringReplace {
 
     public static final String NAME = "node_version";
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/RebalanceOnlyWhenActiveAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/RebalanceOnlyWhenActiveAllocationDecider.java
@@ -15,7 +15,7 @@ import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 /**
  * Only allow rebalancing when all shards are active within the shard replication group.
  */
-public class RebalanceOnlyWhenActiveAllocationDecider extends AllocationDecider {
+public class RebalanceOnlyWhenActiveAllocationDecider implements AllocationDecider.ShardRebalance {
 
     public static final String NAME = "rebalance_only_when_active";
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ReplicaAfterPrimaryActiveAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ReplicaAfterPrimaryActiveAllocationDecider.java
@@ -16,7 +16,11 @@ import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 /**
  * An allocation strategy that only allows for a replica to be allocated when the primary is active.
  */
-public class ReplicaAfterPrimaryActiveAllocationDecider extends AllocationDecider {
+public class ReplicaAfterPrimaryActiveAllocationDecider
+    implements
+        AllocationDecider.ShardToNode,
+        AllocationDecider.ShardToCluster,
+        AllocationDecider.ForceDuringReplace {
 
     private static final String NAME = "replica_after_primary_active";
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ResizeAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ResizeAllocationDecider.java
@@ -24,7 +24,12 @@ import java.util.Set;
 /**
  * An allocation decider that ensures we allocate the shards of a target index for resize operations next to the source primaries
  */
-public class ResizeAllocationDecider extends AllocationDecider {
+public class ResizeAllocationDecider
+    implements
+        AllocationDecider.ShardToCluster,
+        AllocationDecider.ShardToNode,
+        AllocationDecider.ForceDuringReplace,
+        AllocationDecider.ForcedInitialShardAllocation {
 
     public static final String NAME = "resize";
 
@@ -66,7 +71,7 @@ public class ResizeAllocationDecider extends AllocationDecider {
                 return allocation.decision(Decision.YES, NAME, "source primary is active");
             }
         }
-        return super.canAllocate(shardRouting, node, allocation);
+        return Decision.ALWAYS;
     }
 
     @Override
@@ -102,6 +107,6 @@ public class ResizeAllocationDecider extends AllocationDecider {
             }
             return Optional.of(Set.of(activePrimary.currentNodeId()));
         }
-        return super.getForcedInitialShardAllocationToNodes(shardRouting, allocation);
+        return Optional.empty();
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDecider.java
@@ -19,7 +19,11 @@ import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
  * This {@link AllocationDecider} prevents shards that have failed to be
  * restored from a snapshot to be allocated.
  */
-public class RestoreInProgressAllocationDecider extends AllocationDecider {
+public class RestoreInProgressAllocationDecider
+    implements
+        AllocationDecider.ShardToNode,
+        AllocationDecider.ShardToCluster,
+        AllocationDecider.ForceDuringReplace {
 
     public static final String NAME = "restore_in_progress";
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/SameShardAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/SameShardAllocationDecider.java
@@ -33,7 +33,7 @@ import org.elasticsearch.common.settings.Setting.Property;
  * {@code node} are not allowed independently of this setting.
  * </p>
  */
-public class SameShardAllocationDecider extends AllocationDecider {
+public class SameShardAllocationDecider implements AllocationDecider.ShardToNode, AllocationDecider.ForceDuringReplace {
 
     public static final String NAME = "same_shard";
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ShardsLimitAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ShardsLimitAllocationDecider.java
@@ -40,7 +40,7 @@ import java.util.function.BiPredicate;
  * trigger relocation and significant additional load on the clusters nodes.
  * </p>
  */
-public class ShardsLimitAllocationDecider extends AllocationDecider {
+public class ShardsLimitAllocationDecider implements AllocationDecider.ShardToNode, AllocationDecider.ShardRemain {
 
     public static final String NAME = "shards_limit";
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/SnapshotInProgressAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/SnapshotInProgressAllocationDecider.java
@@ -19,37 +19,16 @@ import org.elasticsearch.core.FixForMultiProject;
 import java.util.Objects;
 
 /**
- * This {@link org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider} prevents shards that
+ * This {@link AllocationDecider} prevents shards that
  * are currently been snapshotted to be moved to other nodes.
  */
-public class SnapshotInProgressAllocationDecider extends AllocationDecider {
+public class SnapshotInProgressAllocationDecider
+    implements
+        AllocationDecider.ShardRebalance,
+        AllocationDecider.ShardToNode,
+        AllocationDecider.ForceDuringReplace {
 
     public static final String NAME = "snapshot_in_progress";
-
-    /**
-     * Returns a {@link Decision} whether the given shard routing can be
-     * re-balanced to the given allocation. The default is
-     * {@link Decision#ALWAYS}.
-     */
-    @Override
-    public Decision canRebalance(ShardRouting shardRouting, RoutingAllocation allocation) {
-        return canMove(shardRouting, allocation);
-    }
-
-    /**
-     * Returns a {@link Decision} whether the given shard routing can be
-     * allocated on the given node. The default is {@link Decision#ALWAYS}.
-     */
-    @Override
-    public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
-        return canMove(shardRouting, allocation);
-    }
-
-    @Override
-    public Decision canForceAllocateDuringReplace(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
-        return canAllocate(shardRouting, node, allocation);
-    }
-
     private static final Decision YES_NOT_RUNNING = Decision.single(Decision.Type.YES, NAME, "no snapshots are currently running");
     private static final Decision YES_NOT_SNAPSHOTTED = Decision.single(Decision.Type.YES, NAME, "the shard is not being snapshotted");
 
@@ -130,5 +109,29 @@ public class SnapshotInProgressAllocationDecider extends AllocationDecider {
         }
 
         return YES_NOT_SNAPSHOTTED;
+    }
+
+    /**
+     * Returns a {@link Decision} whether the given shard routing can be
+     * re-balanced to the given allocation. The default is
+     * {@link Decision#ALWAYS}.
+     */
+    @Override
+    public Decision canRebalance(ShardRouting shardRouting, RoutingAllocation allocation) {
+        return canMove(shardRouting, allocation);
+    }
+
+    /**
+     * Returns a {@link Decision} whether the given shard routing can be
+     * allocated on the given node. The default is {@link Decision#ALWAYS}.
+     */
+    @Override
+    public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+        return canMove(shardRouting, allocation);
+    }
+
+    @Override
+    public Decision canForceAllocateDuringReplace(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+        return canAllocate(shardRouting, node, allocation);
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ThrottlingAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ThrottlingAllocationDecider.java
@@ -41,7 +41,7 @@ import static org.elasticsearch.cluster.routing.allocation.decider.Decision.YES;
  * the allocation process to prevent overloading nodes due to too many concurrent recovery
  * processes.
  */
-public class ThrottlingAllocationDecider extends AllocationDecider {
+public class ThrottlingAllocationDecider implements AllocationDecider.ShardToNode, AllocationDecider.ForceDuringReplace {
 
     private static final Logger logger = LogManager.getLogger(ThrottlingAllocationDecider.class);
 

--- a/server/src/test/java/org/elasticsearch/cluster/ClusterModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterModuleTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.AwarenessAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.ClusterRebalanceAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.ConcurrentRebalanceAllocationDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.DefaultAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.FilterAllocationDecider;
@@ -99,7 +100,7 @@ public class ClusterModuleTests extends ModuleTestCase {
         clusterService.close();
     }
 
-    static class FakeAllocationDecider extends AllocationDecider {
+    static class FakeAllocationDecider extends DefaultAllocationDecider {
         protected FakeAllocationDecider() {}
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/BalancedSingleShardTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/BalancedSingleShardTests.java
@@ -21,10 +21,10 @@ import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
-import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision.Type;
+import org.elasticsearch.cluster.routing.allocation.decider.DefaultAllocationDecider;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.snapshots.SnapshotShardSizeInfo;
@@ -87,7 +87,7 @@ public class BalancedSingleShardTests extends ESAllocationTestCase {
 
     public void testRebalancingNotAllowedDueToCanRebalance() {
         final Decision canRebalanceDecision = randomFrom(Decision.NO, Decision.THROTTLE);
-        AllocationDecider noRebalanceDecider = new AllocationDecider() {
+        DefaultAllocationDecider noRebalanceDecider = new DefaultAllocationDecider() {
             @Override
             public Decision canRebalance(ShardRouting shardRouting, RoutingAllocation allocation) {
                 return allocation.decision(canRebalanceDecision, "TEST", "foobar");
@@ -126,7 +126,7 @@ public class BalancedSingleShardTests extends ESAllocationTestCase {
     }
 
     public void testRebalancePossible() {
-        AllocationDecider canAllocateDecider = new AllocationDecider() {
+        DefaultAllocationDecider canAllocateDecider = new DefaultAllocationDecider() {
             @Override
             public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
                 return Decision.YES;
@@ -141,7 +141,7 @@ public class BalancedSingleShardTests extends ESAllocationTestCase {
     }
 
     public void testRebalancingNotAllowedDueToCanAllocate() {
-        AllocationDecider canAllocateDecider = new AllocationDecider() {
+        DefaultAllocationDecider canAllocateDecider = new DefaultAllocationDecider() {
             @Override
             public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
                 return Decision.NO;
@@ -163,7 +163,7 @@ public class BalancedSingleShardTests extends ESAllocationTestCase {
     }
 
     public void testDontBalanceShardWhenThresholdNotMet() {
-        AllocationDecider canAllocateDecider = new AllocationDecider() {
+        DefaultAllocationDecider canAllocateDecider = new DefaultAllocationDecider() {
             @Override
             public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
                 return Decision.YES;
@@ -215,7 +215,7 @@ public class BalancedSingleShardTests extends ESAllocationTestCase {
         }
         clusterState = ClusterState.builder(clusterState).nodes(nodesBuilder).build();
 
-        AllocationDecider allocationDecider = new AllocationDecider() {
+        DefaultAllocationDecider allocationDecider = new DefaultAllocationDecider() {
             @Override
             public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
                 if (excludeNodes.contains(node.nodeId())) {
@@ -224,13 +224,13 @@ public class BalancedSingleShardTests extends ESAllocationTestCase {
                 return Decision.YES;
             }
         };
-        AllocationDecider rebalanceDecider = new AllocationDecider() {
+        DefaultAllocationDecider rebalanceDecider = new DefaultAllocationDecider() {
             @Override
             public Decision canRebalance(ShardRouting shardRouting, RoutingAllocation allocation) {
                 return Decision.YES;
             }
         };
-        List<AllocationDecider> allocationDeciders = Arrays.asList(rebalanceDecider, allocationDecider);
+        List<DefaultAllocationDecider> allocationDeciders = Arrays.asList(rebalanceDecider, allocationDecider);
         RoutingAllocation routingAllocation = newRoutingAllocation(new AllocationDeciders(allocationDeciders), clusterState);
         // allocate and get the node that is now relocating
         BalancedShardsAllocator allocator = new BalancedShardsAllocator(Settings.EMPTY);
@@ -321,7 +321,7 @@ public class BalancedSingleShardTests extends ESAllocationTestCase {
         final ClusterState clusterState,
         final Set<String> noDecisionNodes
     ) {
-        AllocationDecider allocationDecider = new AllocationDecider() {
+        DefaultAllocationDecider allocationDecider = new DefaultAllocationDecider() {
             @Override
             public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
                 if (noDecisionNodes.contains(node.nodeId())) {
@@ -330,7 +330,7 @@ public class BalancedSingleShardTests extends ESAllocationTestCase {
                 return Decision.YES;
             }
         };
-        AllocationDecider rebalanceDecider = new AllocationDecider() {
+        DefaultAllocationDecider rebalanceDecider = new DefaultAllocationDecider() {
             @Override
             public Decision canRebalance(ShardRouting shardRouting, RoutingAllocation allocation) {
                 return Decision.YES;
@@ -358,17 +358,17 @@ public class BalancedSingleShardTests extends ESAllocationTestCase {
     }
 
     private Tuple<ClusterState, MoveDecision> setupStateAndRebalance(
-        AllocationDecider allocationDecider,
+        DefaultAllocationDecider allocationDecider,
         Settings balancerSettings,
         boolean rebalanceExpected
     ) {
-        AllocationDecider rebalanceDecider = new AllocationDecider() {
+        DefaultAllocationDecider rebalanceDecider = new DefaultAllocationDecider() {
             @Override
             public Decision canRebalance(ShardRouting shardRouting, RoutingAllocation allocation) {
                 return Decision.YES;
             }
         };
-        List<AllocationDecider> allocationDeciders = Arrays.asList(rebalanceDecider, allocationDecider);
+        List<DefaultAllocationDecider> allocationDeciders = Arrays.asList(rebalanceDecider, allocationDecider);
         final int numShards = randomIntBetween(8, 13);
         BalancedShardsAllocator allocator = new BalancedShardsAllocator(balancerSettings);
         ClusterState clusterState = ClusterStateCreationUtils.state("idx", 2, numShards);

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/RandomAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/RandomAllocationDeciderTests.java
@@ -24,9 +24,9 @@ import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
-import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.cluster.routing.allocation.decider.DefaultAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.ReplicaAfterPrimaryActiveAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.SameShardAllocationDecider;
 import org.elasticsearch.common.settings.Settings;
@@ -194,7 +194,7 @@ public class RandomAllocationDeciderTests extends ESAllocationTestCase {
         }
     }
 
-    public static final class RandomAllocationDecider extends AllocationDecider {
+    public static final class RandomAllocationDecider extends DefaultAllocationDecider {
 
         private final Random random;
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocatorTests.java
@@ -35,9 +35,9 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.allocation.AllocateUnassignedDecision;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
-import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.cluster.routing.allocation.decider.DefaultAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.Settings;
@@ -865,7 +865,7 @@ public class BalancedShardsAllocatorTests extends ESAllocationTestCase {
      * as the index they're from
      */
     private AllocationDeciders prefixAllocationDeciders() {
-        return new AllocationDeciders(List.of(new AllocationDecider() {
+        return new AllocationDeciders(List.of(new DefaultAllocationDecider() {
             @Override
             public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
                 return nodePrefixMatchesIndexPrefix(shardRouting, node);

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecidersTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecidersTests.java
@@ -246,11 +246,11 @@ public class AllocationDecidersTests extends ESAllocationTestCase {
         return new RoutingAllocation(deciders, ClusterState.builder(new ClusterName("test")).build(), null, null, 0L);
     }
 
-    private static final class AnyNodeInitialShardAllocationDecider extends AllocationDecider {
+    private static final class AnyNodeInitialShardAllocationDecider extends DefaultAllocationDecider {
 
     }
 
-    private static final class FixedNodesInitialShardAllocationDecider extends AllocationDecider {
+    private static final class FixedNodesInitialShardAllocationDecider extends DefaultAllocationDecider {
         private final Set<String> initialNodeIds;
 
         private FixedNodesInitialShardAllocationDecider(Set<String> initialNodeIds) {
@@ -263,7 +263,7 @@ public class AllocationDecidersTests extends ESAllocationTestCase {
         }
     }
 
-    private static final class TestAllocationDecider extends AllocationDecider {
+    private static final class TestAllocationDecider extends DefaultAllocationDecider {
 
         private final Supplier<Decision> decision;
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
@@ -1030,7 +1030,7 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
             clusterInfo,
             diskThresholdDecider,
             // fake allocation decider to block allocation of the `foo` shard
-            new AllocationDecider() {
+            new DefaultAllocationDecider() {
                 @Override
                 public Decision canAllocate(IndexMetadata indexMetadata, RoutingNode node, RoutingAllocation allocation) {
                     return cannotAllocateFooShards(indexMetadata.getIndex());

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationShortCircuitTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/EnableAllocationShortCircuitTests.java
@@ -226,7 +226,7 @@ public class EnableAllocationShortCircuitTests extends ESAllocationTestCase {
             return Collections.singletonList(new RebalanceShortCircuitAllocationDecider());
         }
 
-        private class RebalanceShortCircuitAllocationDecider extends AllocationDecider {
+        private class RebalanceShortCircuitAllocationDecider extends DefaultAllocationDecider {
 
             @Override
             public Decision canRebalance(ShardRouting shardRouting, RoutingAllocation allocation) {
@@ -250,7 +250,7 @@ public class EnableAllocationShortCircuitTests extends ESAllocationTestCase {
             return Collections.singletonList(new AllocateShortCircuitAllocationDecider());
         }
 
-        private class AllocateShortCircuitAllocationDecider extends AllocationDecider {
+        private class AllocateShortCircuitAllocationDecider extends DefaultAllocationDecider {
 
             @Override
             public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDeciderTests.java
@@ -207,7 +207,7 @@ public class RestoreInProgressAllocationDeciderTests extends ESAllocationTestCas
     }
 
     private Decision executeAllocation(final ClusterState clusterState, final ShardRouting shardRouting) {
-        final AllocationDecider decider = new RestoreInProgressAllocationDecider();
+        final var decider = new RestoreInProgressAllocationDecider();
         final RoutingAllocation allocation = new RoutingAllocation(
             new AllocationDeciders(Collections.singleton(decider)),
             clusterState,

--- a/server/src/test/java/org/elasticsearch/gateway/PrimaryShardAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/PrimaryShardAllocatorTests.java
@@ -243,7 +243,7 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
 
     /**
      * Tests that when the nodes with prior copies of the given shard all return a decision of NO, but
-     * {@link AllocationDecider#canForceAllocatePrimary(ShardRouting, RoutingNode, RoutingAllocation)}
+     * {@link AllocationDecider.ShardToNode#canForceAllocatePrimary(ShardRouting, RoutingNode, RoutingAllocation)}
      * returns a YES decision for at least one of those NO nodes, then we force allocate to one of them
      */
     public void testForceAllocatePrimary() {
@@ -267,7 +267,7 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
 
     /**
      * Tests that when the nodes with prior copies of the given shard all return a decision of NO, and
-     * {@link AllocationDecider#canForceAllocatePrimary(ShardRouting, RoutingNode, RoutingAllocation)}
+     * {@link AllocationDecider.ShardToNode#canForceAllocatePrimary(ShardRouting, RoutingNode, RoutingAllocation)}
      * returns a NO or THROTTLE decision for a node, then we do not force allocate to that node.
      */
     public void testDontAllocateOnNoOrThrottleForceAllocationDecision() {

--- a/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorTests.java
@@ -30,9 +30,9 @@ import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
-import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.cluster.routing.allocation.decider.DefaultAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.SameShardAllocationDecider;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.set.Sets;
@@ -372,7 +372,7 @@ public class ReplicaShardAllocatorTests extends ESAllocationTestCase {
                 Arrays.asList(
                     new TestAllocateDecision(Decision.YES),
                     new SameShardAllocationDecider(createBuiltInClusterSettings()),
-                    new AllocationDecider() {
+                    new DefaultAllocationDecider() {
                         @Override
                         public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
                             if (node.node().equals(node2)) {

--- a/test/framework/src/main/java/org/elasticsearch/cluster/ESAllocationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/ESAllocationTestCase.java
@@ -38,6 +38,7 @@ import org.elasticsearch.cluster.routing.allocation.allocator.ShardsAllocator;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.cluster.routing.allocation.decider.DefaultAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.SameShardAllocationDecider;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -346,7 +347,7 @@ public abstract class ESAllocationTestCase extends ESTestCase {
         return result;
     }
 
-    public static class TestAllocateDecision extends AllocationDecider {
+    public static class TestAllocateDecision extends DefaultAllocationDecider {
 
         private final Decision decision;
 

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ProactiveStorageDeciderServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ProactiveStorageDeciderServiceTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.cluster.routing.allocation.decider.DefaultAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -90,7 +91,7 @@ public class ProactiveStorageDeciderServiceTests extends AutoscalingTestCase {
         Collection<AllocationDecider> allocationDecidersList = new ArrayList<>(
             ClusterModule.createAllocationDeciders(Settings.EMPTY, clusterSettings, Collections.emptyList())
         );
-        allocationDecidersList.add(new AllocationDecider() {
+        allocationDecidersList.add(new DefaultAllocationDecider() {
             @Override
             public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
                 return allocation.decision(Decision.NO, DiskThresholdDecider.NAME, "test");

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderDecisionTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderDecisionTests.java
@@ -34,6 +34,7 @@ import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllo
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.cluster.routing.allocation.decider.DefaultAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider;
@@ -88,13 +89,13 @@ import static org.hamcrest.Matchers.sameInstance;
 public class ReactiveStorageDeciderDecisionTests extends AutoscalingTestCase {
     private static final Logger logger = LogManager.getLogger(ReactiveStorageDeciderDecisionTests.class);
 
-    private static final AllocationDecider CAN_ALLOCATE_NO_DECIDER = new AllocationDecider() {
+    private static final DefaultAllocationDecider CAN_ALLOCATE_NO_DECIDER = new DefaultAllocationDecider() {
         @Override
         public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
             return Decision.NO;
         }
     };
-    private static final AllocationDecider CAN_REMAIN_NO_DECIDER = new AllocationDecider() {
+    private static final DefaultAllocationDecider CAN_REMAIN_NO_DECIDER = new DefaultAllocationDecider() {
         @Override
         public Decision canRemain(IndexMetadata indexMetadata, ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
             return Decision.NO;
@@ -112,7 +113,7 @@ public class ReactiveStorageDeciderDecisionTests extends AutoscalingTestCase {
     // these are the shards that the decider tests work on
     private Set<ShardId> subjectShards;
     // say NO with disk label for subject shards
-    private final AllocationDecider mockCanAllocateDiskDecider = new AllocationDecider() {
+    private final DefaultAllocationDecider mockCanAllocateDiskDecider = new DefaultAllocationDecider() {
         @Override
         public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
             if (subjectShards.contains(shardRouting.shardId()) && node.node().getName().startsWith("hot")) {
@@ -122,7 +123,7 @@ public class ReactiveStorageDeciderDecisionTests extends AutoscalingTestCase {
         }
     };
     // say NO with disk label for subject shards
-    private final AllocationDecider mockCanRemainDiskDecider = new AllocationDecider() {
+    private final AllocationDecider mockCanRemainDiskDecider = new DefaultAllocationDecider() {
         @Override
         public Decision canRemain(IndexMetadata indexMetadata, ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
             if (subjectShards.contains(shardRouting.shardId()) && node.node().getName().startsWith("hot")) return allocation.decision(

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderServiceTests.java
@@ -36,6 +36,7 @@ import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.elasticsearch.cluster.routing.allocation.decider.AwarenessAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.cluster.routing.allocation.decider.DefaultAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.FilterAllocationDecider;
@@ -595,7 +596,7 @@ public class ReactiveStorageDeciderServiceTests extends AutoscalingTestCase {
             ShardRoutingState.STARTED
         );
 
-        AllocationDecider no = new AllocationDecider() {
+        DefaultAllocationDecider no = new DefaultAllocationDecider() {
             @Override
             public Decision canRemain(
                 IndexMetadata indexMetadata,
@@ -704,19 +705,19 @@ public class ReactiveStorageDeciderServiceTests extends AutoscalingTestCase {
             ShardRoutingState.STARTED
         );
 
-        AllocationDecider noFilter = new AllocationDecider() {
+        DefaultAllocationDecider noFilter = new DefaultAllocationDecider() {
             @Override
             public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
                 return Decision.single(Decision.Type.NO, FilterAllocationDecider.NAME, "test");
             }
         };
-        AllocationDecider noSameShard = new AllocationDecider() {
+        DefaultAllocationDecider noSameShard = new DefaultAllocationDecider() {
             @Override
             public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
                 return Decision.single(Decision.Type.NO, SameShardAllocationDecider.NAME, "test");
             }
         };
-        AllocationDecider no = new AllocationDecider() {
+        DefaultAllocationDecider no = new DefaultAllocationDecider() {
             @Override
             public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
                 return Decision.single(Decision.Type.NO, AwarenessAllocationDecider.NAME, "test");
@@ -732,7 +733,7 @@ public class ReactiveStorageDeciderServiceTests extends AutoscalingTestCase {
         ClusterState clusterState,
         ShardRouting shardRouting,
         boolean expected,
-        AllocationDecider... deciders
+        DefaultAllocationDecider... deciders
     ) {
         AllocationDeciders allocationDeciders = new AllocationDeciders(Arrays.asList(deciders));
         ReactiveStorageDeciderService.AllocationState allocationState = new ReactiveStorageDeciderService.AllocationState(

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/allocation/CcrPrimaryFollowerAllocationDecider.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/allocation/CcrPrimaryFollowerAllocationDecider.java
@@ -22,7 +22,7 @@ import org.elasticsearch.xpack.ccr.CcrSettings;
  * remote cluster client role. This is necessary as those nodes reach out to the leader shards on the remote cluster to copy Lucene segment
  * files and periodically renew retention leases during the bootstrap.
  */
-public final class CcrPrimaryFollowerAllocationDecider extends AllocationDecider {
+public final class CcrPrimaryFollowerAllocationDecider implements AllocationDecider.ShardToNode {
     static final String NAME = "ccr_primary_follower";
 
     @Override

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/allocation/CcrPrimaryFollowerAllocationDeciderTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/allocation/CcrPrimaryFollowerAllocationDeciderTests.java
@@ -213,7 +213,7 @@ public class CcrPrimaryFollowerAllocationDeciderTests extends ESAllocationTestCa
     }
 
     static Decision executeAllocation(ClusterState clusterState, ShardRouting shardRouting, DiscoveryNode node) {
-        final AllocationDecider decider = new CcrPrimaryFollowerAllocationDecider();
+        final AllocationDecider.ShardToNode decider = new CcrPrimaryFollowerAllocationDecider();
         final RoutingAllocation routingAllocation = new RoutingAllocation(
             new AllocationDeciders(List.of(decider)),
             RoutingNodes.immutable(clusterState.globalRoutingTable(), clusterState.nodes()),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDecider.java
@@ -34,7 +34,12 @@ import java.util.Set;
  * {@link org.elasticsearch.cluster.routing.allocation.decider.FilterAllocationDecider}, however it
  * is specific to the {@code _tier} setting for both the cluster and index level.
  */
-public final class DataTierAllocationDecider extends AllocationDecider {
+public final class DataTierAllocationDecider
+    implements
+        AllocationDecider.ShardToNode,
+        AllocationDecider.IndexToNode,
+        AllocationDecider.ShardRemain,
+        AllocationDecider.AutoExpandToNode {
 
     public static final String NAME = "data_tier";
 

--- a/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/ArchiveAllocationDecider.java
+++ b/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/ArchiveAllocationDecider.java
@@ -16,7 +16,11 @@ import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 
 import java.util.function.BooleanSupplier;
 
-public class ArchiveAllocationDecider extends AllocationDecider {
+public class ArchiveAllocationDecider
+    implements
+        AllocationDecider.ShardToNode,
+        AllocationDecider.ShardToCluster,
+        AllocationDecider.IndexToNode {
 
     static final String NAME = "archive";
 

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/SearchableSnapshotsBlobStoreCacheIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/SearchableSnapshotsBlobStoreCacheIntegTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.cluster.routing.allocation.DataTier;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.cluster.routing.allocation.decider.DefaultAllocationDecider;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
@@ -391,7 +392,7 @@ public class SearchableSnapshotsBlobStoreCacheIntegTests extends BaseFrozenSearc
                 return List.of();
             }
             final String name = "wait_for_snapshot_blob_cache_shards_active";
-            return List.of(new AllocationDecider() {
+            return List.of(new DefaultAllocationDecider() {
 
                 @Override
                 public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/decider/DedicatedFrozenNodeAllocationDecider.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/decider/DedicatedFrozenNodeAllocationDecider.java
@@ -18,7 +18,12 @@ import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 
 import static org.elasticsearch.cluster.node.DiscoveryNodeRole.DATA_FROZEN_NODE_ROLE;
 
-public class DedicatedFrozenNodeAllocationDecider extends AllocationDecider {
+public class DedicatedFrozenNodeAllocationDecider
+    implements
+        AllocationDecider.ShardToNode,
+        AllocationDecider.ShardRemain,
+        AllocationDecider.IndexToNode,
+        AllocationDecider.AutoExpandToNode {
 
     private static final String NAME = "dedicated_frozen_node";
 

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/decider/HasFrozenCacheAllocationDecider.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/decider/HasFrozenCacheAllocationDecider.java
@@ -18,7 +18,12 @@ import org.elasticsearch.xpack.searchablesnapshots.cache.shared.FrozenCacheInfoS
 
 import static org.elasticsearch.blobcache.shared.SharedBlobCacheService.SHARED_CACHE_SIZE_SETTING;
 
-public class HasFrozenCacheAllocationDecider extends AllocationDecider {
+public class HasFrozenCacheAllocationDecider
+    implements
+        AllocationDecider.ShardToNode,
+        AllocationDecider.IndexToNode,
+        AllocationDecider.ShardRemain,
+        AllocationDecider.AutoExpandToNode {
 
     private static final String NAME = "has_frozen_cache";
 

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/decider/SearchableSnapshotAllocationDecider.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/decider/SearchableSnapshotAllocationDecider.java
@@ -16,7 +16,11 @@ import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 
 import java.util.function.BooleanSupplier;
 
-public class SearchableSnapshotAllocationDecider extends AllocationDecider {
+public class SearchableSnapshotAllocationDecider
+    implements
+        AllocationDecider.ShardToNode,
+        AllocationDecider.ShardToCluster,
+        AllocationDecider.IndexToNode {
 
     static final String NAME = "searchable_snapshots";
 

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/decider/SearchableSnapshotEnableAllocationDecider.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/decider/SearchableSnapshotEnableAllocationDecider.java
@@ -17,7 +17,7 @@ import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDeci
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 
-public class SearchableSnapshotEnableAllocationDecider extends AllocationDecider {
+public class SearchableSnapshotEnableAllocationDecider implements AllocationDecider.ShardToNode, AllocationDecider.ShardToCluster {
 
     static final String NAME = "searchable_snapshots_enable";
 

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/decider/SearchableSnapshotRepositoryExistsAllocationDecider.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/decider/SearchableSnapshotRepositoryExistsAllocationDecider.java
@@ -23,7 +23,11 @@ import java.util.List;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots.SNAPSHOT_REPOSITORY_NAME_SETTING;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots.SNAPSHOT_REPOSITORY_UUID_SETTING;
 
-public class SearchableSnapshotRepositoryExistsAllocationDecider extends AllocationDecider {
+public class SearchableSnapshotRepositoryExistsAllocationDecider
+    implements
+        AllocationDecider.ShardToNode,
+        AllocationDecider.ShardToCluster,
+        AllocationDecider.IndexToNode {
 
     private static final String NAME = "searchable_snapshot_repository_exists";
 
@@ -38,21 +42,6 @@ public class SearchableSnapshotRepositoryExistsAllocationDecider extends Allocat
         NAME,
         "the repository containing the data for this index exists"
     );
-
-    @Override
-    public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
-        return allowAllocation(allocation.metadata().indexMetadata(shardRouting.index()), allocation);
-    }
-
-    @Override
-    public Decision canAllocate(ShardRouting shardRouting, RoutingAllocation allocation) {
-        return allowAllocation(allocation.metadata().indexMetadata(shardRouting.index()), allocation);
-    }
-
-    @Override
-    public Decision canAllocate(IndexMetadata indexMetadata, RoutingNode node, RoutingAllocation allocation) {
-        return allowAllocation(indexMetadata, allocation);
-    }
 
     private static Decision allowAllocation(IndexMetadata indexMetadata, RoutingAllocation allocation) {
         if (indexMetadata.isSearchableSnapshot()) {
@@ -96,5 +85,20 @@ public class SearchableSnapshotRepositoryExistsAllocationDecider extends Allocat
         } else {
             return YES_INAPPLICABLE;
         }
+    }
+
+    @Override
+    public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+        return allowAllocation(allocation.metadata().indexMetadata(shardRouting.index()), allocation);
+    }
+
+    @Override
+    public Decision canAllocate(ShardRouting shardRouting, RoutingAllocation allocation) {
+        return allowAllocation(allocation.metadata().indexMetadata(shardRouting.index()), allocation);
+    }
+
+    @Override
+    public Decision canAllocate(IndexMetadata indexMetadata, RoutingNode node, RoutingAllocation allocation) {
+        return allowAllocation(indexMetadata, allocation);
     }
 }

--- a/x-pack/plugin/shutdown/src/test/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusActionTests.java
+++ b/x-pack/plugin/shutdown/src/test/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusActionTests.java
@@ -31,9 +31,9 @@ import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.routing.allocation.Explanations;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
-import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.cluster.routing.allocation.decider.DefaultAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.NodeReplacementAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.NodeShutdownAllocationDecider;
 import org.elasticsearch.common.settings.Settings;
@@ -106,7 +106,7 @@ public class TransportGetShutdownStatusActionTests extends ESTestCase {
 
         clusterInfoService = EmptyClusterInfoService.INSTANCE;
         allocationDeciders = new AllocationDeciders(
-            List.of(new NodeShutdownAllocationDecider(), new NodeReplacementAllocationDecider(), new AllocationDecider() {
+            List.of(new NodeShutdownAllocationDecider(), new NodeReplacementAllocationDecider(), new DefaultAllocationDecider() {
                 @Override
                 public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
                     return canAllocate.get().test(shardRouting, node, allocation);


### PR DESCRIPTION
This change splits `AllocationDecider` into collection of interfaces. This should help with applying deciders that implement interfaces rather than calling all of them with default "Decision.ALWAYS" result. Every decider now explicitly tell which interface it implements:

```java
public class DiskThresholdDecider extends AllocationDecider {
// become
public class DiskThresholdDecider
    implements
        AllocationDecider.ShardToNode,
        AllocationDecider.ForceDuringReplace,
        AllocationDecider.ShardRemain {
```

So `AllocationDeciders` can use this type information to group deciders for specific API call.

```java
    public Decision canAllocate(ShardRouting shardRouting, RoutingAllocation allocation) {
        return withDeciders(
            allocation,
            shardToClusterDeciders, // explicitly pass which deciders to use
            decider -> decider.canAllocate(shardRouting, allocation),
            (decider, decision) -> Strings.format("Can not allocate [%s] on any node. [%s]: %s", shardRouting, decider, decision)
        );
    }
```

For testing ease added a new class DefaultAllocationDecider that uses previous behaviour of abstract class with "Decision.ALWAYS".

Major change in `AllocationDecider` and `AllocationDeciders`. I do preserve default behaviour. Especially for ShardToNode decider that combines `canAllocate`, `canForceAllocatePrimary`, and `canAllocateReplicaWhenThereIsRetentionLease`, since later two depends on `canAllocate`.