### PR TITLE
[9.0] Add missing query parameters to eql.search rest-api-spec (#130719)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/eql.search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/eql.search.json
@@ -51,6 +51,31 @@
         "type":"boolean",
         "description":"Control whether a sequence query should return partial results or no results at all in case of shard failures. This option has effect only if [allow_partial_search_results] is true.",
         "default":false
+      },
+      "ccs_minimize_roundtrips":{
+        "type":"boolean",
+        "description":"Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution",
+        "default":true
+      },
+      "ignore_unavailable":{
+        "type":"boolean",
+        "description":"Whether specified concrete indices should be ignored when unavailable (missing or closed)"
+      },
+      "allow_no_indices":{
+        "type":"boolean",
+        "description":"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+      },
+      "expand_wildcards":{
+        "type":"enum",
+        "options":[
+          "open",
+          "closed",
+          "hidden",
+          "none",
+          "all"
+        ],
+        "default":"open",
+        "description":"Whether to expand wildcard expression to concrete indices that are open, closed or both."
       }
     },
     "body":{


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Add missing query parameters to eql.search rest-api-spec (#130719)