### PR TITLE
ES|QL: fix MultiClustersIT.testNotLikeListKeyword

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -546,9 +546,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/131154
-- class: org.elasticsearch.xpack.esql.ccq.MultiClustersIT
-  method: testNotLikeListKeyword
-  issue: https://github.com/elastic/elasticsearch/issues/131155
 - class: org.elasticsearch.index.engine.ThreadPoolMergeExecutorServiceDiskSpaceTests
   method: testEnqueuedMergeTasksAreUnblockedWhenEstimatedMergeSizeChanges
   issue: https://github.com/elastic/elasticsearch/issues/131165

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -534,7 +534,6 @@ public abstract class ESTestCase extends LuceneTestCase {
             TestEntitlementBootstrap.setActive(false == withoutEntitlements);
             TestEntitlementBootstrap.setTriviallyAllowingTestCode(false == withEntitlementsOnTestCode);
             if (entitledPackages != null) {
-                assert withEntitlementsOnTestCode == false : "Cannot use @WithEntitlementsOnTestCode together with @EntitledTestPackages";
                 assert entitledPackages.value().length > 0 : "No test packages specified in @EntitledTestPackages";
                 TestEntitlementBootstrap.setEntitledTestPackages(entitledPackages.value());
             }

--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/MultiClustersIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/MultiClustersIT.java
@@ -629,10 +629,16 @@ public class MultiClustersIT extends ESRestTestCase {
             """, includeCCSMetadata);
         var columns = List.of(Map.of("name", "c", "type", "long"), Map.of("name", "_index", "type", "keyword"));
         Predicate<Doc> filter = d -> false == (d.color.contains("blue") || d.color.contains("red"));
-        var values = List.of(
-            List.of((int) remoteDocs.stream().filter(filter).count(), REMOTE_CLUSTER_NAME + ":" + remoteIndex),
-            List.of((int) localDocs.stream().filter(filter).count(), localIndex)
-        );
+
+        var values = new ArrayList<>();
+        int remoteCount = (int) remoteDocs.stream().filter(filter).count();
+        int localCount = (int) localDocs.stream().filter(filter).count();
+        if (remoteCount > 0) {
+            values.add(List.of(remoteCount, REMOTE_CLUSTER_NAME + ":" + remoteIndex));
+        }
+        if (localCount > 0) {
+            values.add(List.of(localCount, localIndex));
+        }
         assertResultMapForLike(includeCCSMetadata, result, columns, values, false, true);
     }
 


### PR DESCRIPTION
Make testNotLikeListKeyword more deterministic: in some cases, it returns no values for the remote or for the local cluster, that is just a consequence of the randomization.

Fixes: https://github.com/elastic/elasticsearch/issues/131155