### PR TITLE
Fix verifier test for 9.0

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -244,9 +244,6 @@ tests:
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test070BindMountCustomPathConfAndJvmOptions
   issue: https://github.com/elastic/elasticsearch/issues/131366
-- class: org.elasticsearch.xpack.esql.analysis.VerifierTests
-  method: testRemoteEnrichAfterLookupJoin
-  issue: https://github.com/elastic/elasticsearch/issues/131631
 
 # Examples:
 #

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTestUtils.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTestUtils.java
@@ -143,7 +143,12 @@ public final class AnalyzerTestUtils {
     }
 
     public static Map<String, IndexResolution> defaultLookupResolution() {
-        return Map.of("languages_lookup", loadMapping("mapping-languages.json", "languages_lookup", IndexMode.LOOKUP));
+        return Map.of(
+            "languages_lookup",
+            loadMapping("mapping-languages.json", "languages_lookup", IndexMode.LOOKUP),
+            "test_lookup",
+            loadMapping("mapping-basic.json", "test_lookup", IndexMode.LOOKUP)
+        );
     }
 
     public static EnrichResolution defaultEnrichResolution() {


### PR DESCRIPTION
Lookup table `test_lookup` was used by test but not defined. 

Fixes https://github.com/elastic/elasticsearch/issues/131631