### PR TITLE
CompressorFactory.compressor

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
@@ -130,7 +130,7 @@ public class PublicationTransportHandler {
         ActionListener<PublishWithJoinResponse> publishResponseListener
     ) throws IOException {
         assert ThreadPool.assertCurrentThreadPool(GENERIC);
-        final Compressor compressor = CompressorFactory.compressor(request.bytes());
+        final Compressor compressor = CompressorFactory.compressorForUnknownXContentType(request.bytes());
         StreamInput in = request.bytes().streamInput();
         try {
             if (compressor != null) {

--- a/server/src/main/java/org/elasticsearch/common/compress/CompressedXContent.java
+++ b/server/src/main/java/org/elasticsearch/common/compress/CompressedXContent.java
@@ -135,7 +135,7 @@ public final class CompressedXContent implements Writeable {
      * that may already be compressed.
      */
     public CompressedXContent(BytesReference data) throws IOException {
-        Compressor compressor = CompressorFactory.compressor(data);
+        Compressor compressor = CompressorFactory.compressorForUnknownXContentType(data);
         if (compressor != null) {
             // already compressed...
             this.bytes = BytesReference.toBytes(data);
@@ -148,7 +148,7 @@ public final class CompressedXContent implements Writeable {
     }
 
     private void assertConsistent() {
-        assert CompressorFactory.compressor(new BytesArray(bytes)) != null;
+        assert CompressorFactory.compressorForUnknownXContentType(new BytesArray(bytes)) != null;
         assert this.sha256.equals(sha256(uncompressed()));
         assert this.sha256.equals(sha256FromCompressed(bytes));
     }

--- a/server/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
@@ -67,7 +67,7 @@ public class XContentHelper {
      */
     @Deprecated
     public static XContentParser createParser(XContentParserConfiguration config, BytesReference bytes) throws IOException {
-        Compressor compressor = CompressorFactory.compressor(bytes);
+        Compressor compressor = CompressorFactory.compressorForUnknownXContentType(bytes);
         if (compressor != null) {
             InputStream compressedInput = compressor.threadLocalInputStream(bytes.streamInput());
             if (compressedInput.markSupported() == false) {
@@ -120,7 +120,7 @@ public class XContentHelper {
     public static XContentParser createParser(XContentParserConfiguration config, BytesReference bytes, XContentType xContentType)
         throws IOException {
         Objects.requireNonNull(xContentType);
-        Compressor compressor = CompressorFactory.compressor(bytes);
+        Compressor compressor = CompressorFactory.compressorForUnknownXContentType(bytes);
         if (compressor != null) {
             return XContentFactory.xContent(xContentType).createParser(config, compressor.threadLocalInputStream(bytes.streamInput()));
         } else {
@@ -568,7 +568,7 @@ public class XContentHelper {
     @Deprecated
     public static void writeRawField(String field, BytesReference source, XContentBuilder builder, ToXContent.Params params)
         throws IOException {
-        Compressor compressor = CompressorFactory.compressor(source);
+        Compressor compressor = CompressorFactory.compressorForUnknownXContentType(source);
         if (compressor != null) {
             try (InputStream compressedStreamInput = compressor.threadLocalInputStream(source.streamInput())) {
                 builder.rawField(field, compressedStreamInput);
@@ -592,7 +592,7 @@ public class XContentHelper {
         ToXContent.Params params
     ) throws IOException {
         Objects.requireNonNull(xContentType);
-        Compressor compressor = CompressorFactory.compressor(source);
+        Compressor compressor = CompressorFactory.compressorForUnknownXContentType(source);
         if (compressor != null) {
             try (InputStream compressedStreamInput = compressor.threadLocalInputStream(source.streamInput())) {
                 builder.rawField(field, compressedStreamInput, xContentType);
@@ -677,7 +677,7 @@ public class XContentHelper {
      */
     @Deprecated
     public static XContentType xContentTypeMayCompressed(BytesReference bytes) {
-        Compressor compressor = CompressorFactory.compressor(bytes);
+        Compressor compressor = CompressorFactory.compressorForUnknownXContentType(bytes);
         if (compressor != null) {
             try {
                 InputStream compressedStreamInput = compressor.threadLocalInputStream(bytes.streamInput());

--- a/server/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
@@ -120,7 +120,7 @@ public class XContentHelper {
     public static XContentParser createParser(XContentParserConfiguration config, BytesReference bytes, XContentType xContentType)
         throws IOException {
         Objects.requireNonNull(xContentType);
-        Compressor compressor = CompressorFactory.compressorForUnknownXContentType(bytes);
+        Compressor compressor = CompressorFactory.compressor(bytes);
         if (compressor != null) {
             return XContentFactory.xContent(xContentType).createParser(config, compressor.threadLocalInputStream(bytes.streamInput()));
         } else {

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
@@ -145,7 +145,7 @@ public class PublicationTransportHandlerTests extends ESTestCase {
             StreamInput in = null;
             try {
                 in = request.bytes().streamInput();
-                final Compressor compressor = CompressorFactory.compressor(request.bytes());
+                final Compressor compressor = CompressorFactory.compressorForUnknownXContentType(request.bytes());
                 if (compressor != null) {
                     in = compressor.threadLocalStreamInput(in);
                 }

--- a/server/src/test/java/org/elasticsearch/common/xcontent/support/XContentHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/support/XContentHelperTests.java
@@ -12,12 +12,14 @@ package org.elasticsearch.common.xcontent.support;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.compress.NotXContentException;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParseException;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
@@ -420,5 +422,20 @@ public class XContentHelperTests extends ESTestCase {
         }, new BytesArray(json), XContentType.JSON, null).v2();
 
         assertThat(names, equalTo(Set.of("a", "c")));
+    }
+
+    public void testGetParserWithInvalidInput() throws IOException {
+        assertThrows(
+            "Should detect bad JSON",
+            NotXContentException.class,
+            () -> XContentHelper.createParser(XContentParserConfiguration.EMPTY, new BytesArray("not actually XContent"))
+        );
+        XContentParser parser = XContentHelper.createParser(
+            XContentParserConfiguration.EMPTY,
+            new BytesArray("not actually XContent"),
+            XContentType.JSON
+        );
+        assertNotNull("Should not detect bad JSON", parser); // This is more like assertNotThrows
+        assertThrows("Should detect bad JSON at parse time", XContentParseException.class, parser::numberValue);
     }
 }


### PR DESCRIPTION
`CompressorFactory.compressor` was over-eager in detecting XContent type even when the type was already known.

1. Refactor out a non-detecting version of the `CompressorFactory.compress` method
2. Add a failing unit test for #131605 
3. Fix the bug

Fixes #131605.