### PR TITLE
[8.19] Add missing query params to index recovery API spec (#131490)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.recovery.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.recovery.json
@@ -41,6 +41,28 @@
         "type":"boolean",
         "description":"Display only those recoveries that are currently on-going",
         "default":false
+      },
+      "ignore_unavailable":{
+        "type":"boolean",
+        "description":"Whether specified concrete indices should be ignored when unavailable (missing or closed)",
+        "default":false
+      },
+      "allow_no_indices":{
+        "type":"boolean",
+        "description":"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
+        "default":true
+      },
+      "expand_wildcards":{
+        "type":"enum",
+        "options":[
+          "open",
+          "closed",
+          "hidden",
+          "none",
+          "all"
+        ],
+        "default":"open",
+        "description":"Whether to expand wildcard expression to concrete indices that are open, closed or both."
       }
     }
   }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.recovery/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.recovery/10_basic.yml
@@ -17,6 +17,9 @@
       indices.recovery:
         index: [test_1]
         human: true
+        ignore_unavailable: false
+        allow_no_indices: true
+        expand_wildcards: open
 
   - match: { test_1.shards.0.type:                                 "EMPTY_STORE"           }
   - match: { test_1.shards.0.stage:                                "DONE"                  }


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Add missing query params to index recovery API spec (#131490)