### PR TITLE
Fixing PipelineFactoryTests.testCreateUnsupportedFieldAccessPattern()

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -495,9 +495,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.inference.bulk.BulkInferenceExecutorTests
   method: testSuccessfulExecution
   issue: https://github.com/elastic/elasticsearch/issues/130306
-- class: org.elasticsearch.ingest.PipelineFactoryTests
-  method: testCreateUnsupportedFieldAccessPattern
-  issue: https://github.com/elastic/elasticsearch/issues/130422
 - class: org.elasticsearch.test.rest.yaml.RcsCcsCommonYamlTestSuiteIT
   method: test {p0=msearch/20_typed_keys/Multisearch test with typed_keys parameter for sampler and significant terms}
   issue: https://github.com/elastic/elasticsearch/issues/130472

--- a/server/src/test/java/org/elasticsearch/ingest/PipelineFactoryTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/PipelineFactoryTests.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assume.assumeTrue;
 import static org.mockito.Mockito.mock;
 
 public class PipelineFactoryTests extends ESTestCase {
@@ -221,12 +222,15 @@ public class PipelineFactoryTests extends ESTestCase {
     }
 
     public void testCreateUnsupportedFieldAccessPattern() throws Exception {
+        assumeTrue("Test is only valid if the logs stream feature flag is enabled", DataStream.LOGS_STREAM_FEATURE_FLAG);
         Map<String, Object> processorConfig = new HashMap<>();
         processorConfig.put(ConfigurationUtils.TAG_KEY, "test-processor");
         Map<String, Object> pipelineConfig = new HashMap<>();
         pipelineConfig.put(Pipeline.DESCRIPTION_KEY, "_description");
         pipelineConfig.put(Pipeline.VERSION_KEY, versionString);
-        pipelineConfig.put(Pipeline.FIELD_ACCESS_PATTERN, "random");
+        if (DataStream.LOGS_STREAM_FEATURE_FLAG) {
+            pipelineConfig.put(Pipeline.FIELD_ACCESS_PATTERN, "random");
+        }
         if (metadata != null) {
             pipelineConfig.put(Pipeline.META_KEY, metadata);
         }


### PR DESCRIPTION
If testCreateUnsupportedFieldAccessPattern() is run with `-Dbuild.snapshot=false` then the logs stream feature flag is not enabled and the test fails. This change makes it so that the test only runs if the logs stream is enabled.
Closes #130422