### PR TITLE
[8.18] ES|QL: let mixed-cluster tests run only with GA versions (#131101)

### DIFF
--- a/x-pack/plugin/esql/qa/server/mixed-cluster/build.gradle
+++ b/x-pack/plugin/esql/qa/server/mixed-cluster/build.gradle
@@ -27,9 +27,9 @@ dependencies {
 
 GradleUtils.extendSourceSet(project, "javaRestTest", "yamlRestTest")
 
-// ESQL is available in 8.11 or later
+// ES|QL becomes GA in 8.14
 def supportedVersion = bwcVersion -> {
-  return bwcVersion.onOrAfter(Version.fromString("8.11.0")) && bwcVersion != VersionProperties.elasticsearchVersion
+  return bwcVersion.onOrAfter(Version.fromString("8.14.0")) && bwcVersion != VersionProperties.elasticsearchVersion
 }
 
 buildParams.bwcVersions.withWireCompatible(supportedVersion) { bwcVersion, baseName ->


### PR DESCRIPTION
Backports the following commits to 8.18:
 - ES|QL: let mixed-cluster tests run only with GA versions (#131101)