### PR TITLE
[ML] Refactoring streaming error handling

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/BaseResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/BaseResponseHandler.java
@@ -95,7 +95,7 @@ public abstract class BaseResponseHandler implements ResponseHandler {
 
     protected abstract void checkForFailureStatusCode(Request request, HttpResult result);
 
-    private void checkForErrorObject(Request request, HttpResult result) {
+    protected void checkForErrorObject(Request request, HttpResult result) {
         var errorEntity = errorParseFunction.apply(result);
 
         if (errorEntity.errorStructureFound()) {
@@ -116,12 +116,12 @@ public abstract class BaseResponseHandler implements ResponseHandler {
     protected Exception buildError(String message, Request request, HttpResult result, ErrorResponse errorResponse) {
         var responseStatusCode = result.response().getStatusLine().getStatusCode();
         return new ElasticsearchStatusException(
-            errorMessage(message, request, result, errorResponse, responseStatusCode),
+            constructErrorMessage(message, request, errorResponse, responseStatusCode),
             toRestStatus(responseStatusCode)
         );
     }
 
-    protected String errorMessage(String message, Request request, HttpResult result, ErrorResponse errorResponse, int statusCode) {
+    public static String constructErrorMessage(String message, Request request, ErrorResponse errorResponse, int statusCode) {
         return (errorResponse == null
             || errorResponse.errorStructureFound() == false
             || Strings.isNullOrEmpty(errorResponse.getErrorMessage()))

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/ChatCompletionErrorResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/ChatCompletionErrorResponseHandler.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.external.http.retry;
+
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.xpack.core.inference.results.UnifiedChatCompletionException;
+import org.elasticsearch.xpack.inference.external.http.HttpResult;
+import org.elasticsearch.xpack.inference.external.request.Request;
+
+import java.util.Locale;
+import java.util.Objects;
+
+import static org.elasticsearch.core.Strings.format;
+import static org.elasticsearch.xpack.inference.external.http.retry.BaseResponseHandler.SERVER_ERROR_OBJECT;
+import static org.elasticsearch.xpack.inference.external.http.retry.BaseResponseHandler.toRestStatus;
+
+public class ChatCompletionErrorResponseHandler {
+    private static final String STREAM_ERROR = "stream_error";
+
+    private final UnifiedChatCompletionErrorParser unifiedChatCompletionErrorParser;
+
+    public ChatCompletionErrorResponseHandler(UnifiedChatCompletionErrorParser errorParser) {
+        this.unifiedChatCompletionErrorParser = Objects.requireNonNull(errorParser);
+    }
+
+    public void checkForErrorObject(Request request, HttpResult result) {
+        var errorEntity = unifiedChatCompletionErrorParser.parse(result);
+
+        if (errorEntity.errorStructureFound()) {
+            // We don't really know what happened because the status code was 200 so we'll return a failure and let the
+            // client retry if necessary
+            // If we did want to retry here, we'll need to determine if this was a streaming request, if it was
+            // we shouldn't retry because that would replay the entire streaming request and the client would get
+            // duplicate chunks back
+            throw new RetryException(false, buildChatCompletionErrorInternal(SERVER_ERROR_OBJECT, request, result, errorEntity));
+        }
+    }
+
+    public UnifiedChatCompletionException buildChatCompletionError(String message, Request request, HttpResult result) {
+        var errorResponse = unifiedChatCompletionErrorParser.parse(result);
+        return buildChatCompletionErrorInternal(message, request, result, errorResponse);
+    }
+
+    /**
+     * Returns an exception that adheres to the chat completion error response format.
+     *
+     * @param message            the error message to include in the exception
+     * @param request            the request that caused the error
+     * @param result             the HTTP result containing the error response
+     * @param errorResponse      the parsed error response from the HTTP result
+     * @return an instance of {@link UnifiedChatCompletionException} with details from the error response
+     */
+    private UnifiedChatCompletionException buildChatCompletionErrorInternal(
+        String message,
+        Request request,
+        HttpResult result,
+        UnifiedChatCompletionErrorResponse errorResponse
+    ) {
+        assert request.isStreaming() : "Only streaming requests support this format";
+        var statusCode = result.response().getStatusLine().getStatusCode();
+        var errorMessage = BaseResponseHandler.constructErrorMessage(message, request, errorResponse, statusCode);
+        var restStatus = toRestStatus(statusCode);
+
+        if (errorResponse.errorStructureFound()) {
+            return new UnifiedChatCompletionException(
+                restStatus,
+                errorMessage,
+                errorResponse.type(),
+                errorResponse.code(),
+                errorResponse.param()
+            );
+        } else {
+            return buildDefaultChatCompletionError(errorResponse, errorMessage, restStatus);
+        }
+    }
+
+    /**
+     * Builds a default {@link UnifiedChatCompletionException} for a streaming request.
+     * This method is used when an error response is received but no specific error handling is implemented.
+     * Only streaming requests should use this method.
+     *
+     * @param errorResponse the error response parsed from the HTTP result
+     * @param errorMessage  the error message to include in the exception
+     * @param restStatus    the REST status code of the response
+     * @return an instance of {@link UnifiedChatCompletionException} with details from the error response
+     */
+    public static UnifiedChatCompletionException buildDefaultChatCompletionError(
+        ErrorResponse errorResponse,
+        String errorMessage,
+        RestStatus restStatus
+    ) {
+        return new UnifiedChatCompletionException(
+            restStatus,
+            errorMessage,
+            createErrorType(errorResponse),
+            restStatus.name().toLowerCase(Locale.ROOT)
+        );
+    }
+
+    /**
+     * Builds a mid-stream error for a streaming request with a custom error type.
+     * This method is used when an error occurs while processing a streaming response and allows for custom error handling.
+     * Only streaming requests should use this method.
+     *
+     * @param inferenceEntityId the ID of the inference entity
+     * @param message           the error message
+     * @param e                the exception that caused the error, can be null
+     * @return a {@link UnifiedChatCompletionException} representing the mid-stream error
+     */
+    public UnifiedChatCompletionException buildMidStreamChatCompletionError(String inferenceEntityId, String message, Exception e) {
+        var error = unifiedChatCompletionErrorParser.parse(message);
+
+        if (error.errorStructureFound()) {
+            return new UnifiedChatCompletionException(
+                RestStatus.INTERNAL_SERVER_ERROR,
+                format(
+                    "%s for request from inference entity id [%s]. Error message: [%s]",
+                    SERVER_ERROR_OBJECT,
+                    inferenceEntityId,
+                    error.getErrorMessage()
+                ),
+                error.type(),
+                error.code(),
+                error.param()
+            );
+        } else if (e != null) {
+            // If the error response does not match, we can still return an exception based on the original throwable
+            return UnifiedChatCompletionException.fromThrowable(e);
+        } else {
+            // If no specific error response is found, we return a default mid-stream error
+            return buildDefaultMidStreamChatCompletionError(inferenceEntityId, error);
+        }
+    }
+
+    /**
+     * Builds a default mid-stream error for a streaming request.
+     * This method is used when no specific error response is found in the message.
+     * Only streaming requests should use this method.
+     *
+     * @param inferenceEntityId the ID of the inference entity
+     * @param errorResponse     the error response extracted from the message
+     * @return a {@link UnifiedChatCompletionException} representing the default mid-stream error
+     */
+    public static UnifiedChatCompletionException buildDefaultMidStreamChatCompletionError(
+        String inferenceEntityId,
+        ErrorResponse errorResponse
+    ) {
+        return new UnifiedChatCompletionException(
+            RestStatus.INTERNAL_SERVER_ERROR,
+            format("%s for request from inference entity id [%s]", SERVER_ERROR_OBJECT, inferenceEntityId),
+            createErrorType(errorResponse),
+            STREAM_ERROR
+        );
+    }
+
+    /**
+     * Creates a string representation of the error type based on the provided ErrorResponse.
+     * This method is used to generate a human-readable error type for logging or exception messages.
+     *
+     * @param errorResponse the ErrorResponse object
+     * @return a string representing the error type
+     */
+    private static String createErrorType(ErrorResponse errorResponse) {
+        return errorResponse != null ? errorResponse.getClass().getSimpleName() : "unknown";
+    }
+}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/ChatCompletionErrorResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/ChatCompletionErrorResponseHandler.java
@@ -46,15 +46,6 @@ public class ChatCompletionErrorResponseHandler {
         return buildChatCompletionErrorInternal(message, request, result, errorResponse);
     }
 
-    /**
-     * Returns an exception that adheres to the chat completion error response format.
-     *
-     * @param message            the error message to include in the exception
-     * @param request            the request that caused the error
-     * @param result             the HTTP result containing the error response
-     * @param errorResponse      the parsed error response from the HTTP result
-     * @return an instance of {@link UnifiedChatCompletionException} with details from the error response
-     */
     private UnifiedChatCompletionException buildChatCompletionErrorInternal(
         String message,
         Request request,
@@ -81,15 +72,15 @@ public class ChatCompletionErrorResponseHandler {
 
     /**
      * Builds a default {@link UnifiedChatCompletionException} for a streaming request.
-     * This method is used when an error response is received but no specific error handling is implemented.
+     * This method is used when an error response is received we were unable to parse it in the format we were expecting.
      * Only streaming requests should use this method.
      *
-     * @param errorResponse the error response parsed from the HTTP result
-     * @param errorMessage  the error message to include in the exception
-     * @param restStatus    the REST status code of the response
+     * @param errorResponse the error response extracted from the HTTP result
+     * @param errorMessage the error message to include in the exception
+     * @param restStatus the REST status code of the response
      * @return an instance of {@link UnifiedChatCompletionException} with details from the error response
      */
-    public static UnifiedChatCompletionException buildDefaultChatCompletionError(
+    private static UnifiedChatCompletionException buildDefaultChatCompletionError(
         ErrorResponse errorResponse,
         String errorMessage,
         RestStatus restStatus
@@ -103,13 +94,13 @@ public class ChatCompletionErrorResponseHandler {
     }
 
     /**
-     * Builds a mid-stream error for a streaming request with a custom error type.
-     * This method is used when an error occurs while processing a streaming response and allows for custom error handling.
+     * Builds a mid-stream error for a streaming request.
+     * This method is used when an error occurs while processing a streaming response.
      * Only streaming requests should use this method.
      *
      * @param inferenceEntityId the ID of the inference entity
-     * @param message           the error message
-     * @param e                the exception that caused the error, can be null
+     * @param message the error message
+     * @param e the exception that caused the error, can be null
      * @return a {@link UnifiedChatCompletionException} representing the mid-stream error
      */
     public UnifiedChatCompletionException buildMidStreamChatCompletionError(String inferenceEntityId, String message, Exception e) {
@@ -146,7 +137,7 @@ public class ChatCompletionErrorResponseHandler {
      * @param errorResponse     the error response extracted from the message
      * @return a {@link UnifiedChatCompletionException} representing the default mid-stream error
      */
-    public static UnifiedChatCompletionException buildDefaultMidStreamChatCompletionError(
+    private static UnifiedChatCompletionException buildDefaultMidStreamChatCompletionError(
         String inferenceEntityId,
         ErrorResponse errorResponse
     ) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/ErrorResponse.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/ErrorResponse.java
@@ -22,7 +22,7 @@ public class ErrorResponse {
         this.errorStructureFound = true;
     }
 
-    private ErrorResponse(boolean errorStructureFound) {
+    protected ErrorResponse(boolean errorStructureFound) {
         this.errorMessage = "";
         this.errorStructureFound = errorStructureFound;
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/UnifiedChatCompletionErrorParser.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/UnifiedChatCompletionErrorParser.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.external.http.retry;
+
+import org.elasticsearch.xpack.inference.external.http.HttpResult;
+
+public interface UnifiedChatCompletionErrorParser {
+    UnifiedChatCompletionErrorResponse parse(HttpResult result);
+
+    UnifiedChatCompletionErrorResponse parse(String result);
+}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/UnifiedChatCompletionErrorResponse.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/UnifiedChatCompletionErrorResponse.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.external.http.retry;
+
+import org.elasticsearch.core.Nullable;
+
+import java.util.Objects;
+
+public class UnifiedChatCompletionErrorResponse extends ErrorResponse {
+    public static final UnifiedChatCompletionErrorResponse UNDEFINED_ERROR = new UnifiedChatCompletionErrorResponse();
+
+    @Nullable
+    private final String code;
+    @Nullable
+    private final String param;
+    private final String type;
+
+    public UnifiedChatCompletionErrorResponse(String errorMessage, String type, @Nullable String code, @Nullable String param) {
+        super(errorMessage);
+        this.code = code;
+        this.param = param;
+        this.type = Objects.requireNonNull(type);
+    }
+
+    private UnifiedChatCompletionErrorResponse() {
+        super(false);
+        this.code = null;
+        this.param = null;
+        this.type = "unknown";
+    }
+
+    @Nullable
+    public String code() {
+        return code;
+    }
+
+    @Nullable
+    public String param() {
+        return param;
+    }
+
+    public String type() {
+        return type;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        if (super.equals(o) == false) return false;
+        UnifiedChatCompletionErrorResponse that = (UnifiedChatCompletionErrorResponse) o;
+        return Objects.equals(code, that.code) && Objects.equals(param, that.param) && Objects.equals(type, that.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), code, param, type);
+    }
+}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceUnifiedChatCompletionResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceUnifiedChatCompletionResponseHandler.java
@@ -49,7 +49,7 @@ public class ElasticInferenceServiceUnifiedChatCompletionResponseHandler extends
             var restStatus = toRestStatus(responseStatusCode);
             return new UnifiedChatCompletionException(
                 restStatus,
-                errorMessage(message, request, result, errorResponse, responseStatusCode),
+                constructErrorMessage(message, request, errorResponse, responseStatusCode),
                 "error",
                 restStatus.name().toLowerCase(Locale.ROOT)
             );

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiUnifiedChatCompletionResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/GoogleVertexAiUnifiedChatCompletionResponseHandler.java
@@ -10,9 +10,6 @@ package org.elasticsearch.xpack.inference.services.googlevertexai;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.InferenceServiceResults;
-import org.elasticsearch.logging.LogManager;
-import org.elasticsearch.logging.Logger;
-import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentFactory;
@@ -22,19 +19,17 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.results.StreamingUnifiedChatCompletionResults;
 import org.elasticsearch.xpack.core.inference.results.UnifiedChatCompletionException;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
-import org.elasticsearch.xpack.inference.external.http.retry.ErrorResponse;
+import org.elasticsearch.xpack.inference.external.http.retry.ChatCompletionErrorResponseHandler;
+import org.elasticsearch.xpack.inference.external.http.retry.UnifiedChatCompletionErrorParser;
+import org.elasticsearch.xpack.inference.external.http.retry.UnifiedChatCompletionErrorResponse;
 import org.elasticsearch.xpack.inference.external.request.Request;
 import org.elasticsearch.xpack.inference.external.response.streaming.ServerSentEventParser;
 import org.elasticsearch.xpack.inference.external.response.streaming.ServerSentEventProcessor;
 import org.elasticsearch.xpack.inference.services.googlevertexai.response.GoogleVertexAiCompletionResponseEntity;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Locale;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Flow;
-
-import static org.elasticsearch.core.Strings.format;
 
 public class GoogleVertexAiUnifiedChatCompletionResponseHandler extends GoogleVertexAiResponseHandler {
 
@@ -42,9 +37,13 @@ public class GoogleVertexAiUnifiedChatCompletionResponseHandler extends GoogleVe
     private static final String ERROR_CODE_FIELD = "code";
     private static final String ERROR_MESSAGE_FIELD = "message";
     private static final String ERROR_STATUS_FIELD = "status";
+    private static final GoogleVertexAiErrorParser ERROR_PARSER = new GoogleVertexAiErrorParser();
+
+    private final ChatCompletionErrorResponseHandler chatCompletionErrorResponseHandler;
 
     public GoogleVertexAiUnifiedChatCompletionResponseHandler(String requestType) {
         super(requestType, GoogleVertexAiCompletionResponseEntity::fromResponse, GoogleVertexAiErrorResponse::fromResponse, true);
+        this.chatCompletionErrorResponseHandler = new ChatCompletionErrorResponseHandler(ERROR_PARSER);
     }
 
     @Override
@@ -52,7 +51,9 @@ public class GoogleVertexAiUnifiedChatCompletionResponseHandler extends GoogleVe
         assert request.isStreaming() : "GoogleVertexAiUnifiedChatCompletionResponseHandler only supports streaming requests";
 
         var serverSentEventProcessor = new ServerSentEventProcessor(new ServerSentEventParser());
-        var googleVertexAiProcessor = new GoogleVertexAiUnifiedStreamingProcessor((m, e) -> buildMidStreamError(request, m, e));
+        var googleVertexAiProcessor = new GoogleVertexAiUnifiedStreamingProcessor(
+            (m, e) -> chatCompletionErrorResponseHandler.buildMidStreamChatCompletionError(request.getInferenceEntityId(), m, e)
+        );
 
         flow.subscribe(serverSentEventProcessor);
         serverSentEventProcessor.subscribe(googleVertexAiProcessor);
@@ -60,63 +61,35 @@ public class GoogleVertexAiUnifiedChatCompletionResponseHandler extends GoogleVe
     }
 
     @Override
-    protected Exception buildError(String message, Request request, HttpResult result, ErrorResponse errorResponse) {
-        assert request.isStreaming() : "Only streaming requests support this format";
-
-        var responseStatusCode = result.response().getStatusLine().getStatusCode();
-        var errorMessage = errorMessage(message, request, result, errorResponse, responseStatusCode);
-        var restStatus = toRestStatus(responseStatusCode);
-
-        return errorResponse instanceof GoogleVertexAiErrorResponse vertexAIErrorResponse
-            ? new UnifiedChatCompletionException(
-                restStatus,
-                errorMessage,
-                vertexAIErrorResponse.status(),
-                String.valueOf(vertexAIErrorResponse.code()),
-                null
-            )
-            : new UnifiedChatCompletionException(
-                restStatus,
-                errorMessage,
-                errorResponse != null ? errorResponse.getClass().getSimpleName() : "unknown",
-                restStatus.name().toLowerCase(Locale.ROOT)
-            );
+    protected UnifiedChatCompletionException buildError(String message, Request request, HttpResult result) {
+        return chatCompletionErrorResponseHandler.buildChatCompletionError(message, request, result);
     }
 
-    private static Exception buildMidStreamError(Request request, String message, Exception e) {
-        var errorResponse = GoogleVertexAiErrorResponse.fromString(message);
-        if (errorResponse instanceof GoogleVertexAiErrorResponse gver) {
-            return new UnifiedChatCompletionException(
-                RestStatus.INTERNAL_SERVER_ERROR,
-                format(
-                    "%s for request from inference entity id [%s]. Error message: [%s]",
-                    SERVER_ERROR_OBJECT,
-                    request.getInferenceEntityId(),
-                    errorResponse.getErrorMessage()
-                ),
-                gver.status(),
-                String.valueOf(gver.code()),
-                null
-            );
-        } else if (e != null) {
-            return UnifiedChatCompletionException.fromThrowable(e);
-        } else {
-            return new UnifiedChatCompletionException(
-                RestStatus.INTERNAL_SERVER_ERROR,
-                format("%s for request from inference entity id [%s]", SERVER_ERROR_OBJECT, request.getInferenceEntityId()),
-                errorResponse != null ? errorResponse.getClass().getSimpleName() : "unknown",
-                "stream_error"
-            );
+    @Override
+    protected void checkForErrorObject(Request request, HttpResult result) {
+        chatCompletionErrorResponseHandler.checkForErrorObject(request, result);
+    }
+
+    private static class GoogleVertexAiErrorParser implements UnifiedChatCompletionErrorParser {
+
+        @Override
+        public UnifiedChatCompletionErrorResponse parse(HttpResult result) {
+            return GoogleVertexAiErrorResponse.fromResponse(result);
+        }
+
+        @Override
+        public UnifiedChatCompletionErrorResponse parse(String response) {
+            return GoogleVertexAiErrorResponse.fromString(response);
         }
     }
 
-    public static class GoogleVertexAiErrorResponse extends ErrorResponse {
-        private static final Logger logger = LogManager.getLogger(GoogleVertexAiErrorResponse.class);
-        private static final ConstructingObjectParser<Optional<ErrorResponse>, Void> ERROR_PARSER = new ConstructingObjectParser<>(
-            "google_vertex_ai_error_wrapper",
-            true,
-            args -> Optional.ofNullable((GoogleVertexAiErrorResponse) args[0])
-        );
+    public static class GoogleVertexAiErrorResponse extends UnifiedChatCompletionErrorResponse {
+        private static final ConstructingObjectParser<Optional<UnifiedChatCompletionErrorResponse>, Void> ERROR_PARSER =
+            new ConstructingObjectParser<>(
+                "google_vertex_ai_error_wrapper",
+                true,
+                args -> Optional.ofNullable((GoogleVertexAiErrorResponse) args[0])
+            );
 
         private static final ConstructingObjectParser<GoogleVertexAiErrorResponse, Void> ERROR_BODY_PARSER = new ConstructingObjectParser<>(
             "google_vertex_ai_error_body",
@@ -137,46 +110,39 @@ public class GoogleVertexAiUnifiedChatCompletionResponseHandler extends GoogleVe
             );
         }
 
-        public static ErrorResponse fromResponse(HttpResult response) {
+        public static UnifiedChatCompletionErrorResponse fromResponse(HttpResult response) {
             try (
                 XContentParser parser = XContentFactory.xContent(XContentType.JSON)
                     .createParser(XContentParserConfiguration.EMPTY, response.body())
             ) {
-                return ERROR_PARSER.apply(parser, null).orElse(ErrorResponse.UNDEFINED_ERROR);
+                return ERROR_PARSER.apply(parser, null).orElse(UnifiedChatCompletionErrorResponse.UNDEFINED_ERROR);
             } catch (Exception e) {
                 var resultAsString = new String(response.body(), StandardCharsets.UTF_8);
-                return new ErrorResponse(Strings.format("Unable to parse the Google Vertex AI error, response body: [%s]", resultAsString));
+                return new GoogleVertexAiErrorResponse(
+                    Strings.format("Unable to parse the Google Vertex AI error, response body: [%s]", resultAsString)
+                );
             }
         }
 
-        static ErrorResponse fromString(String response) {
+        static UnifiedChatCompletionErrorResponse fromString(String response) {
             try (
                 XContentParser parser = XContentFactory.xContent(XContentType.JSON)
                     .createParser(XContentParserConfiguration.EMPTY, response)
             ) {
-                return ERROR_PARSER.apply(parser, null).orElse(ErrorResponse.UNDEFINED_ERROR);
+                return ERROR_PARSER.apply(parser, null).orElse(UnifiedChatCompletionErrorResponse.UNDEFINED_ERROR);
             } catch (Exception e) {
-                return new ErrorResponse(Strings.format("Unable to parse the Google Vertex AI error, response body: [%s]", response));
+                return new GoogleVertexAiErrorResponse(
+                    Strings.format("Unable to parse the Google Vertex AI error, response body: [%s]", response)
+                );
             }
         }
 
-        private final int code;
-        @Nullable
-        private final String status;
-
-        GoogleVertexAiErrorResponse(Integer code, String errorMessage, @Nullable String status) {
-            super(Objects.requireNonNull(errorMessage));
-            this.code = code == null ? 0 : code;
-            this.status = status;
+        GoogleVertexAiErrorResponse(@Nullable Integer code, String errorMessage, @Nullable String status) {
+            super(errorMessage, status != null ? status : "google_vertex_ai_error", code == null ? "0" : String.valueOf(code), null);
         }
 
-        public int code() {
-            return code;
-        }
-
-        @Nullable
-        public String status() {
-            return status != null ? status : "google_vertex_ai_error";
+        GoogleVertexAiErrorResponse(String errorMessage) {
+            super(errorMessage, "google_vertex_ai_error", null, null);
         }
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceChatCompletionResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceChatCompletionResponseHandler.java
@@ -45,7 +45,7 @@ public class HuggingFaceChatCompletionResponseHandler extends OpenAiUnifiedChatC
         assert request.isStreaming() : "Only streaming requests support this format";
         var responseStatusCode = result.response().getStatusLine().getStatusCode();
         if (request.isStreaming()) {
-            var errorMessage = errorMessage(message, request, result, errorResponse, responseStatusCode);
+            var errorMessage = constructErrorMessage(message, request, errorResponse, responseStatusCode);
             var restStatus = toRestStatus(responseStatusCode);
             return errorResponse instanceof HuggingFaceErrorResponseEntity
                 ? new UnifiedChatCompletionException(

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonUnifiedChatCompletionResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonUnifiedChatCompletionResponseHandler.java
@@ -34,7 +34,7 @@ public class IbmWatsonUnifiedChatCompletionResponseHandler extends OpenAiUnified
         assert request.isStreaming() : "Only streaming requests support this format";
         var responseStatusCode = result.response().getStatusLine().getStatusCode();
         if (request.isStreaming()) {
-            var errorMessage = errorMessage(message, request, result, errorResponse, responseStatusCode);
+            var errorMessage = constructErrorMessage(message, request, errorResponse, responseStatusCode);
             var restStatus = toRestStatus(responseStatusCode);
             return errorResponse instanceof IbmWatsonxErrorResponseEntity
                 ? new UnifiedChatCompletionException(restStatus, errorMessage, WATSONX_ERROR, restStatus.name().toLowerCase(Locale.ROOT))

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/mistral/MistralUnifiedChatCompletionResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/mistral/MistralUnifiedChatCompletionResponseHandler.java
@@ -34,7 +34,7 @@ public class MistralUnifiedChatCompletionResponseHandler extends OpenAiUnifiedCh
         assert request.isStreaming() : "Only streaming requests support this format";
         var responseStatusCode = result.response().getStatusLine().getStatusCode();
         if (request.isStreaming()) {
-            var errorMessage = errorMessage(message, request, result, errorResponse, responseStatusCode);
+            var errorMessage = constructErrorMessage(message, request, errorResponse, responseStatusCode);
             var restStatus = toRestStatus(responseStatusCode);
             return errorResponse instanceof MistralErrorResponse
                 ? new UnifiedChatCompletionException(restStatus, errorMessage, MISTRAL_ERROR, restStatus.name().toLowerCase(Locale.ROOT))

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiUnifiedChatCompletionResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiUnifiedChatCompletionResponseHandler.java
@@ -56,7 +56,7 @@ public class OpenAiUnifiedChatCompletionResponseHandler extends OpenAiChatComple
         assert request.isStreaming() : "Only streaming requests support this format";
         var responseStatusCode = result.response().getStatusLine().getStatusCode();
         if (request.isStreaming()) {
-            var errorMessage = errorMessage(message, request, result, errorResponse, responseStatusCode);
+            var errorMessage = constructErrorMessage(message, request, errorResponse, responseStatusCode);
             var restStatus = toRestStatus(responseStatusCode);
             return errorResponse instanceof StreamingErrorResponse oer
                 ? new UnifiedChatCompletionException(restStatus, errorMessage, oer.type(), oer.code(), oer.param())


### PR DESCRIPTION
This PR is an iteration of this one: https://github.com/elastic/elasticsearch/pull/128923

Currently when we add new integrations that support chat completion streaming we have to duplicate some of the error handling code. This PR aims to reduce some of the duplication and move the logic to a new class `ChatCompletionErrorResponseHandler`. This solution uses composition. Ideally we'd push the common logic into the `BaseResponseHandler` but I feel like it is confusing since that class was originally only handling non-streaming logic. This solution separates the chat completion error handling logic from the other implementations (like `completion` and other task types).

I'm open to other ideas for simplifying things.

This PR only refactors the google vertex ai chat completion implementation to give an example of what we'd need to do for the other providers.

I did some manual testing with these requests to generate some errors:

```
PUT _inference/chat_completion/test-chat
{
    "service": "googlevertexai",
    "service_settings": {
        "service_account_json": "<service account>",
        "model_id": "gemini-2.0-flash-lite-001",
        "location": "us-central1",
        "project_id": "elastic-ml"
    }
}


POST _inference/chat_completion/test-chat/_stream
{
    "model": "mistralai/Mistral-7B-Instruct-v0.3",
    "messages": [
        {
            "role": "system",
            "content": "You are a helpful assistant that can call functions to get live data."
        },
        {
            "role": "user",
            "content": "What is the weather like in Paris today?"
        }
    ]
}
```

That should generate an error like:

```
event: error
data: {"error":{"code":"400","message":"Received an unsuccessful status code for request from inference entity id [test-chat] status [400]. Error message: [Invalid Endpoint name: projects/elastic-ml/locations/global/publishers/google/models/mistralai%2FMistral-7B-Instruct-v0.3.]","type":"INVALID_ARGUMENT"}}
```