### PR TITLE
Clarify heap size configuration

### DIFF
--- a/docs/reference/elasticsearch/jvm-settings.md
+++ b/docs/reference/elasticsearch/jvm-settings.md
@@ -92,7 +92,7 @@ The heap size should be based on the available RAM:
     ::::{note}
     When running in a container, such as [Docker](docs-content://deploy-manage/deploy/self-managed/install-elasticsearch-with-docker.md), the total memory available to {{es}} means the amount of memory available within the container, not the total system memory on the host.
 
-    If you are running multiple {{es}} nodes on the same host, or in the same container, the total of all the nodes' heap sizes should not exceed 50% of the total available memory on the host.
+    If you are running multiple {{es}} nodes on the same host, or in the same container, the total of all the nodes' heap sizes should not exceed 50% of the total available memory.
 
     Account for the memory usage of other processes running on the same host, or in the same container, when computing the total memory available to {{es}}.
 

--- a/docs/reference/elasticsearch/jvm-settings.md
+++ b/docs/reference/elasticsearch/jvm-settings.md
@@ -87,10 +87,18 @@ To override the default heap size, set the minimum and maximum heap size setting
 
 The heap size should be based on the available RAM:
 
-* Set `Xms` and `Xmx` to no more than 50% of your total memory. {{es}} requires memory for purposes other than the JVM heap. For example, {{es}} uses off-heap buffers for efficient network communication and relies on the operating system’s filesystem cache for efficient access to files. The JVM itself also requires some memory. It’s normal for {{es}} to use more memory than the limit configured with the `Xmx` setting.
+* Set `Xms` and `Xmx` to no more than 50% of the total memory available to each {{es}} node. {{es}} requires memory for purposes other than the JVM heap. For example, {{es}} uses off-heap buffers for efficient network communication and relies on the operating system’s filesystem cache for efficient access to files. The JVM itself also requires some memory. It’s normal for {{es}} to use more memory than the limit configured with the `Xmx` setting.
 
     ::::{note}
-    When running in a container, such as [Docker](docs-content://deploy-manage/deploy/self-managed/install-elasticsearch-with-docker.md), total memory is defined as the amount of memory visible to the container, not the total system memory on the host.
+    When running in a container, such as [Docker](docs-content://deploy-manage/deploy/self-managed/install-elasticsearch-with-docker.md), the total memory available to {{es}} means the amount of memory available within the container, not the total system memory on the host.
+
+    If you are running multiple {{es}} nodes on the same host, or in the same container, the total of all the nodes' heap sizes should not exceed 50% of the total available memory on the host.
+
+    Account for the memory usage of other processes running on the same host, or in the same container, when computing the total memory available to {{es}}.
+
+    The 50% guideline is intended as a safe upper bound on the heap size. You may find that heap sizes smaller than this maximum offer better performance, for instance by allowing your operating system to use a larger filesystem cache.
+
+    If you set the heap size too large, {{es}} may perform poorly and nodes may be terminated by the operating system.
     ::::
 
 * Set `Xms` and `Xmx` to no more than the threshold for compressed ordinary object pointers (oops). The exact threshold varies but 26GB is safe on most systems and can be as large as 30GB on some systems. To verify you are under the threshold, check the {{es}} log for an entry like this:


### PR DESCRIPTION
Spell out that total memory needs to account for multiple nodes, and
other processes, and that the OOM killer might react if you ignore this
guidance.