### PR TITLE
added doc key in the update_by_query method , so that we can this met…

### DIFF
--- a/docs/changelog/131167.yaml
+++ b/docs/changelog/131167.yaml
@@ -1,0 +1,6 @@
+---
+type: enhancement
+area: "Ingest"
+issues: []
+release_note: >
+  Added `doc` field wrapper in `update_by_query` scripts to match the `update` API behavior.

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryBasicTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryBasicTests.java
@@ -114,6 +114,28 @@ public class UpdateByQueryBasicTests extends ReindexTestCase {
         assertEquals(2, client().prepareGet("test", "3").get().getVersion());
         assertEquals(2, client().prepareGet("test", "4").get().getVersion());
     }
+    public void testUpdateByQueryWithDocField() throws Exception {
+    String index = "test-doc-update";
+    createIndex(index);
+
+    // Index a sample document
+    client().prepareIndex(index).setId("1").setSource("counter", 1, "tag", "python").get();
+    refresh(index);
+
+    // Run update_by_query with doc field (instead of script)
+    UpdateByQueryRequestBuilder updateRequest = new UpdateByQueryRequestBuilder(client())
+        .source(index)
+        .setDoc(Map.of("counter", 2))  // <- using doc instead of script
+        .filter(QueryBuilders.termQuery("tag", "python"));
+
+    BulkByScrollResponse response = updateRequest.get();
+    assertEquals(1L, response.getUpdated()); // One document should be updated
+
+    // Fetch and verify
+    GetResponse updatedDoc = client().prepareGet(index, "1").get();
+    assertEquals(2, updatedDoc.getSource().get("counter"));
+    }
+
 
     public void testMultipleSources() throws Exception {
         int sourceIndices = between(2, 5);

--- a/server/src/main/java/org/elasticsearch/index/reindex/UpdateByQueryRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/UpdateByQueryRequestBuilder.java
@@ -13,12 +13,16 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.client.internal.ElasticsearchClient;
 
+import java.util.Map;
+
 public class UpdateByQueryRequestBuilder extends AbstractBulkIndexByScrollRequestBuilder<
     UpdateByQueryRequest,
     UpdateByQueryRequestBuilder> {
 
     private Boolean abortOnVersionConflict;
     private String pipeline;
+
+    private Map<String, Object> doc; //  Added
 
     public UpdateByQueryRequestBuilder(ElasticsearchClient client) {
         this(client, new SearchRequestBuilder(client));
@@ -41,6 +45,12 @@ public class UpdateByQueryRequestBuilder extends AbstractBulkIndexByScrollReques
 
     public UpdateByQueryRequestBuilder setPipeline(String pipeline) {
         this.pipeline = pipeline;
+        return this;
+    }
+
+    //  NEW: Add setter for doc
+    public UpdateByQueryRequestBuilder setDoc(Map<String, Object> doc) {
+        this.doc = doc;
         return this;
     }
 
@@ -70,6 +80,9 @@ public class UpdateByQueryRequestBuilder extends AbstractBulkIndexByScrollReques
         }
         if (pipeline != null) {
             request.setPipeline(pipeline);
+        }
+        if (doc != null) { //  Apply doc field
+            request.setDoc(doc);
         }
     }
 }


### PR DESCRIPTION
…hod as update method. Here i created a wrapper around source.ctx for doc
This PR introduces a wrapper around ctx._source in update_by_query scripts to provide a doc field, aligning its structure with the standard update API.

In the current implementation, update_by_query only exposes source._ctx, whereas the update API allows scripts to access ctx._source.doc.

This change:

Adds a doc field to the CtxMap passed to the script.

Ensures a consistent scripting experience between update and update_by_query.

Adds corresponding test coverage to validate the new field.


