### PR TITLE
[ML] SPLADE embedding support

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -353,6 +353,7 @@ public class TransportVersions {
     public static final TransportVersion ESQL_TOPN_TIMINGS = def(9_128_0_00);
     public static final TransportVersion NODE_WEIGHTS_ADDED_TO_NODE_BALANCE_STATS = def(9_129_0_00);
     public static final TransportVersion RERANK_SNIPPETS = def(9_130_0_00);
+    public static final TransportVersion ML_EXPANSION_TYPE = def(9_131_0_00);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextExpansionConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextExpansionConfig.java
@@ -92,7 +92,11 @@ public class TextExpansionConfig implements NlpConfig {
         vocabularyConfig = new VocabularyConfig(in);
         tokenization = in.readNamedWriteable(Tokenization.class);
         resultsField = in.readOptionalString();
-        expansionType = in.readOptionalString();
+        if (in.getTransportVersion().onOrAfter(TransportVersions.ML_EXPANSION_TYPE)) {
+            expansionType = in.readOptionalString();
+        } else {
+            expansionType = EXPANSION_TYPE_ELSER; // Default to ELSER
+        }
     }
 
     @Override
@@ -100,7 +104,9 @@ public class TextExpansionConfig implements NlpConfig {
         vocabularyConfig.writeTo(out);
         out.writeNamedWriteable(tokenization);
         out.writeOptionalString(resultsField);
-        out.writeOptionalString(expansionType);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.ML_EXPANSION_TYPE)) {
+            out.writeOptionalString(expansionType);
+        }
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextExpansionConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextExpansionConfig.java
@@ -166,7 +166,9 @@ public class TextExpansionConfig implements NlpConfig {
         return resultsField;
     }
 
-    public String getExpansionType() { return expansionType; }
+    public String getExpansionType() {
+        return expansionType;
+    }
 
     @Override
     public VocabularyConfig getVocabularyConfig() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextExpansionConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextExpansionConfig.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ml.MlConfigVersion;
