### PR TITLE
Fix bug in point in time response

### DIFF
--- a/docs/changelog/131391.yaml
+++ b/docs/changelog/131391.yaml
@@ -1,0 +1,6 @@
+pr: 131391
+summary: Fix bug in point in time response
+area: Search
+type: bug
+issues:
+ - 131026

--- a/server/src/main/java/org/elasticsearch/action/search/OpenPointInTimeResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/OpenPointInTimeResponse.java
@@ -59,7 +59,7 @@ public final class OpenPointInTimeResponse extends ActionResponse implements ToX
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field("id", Base64.getUrlEncoder().encodeToString(BytesReference.toBytes(pointInTimeId)));
-        buildBroadcastShardsHeader(builder, params, totalShards, successfulShards, failedShards, skippedShards, null);
+        buildBroadcastShardsHeader(builder, params, totalShards, successfulShards, skippedShards, failedShards, null);
         builder.endObject();
         return builder;
     }

--- a/server/src/test/java/org/elasticsearch/action/search/OpenPointInTimeResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/OpenPointInTimeResponseTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.Base64;
+import java.util.Locale;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 
@@ -40,7 +41,7 @@ public class OpenPointInTimeResponseTests extends ESTestCase {
         }
 
         String encodedId = Base64.getUrlEncoder().encodeToString(BytesReference.toBytes(pointInTimeId));
-        BytesReference expected = new BytesArray(String.format("""
+        BytesReference expected = new BytesArray(String.format(Locale.ROOT, """
             {
               "id": "%s",
               "_shards": {

--- a/server/src/test/java/org/elasticsearch/action/search/OpenPointInTimeResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/OpenPointInTimeResponseTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.action.search;
+
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentType;
+
+import java.io.IOException;
+import java.util.Base64;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
+
+public class OpenPointInTimeResponseTests extends ESTestCase {
+
+    public void testIdCantBeNull() {
+        BytesReference pointInTimeId = null;
+        expectThrows(NullPointerException.class, () -> { new OpenPointInTimeResponse(pointInTimeId, 11, 8, 2, 1); });
+    }
+
+    public void testToXContent() throws IOException {
+        String id = "test-id";
+        BytesReference pointInTimeId = new BytesArray(id);
+
+        BytesReference actual;
+        try (XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent())) {
+            OpenPointInTimeResponse response = new OpenPointInTimeResponse(pointInTimeId, 11, 8, 2, 1);
+            response.toXContent(builder, ToXContent.EMPTY_PARAMS);
+            actual = BytesReference.bytes(builder);
+        }
+
+        String encodedId = Base64.getUrlEncoder().encodeToString(BytesReference.toBytes(pointInTimeId));
+        BytesReference expected = new BytesArray(String.format("""
+            {
+              "id": "%s",
+              "_shards": {
+                "total": 11,
+                "successful": 8,
+                "failed": 2,
+                "skipped": 1
+              }
+            }
+            """, encodedId));
+        assertToXContentEquivalent(expected, actual, XContentType.JSON);
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/elastic/elasticsearch/issues/131026.

The failed and skipped parameters are swapped.

See: https://github.com/elastic/elasticsearch/blob/8bcb0c4c652a9e102a0831ea1ebad7d73a18d78e/server/src/main/java/org/elasticsearch/rest/action/RestActions.java#L80-L88