### PR TITLE
Remove Transport Version from Serialization

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/ClusterBalanceStats.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/ClusterBalanceStats.java
@@ -271,10 +271,10 @@ public record ClusterBalanceStats(
 
         public static NodeBalanceStats readFrom(StreamInput in) throws IOException {
             return new NodeBalanceStats(
-                in.getTransportVersion().onOrAfter(TransportVersions.V_8_8_0) ? in.readString() : UNKNOWN_NODE_ID,
-                in.getTransportVersion().onOrAfter(TransportVersions.V_8_8_0) ? in.readStringCollectionAsList() : List.of(),
+                in.readString(),
+                in.readStringCollectionAsList(),
                 in.readInt(),
-                in.getTransportVersion().onOrAfter(TransportVersions.V_8_12_0) ? in.readVInt() : -1,
+                in.readVInt(),
                 in.readDouble(),
                 in.readLong(),
                 in.readLong(),
@@ -286,14 +286,10 @@ public record ClusterBalanceStats(
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_8_0)) {
-                out.writeString(nodeId);
-                out.writeStringCollection(roles);
-            }
+            out.writeString(nodeId);
+            out.writeStringCollection(roles);
             out.writeInt(shards);
-            if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_12_0)) {
-                out.writeVInt(undesiredShardAllocations);
-            }
+            out.writeVInt(undesiredShardAllocations);
             out.writeDouble(forecastWriteLoad);
             out.writeLong(forecastShardSize);
             out.writeLong(actualShardSize);

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/NodeBalanceStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/NodeBalanceStatsTests.java
@@ -56,42 +56,6 @@ public class NodeBalanceStatsTests extends AbstractWireSerializingTestCase<Clust
         return createTestInstance();
     }
 
-    public void testSerializationWithTransportVersionV_8_7_0() throws IOException {
-        ClusterBalanceStats.NodeBalanceStats instance = createTestInstance();
-        // Serialization changes based on this version
-        final var oldVersion = TransportVersionUtils.randomVersionBetween(
-            random(),
-            TransportVersions.V_8_0_0,
-            TransportVersionUtils.getPreviousVersion(TransportVersions.V_8_8_0)
-        );
-        ClusterBalanceStats.NodeBalanceStats deserialized = copyInstance(instance, oldVersion);
-
-        // Assert the default values are as expected
-        assertEquals(UNKNOWN, deserialized.nodeId());
-        assertEquals(List.of(), deserialized.roles());
-        assertEquals(UNDESIRED_SHARD_ALLOCATION_DEFAULT_VALUE, deserialized.undesiredShardAllocations());
-        assertNull(deserialized.nodeWeight());
-    }
-
-    public void testSerializationWithTransportVersionV_8_8_0() throws IOException {
-        ClusterBalanceStats.NodeBalanceStats instance = createTestInstance();
-        // Serialization changes based on this version
-        final var oldVersion = TransportVersionUtils.randomVersionBetween(
-            random(),
-            TransportVersions.V_8_8_0,
-            TransportVersionUtils.getPreviousVersion(TransportVersions.V_8_12_0)
-        );
-        ClusterBalanceStats.NodeBalanceStats deserialized = copyInstance(instance, oldVersion);
-
-        // Assert the values are as expected
-        assertEquals(instance.nodeId(), deserialized.nodeId());
-        assertEquals(instance.roles(), deserialized.roles());
-
-        // Assert the default values are as expected
-        assertEquals(UNDESIRED_SHARD_ALLOCATION_DEFAULT_VALUE, deserialized.undesiredShardAllocations());
-        assertNull(deserialized.nodeWeight());
-    }
-
     public void testSerializationWithTransportVersionV_8_12_0() throws IOException {
         ClusterBalanceStats.NodeBalanceStats instance = createTestInstance();
         // Serialization changes based on this version


### PR DESCRIPTION
Removes conditional statements from the `NodeBalanceStats` `readFrom` and `writeTo` methods that serialised depending on `TransportVersions .V_8_8_0` and `TransportVersions.V_8_12_0` since these transport versions are old and can be removed.

Jira: ES-10337