### PR TITLE
Disable newly added Enrich tests for Old Elastic Versions

### DIFF
--- a/docs/changelog/131640.yaml
+++ b/docs/changelog/131640.yaml
@@ -1,0 +1,5 @@
+pr: 131640
+summary: Disable newly added Enrich tests for Old Elastic Versions
+area: ES|QL
+type: bug
+issues: []

--- a/docs/changelog/131640.yaml
+++ b/docs/changelog/131640.yaml
@@ -2,4 +2,13 @@ pr: 131640
 summary: Disable newly added Enrich tests for Old Elastic Versions
 area: ES|QL
 type: bug
-issues: []
+issues:
+ - 131590
+ - 131574
+ - 131591
+ - 131575
+ - 131578
+ - 131624
+ - 131576
+ - 131577
+ - 131580

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/enrich.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/enrich.csv-spec
@@ -664,7 +664,7 @@ Fyodor Dostoevsky     |1211           |null             |null          |null    
 ;
 
 
-statsAfterRemoteEnrich
+statsAfterRemoteEnrich#[skip:-8.17.99]
 required_capability: enrich_load
 
 FROM sample_data
@@ -680,7 +680,7 @@ messages:long | language_name:keyword
 ;
 
 
-enrichAfterRemoteEnrich
+enrichAfterRemoteEnrich#[skip:-8.17.99]
 required_capability: enrich_load
 
 FROM sample_data
@@ -697,7 +697,7 @@ Connected to 10.1.0.1 | 1                     | English                     | En
 ;
 
 
-coordinatorEnrichAfterRemoteEnrich
+coordinatorEnrichAfterRemoteEnrich#[skip:-8.17.99]
 required_capability: enrich_load
 
 FROM sample_data
@@ -714,7 +714,7 @@ Connected to 10.1.0.1 | 1                     | English                     | En
 ;
 
 
-doubleRemoteEnrich
+doubleRemoteEnrich#[skip:-8.17.99]
 required_capability: enrich_load
 
 FROM sample_data
@@ -731,7 +731,7 @@ Connected to 10.1.0.1 | 1                     | English                     | En
 ;
 
 
-enrichAfterCoordinatorEnrich
+enrichAfterCoordinatorEnrich#[skip:-8.17.99]
 required_capability: enrich_load
 
 FROM sample_data
@@ -748,7 +748,7 @@ Connected to 10.1.0.1 | 1                     | English                     | En
 ;
 
 
-doubleCoordinatorEnrich
+doubleCoordinatorEnrich#[skip:-8.17.99]
 required_capability: enrich_load
 
 FROM sample_data


### PR DESCRIPTION
Builds older than 8.18 cannot run plan validation with remote enrich due to missing https://github.com/elastic/elasticsearch/pull/118302 and especially https://github.com/elastic/elasticsearch/pull/118302/commits/eb96a870c92005603417ee009f2b4644ba42556d
https://github.com/elastic/elasticsearch/pull/131535 added some test cases and they started failing. 
In this PR we disable those newly added cases for old versions of elastic. 

Closes https://github.com/elastic/elasticsearch/issues/131624
Closes https://github.com/elastic/elasticsearch/issues/131591
Closes https://github.com/elastic/elasticsearch/issues/131590
Closes https://github.com/elastic/elasticsearch/issues/131580
Closes https://github.com/elastic/elasticsearch/issues/131578
Closes https://github.com/elastic/elasticsearch/issues/131578
Closes https://github.com/elastic/elasticsearch/issues/131577
Closes https://github.com/elastic/elasticsearch/issues/131576
Closes https://github.com/elastic/elasticsearch/issues/131575
Closes https://github.com/elastic/elasticsearch/issues/131574