### PR TITLE
Add availability information for `monitor_esql` privilege

### DIFF
--- a/docs/reference/elasticsearch/security-privileges.md
+++ b/docs/reference/elasticsearch/security-privileges.md
@@ -194,7 +194,7 @@ This section lists the privileges that you can assign to a role.
 :   All cluster read-only operations, like cluster health and state, hot threads, node info, node and cluster stats, and pending cluster tasks.
 
 `monitor_data_stream_global_retention`
-:   This privilege has no effect.
+:   This privilege has no effect.[8.16]
 
 `monitor_enrich`
 :   All read-only operations related to managing and executing enrich policies.

--- a/docs/reference/elasticsearch/security-privileges.md
+++ b/docs/reference/elasticsearch/security-privileges.md
@@ -194,12 +194,12 @@ This section lists the privileges that you can assign to a role.
 :   All cluster read-only operations, like cluster health and state, hot threads, node info, node and cluster stats, and pending cluster tasks.
 
 `monitor_data_stream_global_retention`
-:   This privilege has no effect.[8.16]
+:   This privilege has no effect.
 
 `monitor_enrich`
 :   All read-only operations related to managing and executing enrich policies.
 
-`monitor_esql`
+`monitor_esql` {applies_to}`stack: ga 9.1`
 :   All read-only operations related to ES|QL queries.
 
 `monitor_inference`


### PR DESCRIPTION
Followup to #124832 

This PR adds availability information for the new `monitor_esql` security privilege (introduced for 9.1+). 

Docs are now [cumulative](https://elastic.github.io/docs-builder/contribute/cumulative-docs/), which means that we need to clearly tag changes introduced in each version going forward.