### PR TITLE
Fix #129452

### DIFF
--- a/x-pack/qa/xpack-prefix-rest-compat/src/yamlRestTestV7Compat/java/org/elasticsearch/xpack/test/rest/XPackRestIT.java
+++ b/x-pack/qa/xpack-prefix-rest-compat/src/yamlRestTestV7Compat/java/org/elasticsearch/xpack/test/rest/XPackRestIT.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.test.rest;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
+import org.junit.Before;
 
 public class XPackRestIT extends AbstractXPackRestTest {
 
@@ -20,5 +21,13 @@ public class XPackRestIT extends AbstractXPackRestTest {
     @ParametersFactory
     public static Iterable<Object[]> parameters() throws Exception {
         return createParameters();
+    }
+
+    /**
+     * Some rest tests depend on the trial license being generated before they run
+     */
+    @Before
+    public void setupLicense() {
+        super.waitForLicense();
     }
 }


### PR DESCRIPTION
Closes #129452 

The linked test is occasionally failing because it's trying to fetch the license state before the license has been initialised.

Confusingly, there are two XPackRestIT classes; the other XPackRestIT works around this exact issue using an `@Before` that ensures the license is initialised first, so I've copied it into this XPackRestIT