### PR TITLE
Renaming bbq_ivf to bbq_disk

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/135_knn_query_nested_search_ivf.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/135_knn_query_nested_search_ivf.yml
@@ -1,7 +1,7 @@
 setup:
   - requires:
-      cluster_features: "mapper.ivf_nested_support"
-      reason: 'ivf nested support required'
+      cluster_features: "mapper.bbq_disk_support"
+      reason: 'bbq disk support required'
   - do:
       indices.create:
         index: test
@@ -24,7 +24,7 @@ setup:
                     index: true
                     similarity: l2_norm
                     index_options:
-                      type: bbq_ivf
+                      type: bbq_disk
 
           aliases:
             my_alias:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/46_knn_search_bbq_ivf.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/46_knn_search_bbq_ivf.yml
@@ -1,12 +1,12 @@
 setup:
   - requires:
-      cluster_features: ["mapper.ivf_format_cluster_feature"]
-      reason: Needs mapper.ivf_format_cluster_feature feature
+      cluster_features: ["mapper.bbq_disk_support"]
+      reason: Needs mapper.bbq_disk_support feature
   - skip:
       features: "headers"
   - do:
       indices.create:
-        index: bbq_ivf
+        index: bbq_disk
         body:
           settings:
             index:
@@ -19,11 +19,11 @@ setup:
                 index: true
                 similarity: max_inner_product
                 index_options:
-                  type: bbq_ivf
+                  type: bbq_disk
 
   - do:
       index:
