### PR TITLE
[9.0] Upgrade tests to MinIO `RELEASE.2025-06-13T11-33-47Z` (#129920)

### DIFF
--- a/test/fixtures/minio-fixture/src/main/java/org/elasticsearch/test/fixtures/minio/MinioTestContainer.java
+++ b/test/fixtures/minio-fixture/src/main/java/org/elasticsearch/test/fixtures/minio/MinioTestContainer.java
@@ -16,7 +16,9 @@ import org.testcontainers.images.builder.ImageFromDockerfile;
 public final class MinioTestContainer extends DockerEnvironmentAwareTestContainer {
 
     private static final int servicePort = 9000;
-    public static final String DOCKER_BASE_IMAGE = "minio/minio:RELEASE.2024-12-18T13-15-44Z";
+    // NB releases earlier than 2025-05-24 are buggy, see https://github.com/minio/minio/issues/21189, and #127166 for a workaround
+    // However the 2025-05-24 release is also buggy, see https://github.com/minio/minio/issues/21377, and this has no workaround
+    public static final String DOCKER_BASE_IMAGE = "minio/minio:RELEASE.2025-06-13T11-33-47Z";
     private final boolean enabled;
 
     public MinioTestContainer(boolean enabled, String accessKey, String secretKey, String bucketName) {

--- a/x-pack/plugin/snapshot-repo-test-kit/qa/minio/src/javaRestTest/java/org/elasticsearch/repositories/blobstore/testkit/analyze/MinioRepositoryAnalysisRestIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/qa/minio/src/javaRestTest/java/org/elasticsearch/repositories/blobstore/testkit/analyze/MinioRepositoryAnalysisRestIT.java
@@ -34,7 +34,6 @@ public class MinioRepositoryAnalysisRestIT extends AbstractRepositoryAnalysisRes
         .setting("s3.client.repository_test_kit.protocol", () -> "http")
         .setting("s3.client.repository_test_kit.endpoint", minioFixture::getAddress)
         .setting("xpack.security.enabled", "false")
-        // Additional tracing related to investigation into https://github.com/elastic/elasticsearch/issues/102294
         .setting("xpack.ml.enabled", "false")
         .build();
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Upgrade tests to MinIO &#x60;RELEASE.2025-06-13T11-33-47Z&#x60; (#129920)](https://github.com/elastic/elasticsearch/pull/129920)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)