### PR TITLE
Add availability information for node allocation stats cache

### DIFF
--- a/docs/reference/elasticsearch/configuration-reference/cluster-level-shard-allocation-routing-settings.md
+++ b/docs/reference/elasticsearch/configuration-reference/cluster-level-shard-allocation-routing-settings.md
@@ -306,7 +306,7 @@ PUT _cluster/settings
 ```
 
 
-## Node Allocation Stats Cache [node-allocation-stats-cache]
+## Node allocation stats cache [node-allocation-stats-cache]
 
 `cluster.routing.allocation.stats.cache.ttl` {applies_to}`stack: ga 9.1`
 :   ([Dynamic](docs-content://deploy-manage/stack-settings.md#dynamic-cluster-setting)) Calculating the node allocation stats for a [Get node statistics API call](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-nodes-stats) can become expensive on the master for clusters with a high number of nodes. To prevent overloading the master the node allocation stats are cached on the master for 1 minute `1m` by default.  This setting can be used to adjust the cache time to live value, if necessary, keeping in mind the tradeoff between the freshness of the statistics and the processing costs on the master.  The cache can be disabled (not recommended) by setting the value to `0s` (the minimum value). The maximum value is 10 minutes `10m`.

--- a/docs/reference/elasticsearch/configuration-reference/cluster-level-shard-allocation-routing-settings.md
+++ b/docs/reference/elasticsearch/configuration-reference/cluster-level-shard-allocation-routing-settings.md
@@ -308,5 +308,5 @@ PUT _cluster/settings
 
 ## Node Allocation Stats Cache [node-allocation-stats-cache]
 
-`cluster.routing.allocation.stats.cache.ttl`
+`cluster.routing.allocation.stats.cache.ttl` {applies_to}`stack: ga 9.1`
 :   ([Dynamic](docs-content://deploy-manage/stack-settings.md#dynamic-cluster-setting)) Calculating the node allocation stats for a [Get node statistics API call](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-nodes-stats) can become expensive on the master for clusters with a high number of nodes. To prevent overloading the master the node allocation stats are cached on the master for 1 minute `1m` by default.  This setting can be used to adjust the cache time to live value, if necessary, keeping in mind the tradeoff between the freshness of the statistics and the processing costs on the master.  The cache can be disabled (not recommended) by setting the value to `0s` (the minimum value). The maximum value is 10 minutes `10m`.


### PR DESCRIPTION
Followup to https://github.com/elastic/elasticsearch/pull/124898

This PR adds availability information for the new 9.1 `cluster.routing.allocation.stats.cache.ttl` setting. (also makes the title sentence case to match the others)

Docs are now [cumulative](https://elastic.github.io/docs-builder/contribute/cumulative-docs/), which means that we need to clearly tag changes introduced in each version going forward.