### PR TITLE
Re-enable testStopQueryLocal

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -517,9 +517,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.action.EsqlActionBreakerIT
   method: testRowStatsProjectGroupByInt
   issue: https://github.com/elastic/elasticsearch/issues/131024
-- class: org.elasticsearch.xpack.esql.action.CrossClusterAsyncQueryStopIT
-  method: testStopQueryLocal
-  issue: https://github.com/elastic/elasticsearch/issues/121672
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
   method: test {lookup-join.MvJoinKeyOnFromAfterStats ASYNC}
   issue: https://github.com/elastic/elasticsearch/issues/131148

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterAsyncQueryStopIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterAsyncQueryStopIT.java
@@ -13,6 +13,7 @@ import org.elasticsearch.core.Tuple;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.tasks.TaskInfo;
+import org.elasticsearch.test.junit.annotations.TestIssueLogging;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.async.AsyncStopRequest;
 import org.elasticsearch.xpack.esql.plugin.EsqlPlugin;
@@ -37,6 +38,10 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
+@TestIssueLogging(
+    value = "org.elasticsearch.xpack.esql.plugin.TransportEsqlAsyncStopAction:DEBUG",
+    issueUrl = "https://github.com/elastic/elasticsearch/issues/121672"
+)
 public class CrossClusterAsyncQueryStopIT extends AbstractCrossClusterTestCase {
 
     private static final Logger LOGGER = LogManager.getLogger(CrossClusterAsyncQueryStopIT.class);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlAsyncStopAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlAsyncStopAction.java
@@ -116,8 +116,8 @@ public class TransportEsqlAsyncStopAction extends HandledTransportAction<AsyncSt
             getResultsAction.execute(task, getAsyncResultRequest, listener);
             return;
         }
-        logger.debug("Async stop for task {} - stopping", asyncIdStr);
         final EsqlExecutionInfo esqlExecutionInfo = asyncTask.executionInfo();
+        logger.debug("Async stop for task {} current execution info {}", asyncIdStr, esqlExecutionInfo);
         if (esqlExecutionInfo != null) {
             esqlExecutionInfo.markAsStopped();
         }


### PR DESCRIPTION
I suspect a visibility issue with the executionInfo field in EsqlQueryTask. This field should be volatile, but based on the execution timing, I doubt it is the actual cause. This PR re-enables the test with additional debug logging first instead.

Relates #121672