### PR TITLE
Unmuting 41_knn_search_byte_quantized

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -209,9 +209,6 @@ tests:
 - class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
   method: testDeploymentSurvivesRestart {cluster=OLD}
   issue: https://github.com/elastic/elasticsearch/issues/124160
-- class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
-  method: test {yaml=search.vectors/41_knn_search_byte_quantized/kNN search plus query}
-  issue: https://github.com/elastic/elasticsearch/issues/124687
 - class: org.elasticsearch.packaging.test.BootstrapCheckTests
   method: test20RunWithBootstrapChecks
   issue: https://github.com/elastic/elasticsearch/issues/124940


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch/issues/124687

Unmuting test, as failures were not related to this test:

```
CoreWithMultipleProjectsClientYamlTestSuiteIT > test {yaml=search.vectors/45_knn_search_bit/kNN search plus query} FAILED
    java.lang.RuntimeException: Failure at [search.vectors/45_knn_search_bit:2]: Connection refused
        at org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase.executeSection(ESClientYamlSuiteTestCase.java:524)
        at org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase.test(ESClientYamlSuiteTestCase.java:473)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
        at java.base/java.lang.reflect.Method.invoke(Method.java:580)
        at com.carrotsearch.randomizedtesting.RandomizedRunner.invoke(RandomizedRunner.java:1763)
        at com.carrotsearch.randomizedtesting.RandomizedRunner$8.evaluate(RandomizedRunner.java:946)
        at com.carrotsearch.randomizedtesting.RandomizedRunner$9.evaluate(RandomizedRunner.java:982)
        at com.carrotsearch.randomizedtesting.RandomizedRunner$10.evaluate(RandomizedRunner.java:996)
        at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
        at org.junit.rules.RunRules.evaluate(RunRules.java:20)
        at org.apache.lucene.tests.util.TestRuleSetupTeardownChained$1.evaluate(TestRuleSetupTeardownChained.java:48)
        at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43)
        at org.apache.lucene.tests.util.TestRuleThreadAndTestName$1.evaluate(TestRuleThreadAndTestName.java:45)
        at org.apache.lucene.tests.util.TestRuleIgnoreAfterMaxFailures$1.evaluate(TestRuleIgnoreAfterMaxFailures.java:60)
        at org.apache.lucene.tests.util.TestRuleMarkFailure$1.evaluate(TestRuleMarkFailure.java:44)
        at org.junit.rules.RunRules.evaluate(RunRules.java:20)
        at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
        at com.carrotsearch.randomizedtesting.ThreadLeakControl$StatementRunner.run(ThreadLeakControl.java:390)
```

The cause is a fatal error tripped by an assertion:

```
java.lang.AssertionError: Current thread has made an unsafe access to the engine
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.index.engine.SafeEngineAccessThreadLocal.getAccessorSafe(SafeEngineAccessThreadLocal.java:63)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.index.engine.SafeEngineAccessThreadLocal.accessEnd(SafeEngineAccessThreadLocal.java:77)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.index.engine.AbstractReaderManager$AssertingRefreshListener.afterRefresh(AbstractReaderManager.java:100)
	at org.apache.lucene.core@10.1.0/org.apache.lucene.search.ReferenceManager.notifyRefreshListenersRefreshed(ReferenceManager.java:275)
	at org.apache.lucene.core@10.1.0/org.apache.lucene.search.ReferenceManager.doMaybeRefresh(ReferenceManager.java:182)
	at org.apache.lucene.core@10.1.0/org.apache.lucene.search.ReferenceManager.maybeRefresh(ReferenceManager.java:213)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.index.engine.InternalEngine.refresh(InternalEngine.java:2044)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.index.engine.InternalEngine.lambda$maybeRefresh$9(InternalEngine.java:2017)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.action.ActionListener.completeWith(ActionListener.java:367)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.index.engine.InternalEngine.maybeRefresh(InternalEngine.java:2017)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.index.shard.IndexShard.lambda$scheduledRefresh$47(IndexShard.java:4056)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.action.ActionListener.run(ActionListener.java:463)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.index.shard.IndexShard.scheduledRefresh(IndexShard.java:4037)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.index.IndexService.maybeRefreshEngine(IndexService.java:1086)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.index.IndexService$AsyncRefreshTask.runInternal(IndexService.java:1222)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.common.util.concurrent.AbstractAsyncTask.run(AbstractAsyncTask.java:138)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:977)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1575)
Caused by: java.lang.AssertionError: thread [Thread[#132,elasticsearch[test-cluster-1][refresh][T#2],5,main]] should not access the engine using the getEngineOrNull() method
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.index.engine.SafeEngineAccessThreadLocal.assertNoAccessByCurrentThread(SafeEngineAccessThreadLocal.java:90)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.index.shard.IndexShard.getEngineOrNull(IndexShard.java:3317)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.index.shard.IndexShard.getEngine(IndexShard.java:3305)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.index.shard.IndexShard.getLocalCheckpoint(IndexShard.java:2974)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.action.support.replication.TransportReplicationAction$PrimaryShardReference.localCheckpoint(TransportReplicationAction.java:1192)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.action.support.replication.ReplicationOperation.updateCheckPoints(ReplicationOperation.java:384)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.action.support.replication.ReplicationOperation$1.onResponse(ReplicationOperation.java:202)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.action.support.replication.ReplicationOperation$1.onResponse(ReplicationOperation.java:197)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.action.support.replication.TransportWriteAction$WritePrimaryResult$1.onSuccess(TransportWriteAction.java:341)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.action.support.replication.TransportWriteAction$AsyncAfterWriteAction.maybeFinish(TransportWriteAction.java:498)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.action.support.replication.TransportWriteAction$AsyncAfterWriteAction$1.onResponse(TransportWriteAction.java:524)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.action.support.replication.TransportWriteAction$AsyncAfterWriteAction$1.onResponse(TransportWriteAction.java:516)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.index.shard.RefreshListeners.lambda$addOrNotify$1(RefreshListeners.java:152)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.index.shard.RefreshListeners.fireListeners(RefreshListeners.java:432)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.index.shard.RefreshListeners.afterRefresh(RefreshListeners.java:420)
	at org.elasticsearch.server@9.1.0-SNAPSHOT/org.elasticsearch.index.engine.AbstractReaderManager$AssertingRefreshListener.afterRefresh(AbstractReaderManager.java:98
```