### PR TITLE
[9.0] Fix msearch rest-api-spec (#130627)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/msearch.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/msearch.json
@@ -69,6 +69,38 @@
         "type":"boolean",
         "description":"Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution",
         "default":"true"
+      },
+      "index":{
+        "type":"list",
+        "description":"A comma-separated list of index names to use as default"
+      },
+      "ignore_unavailable":{
+        "type":"boolean",
+        "description":"Whether specified concrete indices should be ignored when unavailable (missing or closed)"
+      },
+      "ignore_throttled":{
+        "type":"boolean",
+        "description":"Whether specified concrete, expanded or aliased indices should be ignored when throttled",
+        "deprecated":true
+      },
+      "allow_no_indices":{
+        "type":"boolean",
+        "description":"Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
+      },
+      "expand_wildcards":{
+        "type":"enum",
+        "options": ["open", "closed", "hidden", "none", "all"],
+        "default":"open",
+        "description":"Whether to expand wildcard expression to concrete indices that are open, closed or both."
+      },
+      "routing":{
+        "type":"list",
+        "description":"A comma-separated list of specific routing values"
+      },
+      "include_named_queries_score":{
+        "type":"boolean",
+        "description":"Indicates whether hit.matched_queries should be rendered as a map that includes the name of the matched query associated with its score (true) or as an array containing the name of the matched queries (false)",
+        "default": false
       }
     },
     "body":{

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/msearch/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/msearch/10_basic.yml
@@ -1,5 +1,7 @@
 ---
 setup:
+  - requires:
+      test_runner_features: allowed_warnings
 
   - do:
       index:
@@ -67,6 +69,12 @@ setup:
         rest_total_hits_as_int: true
         max_concurrent_shard_requests: 1
         max_concurrent_searches: 1
+        ignore_unavailable: false
+        ignore_throttled: false
+        allow_no_indices: false
+        expand_wildcards: open
+        include_named_queries_score: false
+        index: index_*
         body:
           - index: index_*
           - query:
@@ -83,6 +91,8 @@ setup:
           - {}
           - query:
               match_all: {}
+      allowed_warnings:
+        - "[ignore_throttled] parameter is deprecated because frozen indices have been deprecated. Consider cold or frozen tiers in place of frozen indices."
 
   - match:  { responses.0.hits.total:     2  }
   - match:  { responses.1.hits.total:     1  }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/msearch/40_routing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/msearch/40_routing.yml
@@ -1,0 +1,25 @@
+---
+setup:
+  - do:
+      index:
+          index:  index_1
+          routing: "1"
+          id:     "1"
+          body:   { foo: bar }
+
+  - do:
+      indices.refresh: {}
+
+---
+"Routing":
+
+  - do:
+      msearch:
+        rest_total_hits_as_int: true
+        routing: "1"
+        body:
+          - {}
+          - query:
+              match_all: {}
+
+  - match:  { responses.0.hits.total:     1  }


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Fix msearch rest-api-spec (#130627)