### PR TITLE
Add JNA dep to testcontainers

### DIFF
--- a/test/fixtures/testcontainer-utils/build.gradle
+++ b/test/fixtures/testcontainer-utils/build.gradle
@@ -18,5 +18,5 @@ dependencies {
   runtimeOnly "org.rnorth.duct-tape:duct-tape:${versions.ductTape}"
   runtimeOnly "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
   runtimeOnly "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
-
+  runtimeOnly "net.java.dev.jna:jna:${versions.jna}"
 }


### PR DESCRIPTION
Running Docker-testcontainer-related tests on a completely freshly
rebuilt Ubuntu machine fail for me with the following exception:

```
[SUITE-S3RepositoryThirdPartyTests-seed#[F84B73F349864988]] INFO org.elasticsearch.test.fixtures.testcontainers.DockerEnvironmentAwareTestContainer - Probing docker environment...
[SUITE-S3RepositoryThirdPartyTests-seed#[F84B73F349864988]] WARN org.elasticsearch.test.fixtures.testcontainers.DockerEnvironmentAwareTestContainer - Probing docker has failed; disabling test
java.lang.NoClassDefFoundError: com/sun/jna/Library
        at java.base/java.lang.ClassLoader.defineClass1(Native Method)
        at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1027)
        at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:150)
        at java.base/jdk.internal.loader.BuiltinClassLoader.defineClass(BuiltinClassLoader.java:862)
        at java.base/jdk.internal.loader.BuiltinClassLoader.findClassOnClassPathOrNull(BuiltinClassLoader.java:760)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:681)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:639)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
        at org.testcontainers.dockerclient.RootlessDockerClientProviderStrategy.lambda$null$0(RootlessDockerClientProviderStrategy.java:37)
        at java.base/java.util.Optional.orElseGet(Optional.java:364)
        at org.testcontainers.dockerclient.RootlessDockerClientProviderStrategy.lambda$resolveSocketPath$1(RootlessDockerClientProviderStrategy.java:36)
        at java.base/java.util.Optional.orElseGet(Optional.java:364)
        at org.testcontainers.dockerclient.RootlessDockerClientProviderStrategy.resolveSocketPath(RootlessDockerClientProviderStrategy.java:33)
        at org.testcontainers.dockerclient.RootlessDockerClientProviderStrategy.getSocketPath(RootlessDockerClientProviderStrategy.java:29)
        at org.testcontainers.dockerclient.RootlessDockerClientProviderStrategy.isApplicable(RootlessDockerClientProviderStrategy.java:82)
        at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:178)
        at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
        at java.base/java.util.ArrayList$ArrayListSpliterator.tryAdvance(ArrayList.java:1685)
        at java.base/java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:129)
        at java.base/java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:527)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:513)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
        at java.base/java.util.stream.FindOps$FindOp.evaluateSequential(FindOps.java:150)
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base/java.util.stream.ReferencePipeline.findFirst(ReferencePipeline.java:647)
        at org.testcontainers.dockerclient.DockerClientProviderStrategy.getFirstValidStrategy(DockerClientProviderStrategy.java:267)
        at org.testcontainers.DockerClientFactory.getOrInitializeStrategy(DockerClientFactory.java:152)
        at org.testcontainers.DockerClientFactory.client(DockerClientFactory.java:194)
        at org.elasticsearch.test.fixtures.testcontainers.DockerEnvironmentAwareTestContainer.isDockerAvailable(DockerEnvironmentAwareTestContainer.java:51)
        at org.elasticsearch.test.fixtures.testcontainers.DockerEnvironmentAwareTestContainer.&lt;clinit&gt;(DockerEnvironmentAwareTestContainer.java:43)
        at org.elasticsearch.repositories.s3.S3RepositoryThirdPartyTests.&lt;clinit&gt;(S3RepositoryThirdPartyTests.java:64)
        at java.base/java.lang.Class.forName0(Native Method)
        at java.base/java.lang.Class.forName(Class.java:534)
        at java.base/java.lang.Class.forName(Class.java:513)
        at com.carrotsearch.randomizedtesting.RandomizedRunner$2.run(RandomizedRunner.java:631)
Caused by: java.lang.ClassNotFoundException: com.sun.jna.Library
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
        ... 36 more
```

This change fixes it for me. Oddly enough this line doesn't seem
necessary after the first time I run such a test.