### PR TITLE
[9.1] fix: enable date_detection for all apm data streams

### DIFF
--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/apm@mappings.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/apm@mappings.yaml
@@ -4,6 +4,7 @@ _meta:
   managed: true
 template:
   mappings:
+    date_detection: false
     dynamic: true
     dynamic_templates:
     - numeric_labels:

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm@mappings.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm@mappings.yaml
@@ -6,6 +6,8 @@ _meta:
 template:
   mappings:
     properties:
+      system.process.cpu.start_time:
+        type: date
       processor.event:
         type: constant_keyword
         value: metric

--- a/x-pack/plugin/apm-data/src/main/resources/resources.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/resources.yaml
@@ -1,7 +1,7 @@
 # "version" holds the version of the templates and ingest pipelines installed
 # by xpack-plugin apm-data. This must be increased whenever an existing template or
 # pipeline is changed, in order for it to be updated on Elasticsearch upgrade.
-version: 100
+version: 101
 
 component-templates:
   # Data lifecycle.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [fix: enable date_detection for all apm data streams (#130466)](https://github.com/elastic/elasticsearch/pull/130466)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)