### PR TITLE
Update JDK base image for OIDC fixture

### DIFF
--- a/x-pack/test/idp-fixture/src/main/resources/oidc/Dockerfile
+++ b/x-pack/test/idp-fixture/src/main/resources/oidc/Dockerfile
@@ -1,5 +1,5 @@
 FROM c2id/c2id-server-demo:16.1.1 AS c2id
-FROM openjdk:21-jdk-buster
+FROM eclipse-temurin:17-noble
 
 # Using this to launch a fake server on container start; see `setup.sh`
 RUN apt-get update -qqy && apt-get install -qqy python3


### PR DESCRIPTION
This upgrades the JDK base image for the OIDC fixture.

The old image used Debian 10 (buster) which is no longer supported and it appears the APT repos have been shutdown

We now use a temurin supplied image based on Ubuntu 24 (Noble Numbat)

Resolves: https://github.com/elastic/elasticsearch/issues/131158
