### PR TITLE
[9.0] Add register_operation_count to snapshot.repository_analyze rest-api-spec (#131082)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.repository_analyze.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.repository_analyze.json
@@ -36,6 +36,10 @@
         "type":"number",
         "description":"Number of operations to run concurrently during the test. Defaults to 10."
       },
+      "register_operation_count":{
+        "type":"number",
+        "description":"The minimum number of linearizable register operations to perform in total. Defaults to 10."
+      },
       "read_node_count":{
         "type":"number",
         "description":"Number of nodes on which to read a blob after writing. Defaults to 10."


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Add register_operation_count to snapshot.repository_analyze rest-api-spec (#131082)