### PR TITLE
[8.18] Add watcher YAML REST tests to restResourcesZip (#130805)

### DIFF
--- a/x-pack/rest-resources-zip/build.gradle
+++ b/x-pack/rest-resources-zip/build.gradle
@@ -29,6 +29,7 @@ dependencies {
   platinumTests project(path: ':x-pack:plugin:eql:qa:rest', configuration: 'restXpackTests')
   platinumTests project(path: ':x-pack:plugin:ent-search', configuration: 'restXpackTests')
   platinumTests project(path: ':x-pack:plugin:inference', configuration: 'restXpackTests')
+  platinumTests project(path: ':x-pack:plugin:watcher:qa:rest', configuration: 'restXpackTests')
   platinumCompatTests project(path: ':x-pack:plugin', configuration: 'restCompatTests')
   platinumCompatTests project(path: ':x-pack:plugin:eql:qa:rest', configuration: 'restCompatTests')
 }


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Add watcher YAML REST tests to restResourcesZip (#130805)