### PR TITLE
[8.19] Unmute docker tests, add more logging and increase startup timeout (#131203)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -309,8 +309,6 @@ tests:
   - class: org.elasticsearch.xpack.test.rest.XPackRestIT
     method: test {p0=snapshot/20_operator_privileges_disabled/Operator only settings can be set and restored by non-operator user when operator privileges is disabled}
     issue: https://github.com/elastic/elasticsearch/issues/120973
-  - class: org.elasticsearch.packaging.test.DockerTests
-    issue: https://github.com/elastic/elasticsearch/issues/120978
   - class: org.elasticsearch.xpack.security.authc.service.ServiceAccountIT
     method: testAuthenticateShouldNotFallThroughInCaseOfFailure
     issue: https://github.com/elastic/elasticsearch/issues/120902

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
@@ -145,6 +145,10 @@ public abstract class PackagingTestCase extends Assert {
         @Override
         protected void failed(Throwable e, Description description) {
             failed = true;
+            if (installation != null && installation.distribution.isDocker()) {
+                logger.warn("Test {} failed. Printing logs for failed test...", description.getMethodName());
+                FileUtils.logAllLogs(installation.logs, logger);
+            }
         }
     };
 

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
@@ -147,7 +147,7 @@ public abstract class PackagingTestCase extends Assert {
             failed = true;
             if (installation != null && installation.distribution.isDocker()) {
                 logger.warn("Test {} failed. Printing logs for failed test...", description.getMethodName());
-                FileUtils.logAllLogs(installation.logs, logger);
+                dumpDebug();
             }
         }
     };

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/ServerUtils.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/ServerUtils.java
@@ -150,7 +150,19 @@ public class ServerUtils {
             executor.auth(username, password);
             executor.authPreemptive(new HttpHost("localhost", 9200));
         }
-        return executor.execute(request).returnResponse();
+        try {
+            return executor.execute(request).returnResponse();
+        } catch (Exception e) {
+            logger.warn(
+                "Failed to execute request [{}] with username/password [{}/{}] and caCert [{}]",
+                request.toString(),
+                username,
+                password,
+                caCert,
+                e
+            );
+            throw e;
+        }
     }
 
     // polls every two seconds for Elasticsearch to be running on 9200
@@ -238,14 +250,13 @@ public class ServerUtils {
         long timeElapsed = 0;
         boolean started = false;
         Throwable thrownException = null;
-        if (caCert == null) {
-            caCert = getCaCert(installation);
-        }
 
         while (started == false && timeElapsed < waitTime) {
             if (System.currentTimeMillis() - lastRequest > requestInterval) {
+                if (caCert == null) {
+                    caCert = getCaCert(installation);
+                }
                 try {
-
                     final HttpResponse response = execute(
                         Request.Get((caCert != null ? "https" : "http") + "://localhost:9200/_cluster/health")
                             .connectTimeout((int) timeoutLength)
@@ -276,7 +287,7 @@ public class ServerUtils {
                     }
                     started = true;
 
-                } catch (IOException e) {
+                } catch (Exception e) {
                     if (thrownException == null) {
                         thrownException = e;
                     } else {

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
@@ -73,7 +73,7 @@ public class Docker {
     public static final Shell sh = new Shell();
     public static final DockerShell dockerShell = new DockerShell();
     public static final int STARTUP_SLEEP_INTERVAL_MILLISECONDS = 1000;
-    public static final int STARTUP_ATTEMPTS_MAX = 30;
+    public static final int STARTUP_ATTEMPTS_MAX = 45;
 
     /**
      * The length of the command exceeds what we can use for COLUMNS so we use


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Unmute docker tests, add more logging and increase startup timeout (#131203)](https://github.com/elastic/elasticsearch/pull/131203)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)