### PR TITLE
Unmute DockerTests#test090SecurityCliPackaging

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -427,9 +427,6 @@ tests:
 - class: org.elasticsearch.test.rest.yaml.RcsCcsCommonYamlTestSuiteIT
   method: test {p0=field_caps/40_time_series/Get simple time series field caps}
   issue: https://github.com/elastic/elasticsearch/issues/131225
-- class: org.elasticsearch.packaging.test.DockerTests
-  method: test090SecurityCliPackaging
-  issue: https://github.com/elastic/elasticsearch/issues/131107
 
 # Examples:
 #

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
@@ -147,7 +147,7 @@ public abstract class PackagingTestCase extends Assert {
             failed = true;
             if (installation != null && installation.distribution.isDocker()) {
                 logger.warn("Test {} failed. Printing logs for failed test...", description.getMethodName());
-                FileUtils.logAllLogs(installation.logs, logger);
+                dumpDebug();
             }
         }
     };


### PR DESCRIPTION
This test timed out due to slow security auto-configuration. 
The #131203 increased timeout from 30s to 45s, which should hopefully be enough.

Resolves #131107
