### PR TITLE
[docs] Remove references to old lifecycles

### DIFF
--- a/docs/reference/search-connectors/elastic-managed-connectors.md
+++ b/docs/reference/search-connectors/elastic-managed-connectors.md
@@ -1,6 +1,6 @@
 ---
 applies_to:
-  ess: discontinued 9.0.0
+  ess: removed 9.0.0
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/es-native-connectors.html
 ---


### PR DESCRIPTION
Related to https://github.com/elastic/docs-projects/issues/508 

Remove references to old lifecycles:

- [x] `discontinued`
- [x] ~~`planned`~~ no instances in this repo