### PR TITLE
Checking failure store used for wrong data_stream.type from 9.2.0

### DIFF
--- a/x-pack/plugin/stack/src/yamlRestTest/resources/rest-api-spec/test/stack/10_basic.yml
+++ b/x-pack/plugin/stack/src/yamlRestTest/resources/rest-api-spec/test/stack/10_basic.yml
@@ -263,7 +263,7 @@ setup:
         name: .kibana-reporting-foo
 
 ---
-"Test wrong data_stream type":
+"Test wrong data_stream type - synthetics and metrics":
 
  - do:
       catch: bad_request
@@ -278,19 +278,25 @@ setup:
  - do:
       catch: bad_request
       index:
-        index: logs-dataset0-namespace1
-        body:
-          "@timestamp": "2020-01-01"
-          data_stream.type: "metrics"
-          data_stream.dataset: "dataset0"
-          data_stream.namespace: "namespace1"
-
- - do:
-      catch: bad_request
-      index:
         index: metrics-dataset0-namespace1
         body:
           "@timestamp": "2020-01-01"
           data_stream.type: "synthetics"
           data_stream.dataset: "dataset0"
           data_stream.namespace: "namespace1"
+
+---
+"Test wrong data_stream type - logs from 9.2.0":
+  - requires:
+      cluster_features: [ "gte_v9.1.99" ]
+      reason: "failure store is enabled by default for log data streams since 9.2.0"
+
+  - do:
+      index:
+        index: logs-dataset0-namespace1
+        body:
+          "@timestamp": "2020-01-01"
+          data_stream.type: "metrics"
+          data_stream.dataset: "dataset0"
+          data_stream.namespace: "namespace1"
+  - match: { failure_store: used }


### PR DESCRIPTION
A followup of https://github.com/elastic/elasticsearch/pull/131261 - starting in 9.2.0, the failure store will be enabled by default for `logs-*-*` data streams, so sending the wrong `data_stream.type` doesn't cause 400s anymore, but rather 201 responses with `failure_store: used`. This causes failures in the compatibility tests, hence this PR.

I couldn't find a way to add another test - `Test wrong data_stream type - logs before 9.2.0` (e.g. to that 8.19 builds keep verifying the current behavior), because I don't know how to restrict a REST yaml test from running up to a specific version. 

@elastic/es-core-infra please review the technical aspect of this. 

I am still looking for approval for the conceptual issue of whether stop responding with errors can be considered a non-breaking change by default.