### PR TITLE
Throw better exception if verifying empty repo

### DIFF
--- a/docs/changelog/131677.yaml
+++ b/docs/changelog/131677.yaml
@@ -1,0 +1,5 @@
+pr: 131677
+summary: Throw better exception if verifying empty repo
+area: Snapshot/Restore
+type: bug
+issues: []

--- a/x-pack/plugin/snapshot-repo-test-kit/src/test/java/org/elasticsearch/repositories/blobstore/testkit/integrity/TransportRepositoryVerifyIntegrityActionTests.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/test/java/org/elasticsearch/repositories/blobstore/testkit/integrity/TransportRepositoryVerifyIntegrityActionTests.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.repositories.blobstore.testkit.integrity;
+
+import org.elasticsearch.repositories.RepositoryData;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class TransportRepositoryVerifyIntegrityActionTests extends ESTestCase {
+    public void testEnsureValidGenId() {
+        TransportRepositoryVerifyIntegrityAction.ensureValidGenId(0);
+        TransportRepositoryVerifyIntegrityAction.ensureValidGenId(randomNonNegativeLong());
+        assertThat(
+            expectThrows(
+                IllegalArgumentException.class,
+                () -> TransportRepositoryVerifyIntegrityAction.ensureValidGenId(RepositoryData.EMPTY_REPO_GEN)
+            ).getMessage(),
+            equalTo("repository is empty, cannot verify its integrity")
+        );
+        assertThat(expectThrows(IllegalStateException.class, () -> {
+            try {
+                TransportRepositoryVerifyIntegrityAction.ensureValidGenId(RepositoryData.CORRUPTED_REPO_GEN);
+            } catch (AssertionError e) {
+                // if assertions disabled, we throw the cause directly
+                throw e.getCause();
+            }
+        }).getMessage(), equalTo("repository is in an unexpected state [-3], cannot verify its integrity"));
+    }
+}


### PR DESCRIPTION
Today if you attempt to verify the integrity of a brand-new repository
(no `index-${N}` blob) then it will fail because the repository
generation is `-1` which cannot be sent over the wire. But it makes no
sense to verify the integrity of such a repository anyway, so with this
commit we fail such requests up-front with a more helpful error message.