### PR TITLE
[DOCS][8.x]:Update depreciation notice for index mapping updates privileges

### DIFF
--- a/docs/reference/security/authorization/privileges.asciidoc
+++ b/docs/reference/security/authorization/privileges.asciidoc
@@ -328,11 +328,11 @@ be mapped rather than an explicit <<indices-put-mapping,update mapping>> request
 `create`::
 Privilege to index documents.
 +
-deprecated:[8.0] Also grants the permission to update the index mapping (but
-not the data streams mapping), using
-the {ref}/indices-put-mapping.html[updating mapping API] or by relying on
-{ref}/dynamic-mapping.html[dynamic field mapping]. In a future major release,
-this privilege will not grant any mapping update permissions.
+deprecated:[8.0] Starting from 8.0, this privilege no longer grants the permission 
+to update index mappings. In earlier versions, it implicitly permitted index mapping 
+updates (excluding data stream mappings) via the {ref}/indices-put-mapping.html[updating mapping API] 
+or through {ref}/dynamic-mapping.html[dynamic field mapping]. 
+Mapping update capabilities will be fully removed in a future major release.
 +
 --
 NOTE: This privilege does not restrict the index operation to the creation
@@ -346,11 +346,11 @@ privilege for an alternative.
 Privilege to index documents.
 It does not grant the permission to update or overwrite existing documents.
 +
-deprecated:[8.0] Also grants the permission to update the index mapping (but
-not the data streams mapping), using
-the {ref}/indices-put-mapping.html[updating mapping API] or by relying on
-{ref}/dynamic-mapping.html[dynamic field mapping]. In a future major release,
-this privilege will not grant any mapping update permissions.
+deprecated:[8.0] Starting from 8.0, this privilege no longer grants the permission 
+to update index mappings. In earlier versions, it implicitly permitted index mapping 
+updates (excluding data stream mappings) via the {ref}/indices-put-mapping.html[updating mapping API] 
+or through {ref}/dynamic-mapping.html[dynamic field mapping]. 
+Mapping update capabilities will be fully removed in a future major release.
 +
 --
 [NOTE]
@@ -403,11 +403,11 @@ Privilege to delete an index or data stream.
 `index`::
 Privilege to index and update documents.
 +
-deprecated:[8.0] Also grants the permission to update the index mapping (but
-not the data streams mapping), using
-the {ref}/indices-put-mapping.html[updating mapping API] or by relying on
-{ref}/dynamic-mapping.html[dynamic field mapping]. In a future major release,
-this privilege will not grant any mapping update permissions.
+deprecated:[8.0] Starting from 8.0, this privilege no longer grants the permission 
+to update index mappings. In earlier versions, it implicitly permitted index mapping 
+updates (excluding data stream mappings) via the {ref}/indices-put-mapping.html[updating mapping API] 
+or through {ref}/dynamic-mapping.html[dynamic field mapping]. 
+Mapping update capabilities will be fully removed in a future major release.
 
 `maintenance`::
 Permits refresh, flush, synced flush and force merge index administration operations.
@@ -468,9 +468,11 @@ Privilege to perform all write operations to documents, which includes the
 permission to index, update, and delete documents as well as performing bulk
 operations, while also allowing to dynamically update the index mapping.
 +
-deprecated:[8.0] It also grants the permission to update the index mapping (but
-not the data streams mapping), using the {ref}/indices-put-mapping.html[updating mapping API].
-This will be retracted in a future major release.
+deprecated:[8.0] Starting from 8.0, this privilege no longer grants the permission 
+to update index mappings. In earlier versions, it implicitly permitted index mapping 
+updates (excluding data stream mappings) via the {ref}/indices-put-mapping.html[updating mapping API] 
+or through {ref}/dynamic-mapping.html[dynamic field mapping]. 
+Mapping update capabilities will be fully removed in a future major release.
 
 
 ==== Run as privilege

--- a/docs/reference/security/authorization/privileges.asciidoc
+++ b/docs/reference/security/authorization/privileges.asciidoc
@@ -328,7 +328,7 @@ be mapped rather than an explicit <<indices-put-mapping,update mapping>> request
 `create`::
 Privilege to index documents.
 +
-deprecated:[8.0] Starting from 8.0, this privilege no longer grants the permission 
+IMPORTANT: Starting from 8.0, this privilege no longer grants the permission 
 to update index mappings. In earlier versions, it implicitly permitted index mapping 
 updates (excluding data stream mappings) via the {ref}/indices-put-mapping.html[updating mapping API] 
 or through {ref}/dynamic-mapping.html[dynamic field mapping]. 
@@ -346,7 +346,7 @@ privilege for an alternative.
 Privilege to index documents.
 It does not grant the permission to update or overwrite existing documents.
 +
-deprecated:[8.0] Starting from 8.0, this privilege no longer grants the permission 
+IMPORTANT: Starting from 8.0, this privilege no longer grants the permission 
 to update index mappings. In earlier versions, it implicitly permitted index mapping 
 updates (excluding data stream mappings) via the {ref}/indices-put-mapping.html[updating mapping API] 
 or through {ref}/dynamic-mapping.html[dynamic field mapping]. 
@@ -403,7 +403,7 @@ Privilege to delete an index or data stream.
 `index`::
 Privilege to index and update documents.
 +
-deprecated:[8.0] Starting from 8.0, this privilege no longer grants the permission 
+IMPORTANT: Starting from 8.0, this privilege no longer grants the permission 
 to update index mappings. In earlier versions, it implicitly permitted index mapping 
 updates (excluding data stream mappings) via the {ref}/indices-put-mapping.html[updating mapping API] 
 or through {ref}/dynamic-mapping.html[dynamic field mapping]. 
@@ -468,7 +468,7 @@ Privilege to perform all write operations to documents, which includes the
 permission to index, update, and delete documents as well as performing bulk
 operations, while also allowing to dynamically update the index mapping.
 +
-deprecated:[8.0] Starting from 8.0, this privilege no longer grants the permission 
+IMPORTANT: Starting from 8.0, this privilege no longer grants the permission 
 to update index mappings. In earlier versions, it implicitly permitted index mapping 
 updates (excluding data stream mappings) via the {ref}/indices-put-mapping.html[updating mapping API] 
 or through {ref}/dynamic-mapping.html[dynamic field mapping]. 


### PR DESCRIPTION
This PR updates the depreciation notice for 4 write-related operations on indices: (8.x asciidoc version)

- `create`
- `create_doc`
- `index`
- `write`

Based on: https://github.com/elastic/docs-content/issues/1668
9.x Version: https://github.com/elastic/elasticsearch/pull/130894