### PR TITLE
Drop unused plugin declaration `com.gradleup.nmcp.aggregation`

### DIFF
--- a/docs/changelog/131435.yaml
+++ b/docs/changelog/131435.yaml
@@ -1,0 +1,5 @@
+pr: 131435
+summary: Drop unused plugin declaration `com.gradleup.nmcp.aggregation`
+area: build.versions.toml
+type: chore
+issues: []

--- a/gradle/build.versions.toml
+++ b/gradle/build.versions.toml
@@ -51,4 +51,3 @@ xmlunit-core = "org.xmlunit:xmlunit-core:2.8.2"
 
 [plugins]
 ospackage = { id = "com.netflix.nebula.ospackage-base", version = "11.11.2" }
-nmcp-aggregation = { id = "com.gradleup.nmcp.aggregation", version.ref="nmcp" }


### PR DESCRIPTION
Drop unused plugin declaration `com.gradleup.nmcp.aggregation`


---------

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
