### PR TITLE
[9.1] Disable queryable built-in feature for smoke-test-plugins-ssl (#131523)

### DIFF
--- a/x-pack/qa/smoke-test-plugins-ssl/build.gradle
+++ b/x-pack/qa/smoke-test-plugins-ssl/build.gradle
@@ -83,6 +83,8 @@ testClusters.matching { it.name == "yamlRestTest" }.configureEach {
   user username: "test_user", password: "x-pack-test-password"
   user username: "monitoring_agent", password: "x-pack-test-password", role: "remote_monitoring_agent"
 
+  systemProperty 'es.queryable_built_in_roles_enabled', 'false'
+
   pluginPaths.each { pluginPath ->
     plugin pluginPath
   }


### PR DESCRIPTION
Backports the following commits to 9.1:
 - Disable queryable built-in feature for smoke-test-plugins-ssl (#131523)