### PR TITLE
[9.0] Standardize on docker image arch classifier (#130643)

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/Architecture.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/Architecture.java
@@ -11,15 +11,17 @@ package org.elasticsearch.gradle;
 
 public enum Architecture {
 
-    X64("x86_64", "linux/amd64"),
-    AARCH64("aarch64", "linux/arm64");
+    X64("x86_64", "linux/amd64", "amd64"),
+    AARCH64("aarch64", "linux/arm64", "arm64");
 
     public final String classifier;
     public final String dockerPlatform;
+    public final String dockerClassifier;
 
-    Architecture(String classifier, String dockerPlatform) {
+    Architecture(String classifier, String dockerPlatform, String dockerClassifier) {
         this.classifier = classifier;
         this.dockerPlatform = dockerPlatform;
+        this.dockerClassifier = dockerClassifier;
     }
 
     public static Architecture current() {

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -643,7 +643,7 @@ subprojects { Project subProject ->
       it.setCompression(Compression.GZIP)
       it.getArchiveBaseName().set("elasticsearch${base.suffix}-${VersionProperties.elasticsearch}-docker-image")
       it.getArchiveVersion().set("")
-      it.getArchiveClassifier().set(architecture == Architecture.AARCH64 ? 'aarch64' : '')
+      it.getArchiveClassifier().set(architecture.dockerClassifier)
       it.getDestinationDirectory().set(new File(project.parent.buildDir, 'distributions'))
       it.dependsOn(exportTask)
     }


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Standardize on docker image arch classifier (#130643)