### PR TITLE
ESQL - Unmute knn tests muted in #129550

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/knn-function.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/knn-function.csv-spec
@@ -29,8 +29,7 @@ chartreuse | [127.0, 255.0, 0.0]
 // end::knn-function-result[]
 ;
 
-# https://github.com/elastic/elasticsearch/issues/129550 - Add as an example to knn function documentation
-knnSearchWithSimilarityOption-Ignore
+knnSearchWithSimilarityOption
 required_capability: knn_function_v2
 
 from colors metadata _score 
@@ -208,8 +207,7 @@ green      | false
 maroon     | false
 ;
 
-# https://github.com/elastic/elasticsearch/issues/129550
-testKnnWithNonPushableDisjunctions-Ignore
+testKnnWithNonPushableDisjunctions
 required_capability: knn_function_v2
 
 from colors metadata _score 
@@ -225,8 +223,7 @@ lemon chiffon
 papaya whip
 ;
 
-# https://github.com/elastic/elasticsearch/issues/129550
-testKnnWithNonPushableDisjunctionsOnComplexExpressions-Ignore
+testKnnWithNonPushableDisjunctionsOnComplexExpressions
 required_capability: knn_function_v2
 
 from colors metadata _score 


### PR DESCRIPTION
Unmute tests muted in #129550 as they were fixed in #127322.

Closes https://github.com/elastic/elasticsearch/issues/129550