### PR TITLE
ES|QL: fix generative tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -546,12 +546,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.action.CrossClusterAsyncQueryStopIT
   method: testStopQueryLocal
   issue: https://github.com/elastic/elasticsearch/issues/121672
-- class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/130067
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/130067
 - class: org.elasticsearch.xpack.esql.action.EsqlRemoteErrorWrapIT
   method: testThatRemoteErrorsAreWrapped
   issue: https://github.com/elastic/elasticsearch/issues/130794

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/EsqlQueryGenerator.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/EsqlQueryGenerator.java
@@ -107,10 +107,6 @@ public class EsqlQueryGenerator {
         return policies.stream().filter(x -> Set.of("languages_policy").contains(x.policyName())).toList();
     }
 
-    public static String randomNonVector(List<Column> previousOutput) {
-        return randomName(previousOutput.stream().filter(x -> x.type().contains("vector") == false).toList());
-    }
-
     public static String randomName(List<Column> previousOutput) {
         String result = randomRawName(previousOutput);
         if (result == null) {
@@ -292,7 +288,9 @@ public class EsqlQueryGenerator {
         // https://github.com/elastic/elasticsearch/issues/121741
         field.name().equals("<all-fields-projected>")
             // this is a known pathological case, no need to test it for now
-            || field.name().equals("<no-fields>")) == false;
+            || field.name().equals("<no-fields>")
+            // no dense vectors for now, they are not supported in most commands
+            || field.type().contains("vector")) == false;
     }
 
     public static String unquote(String colName) {

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/command/pipe/MvExpandGenerator.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/command/pipe/MvExpandGenerator.java
@@ -25,7 +25,7 @@ public class MvExpandGenerator implements CommandGenerator {
         List<EsqlQueryGenerator.Column> previousOutput,
         QuerySchema schema
     ) {
-        String toExpand = EsqlQueryGenerator.randomNonVector(previousOutput);
+        String toExpand = EsqlQueryGenerator.randomName(previousOutput);
         if (toExpand == null) {
             return EMPTY_DESCRIPTION; // no columns to expand
         }


### PR DESCRIPTION
Excluding dense vector fields for now, since they are not supported by most commands

Fixes: https://github.com/elastic/elasticsearch/issues/130067