### PR TITLE
[8.19] Fail request when all target shards fail in runtime (#131177)

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlNodeFailureIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlNodeFailureIT.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.esql.EsqlTestUtils;
 import org.elasticsearch.xpack.esql.plugin.EsqlPlugin;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -30,6 +31,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
@@ -98,38 +100,30 @@ public class EsqlNodeFailureIT extends AbstractEsqlIntegTestCase {
 
     public void testPartialResults() throws Exception {
         Set<String> okIds = populateIndices();
-        {
-            EsqlQueryRequest request = new EsqlQueryRequest();
-            request.query("FROM fail,ok | LIMIT 100");
-            request.allowPartialResults(true);
-            request.pragmas(randomPragmas());
-            try (EsqlQueryResponse resp = run(request)) {
-                assertTrue(resp.isPartial());
-                List<List<Object>> rows = EsqlTestUtils.getValuesList(resp);
-                assertThat(rows.size(), lessThanOrEqualTo(okIds.size()));
+        EsqlQueryRequest request = new EsqlQueryRequest();
+        request.query("FROM fail,ok METADATA _id | KEEP _id, fail_me | LIMIT 100");
+        request.allowPartialResults(true);
+        // have to run one shard at a time to avoid failing all shards
+        QueryPragmas pragma = new QueryPragmas(
+            Settings.builder().put(randomPragmas().getSettings()).put(QueryPragmas.MAX_CONCURRENT_SHARDS_PER_NODE.getKey(), 1).build()
+        );
+        request.pragmas(pragma);
+        request.acceptedPragmaRisks(true);
+        try (EsqlQueryResponse resp = run(request)) {
+            assertTrue(resp.isPartial());
+            List<List<Object>> rows = EsqlTestUtils.getValuesList(resp);
+            assertThat(rows.size(), equalTo(okIds.size()));
+            Set<String> actualIds = new HashSet<>();
+            for (List<Object> row : rows) {
+                assertThat(row.size(), equalTo(2));
+                String id = (String) row.get(0);
+                assertThat(id, in(okIds));
+                assertTrue(actualIds.add(id));
             }
-        }
-        {
-            EsqlQueryRequest request = new EsqlQueryRequest();
-            request.query("FROM fail,ok METADATA _id | KEEP _id, fail_me | LIMIT 100");
-            request.allowPartialResults(true);
-            request.pragmas(randomPragmas());
-            try (EsqlQueryResponse resp = run(request)) {
-                assertTrue(resp.isPartial());
-                List<List<Object>> rows = EsqlTestUtils.getValuesList(resp);
-                assertThat(rows.size(), lessThanOrEqualTo(okIds.size()));
-                Set<String> actualIds = new HashSet<>();
-                for (List<Object> row : rows) {
-                    assertThat(row.size(), equalTo(2));
-                    String id = (String) row.get(0);
-                    assertThat(id, in(okIds));
-                    assertTrue(actualIds.add(id));
-                }
-                EsqlExecutionInfo.Cluster localInfo = resp.getExecutionInfo().getCluster(RemoteClusterService.LOCAL_CLUSTER_GROUP_KEY);
-                assertThat(localInfo.getFailures(), not(empty()));
-                assertThat(localInfo.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.PARTIAL));
-                assertThat(localInfo.getFailures().get(0).reason(), containsString("Accessing failing field"));
-            }
+            EsqlExecutionInfo.Cluster localInfo = resp.getExecutionInfo().getCluster(RemoteClusterService.LOCAL_CLUSTER_GROUP_KEY);
+            assertThat(localInfo.getFailures(), not(empty()));
+            assertThat(localInfo.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.PARTIAL));
+            assertThat(localInfo.getFailures().get(0).reason(), containsString("Accessing failing field"));
         }
     }
 
@@ -147,6 +141,15 @@ public class EsqlNodeFailureIT extends AbstractEsqlIntegTestCase {
                 EsqlQueryRequest request = new EsqlQueryRequest();
                 request.query("FROM fail,ok | LIMIT 100");
                 request.pragmas(randomPragmas());
+                // have to run one shard at a time to avoid failing all shards
+                QueryPragmas pragma = new QueryPragmas(
+                    Settings.builder()
+                        .put(randomPragmas().getSettings())
+                        .put(QueryPragmas.MAX_CONCURRENT_SHARDS_PER_NODE.getKey(), 1)
+                        .build()
+                );
+                request.pragmas(pragma);
+                request.acceptedPragmaRisks(true);
                 if (randomBoolean()) {
                     request.allowPartialResults(true);
                 }
@@ -154,6 +157,7 @@ public class EsqlNodeFailureIT extends AbstractEsqlIntegTestCase {
                     assertTrue(resp.isPartial());
                     List<List<Object>> rows = EsqlTestUtils.getValuesList(resp);
                     assertThat(rows.size(), lessThanOrEqualTo(okIds.size()));
+                    assertThat(rows.size(), greaterThan(0));
                 }
             }
             // allow_partial_results = false

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.plugin;
 
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.action.search.SearchRequest;
@@ -226,9 +227,10 @@ public class ComputeService {
             var computeListener = new ComputeListener(
                 transportService.getThreadPool(),
                 cancelQueryOnFailure,
-                listener.map(completionInfo -> {
+                listener.delegateFailureAndWrap((l, completionInfo) -> {
+                    failIfAllShardsFailed(execInfo, collectedPages);
                     execInfo.markEndQuery();  // TODO: revisit this time recording model as part of INLINESTATS improvements
-                    return new Result(outputAttributes, collectedPages, completionInfo, execInfo);
+                    l.onResponse(new Result(outputAttributes, collectedPages, completionInfo, execInfo));
                 })
             )
         ) {
@@ -389,6 +391,47 @@ public class ComputeService {
                 });
             }
         }
+    }
+
+    /**
+     * If all of target shards excluding the skipped shards failed from the local or remote clusters, then we should fail the entire query
+     * regardless of the partial_results configuration or skip_unavailable setting. This behavior doesn't fully align with the search API,
+     * which doesn't consider the failures from the remote clusters when skip_unavailable is true.
+     */
+    static void failIfAllShardsFailed(EsqlExecutionInfo execInfo, List<Page> finalResults) {
+        // do not fail if any final result has results
+        if (finalResults.stream().anyMatch(p -> p.getPositionCount() > 0)) {
+            return;
+        }
+        int totalFailedShards = 0;
+        for (EsqlExecutionInfo.Cluster cluster : execInfo.clusterInfo.values()) {
+            final Integer successfulShards = cluster.getSuccessfulShards();
+            if (successfulShards != null && successfulShards > 0) {
+                return;
+            }
+            if (cluster.getFailedShards() != null) {
+                totalFailedShards += cluster.getFailedShards();
+            }
+        }
+        if (totalFailedShards == 0) {
+            return;
+        }
+        final var failureCollector = new FailureCollector();
+        for (EsqlExecutionInfo.Cluster cluster : execInfo.clusterInfo.values()) {
+            var failedShards = cluster.getFailedShards();
+            if (failedShards != null && failedShards > 0) {
+                assert cluster.getFailures().isEmpty() == false : "expected failures for cluster [" + cluster.getClusterAlias() + "]";
+                for (ShardSearchFailure failure : cluster.getFailures()) {
+                    if (failure.getCause() instanceof Exception e) {
+                        failureCollector.unwrapAndCollect(e);
+                    } else {
+                        assert false : "unexpected failure: " + new AssertionError(failure.getCause());
+                        failureCollector.unwrapAndCollect(failure);
+                    }
+                }
+            }
+        }
+        ExceptionsHelper.reThrowIfNotNull(failureCollector.getFailure());
     }
 
     void runCompute(CancellableTask task, ComputeContext context, PhysicalPlan plan, ActionListener<DriverCompletionInfo> listener) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fail request when all target shards fail in runtime (#131177)](https://github.com/elastic/elasticsearch/pull/131177)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)