### PR TITLE
add availability information for `rescore_vector`

### DIFF
--- a/docs/reference/elasticsearch/mapping-reference/dense-vector.md
+++ b/docs/reference/elasticsearch/mapping-reference/dense-vector.md
@@ -273,7 +273,7 @@ $$$dense-vector-index-options$$$
 :   (Optional, float) Only applicable to `int8_hnsw`, `int4_hnsw`, `int8_flat`, and `int4_flat` index types. The confidence interval to use when quantizing the vectors. Can be any value between and including `0.90` and `1.0` or exactly `0`. When the value is `0`, this indicates that dynamic quantiles should be calculated for optimized quantization. When between `0.90` and `1.0`, this value restricts the values used when calculating the quantization thresholds. For example, a value of `0.95` will only use the middle 95% of the values when calculating the quantization thresholds (e.g. the highest and lowest 2.5% of values will be ignored). Defaults to `1/(dims + 1)` for `int8` quantized vectors and `0` for `int4` for dynamic quantile calculation.
 
 
-`rescore_vector`
+`rescore_vector` {applies_to}`stack: preview 9.0, ga 9.1`
 :   (Optional, object) An optional section that configures automatic vector rescoring on knn queries for the given field. Only applicable to quantized index types.
 :::::{dropdown} Properties of rescore_vector
 `oversample`

--- a/docs/reference/elasticsearch/rest-apis/retrievers/knn-retriever.md
+++ b/docs/reference/elasticsearch/rest-apis/retrievers/knn-retriever.md
@@ -60,7 +60,7 @@ A kNN retriever returns top documents from a [k-nearest neighbor search (kNN)](d
     Read more here: [knn similarity search](docs-content://solutions/search/vector/knn.md#knn-similarity-search)
 
 
-`rescore_vector`
+`rescore_vector` {applies_to}`stack: preview 9.0, ga 9.1`
 :   (Optional, object) Apply oversampling and rescoring to quantized vectors.
 
 ::::{note}

--- a/docs/reference/query-languages/query-dsl/query-dsl-knn-query.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-knn-query.md
@@ -97,7 +97,7 @@ The filter is a pre-filter, meaning that it is applied **during** the approximat
 :   (Optional, float) The minimum similarity required for a document to be considered a match. The similarity value calculated relates to the raw [`similarity`](/reference/elasticsearch/mapping-reference/dense-vector.md#dense-vector-similarity) used. Not the document score. The matched documents are then scored according to [`similarity`](/reference/elasticsearch/mapping-reference/dense-vector.md#dense-vector-similarity) and the provided `boost` is applied.
 
 
-`rescore_vector`
+`rescore_vector` {applies_to}`stack: preview 9.0, ga 9.1`
 :   (Optional, object) Apply oversampling and rescoring to quantized vectors.
 
 ::::{note}


### PR DESCRIPTION
Followup to https://github.com/elastic/elasticsearch/pull/126038

This PR adds availability information for the rescore_vector param. Added 9.0 status (preview) as well as 9.1 (ga) so people on 9.0 or 9.1 can understand the state of the feature

Docs are now [cumulative](https://elastic.github.io/docs-builder/contribute/cumulative-docs/), which means that we need to clearly tag changes introduced in each version going forward.