### PR TITLE
Fixing DataStreamDeprecationCheckerTests.testOldIndicesCheckWithOnlyNewIndices()

### DIFF
--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/DataStreamDeprecationCheckerTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/DataStreamDeprecationCheckerTests.java
@@ -75,7 +75,7 @@ public class DataStreamDeprecationCheckerTests extends ESTestCase {
 
     public void testOldIndicesCheckWithOnlyNewIndices() {
         // This tests what happens when any old indices that we have are closed. We expect no deprecation warning.
-        int newOpenIndexCount = randomIntBetween(0, 100);
+        int newOpenIndexCount = randomIntBetween(1, 100);
         int newClosedIndexCount = randomIntBetween(0, 100);
 
         Map<String, IndexMetadata> nameToIndexMetadata = new HashMap<>();


### PR DESCRIPTION
Fixing DataStreamDeprecationCheckerTests.testOldIndicesCheckWithOnlyNewIndices() fails if it attempts to create a data stream with 0 backing indices. This happens if both `newOpenIndexCount` and `newClosedIndexCount` are randomly 0, which happens less than 1 in 10,000 times.
Closes #130285