### PR TITLE
Add bulk processing capabilities to ES91Int4VectorsScorer

### DIFF
--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/ES91Int4VectorsScorer.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/ES91Int4VectorsScorer.java
@@ -8,9 +8,14 @@
  */
 package org.elasticsearch.simdvec;
 
+import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.VectorUtil;
 
 import java.io.IOException;
+
+import static org.apache.lucene.index.VectorSimilarityFunction.EUCLIDEAN;
+import static org.apache.lucene.index.VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT;
 
 /** Scorer for quantized vectors stored as an {@link IndexInput}.
  * <p>
@@ -20,10 +25,18 @@ import java.io.IOException;
  * */
 public class ES91Int4VectorsScorer {
 
+    public static final int BULK_SIZE = 16;
+    protected static final float FOUR_BIT_SCALE = 1f / ((1 << 4) - 1);
+
     /** The wrapper {@link IndexInput}. */
     protected final IndexInput in;
     protected final int dimensions;
     protected byte[] scratch;
+
+    protected final float[] lowerIntervals = new float[BULK_SIZE];
+    protected final float[] upperIntervals = new float[BULK_SIZE];
+    protected final int[] targetComponentSums = new int[BULK_SIZE];
+    protected final float[] additionalCorrections = new float[BULK_SIZE];
 
     /** Sole constructor, called by sub-classes. */
     public ES91Int4VectorsScorer(IndexInput in, int dimensions) {
@@ -32,6 +45,10 @@ public class ES91Int4VectorsScorer {
         scratch = new byte[dimensions];
     }
 
+    /**
+     * compute the quantize distance between the provided quantized query and the quantized vector
+     * that is read from the wrapped {@link IndexInput}.
+     */
     public long int4DotProduct(byte[] b) throws IOException {
         in.readBytes(scratch, 0, dimensions);
         int total = 0;
@@ -39,5 +56,130 @@ public class ES91Int4VectorsScorer {
             total += scratch[i] * b[i];
         }
         return total;
+    }
+
+    /**
+     * compute the quantize distance between the provided quantized query and the quantized vectors
+     * that are read from the wrapped {@link IndexInput}. The number of quantized vectors to read is
+     * determined by {code count} and the results are stored in the provided {@code scores} array.
+     */
+    public void int4DotProductBulk(byte[] b, int count, float[] scores) throws IOException {
+        for (int i = 0; i < count; i++) {
+            scores[i] = int4DotProduct(b);
+        }
+    }
+
+    /**
+     * Computes the score by applying the necessary corrections to the provided quantized distance.
+     */
+    public float score(
+        byte[] q,
+        float queryLowerInterval,
+        float queryUpperInterval,
+        int queryComponentSum,
+        float queryAdditionalCorrection,
+        VectorSimilarityFunction similarityFunction,
+        float centroidDp
+    ) throws IOException {
+        float score = int4DotProduct(q);
+        in.readFloats(lowerIntervals, 0, 3);
+        int addition = Short.toUnsignedInt(in.readShort());
+        return applyCorrections(
+            queryLowerInterval,
+            queryUpperInterval,
+            queryComponentSum,
+            queryAdditionalCorrection,
+            similarityFunction,
+            centroidDp,
+            lowerIntervals[0],
+            lowerIntervals[1],
+            addition,
+            lowerIntervals[2],
+            score
+        );
+    }
+
+    /**
+     * compute the distance between the provided quantized query and the quantized vectors that are
+     * read from the wrapped {@link IndexInput}.
+     *
+     * <p>The number of vectors to score is defined by {@link #BULK_SIZE}. The expected format of the
+     * input is as follows: First the quantized vectors are read from the input,then all the lower
+     * intervals as floats, then all the upper intervals as floats, then all the target component sums
+     * as shorts, and finally all the additional corrections as floats.
+     *
+     * <p>The results are stored in the provided scores array.
+     */
+    public void scoreBulk(
+        byte[] q,
+        float queryLowerInterval,
+        float queryUpperInterval,
+        int queryComponentSum,
+        float queryAdditionalCorrection,
+        VectorSimilarityFunction similarityFunction,
+        float centroidDp,
+        float[] scores
+    ) throws IOException {
+        int4DotProductBulk(q, BULK_SIZE, scores);
+        in.readFloats(lowerIntervals, 0, BULK_SIZE);
+        in.readFloats(upperIntervals, 0, BULK_SIZE);
+        for (int i = 0; i < BULK_SIZE; i++) {
+            targetComponentSums[i] = Short.toUnsignedInt(in.readShort());
+        }
+        in.readFloats(additionalCorrections, 0, BULK_SIZE);
+        for (int i = 0; i < BULK_SIZE; i++) {
+            scores[i] = applyCorrections(
+                queryLowerInterval,
+                queryUpperInterval,
+                queryComponentSum,
+                queryAdditionalCorrection,
+                similarityFunction,
+                centroidDp,
+                lowerIntervals[i],
+                upperIntervals[i],
+                targetComponentSums[i],
+                additionalCorrections[i],
+                scores[i]
+            );
+        }
+    }
+
+    /**
+     * Computes the score by applying the necessary corrections to the provided quantized distance.
+     */
+    public float applyCorrections(
+        float queryLowerInterval,
+        float queryUpperInterval,
+        int queryComponentSum,
+        float queryAdditionalCorrection,
+        VectorSimilarityFunction similarityFunction,
+        float centroidDp,
+        float lowerInterval,
+        float upperInterval,
+        int targetComponentSum,
+        float additionalCorrection,
+        float qcDist
+    ) {
+        float ax = lowerInterval;
+        // Here we assume `lx` is simply bit vectors, so the scaling isn't necessary
+        float lx = upperInterval - ax;
+        float ay = queryLowerInterval;
+        float ly = (queryUpperInterval - ay) * FOUR_BIT_SCALE;
+        float y1 = queryComponentSum;
+        float score = ax * ay * dimensions + ay * lx * (float) targetComponentSum + ax * ly * y1 + lx * ly * qcDist;
+        // For euclidean, we need to invert the score and apply the additional correction, which is
+        // assumed to be the squared l2norm of the centroid centered vectors.
+        if (similarityFunction == EUCLIDEAN) {
+            score = queryAdditionalCorrection + additionalCorrection - 2 * score;
+            return Math.max(1 / (1f + score), 0);
+        } else {
+            // For cosine and max inner product, we need to apply the additional correction, which is
+            // assumed to be the non-centered dot-product between the vector and the centroid
+            score += queryAdditionalCorrection + additionalCorrection - centroidDp;
+            if (similarityFunction == MAXIMUM_INNER_PRODUCT) {
+                return VectorUtil.scaleMaxInnerProductScore(score);
+            }
+            return Math.max((1f + score) / 2f, 0);
+        }
     }
 }

--- a/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/MemorySegmentES91Int4VectorsScorer.java
+++ b/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/MemorySegmentES91Int4VectorsScorer.java
@@ -9,22 +9,30 @@
 package org.elasticsearch.simdvec.internal.vectorization;
 
 import jdk.incubator.vector.ByteVector;
+import jdk.incubator.vector.FloatVector;
 import jdk.incubator.vector.IntVector;
 import jdk.incubator.vector.ShortVector;
 import jdk.incubator.vector.Vector;
+import jdk.incubator.vector.VectorOperators;
+import jdk.incubator.vector.VectorShape;
 import jdk.incubator.vector.VectorSpecies;
 
+import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.VectorUtil;
 import org.elasticsearch.simdvec.ES91Int4VectorsScorer;
 
 import java.io.IOException;
 import java.lang.foreign.MemorySegment;
+import java.nio.ByteOrder;
 
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static jdk.incubator.vector.VectorOperators.ADD;
 import static jdk.incubator.vector.VectorOperators.B2I;
 import static jdk.incubator.vector.VectorOperators.B2S;
 import static jdk.incubator.vector.VectorOperators.S2I;
+import static org.apache.lucene.index.VectorSimilarityFunction.EUCLIDEAN;
+import static org.apache.lucene.index.VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT;
 
 /** Panamized scorer for quantized vectors stored as an {@link IndexInput}.
  * <p>
@@ -42,6 +50,15 @@ public final class MemorySegmentES91Int4VectorsScorer extends ES91Int4VectorsSco
     private static final VectorSpecies<Integer> INT_SPECIES_128 = IntVector.SPECIES_128;
     private static final VectorSpecies<Integer> INT_SPECIES_256 = IntVector.SPECIES_256;
     private static final VectorSpecies<Integer> INT_SPECIES_512 = IntVector.SPECIES_512;
+
+    private static final VectorSpecies<Float> FLOAT_SPECIES;
+    private static final VectorSpecies<Short> SHORT_SPECIES;
+
+    static {
+        // default to platform supported bitsize
+        FLOAT_SPECIES = VectorSpecies.of(float.class, VectorShape.forBitSize(PanamaESVectorUtilSupport.VECTOR_BITSIZE));
+        SHORT_SPECIES = VectorSpecies.of(short.class, VectorShape.forBitSize(PanamaESVectorUtilSupport.VECTOR_BITSIZE));
+    }
 
     private final MemorySegment memorySegment;
 
@@ -99,12 +116,11 @@ public final class MemorySegmentES91Int4VectorsScorer extends ES91Int4VectorsSco
     }
 
     private long dotProduct(byte[] q) throws IOException {
-        int i = 0;
-        int res = 0;
-
         // only vectorize if we'll at least enter the loop a single time, and we have at least 128-bit
         // vectors (256-bit on intel to dodge performance landmines)
         if (dimensions >= 16 && PanamaESVectorUtilSupport.HAS_FAST_INTEGER_VECTORS) {
+            int i = 0;
+            int res = 0;
             // compute vectorized dot product consistent with VPDPBUSD instruction
             if (PanamaESVectorUtilSupport.VECTOR_BITSIZE >= 512) {
                 i += BYTE_SPECIES_128.loopBound(dimensions);
@@ -113,16 +129,15 @@ public final class MemorySegmentES91Int4VectorsScorer extends ES91Int4VectorsSco
                 i += BYTE_SPECIES_64.loopBound(dimensions);
                 res += dotProductBody256(q, i);
             } else {
-                // tricky: we don't have SPECIES_32, so we workaround with "overlapping read"
-                i += BYTE_SPECIES_64.loopBound(dimensions - BYTE_SPECIES_64.length());
-                res += dotProductBody128(q, i);
+                throw new IllegalArgumentException("Unreacheable statement");
             }
+            // scalar tail
+            for (; i < q.length; i++) {
+                res += in.readByte() * q[i];
+            }
+            return res;
         }
-        // scalar tail
-        for (; i < q.length; i++) {
-            res += in.readByte() * q[i];
-        }
-        return res;
+        return super.int4DotProduct(q);
     }
 
     /** vectorized dot product body (512 bit vectors) */
@@ -166,26 +181,222 @@ public final class MemorySegmentES91Int4VectorsScorer extends ES91Int4VectorsSco
         return acc.reduceLanes(ADD);
     }
 