-        index: bbq_ivf
+        index: bbq_disk
         id: "1"
         body:
           vector: [0.077,  0.32 , -0.205,  0.63 ,  0.032,  0.201,  0.167, -0.313,
@@ -37,11 +37,11 @@ setup:
   # Flush in order to provoke a merge later
   - do:
       indices.flush:
-        index: bbq_ivf
+        index: bbq_disk
 
   - do:
       index:
-        index: bbq_ivf
+        index: bbq_disk
         id: "2"
         body:
           vector: [0.196,  0.514,  0.039,  0.555, -0.042,  0.242,  0.463, -0.348,
@@ -55,11 +55,11 @@ setup:
   # Flush in order to provoke a merge later
   - do:
       indices.flush:
-        index: bbq_ivf
+        index: bbq_disk
 
   - do:
       index:
-        index: bbq_ivf
+        index: bbq_disk
         id: "3"
         body:
           name: rabbit.jpg
@@ -74,11 +74,11 @@ setup:
   # Flush in order to provoke a merge later
   - do:
       indices.flush:
-        index: bbq_ivf
+        index: bbq_disk
 
   - do:
       indices.forcemerge:
-        index: bbq_ivf
+        index: bbq_disk
         max_num_segments: 1
 
   - do:
@@ -87,7 +87,7 @@ setup:
 "Test knn search":
   - do:
       search:
-        index: bbq_ivf
+        index: bbq_disk
         body:
           knn:
             field: vector
@@ -116,7 +116,7 @@ setup:
         Content-Type: application/json
       search:
         rest_total_hits_as_int: true
-        index: bbq_ivf
+        index: bbq_disk
         body:
           knn:
             field: vector
@@ -182,7 +182,7 @@ setup:
                 element_type: byte
                 index: true
                 index_options:
-                  type: bbq_ivf
+                  type: bbq_disk
 
   - do:
       catch: bad_request
@@ -196,7 +196,7 @@ setup:
                 dims: 64
                 index: false
                 index_options:
-                  type: bbq_ivf
+                  type: bbq_disk
 ---
 "Test index configured rescore vector":
   - skip:
@@ -216,7 +216,7 @@ setup:
                 index: true
                 similarity: max_inner_product
                 index_options:
-                  type: bbq_ivf
+                  type: bbq_disk
                   rescore_vector:
                     oversample: 1.5
 
@@ -298,7 +298,7 @@ setup:
               vector:
                 type: dense_vector
                 index_options:
-                  type: bbq_ivf
+                  type: bbq_disk
                   rescore_vector:
                     oversample: 0
 
@@ -314,7 +314,7 @@ setup:
               vector:
                 type: dense_vector
                 index_options:
-                  type: bbq_ivf
+                  type: bbq_disk
                   rescore_vector:
                     oversample: 1
 
@@ -326,7 +326,7 @@ setup:
             vector:
               type: dense_vector
               index_options:
-                type: bbq_ivf
+                type: bbq_disk
                 rescore_vector:
                   oversample: 0
 
@@ -354,7 +354,7 @@ setup:
                 index: true
                 similarity: max_inner_product
                 index_options:
-                  type: bbq_ivf
+                  type: bbq_disk
                   rescore_vector:
                     oversample: 0
 
@@ -430,7 +430,7 @@ setup:
               index: true
               similarity: max_inner_product
               index_options:
-                type: bbq_ivf
+                type: bbq_disk
                 rescore_vector:
                   oversample: 2
 
@@ -470,7 +470,7 @@ setup:
               index: true
               similarity: max_inner_product
               index_options:
-                type: bbq_ivf
+                type: bbq_disk
                 rescore_vector:
                   oversample: 0
 
@@ -509,6 +509,6 @@ setup:
 "default oversample value":
   - do:
       indices.get_mapping:
-        index: bbq_ivf
+        index: bbq_disk
 
-  - match: { bbq_ivf.mappings.properties.vector.index_options.rescore_vector.oversample: 3.0 }
+  - match: { bbq_disk.mappings.properties.vector.index_options.rescore_vector.oversample: 3.0 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -42,6 +42,8 @@ public class MapperFeatures implements FeatureSpecification {
         "mapper.unknown_field_mapping_update_error_message"
     );
     static final NodeFeature NPE_ON_DIMS_UPDATE_FIX = new NodeFeature("mapper.npe_on_dims_update_fix");
+    static final NodeFeature IVF_FORMAT_CLUSTER_FEATURE = new NodeFeature("mapper.ivf_format_cluster_feature");
+    static final NodeFeature IVF_NESTED_SUPPORT = new NodeFeature("mapper.ivf_nested_support");
     static final NodeFeature BBQ_DISK_SUPPORT = new NodeFeature("mapper.bbq_disk_support");
     static final NodeFeature SEARCH_LOAD_PER_SHARD = new NodeFeature("mapper.search_load_per_shard");
     static final NodeFeature PATTERNED_TEXT = new NodeFeature("mapper.patterned_text");
@@ -73,6 +75,8 @@ public class MapperFeatures implements FeatureSpecification {
             NPE_ON_DIMS_UPDATE_FIX,
             RESCORE_ZERO_VECTOR_QUANTIZED_VECTOR_MAPPING,
             USE_DEFAULT_OVERSAMPLE_VALUE_FOR_BBQ,
+            IVF_FORMAT_CLUSTER_FEATURE,
+            IVF_NESTED_SUPPORT,
             BBQ_DISK_SUPPORT,
             SEARCH_LOAD_PER_SHARD,
             SPARSE_VECTOR_INDEX_OPTIONS_FEATURE,

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -42,8 +42,7 @@ public class MapperFeatures implements FeatureSpecification {
         "mapper.unknown_field_mapping_update_error_message"
     );
     static final NodeFeature NPE_ON_DIMS_UPDATE_FIX = new NodeFeature("mapper.npe_on_dims_update_fix");
-    static final NodeFeature IVF_FORMAT_CLUSTER_FEATURE = new NodeFeature("mapper.ivf_format_cluster_feature");
-    static final NodeFeature IVF_NESTED_SUPPORT = new NodeFeature("mapper.ivf_nested_support");
+    static final NodeFeature BBQ_DISK_SUPPORT = new NodeFeature("mapper.bbq_disk_support");
     static final NodeFeature SEARCH_LOAD_PER_SHARD = new NodeFeature("mapper.search_load_per_shard");
     static final NodeFeature PATTERNED_TEXT = new NodeFeature("mapper.patterned_text");
 
@@ -74,8 +73,7 @@ public class MapperFeatures implements FeatureSpecification {
             NPE_ON_DIMS_UPDATE_FIX,
             RESCORE_ZERO_VECTOR_QUANTIZED_VECTOR_MAPPING,
             USE_DEFAULT_OVERSAMPLE_VALUE_FOR_BBQ,
-            IVF_FORMAT_CLUSTER_FEATURE,
-            IVF_NESTED_SUPPORT,
+            BBQ_DISK_SUPPORT,
             SEARCH_LOAD_PER_SHARD,
             SPARSE_VECTOR_INDEX_OPTIONS_FEATURE,
             PATTERNED_TEXT

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -1675,7 +1675,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
                 return dims >= BBQ_MIN_DIMS;
             }
         },
-        BBQ_IVF("bbq_ivf", true) {
+        BBQ_IVF("bbq_disk", true) {
             @Override
             public DenseVectorIndexOptions parseIndexOptions(String fieldName, Map<String, ?> indexOptionsMap, IndexVersion indexVersion) {
                 Object clusterSizeNode = indexOptionsMap.remove("cluster_size");

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -1675,7 +1675,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
                 return dims >= BBQ_MIN_DIMS;
             }
         },
-        BBQ_IVF("bbq_disk", true) {
+        BBQ_DISK("bbq_disk", true) {
             @Override
             public DenseVectorIndexOptions parseIndexOptions(String fieldName, Map<String, ?> indexOptionsMap, IndexVersion indexVersion) {
                 Object clusterSizeNode = indexOptionsMap.remove("cluster_size");
@@ -2295,7 +2295,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
         final int defaultNProbe;
 
         BBQIVFIndexOptions(int clusterSize, int defaultNProbe, RescoreVector rescoreVector) {
-            super(VectorIndexType.BBQ_IVF, rescoreVector);
+            super(VectorIndexType.BBQ_DISK, rescoreVector);
             this.clusterSize = clusterSize;
             this.defaultNProbe = defaultNProbe;
         }

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
@@ -1367,7 +1367,7 @@ public class DenseVectorFieldMapperTests extends SyntheticVectorsMapperTestCase 
                 b.field("index", true);
                 b.field("similarity", "dot_product");
                 b.startObject("index_options");
-                b.field("type", "bbq_ivf");
+                b.field("type", "bbq_disk");
                 b.endObject();
             }));
 
@@ -1386,7 +1386,7 @@ public class DenseVectorFieldMapperTests extends SyntheticVectorsMapperTestCase 
                 b.field("index", true);
                 b.field("similarity", "dot_product");
                 b.startObject("index_options");
-                b.field("type", "bbq_ivf");
+                b.field("type", "bbq_disk");
                 b.field("cluster_size", 1000);
                 b.field("default_n_probe", 10);
                 b.field(DenseVectorFieldMapper.RescoreVector.NAME, Map.of("oversample", 2.0f));
@@ -1413,7 +1413,7 @@ public class DenseVectorFieldMapperTests extends SyntheticVectorsMapperTestCase 
                     b -> b.field("type", "dense_vector")
                         .field("dims", dims)
                         .startObject("index_options")
-                        .field("type", "bbq_ivf")
+                        .field("type", "bbq_disk")
                         .endObject()
                 )
             )
@@ -2815,7 +2815,7 @@ public class DenseVectorFieldMapperTests extends SyntheticVectorsMapperTestCase 
             b.field("index", true);
             b.field("similarity", "dot_product");
             b.startObject("index_options");
-            b.field("type", "bbq_ivf");
+            b.field("type", "bbq_disk");
             b.endObject();
         }));
         CodecService codecService = new CodecService(mapperService, BigArrays.NON_RECYCLING_INSTANCE);


### PR DESCRIPTION
This renames the format type name from bbq_ivf to bbq_disk.

This doesn't update any of the internal classes, we can defer that until major internal changes are complete (to prevent large conflicts).