### PR TITLE
Allow filtering of operator requests in `ApiFilteringActionFilter`

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/api/filtering/ApiFilteringActionFilter.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/api/filtering/ApiFilteringActionFilter.java
@@ -22,14 +22,25 @@ public abstract class ApiFilteringActionFilter<Res extends ActionResponse> imple
     private final ThreadContext threadContext;
     private final String actionName;
     private final Class<Res> responseClass;
+    private final boolean filterOperatorRequests;
 
     protected ApiFilteringActionFilter(ThreadContext threadContext, String actionName, Class<Res> responseClass) {
+        this(threadContext, actionName, responseClass, false);
+    }
+
+    protected ApiFilteringActionFilter(
+        ThreadContext threadContext,
+        String actionName,
+        Class<Res> responseClass,
+        boolean filterOperatorRequests
+    ) {
         assert threadContext != null : "threadContext cannot be null";
         assert actionName != null : "actionName cannot be null";
         assert responseClass != null : "responseClass cannot be null";
         this.threadContext = threadContext;
         this.actionName = actionName;
         this.responseClass = responseClass;
+        this.filterOperatorRequests = filterOperatorRequests;
     }
 
     @Override
@@ -46,7 +57,7 @@ public abstract class ApiFilteringActionFilter<Res extends ActionResponse> imple
         ActionFilterChain<Request, Response> chain
     ) {
         final ActionListener<Response> responseFilteringListener;
-        if (isOperator(threadContext) == false && actionName.equals(action)) {
+        if ((filterOperatorRequests || isOperator(threadContext) == false) && actionName.equals(action)) {
             responseFilteringListener = listener.map(this::filter);
         } else {
             responseFilteringListener = listener;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/api/filtering/ApiFilteringActionFilterTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/api/filtering/ApiFilteringActionFilterTests.java
@@ -30,7 +30,7 @@ public class ApiFilteringActionFilterTests extends ESTestCase {
         boolean isOperator = randomBoolean();
         final ThreadContext threadContext = getTestThreadContext(isOperator);
         String action = "test.action";
-        ApiFilteringActionFilter<TestResponse> filter = new TestFilter(threadContext);
+        ApiFilteringActionFilter<TestResponse> filter = new TestFilter(threadContext, false);
         Task task = null;
         TestRequest request = new TestRequest();
         AtomicBoolean listenerCalled = new AtomicBoolean(false);
@@ -57,6 +57,37 @@ public class ApiFilteringActionFilterTests extends ESTestCase {
         assertThat(listenerCalled.get(), equalTo(true));
         // The response should only have been modified if we are not an operator user
         assertThat(responseModified.get(), equalTo(isOperator == false));
+    }
+
+    public void testApplyAsOperator() {
+        final ThreadContext threadContext = getTestThreadContext(true);
+        ApiFilteringActionFilter<TestResponse> filter = new TestFilter(threadContext, true);
+        Task task = null;
+        TestRequest request = new TestRequest();
+        AtomicBoolean listenerCalled = new AtomicBoolean(false);
+        AtomicBoolean responseModified = new AtomicBoolean(false);
+        ActionListener<TestResponse> listener = new ActionListener<>() {
+            @Override
+            public void onResponse(TestResponse testResponse) {
+                listenerCalled.set(true);
+                responseModified.set(testResponse.modified);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                fail(Strings.format("Unexpected exception: %s", e.getMessage()));
+            }
+        };
+        ActionFilterChain<TestRequest, TestResponse> chain = (task1, action1, request1, listener1) -> {
+            listener1.onResponse(new TestResponse());
+        };
+        filter.apply(task, "wrong.action", request, listener, chain);
+        assertThat(listenerCalled.get(), equalTo(true));
+        assertThat(responseModified.get(), equalTo(false));
+        filter.apply(task, "test.action", request, listener, chain);
+        assertThat(listenerCalled.get(), equalTo(true));
+        // The response should always be modified
+        assertThat(responseModified.get(), equalTo(true));
     }
 
     public void testApplyWithException() {
@@ -94,8 +125,8 @@ public class ApiFilteringActionFilterTests extends ESTestCase {
 
     private static class TestFilter extends ApiFilteringActionFilter<TestResponse> {
 
-        TestFilter(ThreadContext threadContext) {
-            super(threadContext, "test.action", TestResponse.class);
+        TestFilter(ThreadContext threadContext, boolean filterOperatorRequests) {
+            super(threadContext, "test.action", TestResponse.class, filterOperatorRequests);
         }
 
         @Override


### PR DESCRIPTION
There may be cases where we want to filter transport action responses even for operator requests. This adds an optional constructor to `ApiFilteringActionFilter` to explicitly specify if operator requests should be filtered. The default behavior is still to _not_ filter operator requests.