-    /** vectorized dot product body (128 bit vectors) */
-    private int dotProductBody128(byte[] q, int limit) throws IOException {
-        IntVector acc = IntVector.zero(INT_SPECIES_128);
-        long offset = in.getFilePointer();
-        // 4 bytes at a time (re-loading half the vector each time!)
-        for (int i = 0; i < limit; i += BYTE_SPECIES_64.length() >> 1) {
-            // load 8 bytes
-            ByteVector va8 = ByteVector.fromArray(BYTE_SPECIES_64, q, i);
-            ByteVector vb8 = ByteVector.fromMemorySegment(BYTE_SPECIES_64, memorySegment, offset + i, LITTLE_ENDIAN);
-
-            // process first "half" only: 16-bit multiply
-            Vector<Short> va16 = va8.convert(B2S, 0);
-            Vector<Short> vb16 = vb8.convert(B2S, 0);
-            Vector<Short> prod16 = va16.mul(vb16);
-
-            // 32-bit add
-            acc = acc.add(prod16.convertShape(S2I, INT_SPECIES_128, 0));
+    @Override
+    public void int4DotProductBulk(byte[] q, float[] scores) throws IOException {
+        if (PanamaESVectorUtilSupport.VECTOR_BITSIZE >= 512 || PanamaESVectorUtilSupport.VECTOR_BITSIZE == 256) {
+            dotProductBulk(q, scores);
+            return;
         }
-        in.seek(offset + limit);
-        // reduce
-        return acc.reduceLanes(ADD);
+        if (dimensions >= 32 && PanamaESVectorUtilSupport.HAS_FAST_INTEGER_VECTORS) {
+            int4DotProductBody128Bulk(q, scores);
+            return;
+        }
+        super.int4DotProductBulk(q, scores);
+    }
+
+    private void int4DotProductBody128Bulk(byte[] q, float[] scores) throws IOException {
+        int limit = BYTE_SPECIES_128.loopBound(dimensions);
+        for (int iter = 0; iter < BULK_SIZE; iter++) {
+            int sum = 0;
+            long offset = in.getFilePointer();
+            for (int i = 0; i < limit; i += 1024) {
+                ShortVector acc0 = ShortVector.zero(SHORT_SPECIES_128);
+                ShortVector acc1 = ShortVector.zero(SHORT_SPECIES_128);
+
+                int innerLimit = Math.min(limit - i, 1024);
+                for (int j = 0; j < innerLimit; j += BYTE_SPECIES_128.length()) {
+                    ByteVector va8 = ByteVector.fromArray(BYTE_SPECIES_64, q, i + j);
+                    ByteVector vb8 = ByteVector.fromMemorySegment(BYTE_SPECIES_64, memorySegment, offset + i + j, LITTLE_ENDIAN);
+
+                    ByteVector prod8 = va8.mul(vb8);
+                    ShortVector prod16 = prod8.convertShape(B2S, ShortVector.SPECIES_128, 0).reinterpretAsShorts();
+                    acc0 = acc0.add(prod16.and((short) 255));
+
+                    va8 = ByteVector.fromArray(BYTE_SPECIES_64, q, i + j + 8);
+                    vb8 = ByteVector.fromMemorySegment(BYTE_SPECIES_64, memorySegment, offset + i + j + 8, LITTLE_ENDIAN);
+
+                    prod8 = va8.mul(vb8);
+                    prod16 = prod8.convertShape(B2S, SHORT_SPECIES_128, 0).reinterpretAsShorts();
+                    acc1 = acc1.add(prod16.and((short) 255));
+                }
+
+                IntVector intAcc0 = acc0.convertShape(S2I, INT_SPECIES_128, 0).reinterpretAsInts();
+                IntVector intAcc1 = acc0.convertShape(S2I, INT_SPECIES_128, 1).reinterpretAsInts();
+                IntVector intAcc2 = acc1.convertShape(S2I, INT_SPECIES_128, 0).reinterpretAsInts();
+                IntVector intAcc3 = acc1.convertShape(S2I, INT_SPECIES_128, 1).reinterpretAsInts();
+                sum += intAcc0.add(intAcc1).add(intAcc2).add(intAcc3).reduceLanes(ADD);
+            }
+            in.seek(offset + limit);
+            in.readBytes(scratch, limit, dimensions - limit);
+            for (int j = limit; j < dimensions; j++) {
+                sum += scratch[j] * q[j];
+            }
+            scores[iter] = sum;
+        }
+    }
+
+    private void dotProductBulk(byte[] q, float[] scores) throws IOException {
+        // only vectorize if we'll at least enter the loop a single time, and we have at least 128-bit
+        // vectors (256-bit on intel to dodge performance landmines)
+        if (dimensions >= 16 && PanamaESVectorUtilSupport.HAS_FAST_INTEGER_VECTORS) {
+            // compute vectorized dot product consistent with VPDPBUSD instruction
+            if (PanamaESVectorUtilSupport.VECTOR_BITSIZE >= 512) {
+                dotProductBody512Bulk(q, scores);
+            } else if (PanamaESVectorUtilSupport.VECTOR_BITSIZE == 256) {
+                dotProductBody256Bulk(q, scores);
+            } else {
+                throw new IllegalArgumentException("Unreacheable statement");
+            }
+            return;
+        }
+        super.int4DotProductBulk(q, scores);
+    }
+
+    /** vectorized dot product body (512 bit vectors) */
+    private void dotProductBody512Bulk(byte[] q, float[] scores) throws IOException {
+        int limit = BYTE_SPECIES_128.loopBound(dimensions);
+        for (int iter = 0; iter < BULK_SIZE; iter++) {
+            IntVector acc = IntVector.zero(INT_SPECIES_512);
+            long offset = in.getFilePointer();
+            int i = 0;
+            for (; i < limit; i += BYTE_SPECIES_128.length()) {
+                ByteVector va8 = ByteVector.fromArray(BYTE_SPECIES_128, q, i);
+                ByteVector vb8 = ByteVector.fromMemorySegment(BYTE_SPECIES_128, memorySegment, offset + i, LITTLE_ENDIAN);
+
+                // 16-bit multiply: avoid AVX-512 heavy multiply on zmm
+                Vector<Short> va16 = va8.convertShape(B2S, SHORT_SPECIES_256, 0);
+                Vector<Short> vb16 = vb8.convertShape(B2S, SHORT_SPECIES_256, 0);
+                Vector<Short> prod16 = va16.mul(vb16);
+
+                // 32-bit add
+                Vector<Integer> prod32 = prod16.convertShape(S2I, INT_SPECIES_512, 0);
+                acc = acc.add(prod32);
+            }
+
+            in.seek(offset + limit); // advance the input stream
+            // reduce
+            long res = acc.reduceLanes(ADD);
+            for (; i < q.length; i++) {
+                res += in.readByte() * q[i];
+            }
+            scores[iter] = res;
+        }
+    }
+
+    /** vectorized dot product body (256 bit vectors) */
+    private void dotProductBody256Bulk(byte[] q, float[] scores) throws IOException {
+        int limit = BYTE_SPECIES_128.loopBound(dimensions);
+        for (int iter = 0; iter < BULK_SIZE; iter++) {
+            IntVector acc = IntVector.zero(INT_SPECIES_256);
+            long offset = in.getFilePointer();
+            int i = 0;
+            for (; i < limit; i += BYTE_SPECIES_64.length()) {
+                ByteVector va8 = ByteVector.fromArray(BYTE_SPECIES_64, q, i);
+                ByteVector vb8 = ByteVector.fromMemorySegment(BYTE_SPECIES_64, memorySegment, offset + i, LITTLE_ENDIAN);
+
+                // 32-bit multiply and add into accumulator
+                Vector<Integer> va32 = va8.convertShape(B2I, INT_SPECIES_256, 0);
+                Vector<Integer> vb32 = vb8.convertShape(B2I, INT_SPECIES_256, 0);
+                acc = acc.add(va32.mul(vb32));
+            }
+            in.seek(offset + limit);
+            // reduce
+            long res = acc.reduceLanes(ADD);
+            for (; i < q.length; i++) {
+                res += in.readByte() * q[i];
+            }
+            scores[iter] = res;
+        }
+    }
+
+    @Override
+    public void scoreBulk(
+        byte[] q,
+        float queryLowerInterval,
+        float queryUpperInterval,
+        int queryComponentSum,
+        float queryAdditionalCorrection,
+        VectorSimilarityFunction similarityFunction,
+        float centroidDp,
+        float[] scores
+    ) throws IOException {
+        int4DotProductBulk(q, scores);
+        applyCorrectionsBulk(
+            queryLowerInterval,
+            queryUpperInterval,
+            queryComponentSum,
+            queryAdditionalCorrection,
+            similarityFunction,
+            centroidDp,
+            scores
+        );
+    }
+
+    private void applyCorrectionsBulk(
+        float queryLowerInterval,
+        float queryUpperInterval,
+        int queryComponentSum,
+        float queryAdditionalCorrection,
+        VectorSimilarityFunction similarityFunction,
+        float centroidDp,
+        float[] scores
+    ) throws IOException {
+        int limit = FLOAT_SPECIES.loopBound(BULK_SIZE);
+        int i = 0;
+        long offset = in.getFilePointer();
+        float ay = queryLowerInterval;
+        float ly = (queryUpperInterval - ay) * FOUR_BIT_SCALE;
+        float y1 = queryComponentSum;
+        for (; i < limit; i += FLOAT_SPECIES.length()) {
+            var ax = FloatVector.fromMemorySegment(FLOAT_SPECIES, memorySegment, offset + i * Float.BYTES, ByteOrder.LITTLE_ENDIAN);
+            var lx = FloatVector.fromMemorySegment(
+                FLOAT_SPECIES,
+                memorySegment,
+                offset + 4 * BULK_SIZE + i * Float.BYTES,
+                ByteOrder.LITTLE_ENDIAN
+            ).sub(ax);
+            var targetComponentSums = ShortVector.fromMemorySegment(
+                SHORT_SPECIES,
+                memorySegment,
+                offset + 8 * BULK_SIZE + i * Short.BYTES,
+                ByteOrder.LITTLE_ENDIAN
+            ).convert(VectorOperators.S2I, 0).reinterpretAsInts().and(0xffff).convert(VectorOperators.I2F, 0);
+            var additionalCorrections = FloatVector.fromMemorySegment(
+                FLOAT_SPECIES,
+                memorySegment,
+                offset + 10 * BULK_SIZE + i * Float.BYTES,
+                ByteOrder.LITTLE_ENDIAN
+            );
+            var qcDist = FloatVector.fromArray(FLOAT_SPECIES, scores, i);
+            // ax * ay * dimensions + ay * lx * (float) targetComponentSum + ax * ly * y1 + lx * ly *
+            // qcDist;
+            var res1 = ax.mul(ay).mul(dimensions);
+            var res2 = lx.mul(ay).mul(targetComponentSums);
+            var res3 = ax.mul(ly).mul(y1);
+            var res4 = lx.mul(ly).mul(qcDist);
+            var res = res1.add(res2).add(res3).add(res4);
+            // For euclidean, we need to invert the score and apply the additional correction, which is
+            // assumed to be the squared l2norm of the centroid centered vectors.
+            if (similarityFunction == EUCLIDEAN) {
+                res = res.mul(-2).add(additionalCorrections).add(queryAdditionalCorrection).add(1f);
+                res = FloatVector.broadcast(FLOAT_SPECIES, 1).div(res).max(0);
+                res.intoArray(scores, i);
+            } else {
+                // For cosine and max inner product, we need to apply the additional correction, which is
+                // assumed to be the non-centered dot-product between the vector and the centroid
+                res = res.add(queryAdditionalCorrection).add(additionalCorrections).sub(centroidDp);
+                if (similarityFunction == MAXIMUM_INNER_PRODUCT) {
+                    res.intoArray(scores, i);
+                    // not sure how to do it better
+                    for (int j = 0; j < FLOAT_SPECIES.length(); j++) {
+                        scores[i + j] = VectorUtil.scaleMaxInnerProductScore(scores[i + j]);
+                    }
+                } else {
+                    res = res.add(1f).mul(0.5f).max(0);
+                    res.intoArray(scores, i);
+                }
+            }
+        }
+        in.seek(offset + 14L * BULK_SIZE);
     }
 }

--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/internal/vectorization/ES91Int4VectorScorerTests.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/internal/vectorization/ES91Int4VectorScorerTests.java
@@ -9,13 +9,18 @@
 
 package org.elasticsearch.simdvec.internal.vectorization;
 
+import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.util.VectorUtil;
+import org.elasticsearch.index.codec.vectors.OptimizedScalarQuantizer;
 import org.elasticsearch.simdvec.ES91Int4VectorsScorer;
+import org.elasticsearch.simdvec.ES91OSQVectorsScorer;
+
+import static org.hamcrest.Matchers.lessThan;
 
 public class ES91Int4VectorScorerTests extends BaseVectorizationTests {
 
@@ -54,6 +59,155 @@ public class ES91Int4VectorScorerTests extends BaseVectorizationTests {
                     assertEquals(in.getFilePointer(), slice2.getFilePointer());
                 }
                 assertEquals((long) dimensions * numVectors, in.getFilePointer());
+            }
+        }
+    }
+
+    public void testInt4Score() throws Exception {
+        // only even dimensions are supported
+        final int dimensions = random().nextInt(1, 1000) * 2;
+        final int numVectors = random().nextInt(1, 100);
+        final byte[] vector = new byte[dimensions];
+        final byte[] corrections = new byte[14];
+        try (Directory dir = new MMapDirectory(createTempDir())) {
+            try (IndexOutput out = dir.createOutput("tests.bin", IOContext.DEFAULT)) {
+                for (int i = 0; i < numVectors; i++) {
+                    for (int j = 0; j < dimensions; j++) {
+                        vector[j] = (byte) random().nextInt(16); // 4-bit quantization
+                    }
+                    out.writeBytes(vector, 0, dimensions);
+                    random().nextBytes(corrections);
+                    out.writeBytes(corrections, 0, corrections.length);
+                }
+            }
+            final byte[] query = new byte[dimensions];
+            for (int j = 0; j < dimensions; j++) {
+                query[j] = (byte) random().nextInt(16); // 4-bit quantization
+            }
+            OptimizedScalarQuantizer.QuantizationResult queryCorrections = new OptimizedScalarQuantizer.QuantizationResult(
+                random().nextFloat(),
+                random().nextFloat(),
+                random().nextFloat(),
+                Short.toUnsignedInt((short) random().nextInt())
+            );
+            float centroidDp = random().nextFloat();
+            VectorSimilarityFunction similarityFunction = randomFrom(VectorSimilarityFunction.values());
+            try (IndexInput in = dir.openInput("tests.bin", IOContext.DEFAULT)) {
+                // Work on a slice that has just the right number of bytes to make the test fail with an
+                // index-out-of-bounds in case the implementation reads more than the allowed number of
+                // padding bytes.
+                final IndexInput slice = in.slice("test", 0, (long) (dimensions + 14) * numVectors);
+                final ES91Int4VectorsScorer defaultScorer = defaultProvider().newES91Int4VectorsScorer(in, dimensions);
+                final ES91Int4VectorsScorer panamaScorer = maybePanamaProvider().newES91Int4VectorsScorer(slice, dimensions);
+                for (int i = 0; i < numVectors; i++) {
+                    float scoreDefault = defaultScorer.score(
+                        query,
+                        queryCorrections.lowerInterval(),
+                        queryCorrections.upperInterval(),
+                        queryCorrections.quantizedComponentSum(),
+                        queryCorrections.additionalCorrection(),
+                        similarityFunction,
+                        centroidDp
+                    );
+                    float scorePanama = panamaScorer.score(
+                        query,
+                        queryCorrections.lowerInterval(),
+                        queryCorrections.upperInterval(),
+                        queryCorrections.quantizedComponentSum(),
+                        queryCorrections.additionalCorrection(),
+                        similarityFunction,
+                        centroidDp
+                    );
+                    assertEquals(scoreDefault, scorePanama, 0.001f);
+                    assertEquals(in.getFilePointer(), slice.getFilePointer());
+                }
+                assertEquals((long) (dimensions + 14) * numVectors, in.getFilePointer());
+            }
+        }
+    }
+
+    public void testInt4ScoreBulk() throws Exception {
+        // only even dimensions are supported
+        final int dimensions = random().nextInt(1, 1000) * 2;
+        final int numVectors = random().nextInt(1, 10) * ES91Int4VectorsScorer.BULK_SIZE;
+        final byte[] vector = new byte[ES91Int4VectorsScorer.BULK_SIZE * dimensions];
+        final byte[] corrections = new byte[ES91Int4VectorsScorer.BULK_SIZE * 14];
+        try (Directory dir = new MMapDirectory(createTempDir())) {
+            try (IndexOutput out = dir.createOutput("tests.bin", IOContext.DEFAULT)) {
+                for (int i = 0; i < numVectors; i += ES91Int4VectorsScorer.BULK_SIZE) {
+                    for (int j = 0; j < ES91Int4VectorsScorer.BULK_SIZE * dimensions; j++) {
+                        vector[j] = (byte) random().nextInt(16); // 4-bit quantization
+                    }
+                    out.writeBytes(vector, 0, vector.length);
+                    random().nextBytes(corrections);
+                    out.writeBytes(corrections, 0, corrections.length);
+                }
+            }
+            final byte[] query = new byte[dimensions];
+            for (int j = 0; j < dimensions; j++) {
+                query[j] = (byte) random().nextInt(16); // 4-bit quantization
+            }
+            OptimizedScalarQuantizer.QuantizationResult queryCorrections = new OptimizedScalarQuantizer.QuantizationResult(
+                random().nextFloat(),
+                random().nextFloat(),
+                random().nextFloat(),
+                Short.toUnsignedInt((short) random().nextInt())
+            );
+            float centroidDp = random().nextFloat();
+            VectorSimilarityFunction similarityFunction = randomFrom(VectorSimilarityFunction.values());
+            try (IndexInput in = dir.openInput("tests.bin", IOContext.DEFAULT)) {
+                // Work on a slice that has just the right number of bytes to make the test fail with an
+                // index-out-of-bounds in case the implementation reads more than the allowed number of
+                // padding bytes.
+                final IndexInput slice = in.slice("test", 0, (long) (dimensions + 14) * numVectors);
+                final ES91Int4VectorsScorer defaultScorer = defaultProvider().newES91Int4VectorsScorer(in, dimensions);
+                final ES91Int4VectorsScorer panamaScorer = maybePanamaProvider().newES91Int4VectorsScorer(slice, dimensions);
+                float[] scoresDefault = new float[ES91Int4VectorsScorer.BULK_SIZE];
+                float[] scoresPanama = new float[ES91Int4VectorsScorer.BULK_SIZE];
+                for (int i = 0; i < numVectors; i += ES91Int4VectorsScorer.BULK_SIZE) {
+                    defaultScorer.scoreBulk(
+                        query,
+                        queryCorrections.lowerInterval(),
+                        queryCorrections.upperInterval(),
+                        queryCorrections.quantizedComponentSum(),
+                        queryCorrections.additionalCorrection(),
+                        similarityFunction,
+                        centroidDp,
+                        scoresDefault
+                    );
+                    panamaScorer.scoreBulk(
+                        query,
+                        queryCorrections.lowerInterval(),
+                        queryCorrections.upperInterval(),
+                        queryCorrections.quantizedComponentSum(),
+                        queryCorrections.additionalCorrection(),
+                        similarityFunction,
+                        centroidDp,
+                        scoresPanama
+                    );
+                    for (int j = 0; j < ES91OSQVectorsScorer.BULK_SIZE; j++) {
+                        if (scoresDefault[j] == scoresPanama[j]) {
+                            continue;
+                        }
+                        if (scoresDefault[j] > (1000 * Byte.MAX_VALUE)) {
+                            float diff = Math.abs(scoresDefault[j] - scoresPanama[j]);
+                            assertThat(
+                                "defaultScores: " + scoresDefault[j] + " bulkScores: " + scoresPanama[j],
+                                diff / scoresDefault[j],
+                                lessThan(1e-5f)
+                            );
+                            assertThat(
+                                "defaultScores: " + scoresDefault[j] + " bulkScores: " + scoresPanama[j],
+                                diff / scoresPanama[j],
+                                lessThan(1e-5f)
+                            );
+                        } else {
+                            assertEquals(scoresDefault[j], scoresPanama[j], 1e-2f);
+                        }
+                    }
+                    assertEquals(in.getFilePointer(), slice.getFilePointer());
+                }
+                assertEquals((long) (dimensions + 14) * numVectors, in.getFilePointer());
             }
         }
     }


