### PR TITLE
ES|QL: fix generative test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -469,9 +469,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.action.EsqlActionBreakerIT
   method: testFromEvalStats
   issue: https://github.com/elastic/elasticsearch/issues/131503
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/131508
 - class: org.elasticsearch.xpack.downsample.DownsampleWithBasicRestIT
   method: test {p0=downsample-with-security/10_basic/Downsample index}
   issue: https://github.com/elastic/elasticsearch/issues/131513

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
@@ -50,6 +50,7 @@ public abstract class GenerativeRestTest extends ESRestTestCase {
         "Plan \\[ProjectExec\\[\\[<no-fields>.* optimized incorrectly due to missing references", // https://github.com/elastic/elasticsearch/issues/125866
         "The incoming YAML document exceeds the limit:", // still to investigate, but it seems to be specific to the test framework
         "Data too large", // Circuit breaker exceptions eg. https://github.com/elastic/elasticsearch/issues/130072
+        "optimized incorrectly due to missing references", // https://github.com/elastic/elasticsearch/issues/131509
 
         // Awaiting fixes for correctness
         "Expecting at most \\[.*\\] columns, got \\[.*\\]" // https://github.com/elastic/elasticsearch/issues/129561


### PR DESCRIPTION
Allowing "optimized incorrectly due to missing references" errors

Fixes: https://github.com/elastic/elasticsearch/issues/131508