### PR TITLE
Disable queryable built-in feature for smoke-test-plugins-ssl

### DIFF
--- a/x-pack/qa/smoke-test-plugins-ssl/build.gradle
+++ b/x-pack/qa/smoke-test-plugins-ssl/build.gradle
@@ -78,6 +78,8 @@ testClusters.matching { it.name == "yamlRestTest" }.configureEach {
   user username: "test_user", password: "x-pack-test-password"
   user username: "monitoring_agent", password: "x-pack-test-password", role: "remote_monitoring_agent"
 
+  systemProperty 'es.queryable_built_in_roles_enabled', 'false'
+
   pluginPaths.each { pluginPath ->
     plugin pluginPath
   }


### PR DESCRIPTION
Resolves #131498 

The test fails when it runs before the security index is ready. Apply the same fix from [here](https://github.com/elastic/elasticsearch/pull/124684) to address this.