### PR TITLE
[9.1] Remove 'index' from snapshot clear_cache query params (#131067)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/searchable_snapshots.clear_cache.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/searchable_snapshots.clear_cache.json
@@ -50,10 +50,6 @@
         ],
         "default": "open",
         "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both."
-      },
-      "index": {
-        "type": "list",
-        "description": "A comma-separated list of index name to limit the operation"
       }
     }
   }


### PR DESCRIPTION
Backports the following commits to 9.1:
 - Remove 'index' from snapshot clear_cache query params (#131067)