### PR TITLE
Add register_operation_count to snapshot.repository_analyze rest-api-spec

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.repository_analyze.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.repository_analyze.json
@@ -38,7 +38,7 @@
       },
       "register_operation_count":{
         "type":"number",
-        "description":"The minimum number of linearizable register operations to perform in total. For realistic experiments, you should set it to at least `100`. Defaults to 10."
+        "description":"The minimum number of linearizable register operations to perform in total. Defaults to 10."
       },
       "read_node_count":{
         "type":"number",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.repository_analyze.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.repository_analyze.json
@@ -36,6 +36,10 @@
         "type":"number",
         "description":"Number of operations to run concurrently during the test. Defaults to 10."
       },
+      "register_operation_count":{
+        "type":"number",
+        "description":"The minimum number of linearizable register operations to perform in total. For realistic experiments, you should set it to at least `100`. Defaults to 10."
+      },
       "read_node_count":{
         "type":"number",
         "description":"Number of nodes on which to read a blob after writing. Defaults to 10."


### PR DESCRIPTION
This was added in https://github.com/elastic/elasticsearch/pull/102051