### PR TITLE
Adding index.refresh_interval as a data stream setting

### DIFF
--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportUpdateDataStreamSettingsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportUpdateDataStreamSettingsAction.java
@@ -54,7 +54,11 @@ public class TransportUpdateDataStreamSettingsAction extends TransportMasterNode
     UpdateDataStreamSettingsAction.Request,
     UpdateDataStreamSettingsAction.Response> {
     private static final Logger logger = LogManager.getLogger(TransportUpdateDataStreamSettingsAction.class);
-    private static final Set<String> APPLY_TO_BACKING_INDICES = Set.of("index.lifecycle.name", IndexSettings.PREFER_ILM);
+    private static final Set<String> APPLY_TO_BACKING_INDICES = Set.of(
+        "index.lifecycle.name",
+        IndexSettings.PREFER_ILM,
+        "index.refresh_interval"
+    );
     private static final Set<String> APPLY_TO_DATA_STREAM_ONLY = Set.of("index.number_of_shards");
     private final MetadataDataStreamsService metadataDataStreamsService;
     private final MetadataUpdateSettingsService updateSettingsService;

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/240_data_stream_settings.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/240_data_stream_settings.yml
@@ -51,18 +51,21 @@ setup:
         body:
           index:
             number_of_shards: 2
+            refresh_interval: 29s
             lifecycle:
               name: my-new-policy
               prefer_ilm: true
   - match: { data_streams.0.name: my-data-stream-1 }
   - match: { data_streams.0.applied_to_data_stream: true }
   - match: { data_streams.0.index_settings_results.applied_to_data_stream_only: [index.number_of_shards]}
-  - length: { data_streams.0.index_settings_results.applied_to_data_stream_and_backing_indices: 2  }
+  - length: { data_streams.0.index_settings_results.applied_to_data_stream_and_backing_indices: 3  }
   - match: { data_streams.0.settings.index.number_of_shards: "2" }
+  - match: { data_streams.0.settings.index.refresh_interval: "29s" }
   - match: { data_streams.0.settings.index.lifecycle.name: "my-new-policy" }
   - match: { data_streams.0.settings.index.lifecycle.prefer_ilm: "true" }
   - match: { data_streams.0.effective_settings.index.number_of_shards: "2" }
   - match: { data_streams.0.effective_settings.index.number_of_replicas: "0" }
+  - match: { data_streams.0.effective_settings.index.refresh_interval: "29s" }
   - match: { data_streams.0.effective_settings.index.lifecycle.name: "my-new-policy" }
   - match: { data_streams.0.effective_settings.index.lifecycle.prefer_ilm: "true" }
 
@@ -81,6 +84,7 @@ setup:
   - match: { data_streams.0.name: my-data-stream-1 }
   - match: { data_streams.0.settings.index.number_of_shards: "2" }
   - match: { data_streams.0.effective_settings.index.number_of_shards: "2" }
+  - match: { data_streams.0.effective_settings.index.refresh_interval: "29s" }
   - match: { data_streams.0.effective_settings.index.number_of_replicas: "0" }
   - match: { data_streams.0.effective_settings.index.lifecycle.name: "my-new-policy" }
   - match: { data_streams.0.effective_settings.index.lifecycle.prefer_ilm: "true" }
@@ -90,6 +94,7 @@ setup:
         name: my-data-stream-1
   - match: { data_streams.0.name: my-data-stream-1 }
   - match: { data_streams.0.settings.index.number_of_shards: "2" }
+  - match: { data_streams.0.settings.index.refresh_interval: "29s" }
   - match: { data_streams.0.settings.index.lifecycle.name: "my-new-policy" }
   - match: { data_streams.0.settings.index.lifecycle.prefer_ilm: "true" }
   - match: { data_streams.0.effective_settings: null }
@@ -106,6 +111,7 @@ setup:
   - match: { .$idx0name.settings.index.number_of_shards: "1" }
   - match: { .$idx0name.settings.index.lifecycle.name: "my-new-policy" }
   - match: { .$idx1name.settings.index.number_of_shards: "2" }
+  - match: { .$idx1name.settings.index.refresh_interval: "29s" }
   - match: { .$idx1name.settings.index.lifecycle.name: "my-new-policy" }
   - match: { .$idx1name.settings.index.lifecycle.prefer_ilm: "true" }
 


### PR DESCRIPTION
This adds `index.refresh_interval` as a setting that can be applied to a data stream with the data stream settings API. This setting is applied to all backing indices of the data stream (as well as any future ones).