### PR TITLE
Refactor `CacheStats` to `Stats` across all relevant classes and tests

### DIFF
--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpCache.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpCache.java
@@ -120,7 +120,7 @@ public final class GeoIpCache {
      * @return Current stats about this cache
      */
     public CacheStats getCacheStats() {
-        Cache.CacheStats stats = cache.stats();
+        Cache.Stats stats = cache.stats();
         return new CacheStats(
             cache.count(),
             stats.getHits(),

--- a/server/src/main/java/org/elasticsearch/common/cache/Cache.java
+++ b/server/src/main/java/org/elasticsearch/common/cache/Cache.java
@@ -746,16 +746,16 @@ public class Cache<K, V> {
      *
      * @return the current cache statistics
      */
-    public CacheStats stats() {
-        return new CacheStats(this.hits.sum(), misses.sum(), evictions.sum());
+    public Stats stats() {
+        return new Stats(this.hits.sum(), misses.sum(), evictions.sum());
     }
 
-    public static class CacheStats {
+    public static class Stats {
         private final long hits;
         private final long misses;
         private final long evictions;
 
-        public CacheStats(long hits, long misses, long evictions) {
+        public Stats(long hits, long misses, long evictions) {
             this.hits = hits;
             this.misses = misses;
             this.evictions = evictions;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/FieldPermissionsCache.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/FieldPermissionsCache.java
@@ -49,7 +49,7 @@ public final class FieldPermissionsCache {
             .build();
     }
 
-    public Cache.CacheStats getCacheStats() {
+    public Cache.Stats getCacheStats() {
         return cache.stats();
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/RoleDescriptorTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/RoleDescriptorTests.java
@@ -578,7 +578,7 @@ public class RoleDescriptorTests extends ESTestCase {
         FieldPermissionsCache fieldPermissionsCache = new FieldPermissionsCache(Settings.EMPTY);
         RoleDescriptor.setFieldPermissionsCache(fieldPermissionsCache);
 
-        final Cache.CacheStats beforeStats = fieldPermissionsCache.getCacheStats();
+        final Cache.Stats beforeStats = fieldPermissionsCache.getCacheStats();
 
         final String json = """
             {
@@ -604,7 +604,7 @@ public class RoleDescriptorTests extends ESTestCase {
         RoleDescriptor.parserBuilder().build().parse("test", new BytesArray(json), XContentType.JSON);
 
         final int numberOfFieldSecurityBlocks = 2;
-        final Cache.CacheStats betweenStats = fieldPermissionsCache.getCacheStats();
+        final Cache.Stats betweenStats = fieldPermissionsCache.getCacheStats();
         assertThat(betweenStats.getMisses(), equalTo(beforeStats.getMisses() + numberOfFieldSecurityBlocks));
         assertThat(betweenStats.getHits(), equalTo(beforeStats.getHits()));
 
@@ -613,7 +613,7 @@ public class RoleDescriptorTests extends ESTestCase {
             RoleDescriptor.parserBuilder().build().parse("test", new BytesArray(json), XContentType.JSON);
         }
 
-        final Cache.CacheStats afterStats = fieldPermissionsCache.getCacheStats();
+        final Cache.Stats afterStats = fieldPermissionsCache.getCacheStats();
         assertThat(afterStats.getMisses(), equalTo(betweenStats.getMisses()));
         assertThat(afterStats.getHits(), equalTo(beforeStats.getHits() + numberOfFieldSecurityBlocks * iterations));
     }

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichCache.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichCache.java
@@ -137,7 +137,7 @@ public final class EnrichCache {
     }
 
     public EnrichStatsAction.Response.CacheStats getStats(String localNodeId) {
-        Cache.CacheStats cacheStats = cache.stats();
+        Cache.Stats cacheStats = cache.stats();
         return new EnrichStatsAction.Response.CacheStats(
             localNodeId,
             cache.count(),


### PR DESCRIPTION
Refactoring Cache.CacheStats to Cache.Stats

pulled out of https://github.com/elastic/elasticsearch/pull/130964