### PR TITLE
Exclude `.triggered-watches` from indices cleanup in REST tests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -1228,7 +1228,7 @@ public abstract class ESRestTestCase extends ESTestCase {
         try {
             // remove all indices except some history indices which can pop up after deleting all data streams but shouldn't interfere
             final List<String> indexPatterns = new ArrayList<>(
-                List.of("*", "-.ds-ilm-history-*", "-.ds-.slm-history-*", "-.ds-.watcher-history-*")
+                List.of("*", "-.ds-ilm-history-*", "-.ds-.slm-history-*", "-.ds-.watcher-history-*", "-.ds-.triggered_watches-*")
             );
             if (preserveSecurityIndices) {
                 indexPatterns.add("-.security-*");


### PR DESCRIPTION
Some tests were seeing an unexpected warning header from wiping all indices in the test cleanup, caused by the `.triggered-watches` data stream being present. We exclude the backing indices of this data stream from the indices wipe to avoid the warning header. The presence of this data stream shouldn't intefere with tests, and any tests that do interact with that data stream should assert/control its state by themselves to ensure consistency.

Fixes #129682