### PR TITLE
[8.17] Fix msearch request parsing when index expression is null (#130776)

### DIFF
--- a/docs/changelog/130776.yaml
+++ b/docs/changelog/130776.yaml
@@ -1,0 +1,6 @@
+pr: 130776
+summary: Fix msearch request parsing when index expression is null
+area: Search
+type: bug
+issues:
+ - 129631

--- a/server/src/main/java/org/elasticsearch/common/xcontent/support/XContentMapValues.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/support/XContentMapValues.java
@@ -567,6 +567,9 @@ public class XContentMapValues {
      * Otherwise the node is treated as a comma-separated string.
      */
     public static String[] nodeStringArrayValue(Object node) {
+        if (node == null) {
+            throw new ElasticsearchParseException("Expected a list of strings but got null");
+        }
         if (isArray(node)) {
             List<?> list = (List<?>) node;
             String[] arr = new String[list.size()];

--- a/server/src/test/java/org/elasticsearch/action/search/MultiSearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/MultiSearchRequestTests.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.action.search;
 
+import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.Strings;
@@ -592,6 +593,14 @@ public class MultiSearchRequestTests extends ESTestCase {
                 )
             );
         }
+    }
+
+    public void testNullIndex() throws IOException {
+        ElasticsearchParseException e = expectThrows(ElasticsearchParseException.class, () -> parseMultiSearchRequestFromString("""
+            {"index": null}
+            { "query": {"match_all": {}}}
+            """));
+        assertThat(e.getMessage(), containsString("Expected a list of strings but got null"));
     }
 
     private static MultiSearchRequest mutate(MultiSearchRequest searchRequest) throws IOException {

--- a/server/src/test/java/org/elasticsearch/action/search/MultiSearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/MultiSearchRequestTests.java
@@ -599,7 +599,7 @@ public class MultiSearchRequestTests extends ESTestCase {
         ElasticsearchParseException e = expectThrows(ElasticsearchParseException.class, () -> parseMultiSearchRequestFromString("""
             {"index": null}
             { "query": {"match_all": {}}}
-            """));
+            """, null));
         assertThat(e.getMessage(), containsString("Expected a list of strings but got null"));
     }
 


### PR DESCRIPTION
Backports the following commits to 8.17:
 - Fix msearch request parsing when index expression is null (#130776)