### PR TITLE
grant azure core required manage_threads entitlement

### DIFF
--- a/docs/changelog/131284.yaml
+++ b/docs/changelog/131284.yaml
@@ -1,0 +1,6 @@
+pr: 131284
+summary: Grant azure core required `manage_threads` entitlement
+area: Authentication
+type: bug
+issues:
+ - 131246

--- a/docs/changelog/131284.yaml
+++ b/docs/changelog/131284.yaml
@@ -1,6 +1,0 @@
-pr: 131284
-summary: Grant azure core required `manage_threads` entitlement
-area: Authentication
-type: bug
-issues:
- - 131246

--- a/x-pack/extras/plugins/microsoft-graph-authz/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/x-pack/extras/plugins/microsoft-graph-authz/src/main/plugin-metadata/entitlement-policy.yaml
@@ -3,3 +3,5 @@ okhttp3:
   - manage_threads
 okio:
   - manage_threads
+com.azure.core:
+  - manage_threads


### PR DESCRIPTION
The Azure Core dependency of the ms-graph-authz plugin will use virtual threads where possible, and fall back to real threads otherwise.

We developed and tested against JDK 24, so this wasn't an issue, but on JDK 17, virtual threads are unavailable, so we need to grant the library the appropriate entitlement to create the thread.

Fixes https://github.com/elastic/elasticsearch/issues/131246, https://github.com/elastic/elasticsearch/issues/131247