### PR TITLE
Create a Builder for ClusterInfo

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
@@ -452,4 +452,72 @@ public class ClusterInfo implements ChunkedToXContent, Writeable {
             }
         }
     }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Map<String, DiskUsage> leastAvailableSpaceUsage = Map.of();
+        private Map<String, DiskUsage> mostAvailableSpaceUsage = Map.of();
+        private Map<String, Long> shardSizes = Map.of();
+        private Map<ShardId, Long> shardDataSetSizes = Map.of();
+        private Map<NodeAndShard, String> dataPath = Map.of();
+        private Map<NodeAndPath, ReservedSpace> reservedSpace = Map.of();
+        private Map<String, EstimatedHeapUsage> estimatedHeapUsages = Map.of();
+        private Map<String, NodeUsageStatsForThreadPools> nodeUsageStatsForThreadPools = Map.of();
+
+        public ClusterInfo build() {
+            return new ClusterInfo(
+                leastAvailableSpaceUsage,
+                mostAvailableSpaceUsage,
+                shardSizes,
+                shardDataSetSizes,
+                dataPath,
+                reservedSpace,
+                estimatedHeapUsages,
+                nodeUsageStatsForThreadPools
+            );
+        }
+
+        public Builder leastAvailableSpaceUsage(Map<String, DiskUsage> leastAvailableSpaceUsage) {
+            this.leastAvailableSpaceUsage = leastAvailableSpaceUsage;
+            return this;
+        }
+
+        public Builder mostAvailableSpaceUsage(Map<String, DiskUsage> mostAvailableSpaceUsage) {
+            this.mostAvailableSpaceUsage = mostAvailableSpaceUsage;
+            return this;
+        }
+
+        public Builder shardSizes(Map<String, Long> shardSizes) {
+            this.shardSizes = shardSizes;
+            return this;
+        }
+
+        public Builder shardDataSetSizes(Map<ShardId, Long> shardDataSetSizes) {
+            this.shardDataSetSizes = shardDataSetSizes;
+            return this;
+        }
+
+        public Builder dataPath(Map<NodeAndShard, String> dataPath) {
+            this.dataPath = dataPath;
+            return this;
+        }
+
+        public Builder reservedSpace(Map<NodeAndPath, ReservedSpace> reservedSpace) {
+            this.reservedSpace = reservedSpace;
+            return this;
+        }
+
+        public Builder estimatedHeapUsages(Map<String, EstimatedHeapUsage> estimatedHeapUsages) {
+            this.estimatedHeapUsages = estimatedHeapUsages;
+            return this;
+        }
+
+        public Builder nodeUsageStatsForThreadPools(Map<String, NodeUsageStatsForThreadPools> nodeUsageStatsForThreadPools) {
+            this.nodeUsageStatsForThreadPools = nodeUsageStatsForThreadPools;
+            return this;
+        }
+    }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/ExpectedShardSizeEstimatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/ExpectedShardSizeEstimatorTests.java
@@ -199,16 +199,7 @@ public class ExpectedShardSizeEstimatorTests extends ESAllocationTestCase {
     }
 
     private static ClusterInfo createClusterInfo(ShardRouting shard, Long size) {
-        return new ClusterInfo(
-            Map.of(),
-            Map.of(),
-            Map.of(ClusterInfo.shardIdentifierFromRouting(shard), size),
-            Map.of(),
-            Map.of(),
-            Map.of(),
-            Map.of(),
-            Map.of()
-        );
+        return ClusterInfo.builder().shardSizes(Map.of(ClusterInfo.shardIdentifierFromRouting(shard), size)).build();
     }
 
     private ClusterState buildRoutingTable(ClusterState state) {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationStatsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationStatsServiceTests.java
@@ -72,16 +72,9 @@ public class AllocationStatsServiceTests extends ESAllocationTestCase {
             )
             .build();
 
-        var clusterInfo = new ClusterInfo(
-            Map.of(),
-            Map.of(),
-            Map.of(ClusterInfo.shardIdentifierFromRouting(shardId, true), currentShardSize),
-            Map.of(),
-            Map.of(),
-            Map.of(),
-            Map.of(),
-            Map.of()
-        );
+        var clusterInfo = ClusterInfo.builder()
+            .shardSizes(Map.of(ClusterInfo.shardIdentifierFromRouting(shardId, true), currentShardSize))
+            .build();
 
         var queue = new DeterministicTaskQueue();
         try (var clusterService = ClusterServiceUtils.createClusterService(state, queue.getThreadPool())) {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitorTests.java
@@ -1580,7 +1580,7 @@ public class DiskThresholdMonitorTests extends ESAllocationTestCase {
         Map<String, DiskUsage> diskUsages,
         Map<ClusterInfo.NodeAndPath, ClusterInfo.ReservedSpace> reservedSpace
     ) {
-        return new ClusterInfo(diskUsages, Map.of(), Map.of(), Map.of(), Map.of(), reservedSpace, Map.of(), Map.of());
+        return ClusterInfo.builder().leastAvailableSpaceUsage(diskUsages).reservedSpace(reservedSpace).build();
     }
 
     private static DiscoveryNode newFrozenOnlyNode(String nodeId) {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ExpectedShardSizeAllocationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ExpectedShardSizeAllocationTests.java
@@ -249,22 +249,17 @@ public class ExpectedShardSizeAllocationTests extends ESAllocationTestCase {
     }
 
     private static ClusterInfo createClusterInfoWith(ShardId shardId, long size) {
-        return new ClusterInfo(
-            Map.of(),
-            Map.of(),
-            Map.ofEntries(
-                Map.entry(ClusterInfo.shardIdentifierFromRouting(shardId, true), size),
-                Map.entry(ClusterInfo.shardIdentifierFromRouting(shardId, false), size)
-            ),
-            Map.of(),
-            Map.of(),
-            Map.of(),
-            Map.of(),
-            Map.of()
-        );
+        return ClusterInfo.builder()
+            .shardSizes(
+                Map.ofEntries(
+                    Map.entry(ClusterInfo.shardIdentifierFromRouting(shardId, true), size),
+                    Map.entry(ClusterInfo.shardIdentifierFromRouting(shardId, false), size)
+                )
+            )
+            .build();
     }
 
     private static ClusterInfo createClusterInfo(Map<String, DiskUsage> diskUsage, Map<String, Long> shardSizes) {
-        return new ClusterInfo(diskUsage, diskUsage, shardSizes, Map.of(), Map.of(), Map.of(), Map.of(), Map.of());
+        return ClusterInfo.builder().leastAvailableSpaceUsage(diskUsage).mostAvailableSpaceUsage(diskUsage).shardSizes(shardSizes).build();
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocatorTests.java
@@ -597,21 +597,16 @@ public class BalancedShardsAllocatorTests extends ESAllocationTestCase {
 
         var allocationService = createAllocationService(
             Settings.EMPTY,
-            () -> new ClusterInfo(
-                Map.of(),
-                Map.of(),
-                Map.of(
-                    ClusterInfo.shardIdentifierFromRouting(new ShardId(index, 0), true),
-                    0L,
-                    ClusterInfo.shardIdentifierFromRouting(new ShardId(index, 1), true),
-                    ByteSizeUnit.GB.toBytes(500)
-                ),
-                Map.of(),
-                Map.of(),
-                Map.of(),
-                Map.of(),
-                Map.of()
-            )
+            () -> ClusterInfo.builder()
+                .shardSizes(
+                    Map.of(
+                        ClusterInfo.shardIdentifierFromRouting(new ShardId(index, 0), true),
+                        0L,
+                        ClusterInfo.shardIdentifierFromRouting(new ShardId(index, 1), true),
+                        ByteSizeUnit.GB.toBytes(500)
+                    )
+                )
+                .build()
         );
 
         assertSame(clusterState, reroute(allocationService, clusterState));
@@ -706,7 +701,7 @@ public class BalancedShardsAllocatorTests extends ESAllocationTestCase {
     }
 
     private static ClusterInfo createClusterInfo(Map<String, Long> indexSizes) {
-        return new ClusterInfo(Map.of(), Map.of(), indexSizes, Map.of(), Map.of(), Map.of(), Map.of(), Map.of());
+        return ClusterInfo.builder().shardSizes(indexSizes).build();
     }
 
     private static IndexMetadata.Builder anIndex(String name) {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/ClusterAllocationSimulationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/ClusterAllocationSimulationTests.java
@@ -561,7 +561,12 @@ public class ClusterAllocationSimulationTests extends ESAllocationTestCase {
                 dataPath.put(new ClusterInfo.NodeAndShard(shardRouting.currentNodeId(), shardRouting.shardId()), "/data");
             }
 
-            return new ClusterInfo(diskSpaceUsage, diskSpaceUsage, shardSizes, Map.of(), dataPath, Map.of(), Map.of(), Map.of());
+            return ClusterInfo.builder()
+                .leastAvailableSpaceUsage(diskSpaceUsage)
+                .mostAvailableSpaceUsage(diskSpaceUsage)
+                .shardSizes(shardSizes)
+                .dataPath(dataPath)
+                .build();
         }
 
     }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/ClusterBalanceStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/ClusterBalanceStatsTests.java
@@ -329,26 +329,21 @@ public class ClusterBalanceStatsTests extends ESAllocationTestCase {
     }
 
     private ClusterInfo createClusterInfo(List<Tuple<String, long[]>> shardSizes) {
-        return new ClusterInfo(
-            Map.of(),
-            Map.of(),
-            shardSizes.stream()
-                .flatMap(
-                    entry -> IntStream.range(0, entry.v2().length)
-                        .mapToObj(
-                            index -> Map.entry(
-                                ClusterInfo.shardIdentifierFromRouting(new ShardId(entry.v1(), "_na_", index), true),
-                                entry.v2()[index]
+        return ClusterInfo.builder()
+            .shardSizes(
+                shardSizes.stream()
+                    .flatMap(
+                        entry -> IntStream.range(0, entry.v2().length)
+                            .mapToObj(
+                                index -> Map.entry(
+                                    ClusterInfo.shardIdentifierFromRouting(new ShardId(entry.v1(), "_na_", index), true),
+                                    entry.v2()[index]
+                                )
                             )
-                        )
-                )
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)),
-            Map.of(),
-            Map.of(),
-            Map.of(),
-            Map.of(),
-            Map.of()
-        );
+                    )
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
+            )
+            .build();
     }
 
     private static Tuple<String, long[]> indexSizes(String name, long... sizes) {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/ClusterInfoSimulatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/ClusterInfoSimulatorTests.java
@@ -690,16 +690,12 @@ public class ClusterInfoSimulatorTests extends ESAllocationTestCase {
         }
 
         public ClusterInfo build() {
-            return new ClusterInfo(
-                leastAvailableSpaceUsage,
-                mostAvailableSpaceUsage,
-                shardSizes,
-                Map.of(),
-                Map.of(),
-                reservedSpace,
-                Map.of(),
-                Map.of()
-            );
+            return ClusterInfo.builder()
+                .leastAvailableSpaceUsage(leastAvailableSpaceUsage)
+                .mostAvailableSpaceUsage(mostAvailableSpaceUsage)
+                .shardSizes(shardSizes)
+                .reservedSpace(reservedSpace)
+                .build();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputerTests.java
@@ -690,7 +690,12 @@ public class DesiredBalanceComputerTests extends ESAllocationTestCase {
             .stream()
             .collect(toMap(Map.Entry::getKey, it -> new DiskUsage(it.getKey(), it.getKey(), "/data", diskSize, diskSize - it.getValue())));
 
-        var clusterInfo = new ClusterInfo(diskUsage, diskUsage, shardSizes, Map.of(), dataPath, Map.of(), Map.of(), Map.of());
+        var clusterInfo = ClusterInfo.builder()
+            .leastAvailableSpaceUsage(diskUsage)
+            .mostAvailableSpaceUsage(diskUsage)
+            .shardSizes(shardSizes)
+            .dataPath(dataPath)
+            .build();
 
         var settings = Settings.EMPTY;
 
@@ -1196,7 +1201,12 @@ public class DesiredBalanceComputerTests extends ESAllocationTestCase {
         }
 
         public ClusterInfo build() {
-            return new ClusterInfo(diskUsage, diskUsage, shardSizes, Map.of(), Map.of(), reservedSpace, Map.of(), Map.of());
+            return ClusterInfo.builder()
+                .leastAvailableSpaceUsage(diskUsage)
+                .mostAvailableSpaceUsage(diskUsage)
+                .shardSizes(shardSizes)
+                .reservedSpace(reservedSpace)
+                .build();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderUnitTests.java
@@ -843,16 +843,11 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
         allFullUsages.put("node_0", new DiskUsage("node_0", "node_0", "_na_", 100, 0)); // all full
         allFullUsages.put("node_1", new DiskUsage("node_1", "node_1", "_na_", 100, 0)); // all full
 
-        final ClusterInfo clusterInfo = new ClusterInfo(
-            allFullUsages,
-            allFullUsages,
-            Map.of("[test][0][p]", 10L),
-            Map.of(),
-            Map.of(),
-            Map.of(),
-            Map.of(),
-            Map.of()
-        );
+        final ClusterInfo clusterInfo = ClusterInfo.builder()
+            .leastAvailableSpaceUsage(allFullUsages)
+            .mostAvailableSpaceUsage(allFullUsages)
+            .shardSizes(Map.of("[test][0][p]", 10L))
+            .build();
         RoutingAllocation allocation = new RoutingAllocation(
             new AllocationDeciders(Collections.singleton(decider)),
             clusterState,
@@ -912,16 +907,11 @@ public class DiskThresholdDeciderUnitTests extends ESAllocationTestCase {
         // bigger than available space
         final long shardSize = randomIntBetween(1, 10);
         shardSizes.put("[test][0][p]", shardSize);
-        ClusterInfo clusterInfo = new ClusterInfo(
-            leastAvailableUsages,
-            mostAvailableUsage,
-            shardSizes,
-            Map.of(),
-            Map.of(),
-            Map.of(),
-            Map.of(),
-            Map.of()
-        );
+        ClusterInfo clusterInfo = ClusterInfo.builder()
+            .leastAvailableSpaceUsage(leastAvailableUsages)
+            .mostAvailableSpaceUsage(mostAvailableUsage)
+            .shardSizes(shardSizes)
+            .build();
         RoutingAllocation allocation = new RoutingAllocation(
             new AllocationDeciders(Collections.singleton(decider)),
             clusterState,

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCalculateCapacityServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCalculateCapacityServiceTests.java
@@ -262,7 +262,7 @@ public class AutoscalingCalculateCapacityServiceTests extends AutoscalingTestCas
             }
         }
         state = ClusterState.builder(ClusterName.DEFAULT).nodes(nodes).build();
-        info = new ClusterInfo(leastUsages, mostUsages, Map.of(), Map.of(), Map.of(), Map.of(), Map.of(), Map.of());
+        info = ClusterInfo.builder().leastAvailableSpaceUsage(leastUsages).mostAvailableSpaceUsage(mostUsages).build();
         context = new AutoscalingCalculateCapacityService.DefaultAutoscalingDeciderContext(
             roleNames,
             state,
@@ -311,7 +311,7 @@ public class AutoscalingCalculateCapacityServiceTests extends AutoscalingTestCas
                 )
             );
 
-            info = new ClusterInfo(leastUsages, mostUsages, Map.of(), Map.of(), Map.of(), Map.of(), Map.of(), Map.of());
+            info = ClusterInfo.builder().leastAvailableSpaceUsage(leastUsages).mostAvailableSpaceUsage(mostUsages).build();
             context = new AutoscalingCalculateCapacityService.DefaultAutoscalingDeciderContext(
                 roleNames,
                 state,

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/FrozenStorageDeciderServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/FrozenStorageDeciderServiceTests.java
@@ -109,7 +109,7 @@ public class FrozenStorageDeciderServiceTests extends AutoscalingTestCase {
             // add irrelevant shards noise for completeness (should not happen IRL).
             sizes.put(new ShardId(index, i), randomLongBetween(0, Integer.MAX_VALUE));
         }
-        ClusterInfo info = new ClusterInfo(Map.of(), Map.of(), Map.of(), sizes, Map.of(), Map.of(), Map.of(), Map.of());
+        ClusterInfo info = ClusterInfo.builder().shardDataSetSizes(sizes).build();
         return Tuple.tuple(totalSize, info);
     }
 }

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ProactiveStorageDeciderServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ProactiveStorageDeciderServiceTests.java
@@ -408,7 +408,7 @@ public class ProactiveStorageDeciderServiceTests extends AutoscalingTestCase {
         for (var id : projectState.cluster().nodes().getDataNodes().keySet()) {
             diskUsage.put(id, new DiskUsage(id, id, "/test", Long.MAX_VALUE, Long.MAX_VALUE));
         }
-        return new ClusterInfo(diskUsage, diskUsage, shardSizes, Map.of(), Map.of(), Map.of(), Map.of(), Map.of());
+        return ClusterInfo.builder().leastAvailableSpaceUsage(diskUsage).mostAvailableSpaceUsage(diskUsage).shardSizes(shardSizes).build();
     }
 
     private ProjectMetadata applyCreatedDates(ProjectMetadata project, DataStream ds, long last, long decrement) {

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderServiceTests.java
@@ -379,7 +379,7 @@ public class ReactiveStorageDeciderServiceTests extends AutoscalingTestCase {
     }
 
     private ReactiveStorageDeciderService.AllocationState createAllocationState(Map<String, Long> shardSize, ClusterState clusterState) {
-        ClusterInfo info = new ClusterInfo(Map.of(), Map.of(), shardSize, Map.of(), Map.of(), Map.of(), Map.of(), Map.of());
+        ClusterInfo info = ClusterInfo.builder().shardSizes(shardSize).build();
         ReactiveStorageDeciderService.AllocationState allocationState = new ReactiveStorageDeciderService.AllocationState(
             clusterState,
             null,
@@ -544,7 +544,11 @@ public class ReactiveStorageDeciderServiceTests extends AutoscalingTestCase {
         }
 
         var diskUsages = Map.of(nodeId, new DiskUsage(nodeId, null, null, ByteSizeUnit.KB.toBytes(100), ByteSizeUnit.KB.toBytes(5)));
-        ClusterInfo info = new ClusterInfo(diskUsages, diskUsages, shardSize, Map.of(), Map.of(), Map.of(), Map.of(), Map.of());
+        ClusterInfo info = ClusterInfo.builder()
+            .leastAvailableSpaceUsage(diskUsages)
+            .mostAvailableSpaceUsage(diskUsages)
+            .shardSizes(shardSize)
+            .build();
 
         ReactiveStorageDeciderService.AllocationState allocationState = new ReactiveStorageDeciderService.AllocationState(
             clusterState,

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckActionTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckActionTests.java
@@ -167,16 +167,9 @@ public class TransportNodeDeprecationCheckActionTests extends ESTestCase {
         String nodeId = "123";
         long totalBytesOnMachine = 100;
         long totalBytesFree = 70;
-        ClusterInfo clusterInfo = new ClusterInfo(
-            Map.of(),
-            Map.of(nodeId, new DiskUsage(nodeId, "", "", totalBytesOnMachine, totalBytesFree)),
-            Map.of(),
-            Map.of(),
-            Map.of(),
-            Map.of(),
-            Map.of(),
-            Map.of()
-        );
+        ClusterInfo clusterInfo = ClusterInfo.builder()
+            .mostAvailableSpaceUsage(Map.of(nodeId, new DiskUsage(nodeId, "", "", totalBytesOnMachine, totalBytesFree)))
+            .build();
         DeprecationIssue issue = TransportNodeDeprecationCheckAction.checkDiskLowWatermark(
             nodeSettings,
             dynamicSettings,


### PR DESCRIPTION
This came out of another PR, where there was a lot of busy work changing all the ClusterInfo constructor call sites when a new param is added, and a lot of the callers have empty map param values.