### PR DESCRIPTION
Similar to what we did for `ES91OSQVectorsScorer`, this PR adds bulk processing capabilities to ES91Int4VectorsScorer. It uses the same approach and microbenchmarks show improvements from 5% to 20%:

preferredBitSize=128:
```
Benchmark                                       (dims)   Mode  Cnt   Score   Error   Units
Int4ScorerBenchmark.scoreFromArray                 384  thrpt    5  14.661 ± 3.043  ops/ms
Int4ScorerBenchmark.scoreFromArray                 782  thrpt    5   9.341 ± 1.539  ops/ms
Int4ScorerBenchmark.scoreFromArray                1024  thrpt    5   8.543 ± 0.069  ops/ms
Int4ScorerBenchmark.scoreFromMemorySegment         384  thrpt    5  17.208 ± 1.126  ops/ms
Int4ScorerBenchmark.scoreFromMemorySegment         782  thrpt    5  10.015 ± 0.500  ops/ms
Int4ScorerBenchmark.scoreFromMemorySegment        1024  thrpt    5  10.083 ± 0.217  ops/ms
Int4ScorerBenchmark.scoreFromMemorySegmentBulk     384  thrpt    5  22.812 ± 0.236  ops/ms
Int4ScorerBenchmark.scoreFromMemorySegmentBulk     782  thrpt    5  10.738 ± 0.106  ops/ms
Int4ScorerBenchmark.scoreFromMemorySegmentBulk    1024  thrpt    5  11.811 ± 0.053  ops/ms
```

