### PR TITLE
Disable entitlements for DirectIOIT, the suite requires delegation to work

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/index/store/DirectIOIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/store/DirectIOIT.java
@@ -22,6 +22,7 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.vectors.KnnSearchBuilder;
 import org.elasticsearch.search.vectors.VectorData;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.InternalSettingsPlugin;
 import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
@@ -41,6 +42,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 @LuceneTestCase.SuppressCodecs("*") // only use our own codecs
+@ESTestCase.WithoutEntitlements // requires entitlement delegation ES-10920
 public class DirectIOIT extends ESIntegTestCase {
 
     @BeforeClass


### PR DESCRIPTION
Disable entitlements for DirectIOIT, the suite requires delegation to work.

On main the suite is skipped (direct IO is disabled by default), but this blocks backports.