### PR TITLE
[8.19] Add missing timeouts to rest-api-spec ILM APIs (#118837)

### DIFF
--- a/docs/changelog/118837.yaml
+++ b/docs/changelog/118837.yaml
@@ -1,0 +1,5 @@
+pr: 118837
+summary: Add missing timeouts to rest-api-spec ILM APIs
+area: "ILM+SLM"
+type: bug
+issues: []

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.delete_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.delete_lifecycle.json
@@ -25,6 +25,15 @@
         }
       ]
     },
-    "params":{}
+    "params":{
+      "master_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout"
+      }
+    }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.explain_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.explain_lifecycle.json
@@ -33,6 +33,10 @@
       "only_errors": {
         "type": "boolean",
         "description": "filters the indices included in the response to ones in an ILM error state, implies only_managed"
+      },
+      "master_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to master node"
       }
     }
   }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.get_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.get_lifecycle.json
@@ -31,6 +31,15 @@
         }
       ]
     },
-    "params":{}
+    "params":{
+      "master_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout"
+      }
+    }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.put_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.put_lifecycle.json
@@ -26,7 +26,16 @@
         }
       ]
     },
-    "params":{},
+    "params":{
+      "master_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout"
+      }
+    },
     "body":{
       "description":"The lifecycle policy definition to register"
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.start.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.start.json
@@ -19,6 +19,15 @@
         }
       ]
     },
-    "params":{}
+    "params":{
+      "master_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout"
+      }
+    }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.stop.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.stop.json
@@ -19,6 +19,15 @@
         }
       ]
     },
-    "params":{}
+    "params":{
+      "master_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout"
+      }
+    }
   }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Add missing timeouts to rest-api-spec ILM APIs (#118837)](https://github.com/elastic/elasticsearch/pull/118837)

I forgot to port this commit to branch 8.x at the time, which means this commit is in 8.16 and 8.17 but not yet in 8.18 and 8.19.

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)