preferredBitSize=256:
```
Benchmark                                       (dims)   Mode  Cnt   Score   Error   Units
Int4ScorerBenchmark.scoreFromArray                 384  thrpt    5   8.040 ± 0.509  ops/ms
Int4ScorerBenchmark.scoreFromArray                 782  thrpt    5   4.981 ± 0.181  ops/ms
Int4ScorerBenchmark.scoreFromArray                1024  thrpt    5   4.142 ± 0.063  ops/ms
Int4ScorerBenchmark.scoreFromMemorySegment         384  thrpt    5   9.278 ± 0.025  ops/ms
Int4ScorerBenchmark.scoreFromMemorySegment         782  thrpt    5   5.088 ± 0.019  ops/ms
Int4ScorerBenchmark.scoreFromMemorySegment        1024  thrpt    5   4.393 ± 0.398  ops/ms
Int4ScorerBenchmark.scoreFromMemorySegmentBulk     384  thrpt    5  12.119 ± 0.801  ops/ms
Int4ScorerBenchmark.scoreFromMemorySegmentBulk     782  thrpt    5   5.332 ± 0.019  ops/ms
Int4ScorerBenchmark.scoreFromMemorySegmentBulk    1024  thrpt    5   5.120 ± 0.061  ops/ms
```

preferredBitSize=512:
```
Benchmark                                       (dims)   Mode  Cnt   Score   Error   Units
Int4ScorerBenchmark.scoreFromArray                 384  thrpt    5   6.769 ± 0.066  ops/ms
Int4ScorerBenchmark.scoreFromArray                 782  thrpt    5   4.298 ± 0.394  ops/ms
Int4ScorerBenchmark.scoreFromArray                1024  thrpt    5   4.395 ± 0.050  ops/ms
Int4ScorerBenchmark.scoreFromMemorySegment         384  thrpt    5   7.401 ± 0.088  ops/ms
Int4ScorerBenchmark.scoreFromMemorySegment         782  thrpt    5   4.318 ± 0.291  ops/ms
Int4ScorerBenchmark.scoreFromMemorySegment        1024  thrpt    5   4.687 ± 0.052  ops/ms
Int4ScorerBenchmark.scoreFromMemorySegmentBulk     384  thrpt    5  10.768 ± 0.737  ops/ms
Int4ScorerBenchmark.scoreFromMemorySegmentBulk     782  thrpt    5   5.475 ± 0.028  ops/ms
Int4ScorerBenchmark.scoreFromMemorySegmentBulk    1024  thrpt    5   6.194 ± 0.085  ops/ms
```
