### PR TITLE
ESQL: Fix more mv string bwc tests for string not/equals

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -2316,8 +2316,7 @@ warning:Line 2:9: java.lang.IllegalArgumentException: single-value function enco
 2023-10-23T13:55:01.544Z|Connected to 10.1.0.1
 ;
 
-mvStringEqualsLongString
-required_capability: mv_warn
+mvStringEqualsLongString#[skip:-8.12.99,reason:changed how we push down equals]
 
 FROM mv_text
 | WHERE message == "More than one hundred characters long so it isn't indexed by the sub keyword field with ignore_above:100"
@@ -2345,8 +2344,7 @@ warning:Line 2:9: java.lang.IllegalArgumentException: single-value function enco
 2023-10-23T13:55:01.546Z|More than one hundred characters long so it isn't indexed by the sub keyword field with ignore_above:100
 ;
 
-mvStringNotEqualsFound
-required_capability: mv_warn
+mvStringNotEqualsFound#[skip:-8.12.99,reason:changed how we push down not equals]
 
 FROM mv_text
 | WHERE message != "Connected to 10.1.0.1"
@@ -2359,8 +2357,7 @@ warning:Line 2:9: java.lang.IllegalArgumentException: single-value function enco
 2023-10-23T13:55:01.546Z|More than one hundred characters long so it isn't indexed by the sub keyword field with ignore_above:100
 ;
 
-mvStringNotEqualsLong
-required_capability: mv_warn
+mvStringNotEqualsLong#[skip:-8.12.99,reason:changed how we push down not equals]
 
 FROM mv_text
 | WHERE message != "More than one hundred characters long so it isn't indexed by the sub keyword field with ignore_above:100"


### PR DESCRIPTION
Fix https://github.com/elastic/elasticsearch/issues/130977
Fix https://github.com/elastic/elasticsearch/issues/130976

I'm just muting all the csv tests from https://github.com/elastic/elasticsearch/pull/128156 in the 8.12->8.19 bwc scenario; previously, it looked like only 2 of those failed but it looks like we're generally incompatible here. Which is fine because 8.12 was pre-GA for ES|QL and is outside the support matrix, anyway.