### PR TITLE
Unmute #130640 - test failure was unrelated

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -484,9 +484,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.action.EsqlActionBreakerIT
   method: testTopNPushedToLucene
   issue: https://github.com/elastic/elasticsearch/issues/130505
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {match-operator.MatchWithMoreComplexDisjunctionAndConjunction SYNC}
-  issue: https://github.com/elastic/elasticsearch/issues/130640
 - class: org.elasticsearch.gradle.LoggedExecFuncTest
   method: failed tasks output logged to console when spooling true
   issue: https://github.com/elastic/elasticsearch/issues/119509


### PR DESCRIPTION
Closes #130640

Does what it says on the tin.

The failures are unrelated to the test:

```
EsqlSpecIT > test {match-operator.MatchWithMoreComplexDisjunctionAndConjunction SYNC} FAILED
    java.net.ConnectException: Connection refused
        at org.elasticsearch.client.RestClient.extractAndWrapCause(RestClient.java:934)
        at org.elasticsearch.client.RestClient.performRequest(RestClient.java:304)
        at org.elasticsearch.client.RestClient.performRequest(RestClient.java:292)
        at org.elasticsearch.xpack.esql.CsvTestsDataLoader.clusterHasInferenceEndpoint(CsvTestsDataLoader.java:476)
        at org.elasticsearch.xpack.esql.CsvTestsDataLoader.clusterHasSparseEmbeddingInferenceEndpoint(CsvTestsDataLoader.java:427)
        at org.elasticsearch.xpack.esql.CsvTestsDataLoader.createInferenceEndpoints(CsvTestsDataLoader.java:392)
        at org.elasticsearch.xpack.esql.qa.rest.EsqlSpecTestCase.setup(EsqlSpecTestCase.java:142)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
```

An assertion was tripped on other test:

```
java.lang.AssertionError
	at org.elasticsearch.server@9.2.0-SNAPSHOT/org.elasticsearch.common.util.BigArrays$ByteArrayAsIntArrayWrapper.get(BigArrays.java:212)
	at org.elasticsearch.compute.aggregation.ValuesBytesRefAggregator$GroupingState.buildOrdinalOutputBlock(ValuesBytesRefAggregator.java:336)
	at org.elasticsearch.compute.aggregation.ValuesBytesRefAggregator$GroupingState.toBlock(ValuesBytesRefAggregator.java:269)
	at org.elasticsearch.compute.aggregation.ValuesBytesRefAggregator$GroupingState.toIntermediate(ValuesBytesRefAggregator.java:178)
	at org.elasticsearch.compute.aggregation.ValuesBytesRefGroupingAggregatorFunction.evaluateIntermediate(ValuesBytesRefGroupingAggregatorFunction.java:242)
	at org.elasticsearch.compute.aggregation.GroupingAggregator.evaluate(GroupingAggregator.java:87)
	at org.elasticsearch.compute.operator.OrdinalsGroupingOperator.mergeOrdinalsSegmentResults(OrdinalsGroupingOperator.java:299)
	at org.elasticsearch.compute.operator.OrdinalsGroupingOperator.getOutput(OrdinalsGroupingOperator.java:222)
	at org.elasticsearch.compute.operator.Driver.runSingleLoopIteration(Driver.java:272)
	at org.elasticsearch.compute.operator.Driver.run(Driver.java:186)
	at org.elasticsearch.compute.operator.Driver$1.doRun(Driver.java:420)
	at org.elasticsearch.server@9.2.0-SNAPSHOT/org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:27)
	at org.elasticsearch.compute.operator.DriverScheduler$1.doRun(DriverScheduler.java:57)
	at org.elasticsearch.server@9.2.0-SNAPSHOT/org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:27)
	at org.elasticsearch.server@9.2.0-SNAPSHOT/org.elasticsearch.common.util.concurrent.TimedRunnable.doRun(TimedRunnable.java:35)
	at org.elasticsearch.server@9.2.0-SNAPSHOT/org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:1044)
	at org.elasticsearch.server@9.2.0-SNAPSHOT/org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:27)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1095)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:619)
	at java.base/java.lang.Thread.run(Thread.java:1447)
```