### PR TITLE
Use `try` to close query response and unmute `testThatRemoteErrorsAreWrapped`

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -543,9 +543,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.action.CrossClusterAsyncQueryStopIT
   method: testStopQueryLocal
   issue: https://github.com/elastic/elasticsearch/issues/121672
-- class: org.elasticsearch.xpack.esql.action.EsqlRemoteErrorWrapIT
-  method: testThatRemoteErrorsAreWrapped
-  issue: https://github.com/elastic/elasticsearch/issues/130794
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=mtermvectors/10_basic/Tests catching other exceptions per item}
   issue: https://github.com/elastic/elasticsearch/issues/122414

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlRemoteErrorWrapIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlRemoteErrorWrapIT.java
@@ -34,10 +34,9 @@ public class EsqlRemoteErrorWrapIT extends AbstractCrossClusterTestCase {
             );
         }
 
-        RemoteException wrappedError = expectThrows(
-            RemoteException.class,
-            () -> runQuery("FROM " + REMOTE_CLUSTER_1 + ":*," + REMOTE_CLUSTER_2 + ":* | LIMIT 100", false)
-        );
+        RemoteException wrappedError = expectThrows(RemoteException.class, () -> {
+            try (EsqlQueryResponse ignored = runQuery("FROM " + REMOTE_CLUSTER_1 + ":*," + REMOTE_CLUSTER_2 + ":* | LIMIT 100", false)) {}
+        });
         assertThat(wrappedError.getMessage(), is("Remote [cluster-a] encountered an error"));
     }
 }


### PR DESCRIPTION
This test was added way back in April and there are only 5 failures out of 20,000+ executions. All these failures occurred on 8th July. I looked at the logs for a run and saw a few other test failures with error messages pointing towards certain "leaks". I suspect that these failures are isolated to that run and have nothing to do with the test itself. Nevertheless, I made a small change to close out the ES|QL response we're obtaining in the test to be on the safer side and also unmuted the test.

Resolves https://github.com/elastic/elasticsearch/issues/130794.