### PR TITLE
[WIP] increase mapping field meta char limit

### DIFF
--- a/docs/reference/elasticsearch/mapping-reference/mapping-field-meta.md
+++ b/docs/reference/elasticsearch/mapping-reference/mapping-field-meta.md
@@ -24,7 +24,7 @@ PUT my-index-000001
 ```
 
 ::::{note}
-Field metadata enforces at most 5 entries, that keys have a length that is less than or equal to 20, and that values are strings whose length is less than or equal to 50.
+Field metadata enforces at most 5 entries, that keys have a length that is less than or equal to 20, and that values are strings whose length is less than or equal to 500.
 ::::
 
 

--- a/docs/reference/elasticsearch/mapping-reference/mapping-field-meta.md
+++ b/docs/reference/elasticsearch/mapping-reference/mapping-field-meta.md
@@ -25,6 +25,7 @@ PUT my-index-000001
 
 ::::{note}
 Field metadata enforces at most 5 entries, that keys have a length that is less than or equal to 20, and that values are strings whose length is less than or equal to 500.
+The value limit is configurable, with the index setting: `index.mapping.meta.length_limit`.
 ::::
 
 

--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -173,7 +173,6 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 MapperService.INDEX_MAPPING_DIMENSION_FIELDS_LIMIT_SETTING,
                 MapperService.INDEX_MAPPING_FIELD_NAME_LENGTH_LIMIT_SETTING,
                 MapperService.INDEX_MAPPER_DYNAMIC_SETTING,
-                MapperService.INDEX_MAPPING_META_LENGTH_LIMIT_SETTING,
                 BitsetFilterCache.INDEX_LOAD_RANDOM_ACCESS_FILTERS_EAGERLY_SETTING,
                 IndexModule.INDEX_STORE_TYPE_SETTING,
                 IndexModule.INDEX_STORE_PRE_LOAD_SETTING,
@@ -205,6 +204,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 IndexSettings.INDEX_MAPPER_SOURCE_MODE_SETTING,
                 IndexSettings.RECOVERY_USE_SYNTHETIC_SOURCE_SETTING,
                 InferenceMetadataFieldsMapper.USE_LEGACY_SEMANTIC_TEXT_FORMAT,
+                IndexSettings.INDEX_MAPPING_META_LENGTH_LIMIT_SETTING,
 
                 // validate that built-in similarities don't get redefined
                 Setting.groupSetting("index.similarity.", (s) -> {

--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -204,6 +204,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 IndexSettings.INDEX_MAPPER_SOURCE_MODE_SETTING,
                 IndexSettings.RECOVERY_USE_SYNTHETIC_SOURCE_SETTING,
                 InferenceMetadataFieldsMapper.USE_LEGACY_SEMANTIC_TEXT_FORMAT,
+                IndexSettings.INDEX_MAPPING_META_LENGTH_LIMIT_SETTING,
 
                 // validate that built-in similarities don't get redefined
                 Setting.groupSetting("index.similarity.", (s) -> {

--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -205,7 +205,6 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 IndexSettings.INDEX_MAPPER_SOURCE_MODE_SETTING,
                 IndexSettings.RECOVERY_USE_SYNTHETIC_SOURCE_SETTING,
                 InferenceMetadataFieldsMapper.USE_LEGACY_SEMANTIC_TEXT_FORMAT,
-                // IndexSettings.INDEX_MAPPING_META_LENGTH_LIMIT_SETTING,
 
                 // validate that built-in similarities don't get redefined
                 Setting.groupSetting("index.similarity.", (s) -> {

--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -173,6 +173,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 MapperService.INDEX_MAPPING_DIMENSION_FIELDS_LIMIT_SETTING,
                 MapperService.INDEX_MAPPING_FIELD_NAME_LENGTH_LIMIT_SETTING,
                 MapperService.INDEX_MAPPER_DYNAMIC_SETTING,
+                MapperService.INDEX_MAPPING_META_LENGTH_LIMIT_SETTING,
                 BitsetFilterCache.INDEX_LOAD_RANDOM_ACCESS_FILTERS_EAGERLY_SETTING,
                 IndexModule.INDEX_STORE_TYPE_SETTING,
                 IndexModule.INDEX_STORE_PRE_LOAD_SETTING,
@@ -204,7 +205,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 IndexSettings.INDEX_MAPPER_SOURCE_MODE_SETTING,
                 IndexSettings.RECOVERY_USE_SYNTHETIC_SOURCE_SETTING,
                 InferenceMetadataFieldsMapper.USE_LEGACY_SEMANTIC_TEXT_FORMAT,
-                IndexSettings.INDEX_MAPPING_META_LENGTH_LIMIT_SETTING,
+                // IndexSettings.INDEX_MAPPING_META_LENGTH_LIMIT_SETTING,
 
                 // validate that built-in similarities don't get redefined
                 Setting.groupSetting("index.similarity.", (s) -> {

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -858,8 +858,8 @@ public final class IndexSettings {
 
     public static final Setting<Integer> INDEX_MAPPING_META_LENGTH_LIMIT_SETTING = Setting.intSetting(
         "index.mapping.meta.length_limit",
-        500, // default value
-        20,  // minimum value
+        500,
+        0,
         Property.IndexScope,
         Property.Final
     );

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -856,14 +856,6 @@ public final class IndexSettings {
         Property.ServerlessPublic
     );
 
-    public static final Setting<Integer> INDEX_MAPPING_META_LENGTH_LIMIT_SETTING = Setting.intSetting(
-        "index.mapping.meta.length_limit",
-        500,
-        0,
-        Property.IndexScope,
-        Property.Final
-    );
-
     private final Index index;
     private final IndexVersion version;
     private final Logger logger;

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -856,6 +856,14 @@ public final class IndexSettings {
         Property.ServerlessPublic
     );
 
+    public static final Setting<Integer> INDEX_MAPPING_META_LENGTH_LIMIT_SETTING = Setting.intSetting(
+        "index.mapping.meta.length_limit",
+        500, // default value
+        20,  // minimum value
+        Property.IndexScope,
+        Property.Final
+    );
+
     private final Index index;
     private final IndexVersion version;
     private final Logger logger;

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -856,6 +856,14 @@ public final class IndexSettings {
         Property.ServerlessPublic
     );
 
+    public static final Setting<Integer> INDEX_MAPPING_META_LENGTH_LIMIT_SETTING = Setting.intSetting(
+        "index.mapping.meta.length_limit",
+        500,
+        0,
+        Property.Dynamic,
+        Property.IndexScope
+    );
+
     private final Index index;
     private final IndexVersion version;
     private final Logger logger;

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -1298,7 +1298,7 @@ public abstract class FieldMapper extends Mapper {
                 "meta",
                 true,
                 Map::of,
-                (n, c, o) -> TypeParsers.parseMeta(n, o),
+                (n, c, o) -> TypeParsers.parseMeta(n, o, c),
                 m -> m.fieldType().meta(),
                 XContentBuilder::stringStringMap,
                 Objects::toString

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -175,6 +175,13 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         Property.IndexScope,
         Property.IndexSettingDeprecatedInV7AndRemovedInV8
     );
+    public static final Setting<Integer> INDEX_MAPPING_META_LENGTH_LIMIT_SETTING = Setting.intSetting(
+        "index.mapping.meta.length_limit",
+        500,
+        0,
+        Property.IndexScope,
+        Property.Final
+    );
 
     private final IndexAnalyzers indexAnalyzers;
     private final MappingParser mappingParser;

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -175,13 +175,6 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         Property.IndexScope,
         Property.IndexSettingDeprecatedInV7AndRemovedInV8
     );
-    public static final Setting<Integer> INDEX_MAPPING_META_LENGTH_LIMIT_SETTING = Setting.intSetting(
-        "index.mapping.meta.length_limit",
-        500,
-        0,
-        Property.Dynamic,
-        Property.IndexScope
-    );
 
     private final IndexAnalyzers indexAnalyzers;
     private final MappingParser mappingParser;

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -179,8 +179,8 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         "index.mapping.meta.length_limit",
         500,
         0,
-        Property.IndexScope,
-        Property.Final
+        Property.Dynamic,
+        Property.IndexScope
     );
 
     private final IndexAnalyzers indexAnalyzers;

--- a/server/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
@@ -29,6 +29,9 @@ import static org.elasticsearch.index.IndexSettings.INDEX_MAPPING_META_LENGTH_LI
 public class TypeParsers {
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(TypeParsers.class);
 
+    /**
+     * Parse the {@code meta} key of the mapping.
+     */
     public static Map<String, String> parseMeta(String name, Object metaObject, MappingParserContext parserContext) {
         if (metaObject instanceof Map == false) {
             throw new MapperParsingException(

--- a/server/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
@@ -54,9 +54,9 @@ public class TypeParsers {
         }
         for (Object value : meta.values()) {
             if (value instanceof String sValue) {
-                if (sValue.codePointCount(0, sValue.length()) > 50) {
+                if (sValue.codePointCount(0, sValue.length()) > 500) {
                     throw new MapperParsingException(
-                        "[meta] values can't be longer than 50 chars, but got [" + value + "] for field [" + name + "]"
+                        "[meta] values can't be longer than 500 chars, but got [" + value + "] for field [" + name + "]"
                     );
                 }
             } else if (value == null) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
@@ -24,7 +24,7 @@ import java.util.function.Consumer;
 
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.isArray;
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeStringValue;
-import static org.elasticsearch.index.IndexSettings.INDEX_MAPPING_META_LENGTH_LIMIT_SETTING;
+import static org.elasticsearch.index.mapper.MapperService.INDEX_MAPPING_META_LENGTH_LIMIT_SETTING;
 
 public class TypeParsers {
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(TypeParsers.class);

--- a/server/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
@@ -24,7 +24,7 @@ import java.util.function.Consumer;
 
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.isArray;
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeStringValue;
-import static org.elasticsearch.index.mapper.MapperService.INDEX_MAPPING_META_LENGTH_LIMIT_SETTING;
+import static org.elasticsearch.index.IndexSettings.INDEX_MAPPING_META_LENGTH_LIMIT_SETTING;
 
 public class TypeParsers {
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(TypeParsers.class);

--- a/server/src/test/java/org/elasticsearch/index/mapper/TypeParsersTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TypeParsersTests.java
@@ -38,6 +38,7 @@ import java.util.stream.IntStream;
 import static org.elasticsearch.index.analysis.AnalysisRegistry.DEFAULT_ANALYZER_NAME;
 import static org.elasticsearch.index.analysis.AnalysisRegistry.DEFAULT_SEARCH_ANALYZER_NAME;
 import static org.elasticsearch.index.analysis.AnalysisRegistry.DEFAULT_SEARCH_QUOTED_ANALYZER_NAME;
+import static org.elasticsearch.index.mapper.MapperService.INDEX_MAPPING_META_LENGTH_LIMIT_SETTING;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -199,7 +200,7 @@ public class TypeParsersTests extends ESTestCase {
                 .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
                 .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
                 .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-                .put(IndexSettings.INDEX_MAPPING_META_LENGTH_LIMIT_SETTING.getKey(), 300)
+                .put(INDEX_MAPPING_META_LENGTH_LIMIT_SETTING.getKey(), 300)
                 .build();
             MappingParserContext otherParserContext = createParserContext(otherSettings);
             String longString = IntStream.range(0, 301).mapToObj(Integer::toString).collect(Collectors.joining());

--- a/server/src/test/java/org/elasticsearch/index/mapper/TypeParsersTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TypeParsersTests.java
@@ -35,10 +35,10 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.elasticsearch.index.IndexSettings.INDEX_MAPPING_META_LENGTH_LIMIT_SETTING;
 import static org.elasticsearch.index.analysis.AnalysisRegistry.DEFAULT_ANALYZER_NAME;
 import static org.elasticsearch.index.analysis.AnalysisRegistry.DEFAULT_SEARCH_ANALYZER_NAME;
 import static org.elasticsearch.index.analysis.AnalysisRegistry.DEFAULT_SEARCH_QUOTED_ANALYZER_NAME;
-import static org.elasticsearch.index.mapper.MapperService.INDEX_MAPPING_META_LENGTH_LIMIT_SETTING;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/server/src/test/java/org/elasticsearch/index/mapper/TypeParsersTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TypeParsersTests.java
@@ -161,10 +161,10 @@ public class TypeParsersTests extends ESTestCase {
         }
 
         {
-            String longString = IntStream.range(0, 51).mapToObj(Integer::toString).collect(Collectors.joining());
+            String longString = IntStream.range(0, 501).mapToObj(Integer::toString).collect(Collectors.joining());
             Map<String, Object> mapping = Map.of("foo", longString);
             MapperParsingException e = expectThrows(MapperParsingException.class, () -> TypeParsers.parseMeta("foo", mapping));
-            assertThat(e.getMessage(), Matchers.startsWith("[meta] values can't be longer than 50 chars"));
+            assertThat(e.getMessage(), Matchers.startsWith("[meta] values can't be longer than 500 chars"));
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/TypeParsersTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TypeParsersTests.java
@@ -133,10 +133,7 @@ public class TypeParsersTests extends ESTestCase {
         MappingParserContext parserContext = createParserContext(buildSettings());
 
         {
-            MapperParsingException e = expectThrows(
-                MapperParsingException.class,
-                () -> TypeParsers.parseMeta("foo", 3, parserContext)
-            );
+            MapperParsingException e = expectThrows(MapperParsingException.class, () -> TypeParsers.parseMeta("foo", 3, parserContext));
             assertEquals("[meta] must be an object, got Integer[3] for field [foo]", e.getMessage());
         }
 
@@ -178,10 +175,7 @@ public class TypeParsersTests extends ESTestCase {
         {
             Map<String, String> meta = new HashMap<>();
             meta.put("foo", null);
-            MapperParsingException e = expectThrows(
-                MapperParsingException.class,
-                () -> TypeParsers.parseMeta("foo", meta, parserContext)
-            );
+            MapperParsingException e = expectThrows(MapperParsingException.class, () -> TypeParsers.parseMeta("foo", meta, parserContext));
             assertEquals("[meta] values can't be null (field [foo])", e.getMessage());
         }
 

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportResumeFollowAction.java
@@ -496,6 +496,7 @@ public class TransportResumeFollowAction extends AcknowledgedTransportMasterNode
         IndexSettings.INDEX_FLUSH_AFTER_MERGE_THRESHOLD_SIZE_SETTING,
         IndexSettings.INDEX_GC_DELETES_SETTING,
         IndexSettings.MAX_REFRESH_LISTENERS_PER_SHARD,
+        IndexSettings.INDEX_MAPPING_META_LENGTH_LIMIT_SETTING,
         IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING,
         BitsetFilterCache.INDEX_LOAD_RANDOM_ACCESS_FILTERS_EAGERLY_SETTING,
         SearchSlowLog.INDEX_SEARCH_SLOWLOG_THRESHOLD_FETCH_DEBUG_SETTING,


### PR DESCRIPTION
Note: I never put this through review, and am unsure if increasing the default here would cause any significant or nuanced issues.

I did this work with the intent to evaluate how much increased field-level meta (for descriptions) would help an LLM in picking which indices should be searched, given a natural language prompt. Unfortunately, it became clear quite quickly that this approach wouldn't scale. Even just sending 20 index mappings with _no_ metadata was too much for the EIS LLM to process in a single message context. 

Instead, I'm taking an approach outlined in https://github.com/elastic/kibana/pull/232437, to attempt to improve our index selection via top-level descriptions and/or a flat listing of field names. 

We may revisit this topic, but it's probably important first to explore making index metadata searchable, before worrying about expanding how much index metadata we can even set.

### to use this PR
1. `./gradlew localDistro`
2. set the elasticsearch.yml with:
    ```
    xpack:
      inference:
        elastic:
          url: "http://localhost:8443"
      license:
        self_generated:
          type: trial
      security:
        enabled: true
    ```
3. set elasticsearch passwords with:
    ```
    bin/elasticsearch-setup-passwords interactive <<EOF
    Y
    changeme
    changeme
    changeme
    changeme
    changeme
    changeme
    changeme
    changeme
    changeme
    changeme
    changeme
    changeme
    EOF
    ```
4. set the index settings on an index template:
    ```
    curl -X PUT -u elastic:changeme \
      -H "Content-Type: application/json" \
      "http://localhost:9200/_index_template/default-meta-limit" \
      -d '{
        "index_patterns": ["<your indices here>"],
        "priority": 5000,
        "template": {
          "settings": {
            "index.mapping.meta.length_limit": 800
          }
        }
      }'
    ```
5. Run evaluations/experiments