### PR TITLE
Skip stacktrace in info log for s3 region loading issue

### DIFF
--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositoryPlugin.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositoryPlugin.java
@@ -101,7 +101,7 @@ public class S3RepositoryPlugin extends Plugin implements RepositoryPlugin, Relo
         try {
             return DefaultAwsRegionProviderChain.builder().build().getRegion();
         } catch (Exception e) {
-            logger.info("failed to obtain region from default provider chain", e);
+            logger.info("unable to obtain region from default provider chain: {}", e.getMessage());
             return null;
         }
     }


### PR DESCRIPTION
The stacktrace is rather excessive given the level of the log message. The information provided in the exception message should be sufficient for taking actions. Also adjust the wording to better match the contribuation guide for logging messages.
