### PR TITLE
[9.0] Add missing query parameters to create rest-api-spec (#130717)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/create.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/create.json
@@ -73,6 +73,14 @@
       "include_source_on_error": {
         "type": "boolean",
         "description": "True or false if to include the document source in the error message in case of parsing errors. Defaults to true."
+      },
+      "require_alias":{
+        "type":"boolean",
+        "description":"When true, requires destination to be an alias. Default is false"
+      },
+      "require_data_stream":{
+        "type":"boolean",
+        "description":"When true, requires destination to be a data stream (existing or to be created). Default is false"
       }
     },
     "body":{


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Add missing query parameters to create rest-api-spec (#130717)