### PR TITLE
[8.19] Add missing grid_agg to search_mvt rest-api-spec (#130906)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_mvt.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_mvt.json
@@ -73,6 +73,15 @@
         "description":"Determines the geometry type for features in the aggs layer.",
         "default":"grid"
       },
+      "grid_agg":{
+        "type":"enum",
+        "options":[
+          "geotile",
+          "geohex"
+        ],
+        "description":"Aggregation used to create a grid for `field`.",
+        "default":"geotile"
+      },
       "size":{
         "type":"int",
         "description":"Maximum number of features to return in the hits layer. Accepts 0-10000.",


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Add missing grid_agg to search_mvt rest-api-spec (#130906)