### PR TITLE
Fix and unmute `RemoteSearchForceConnectTimeoutIT#testTimeoutSetting()`

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -493,9 +493,6 @@ tests:
 - class: org.elasticsearch.compute.lucene.read.SortedSetOrdinalsBuilderTests
   method: testReader
   issue: https://github.com/elastic/elasticsearch/issues/131573
-- class: org.elasticsearch.indices.cluster.RemoteSearchForceConnectTimeoutIT
-  method: testTimeoutSetting
-  issue: https://github.com/elastic/elasticsearch/issues/131656
 - class: org.elasticsearch.search.SearchWithIndexBlocksIT
   method: testSearchShardsOnIndicesWithIndexRefreshBlocks
   issue: https://github.com/elastic/elasticsearch/issues/131662

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/cluster/RemoteSearchForceConnectTimeoutIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/cluster/RemoteSearchForceConnectTimeoutIT.java
@@ -74,7 +74,7 @@ public class RemoteSearchForceConnectTimeoutIT extends AbstractMultiClustersTest
             MockTransportService mts = (MockTransportService) cluster(LOCAL_CLUSTER).getInstance(TransportService.class, nodeName);
 
             mts.addConnectBehavior(
-                cluster(REMOTE_CLUSTER_1).getInstance(TransportService.class, randomFrom(cluster(REMOTE_CLUSTER_1).getNodeNames())),
+                cluster(REMOTE_CLUSTER_1).getInstance(TransportService.class, (String) null),
                 ((transport, discoveryNode, profile, listener) -> {
                     try {
                         latch.await();


### PR DESCRIPTION
Do not pick a random node. Instead, let the underneath filtering predicate be `Predicates.always()`. For some reason, this seems to be a "better" method of picking a node and stalling the connection(s). 