### PR TITLE
ES|QL: let mixed-cluster tests run only with GA versions

### DIFF
--- a/x-pack/plugin/esql/qa/server/mixed-cluster/build.gradle
+++ b/x-pack/plugin/esql/qa/server/mixed-cluster/build.gradle
@@ -27,9 +27,9 @@ dependencies {
 
 GradleUtils.extendSourceSet(project, "javaRestTest", "yamlRestTest")
 
-// ESQL is available in 8.11 or later
+// ES|QL becomes GA in 8.14
 def supportedVersion = bwcVersion -> {
-  return bwcVersion.onOrAfter(Version.fromString("8.11.0")) && bwcVersion != VersionProperties.elasticsearchVersion
+  return bwcVersion.onOrAfter(Version.fromString("8.14.0")) && bwcVersion != VersionProperties.elasticsearchVersion
 }
 
 buildParams.bwcVersions.withWireCompatible(supportedVersion) { bwcVersion, baseName ->


### PR DESCRIPTION
ES|QL was released as GA in v 8.14, that's where we probably want to run our BWC mixed-cluster tests.
Previous versions tend to make new tests fail (especially after backports from 9.x) just because they lack very basic features.