### PR TITLE
[8.19] [ML] Remove SageMaker Elastic updates (#131301)

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/sagemaker/model/SageMakerModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/sagemaker/model/SageMakerModel.java
@@ -116,7 +116,7 @@ public class SageMakerModel extends Model {
             getConfigurations(),
             getSecrets(),
             serviceSettings,
-            taskSettings.updatedTaskSettings(taskSettingsOverride),
+            taskSettings.override(taskSettingsOverride),
             awsSecretSettings
         );
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/sagemaker/model/SageMakerTaskSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/sagemaker/model/SageMakerTaskSettings.java
@@ -71,11 +71,21 @@ record SageMakerTaskSettings(
     @Override
     public SageMakerTaskSettings updatedTaskSettings(Map<String, Object> newSettings) {
         var validationException = new ValidationException();
-
         var updateTaskSettings = fromMap(newSettings, apiTaskSettings.updatedTaskSettings(newSettings), validationException);
-
         validationException.throwIfValidationErrorsExist();
 
+        return override(updateTaskSettings);
+    }
+
+    public SageMakerTaskSettings override(Map<String, Object> newSettings) {
+        var validationException = new ValidationException();
+        var updateTaskSettings = fromMap(newSettings, apiTaskSettings.override(newSettings), validationException);
+        validationException.throwIfValidationErrorsExist();
+
+        return override(updateTaskSettings);
+    }
+
+    private SageMakerTaskSettings override(SageMakerTaskSettings updateTaskSettings) {
         var updatedExtraTaskSettings = updateTaskSettings.apiTaskSettings().equals(SageMakerStoredTaskSchema.NO_OP)
             ? apiTaskSettings
             : updateTaskSettings.apiTaskSettings();

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/sagemaker/schema/SageMakerStoredTaskSchema.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/sagemaker/schema/SageMakerStoredTaskSchema.java
@@ -61,4 +61,8 @@ public interface SageMakerStoredTaskSchema extends TaskSettings {
 
     @Override
     SageMakerStoredTaskSchema updatedTaskSettings(Map<String, Object> newSettings);
+
+    default SageMakerStoredTaskSchema override(Map<String, Object> newSettings) {
+        return updatedTaskSettings(newSettings);
+    }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/sagemaker/schema/elastic/ElasticPayload.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/sagemaker/schema/elastic/ElasticPayload.java
@@ -88,12 +88,6 @@ interface ElasticPayload extends SageMakerSchemaPayload {
 
     @Override
     default SageMakerElasticTaskSettings apiTaskSettings(Map<String, Object> taskSettings, ValidationException validationException) {
-        if (taskSettings != null && (taskSettings.isEmpty() == false)) {
-            validationException.addValidationError(
-                InferenceAction.Request.TASK_SETTINGS.getPreferredName()
-                    + " is only supported during the inference request and cannot be stored in the inference endpoint."
-            );
-        }
         return SageMakerElasticTaskSettings.empty();
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/sagemaker/schema/elastic/SageMakerElasticTaskSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/sagemaker/schema/elastic/SageMakerElasticTaskSettings.java
@@ -9,10 +9,12 @@ package org.elasticsearch.xpack.inference.services.sagemaker.schema.elastic;
 
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
+import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.inference.services.sagemaker.schema.SageMakerStoredTaskSchema;
 
 import java.io.IOException;
@@ -40,6 +42,16 @@ record SageMakerElasticTaskSettings(@Nullable Map<String, Object> passthroughSet
 
     @Override
     public SageMakerStoredTaskSchema updatedTaskSettings(Map<String, Object> newSettings) {
+        var validationException = new ValidationException();
+        validationException.addValidationError(
+            InferenceAction.Request.TASK_SETTINGS.getPreferredName()
+                + " is only supported during the inference request and cannot be stored in the inference endpoint."
+        );
+        throw validationException;
+    }
+
+    @Override
+    public SageMakerStoredTaskSchema override(Map<String, Object> newSettings) {
         return new SageMakerElasticTaskSettings(newSettings);
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/sagemaker/schema/SageMakerSchemaPayloadTestCase.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/sagemaker/schema/SageMakerSchemaPayloadTestCase.java
@@ -119,7 +119,7 @@ public abstract class SageMakerSchemaPayloadTestCase<T extends SageMakerSchemaPa
         }
     }
 
-    public final void testUpdate() throws IOException {
+    public void testUpdate() throws IOException {
         var taskSettings = randomApiTaskSettings();
         if (taskSettings != SageMakerStoredTaskSchema.NO_OP) {
             var otherTaskSettings = randomValueOtherThan(taskSettings, this::randomApiTaskSettings);


### PR DESCRIPTION
Backports the following commits to 8.19:
 - [ML] Remove SageMaker Elastic updates (#131301)