### PR TITLE
Rename NodeUsageStatsForThreadPoolsCollector to ThreadPoolUsageCollector

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/index/shard/IndexShardIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/shard/IndexShardIT.java
@@ -25,7 +25,7 @@ import org.elasticsearch.cluster.EstimatedHeapUsage;
 import org.elasticsearch.cluster.EstimatedHeapUsageCollector;
 import org.elasticsearch.cluster.InternalClusterInfoService;
 import org.elasticsearch.cluster.NodeUsageStatsForThreadPools;
-import org.elasticsearch.cluster.NodeUsageStatsForThreadPoolsCollector;
+import org.elasticsearch.cluster.ThreadPoolUsageCollector;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -334,7 +334,7 @@ public class IndexShardIT extends ESSingleNodeTestCase {
             ClusterInfoServiceUtils.refresh(clusterInfoService);
             nodeThreadPoolStats = clusterInfoService.getClusterInfo().getNodeUsageStatsForThreadPools();
 
-            /** Verify that each node has usage stats reported. The test {@link BogusNodeUsageStatsForThreadPoolsCollector} implementation
+            /** Verify that each node has usage stats reported. The test {@link BogusThreadPoolUsageCollector} implementation
              * generates random usage values */
             ClusterState state = getInstanceFromNode(ClusterService.class).state();
             assertEquals(state.nodes().size(), nodeThreadPoolStats.size());
@@ -995,17 +995,17 @@ public class IndexShardIT extends ESSingleNodeTestCase {
     }
 
     /**
-     * A simple {@link NodeUsageStatsForThreadPoolsCollector} implementation that creates and returns random
+     * A simple {@link ThreadPoolUsageCollector} implementation that creates and returns random
      * {@link NodeUsageStatsForThreadPools} for each node in the cluster.
      * <p>
      * Note: there's an 'org.elasticsearch.cluster.NodeUsageStatsForThreadPoolsCollector' file that declares this implementation so that the
      * plugin system can pick it up and use it for the test set-up.
      */
-    public static class BogusNodeUsageStatsForThreadPoolsCollector implements NodeUsageStatsForThreadPoolsCollector {
+    public static class BogusThreadPoolUsageCollector implements ThreadPoolUsageCollector {
 
         private final BogusNodeUsageStatsForThreadPoolsCollectorPlugin plugin;
 
-        public BogusNodeUsageStatsForThreadPoolsCollector(BogusNodeUsageStatsForThreadPoolsCollectorPlugin plugin) {
+        public BogusThreadPoolUsageCollector(BogusNodeUsageStatsForThreadPoolsCollectorPlugin plugin) {
             this.plugin = plugin;
         }
 

--- a/server/src/internalClusterTest/resources/META-INF/services/org.elasticsearch.cluster.ThreadPoolUsageCollector
+++ b/server/src/internalClusterTest/resources/META-INF/services/org.elasticsearch.cluster.ThreadPoolUsageCollector
@@ -7,4 +7,4 @@
 # License v3.0 only", or the "Server Side Public License, v 1".
 #
 
-org.elasticsearch.index.shard.IndexShardIT$BogusNodeUsageStatsForThreadPoolsCollector
+org.elasticsearch.index.shard.IndexShardIT$BogusThreadPoolUsageCollector

--- a/server/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
@@ -113,7 +113,7 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
     private final Object mutex = new Object();
     private final List<ActionListener<ClusterInfo>> nextRefreshListeners = new ArrayList<>();
     private final EstimatedHeapUsageCollector estimatedHeapUsageCollector;
-    private final NodeUsageStatsForThreadPoolsCollector nodeUsageStatsForThreadPoolsCollector;
+    private final ThreadPoolUsageCollector threadPoolUsageCollector;
 
     private AsyncRefresh currentRefresh;
     private RefreshScheduler refreshScheduler;
@@ -125,7 +125,7 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
         ThreadPool threadPool,
         Client client,
         EstimatedHeapUsageCollector estimatedHeapUsageCollector,
-        NodeUsageStatsForThreadPoolsCollector nodeUsageStatsForThreadPoolsCollector
+        ThreadPoolUsageCollector nodeUsageStatsForThreadPoolsCollector
     ) {
         this.leastAvailableSpaceUsages = Map.of();
         this.mostAvailableSpaceUsages = Map.of();
@@ -136,7 +136,7 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
         this.threadPool = threadPool;
         this.client = client;
         this.estimatedHeapUsageCollector = estimatedHeapUsageCollector;
-        this.nodeUsageStatsForThreadPoolsCollector = nodeUsageStatsForThreadPoolsCollector;
+        this.threadPoolUsageCollector = nodeUsageStatsForThreadPoolsCollector;
         this.updateFrequency = INTERNAL_CLUSTER_INFO_UPDATE_INTERVAL_SETTING.get(settings);
         this.fetchTimeout = INTERNAL_CLUSTER_INFO_TIMEOUT_SETTING.get(settings);
         this.diskThresholdEnabled = DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.get(settings);
@@ -270,7 +270,7 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
         }
 
         private void fetchNodesUsageStatsForThreadPools() {
-            nodeUsageStatsForThreadPoolsCollector.collectUsageStats(ActionListener.releaseAfter(new ActionListener<>() {
+            threadPoolUsageCollector.collectUsageStats(ActionListener.releaseAfter(new ActionListener<>() {
                 @Override
                 public void onResponse(Map<String, NodeUsageStatsForThreadPools> writeLoads) {
                     nodeThreadPoolUsageStatsPerNode = writeLoads;

--- a/server/src/main/java/org/elasticsearch/cluster/ThreadPoolUsageCollector.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ThreadPoolUsageCollector.java
@@ -18,11 +18,11 @@ import java.util.Map;
  * <p>
  * Results are returned as a map of node ID to node usage stats.
  */
-public interface NodeUsageStatsForThreadPoolsCollector {
+public interface ThreadPoolUsageCollector {
     /**
      * This will be used when there is no NodeUsageLoadCollector available.
      */
-    NodeUsageStatsForThreadPoolsCollector EMPTY = listener -> listener.onResponse(Map.of());
+    ThreadPoolUsageCollector EMPTY = listener -> listener.onResponse(Map.of());
 
     /**
      * Collects the write load estimates from the cluster.

--- a/server/src/main/java/org/elasticsearch/node/NodeServiceProvider.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeServiceProvider.java
@@ -14,7 +14,7 @@ import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.cluster.ClusterInfoService;
 import org.elasticsearch.cluster.EstimatedHeapUsageCollector;
 import org.elasticsearch.cluster.InternalClusterInfoService;
-import org.elasticsearch.cluster.NodeUsageStatsForThreadPoolsCollector;
+import org.elasticsearch.cluster.ThreadPoolUsageCollector;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.breaker.CircuitBreaker;
@@ -80,10 +80,10 @@ class NodeServiceProvider {
             EstimatedHeapUsageCollector.class,
             () -> EstimatedHeapUsageCollector.EMPTY
         );
-        final NodeUsageStatsForThreadPoolsCollector nodeUsageStatsForThreadPoolsCollector = pluginsService.loadSingletonServiceProvider(
-            NodeUsageStatsForThreadPoolsCollector.class,
-            () -> NodeUsageStatsForThreadPoolsCollector.EMPTY
-        );
+        final ThreadPoolUsageCollector nodeUsageStatsForThreadPoolsCollector = pluginsService.loadSingletonServiceProvider(
+            ThreadPoolUsageCollector.class,
+            () -> ThreadPoolUsageCollector.EMPTY
+                                                                                                                          );
         final InternalClusterInfoService service = new InternalClusterInfoService(
             settings,
             clusterService,

--- a/server/src/main/java/org/elasticsearch/node/NodeServiceProvider.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeServiceProvider.java
@@ -83,7 +83,7 @@ class NodeServiceProvider {
         final ThreadPoolUsageCollector nodeUsageStatsForThreadPoolsCollector = pluginsService.loadSingletonServiceProvider(
             ThreadPoolUsageCollector.class,
             () -> ThreadPoolUsageCollector.EMPTY
-                                                                                                                          );
+        );
         final InternalClusterInfoService service = new InternalClusterInfoService(
             settings,
             clusterService,

--- a/server/src/test/java/org/elasticsearch/cluster/InternalClusterInfoServiceSchedulingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/InternalClusterInfoServiceSchedulingTests.java
@@ -84,9 +84,7 @@ public class InternalClusterInfoServiceSchedulingTests extends ESTestCase {
 
         final FakeClusterInfoServiceClient client = new FakeClusterInfoServiceClient(threadPool);
         final EstimatedHeapUsageCollector mockEstimatedHeapUsageCollector = spy(new StubEstimatedEstimatedHeapUsageCollector());
-        final ThreadPoolUsageCollector mockNodeUsageStatsForThreadPoolsCollector = spy(
-            new StubThreadPoolUsageCollector()
-                                                                                      );
+        final ThreadPoolUsageCollector mockNodeUsageStatsForThreadPoolsCollector = spy(new StubThreadPoolUsageCollector());
         final InternalClusterInfoService clusterInfoService = new InternalClusterInfoService(
             settings,
             clusterService,

--- a/server/src/test/java/org/elasticsearch/cluster/InternalClusterInfoServiceSchedulingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/InternalClusterInfoServiceSchedulingTests.java
@@ -84,9 +84,9 @@ public class InternalClusterInfoServiceSchedulingTests extends ESTestCase {
 
         final FakeClusterInfoServiceClient client = new FakeClusterInfoServiceClient(threadPool);
         final EstimatedHeapUsageCollector mockEstimatedHeapUsageCollector = spy(new StubEstimatedEstimatedHeapUsageCollector());
-        final NodeUsageStatsForThreadPoolsCollector mockNodeUsageStatsForThreadPoolsCollector = spy(
-            new StubNodeUsageStatsForThreadPoolsCollector()
-        );
+        final ThreadPoolUsageCollector mockNodeUsageStatsForThreadPoolsCollector = spy(
+            new StubThreadPoolUsageCollector()
+                                                                                      );
         final InternalClusterInfoService clusterInfoService = new InternalClusterInfoService(
             settings,
             clusterService,
@@ -164,10 +164,10 @@ public class InternalClusterInfoServiceSchedulingTests extends ESTestCase {
     }
 
     /**
-     * Simple for test {@link NodeUsageStatsForThreadPoolsCollector} implementation that returns an empty map of nodeId string to
+     * Simple for test {@link ThreadPoolUsageCollector} implementation that returns an empty map of nodeId string to
      * {@link NodeUsageStatsForThreadPools}.
      */
-    private static class StubNodeUsageStatsForThreadPoolsCollector implements NodeUsageStatsForThreadPoolsCollector {
+    private static class StubThreadPoolUsageCollector implements ThreadPoolUsageCollector {
         @Override
         public void collectUsageStats(ActionListener<Map<String, NodeUsageStatsForThreadPools>> listener) {
             listener.onResponse(Map.of());

--- a/test/framework/src/main/java/org/elasticsearch/cluster/MockInternalClusterInfoService.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/MockInternalClusterInfoService.java
@@ -43,7 +43,7 @@ public class MockInternalClusterInfoService extends InternalClusterInfoService {
     private volatile BiFunction<DiscoveryNode, FsInfo.Path, FsInfo.Path> diskUsageFunction;
 
     public MockInternalClusterInfoService(Settings settings, ClusterService clusterService, ThreadPool threadPool, NodeClient client) {
-        super(settings, clusterService, threadPool, client, EstimatedHeapUsageCollector.EMPTY, NodeUsageStatsForThreadPoolsCollector.EMPTY);
+        super(settings, clusterService, threadPool, client, EstimatedHeapUsageCollector.EMPTY, ThreadPoolUsageCollector.EMPTY);
     }
 
     public void setDiskUsageFunctionAndRefresh(BiFunction<DiscoveryNode, FsInfo.Path, FsInfo.Path> diskUsageFn) {


### PR DESCRIPTION
A shorter name `NodeUsageStatsForThreadPoolsCollector -> ThreadPoolUsageCollector`. Also aligns with `EstimatedHeapUsageCollector`.