### PR TITLE
[9.1] Track & log when there is insufficient disk space available to execute merges (#131711)

### DIFF
--- a/docs/changelog/131711.yaml
+++ b/docs/changelog/131711.yaml
@@ -1,0 +1,5 @@
+pr: 131711
+summary: Track & log when there is insufficient disk space available to execute merges
+area: Engine
+type: enhancement
+issues: []


### PR DESCRIPTION
Backports the following commits to 9.1:
 - Track & log when there is insufficient disk space available to execute merges (#131711)