### PR TITLE
ESQL: Fewer serverless docs in tests

### DIFF
--- a/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
+++ b/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
@@ -884,8 +884,19 @@ public class HeapAttackIT extends ESRestTestCase {
     }
 
     private void initGiantTextField(int docs) throws IOException {
-        logger.info("loading many documents with one big text field");
-        int docsPerBulk = 3;
+        int docsPerBulk = 10;
+        for (Map<?, ?> nodeInfo : getNodesInfo(adminClient()).values()) {
+            for (Object module : (List<?>) nodeInfo.get("modules")) {
+                Map<?, ?> moduleInfo = (Map<?, ?>) module;
+                final String moduleName = moduleInfo.get("name").toString();
+                if (moduleName.startsWith("serverless-")) {
+                    docsPerBulk = 3;
+                }
+            }
+        }
+
+        logger.info("loading many documents with one big text field - docs per bulk {}", docsPerBulk);
+
         int fieldSize = Math.toIntExact(ByteSizeValue.ofMb(5).getBytes());
 
         Request request = new Request("PUT", "/bigtext");
@@ -912,6 +923,7 @@ public class HeapAttackIT extends ESRestTestCase {
             }
         }
         initIndex("bigtext", bulk.toString());
+        logger.info("loaded");
     }
 
     private void initMvLongsIndex(int docs, int fields, int fieldValues) throws IOException {


### PR DESCRIPTION
Drops the number of docs per bulk in test using 5mb text fields for serverless. And raises the number in stateful. Not sure what's up, sending it to the serverless friends to dig more. But this should make it stable in the mean time.
