### PR TITLE
[8.19] Add exception logging when interrupted (#131153)

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/AbstractAsyncTaskTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/AbstractAsyncTaskTests.java
@@ -59,12 +59,14 @@ public class AbstractAsyncTaskTests extends ESTestCase {
                 try {
                     barrier1.await();
                 } catch (Exception e) {
+                    logger.error("barrier1 interrupted", e);
                     fail("interrupted");
                 }
                 count.incrementAndGet();
                 try {
                     barrier2.await();
                 } catch (Exception e) {
+                    logger.error("barrier2 interrupted", e);
                     fail("interrupted");
                 }
                 if (shouldRunThrowException) {
@@ -112,6 +114,7 @@ public class AbstractAsyncTaskTests extends ESTestCase {
                 try {
                     barrier.await();
                 } catch (Exception e) {
+                    logger.error("barrier interrupted", e);
                     fail("interrupted");
                 }
                 if (shouldRunThrowException) {


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Add exception logging when interrupted (#131153)