### PR TITLE
Adds support for more than one input doc file for Knnindextester

### DIFF
--- a/qa/vector/src/main/java/org/elasticsearch/test/knn/KnnIndexTester.java
+++ b/qa/vector/src/main/java/org/elasticsearch/test/knn/KnnIndexTester.java
@@ -83,7 +83,7 @@ public class KnnIndexTester {
                 suffix.add(Integer.toString(args.quantizeBits()));
             }
         }
-        return INDEX_DIR + "/" + args.docVectors().getFileName() + "-" + String.join("-", suffix) + ".index";
+        return INDEX_DIR + "/" + args.docVectors().get(0).getFileName() + "-" + String.join("-", suffix) + ".index";
     }
 
     static Codec createCodec(CmdLineArgs args) {
@@ -137,7 +137,7 @@ public class KnnIndexTester {
             System.out.println(
                 Strings.toString(
                     new CmdLineArgs.Builder().setDimensions(64)
-                        .setDocVectors("/doc/vectors/path")
+                        .setDocVectors(List.of("/doc/vectors/path"))
                         .setQueryVectors("/query/vectors/path")
                         .build(),
                     true,
@@ -179,7 +179,7 @@ public class KnnIndexTester {
                 : new int[] { 0 };
             String indexType = cmdLineArgs.indexType().name().toLowerCase(Locale.ROOT);
             Results indexResults = new Results(
-                cmdLineArgs.docVectors().getFileName().toString(),
+                cmdLineArgs.docVectors().get(0).getFileName().toString(),
                 indexType,
                 cmdLineArgs.numDocs(),
                 cmdLineArgs.filterSelectivity()
@@ -187,7 +187,7 @@ public class KnnIndexTester {
             Results[] results = new Results[nProbes.length];
             for (int i = 0; i < nProbes.length; i++) {
                 results[i] = new Results(
-                    cmdLineArgs.docVectors().getFileName().toString(),
+                    cmdLineArgs.docVectors().get(0).getFileName().toString(),
                     indexType,
                     cmdLineArgs.numDocs(),
                     cmdLineArgs.filterSelectivity()

--- a/qa/vector/src/main/java/org/elasticsearch/test/knn/KnnSearcher.java
+++ b/qa/vector/src/main/java/org/elasticsearch/test/knn/KnnSearcher.java
@@ -98,7 +98,7 @@ import static org.elasticsearch.test.knn.KnnIndexer.VECTOR_FIELD;
 
 class KnnSearcher {
 
-    private final Path docPath;
+    private final List<Path> docPath;
     private final Path indexPath;
     private final Path queryPath;
     private final int numDocs;
@@ -153,12 +153,6 @@ class KnnSearcher {
                 : null
         ) {
             long queryPathSizeInBytes = input.size();
-            logger.info(
-                "queryPath size: "
-                    + queryPathSizeInBytes
-                    + " bytes, assuming vector count is "
-                    + (queryPathSizeInBytes / ((long) dim * vectorEncoding.byteSize))
-            );
             if (dim == -1) {
                 offsetByteSize = 4;
                 ByteBuffer preamble = ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN);
@@ -171,6 +165,17 @@ class KnnSearcher {
                     throw new IllegalArgumentException("queryPath \"" + queryPath + "\" has invalid dimension: " + dim);
                 }
             }
+            if (queryPathSizeInBytes % (((long) dim * vectorEncoding.byteSize + offsetByteSize)) != 0) {
+                throw new IllegalArgumentException(
+                    "docsPath \"" + queryPath + "\" does not contain a whole number of vectors?  size=" + queryPathSizeInBytes
+                );
+            }
+            logger.info(
+                "queryPath size: "
+                    + queryPathSizeInBytes
+                    + " bytes, assuming vector count is "
+                    + (queryPathSizeInBytes / ((long) dim * vectorEncoding.byteSize + offsetByteSize))
+            );
             KnnIndexer.VectorReader targetReader = KnnIndexer.VectorReader.create(input, dim, vectorEncoding, offsetByteSize);
             long startNS;
             try (MMapDirectory dir = new MMapDirectory(indexPath)) {
@@ -368,8 +373,13 @@ class KnnSearcher {
         }
     }
 
-    private boolean isNewer(Path path, Path... others) throws IOException {
+    private boolean isNewer(Path path, List<Path> paths, Path... others) throws IOException {
         FileTime modified = Files.getLastModifiedTime(path);
+        for (Path p : paths) {
+            if (Files.getLastModifiedTime(p).compareTo(modified) >= 0) {
+                return false;
+            }
+        }
         for (Path other : others) {
             if (Files.getLastModifiedTime(other).compareTo(modified) >= 0) {
                 return false;


### PR DESCRIPTION
Its possible that knn docs are spread over multiple input files. 

This adds support for multi-file inputs if this is the case for knn indexing tests.