### PR TITLE
ES|QL: fix bwc test for  FORK + ENRICH

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -576,9 +576,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.action.EsqlActionBreakerIT
   method: testRowStatsProjectGroupByInt
   issue: https://github.com/elastic/elasticsearch/issues/131024
-- class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
-  method: test {p0=esql/60_enrich/Enrich in fork}
-  issue: https://github.com/elastic/elasticsearch/issues/131028
 
 # Examples:
 #

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_enrich.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_enrich.yml
@@ -225,7 +225,7 @@ teardown:
         - method: POST
           path: /_query
           parameters: []
-          capabilities: [ no_brackets_in_unquoted_index_names ]
+          capabilities: [ no_brackets_in_unquoted_index_names, fork_v9 ]
       reason: "Change in the grammar"
 
   - do:


### PR DESCRIPTION
Fixes: https://github.com/elastic/elasticsearch/issues/131028

This just needs to be excluded for 8.19, that doesn't have FORK command