### PR TITLE
[9.1] [DOCS] Remove misused applies_to tag (#131349)

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/functions/layout/match_phrase.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/layout/match_phrase.md
@@ -2,7 +2,7 @@
 
 ## `MATCH_PHRASE` [esql-match_phrase]
 ```{applies_to}
-stack: unavailable 9.0, ga 9.1.0
+stack: ga 9.1.0
 ```
 
 **Syntax**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchPhrase.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/MatchPhrase.java
@@ -89,9 +89,7 @@ public class MatchPhrase extends FullTextFunction implements OptionalArgument, P
 
     @FunctionInfo(
         returnType = "boolean",
-        appliesTo = {
-            @FunctionAppliesTo(lifeCycle = FunctionAppliesToLifecycle.UNAVAILABLE, version = "9.0"),
-            @FunctionAppliesTo(lifeCycle = FunctionAppliesToLifecycle.GA, version = "9.1.0") },
+        appliesTo = { @FunctionAppliesTo(lifeCycle = FunctionAppliesToLifecycle.GA, version = "9.1.0") },
         description = """
             Use `MATCH_PHRASE` to perform a [`match_phrase`](/reference/query-languages/query-dsl/query-dsl-match-query-phrase.md) on the
             specified field.


### PR DESCRIPTION
Backports the following commits to 9.1:
 - [DOCS] Remove misused applies_to tag (#131349)