### PR TITLE
[8.18] Add missing timeouts to rest-api-spec SLM APIs (#118958)

### DIFF
--- a/docs/changelog/118958.yaml
+++ b/docs/changelog/118958.yaml
@@ -1,0 +1,5 @@
+pr: 118958
+summary: Add missing timeouts to rest-api-spec SLM APIs
+area: ILM+SLM
+type: bug
+issues: []


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Add missing timeouts to rest-api-spec SLM APIs (#118958)](https://github.com/elastic/elasticsearch/pull/118958)

I forgot to port this commit to branch 8.x at the time, which means this commit is in 8.16 and 8.17 but not yet in 8.18 and 8.19.


<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)