### PR TITLE
[main]Prepare Index Like fix for backport to 9.1 and 8.19

### DIFF
--- a/docs/changelog/130947.yaml
+++ b/docs/changelog/130947.yaml
@@ -1,0 +1,5 @@
+pr: 130947
+summary: "[main]Prepare Index Like fix for backport to 9.1 and 8.19"
+area: ES|QL
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -211,6 +211,7 @@ public class TransportVersions {
     public static final TransportVersion ESQL_DOCUMENTS_FOUND_AND_VALUES_LOADED_8_19 = def(8_841_0_61);
     public static final TransportVersion ESQL_PROFILE_INCLUDE_PLAN_8_19 = def(8_841_0_62);
     public static final TransportVersion ESQL_SPLIT_ON_BIG_VALUES_8_19 = def(8_841_0_63);
+    public static final TransportVersion ESQL_FIXED_INDEX_LIKE_8_19 = def(8_841_0_64);
     public static final TransportVersion V_9_0_0 = def(9_000_0_09);
     public static final TransportVersion INITIAL_ELASTICSEARCH_9_0_1 = def(9_000_0_10);
     public static final TransportVersion INITIAL_ELASTICSEARCH_9_0_2 = def(9_000_0_11);
@@ -328,6 +329,7 @@ public class TransportVersions {
     public static final TransportVersion ESQL_PROFILE_INCLUDE_PLAN = def(9_111_0_00);
     public static final TransportVersion MAPPINGS_IN_DATA_STREAMS = def(9_112_0_00);
     public static final TransportVersion ESQL_SPLIT_ON_BIG_VALUES_9_1 = def(9_112_0_01);
+    public static final TransportVersion ESQL_FIXED_INDEX_LIKE_9_1 = def(9_112_0_02);
     // Below is the first version in 9.2 and NOT in 9.1.
     public static final TransportVersion PROJECT_STATE_REGISTRY_RECORDS_DELETIONS = def(9_113_0_00);
     public static final TransportVersion ESQL_SERIALIZE_TIMESERIES_FIELD_TYPE = def(9_114_0_00);

--- a/server/src/main/java/org/elasticsearch/index/query/WildcardQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/WildcardQueryBuilder.java
@@ -31,9 +31,6 @@ import org.elasticsearch.xcontent.XContentParser;
 import java.io.IOException;
 import java.util.Objects;
 
-import static org.elasticsearch.TransportVersions.ESQL_FIXED_INDEX_LIKE_8_19;
-import static org.elasticsearch.TransportVersions.ESQL_FIXED_INDEX_LIKE_9_1;
-
 /**
  * Implements the wildcard search query. Supported wildcards are {@code *}, which
  * matches any character sequence (including the empty one), and {@code ?},
@@ -107,9 +104,7 @@ public class WildcardQueryBuilder extends AbstractQueryBuilder<WildcardQueryBuil
         value = in.readString();
         rewrite = in.readOptionalString();
         caseInsensitive = in.readBoolean();
-        if (in.getTransportVersion().onOrAfter(TransportVersions.ESQL_FIXED_INDEX_LIKE)
-            || in.getTransportVersion().isPatchFrom(ESQL_FIXED_INDEX_LIKE_8_19)
-            || in.getTransportVersion().isPatchFrom(ESQL_FIXED_INDEX_LIKE_9_1)) {
+        if (expressionTransportSupported(in.getTransportVersion())) {
             forceStringMatch = in.readBoolean();
         } else {
             forceStringMatch = false;
@@ -122,11 +117,18 @@ public class WildcardQueryBuilder extends AbstractQueryBuilder<WildcardQueryBuil
         out.writeString(value);
         out.writeOptionalString(rewrite);
         out.writeBoolean(caseInsensitive);
-        if (out.getTransportVersion().onOrAfter(TransportVersions.ESQL_FIXED_INDEX_LIKE)
-            || out.getTransportVersion().isPatchFrom(ESQL_FIXED_INDEX_LIKE_8_19)
-            || out.getTransportVersion().isPatchFrom(ESQL_FIXED_INDEX_LIKE_9_1)) {
+        if (expressionTransportSupported(out.getTransportVersion())) {
             out.writeBoolean(forceStringMatch);
         }
+    }
+
+    /**
+     * Returns true if the Transport version is compatible with ESQL_FIXED_INDEX_LIKE
+     */
+    public static boolean expressionTransportSupported(TransportVersion version) {
+        return version.onOrAfter(TransportVersions.ESQL_FIXED_INDEX_LIKE)
+            || version.isPatchFrom(TransportVersions.ESQL_FIXED_INDEX_LIKE_8_19)
+            || version.isPatchFrom(TransportVersions.ESQL_FIXED_INDEX_LIKE_9_1);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/query/WildcardQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/WildcardQueryBuilder.java
@@ -31,6 +31,9 @@ import org.elasticsearch.xcontent.XContentParser;
 import java.io.IOException;
 import java.util.Objects;
 
+import static org.elasticsearch.TransportVersions.ESQL_FIXED_INDEX_LIKE_8_19;
+import static org.elasticsearch.TransportVersions.ESQL_FIXED_INDEX_LIKE_9_1;
+
 /**
  * Implements the wildcard search query. Supported wildcards are {@code *}, which
  * matches any character sequence (including the empty one), and {@code ?},
@@ -104,7 +107,9 @@ public class WildcardQueryBuilder extends AbstractQueryBuilder<WildcardQueryBuil
         value = in.readString();
         rewrite = in.readOptionalString();
         caseInsensitive = in.readBoolean();
-        if (in.getTransportVersion().onOrAfter(TransportVersions.ESQL_FIXED_INDEX_LIKE)) {
+        if (in.getTransportVersion().onOrAfter(TransportVersions.ESQL_FIXED_INDEX_LIKE)
+            || in.getTransportVersion().isPatchFrom(ESQL_FIXED_INDEX_LIKE_8_19)
+            || in.getTransportVersion().isPatchFrom(ESQL_FIXED_INDEX_LIKE_9_1)) {
             forceStringMatch = in.readBoolean();
         } else {
             forceStringMatch = false;
@@ -117,7 +122,9 @@ public class WildcardQueryBuilder extends AbstractQueryBuilder<WildcardQueryBuil
         out.writeString(value);
         out.writeOptionalString(rewrite);
         out.writeBoolean(caseInsensitive);
-        if (out.getTransportVersion().onOrAfter(TransportVersions.ESQL_FIXED_INDEX_LIKE)) {
+        if (out.getTransportVersion().onOrAfter(TransportVersions.ESQL_FIXED_INDEX_LIKE)
+            || out.getTransportVersion().isPatchFrom(ESQL_FIXED_INDEX_LIKE_8_19)
+            || out.getTransportVersion().isPatchFrom(ESQL_FIXED_INDEX_LIKE_9_1)) {
             out.writeBoolean(forceStringMatch);
         }
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/regex/WildcardLikeList.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/regex/WildcardLikeList.java
@@ -35,6 +35,9 @@ import java.io.IOException;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.TransportVersions.ESQL_FIXED_INDEX_LIKE_8_19;
+import static org.elasticsearch.TransportVersions.ESQL_FIXED_INDEX_LIKE_9_1;
+
 public class WildcardLikeList extends RegexMatch<WildcardPatternList> {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
         Expression.class,
@@ -145,7 +148,10 @@ public class WildcardLikeList extends RegexMatch<WildcardPatternList> {
     }
 
     private boolean supportsPushdown(TransportVersion version) {
-        return version == null || version.onOrAfter(TransportVersions.ESQL_FIXED_INDEX_LIKE);
+        return version == null
+            || version.onOrAfter(TransportVersions.ESQL_FIXED_INDEX_LIKE)
+            || version.isPatchFrom(ESQL_FIXED_INDEX_LIKE_8_19)
+            || version.isPatchFrom(ESQL_FIXED_INDEX_LIKE_9_1);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/regex/WildcardLikeList.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/regex/WildcardLikeList.java
@@ -11,7 +11,6 @@ import org.apache.lucene.search.MultiTermQuery.RewriteMethod;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.CharacterRunAutomaton;
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -35,8 +34,7 @@ import java.io.IOException;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import static org.elasticsearch.TransportVersions.ESQL_FIXED_INDEX_LIKE_8_19;
-import static org.elasticsearch.TransportVersions.ESQL_FIXED_INDEX_LIKE_9_1;
+import static org.elasticsearch.index.query.WildcardQueryBuilder.expressionTransportSupported;
 
 public class WildcardLikeList extends RegexMatch<WildcardPatternList> {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
@@ -148,10 +146,7 @@ public class WildcardLikeList extends RegexMatch<WildcardPatternList> {
     }
 
     private boolean supportsPushdown(TransportVersion version) {
-        return version == null
-            || version.onOrAfter(TransportVersions.ESQL_FIXED_INDEX_LIKE)
-            || version.isPatchFrom(ESQL_FIXED_INDEX_LIKE_8_19)
-            || version.isPatchFrom(ESQL_FIXED_INDEX_LIKE_9_1);
+        return version == null || expressionTransportSupported(version);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanStreamWrapperQueryBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanStreamWrapperQueryBuilder.java
@@ -20,6 +20,8 @@ import org.elasticsearch.xpack.esql.session.Configuration;
 
 import java.io.IOException;
 
+import static org.elasticsearch.index.query.WildcardQueryBuilder.expressionTransportSupported;
+
 /**
  * A {@link QueryBuilder} that wraps another {@linkplain QueryBuilder}
  * so it read with a {@link PlanStreamInput}.
@@ -58,9 +60,7 @@ public class PlanStreamWrapperQueryBuilder implements QueryBuilder {
 
     @Override
     public boolean supportsVersion(TransportVersion version) {
-        return version.onOrAfter(TransportVersions.ESQL_FIXED_INDEX_LIKE)
-            || version.isPatchFrom(TransportVersions.ESQL_FIXED_INDEX_LIKE_8_19)
-            || version.isPatchFrom(TransportVersions.ESQL_FIXED_INDEX_LIKE_9_1);
+        return expressionTransportSupported(version);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanStreamWrapperQueryBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanStreamWrapperQueryBuilder.java
@@ -57,6 +57,13 @@ public class PlanStreamWrapperQueryBuilder implements QueryBuilder {
     }
 
     @Override
+    public boolean supportsVersion(TransportVersion version) {
+        return version.onOrAfter(TransportVersions.ESQL_FIXED_INDEX_LIKE)
+            || version.isPatchFrom(TransportVersions.ESQL_FIXED_INDEX_LIKE_8_19)
+            || version.isPatchFrom(TransportVersions.ESQL_FIXED_INDEX_LIKE_9_1);
+    }
+
+    @Override
     public Query toQuery(SearchExecutionContext context) throws IOException {
         return next.toQuery(context);
     }


### PR DESCRIPTION
Add transport versions to prepare for backport of https://github.com/elastic/elasticsearch/pull/130849 to 9.1 and 8.19 