### PR TITLE
Add note on o11y to architecture guide

### DIFF
--- a/docs/internal/GeneralArchitectureGuide.md
+++ b/docs/internal/GeneralArchitectureGuide.md
@@ -298,6 +298,20 @@ See the [public upgrade docs][] for the upgrade process.
 
 (what plugins do we have?)
 
+# Observability
+
+Elasticsearch emits logs as described in the [public logging docs][], and exposes a good deal of information about its inner workings using
+all its management and stats APIs. Elasticsearch also integrates with the [Elastic APM Java agent][] to perform distributed tracing (as
+described in [TRACING.md][]) and metrics collection (as described in [METERING.md][]). This agent exposes the data it collects to an
+[OpenTelemetry][] service such as [Elastic APM Server][].
+
+[public logging docs]: https://www.elastic.co/docs/deploy-manage/monitor/logging-configuration
+[Elastic APM Java agent]: https://www.elastic.co/docs/reference/apm/agents/java
+[OpenTelemetry]: https://opentelemetry.io/
+[Elastic APM Server]: https://www.elastic.co/docs/solutions/observability/apm
+[TRACING.md]: https://github.com/elastic/elasticsearch/blob/v8.18.3/TRACING.md
+[METERING.md]: https://github.com/elastic/elasticsearch/blob/v8.18.3/modules/apm/METERING.md
+
 # Testing
 
 (Overview of our testing frameworks. Discuss base test classes.)


### PR DESCRIPTION
Adds brief overview that mostly just serves as a location for links to
other more comprehensive design documentation elsewhere in the source
tree.

Closes ES-9874