### PR TITLE
[9.1] Revert "Put shards failure under a cap flag (#131371)" (#131542)

### DIFF
--- a/test/external-modules/error-query/src/javaRestTest/java/org/elasticsearch/test/esql/EsqlPartialResultsIT.java
+++ b/test/external-modules/error-query/src/javaRestTest/java/org/elasticsearch/test/esql/EsqlPartialResultsIT.java
@@ -214,10 +214,6 @@ public class EsqlPartialResultsIT extends ESRestTestCase {
     }
 
     public void testAllShardsFailed() throws Exception {
-        assumeTrue(
-            "fail functionality is not enabled",
-            clusterHasCapability("POST", "/_query", List.of(), List.of("fail_if_all_shards_fail")).orElse(false)
-        );
         setupRemoteClusters();
         populateIndices();
         try {
@@ -231,26 +227,6 @@ public class EsqlPartialResultsIT extends ESRestTestCase {
                     assertThat(EntityUtils.toString(resp.getEntity()), containsString("Accessing failing field"));
                 }
             }
-        } finally {
-            removeRemoteCluster();
-        }
-    }
-
-    public void testAllShardsFailedOldBehavior() throws Exception {
-        // TODO: drop this once we no longer support the old behavior
-        assumeFalse(
-            "fail functionality is enabled",
-            clusterHasCapability("POST", "/_query", List.of(), List.of("fail_if_all_shards_fail")).orElse(false)
-        );
-        setupRemoteClusters();
-        populateIndices();
-        try {
-            Request request = new Request("POST", "/_query");
-            request.setJsonEntity("{\"query\": \"FROM " + "*:failing*" + " | LIMIT 100\"}");
-            request.addParameter("allow_partial_results", "true");
-            Response resp = client().performRequest(request);
-            Map<String, Object> results = entityAsMap(resp);
-            assertThat(results.get("is_partial"), equalTo(true));
         } finally {
             removeRemoteCluster();
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1250,9 +1250,7 @@ public class EsqlCapabilities {
          * Forbid usage of brackets in unquoted index and enrich policy names
          * https://github.com/elastic/elasticsearch/issues/130378
          */
-        NO_BRACKETS_IN_UNQUOTED_INDEX_NAMES,
-
-        CATEGORIZE_OPTIONS;
+        NO_BRACKETS_IN_UNQUOTED_INDEX_NAMES;
 
         private final boolean enabled;
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1252,10 +1252,7 @@ public class EsqlCapabilities {
          */
         NO_BRACKETS_IN_UNQUOTED_INDEX_NAMES,
 
-        /**
-         * Fail if all shards fail
-         */
-        FAIL_IF_ALL_SHARDS_FAIL(Build.current().isSnapshot());
+        CATEGORIZE_OPTIONS;
 
         private final boolean enabled;
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -47,7 +47,6 @@ import org.elasticsearch.transport.AbstractTransportRequest;
 import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.action.EsqlExecutionInfo;
 import org.elasticsearch.xpack.esql.action.EsqlQueryAction;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
@@ -549,9 +548,6 @@ public class ComputeService {
      * which doesn't consider the failures from the remote clusters when skip_unavailable is true.
      */
     static void failIfAllShardsFailed(EsqlExecutionInfo execInfo, List<Page> finalResults) {
-        if (EsqlCapabilities.Cap.FAIL_IF_ALL_SHARDS_FAIL.isEnabled() == false) {
-            return;
-        }
         // do not fail if any final result has results
         if (finalResults.stream().anyMatch(p -> p.getPositionCount() > 0)) {
             return;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Revert &quot;Put shards failure under a cap flag (#131371)&quot; (#131542)](https://github.com/elastic/elasticsearch/pull/131542)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)