### PR TITLE
[9.1] Add inference.put_custom rest-api-spec (#131660)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_custom.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_custom.json
@@ -1,0 +1,35 @@
+{
+  "inference.put_custom": {
+    "documentation": {
+      "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-inference-put-custom",
+      "description": "Configure a custom inference endpoint"
+    },
+    "stability": "stable",
+    "visibility": "public",
+    "headers": {
+      "accept": ["application/json"],
+      "content_type": ["application/json"]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_inference/{task_type}/{custom_inference_id}",
+          "methods": ["PUT"],
+          "parts": {
+            "task_type": {
+              "type": "string",
+              "description": "The task type"
+            },
+            "custom_inference_id": {
+              "type": "string",
+              "description": "The inference Id"
+            }
+          }
+        }
+      ]
+    },
+    "body": {
+      "description": "The inference endpoint's task and service settings"
+    }
+  }
+}


### PR DESCRIPTION
Backports the following commits to 9.1:
 - Add inference.put_custom rest-api-spec (#131660)