### PR TITLE
[Test] Wait for clsuter to form before assertions

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -564,9 +564,6 @@ tests:
 - class: org.elasticsearch.cluster.ClusterStateSerializationTests
   method: testSerializationPreMultiProject
   issue: https://github.com/elastic/elasticsearch/issues/130872
-- class: org.elasticsearch.cluster.coordination.votingonly.VotingOnlyNodePluginTests
-  method: testPreferFullMasterOverVotingOnlyNodes
-  issue: https://github.com/elastic/elasticsearch/issues/130883
 
 # Examples:
 #

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -965,12 +965,13 @@ public abstract class ESIntegTestCase extends ESTestCase {
     }
 
     /**
-     * Waits for all nodes in the cluster to have a consistent view of which node is currently the master.
+     * Waits for all nodes forming the publish quorum in the cluster to have a consistent view of which node is currently the master.
      */
     public void awaitMasterNode() {
         // The cluster health API always runs on the master node, and the master only completes cluster state publication when all nodes
-        // in the cluster have accepted the new cluster state. By waiting for all events to have finished on the master node, we ensure
-        // that the whole cluster has a consistent view of which node is the master.
+        // forming the publish quorum have accepted the new cluster state. By waiting for all events to have finished on the
+        // master node, we ensure that all nodes that are part of the publish quorum have a consistent view of which node is the master.
+        // But nodes that are _not_ part of the quorum might still not have the same view yet.
         clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setTimeout(TEST_REQUEST_TIMEOUT).setWaitForEvents(Priority.LANGUID).get();
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -965,13 +965,12 @@ public abstract class ESIntegTestCase extends ESTestCase {
     }
 
     /**
-     * Waits for all nodes forming the publish quorum in the cluster to have a consistent view of which node is currently the master.
+     * Waits for all nodes in the cluster to have a consistent view of which node is currently the master.
      */
     public void awaitMasterNode() {
         // The cluster health API always runs on the master node, and the master only completes cluster state publication when all nodes
-        // forming the publish quorum have accepted the new cluster state. By waiting for all events to have finished on the
-        // master node, we ensure that all nodes that are part of the publish quorum have a consistent view of which node is the master.
-        // But nodes that are _not_ part of the quorum might still not have the same view yet.
+        // in the cluster have accepted the new cluster state. By waiting for all events to have finished on the master node, we ensure
+        // that the whole cluster has a consistent view of which node is the master.
         clusterAdmin().prepareHealth(TEST_REQUEST_TIMEOUT).setTimeout(TEST_REQUEST_TIMEOUT).setWaitForEvents(Priority.LANGUID).get();
     }
 

--- a/x-pack/plugin/voting-only-node/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/votingonly/VotingOnlyNodePluginTests.java
+++ b/x-pack/plugin/voting-only-node/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/votingonly/VotingOnlyNodePluginTests.java
@@ -96,7 +96,8 @@ public class VotingOnlyNodePluginTests extends ESIntegTestCase {
         internalCluster().setBootstrapMasterNodeIndex(0);
         internalCluster().startNodes(2);
         internalCluster().startNode(addRoles(Set.of(DiscoveryNodeRole.VOTING_ONLY_NODE_ROLE)));
-        internalCluster().startDataOnlyNodes(randomInt(2));
+        final int numDataNodes = randomInt(2);
+        internalCluster().startDataOnlyNodes(numDataNodes);
         assertBusy(
             () -> assertThat(
                 clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().getLastCommittedConfiguration().getNodeIds().size(),
@@ -108,6 +109,7 @@ public class VotingOnlyNodePluginTests extends ESIntegTestCase {
         internalCluster().stopCurrentMasterNode();
         awaitMasterNode();
         assertNotEquals(originalMaster, internalCluster().getMasterName());
+        ensureStableCluster(2 + numDataNodes); // wait for all nodes to join
         assertThat(
             VotingOnlyNodePlugin.isVotingOnlyNode(
                 clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().nodes().getMasterNode()

--- a/x-pack/plugin/voting-only-node/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/votingonly/VotingOnlyNodePluginTests.java
+++ b/x-pack/plugin/voting-only-node/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/votingonly/VotingOnlyNodePluginTests.java
@@ -10,7 +10,6 @@ import org.elasticsearch.action.admin.cluster.repositories.verify.VerifyReposito
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
 import org.elasticsearch.client.internal.Client;
-import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;

--- a/x-pack/plugin/voting-only-node/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/votingonly/VotingOnlyNodePluginTests.java
+++ b/x-pack/plugin/voting-only-node/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/votingonly/VotingOnlyNodePluginTests.java
@@ -107,11 +107,14 @@ public class VotingOnlyNodePluginTests extends ESIntegTestCase {
         final String originalMaster = internalCluster().getMasterName();
 
         internalCluster().stopCurrentMasterNode();
-        internalCluster().validateClusterFormed();
+        awaitMasterNode();
         assertNotEquals(originalMaster, internalCluster().getMasterName());
-        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
-        assertThat(state.nodes().size(), equalTo(2 + numDataNodes));
-        assertThat(VotingOnlyNodePlugin.isVotingOnlyNode(state.nodes().getMasterNode()), equalTo(false));
+        assertThat(
+            VotingOnlyNodePlugin.isVotingOnlyNode(
+                clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().nodes().getMasterNode()
+            ),
+            equalTo(false)
+        );
     }
 
     public void testBootstrapOnlyVotingOnlyNodes() throws Exception {
@@ -169,7 +172,6 @@ public class VotingOnlyNodePluginTests extends ESIntegTestCase {
 
         // start a fresh full master node, which will be brought into the cluster as master by the voting-only nodes
         final String newMaster = internalCluster().startNode();
-        internalCluster().validateClusterFormed();
         assertEquals(newMaster, internalCluster().getMasterName());
         final String newMasterId = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState().nodes().getMasterNodeId();
         assertNotEquals(oldMasterId, newMasterId);


### PR DESCRIPTION
The original cluster should be properly formed before the tests kick off. This PR ensures that.

Relates: #129118
Resolves: #130883
Resolves: #130979