@@ -28,6 +29,10 @@ import java.util.Optional;
 public class TextExpansionConfig implements NlpConfig {
 
     public static final String NAME = "text_expansion";
+
+    public static final ParseField EXPANSION_TYPE = new ParseField("expansion_type");
+    public static final String EXPANSION_TYPE_ELSER = "elser";
+    public static final String EXPANSION_TYPE_SPLADE = "splade";
 
     public static TextExpansionConfig fromXContentStrict(XContentParser parser) {
         return STRICT_PARSER.apply(parser, null);
@@ -44,7 +49,7 @@ public class TextExpansionConfig implements NlpConfig {
         ConstructingObjectParser<TextExpansionConfig, Void> parser = new ConstructingObjectParser<>(
             NAME,
             ignoreUnknownFields,
-            a -> new TextExpansionConfig((VocabularyConfig) a[0], (Tokenization) a[1], (String) a[2])
+            a -> new TextExpansionConfig((VocabularyConfig) a[0], (Tokenization) a[1], (String) a[2], (String) a[3])
         );
         parser.declareObject(ConstructingObjectParser.optionalConstructorArg(), (p, c) -> {
             if (ignoreUnknownFields == false) {
@@ -61,28 +66,33 @@ public class TextExpansionConfig implements NlpConfig {
             TOKENIZATION
         );
         parser.declareString(ConstructingObjectParser.optionalConstructorArg(), RESULTS_FIELD);
+        parser.declareString(ConstructingObjectParser.optionalConstructorArg(), EXPANSION_TYPE);
         return parser;
     }
 
     private final VocabularyConfig vocabularyConfig;
     private final Tokenization tokenization;
     private final String resultsField;
+    private final String expansionType;
 
     public TextExpansionConfig(
         @Nullable VocabularyConfig vocabularyConfig,
         @Nullable Tokenization tokenization,
-        @Nullable String resultsField
+        @Nullable String resultsField,
+        @Nullable String expansionType
     ) {
         this.vocabularyConfig = Optional.ofNullable(vocabularyConfig)
             .orElse(new VocabularyConfig(InferenceIndexConstants.nativeDefinitionStore()));
         this.tokenization = tokenization == null ? Tokenization.createDefault() : tokenization;
         this.resultsField = resultsField;
+        this.expansionType = expansionType == null ? EXPANSION_TYPE_ELSER : expansionType;
     }
 
     public TextExpansionConfig(StreamInput in) throws IOException {
         vocabularyConfig = new VocabularyConfig(in);
         tokenization = in.readNamedWriteable(Tokenization.class);
         resultsField = in.readOptionalString();
+        expansionType = in.readOptionalString();
     }
 
     @Override
@@ -90,6 +100,7 @@ public class TextExpansionConfig implements NlpConfig {
         vocabularyConfig.writeTo(out);
         out.writeNamedWriteable(tokenization);
         out.writeOptionalString(resultsField);
+        out.writeOptionalString(expansionType);
     }
 
     @Override
@@ -99,6 +110,9 @@ public class TextExpansionConfig implements NlpConfig {
         NamedXContentObjectHelper.writeNamedObject(builder, params, TOKENIZATION.getPreferredName(), tokenization);
         if (resultsField != null) {
             builder.field(RESULTS_FIELD.getPreferredName(), resultsField);
+        }
+        if (expansionType != null) {
+            builder.field(EXPANSION_TYPE.getPreferredName(), expansionType);
         }
         builder.endObject();
         return builder;
@@ -121,11 +135,12 @@ public class TextExpansionConfig implements NlpConfig {
             return new TextExpansionConfig(
                 vocabularyConfig,
                 configUpdate.tokenizationUpdate == null ? tokenization : configUpdate.tokenizationUpdate.apply(tokenization),
-                Optional.ofNullable(configUpdate.getResultsField()).orElse(resultsField)
+                Optional.ofNullable(configUpdate.getResultsField()).orElse(resultsField),
+                Optional.ofNullable(configUpdate.getExpansionType()).orElse(expansionType)
             );
         } else if (update instanceof TokenizationConfigUpdate tokenizationUpdate) {
             var updatedTokenization = getTokenization().updateWindowSettings(tokenizationUpdate.getSpanSettings());
-            return new TextExpansionConfig(vocabularyConfig, updatedTokenization, resultsField);
+            return new TextExpansionConfig(vocabularyConfig, updatedTokenization, resultsField, expansionType);
         } else {
             throw incompatibleUpdateException(update.getName());
         }
@@ -150,6 +165,8 @@ public class TextExpansionConfig implements NlpConfig {
     public String getResultsField() {
         return resultsField;
     }
+
+    public String getExpansionType() { return expansionType; }
 
     @Override
     public VocabularyConfig getVocabularyConfig() {
@@ -178,11 +195,12 @@ public class TextExpansionConfig implements NlpConfig {
         TextExpansionConfig that = (TextExpansionConfig) o;
         return Objects.equals(vocabularyConfig, that.vocabularyConfig)
             && Objects.equals(tokenization, that.tokenization)
-            && Objects.equals(resultsField, that.resultsField);
+            && Objects.equals(resultsField, that.resultsField)
+            && Objects.equals(expansionType, that.expansionType);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(vocabularyConfig, tokenization, resultsField);
+        return Objects.hash(vocabularyConfig, tokenization, resultsField, expansionType);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextExpansionConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextExpansionConfigUpdate.java
@@ -24,22 +24,24 @@ import java.util.Objects;
 
 import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.NlpConfig.RESULTS_FIELD;
 import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.NlpConfig.TOKENIZATION;
+import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextExpansionConfig.EXPANSION_TYPE;
 
 public class TextExpansionConfigUpdate extends NlpConfigUpdate {
 
     public static final String NAME = TextExpansionConfig.NAME;
 
-    public static final TextExpansionConfigUpdate EMPTY_UPDATE = new TextExpansionConfigUpdate(null, null);
+    public static final TextExpansionConfigUpdate EMPTY_UPDATE = new TextExpansionConfigUpdate(null, null, null);
 
     public static TextExpansionConfigUpdate fromMap(Map<String, Object> map) {
         Map<String, Object> options = new HashMap<>(map);
         String resultsField = (String) options.remove(RESULTS_FIELD.getPreferredName());
+        String expansionTypeField = (String) options.remove(EXPANSION_TYPE.getPreferredName());
         TokenizationUpdate tokenizationUpdate = NlpConfigUpdate.tokenizationFromMap(options);
 
         if (options.isEmpty() == false) {
             throw ExceptionsHelper.badRequestException("Unrecognized fields {}.", options.keySet());
         }
-        return new TextExpansionConfigUpdate(resultsField, tokenizationUpdate);
+        return new TextExpansionConfigUpdate(resultsField, expansionTypeField, tokenizationUpdate);
     }
 
     private static final ObjectParser<TextExpansionConfigUpdate.Builder, Void> STRICT_PARSER = createParser(false);
@@ -51,6 +53,7 @@ public class TextExpansionConfigUpdate extends NlpConfigUpdate {
             TextExpansionConfigUpdate.Builder::new
         );
         parser.declareString(TextExpansionConfigUpdate.Builder::setResultsField, RESULTS_FIELD);
+        parser.declareString(TextExpansionConfigUpdate.Builder::setResultsField, EXPANSION_TYPE);
         parser.declareNamedObject(
             TextExpansionConfigUpdate.Builder::setTokenizationUpdate,
             (p, c, n) -> p.namedObject(TokenizationUpdate.class, n, lenient),
@@ -64,27 +67,34 @@ public class TextExpansionConfigUpdate extends NlpConfigUpdate {
     }
 
     private final String resultsField;
+    private final String expansionType;
 
-    public TextExpansionConfigUpdate(String resultsField, TokenizationUpdate tokenizationUpdate) {
+    public TextExpansionConfigUpdate(String resultsField, String expansionType, TokenizationUpdate tokenizationUpdate) {
         super(tokenizationUpdate);
         this.resultsField = resultsField;
+        this.expansionType = expansionType;
     }
 
     public TextExpansionConfigUpdate(StreamInput in) throws IOException {
         super(in);
         this.resultsField = in.readOptionalString();
+        this.expansionType = in.readOptionalString();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeOptionalString(resultsField);
+        out.writeOptionalString(expansionType);
     }
 
     @Override
     public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
         if (resultsField != null) {
             builder.field(RESULTS_FIELD.getPreferredName(), resultsField);
+        }
+        if (expansionType != null) {
+            builder.field(EXPANSION_TYPE.getPreferredName(), expansionType);
         }
         return builder;
     }
@@ -108,6 +118,8 @@ public class TextExpansionConfigUpdate extends NlpConfigUpdate {
     public String getResultsField() {
         return resultsField;
     }
+
+    public String getExpansionType() { return expansionType; }
 
     @Override
     public InferenceConfigUpdate.Builder<? extends InferenceConfigUpdate.Builder<?, ?>, ? extends InferenceConfigUpdate> newBuilder() {
@@ -139,11 +151,17 @@ public class TextExpansionConfigUpdate extends NlpConfigUpdate {
 
     public static class Builder implements InferenceConfigUpdate.Builder<TextExpansionConfigUpdate.Builder, TextExpansionConfigUpdate> {
         private String resultsField;
+        private String expansionType;
         private TokenizationUpdate tokenizationUpdate;
 
         @Override
         public TextExpansionConfigUpdate.Builder setResultsField(String resultsField) {
             this.resultsField = resultsField;
+            return this;
+        }
+
+        public TextExpansionConfigUpdate.Builder setExpansionType(String expansionType) {
+            this.expansionType = expansionType;
             return this;
         }
 
@@ -154,7 +172,7 @@ public class TextExpansionConfigUpdate extends NlpConfigUpdate {
 
         @Override
         public TextExpansionConfigUpdate build() {
-            return new TextExpansionConfigUpdate(resultsField, tokenizationUpdate);
+            return new TextExpansionConfigUpdate(resultsField, expansionType, tokenizationUpdate);
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextExpansionConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextExpansionConfigUpdate.java
@@ -119,7 +119,9 @@ public class TextExpansionConfigUpdate extends NlpConfigUpdate {
         return resultsField;
     }
 
-    public String getExpansionType() { return expansionType; }
+    public String getExpansionType() {
+        return expansionType;
+    }
 
     @Override
     public InferenceConfigUpdate.Builder<? extends InferenceConfigUpdate.Builder<?, ?>, ? extends InferenceConfigUpdate> newBuilder() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextExpansionConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextExpansionConfigUpdate.java
@@ -53,7 +53,7 @@ public class TextExpansionConfigUpdate extends NlpConfigUpdate {
             TextExpansionConfigUpdate.Builder::new
         );
         parser.declareString(TextExpansionConfigUpdate.Builder::setResultsField, RESULTS_FIELD);
-        parser.declareString(TextExpansionConfigUpdate.Builder::setResultsField, EXPANSION_TYPE);
+        parser.declareString(TextExpansionConfigUpdate.Builder::setExpansionType, EXPANSION_TYPE);
         parser.declareNamedObject(
             TextExpansionConfigUpdate.Builder::setTokenizationUpdate,
             (p, c, n) -> p.namedObject(TokenizationUpdate.class, n, lenient),
@@ -125,7 +125,9 @@ public class TextExpansionConfigUpdate extends NlpConfigUpdate {
 
     @Override
     public InferenceConfigUpdate.Builder<? extends InferenceConfigUpdate.Builder<?, ?>, ? extends InferenceConfigUpdate> newBuilder() {
-        return new TextExpansionConfigUpdate.Builder().setResultsField(resultsField).setTokenizationUpdate(tokenizationUpdate);
+        return new TextExpansionConfigUpdate.Builder().setResultsField(resultsField)
+            .setExpansionType(expansionType)
+            .setTokenizationUpdate(tokenizationUpdate);
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextExpansionConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextExpansionConfigTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ml.inference.InferenceConfigItemTestCase;
@@ -35,11 +36,15 @@ public class TextExpansionConfigTests extends InferenceConfigItemTestCase<TextEx
     }
 
     public static TextExpansionConfig mutateForVersion(TextExpansionConfig instance, TransportVersion version) {
+        String expansionType = instance.getExpansionType();
+        if (version.before(TransportVersions.ML_EXPANSION_TYPE)) {
+            expansionType = null;
+        }
         return new TextExpansionConfig(
             instance.getVocabularyConfig(),
             InferenceConfigTestScaffolding.mutateTokenizationForVersion(instance.getTokenization(), version),
             instance.getResultsField(),
-            instance.getExpansionType()
+            expansionType
         );
     }
 
@@ -65,6 +70,6 @@ public class TextExpansionConfigTests extends InferenceConfigItemTestCase<TextEx
 
     @Override
     protected TextExpansionConfig mutateInstanceForVersion(TextExpansionConfig instance, TransportVersion version) {
-        return instance;
+        return mutateForVersion(instance, version);
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextExpansionConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextExpansionConfigTests.java
@@ -30,10 +30,7 @@ public class TextExpansionConfigTests extends InferenceConfigItemTestCase<TextEx
             randomBoolean() ? null : VocabularyConfigTests.createRandom(),
             randomBoolean() ? null : tokenization,
             randomBoolean() ? null : randomAlphaOfLength(5),
-            randomFrom(
-                TextExpansionConfig.EXPANSION_TYPE_ELSER,
-                TextExpansionConfig.EXPANSION_TYPE_SPLADE
-            )
+            randomFrom(TextExpansionConfig.EXPANSION_TYPE_ELSER, TextExpansionConfig.EXPANSION_TYPE_SPLADE)
         );
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextExpansionConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextExpansionConfigTests.java
@@ -29,7 +29,11 @@ public class TextExpansionConfigTests extends InferenceConfigItemTestCase<TextEx
         return new TextExpansionConfig(
             randomBoolean() ? null : VocabularyConfigTests.createRandom(),
             randomBoolean() ? null : tokenization,
-            randomBoolean() ? null : randomAlphaOfLength(5)
+            randomBoolean() ? null : randomAlphaOfLength(5),
+            randomFrom(
+                TextExpansionConfig.EXPANSION_TYPE_ELSER,
+                TextExpansionConfig.EXPANSION_TYPE_SPLADE
+            )
         );
     }
 
@@ -37,7 +41,8 @@ public class TextExpansionConfigTests extends InferenceConfigItemTestCase<TextEx
         return new TextExpansionConfig(
             instance.getVocabularyConfig(),
             InferenceConfigTestScaffolding.mutateTokenizationForVersion(instance.getTokenization(), version),
-            instance.getResultsField()
+            instance.getResultsField(),
+            instance.getExpansionType()
         );
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextExpansionConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextExpansionConfigUpdateTests.java
@@ -32,7 +32,7 @@ public class TextExpansionConfigUpdateTests extends AbstractNlpConfigUpdateTestC
 
     public static TextExpansionConfigUpdate mutateForVersion(TextExpansionConfigUpdate instance, TransportVersion version) {
         if (version.before(TransportVersions.V_8_1_0)) {
-            return new TextExpansionConfigUpdate(instance.getResultsField(), null);
+            return new TextExpansionConfigUpdate(instance.getResultsField(), instance.getExpansionType(), null);
         }
         return instance;
     }
@@ -64,7 +64,7 @@ public class TextExpansionConfigUpdateTests extends AbstractNlpConfigUpdateTestC
 
     @Override
     Tuple<Map<String, Object>, TextExpansionConfigUpdate> fromMapTestInstances(TokenizationUpdate expectedTokenization) {
-        TextExpansionConfigUpdate expected = new TextExpansionConfigUpdate("ml-results", expectedTokenization);
+        TextExpansionConfigUpdate expected = new TextExpansionConfigUpdate("ml-results", TextExpansionConfig.EXPANSION_TYPE_ELSER, expectedTokenization);
         Map<String, Object> config = new HashMap<>() {
             {
                 put(NlpConfig.RESULTS_FIELD.getPreferredName(), "ml-results");

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextExpansionConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextExpansionConfigUpdateTests.java
@@ -64,7 +64,11 @@ public class TextExpansionConfigUpdateTests extends AbstractNlpConfigUpdateTestC
 
     @Override
     Tuple<Map<String, Object>, TextExpansionConfigUpdate> fromMapTestInstances(TokenizationUpdate expectedTokenization) {
-        TextExpansionConfigUpdate expected = new TextExpansionConfigUpdate("ml-results", TextExpansionConfig.EXPANSION_TYPE_ELSER, expectedTokenization);
+        TextExpansionConfigUpdate expected = new TextExpansionConfigUpdate(
+            "ml-results",
+            TextExpansionConfig.EXPANSION_TYPE_ELSER,
+            expectedTokenization
+        );
         Map<String, Object> config = new HashMap<>() {
             {
                 put(NlpConfig.RESULTS_FIELD.getPreferredName(), "ml-results");

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/NlpHelpers.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/NlpHelpers.java
@@ -107,6 +107,15 @@ public final class NlpHelpers {
         return result;
     }
 
+    /**
+     * Applies SPLADE max pooling to the input vector.
+     * @param value
+     * @return
+     */
+    static double spladeMaxPooling(double value) {
+        return Math.log(1 + Math.max(0, value));
+    }
+
     public static class ScoreAndIndex {
         final double score;
         final int index;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/NlpHelpers.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/NlpHelpers.java
@@ -108,12 +108,29 @@ public final class NlpHelpers {
     }
 
     /**
-     * Applies SPLADE max pooling to the input vector.
+     * Calculates the SPLADE value for a given input.
      * @param value
      * @return
      */
-    static double spladeMaxPooling(double value) {
+    static double calculateSpladeValue(double value) {
         return Math.log(1 + Math.max(0, value));
+    }
+
+    /**
+     * Applies SPLADE max pooling.
+     * @param embedding Embeddings from the model. Dimensions: [num_tokens][num_vocabulary]
+     * @return pooled[num_vocabulary]
+     */
+    static double[] spladeMaxPooling(double[][] embedding) {
+        int numTokens = embedding.length;
+        int numVocabulary = embedding[0].length;
+        double[] pooled = new double[embedding[0].length];
+        for (int tokenIndex = 0; tokenIndex < numTokens; tokenIndex++) {
+            for (int vocabIndex = 0; vocabIndex < embedding[tokenIndex].length; vocabIndex++) {
+                pooled[vocabIndex] = Math.max(pooled[vocabIndex], calculateSpladeValue(embedding[tokenIndex][vocabIndex]));
+            }
+        }
+        return pooled;
     }
 
     public static class ScoreAndIndex {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/NlpHelpers.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/NlpHelpers.java
@@ -108,29 +108,29 @@ public final class NlpHelpers {
     }
 
     /**
-     * Calculates the SPLADE value for a given input.
-     * @param value
-     * @return
+     * Saturation function for the SPLADE output.
+     * @param value Value to apply saturation to
+     * @return Saturated value
      */
-    static double calculateSpladeValue(double value) {
+    static double spladeSaturation(double value) {
         return Math.log(1 + Math.max(0, value));
     }
 
     /**
      * Applies SPLADE max pooling.
-     * @param embedding Embeddings from the model. Dimensions: [num_tokens][num_vocabulary]
-     * @return pooled[num_vocabulary]
+     * @param embedding Embeddings from the model. Shape needs to be: [num_tokens][num_vocabulary]
+     * @return Max pooled results for each vocabulary item.
      */
     static double[] spladeMaxPooling(double[][] embedding) {
         int numTokens = embedding.length;
         int numVocabulary = embedding[0].length;
-        double[] pooled = new double[embedding[0].length];
+        double[] results = new double[embedding[0].length];
         for (int tokenIndex = 0; tokenIndex < numTokens; tokenIndex++) {
             for (int vocabIndex = 0; vocabIndex < embedding[tokenIndex].length; vocabIndex++) {
-                pooled[vocabIndex] = Math.max(pooled[vocabIndex], calculateSpladeValue(embedding[tokenIndex][vocabIndex]));
+                results[vocabIndex] = Math.max(results[vocabIndex], spladeSaturation(embedding[tokenIndex][vocabIndex]));
             }
         }
-        return pooled;
+        return results;
     }
 
     public static class ScoreAndIndex {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/TextExpansionProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/TextExpansionProcessor.java
@@ -82,8 +82,7 @@ public class TextExpansionProcessor extends NlpTask.Processor {
             }
 
             // For SPLADE models, the second dimension of the inference result is for each token in the input.
-            var weightedTokens = new ArrayList<WeightedToken>();
-            spladeVectorToTokenWeights(weightedTokens, pyTorchResult.getInferenceResult()[0], tokenization, replacementVocab);
+            var weightedTokens = spladeVectorToTokenWeights(pyTorchResult.getInferenceResult()[0], tokenization, replacementVocab);
             weightedTokens.sort((t1, t2) -> Float.compare(t2.weight(), t1.weight()));
             return new TextExpansionResults(
                 Optional.ofNullable(resultsField).orElse(DEFAULT_RESULTS_FIELD),
@@ -134,23 +133,23 @@ public class TextExpansionProcessor extends NlpTask.Processor {
      * Converts a SPLADE vector to a list of weighted tokens.
      * The SPLADE model uses max pooling, so we apply that to the scores.
      *
-     * @param weightedTokens The list to populate with weighted tokens. Updated in place.
      * @param embedding The SPLADE embedding ([token][vocab]).
      * @param tokenization The tokenization result containing the vocabulary.
      * @param replacementVocab A map of token IDs to their replacements, if any.
      */
-    static void spladeVectorToTokenWeights(
-        List<WeightedToken> weightedTokens,
+    static List<WeightedToken>  spladeVectorToTokenWeights(
         double[][] embedding,
         TokenizationResult tokenization,
         Map<Integer, String> replacementVocab
     ) {
-        double[] spladeResult = NlpHelpers.spladeMaxPooling(embedding);
-        for (int i = 0; i < spladeResult.length; i++) {
-            if (spladeResult[i] > 0.0) {
-                weightedTokens.add(new WeightedToken(tokenForId(i, tokenization, replacementVocab), (float) spladeResult[i]));
+        List<WeightedToken> weightedTokens = new ArrayList<>();
+        double[] spladeResults = NlpHelpers.spladeMaxPooling(embedding);
+        for (int i = 0; i < spladeResults.length; i++) {
+            if (spladeResults[i] > 0.0) {
+                weightedTokens.add(new WeightedToken(tokenForId(i, tokenization, replacementVocab), (float) spladeResults[i]));
             }
         }
+        return weightedTokens;
     }
 
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/TextExpansionProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/TextExpansionProcessor.java
@@ -12,6 +12,7 @@ import org.elasticsearch.inference.WeightedToken;
 import org.elasticsearch.xpack.core.ml.inference.results.MlChunkedTextExpansionResults;
 import org.elasticsearch.xpack.core.ml.inference.results.TextExpansionResults;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.NlpConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextExpansionConfig;
 import org.elasticsearch.xpack.ml.inference.nlp.tokenizers.NlpTokenizer;
 import org.elasticsearch.xpack.ml.inference.nlp.tokenizers.TokenizationResult;
 import org.elasticsearch.xpack.ml.inference.pytorch.results.PyTorchInferenceResult;
@@ -60,7 +61,8 @@ public class TextExpansionProcessor extends NlpTask.Processor {
             pyTorchResult,
             replacementVocab,
             config.getResultsField(),
-            chunkResults
+            chunkResults,
+            ((TextExpansionConfig) config).getExpansionType()
         );
     }
 
@@ -69,10 +71,11 @@ public class TextExpansionProcessor extends NlpTask.Processor {
         PyTorchInferenceResult pyTorchResult,
         Map<Integer, String> replacementVocab,
         String resultsField,
-        boolean chunkResults
+        boolean chunkResults,
+        String expansionType
     ) {
-        boolean isSplade = true; // TODO: Determine if the model is SPLADE or not based on the config or model type.
-        if (isSplade) {
+        // SPLADE type expansion
+        if (TextExpansionConfig.EXPANSION_TYPE_SPLADE.equals(expansionType)) {
             // chunkResults is not supported for SPLADE models
             if (chunkResults) {
                 throw new IllegalArgumentException("chunkResults is not supported for SPLADE models");
@@ -91,6 +94,7 @@ public class TextExpansionProcessor extends NlpTask.Processor {
             );
         }
 
+        // ELSER type expansion
         if (chunkResults) {
             var chunkedResults = new ArrayList<MlChunkedTextExpansionResults.ChunkedResult>();
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/TextExpansionProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/TextExpansionProcessor.java
@@ -137,7 +137,7 @@ public class TextExpansionProcessor extends NlpTask.Processor {
      * @param tokenization The tokenization result containing the vocabulary.
      * @param replacementVocab A map of token IDs to their replacements, if any.
      */
-    static List<WeightedToken>  spladeVectorToTokenWeights(
+    static List<WeightedToken> spladeVectorToTokenWeights(
         double[][] embedding,
         TokenizationResult tokenization,
         Map<Integer, String> replacementVocab
@@ -151,7 +151,6 @@ public class TextExpansionProcessor extends NlpTask.Processor {
         }
         return weightedTokens;
     }
-
 
     static List<WeightedToken> sparseVectorToTokenWeights(
         double[] vector,

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
@@ -973,7 +973,7 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
             .setTags(Collections.singletonList("prepackaged"))
             .setModelSize(1000)
             .setEstimatedOperations(2000)
-            .setInferenceConfig(new TextExpansionConfig(null, null, null))
+            .setInferenceConfig(new TextExpansionConfig(null, null, null, null))
             .build();
         givenTrainedModels(Arrays.asList(trainedModel1, trainedModel2, trainedModel3, trainedModel4));
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/NlpHelpersTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/NlpHelpersTests.java
@@ -119,29 +119,29 @@ public class NlpHelpersTests extends ESTestCase {
         assertEquals(1, scoreAndIndices[3].index);
     }
 
-    public void testCalculateSpladeValue() {
+    public void testSpladeSaturation() {
         // Test case 1: Positive value
         double input1 = 2.0;
         double expected1 = Math.log(1 + 2.0);
-        double result1 = NlpHelpers.calculateSpladeValue(input1);
+        double result1 = NlpHelpers.spladeSaturation(input1);
         assertThat(result1, closeTo(expected1, 0.000001));
 
         // Test case 2: Zero value
         double input2 = 0.0;
         double expected2 = 0.0;
-        double result2 = NlpHelpers.calculateSpladeValue(input2);
+        double result2 = NlpHelpers.spladeSaturation(input2);
         assertThat(result2, closeTo(expected2, 0.000001));
 
         // Test case 3: Negative value
         double input3 = -1.0;
         double expected3 = 0.0; // Negative values are clamped to 0
-        double result3 = NlpHelpers.calculateSpladeValue(input3);
+        double result3 = NlpHelpers.spladeSaturation(input3);
         assertThat(result3, closeTo(expected3, 0.000001));
 
         // Test case 4: Small positive value
         double input4 = 0.01;
         double expected4 = Math.log(1 + 0.01);
-        double result4 = NlpHelpers.calculateSpladeValue(input4);
+        double result4 = NlpHelpers.spladeSaturation(input4);
         assertThat(result4, closeTo(expected4, 0.000001));
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/NlpHelpersTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/NlpHelpersTests.java
@@ -118,4 +118,30 @@ public class NlpHelpersTests extends ESTestCase {
         assertEquals(0, scoreAndIndices[2].index);
         assertEquals(1, scoreAndIndices[3].index);
     }
+
+    public void testSpladeMaxPooling() {
+        // Test case 1: Positive value
+        double input1 = 2.0;
+        double expected1 = Math.log(1 + 2.0);
+        double result1 = NlpHelpers.spladeMaxPooling(input1);
+        assertThat(result1, closeTo(expected1, 0.000001));
+
+        // Test case 2: Zero value
+        double input2 = 0.0;
+        double expected2 = 0.0;
+        double result2 = NlpHelpers.spladeMaxPooling(input2);
+        assertThat(result2, closeTo(expected2, 0.000001));
+
+        // Test case 3: Negative value
+        double input3 = -1.0;
+        double expected3 = 0.0; // Negative values are clamped to 0
+        double result3 = NlpHelpers.spladeMaxPooling(input3);
+        assertThat(result3, closeTo(expected3, 0.000001));
+
+        // Test case 4: Small positive value
+        double input4 = 0.01;
+        double expected4 = Math.log(1 + 0.01);
+        double result4 = NlpHelpers.spladeMaxPooling(input4);
+        assertThat(result4, closeTo(expected4, 0.000001));
+    }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/NlpHelpersTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/NlpHelpersTests.java
@@ -119,29 +119,49 @@ public class NlpHelpersTests extends ESTestCase {
         assertEquals(1, scoreAndIndices[3].index);
     }
 
-    public void testSpladeMaxPooling() {
+    public void testCalculateSpladeValue() {
         // Test case 1: Positive value
         double input1 = 2.0;
         double expected1 = Math.log(1 + 2.0);
-        double result1 = NlpHelpers.spladeMaxPooling(input1);
+        double result1 = NlpHelpers.calculateSpladeValue(input1);
         assertThat(result1, closeTo(expected1, 0.000001));
 
         // Test case 2: Zero value
         double input2 = 0.0;
         double expected2 = 0.0;
-        double result2 = NlpHelpers.spladeMaxPooling(input2);
+        double result2 = NlpHelpers.calculateSpladeValue(input2);
         assertThat(result2, closeTo(expected2, 0.000001));
 
         // Test case 3: Negative value
         double input3 = -1.0;
         double expected3 = 0.0; // Negative values are clamped to 0
-        double result3 = NlpHelpers.spladeMaxPooling(input3);
+        double result3 = NlpHelpers.calculateSpladeValue(input3);
         assertThat(result3, closeTo(expected3, 0.000001));
 
         // Test case 4: Small positive value
         double input4 = 0.01;
         double expected4 = Math.log(1 + 0.01);
-        double result4 = NlpHelpers.spladeMaxPooling(input4);
+        double result4 = NlpHelpers.calculateSpladeValue(input4);
         assertThat(result4, closeTo(expected4, 0.000001));
+    }
+
+    public void testSpladeMaxPoolingEmbedding() {
+        // Test case 1: Single token with positive value
+        double[][] input1 = { { 2.0, 3.0, 4.0 } };
+        double[] expected1 = { Math.log(1 + 2.0), Math.log(1 + 3.0), Math.log(1 + 4.0) };
+        double[] result1 = NlpHelpers.spladeMaxPooling(input1);
+        assertArrayEquals(expected1, result1, 0.000001);
+
+        // Test case 2: Multiple tokens with mixed values
+        double[][] input2 = { { 0.5, -1.0, 2.0 }, { 3.0, 4.0, -2.0 } };
+        double[] expected2 = { Math.log(1 + 3.0), Math.log(1 + 4.0), Math.log(1 + 2.0) };
+        double[] result2 = NlpHelpers.spladeMaxPooling(input2);
+        assertArrayEquals(expected2, result2, 0.000001);
+
+        // Test case 3: All negative values
+        double[][] input3 = { { -1.0, -2.0, -3.0 } };
+        double[] expected3 = { 0.0, 0.0, 0.0 }; // All negative values should result in zero
+        double[] result3 = NlpHelpers.spladeMaxPooling(input3);
+        assertArrayEquals(expected3, result3, 0.000001);
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/TextEmbeddingProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/TextEmbeddingProcessorTests.java
@@ -86,7 +86,14 @@ public class TextEmbeddingProcessorTests extends ESTestCase {
             var input = "";
             var tokenization = tokenizer.tokenize(input, Tokenization.Truncate.NONE, 0, 0, null);
             var tokenizationResult = new BertTokenizationResult(TextExpansionProcessorTests.TEST_CASED_VOCAB, tokenization, 0);
-            var inferenceResult = TextExpansionProcessor.processResult(tokenizationResult, pytorchResult, Map.of(), "foo", true, TextExpansionConfig.EXPANSION_TYPE_ELSER);
+            var inferenceResult = TextExpansionProcessor.processResult(
+                tokenizationResult,
+                pytorchResult,
+                Map.of(),
+                "foo",
+                true,
+                TextExpansionConfig.EXPANSION_TYPE_ELSER
+            );
             assertThat(inferenceResult, instanceOf(MlChunkedTextExpansionResults.class));
 
             var chunkedResult = (MlChunkedTextExpansionResults) inferenceResult;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/TextEmbeddingProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/TextEmbeddingProcessorTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.xpack.core.ml.inference.results.MlChunkedTextEmbeddingF
 import org.elasticsearch.xpack.core.ml.inference.results.MlChunkedTextExpansionResults;
 import org.elasticsearch.xpack.core.ml.inference.results.MlTextEmbeddingResults;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.BertTokenization;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextExpansionConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.Tokenization;
 import org.elasticsearch.xpack.ml.inference.nlp.tokenizers.BertTokenizationResult;
 import org.elasticsearch.xpack.ml.inference.nlp.tokenizers.BertTokenizer;
@@ -85,7 +86,7 @@ public class TextEmbeddingProcessorTests extends ESTestCase {
             var input = "";
             var tokenization = tokenizer.tokenize(input, Tokenization.Truncate.NONE, 0, 0, null);
             var tokenizationResult = new BertTokenizationResult(TextExpansionProcessorTests.TEST_CASED_VOCAB, tokenization, 0);
-            var inferenceResult = TextExpansionProcessor.processResult(tokenizationResult, pytorchResult, Map.of(), "foo", true);
+            var inferenceResult = TextExpansionProcessor.processResult(tokenizationResult, pytorchResult, Map.of(), "foo", true, TextExpansionConfig.EXPANSION_TYPE_ELSER);
             assertThat(inferenceResult, instanceOf(MlChunkedTextExpansionResults.class));
 
             var chunkedResult = (MlChunkedTextExpansionResults) inferenceResult;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/TextExpansionProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/TextExpansionProcessorTests.java
@@ -56,7 +56,8 @@ public class TextExpansionProcessorTests extends ESTestCase {
             new PyTorchInferenceResult(pytorchResult),
             Map.of(),
             "foo",
-            false
+            false,
+            TextExpansionConfig.EXPANSION_TYPE_ELSER
         );
         assertThat(inferenceResult, instanceOf(TextExpansionResults.class));
         var results = (TextExpansionResults) inferenceResult;
@@ -79,7 +80,8 @@ public class TextExpansionProcessorTests extends ESTestCase {
             new PyTorchInferenceResult(pytorchResult),
             Map.of(4, "XXX", 3, "YYY"),
             "foo",
-            false
+            false,
+            TextExpansionConfig.EXPANSION_TYPE_ELSER
         );
         assertThat(inferenceResult, instanceOf(TextExpansionResults.class));
         var results = (TextExpansionResults) inferenceResult;
@@ -107,7 +109,7 @@ public class TextExpansionProcessorTests extends ESTestCase {
         var processor = new TextExpansionProcessor(
             BertTokenizer.builder(vocab, new BertTokenization(null, false, null, Tokenization.Truncate.NONE, -1)).build()
         );
-        var resultProcessor = processor.getResultProcessor(new TextExpansionConfig(null, null, null));
+        var resultProcessor = processor.getResultProcessor(new TextExpansionConfig(null, null, null, null));
 
         var pytorchResult = new PyTorchInferenceResult(new double[][][] { { { 1.0, 2.0, 3.0, 4.0, 5.0 } } });
         TokenizationResult tokenizationResult = new BertTokenizationResult(vocab, List.of(), 0);
@@ -136,7 +138,7 @@ public class TextExpansionProcessorTests extends ESTestCase {
             var input = "Elasticsearch darts champion little red is fun car";
             var tokenization = tokenizer.tokenize(input, Tokenization.Truncate.NONE, 0, 0, null);
             var tokenizationResult = new BertTokenizationResult(TEST_CASED_VOCAB, tokenization, 0);
-            var inferenceResult = TextExpansionProcessor.processResult(tokenizationResult, pytorchResult, Map.of(), "foo", true);
+            var inferenceResult = TextExpansionProcessor.processResult(tokenizationResult, pytorchResult, Map.of(), "foo", true, TextExpansionConfig.EXPANSION_TYPE_ELSER);
             assertThat(inferenceResult, instanceOf(MlChunkedTextExpansionResults.class));
 
             var chunkedResult = (MlChunkedTextExpansionResults) inferenceResult;
@@ -160,7 +162,7 @@ public class TextExpansionProcessorTests extends ESTestCase {
             var input = "";
             var tokenization = tokenizer.tokenize(input, Tokenization.Truncate.NONE, 0, 0, null);
             var tokenizationResult = new BertTokenizationResult(TEST_CASED_VOCAB, tokenization, 0);
-            var inferenceResult = TextExpansionProcessor.processResult(tokenizationResult, pytorchResult, Map.of(), "foo", true);
+            var inferenceResult = TextExpansionProcessor.processResult(tokenizationResult, pytorchResult, Map.of(), "foo", true, TextExpansionConfig.EXPANSION_TYPE_ELSER);
             assertThat(inferenceResult, instanceOf(MlChunkedTextExpansionResults.class));
 
             var chunkedResult = (MlChunkedTextExpansionResults) inferenceResult;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/TextExpansionProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/TextExpansionProcessorTests.java
@@ -71,11 +71,8 @@ public class TextExpansionProcessorTests extends ESTestCase {
     }
 
     public void testProcessResultForSplade() {
-        double[][][] pytorchResult = new double[][][] { {
-            { 0.0, 1.0, 1.0, 3.0, 0.0, -1.0, 0.0 },
-            { 0.0, 0.0, 2.0, 3.0, 3.0, -2.0, 0.0 },
-            { 0.0, 0.0, 0.0, 0.0, 4.0, -3.0, 0.0 }
-        } };
+        double[][][] pytorchResult = new double[][][] {
+            { { 0.0, 1.0, 1.0, 3.0, 0.0, -1.0, 0.0 }, { 0.0, 0.0, 2.0, 3.0, 3.0, -2.0, 0.0 }, { 0.0, 0.0, 0.0, 0.0, 4.0, -3.0, 0.0 } } };
 
         TokenizationResult tokenizationResult = new BertTokenizationResult(List.of("a", "b", "c", "d", "e", "f", "g"), List.of(), 0);
 
@@ -167,7 +164,14 @@ public class TextExpansionProcessorTests extends ESTestCase {
             var input = "Elasticsearch darts champion little red is fun car";
             var tokenization = tokenizer.tokenize(input, Tokenization.Truncate.NONE, 0, 0, null);
             var tokenizationResult = new BertTokenizationResult(TEST_CASED_VOCAB, tokenization, 0);
-            var inferenceResult = TextExpansionProcessor.processResult(tokenizationResult, pytorchResult, Map.of(), "foo", true, TextExpansionConfig.EXPANSION_TYPE_ELSER);
+            var inferenceResult = TextExpansionProcessor.processResult(
+                tokenizationResult,
+                pytorchResult,
+                Map.of(),
+                "foo",
+                true,
+                TextExpansionConfig.EXPANSION_TYPE_ELSER
+            );
             assertThat(inferenceResult, instanceOf(MlChunkedTextExpansionResults.class));
 
             var chunkedResult = (MlChunkedTextExpansionResults) inferenceResult;
@@ -191,7 +195,14 @@ public class TextExpansionProcessorTests extends ESTestCase {
             var input = "";
             var tokenization = tokenizer.tokenize(input, Tokenization.Truncate.NONE, 0, 0, null);
             var tokenizationResult = new BertTokenizationResult(TEST_CASED_VOCAB, tokenization, 0);
-            var inferenceResult = TextExpansionProcessor.processResult(tokenizationResult, pytorchResult, Map.of(), "foo", true, TextExpansionConfig.EXPANSION_TYPE_ELSER);
+            var inferenceResult = TextExpansionProcessor.processResult(
+                tokenizationResult,
+                pytorchResult,
+                Map.of(),
+                "foo",
+                true,
+                TextExpansionConfig.EXPANSION_TYPE_ELSER
+            );
             assertThat(inferenceResult, instanceOf(MlChunkedTextExpansionResults.class));
 
             var chunkedResult = (MlChunkedTextExpansionResults) inferenceResult;


### PR DESCRIPTION
## Overview

Elasticsearch supports sparse embeddings including non-ELSER models which is introduced by #116935.

A significant example of sparse vector model is the SPLADE model, which is a reference model for ELSER. But the format of the output of SPLADE is not same as ELSER, so we need to implement a post processing step for it.

## Interface change

This PR introduces a new `expansion_type` parameter to trained model resource.

```
GET /_ml/trained_models/hotchpotch__japanese-splade-v2?pretty
```

```
{
  "count" : 1,
  "trained_model_configs" : [
    {
      "model_id" : "hotchpotch__japanese-splade-v2",
      "model_type" : "pytorch",
      "created_by" : "api_user",
      "version" : "12.0.0",
      "create_time" : 1753171035706,
      "model_size_bytes" : 0,
      "estimated_operations" : 0,
      "license_level" : "platinum",
      "description" : "Model hotchpotch/japanese-splade-v2 for task type 'text_expansion'",
      "tags" : [ ],
      "metadata" : {
        "per_allocation_memory_bytes" : 392242176,
        "per_deployment_memory_bytes" : 545637376
      },
      "input" : {
        "field_names" : [
          "text_field"
        ]
      },
      "inference_config" : {
        "text_expansion" : {
          "vocabulary" : {
            "index" : ".ml-inference-native-000002"
          },
          "tokenization" : {
            "bert_ja" : {
              "do_lower_case" : false,
              "with_special_tokens" : true,
              "max_sequence_length" : 512,
              "truncate" : "first",
              "span" : -1
            }
          },
          "expansion_type" : "splade"
        }
      },
      "location" : {
        "index" : {
          "name" : ".ml-inference-native-000002"
        }
      }
    }
  ]
}
```

`expansion_type` can be one of `elser` or `splade`. If it is not specified, it defaults to `elser`.

To use the SPLADE model, eland needs to be updated to support the `expansion_type` parameter.
https://github.com/elastic/eland/pull/802

## Logic for SPLADE

SPLADE model outputs a embedding in the shape of [1, input_token_size, vocab_size]. The second dimention is different from ELSER, which is [1, chunk_size, vocab_size].
For SPLADE, we need to apply the saturation function to the output, which is `log(1 + relu(x))`, and then apply max pooling to the second dimension.

## To be considered

- Currently, we only implement max pooling for SPLADE. Should we also implement sum and/or other pooling?
- Top-k expansion is not supported. Some models produce a large amount of output from small input. Should we implement it? If yes, we need to have another option, and it can not be determined by eland automatically.
- I observed OOM when I send infer request with a little long text for japanese-splade-v2 model.

## Reference

- I referred [this](https://github.com/hotchpotch/yasem/blob/358a95360fb0e7f8b305ba59179880cd7e453df4/yasem/splade_embedder.py#L21) for the spladeMaxPooling implementation.

