### PR TITLE
[8.18] Move docker image to registry to address flaky test (#129660) (#129878)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -298,8 +298,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.RegressionIT
   method: testTwoJobsWithSameRandomizeSeedUseSameTrainingSet
   issue: https://github.com/elastic/elasticsearch/issues/117805
-- class: org.elasticsearch.xpack.security.authc.ldap.UserAttributeGroupsResolverTests
-  issue: https://github.com/elastic/elasticsearch/issues/116537
 - class: org.elasticsearch.repositories.s3.RepositoryS3EcsCredentialsRestIT
   method: testNonexistentBucketReadonlyFalse
   issue: https://github.com/elastic/elasticsearch/issues/118225
@@ -324,8 +322,6 @@ tests:
 - class: org.elasticsearch.xpack.restart.FullClusterRestartIT
   method: testWatcherWithApiKey {cluster=UPGRADED}
   issue: https://github.com/elastic/elasticsearch/issues/119396
-- class: org.elasticsearch.xpack.security.authc.ldap.ADLdapUserSearchSessionFactoryTests
-  issue: https://github.com/elastic/elasticsearch/issues/119882
 - class: org.elasticsearch.xpack.security.operator.OperatorPrivilegesIT
   method: testEveryActionIsEitherOperatorOnlyOrNonOperator
   issue: https://github.com/elastic/elasticsearch/issues/119911

--- a/x-pack/test/smb-fixture/src/main/java/org/elasticsearch/test/fixtures/smb/SmbTestContainer.java
+++ b/x-pack/test/smb-fixture/src/main/java/org/elasticsearch/test/fixtures/smb/SmbTestContainer.java
@@ -12,37 +12,18 @@ import com.github.dockerjava.api.model.Capability;
 import org.elasticsearch.test.fixtures.testcontainers.DockerEnvironmentAwareTestContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
-import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.images.RemoteDockerImage;
 
 import java.time.Duration;
 
 public final class SmbTestContainer extends DockerEnvironmentAwareTestContainer {
 
-    private static final String DOCKER_BASE_IMAGE = "ubuntu:24.04";
+    private static final String DOCKER_BASE_IMAGE = "docker.elastic.co/elasticsearch-dev/es-smb-fixture:1.0";
     public static final int AD_LDAP_PORT = 636;
     public static final int AD_LDAP_GC_PORT = 3269;
 
     public SmbTestContainer() {
-        super(
-            new ImageFromDockerfile("es-smb-fixture").withDockerfileFromBuilder(
-                builder -> builder.from(DOCKER_BASE_IMAGE)
-                    .env("TZ", "Etc/UTC")
-                    .run("DEBIAN_FRONTEND=noninteractive apt-get update -qqy && apt-get install -qqy tzdata winbind samba ldap-utils")
-                    .copy("fixture/provision/installsmb.sh", "/fixture/provision/installsmb.sh")
-                    .copy("fixture/certs/ca.key", "/fixture/certs/ca.key")
-                    .copy("fixture/certs/ca.pem", "/fixture/certs/ca.pem")
-                    .copy("fixture/certs/cert.pem", "/fixture/certs/cert.pem")
-                    .copy("fixture/certs/key.pem", "/fixture/certs/key.pem")
-                    .run("chmod +x /fixture/provision/installsmb.sh")
-                    .cmd("/fixture/provision/installsmb.sh && service samba-ad-dc restart && echo Samba started && sleep infinity")
-                    .build()
-            )
-                .withFileFromClasspath("fixture/provision/installsmb.sh", "/smb/provision/installsmb.sh")
-                .withFileFromClasspath("fixture/certs/ca.key", "/smb/certs/ca.key")
-                .withFileFromClasspath("fixture/certs/ca.pem", "/smb/certs/ca.pem")
-                .withFileFromClasspath("fixture/certs/cert.pem", "/smb/certs/cert.pem")
-                .withFileFromClasspath("fixture/certs/key.pem", "/smb/certs/key.pem")
-        );
+        super(new RemoteDockerImage(DOCKER_BASE_IMAGE));
 
         addExposedPort(AD_LDAP_PORT);
         addExposedPort(AD_LDAP_GC_PORT);

--- a/x-pack/test/smb-fixture/src/main/resources/Dockerfile
+++ b/x-pack/test/smb-fixture/src/main/resources/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:24.04
+
+ENV TZ="Etc/UTC"
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -qqy && \
+    apt-get install -qqy tzdata winbind samba ldap-utils
+
+COPY smb/provision/installsmb.sh /fixture/provision/installsmb.sh
+COPY smb/certs/ca.key /fixture/certs/ca.key
+COPY smb/certs/ca.pem /fixture/certs/ca.pem
+COPY smb/certs/cert.pem /fixture/certs/cert.pem
+COPY smb/certs/key.pem /fixture/certs/key.pem
+
+RUN chmod +x /fixture/provision/installsmb.sh
+
+CMD ["/bin/sh", "-c", "/fixture/provision/installsmb.sh && service samba-ad-dc restart && echo Samba started && sleep infinity"]


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.19` to `8.18`:
 - [Move docker image to registry to address flaky test (#129660) (#129878)](https://github.com/elastic/elasticsearch/pull/129878)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

Resolves https://github.com/elastic/elasticsearch/issues/130457