### PR TITLE
[8.19] Add require_alias to reindex rest-api-spec (#130813)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/reindex.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/reindex.json
@@ -57,6 +57,11 @@
       "max_docs":{
         "type":"number",
         "description":"Maximum number of documents to process (default: all documents)"
+      },
+      "require_alias":{
+        "type":"boolean",
+        "default":false,
+        "description":"When true, requires destination to be an alias."
       }
     },
     "body":{


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Add require_alias to reindex rest-api-spec (#130813)