### PR TITLE
update `kibana_system` to grant it access to `.chat-*` system index

### DIFF
--- a/modules/kibana/src/main/java/org/elasticsearch/kibana/KibanaPlugin.java
+++ b/modules/kibana/src/main/java/org/elasticsearch/kibana/KibanaPlugin.java
@@ -38,6 +38,13 @@ public class KibanaPlugin extends Plugin implements SystemIndexPlugin {
         .setAllowedElasticProductOrigins(KIBANA_PRODUCT_ORIGIN)
         .build();
 
+    public static final SystemIndexDescriptor ONECHAT_INDEX_DESCRIPTOR = SystemIndexDescriptor.builder()
+        .setIndexPattern(".chat-*")
+        .setDescription("Onechat system index")
+        .setType(Type.EXTERNAL_UNMANAGED)
+        .setAllowedElasticProductOrigins(KIBANA_PRODUCT_ORIGIN)
+        .build();
+
     public static final SystemIndexDescriptor APM_AGENT_CONFIG_INDEX_DESCRIPTOR = SystemIndexDescriptor.builder()
         .setIndexPattern(".apm-agent-configuration*")
         .setDescription("system index for APM agent configuration")
@@ -57,6 +64,7 @@ public class KibanaPlugin extends Plugin implements SystemIndexPlugin {
         return List.of(
             KIBANA_INDEX_DESCRIPTOR,
             REPORTING_INDEX_DESCRIPTOR,
+            ONECHAT_INDEX_DESCRIPTOR,
             APM_AGENT_CONFIG_INDEX_DESCRIPTOR,
             APM_CUSTOM_LINK_INDEX_DESCRIPTOR
         );

--- a/modules/kibana/src/test/java/org/elasticsearch/kibana/KibanaPluginTests.java
+++ b/modules/kibana/src/test/java/org/elasticsearch/kibana/KibanaPluginTests.java
@@ -20,7 +20,7 @@ public class KibanaPluginTests extends ESTestCase {
     public void testKibanaIndexNames() {
         assertThat(
             new KibanaPlugin().getSystemIndexDescriptors(Settings.EMPTY).stream().map(SystemIndexDescriptor::getIndexPattern).toList(),
-            contains(".kibana_*", ".reporting-*", ".apm-agent-configuration*", ".apm-custom-link*")
+            contains(".kibana_*", ".reporting-*", ".chat-*", ".apm-agent-configuration*", ".apm-custom-link*")
         );
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -109,7 +109,7 @@ class KibanaOwnedReservedRoleDescriptors {
             new RoleDescriptor.IndicesPrivileges[] {
                 // System indices defined in KibanaPlugin
                 RoleDescriptor.IndicesPrivileges.builder()
-                    .indices(".kibana*", ".reporting-*")
+                    .indices(".kibana*", ".reporting-*", ".chat-*")
                     .privileges("all")
                     .allowRestrictedIndices(true)
                     .build(),


### PR DESCRIPTION
Fix https://github.com/elastic/search-team/issues/10469

- Update the Kibana plugin to define the `.chat-*` external system index pattern
- Update the `kibana_system` role descriptor to grant it full access to it
