### PR TITLE
Add availability info for speed loading setting

### DIFF
--- a/docs/reference/elasticsearch/index-settings/index-modules.md
+++ b/docs/reference/elasticsearch/index-settings/index-modules.md
@@ -264,8 +264,8 @@ $$$index-dense-vector-hnsw-filter-heuristic$$$ `index.dense_vector.hnsw_filter_h
 
 $$$index-esql-stored-fields-sequential-proportion$$$
 
-`index.esql.stored_fields_sequential_proportion`
-:   Tuning parameter for deciding when {{esql}} will load [Stored fields](/reference/elasticsearch/rest-apis/retrieve-selected-fields.md#stored-fields) using a strategy tuned for loading dense sequence of documents. Allows values between 0.0 and 1.0 and defaults to 0.2. Indices with documents smaller than 10kb may see speed improvements loading `text` fields by setting this lower.
+`index.esql.stored_fields_sequential_proportion` {applies_to}`stack: ga 9.1`
+:   Tuning parameter for deciding when {{esql}} will load [stored fields](/reference/elasticsearch/rest-apis/retrieve-selected-fields.md#stored-fields) using a strategy tuned for loading dense sequence of documents. Allows values between 0.0 and 1.0 and defaults to 0.2. Indices with documents smaller than 10kb may see speed improvements loading `text` fields by setting this lower.
 
 $$$index-dense-vector-hnsw-early-termination$$$ `index.dense_vector.hnsw_early_termination`
 :   Whether to apply _patience_ based early termination strategy to knn queries over HNSW graphs (see [paper](https://cs.uwaterloo.ca/~jimmylin/publications/Teofili_Lin_ECIR2025.pdf)). This is only applicable to `dense_vector` fields with `hnsw`, `int8_hnsw`, `int4_hnsw` and `bbq_hnsw` index types. Defaults to `false`.


### PR DESCRIPTION
Followup to #127348 

This PR adds availability information for the new `index.esql.stored_fields_sequential_proportion` setting. also made stored fields sentence case

Docs are now [cumulative](https://elastic.github.io/docs-builder/contribute/cumulative-docs/), which means that we need to clearly tag changes introduced in each version going forward.

note: the edits assume that this setting is not available in serverless. if it is, we'll need to add a specific serverless tag as well