### PR TITLE
Mark monitoring code as `NotMultiProjectCapable`

### DIFF
--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexStatsCollector.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexStatsCollector.java
@@ -11,10 +11,12 @@ import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.core.NotMultiProjectCapable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.xpack.core.monitoring.exporter.MonitoringDoc;
@@ -79,13 +81,15 @@ public class IndexStatsCollector extends Collector {
 
         final long timestamp = timestamp();
         final String clusterUuid = clusterUuid(clusterState);
-        final Metadata metadata = clusterState.metadata();
-        final RoutingTable routingTable = clusterState.routingTable();
+        @NotMultiProjectCapable(description = "Monitoring is not available in serverless and will thus not be made project-aware")
+        final var projectId = ProjectId.DEFAULT;
+        final ProjectMetadata metadata = clusterState.metadata().getProject(projectId);
+        final RoutingTable routingTable = clusterState.routingTable(projectId);
 
         // Filters the indices stats to only return the statistics for the indices known by the collector's
         // local cluster state. This way indices/index/shards stats all share a common view of indices state.
         final List<IndexStats> indicesStats = new ArrayList<>();
-        for (final String indexName : metadata.getProject().getConcreteAllIndices()) {
+        for (final String indexName : metadata.getConcreteAllIndices()) {
             final IndexStats indexStats = indicesStatsResponse.getIndex(indexName);
             if (indexStats != null) {
                 // The index appears both in the local cluster state and indices stats response
@@ -98,7 +102,7 @@ public class IndexStatsCollector extends Collector {
                         interval,
                         node,
                         indexStats,
-                        metadata.getProject().index(indexName),
+                        metadata.index(indexName),
                         routingTable.index(indexName)
                     )
                 );

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/shards/ShardsCollector.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/shards/ShardsCollector.java
@@ -8,12 +8,14 @@ package org.elasticsearch.xpack.monitoring.collector.shards;
 
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.core.NotMultiProjectCapable;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.xpack.core.monitoring.exporter.MonitoringDoc;
 import org.elasticsearch.xpack.monitoring.collector.Collector;
@@ -48,7 +50,8 @@ public class ShardsCollector extends Collector {
         throws Exception {
         final List<MonitoringDoc> results = new ArrayList<>(1);
         if (clusterState != null) {
-            RoutingTable routingTable = clusterState.routingTable();
+            @NotMultiProjectCapable(description = "Monitoring is not available in serverless and will thus not be made project-aware")
+            RoutingTable routingTable = clusterState.routingTable(ProjectId.DEFAULT);
             if (routingTable != null) {
                 final String clusterUuid = clusterUuid(clusterState);
                 final String stateUUID = clusterState.stateUUID();

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/BaseCollectorTestCase.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/BaseCollectorTestCase.java
@@ -30,6 +30,7 @@ import org.elasticsearch.xpack.monitoring.collector.Collector;
 
 import java.util.function.Function;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -54,7 +55,7 @@ public abstract class BaseCollectorTestCase extends ESTestCase {
         nodes = mock(DiscoveryNodes.class);
         metadata = mock(Metadata.class);
         projectMetadata = mock(ProjectMetadata.class);
-        when(metadata.getProject()).thenReturn(projectMetadata);
+        when(metadata.getProject(any())).thenReturn(projectMetadata);
         licenseState = mock(MockLicenseState.class);
         client = mock(Client.class);
         ThreadPool threadPool = mock(ThreadPool.class);

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MultiNodesStatsTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MultiNodesStatsTests.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.monitoring;
 
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -109,7 +110,7 @@ public class MultiNodesStatsTests extends MonitoringIntegTestCase {
                 return false;
             }
             for (Index index : indices) {
-                final var indexRoutingTable = cs.routingTable().index(index);
+                final var indexRoutingTable = cs.routingTable(ProjectId.DEFAULT).index(index);
                 if (indexRoutingTable.allPrimaryShardsActive() == false) {
                     return false;
                 }

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexStatsCollectorTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexStatsCollectorTests.java
@@ -35,6 +35,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -70,7 +71,7 @@ public class IndexStatsCollectorTests extends BaseCollectorTestCase {
         whenClusterStateWithUUID(clusterUUID);
 
         final RoutingTable routingTable = mock(RoutingTable.class);
-        when(clusterState.routingTable()).thenReturn(routingTable);
+        when(clusterState.routingTable(any())).thenReturn(routingTable);
 
         final IndicesStatsResponse indicesStatsResponse = mock(IndicesStatsResponse.class);
         final MonitoringDoc.Node node = randomMonitoringNode(random());

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/shards/ShardsCollectorTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/shards/ShardsCollectorTests.java
@@ -38,6 +38,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -92,7 +93,7 @@ public class ShardsCollectorTests extends BaseCollectorTestCase {
         withCollectionIndices(indices);
 
         final RoutingTable routingTable = mockRoutingTable();
-        when(clusterState.routingTable()).thenReturn(routingTable);
+        when(clusterState.routingTable(any())).thenReturn(routingTable);
 
         final DiscoveryNode localNode = localNode("_current");
         final MonitoringDoc.Node node = Collector.convertNode(randomNonNegativeLong(), localNode);


### PR DESCRIPTION
The monitoring plugin is not available in serverless, so we're simply marking the code as not being multi-project capable.