### PR TITLE
Mute flaky RestCancellableNodeClientTests#testConcurrentExecuteAndClose

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -5,6 +5,9 @@ tests:
 - class: org.elasticsearch.packaging.test.CertGenCliTests
   method: test40RunWithCert
   issue: https://github.com/elastic/elasticsearch/issues/109831
+- class: org.elasticsearch.rest.action.RestCancellableNodeClientTests
+  method: testConcurrentExecuteAndClose
+  issue: https://github.com/elastic/elasticsearch/issues/130372
 
 # Examples:
 #


### PR DESCRIPTION
These failures are test bugs that are fixed on later branches. The backporting of the fixes is non-trivial as they depend on things that don't exist in 7.17

As discussed in team sync it's not worth making these fixes given the limited future of 7.17

Closes #130372

