### PR TITLE
Change match_only_text's value fetcher to use `SortedBinaryDocValues` instead of interacting with doc values api directly.

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/logsdb/20_synthetic_source.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/logsdb/20_synthetic_source.yml
@@ -1,0 +1,149 @@
+---
+synthetic_source match_only_text with wildcard as parent field:
+  - requires:
+      cluster_features: [ "mapper.source.mode_from_index_setting" ]
+      reason: "Source mode configured through index setting"
+
+  - do:
+      indices.create:
+        index: synthetic_source_test
+        body:
+          settings:
+            index:
+              mapping.source.mode: synthetic
+          mappings:
+            properties:
+              foo:
+                type: wildcard
+                fields:
+                  text:
+                    type: match_only_text
+
+  - do:
+      index:
+        index: synthetic_source_test
+        id:    "1"
+        refresh: true
+        body:
+          foo: "Apache Lucene powers Elasticsearch"
+
+  - do:
+      search:
+        index: synthetic_source_test
+        body:
+          query:
+            match_phrase:
+              foo.text: apache lucene
+
+  - match: { "hits.total.value": 1 }
+  - match:
+      hits.hits.0._source.foo: "Apache Lucene powers Elasticsearch"
+
+---
+synthetic_source match_only_text with number as parent field:
+  - requires:
+      cluster_features: [ "mapper.source.mode_from_index_setting" ]
+      reason: "Source mode configured through index setting"
+
+  - do:
+      indices.create:
+        index: synthetic_source_test
+        body:
+          settings:
+            index:
+              mapping.source.mode: synthetic
+          mappings:
+            properties:
+              foo:
+                type: long
+                fields:
+                  text:
+                    type: match_only_text
+
+  - do:
+      index:
+        index: synthetic_source_test
+        id:    "1"
+        refresh: true
+        body:
+          foo: [1, 5]
+
+  - do:
+      search:
+        index: synthetic_source_test
+        body:
+          query:
+            match_phrase:
+              foo.text: 1 5
+
+  - match: { "hits.total.value": 0 }
+
+  - do:
+      indices.create:
+        index: stored_source_test
+        body:
+          mappings:
+            properties:
+              foo:
+                type: long
+                fields:
+                  text:
+                    type: match_only_text
+
+  - do:
+      index:
+        index: stored_source_test
+        id:    "1"
+        refresh: true
+        body:
+          foo: [1, 5]
+
+  - do:
+      search:
+        index: stored_source_test
+        body:
+          query:
+            match_phrase:
+              foo.text: 1 5
+
+  - match: { "hits.total.value": 0 }
+
+---
+synthetic_source match_only_text with scaled_float as parent field:
+  - requires:
+      cluster_features: [ "mapper.source.mode_from_index_setting" ]
+      reason: "Source mode configured through index setting"
+
+  - do:
+      indices.create:
+        index: synthetic_source_test
+        body:
+          settings:
+            index:
+              mapping.source.mode: synthetic
+          mappings:
+            properties:
+              foo:
+                type: scaled_float
+                scaling_factor: 10
+                fields:
+                  text:
+                    type: match_only_text
+
+  - do:
+      index:
+        index: synthetic_source_test
+        id:    "1"
+        refresh: true
+        body:
+          foo: [1.1, 5.5]
+
+  - do:
+      search:
+        index: synthetic_source_test
+        body:
+          query:
+            match_phrase:
+              foo.text: 1.1 5.5
+
+  - match: { "hits.total.value": 0 }


### PR DESCRIPTION
Backporting #130854 to 8.19 branch.

This pulls #130845 into the serverless fix branch for patch deployment.  Original description:

Change match_only_text's value fetcher to use SortedBinaryDocValues instead of interacting with doc values api directly.

This way, via field data abstraction, the right doc values type is used, and the right conversions happen. Values of all field types will get converted to strings.