### PR TITLE
[8.19] Add missing timeouts to rest-api-spec ingest APIs (#118844)

### DIFF
--- a/docs/changelog/118844.yaml
+++ b/docs/changelog/118844.yaml
@@ -1,0 +1,5 @@
+pr: 118844
+summary: Add missing timeouts to rest-api-spec ingest APIs
+area: Ingest Node
+type: bug
+issues: []

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.delete_geoip_database.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.delete_geoip_database.json
@@ -26,6 +26,14 @@
       ]
     },
     "params":{
+      "master_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.delete_ip_location_database.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.delete_ip_location_database.json
@@ -26,6 +26,14 @@
       ]
     },
     "params":{
+      "master_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_geoip_database.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_geoip_database.json
@@ -27,6 +27,14 @@
       ]
     },
     "params":{
+      "master_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout"
+      }
     },
     "body":{
       "description":"The database configuration definition",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_ip_location_database.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_ip_location_database.json
@@ -27,6 +27,14 @@
       ]
     },
     "params":{
+      "master_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout"
+      }
     },
     "body":{
       "description":"The database configuration definition",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Add missing timeouts to rest-api-spec ingest APIs (#118844)](https://github.com/elastic/elasticsearch/pull/118844)

I forgot to port this commit to branch 8.x at the time, which means this commit is in 8.16 and 8.17 but not yet in 8.18 and 8.19.


<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)