### PR TITLE
Remove Transport Version from Serialization

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.cluster;
 
-import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.ShardRouting;

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
@@ -49,8 +49,6 @@ public class ClusterInfo implements ChunkedToXContent, Writeable {
 
     public static final ClusterInfo EMPTY = new ClusterInfo();
 
-    public static final TransportVersion DATA_PATH_NEW_KEY_VERSION = TransportVersions.V_8_6_0;
-
     private final Map<String, DiskUsage> leastAvailableSpaceUsage;
     private final Map<String, DiskUsage> mostAvailableSpaceUsage;
     final Map<String, Long> shardSizes;
@@ -105,9 +103,7 @@ public class ClusterInfo implements ChunkedToXContent, Writeable {
         this.mostAvailableSpaceUsage = in.readImmutableMap(DiskUsage::new);
         this.shardSizes = in.readImmutableMap(StreamInput::readLong);
         this.shardDataSetSizes = in.readImmutableMap(ShardId::new, StreamInput::readLong);
-        this.dataPath = in.getTransportVersion().onOrAfter(DATA_PATH_NEW_KEY_VERSION)
-            ? in.readImmutableMap(NodeAndShard::new, StreamInput::readString)
-            : in.readImmutableMap(nested -> NodeAndShard.from(new ShardRouting(nested)), StreamInput::readString);
+        this.dataPath = in.readImmutableMap(NodeAndShard::new, StreamInput::readString);
         this.reservedSpace = in.readImmutableMap(NodeAndPath::new, ReservedSpace::new);
         if (in.getTransportVersion().onOrAfter(TransportVersions.HEAP_USAGE_IN_CLUSTER_INFO)) {
             this.estimatedHeapUsages = in.readImmutableMap(EstimatedHeapUsage::new);
@@ -132,11 +128,7 @@ public class ClusterInfo implements ChunkedToXContent, Writeable {
         out.writeMap(this.mostAvailableSpaceUsage, StreamOutput::writeWriteable);
         out.writeMap(this.shardSizes, (o, v) -> o.writeLong(v == null ? -1 : v));
         out.writeMap(this.shardDataSetSizes, StreamOutput::writeWriteable, StreamOutput::writeLong);
-        if (out.getTransportVersion().onOrAfter(DATA_PATH_NEW_KEY_VERSION)) {
-            out.writeMap(this.dataPath, StreamOutput::writeWriteable, StreamOutput::writeString);
-        } else {
-            out.writeMap(this.dataPath, (o, k) -> createFakeShardRoutingFromNodeAndShard(k).writeTo(o), StreamOutput::writeString);
-        }
+        out.writeMap(this.dataPath, StreamOutput::writeWriteable, StreamOutput::writeString);
         out.writeMap(this.reservedSpace);
         if (out.getTransportVersion().onOrAfter(TransportVersions.HEAP_USAGE_IN_CLUSTER_INFO)) {
             out.writeMap(this.estimatedHeapUsages, StreamOutput::writeWriteable);

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/ClusterBalanceStats.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/ClusterBalanceStats.java
@@ -77,8 +77,8 @@ public record ClusterBalanceStats(
 
     public static ClusterBalanceStats readFrom(StreamInput in) throws IOException {
         return new ClusterBalanceStats(
-            in.getTransportVersion().onOrAfter(TransportVersions.V_8_12_0) ? in.readVInt() : -1,
-            in.getTransportVersion().onOrAfter(TransportVersions.V_8_12_0) ? in.readVInt() : -1,
+            in.readVInt(),
+            in.readVInt(),
             in.readImmutableMap(TierBalanceStats::readFrom),
             in.readImmutableMap(NodeBalanceStats::readFrom)
         );
@@ -86,10 +86,8 @@ public record ClusterBalanceStats(
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_12_0)) {
-            out.writeVInt(shards);
-            out.writeVInt(undesiredShardAllocations);
-        }
+        out.writeVInt(shards);
+        out.writeVInt(undesiredShardAllocations);
         out.writeMap(tiers, StreamOutput::writeWriteable);
         out.writeMap(nodes, StreamOutput::writeWriteable);
     }
@@ -125,9 +123,7 @@ public record ClusterBalanceStats(
         public static TierBalanceStats readFrom(StreamInput in) throws IOException {
             return new TierBalanceStats(
                 MetricStats.readFrom(in),
-                in.getTransportVersion().onOrAfter(TransportVersions.V_8_12_0)
-                    ? MetricStats.readFrom(in)
-                    : new MetricStats(0.0, 0.0, 0.0, 0.0, 0.0),
+                MetricStats.readFrom(in),
                 MetricStats.readFrom(in),
                 MetricStats.readFrom(in),
                 MetricStats.readFrom(in)
@@ -137,9 +133,7 @@ public record ClusterBalanceStats(
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             shardCount.writeTo(out);
-            if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_12_0)) {
-                undesiredShardAllocations.writeTo(out);
-            }
+            undesiredShardAllocations.writeTo(out);
             forecastWriteLoad.writeTo(out);
             forecastShardSize.writeTo(out);
             actualShardSize.writeTo(out);

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceStats.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceStats.java
@@ -9,8 +9,6 @@
 
 package org.elasticsearch.cluster.routing.allocation.allocator;
 
-import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -37,8 +35,6 @@ public record DesiredBalanceStats(
     long undesiredAllocations
 ) implements Writeable, ToXContentObject {
 
-    private static final TransportVersion COMPUTED_SHARD_MOVEMENTS_VERSION = TransportVersions.V_8_8_0;
-
     public DesiredBalanceStats {
         if (lastConvergedIndex < 0) {
             assert false : lastConvergedIndex;
@@ -54,7 +50,7 @@ public record DesiredBalanceStats(
             in.readVLong(),
             in.readVLong(),
             in.readVLong(),
-            in.getTransportVersion().onOrAfter(COMPUTED_SHARD_MOVEMENTS_VERSION) ? in.readVLong() : -1,
+            in.readVLong(),
             in.readVLong(),
             in.readVLong(),
             in.getTransportVersion().onOrAfter(V_8_12_0) ? in.readVLong() : -1,
@@ -71,16 +67,12 @@ public record DesiredBalanceStats(
         out.writeVLong(computationExecuted);
         out.writeVLong(computationConverged);
         out.writeVLong(computationIterations);
-        if (out.getTransportVersion().onOrAfter(COMPUTED_SHARD_MOVEMENTS_VERSION)) {
-            out.writeVLong(computedShardMovements);
-        }
+        out.writeVLong(computedShardMovements);
         out.writeVLong(cumulativeComputationTime);
         out.writeVLong(cumulativeReconciliationTime);
-        if (out.getTransportVersion().onOrAfter(V_8_12_0)) {
-            out.writeVLong(unassignedShards);
-            out.writeVLong(totalAllocations);
-            out.writeVLong(undesiredAllocations);
-        }
+        out.writeVLong(unassignedShards);
+        out.writeVLong(totalAllocations);
+        out.writeVLong(undesiredAllocations);
     }
 
     @Override


### PR DESCRIPTION
Removes conditional logic from `DesiredBalanceResponse` and all classes used in the response (`DesiredBalanceStats`, `ClusterBalanceStats` and `ClusterInfo`) that altered serialization based on transport
versions <= `V_8_18_0` since these are outdated.

Jira: ES-10337