### PR TITLE
[9.1] Fix testStopQueryLocal - always use the same client (same node) (#131253)

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterAsyncQueryStopIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterAsyncQueryStopIT.java
@@ -159,8 +159,8 @@ public class CrossClusterAsyncQueryStopIT extends AbstractCrossClusterTestCase {
             assertTrue(SimplePauseFieldPlugin.startEmitting.await(30, TimeUnit.SECONDS));
 
             // wait until the remotes are done
-            waitForCluster(client(), REMOTE_CLUSTER_1, asyncExecutionId);
-            waitForCluster(client(), REMOTE_CLUSTER_2, asyncExecutionId);
+            waitForCluster(client, REMOTE_CLUSTER_1, asyncExecutionId);
+            waitForCluster(client, REMOTE_CLUSTER_2, asyncExecutionId);
 
             /* at this point:
              *  the query against remotes should be finished


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Fix testStopQueryLocal - always use the same client (same node) (#131253)](https://github.com/elastic/elasticsearch/pull/131253)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)