### PR TITLE
add availability info for the new l2_norm normalizer

### DIFF
--- a/docs/reference/elasticsearch/rest-apis/retrievers/linear-retriever.md
+++ b/docs/reference/elasticsearch/rest-apis/retrievers/linear-retriever.md
@@ -90,4 +90,4 @@ The `linear` retriever supports the following normalizers:
     ```
     score = (score - min) / (max - min)
     ```
-* `l2_norm`: Normalizes scores using the L2 norm of the score values
+* `l2_norm`: Normalizes scores using the L2 norm of the score values {applies_to}`stack: ga 9.1`


### PR DESCRIPTION
Followup to #128504

Adds availability information for linear retriever `l2_norm` normalizer support, introduced in 9.1.

Docs are now [cumulative](https://elastic.github.io/docs-builder/contribute/cumulative-docs/), which means that we need to clearly tag changes introduced in each version going forward.