### PR TITLE
Fix NPE in TimeSeriesExtractFieldOperator

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/TimeSeriesExtractFieldOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/TimeSeriesExtractFieldOperator.java
@@ -254,7 +254,8 @@ public class TimeSeriesExtractFieldOperator extends AbstractPageMappingOperator 
             this.storedFieldsSpec = storedFieldsSpec;
             this.dimensions = new boolean[fields.size()];
             for (int i = 0; i < fields.size(); i++) {
-                dimensions[i] = shardContext.fieldType(fields.get(i).name()).isDimension();
+                final var mappedFieldType = shardContext.fieldType(fields.get(i).name());
+                dimensions[i] = mappedFieldType != null && mappedFieldType.isDimension();
             }
         }
 


### PR DESCRIPTION
We miss checking whether a field exists when populating the dimension attributes. This issue occurs when a field exists in some, but not all target indices.

Labelled this non-issue for an unreleased bug.