### PR TITLE
[8.18] Making sure we never have zero backing indices (#130945)

### DIFF
--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/DataStreamDeprecationCheckerTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/DataStreamDeprecationCheckerTests.java
@@ -77,7 +77,7 @@ public class DataStreamDeprecationCheckerTests extends ESTestCase {
 
     public void testOldIndicesCheckWithOnlyNewIndices() {
         // This tests what happens when any old indices that we have are closed. We expect no deprecation warning.
-        int newOpenIndexCount = randomIntBetween(0, 100);
+        int newOpenIndexCount = randomIntBetween(1, 100);
         int newClosedIndexCount = randomIntBetween(0, 100);
 
         Map<String, IndexMetadata> nameToIndexMetadata = new HashMap<>();


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Making sure we never have zero backing indices (#130945)