### PR TITLE
ES|QL: Fix generative tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -523,9 +523,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
   method: test {lookup-join.MvJoinKeyOnFromAfterStats ASYNC}
   issue: https://github.com/elastic/elasticsearch/issues/131148
-- class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/131154
 - class: org.elasticsearch.index.engine.ThreadPoolMergeExecutorServiceDiskSpaceTests
   method: testEnqueuedMergeTasksAreUnblockedWhenEstimatedMergeSizeChanges
   issue: https://github.com/elastic/elasticsearch/issues/131165
@@ -538,9 +535,6 @@ tests:
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test090SecurityCliPackaging
   issue: https://github.com/elastic/elasticsearch/issues/131107
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/131154
 
 # Examples:
 #

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
@@ -40,7 +40,7 @@ public abstract class GenerativeRestTest extends ESRestTestCase {
         "Cannot use field \\[.*\\] due to ambiguities",
         "cannot sort on .*",
         "argument of \\[count.*\\] must",
-        "Cannot use field \\[.*\\] with unsupported type \\[.*_range\\]",
+        "Cannot use field \\[.*\\] with unsupported type \\[.*\\]",
         "Unbounded sort not supported yet",
         "The field names are too complex to process", // field_caps problem
         "must be \\[any type except counter types\\]", // TODO refine the generation of count()


### PR DESCRIPTION
Now tolerating generic `Cannot use field [...] with unsupported type [...]` errors, that now can also happen with vector types that are not supported by some operators

Fixes: https://github.com/elastic/elasticsearch/issues/131154