### PR TITLE
Fix MultiClusterSpecIT BWC test failures by removing redundant inference endpoint deletions

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -358,9 +358,6 @@ public class CsvTestsDataLoader {
                 }
             }
         }
-        deleteSparseEmbeddingInferenceEndpoint(client);
-        deleteRerankInferenceEndpoint(client);
-        deleteCompletionInferenceEndpoint(client);
     }
 
     /** The semantic_text mapping type require an inference endpoint that needs to be setup before creating the index. */


### PR DESCRIPTION
Fixes #130142 by removing redundant explicit deletion calls that were already handled by the generic endpoint cleanup loop, preventing double deletion errors in MultiClusterSpecIT BWC tests.