### PR TITLE
[9.0] [ML] Including max_tokens through the Service API for Anthropic (#131113)

### DIFF
--- a/docs/changelog/131113.yaml
+++ b/docs/changelog/131113.yaml
@@ -1,0 +1,5 @@
+pr: 131113
+summary: Including `max_tokens` through the Service API for Anthropic
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicService.java
@@ -267,6 +267,19 @@ public class AnthropicService extends SenderService {
                         .build()
                 );
 
+                configurationMap.put(
+                    AnthropicServiceFields.MAX_TOKENS,
+                    new SettingsConfiguration.Builder(EnumSet.of(TaskType.COMPLETION)).setDescription(
+                        "The maximum number of tokens to generate before stopping."
+                    )
+                        .setLabel("Max Tokens")
+                        .setRequired(true)
+                        .setSensitive(false)
+                        .setUpdatable(false)
+                        .setType(SettingsConfigurationFieldType.INTEGER)
+                        .build()
+                );
+
                 configurationMap.putAll(DefaultSecretSettings.toSettingsConfiguration(supportedTaskTypes));
                 configurationMap.putAll(
                     RateLimitSettings.toSettingsConfigurationWithDescription(

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/anthropic/AnthropicServiceTests.java
@@ -628,6 +628,15 @@ public class AnthropicServiceTests extends ESTestCase {
                               "updatable": false,
                               "type": "str",
                               "supported_task_types": ["completion"]
+                          },
+                        "max_tokens": {
+                              "description": "The maximum number of tokens to generate before stopping.",
+                              "label": "Max Tokens",
+                              "required": true,
+                              "sensitive": false,
+                              "updatable": false,
+                              "type": "int",
+                              "supported_task_types": ["completion"]
                           }
                       }
                   }


### PR DESCRIPTION
Backports the following commits to 9.0:
 - [ML] Including max_tokens through the Service API for Anthropic (#131113)