### PR TITLE
[9.0] add missing format param (#130317)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/esql.async_query_get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/esql.async_query_get.json
@@ -26,6 +26,10 @@
       ]
     },
     "params":{
+      "format":{
+        "type":"string",
+        "description":"a short version of the Accept header, e.g. json, yaml"
+      },
       "wait_for_completion_timeout":{
         "type":"time",
         "description":"Specify the time that the request should block waiting for the final response"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [add missing format param (#130317)](https://github.com/elastic/elasticsearch/pull/130317)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)