### PR TITLE
Disable async search rest tests in release builds

### DIFF
--- a/x-pack/plugin/async-search/build.gradle
+++ b/x-pack/plugin/async-search/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
+
 apply plugin: 'elasticsearch.internal-es-plugin'
 apply plugin: 'elasticsearch.internal-cluster-test'
 apply plugin: 'elasticsearch.internal-java-rest-test'
@@ -33,4 +35,9 @@ restResources {
   restApi {
     include '_common', 'indices', 'index', 'async_search'
   }
+}
+
+tasks.withType(StandaloneRestIntegTestTask).configureEach {
+  def isSnapshot = buildParams.snapshotBuild
+  it.onlyIf("snapshot build") { isSnapshot }
 }


### PR DESCRIPTION
These tests rely on test-only modules which can only be installed in snapshot builds of ES. This disables these tests in our release builds.

Closes https://github.com/elastic/elasticsearch/issues/130978