### PR TITLE
[8.18] Split PolicyChecker from PolicyManager (#128004)

### DIFF
--- a/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementChecker.java
+++ b/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementChecker.java
@@ -88,6 +88,9 @@ import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 
+/**
+ * Contains one "check" method for each distinct JDK method we want to instrument.
+ */
 @SuppressWarnings("unused") // Called from instrumentation code inserted by the Entitlements agent
 public interface EntitlementChecker {
 

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/PathActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/PathActions.java
@@ -10,7 +10,7 @@
 package org.elasticsearch.entitlement.qa.test;
 
 import org.elasticsearch.entitlement.qa.entitled.EntitledActions;
-import org.elasticsearch.entitlement.runtime.policy.PolicyManager;
+import org.elasticsearch.entitlement.runtime.policy.PolicyChecker;
 
 import java.io.IOException;
 import java.nio.file.FileSystems;
@@ -19,6 +19,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.WatchEvent;
 import java.util.Arrays;
+import java.util.Objects;
 
 import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAccess.ALWAYS_DENIED;
 import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAccess.PLUGINS;
@@ -37,7 +38,8 @@ class PathActions {
         try {
             EntitledActions.pathToRealPath(invalidLink); // throws NoSuchFileException when checking entitlements due to invalid target
         } catch (NoSuchFileException e) {
-            assert Arrays.stream(e.getStackTrace()).anyMatch(t -> t.getClassName().equals(PolicyManager.class.getName()))
+            assert Arrays.stream(e.getStackTrace())
+                .anyMatch(t -> Objects.equals(t.getModuleName(), PolicyChecker.class.getModule().getName()))
                 : "Expected NoSuchFileException to be thrown by entitlements check";
             throw e;
         }

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/initialization/EntitlementInitialization.java
@@ -15,6 +15,8 @@ import org.elasticsearch.entitlement.bridge.EntitlementChecker;
 import org.elasticsearch.entitlement.runtime.api.ElasticsearchEntitlementChecker;
 import org.elasticsearch.entitlement.runtime.policy.PathLookup;
 import org.elasticsearch.entitlement.runtime.policy.Policy;
+import org.elasticsearch.entitlement.runtime.policy.PolicyChecker;
+import org.elasticsearch.entitlement.runtime.policy.PolicyCheckerImpl;
 import org.elasticsearch.entitlement.runtime.policy.PolicyManager;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -93,25 +95,6 @@ public class EntitlementInitialization {
         }
     }
 
-    private static PolicyManager createPolicyManager() {
-        EntitlementBootstrap.BootstrapArgs bootstrapArgs = EntitlementBootstrap.bootstrapArgs();
-        Map<String, Policy> pluginPolicies = bootstrapArgs.pluginPolicies();
-        PathLookup pathLookup = bootstrapArgs.pathLookup();
-
-        FilesEntitlementsValidation.validate(pluginPolicies, pathLookup);
-
-        return new PolicyManager(
-            HardcodedEntitlements.serverPolicy(pathLookup.pidFile(), bootstrapArgs.serverPolicyPatch()),
-            HardcodedEntitlements.agentEntitlements(),
-            pluginPolicies,
-            EntitlementBootstrap.bootstrapArgs().scopeResolver(),
-            EntitlementBootstrap.bootstrapArgs().sourcePaths(),
-            ENTITLEMENTS_MODULE,
-            pathLookup,
-            bootstrapArgs.suppressFailureLogPackages()
-        );
-    }
-
     /**
      * If bytecode verification is enabled, ensure these classes get loaded before transforming/retransforming them.
      * For these classes, the order in which we transform and verify them matters. Verification during class transformation is at least an
@@ -166,20 +149,44 @@ public class EntitlementInitialization {
     }
 
     private static ElasticsearchEntitlementChecker initChecker() {
-        final PolicyManager policyManager = createPolicyManager();
+        final PolicyChecker policyChecker = createPolicyChecker();
 
         final Class<?> clazz = getVersionSpecificCheckerClass(ElasticsearchEntitlementChecker.class, Runtime.version().feature());
 
         Constructor<?> constructor;
         try {
-            constructor = clazz.getConstructor(PolicyManager.class);
+            constructor = clazz.getConstructor(PolicyChecker.class);
         } catch (NoSuchMethodException e) {
-            throw new AssertionError("entitlement impl is missing no arg constructor", e);
+            throw new AssertionError("entitlement impl is missing required constructor: [" + clazz.getName() + "]", e);
         }
         try {
-            return (ElasticsearchEntitlementChecker) constructor.newInstance(policyManager);
+            return (ElasticsearchEntitlementChecker) constructor.newInstance(policyChecker);
         } catch (IllegalAccessException | InvocationTargetException | InstantiationException e) {
             throw new AssertionError(e);
         }
     }
+
+    private static PolicyCheckerImpl createPolicyChecker() {
+        EntitlementBootstrap.BootstrapArgs bootstrapArgs = EntitlementBootstrap.bootstrapArgs();
+        Map<String, Policy> pluginPolicies = bootstrapArgs.pluginPolicies();
+        PathLookup pathLookup = bootstrapArgs.pathLookup();
+
+        FilesEntitlementsValidation.validate(pluginPolicies, pathLookup);
+
+        PolicyManager policyManager = new PolicyManager(
+            HardcodedEntitlements.serverPolicy(pathLookup.pidFile(), bootstrapArgs.serverPolicyPatch()),
+            HardcodedEntitlements.agentEntitlements(),
+            pluginPolicies,
+            EntitlementBootstrap.bootstrapArgs().scopeResolver(),
+            EntitlementBootstrap.bootstrapArgs().sourcePaths(),
+            pathLookup
+        );
+        return new PolicyCheckerImpl(
+            bootstrapArgs.suppressFailureLogPackages(),
+            ENTITLEMENTS_MODULE,
+            policyManager,
+            bootstrapArgs.pathLookup()
+        );
+    }
+
 }

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/package-info.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/package-info.java
@@ -192,8 +192,8 @@
  * implementation (normally on {@link org.elasticsearch.entitlement.runtime.api.ElasticsearchEntitlementChecker}, unless it is a
  * version-specific method) calls the appropriate methods on {@link org.elasticsearch.entitlement.runtime.policy.PolicyManager},
  * forwarding the caller class and a specific set of arguments. These methods all start with check, roughly matching an entitlement type
- * (e.g. {@link org.elasticsearch.entitlement.runtime.policy.PolicyManager#checkInboundNetworkAccess},
- * {@link org.elasticsearch.entitlement.runtime.policy.PolicyManager#checkFileRead}).
+ * (e.g. {@link org.elasticsearch.entitlement.runtime.policy.PolicyChecker#checkInboundNetworkAccess},
+ * {@link org.elasticsearch.entitlement.runtime.policy.PolicyChecker#checkFileRead}).
  * </p>
  * <p>
  * Most of the entitlements are "flag" entitlements: when present, it grants the caller the right to perform an action (or a set of

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
@@ -106,7 +106,7 @@ import javax.net.ssl.SSLSocketFactory;
 @SuppressForbidden(reason = "Explicitly checking APIs that are forbidden")
 public class ElasticsearchEntitlementChecker implements EntitlementChecker {
 
-    private final PolicyChecker policyChecker;
+    final PolicyChecker policyChecker;
 
     public ElasticsearchEntitlementChecker(PolicyChecker policyChecker) {
         this.policyChecker = policyChecker;

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
@@ -13,7 +13,7 @@ import jdk.nio.Channels;
 
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.entitlement.bridge.EntitlementChecker;
-import org.elasticsearch.entitlement.runtime.policy.PolicyManager;
+import org.elasticsearch.entitlement.runtime.policy.PolicyChecker;
 
 import java.io.File;
 import java.io.FileDescriptor;
@@ -28,11 +28,9 @@ import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.DatagramSocketImplFactory;
 import java.net.FileNameMap;
-import java.net.HttpURLConnection;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.JarURLConnection;
-import java.net.MalformedURLException;
 import java.net.MulticastSocket;
 import java.net.NetworkInterface;
 import java.net.Proxy;
@@ -43,9 +41,7 @@ import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.SocketImplFactory;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
-import java.net.URLConnection;
 import java.net.URLStreamHandler;
 import java.net.URLStreamHandlerFactory;
 import java.net.http.HttpClient;
@@ -70,7 +66,6 @@ import java.nio.file.LinkOption;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.WatchEvent;
 import java.nio.file.WatchService;
@@ -102,17 +97,19 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 
 /**
- * Implementation of the {@link EntitlementChecker} interface, providing additional
- * API methods for managing the checks.
- * The trampoline module loads this object via SPI.
+ * Implementation of the {@link EntitlementChecker} interface
+ * with each method implemented as a one-liner call into {@link PolicyChecker}.
+ * In effect, for each instrumented, this indicates the kind of check to perform;
+ * the actual checking logic is in {@link PolicyChecker}.
+ * The bridge module loads this object via SPI.
  */
 @SuppressForbidden(reason = "Explicitly checking APIs that are forbidden")
 public class ElasticsearchEntitlementChecker implements EntitlementChecker {
 
-    protected final PolicyManager policyManager;
+    private final PolicyChecker policyChecker;
 
-    public ElasticsearchEntitlementChecker(PolicyManager policyManager) {
-        this.policyManager = policyManager;
+    public ElasticsearchEntitlementChecker(PolicyChecker policyChecker) {
+        this.policyChecker = policyChecker;
     }
 
     /// /////////////////
@@ -122,17 +119,17 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
 
     @Override
     public void check$java_lang_Runtime$exit(Class<?> callerClass, Runtime runtime, int status) {
-        policyManager.checkExitVM(callerClass);
+        policyChecker.checkExitVM(callerClass);
     }
 
     @Override
     public void check$java_lang_Runtime$halt(Class<?> callerClass, Runtime runtime, int status) {
-        policyManager.checkExitVM(callerClass);
+        policyChecker.checkExitVM(callerClass);
     }
 
     @Override
     public void check$java_lang_System$$exit(Class<?> callerClass, int status) {
-        policyManager.checkExitVM(callerClass);
+        policyChecker.checkExitVM(callerClass);
     }
 
     /// /////////////////
@@ -142,37 +139,37 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
 
     @Override
     public void check$java_lang_ClassLoader$(Class<?> callerClass) {
-        policyManager.checkCreateClassLoader(callerClass);
+        policyChecker.checkCreateClassLoader(callerClass);
     }
 
     @Override
     public void check$java_lang_ClassLoader$(Class<?> callerClass, ClassLoader parent) {
-        policyManager.checkCreateClassLoader(callerClass);
+        policyChecker.checkCreateClassLoader(callerClass);
     }
 
     @Override
     public void check$java_lang_ClassLoader$(Class<?> callerClass, String name, ClassLoader parent) {
-        policyManager.checkCreateClassLoader(callerClass);
+        policyChecker.checkCreateClassLoader(callerClass);
     }
 
     @Override
     public void check$java_net_URLClassLoader$(Class<?> callerClass, URL[] urls) {
-        policyManager.checkCreateClassLoader(callerClass);
+        policyChecker.checkCreateClassLoader(callerClass);
     }
 
     @Override
     public void check$java_net_URLClassLoader$(Class<?> callerClass, URL[] urls, ClassLoader parent) {
-        policyManager.checkCreateClassLoader(callerClass);
+        policyChecker.checkCreateClassLoader(callerClass);
     }
 
     @Override
     public void check$java_net_URLClassLoader$(Class<?> callerClass, URL[] urls, ClassLoader parent, URLStreamHandlerFactory factory) {
-        policyManager.checkCreateClassLoader(callerClass);
+        policyChecker.checkCreateClassLoader(callerClass);
     }
 
     @Override
     public void check$java_net_URLClassLoader$(Class<?> callerClass, String name, URL[] urls, ClassLoader parent) {
-        policyManager.checkCreateClassLoader(callerClass);
+        policyChecker.checkCreateClassLoader(callerClass);
     }
 
     @Override
@@ -183,22 +180,22 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         ClassLoader parent,
         URLStreamHandlerFactory factory
     ) {
-        policyManager.checkCreateClassLoader(callerClass);
+        policyChecker.checkCreateClassLoader(callerClass);
     }
 
     @Override
     public void check$java_security_SecureClassLoader$(Class<?> callerClass) {
-        policyManager.checkCreateClassLoader(callerClass);
+        policyChecker.checkCreateClassLoader(callerClass);
     }
 
     @Override
     public void check$java_security_SecureClassLoader$(Class<?> callerClass, ClassLoader parent) {
-        policyManager.checkCreateClassLoader(callerClass);
+        policyChecker.checkCreateClassLoader(callerClass);
     }
 
     @Override
     public void check$java_security_SecureClassLoader$(Class<?> callerClass, String name, ClassLoader parent) {
-        policyManager.checkCreateClassLoader(callerClass);
+        policyChecker.checkCreateClassLoader(callerClass);
     }
 
     /// /////////////////
@@ -212,22 +209,22 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         HttpsURLConnection connection,
         SSLSocketFactory sf
     ) {
-        policyManager.checkSetHttpsConnectionProperties(callerClass);
+        policyChecker.checkSetHttpsConnectionProperties(callerClass);
     }
 
     @Override
     public void check$javax_net_ssl_HttpsURLConnection$$setDefaultSSLSocketFactory(Class<?> callerClass, SSLSocketFactory sf) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$javax_net_ssl_HttpsURLConnection$$setDefaultHostnameVerifier(Class<?> callerClass, HostnameVerifier hv) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$javax_net_ssl_SSLContext$$setDefault(Class<?> callerClass, SSLContext context) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     /// /////////////////
@@ -237,12 +234,12 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
 
     @Override
     public void check$java_lang_ProcessBuilder$start(Class<?> callerClass, ProcessBuilder processBuilder) {
-        policyManager.checkStartProcess(callerClass);
+        policyChecker.checkStartProcess(callerClass);
     }
 
     @Override
     public void check$java_lang_ProcessBuilder$$startPipeline(Class<?> callerClass, List<ProcessBuilder> builders) {
-        policyManager.checkStartProcess(callerClass);
+        policyChecker.checkStartProcess(callerClass);
     }
 
     /// /////////////////
@@ -252,17 +249,17 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
 
     @Override
     public void check$java_lang_System$$clearProperty(Class<?> callerClass, String key) {
-        policyManager.checkWriteProperty(callerClass, key);
+        policyChecker.checkWriteProperty(callerClass, key);
     }
 
     @Override
     public void check$java_lang_System$$setProperties(Class<?> callerClass, Properties props) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$java_lang_System$$setProperty(Class<?> callerClass, String key, String value) {
-        policyManager.checkWriteProperty(callerClass, key);
+        policyChecker.checkWriteProperty(callerClass, key);
     }
 
     /// /////////////////
@@ -272,182 +269,182 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
 
     @Override
     public void check$java_lang_System$$setIn(Class<?> callerClass, InputStream in) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$java_lang_System$$setOut(Class<?> callerClass, PrintStream out) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$java_lang_System$$setErr(Class<?> callerClass, PrintStream err) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$java_lang_Runtime$addShutdownHook(Class<?> callerClass, Runtime runtime, Thread hook) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$java_lang_Runtime$removeShutdownHook(Class<?> callerClass, Runtime runtime, Thread hook) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$jdk_tools_jlink_internal_Jlink$(Class<?> callerClass) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$jdk_tools_jlink_internal_Main$$run(Class<?> callerClass, PrintWriter out, PrintWriter err, String... args) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$jdk_vm_ci_services_JVMCIServiceLocator$$getProviders(Class<?> callerClass, Class<?> service) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$jdk_vm_ci_services_Services$$load(Class<?> callerClass, Class<?> service) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$jdk_vm_ci_services_Services$$loadSingle(Class<?> callerClass, Class<?> service, boolean required) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$java_nio_charset_spi_CharsetProvider$(Class<?> callerClass) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$com_sun_tools_jdi_VirtualMachineManagerImpl$$virtualMachineManager(Class<?> callerClass) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$java_lang_Thread$$setDefaultUncaughtExceptionHandler(Class<?> callerClass, Thread.UncaughtExceptionHandler ueh) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$java_util_spi_LocaleServiceProvider$(Class<?> callerClass) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$java_text_spi_BreakIteratorProvider$(Class<?> callerClass) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$java_text_spi_CollatorProvider$(Class<?> callerClass) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$java_text_spi_DateFormatProvider$(Class<?> callerClass) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$java_text_spi_DateFormatSymbolsProvider$(Class<?> callerClass) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$java_text_spi_DecimalFormatSymbolsProvider$(Class<?> callerClass) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$java_text_spi_NumberFormatProvider$(Class<?> callerClass) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$java_util_spi_CalendarDataProvider$(Class<?> callerClass) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$java_util_spi_CalendarNameProvider$(Class<?> callerClass) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$java_util_spi_CurrencyNameProvider$(Class<?> callerClass) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$java_util_spi_LocaleNameProvider$(Class<?> callerClass) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$java_util_spi_TimeZoneNameProvider$(Class<?> callerClass) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$java_util_logging_LogManager$(Class<?> callerClass) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$java_util_Locale$$setDefault(Class<?> callerClass, Locale.Category category, Locale locale) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$java_util_Locale$$setDefault(Class<?> callerClass, Locale locale) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$java_util_TimeZone$$setDefault(Class<?> callerClass, TimeZone zone) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$java_net_DatagramSocket$$setDatagramSocketImplFactory(Class<?> callerClass, DatagramSocketImplFactory fac) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$java_net_HttpURLConnection$$setFollowRedirects(Class<?> callerClass, boolean set) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$java_net_ServerSocket$$setSocketFactory(Class<?> callerClass, SocketImplFactory fac) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$java_net_Socket$$setSocketImplFactory(Class<?> callerClass, SocketImplFactory fac) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$java_net_URL$$setURLStreamHandlerFactory(Class<?> callerClass, URLStreamHandlerFactory fac) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$java_net_URLConnection$$setFileNameMap(Class<?> callerClass, FileNameMap map) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$java_net_URLConnection$$setContentHandlerFactory(Class<?> callerClass, ContentHandlerFactory fac) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     /// /////////////////
@@ -457,341 +454,246 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
 
     @Override
     public void check$java_net_ProxySelector$$setDefault(Class<?> callerClass, ProxySelector ps) {
-        policyManager.checkChangeNetworkHandling(callerClass);
+        policyChecker.checkChangeNetworkHandling(callerClass);
     }
 
     @Override
     public void check$java_net_ResponseCache$$setDefault(Class<?> callerClass, ResponseCache rc) {
-        policyManager.checkChangeNetworkHandling(callerClass);
+        policyChecker.checkChangeNetworkHandling(callerClass);
     }
 
     @Override
     public void check$java_net_spi_InetAddressResolverProvider$(Class<?> callerClass) {
-        policyManager.checkChangeNetworkHandling(callerClass);
+        policyChecker.checkChangeNetworkHandling(callerClass);
     }
 
     @Override
     public void check$java_net_spi_URLStreamHandlerProvider$(Class<?> callerClass) {
-        policyManager.checkChangeNetworkHandling(callerClass);
+        policyChecker.checkChangeNetworkHandling(callerClass);
     }
 
     @Override
     public void check$java_net_URL$(Class<?> callerClass, String protocol, String host, int port, String file, URLStreamHandler handler) {
-        policyManager.checkChangeNetworkHandling(callerClass);
+        policyChecker.checkChangeNetworkHandling(callerClass);
     }
 
     @Override
     public void check$java_net_URL$(Class<?> callerClass, URL context, String spec, URLStreamHandler handler) {
-        policyManager.checkChangeNetworkHandling(callerClass);
+        policyChecker.checkChangeNetworkHandling(callerClass);
     }
 
     @Override
     public void check$java_net_DatagramSocket$bind(Class<?> callerClass, DatagramSocket that, SocketAddress addr) {
-        policyManager.checkInboundNetworkAccess(callerClass);
+        policyChecker.checkInboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$java_net_DatagramSocket$connect(Class<?> callerClass, DatagramSocket that, InetAddress addr) {
-        policyManager.checkAllNetworkAccess(callerClass);
+        policyChecker.checkAllNetworkAccess(callerClass);
     }
 
     @Override
     public void check$java_net_DatagramSocket$connect(Class<?> callerClass, DatagramSocket that, SocketAddress addr) {
-        policyManager.checkAllNetworkAccess(callerClass);
+        policyChecker.checkAllNetworkAccess(callerClass);
     }
 
     @Override
     public void check$java_net_DatagramSocket$send(Class<?> callerClass, DatagramSocket that, DatagramPacket p) {
         if (p.getAddress().isMulticastAddress()) {
-            policyManager.checkAllNetworkAccess(callerClass);
+            policyChecker.checkAllNetworkAccess(callerClass);
         } else {
-            policyManager.checkOutboundNetworkAccess(callerClass);
+            policyChecker.checkOutboundNetworkAccess(callerClass);
         }
     }
 
     @Override
     public void check$java_net_DatagramSocket$receive(Class<?> callerClass, DatagramSocket that, DatagramPacket p) {
-        policyManager.checkInboundNetworkAccess(callerClass);
+        policyChecker.checkInboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$java_net_DatagramSocket$joinGroup(Class<?> caller, DatagramSocket that, SocketAddress addr, NetworkInterface ni) {
-        policyManager.checkAllNetworkAccess(caller);
+        policyChecker.checkAllNetworkAccess(caller);
     }
 
     @Override
     public void check$java_net_DatagramSocket$leaveGroup(Class<?> caller, DatagramSocket that, SocketAddress addr, NetworkInterface ni) {
-        policyManager.checkAllNetworkAccess(caller);
+        policyChecker.checkAllNetworkAccess(caller);
     }
 
     @Override
     public void check$java_net_MulticastSocket$joinGroup(Class<?> caller, MulticastSocket that, InetAddress addr) {
-        policyManager.checkAllNetworkAccess(caller);
+        policyChecker.checkAllNetworkAccess(caller);
     }
 
     @Override
     public void check$java_net_MulticastSocket$joinGroup(Class<?> caller, MulticastSocket that, SocketAddress addr, NetworkInterface ni) {
-        policyManager.checkAllNetworkAccess(caller);
+        policyChecker.checkAllNetworkAccess(caller);
     }
 
     @Override
     public void check$java_net_MulticastSocket$leaveGroup(Class<?> caller, MulticastSocket that, InetAddress addr) {
-        policyManager.checkAllNetworkAccess(caller);
+        policyChecker.checkAllNetworkAccess(caller);
     }
 
     @Override
     public void check$java_net_MulticastSocket$leaveGroup(Class<?> caller, MulticastSocket that, SocketAddress addr, NetworkInterface ni) {
-        policyManager.checkAllNetworkAccess(caller);
+        policyChecker.checkAllNetworkAccess(caller);
     }
 
     @Override
     public void check$java_net_MulticastSocket$send(Class<?> callerClass, MulticastSocket that, DatagramPacket p, byte ttl) {
-        policyManager.checkAllNetworkAccess(callerClass);
+        policyChecker.checkAllNetworkAccess(callerClass);
     }
 
     @Override
     public void check$java_net_ServerSocket$(Class<?> callerClass, int port) {
-        policyManager.checkInboundNetworkAccess(callerClass);
+        policyChecker.checkInboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$java_net_ServerSocket$(Class<?> callerClass, int port, int backlog) {
-        policyManager.checkInboundNetworkAccess(callerClass);
+        policyChecker.checkInboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$java_net_ServerSocket$(Class<?> callerClass, int port, int backlog, InetAddress bindAddr) {
-        policyManager.checkInboundNetworkAccess(callerClass);
+        policyChecker.checkInboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$java_net_ServerSocket$accept(Class<?> callerClass, ServerSocket that) {
-        policyManager.checkInboundNetworkAccess(callerClass);
+        policyChecker.checkInboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$java_net_ServerSocket$implAccept(Class<?> callerClass, ServerSocket that, Socket s) {
-        policyManager.checkInboundNetworkAccess(callerClass);
+        policyChecker.checkInboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$java_net_ServerSocket$bind(Class<?> callerClass, ServerSocket that, SocketAddress endpoint) {
-        policyManager.checkInboundNetworkAccess(callerClass);
+        policyChecker.checkInboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$java_net_ServerSocket$bind(Class<?> callerClass, ServerSocket that, SocketAddress endpoint, int backlog) {
-        policyManager.checkInboundNetworkAccess(callerClass);
+        policyChecker.checkInboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$java_net_Socket$(Class<?> callerClass, Proxy proxy) {
         if (proxy.type() == Proxy.Type.SOCKS || proxy.type() == Proxy.Type.HTTP) {
-            policyManager.checkOutboundNetworkAccess(callerClass);
+            policyChecker.checkOutboundNetworkAccess(callerClass);
         }
     }
 
     @Override
     public void check$java_net_Socket$(Class<?> callerClass, String host, int port) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$java_net_Socket$(Class<?> callerClass, InetAddress address, int port) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$java_net_Socket$(Class<?> callerClass, String host, int port, InetAddress localAddr, int localPort) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$java_net_Socket$(Class<?> callerClass, InetAddress address, int port, InetAddress localAddr, int localPort) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$java_net_Socket$(Class<?> callerClass, String host, int port, boolean stream) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$java_net_Socket$(Class<?> callerClass, InetAddress host, int port, boolean stream) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$java_net_Socket$bind(Class<?> callerClass, Socket that, SocketAddress endpoint) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$java_net_Socket$connect(Class<?> callerClass, Socket that, SocketAddress endpoint) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$java_net_Socket$connect(Class<?> callerClass, Socket that, SocketAddress endpoint, int backlog) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
-    }
-
-    @SuppressWarnings("deprecation")
-    private URL extractJarFileUrl(URL jarUrl) {
-        String spec = jarUrl.getFile();
-        int separator = spec.indexOf("!/");
-
-        // URL does not handle nested JAR URLs (it would be a MalformedURLException upon connection)
-        if (separator == -1) {
-            return null;
-        }
-
-        try {
-            return new URL(spec.substring(0, separator));
-        } catch (MalformedURLException e) {
-            return null;
-        }
-    }
-
-    private boolean handleNetworkOrFileUrlCheck(Class<?> callerClass, URL url) {
-        if (isNetworkUrl(url)) {
-            policyManager.checkOutboundNetworkAccess(callerClass);
-            return true;
-        }
-        if (isFileUrl(url)) {
-            checkURLFileRead(callerClass, url);
-            return true;
-        }
-        return false;
-    }
-
-    private void checkJarURLAccess(Class<?> callerClass, JarURLConnection that) {
-        var jarFileUrl = that.getJarFileURL();
-        if (handleNetworkOrFileUrlCheck(callerClass, jarFileUrl)) {
-            return;
-        }
-        policyManager.checkUnsupportedURLProtocolConnection(callerClass, jarFileUrl.getProtocol());
-    }
-
-    private void checkEntitlementForUrl(Class<?> callerClass, URL that) {
-        if (handleNetworkOrFileUrlCheck(callerClass, that)) {
-            return;
-        }
-        if (isJarUrl(that)) {
-            var jarFileUrl = extractJarFileUrl(that);
-            if (jarFileUrl == null || handleNetworkOrFileUrlCheck(callerClass, jarFileUrl) == false) {
-                policyManager.checkUnsupportedURLProtocolConnection(callerClass, "jar with unsupported inner protocol");
-            }
-        } else {
-            policyManager.checkUnsupportedURLProtocolConnection(callerClass, that.getProtocol());
-        }
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$java_net_URL$openConnection(Class<?> callerClass, java.net.URL that) {
-        checkEntitlementForUrl(callerClass, that);
+        policyChecker.checkEntitlementForUrl(callerClass, that);
     }
 
     @Override
     public void check$java_net_URL$openConnection(Class<?> callerClass, URL that, Proxy proxy) {
         if (proxy.type() != Proxy.Type.DIRECT) {
-            policyManager.checkOutboundNetworkAccess(callerClass);
+            policyChecker.checkOutboundNetworkAccess(callerClass);
         }
-        checkEntitlementForUrl(callerClass, that);
+        policyChecker.checkEntitlementForUrl(callerClass, that);
     }
 
     @Override
     public void check$java_net_URL$openStream(Class<?> callerClass, java.net.URL that) {
-        checkEntitlementForUrl(callerClass, that);
+        policyChecker.checkEntitlementForUrl(callerClass, that);
     }
 
     @Override
     public void check$java_net_URL$getContent(Class<?> callerClass, java.net.URL that) {
-        checkEntitlementForUrl(callerClass, that);
+        policyChecker.checkEntitlementForUrl(callerClass, that);
     }
 
     @Override
     public void check$java_net_URL$getContent(Class<?> callerClass, java.net.URL that, Class<?>[] classes) {
-        checkEntitlementForUrl(callerClass, that);
-    }
-
-    private static final Set<String> NETWORK_PROTOCOLS = Set.of("http", "https", "ftp", "mailto");
-
-    private static boolean isNetworkUrl(java.net.URL url) {
-        return NETWORK_PROTOCOLS.contains(url.getProtocol());
-    }
-
-    private static boolean isFileUrl(java.net.URL url) {
-        return "file".equals(url.getProtocol());
-    }
-
-    private static boolean isJarUrl(java.net.URL url) {
-        return "jar".equals(url.getProtocol());
-    }
-
-    // We have to use class names for sun.net.www classes as java.base does not export them
-    private static final List<String> ADDITIONAL_NETWORK_URL_CONNECT_CLASS_NAMES = List.of(
-        "sun.net.www.protocol.ftp.FtpURLConnection",
-        "sun.net.www.protocol.mailto.MailToURLConnection"
-    );
-
-    private static boolean isNetworkUrlConnection(java.net.URLConnection urlConnection) {
-        var connectionClass = urlConnection.getClass();
-        return HttpURLConnection.class.isAssignableFrom(connectionClass)
-            || ADDITIONAL_NETWORK_URL_CONNECT_CLASS_NAMES.contains(connectionClass.getName());
-    }
-
-    // We have to use class names for sun.net.www classes as java.base does not export them
-    private static boolean isFileUrlConnection(java.net.URLConnection urlConnection) {
-        var connectionClass = urlConnection.getClass();
-        return "sun.net.www.protocol.file.FileURLConnection".equals(connectionClass.getName());
-    }
-
-    private void checkEntitlementForURLConnection(Class<?> callerClass, URLConnection that) {
-        if (isNetworkUrlConnection(that)) {
-            policyManager.checkOutboundNetworkAccess(callerClass);
-        } else if (isFileUrlConnection(that)) {
-            checkURLFileRead(callerClass, that.getURL());
-        } else if (that instanceof JarURLConnection jarURLConnection) {
-            checkJarURLAccess(callerClass, jarURLConnection);
-        } else {
-            policyManager.checkUnsupportedURLProtocolConnection(callerClass, that.getURL().getProtocol());
-        }
+        policyChecker.checkEntitlementForUrl(callerClass, that);
     }
 
     @Override
     public void check$java_net_URLConnection$getContentLength(Class<?> callerClass, java.net.URLConnection that) {
-        checkEntitlementForURLConnection(callerClass, that);
+        policyChecker.checkEntitlementForURLConnection(callerClass, that);
     }
 
     @Override
     public void check$java_net_URLConnection$getContentLengthLong(Class<?> callerClass, java.net.URLConnection that) {
-        checkEntitlementForURLConnection(callerClass, that);
+        policyChecker.checkEntitlementForURLConnection(callerClass, that);
     }
 
     @Override
     public void check$java_net_URLConnection$getContentType(Class<?> callerClass, java.net.URLConnection that) {
-        checkEntitlementForURLConnection(callerClass, that);
+        policyChecker.checkEntitlementForURLConnection(callerClass, that);
     }
 
     @Override
     public void check$java_net_URLConnection$getContentEncoding(Class<?> callerClass, java.net.URLConnection that) {
-        checkEntitlementForURLConnection(callerClass, that);
+        policyChecker.checkEntitlementForURLConnection(callerClass, that);
     }
 
     @Override
     public void check$java_net_URLConnection$getExpiration(Class<?> callerClass, java.net.URLConnection that) {
-        checkEntitlementForURLConnection(callerClass, that);
+        policyChecker.checkEntitlementForURLConnection(callerClass, that);
     }
 
     @Override
     public void check$java_net_URLConnection$getDate(Class<?> callerClass, java.net.URLConnection that) {
-        checkEntitlementForURLConnection(callerClass, that);
+        policyChecker.checkEntitlementForURLConnection(callerClass, that);
     }
 
     @Override
     public void check$java_net_URLConnection$getLastModified(Class<?> callerClass, java.net.URLConnection that) {
-        checkEntitlementForURLConnection(callerClass, that);
+        policyChecker.checkEntitlementForURLConnection(callerClass, that);
     }
 
     @Override
@@ -801,7 +703,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         String name,
         int defaultValue
     ) {
-        checkEntitlementForURLConnection(callerClass, that);
+        policyChecker.checkEntitlementForURLConnection(callerClass, that);
     }
 
     @Override
@@ -811,7 +713,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         String name,
         long defaultValue
     ) {
-        checkEntitlementForURLConnection(callerClass, that);
+        policyChecker.checkEntitlementForURLConnection(callerClass, that);
     }
 
     @Override
@@ -821,27 +723,27 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         String name,
         long defaultValue
     ) {
-        checkEntitlementForURLConnection(callerClass, that);
+        policyChecker.checkEntitlementForURLConnection(callerClass, that);
     }
 
     @Override
     public void check$java_net_URLConnection$getContent(Class<?> callerClass, java.net.URLConnection that) {
-        checkEntitlementForURLConnection(callerClass, that);
+        policyChecker.checkEntitlementForURLConnection(callerClass, that);
     }
 
     @Override
     public void check$java_net_URLConnection$getContent(Class<?> callerClass, java.net.URLConnection that, Class<?>[] classes) {
-        checkEntitlementForURLConnection(callerClass, that);
+        policyChecker.checkEntitlementForURLConnection(callerClass, that);
     }
 
     @Override
     public void check$java_net_HttpURLConnection$getResponseCode(Class<?> callerClass, java.net.HttpURLConnection that) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$java_net_HttpURLConnection$getResponseMessage(Class<?> callerClass, java.net.HttpURLConnection that) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -851,53 +753,53 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         String name,
         long defaultValue
     ) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     // Using java.net.URLConnection for "that" as sun.net.www.URLConnection is not exported
     @Override
     public void check$sun_net_www_URLConnection$getHeaderField(Class<?> callerClass, java.net.URLConnection that, String name) {
-        checkEntitlementForURLConnection(callerClass, that);
+        policyChecker.checkEntitlementForURLConnection(callerClass, that);
     }
 
     @Override
     public void check$sun_net_www_URLConnection$getHeaderFields(Class<?> callerClass, java.net.URLConnection that) {
-        checkEntitlementForURLConnection(callerClass, that);
+        policyChecker.checkEntitlementForURLConnection(callerClass, that);
     }
 
     @Override
     public void check$sun_net_www_URLConnection$getHeaderFieldKey(Class<?> callerClass, java.net.URLConnection that, int n) {
-        checkEntitlementForURLConnection(callerClass, that);
+        policyChecker.checkEntitlementForURLConnection(callerClass, that);
     }
 
     @Override
     public void check$sun_net_www_URLConnection$getHeaderField(Class<?> callerClass, java.net.URLConnection that, int n) {
-        checkEntitlementForURLConnection(callerClass, that);
+        policyChecker.checkEntitlementForURLConnection(callerClass, that);
     }
 
     @Override
     public void check$sun_net_www_URLConnection$getContentType(Class<?> callerClass, java.net.URLConnection that) {
-        checkEntitlementForURLConnection(callerClass, that);
+        policyChecker.checkEntitlementForURLConnection(callerClass, that);
     }
 
     @Override
     public void check$sun_net_www_URLConnection$getContentLength(Class<?> callerClass, java.net.URLConnection that) {
-        checkEntitlementForURLConnection(callerClass, that);
+        policyChecker.checkEntitlementForURLConnection(callerClass, that);
     }
 
     @Override
     public void check$sun_net_www_protocol_ftp_FtpURLConnection$connect(Class<?> callerClass, java.net.URLConnection that) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$sun_net_www_protocol_ftp_FtpURLConnection$getInputStream(Class<?> callerClass, java.net.URLConnection that) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$sun_net_www_protocol_ftp_FtpURLConnection$getOutputStream(Class<?> callerClass, java.net.URLConnection that) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -905,27 +807,27 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         Class<?> callerClass,
         java.net.URLConnection c
     ) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$sun_net_www_protocol_http_HttpURLConnection$connect(Class<?> callerClass, java.net.HttpURLConnection that) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$sun_net_www_protocol_http_HttpURLConnection$getOutputStream(Class<?> callerClass, java.net.HttpURLConnection that) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$sun_net_www_protocol_http_HttpURLConnection$getInputStream(Class<?> callerClass, java.net.HttpURLConnection that) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$sun_net_www_protocol_http_HttpURLConnection$getErrorStream(Class<?> callerClass, java.net.HttpURLConnection that) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -934,12 +836,12 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         java.net.HttpURLConnection that,
         String name
     ) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$sun_net_www_protocol_http_HttpURLConnection$getHeaderFields(Class<?> callerClass, java.net.HttpURLConnection that) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -948,7 +850,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         java.net.HttpURLConnection that,
         int n
     ) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -957,7 +859,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         java.net.HttpURLConnection that,
         int n
     ) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -965,7 +867,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         Class<?> callerClass,
         javax.net.ssl.HttpsURLConnection that
     ) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -973,7 +875,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         Class<?> callerClass,
         javax.net.ssl.HttpsURLConnection that
     ) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -981,7 +883,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         Class<?> callerClass,
         javax.net.ssl.HttpsURLConnection that
     ) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -989,7 +891,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         Class<?> callerClass,
         javax.net.ssl.HttpsURLConnection that
     ) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -998,7 +900,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         javax.net.ssl.HttpsURLConnection that,
         String name
     ) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -1006,7 +908,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         Class<?> callerClass,
         javax.net.ssl.HttpsURLConnection that
     ) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -1015,7 +917,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         javax.net.ssl.HttpsURLConnection that,
         int n
     ) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -1024,7 +926,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         javax.net.ssl.HttpsURLConnection that,
         int n
     ) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -1032,7 +934,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         Class<?> callerClass,
         javax.net.ssl.HttpsURLConnection that
     ) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -1040,7 +942,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         Class<?> callerClass,
         javax.net.ssl.HttpsURLConnection that
     ) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -1048,7 +950,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         Class<?> callerClass,
         javax.net.ssl.HttpsURLConnection that
     ) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -1056,7 +958,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         Class<?> callerClass,
         javax.net.ssl.HttpsURLConnection that
     ) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -1064,7 +966,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         Class<?> callerClass,
         javax.net.ssl.HttpsURLConnection that
     ) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -1072,7 +974,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         Class<?> callerClass,
         javax.net.ssl.HttpsURLConnection that
     ) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -1080,7 +982,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         Class<?> callerClass,
         javax.net.ssl.HttpsURLConnection that
     ) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -1088,7 +990,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         Class<?> callerClass,
         javax.net.ssl.HttpsURLConnection that
     ) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -1096,7 +998,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         Class<?> callerClass,
         javax.net.ssl.HttpsURLConnection that
     ) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -1106,7 +1008,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         String name,
         int defaultValue
     ) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -1116,7 +1018,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         String name,
         long defaultValue
     ) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -1126,7 +1028,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         String name,
         long defaultValue
     ) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -1134,7 +1036,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         Class<?> callerClass,
         javax.net.ssl.HttpsURLConnection that
     ) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -1143,7 +1045,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         javax.net.ssl.HttpsURLConnection that,
         Class<?>[] classes
     ) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -1151,17 +1053,17 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         Class<?> callerClass,
         java.net.HttpURLConnection that
     ) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$sun_net_www_protocol_mailto_MailToURLConnection$connect(Class<?> callerClass, java.net.URLConnection that) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$sun_net_www_protocol_mailto_MailToURLConnection$getOutputStream(Class<?> callerClass, java.net.URLConnection that) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -1171,7 +1073,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         HttpRequest request,
         HttpResponse.BodyHandler<?> responseBodyHandler
     ) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -1181,7 +1083,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         HttpRequest userRequest,
         HttpResponse.BodyHandler<?> responseHandler
     ) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -1192,7 +1094,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         HttpResponse.BodyHandler<?> responseHandler,
         HttpResponse.PushPromiseHandler<?> pushPromiseHandler
     ) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -1232,7 +1134,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         // (connect to an LDAP server). But LDAPCertStore is internal (created via SPI), so we instrument the general factory instead and
         // then do the check only for the path that leads to sensitive code (by looking at the `type` parameter).
         if ("LDAP".equals(type)) {
-            policyManager.checkOutboundNetworkAccess(callerClass);
+            policyChecker.checkOutboundNetworkAccess(callerClass);
         }
     }
 
@@ -1242,7 +1144,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         AsynchronousServerSocketChannel that,
         SocketAddress local
     ) {
-        policyManager.checkInboundNetworkAccess(callerClass);
+        policyChecker.checkInboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -1252,7 +1154,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         SocketAddress local,
         int backlog
     ) {
-        policyManager.checkInboundNetworkAccess(callerClass);
+        policyChecker.checkInboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -1261,17 +1163,17 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         AsynchronousSocketChannel that,
         SocketAddress local
     ) {
-        policyManager.checkInboundNetworkAccess(callerClass);
+        policyChecker.checkInboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$sun_nio_ch_DatagramChannelImpl$bind(Class<?> callerClass, DatagramChannel that, SocketAddress local) {
-        policyManager.checkInboundNetworkAccess(callerClass);
+        policyChecker.checkInboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$java_nio_channels_ServerSocketChannel$bind(Class<?> callerClass, ServerSocketChannel that, SocketAddress local) {
-        policyManager.checkInboundNetworkAccess(callerClass);
+        policyChecker.checkInboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -1281,17 +1183,17 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         SocketAddress local,
         int backlog
     ) {
-        policyManager.checkInboundNetworkAccess(callerClass);
+        policyChecker.checkInboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$sun_nio_ch_SocketChannelImpl$bind(Class<?> callerClass, SocketChannel that, SocketAddress local) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$sun_nio_ch_SocketChannelImpl$connect(Class<?> callerClass, SocketChannel that, SocketAddress remote) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -1300,7 +1202,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         AsynchronousSocketChannel that,
         SocketAddress remote
     ) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -1311,22 +1213,22 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         Object attachment,
         CompletionHandler<Void, Object> handler
     ) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$sun_nio_ch_DatagramChannelImpl$connect(Class<?> callerClass, DatagramChannel that, SocketAddress remote) {
-        policyManager.checkOutboundNetworkAccess(callerClass);
+        policyChecker.checkOutboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$sun_nio_ch_ServerSocketChannelImpl$accept(Class<?> callerClass, ServerSocketChannel that) {
-        policyManager.checkInboundNetworkAccess(callerClass);
+        policyChecker.checkInboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$sun_nio_ch_AsynchronousServerSocketChannelImpl$accept(Class<?> callerClass, AsynchronousServerSocketChannel that) {
-        policyManager.checkInboundNetworkAccess(callerClass);
+        policyChecker.checkInboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -1336,7 +1238,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         Object attachment,
         CompletionHandler<AsynchronousSocketChannel, Object> handler
     ) {
-        policyManager.checkInboundNetworkAccess(callerClass);
+        policyChecker.checkInboundNetworkAccess(callerClass);
     }
 
     @Override
@@ -1347,52 +1249,52 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         SocketAddress target
     ) {
         if (target instanceof InetSocketAddress isa && isa.getAddress().isMulticastAddress()) {
-            policyManager.checkAllNetworkAccess(callerClass);
+            policyChecker.checkAllNetworkAccess(callerClass);
         } else {
-            policyManager.checkOutboundNetworkAccess(callerClass);
+            policyChecker.checkOutboundNetworkAccess(callerClass);
         }
     }
 
     @Override
     public void check$sun_nio_ch_DatagramChannelImpl$receive(Class<?> callerClass, DatagramChannel that, ByteBuffer dst) {
-        policyManager.checkInboundNetworkAccess(callerClass);
+        policyChecker.checkInboundNetworkAccess(callerClass);
     }
 
     @Override
     public void check$java_nio_channels_spi_SelectorProvider$(Class<?> callerClass) {
-        policyManager.checkChangeNetworkHandling(callerClass);
+        policyChecker.checkChangeNetworkHandling(callerClass);
     }
 
     @Override
     public void check$java_nio_channels_spi_AsynchronousChannelProvider$(Class<?> callerClass) {
-        policyManager.checkChangeNetworkHandling(callerClass);
+        policyChecker.checkChangeNetworkHandling(callerClass);
     }
 
     @Override
     public void checkSelectorProviderInheritedChannel(Class<?> callerClass, SelectorProvider that) {
-        policyManager.checkChangeNetworkHandling(callerClass);
+        policyChecker.checkChangeNetworkHandling(callerClass);
     }
 
     @Override
     public void check$java_lang_Runtime$load(Class<?> callerClass, Runtime that, String filename) {
-        policyManager.checkFileRead(callerClass, Path.of(filename));
-        policyManager.checkLoadingNativeLibraries(callerClass);
+        policyChecker.checkFileRead(callerClass, Path.of(filename));
+        policyChecker.checkLoadingNativeLibraries(callerClass);
     }
 
     @Override
     public void check$java_lang_Runtime$loadLibrary(Class<?> callerClass, Runtime that, String libname) {
-        policyManager.checkLoadingNativeLibraries(callerClass);
+        policyChecker.checkLoadingNativeLibraries(callerClass);
     }
 
     @Override
     public void check$java_lang_System$$load(Class<?> callerClass, String filename) {
-        policyManager.checkFileRead(callerClass, Path.of(filename));
-        policyManager.checkLoadingNativeLibraries(callerClass);
+        policyChecker.checkFileRead(callerClass, Path.of(filename));
+        policyChecker.checkLoadingNativeLibraries(callerClass);
     }
 
     @Override
     public void check$java_lang_System$$loadLibrary(Class<?> callerClass, String libname) {
-        policyManager.checkLoadingNativeLibraries(callerClass);
+        policyChecker.checkLoadingNativeLibraries(callerClass);
     }
 
     @Override
@@ -1401,7 +1303,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         ModuleLayer.Controller that,
         Module target
     ) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     /// /////////////////
@@ -1413,286 +1315,286 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
 
     @Override
     public void check$java_io_File$canExecute(Class<?> callerClass, File file) {
-        policyManager.checkFileRead(callerClass, file);
+        policyChecker.checkFileRead(callerClass, file);
     }
 
     @Override
     public void check$java_io_File$canRead(Class<?> callerClass, File file) {
-        policyManager.checkFileRead(callerClass, file);
+        policyChecker.checkFileRead(callerClass, file);
     }
 
     @Override
     public void check$java_io_File$canWrite(Class<?> callerClass, File file) {
-        policyManager.checkFileRead(callerClass, file);
+        policyChecker.checkFileRead(callerClass, file);
     }
 
     @Override
     public void check$java_io_File$createNewFile(Class<?> callerClass, File file) {
-        policyManager.checkFileWrite(callerClass, file);
+        policyChecker.checkFileWrite(callerClass, file);
     }
 
     @Override
     public void check$java_io_File$$createTempFile(Class<?> callerClass, String prefix, String suffix, File directory) {
-        policyManager.checkFileWrite(callerClass, directory);
+        policyChecker.checkFileWrite(callerClass, directory);
     }
 
     @Override
     public void check$java_io_File$delete(Class<?> callerClass, File file) {
-        policyManager.checkFileWrite(callerClass, file);
+        policyChecker.checkFileWrite(callerClass, file);
     }
 
     @Override
     public void check$java_io_File$deleteOnExit(Class<?> callerClass, File file) {
-        policyManager.checkFileWrite(callerClass, file);
+        policyChecker.checkFileWrite(callerClass, file);
     }
 
     @Override
     public void check$java_io_File$exists(Class<?> callerClass, File file) {
-        policyManager.checkFileRead(callerClass, file);
+        policyChecker.checkFileRead(callerClass, file);
     }
 
     @Override
     public void check$java_io_File$isDirectory(Class<?> callerClass, File file) {
-        policyManager.checkFileRead(callerClass, file);
+        policyChecker.checkFileRead(callerClass, file);
     }
 
     @Override
     public void check$java_io_File$isFile(Class<?> callerClass, File file) {
-        policyManager.checkFileRead(callerClass, file);
+        policyChecker.checkFileRead(callerClass, file);
     }
 
     @Override
     public void check$java_io_File$isHidden(Class<?> callerClass, File file) {
-        policyManager.checkFileRead(callerClass, file);
+        policyChecker.checkFileRead(callerClass, file);
     }
 
     @Override
     public void check$java_io_File$lastModified(Class<?> callerClass, File file) {
-        policyManager.checkFileRead(callerClass, file);
+        policyChecker.checkFileRead(callerClass, file);
     }
 
     @Override
     public void check$java_io_File$length(Class<?> callerClass, File file) {
-        policyManager.checkFileRead(callerClass, file);
+        policyChecker.checkFileRead(callerClass, file);
     }
 
     @Override
     public void check$java_io_File$list(Class<?> callerClass, File file) {
-        policyManager.checkFileRead(callerClass, file);
+        policyChecker.checkFileRead(callerClass, file);
     }
 
     @Override
     public void check$java_io_File$list(Class<?> callerClass, File file, FilenameFilter filter) {
-        policyManager.checkFileRead(callerClass, file);
+        policyChecker.checkFileRead(callerClass, file);
     }
 
     @Override
     public void check$java_io_File$listFiles(Class<?> callerClass, File file) {
-        policyManager.checkFileRead(callerClass, file);
+        policyChecker.checkFileRead(callerClass, file);
     }
 
     @Override
     public void check$java_io_File$listFiles(Class<?> callerClass, File file, FileFilter filter) {
-        policyManager.checkFileRead(callerClass, file);
+        policyChecker.checkFileRead(callerClass, file);
     }
 
     @Override
     public void check$java_io_File$listFiles(Class<?> callerClass, File file, FilenameFilter filter) {
-        policyManager.checkFileRead(callerClass, file);
+        policyChecker.checkFileRead(callerClass, file);
     }
 
     @Override
     public void check$java_io_File$mkdir(Class<?> callerClass, File file) {
-        policyManager.checkFileWrite(callerClass, file);
+        policyChecker.checkFileWrite(callerClass, file);
     }
 
     @Override
     public void check$java_io_File$mkdirs(Class<?> callerClass, File file) {
-        policyManager.checkFileWrite(callerClass, file);
+        policyChecker.checkFileWrite(callerClass, file);
     }
 
     @Override
     public void check$java_io_File$renameTo(Class<?> callerClass, File file, File dest) {
-        policyManager.checkFileRead(callerClass, file);
-        policyManager.checkFileWrite(callerClass, dest);
+        policyChecker.checkFileRead(callerClass, file);
+        policyChecker.checkFileWrite(callerClass, dest);
     }
 
     @Override
     public void check$java_io_File$setExecutable(Class<?> callerClass, File file, boolean executable) {
-        policyManager.checkFileWrite(callerClass, file);
+        policyChecker.checkFileWrite(callerClass, file);
     }
 
     @Override
     public void check$java_io_File$setExecutable(Class<?> callerClass, File file, boolean executable, boolean ownerOnly) {
-        policyManager.checkFileWrite(callerClass, file);
+        policyChecker.checkFileWrite(callerClass, file);
     }
 
     @Override
     public void check$java_io_File$setLastModified(Class<?> callerClass, File file, long time) {
-        policyManager.checkFileWrite(callerClass, file);
+        policyChecker.checkFileWrite(callerClass, file);
     }
 
     @Override
     public void check$java_io_File$setReadable(Class<?> callerClass, File file, boolean readable) {
-        policyManager.checkFileWrite(callerClass, file);
+        policyChecker.checkFileWrite(callerClass, file);
     }
 
     @Override
     public void check$java_io_File$setReadable(Class<?> callerClass, File file, boolean readable, boolean ownerOnly) {
-        policyManager.checkFileWrite(callerClass, file);
+        policyChecker.checkFileWrite(callerClass, file);
     }
 
     @Override
     public void check$java_io_File$setReadOnly(Class<?> callerClass, File file) {
-        policyManager.checkFileWrite(callerClass, file);
+        policyChecker.checkFileWrite(callerClass, file);
     }
 
     @Override
     public void check$java_io_File$setWritable(Class<?> callerClass, File file, boolean writable) {
-        policyManager.checkFileWrite(callerClass, file);
+        policyChecker.checkFileWrite(callerClass, file);
     }
 
     @Override
     public void check$java_io_File$setWritable(Class<?> callerClass, File file, boolean writable, boolean ownerOnly) {
-        policyManager.checkFileWrite(callerClass, file);
+        policyChecker.checkFileWrite(callerClass, file);
     }
 
     @Override
     public void check$java_io_FileInputStream$(Class<?> callerClass, File file) {
-        policyManager.checkFileRead(callerClass, file);
+        policyChecker.checkFileRead(callerClass, file);
     }
 
     @Override
     public void check$java_io_FileInputStream$(Class<?> callerClass, FileDescriptor fd) {
-        policyManager.checkFileDescriptorRead(callerClass);
+        policyChecker.checkFileDescriptorRead(callerClass);
     }
 
     @Override
     public void check$java_io_FileInputStream$(Class<?> callerClass, String name) {
-        policyManager.checkFileRead(callerClass, new File(name));
+        policyChecker.checkFileRead(callerClass, new File(name));
     }
 
     @Override
     public void check$java_io_FileOutputStream$(Class<?> callerClass, String name) {
-        policyManager.checkFileWrite(callerClass, new File(name));
+        policyChecker.checkFileWrite(callerClass, new File(name));
     }
 
     @Override
     public void check$java_io_FileOutputStream$(Class<?> callerClass, String name, boolean append) {
-        policyManager.checkFileWrite(callerClass, new File(name));
+        policyChecker.checkFileWrite(callerClass, new File(name));
     }
 
     @Override
     public void check$java_io_FileOutputStream$(Class<?> callerClass, File file) {
-        policyManager.checkFileWrite(callerClass, file);
+        policyChecker.checkFileWrite(callerClass, file);
     }
 
     @Override
     public void check$java_io_FileOutputStream$(Class<?> callerClass, File file, boolean append) {
-        policyManager.checkFileWrite(callerClass, file);
+        policyChecker.checkFileWrite(callerClass, file);
     }
 
     @Override
     public void check$java_io_FileOutputStream$(Class<?> callerClass, FileDescriptor fd) {
-        policyManager.checkFileDescriptorWrite(callerClass);
+        policyChecker.checkFileDescriptorWrite(callerClass);
     }
 
     @Override
     public void check$java_io_FileReader$(Class<?> callerClass, File file) {
-        policyManager.checkFileRead(callerClass, file);
+        policyChecker.checkFileRead(callerClass, file);
     }
 
     @Override
     public void check$java_io_FileReader$(Class<?> callerClass, File file, Charset charset) {
-        policyManager.checkFileRead(callerClass, file);
+        policyChecker.checkFileRead(callerClass, file);
     }
 
     @Override
     public void check$java_io_FileReader$(Class<?> callerClass, FileDescriptor fd) {
-        policyManager.checkFileDescriptorRead(callerClass);
+        policyChecker.checkFileDescriptorRead(callerClass);
     }
 
     @Override
     public void check$java_io_FileReader$(Class<?> callerClass, String name) {
-        policyManager.checkFileRead(callerClass, new File(name));
+        policyChecker.checkFileRead(callerClass, new File(name));
     }
 
     @Override
     public void check$java_io_FileReader$(Class<?> callerClass, String name, Charset charset) {
-        policyManager.checkFileRead(callerClass, new File(name));
+        policyChecker.checkFileRead(callerClass, new File(name));
     }
 
     @Override
     public void check$java_io_FileWriter$(Class<?> callerClass, File file) {
-        policyManager.checkFileWrite(callerClass, file);
+        policyChecker.checkFileWrite(callerClass, file);
     }
 
     @Override
     public void check$java_io_FileWriter$(Class<?> callerClass, File file, boolean append) {
-        policyManager.checkFileWrite(callerClass, file);
+        policyChecker.checkFileWrite(callerClass, file);
     }
 
     @Override
     public void check$java_io_FileWriter$(Class<?> callerClass, File file, Charset charset) {
-        policyManager.checkFileWrite(callerClass, file);
+        policyChecker.checkFileWrite(callerClass, file);
     }
 
     @Override
     public void check$java_io_FileWriter$(Class<?> callerClass, File file, Charset charset, boolean append) {
-        policyManager.checkFileWrite(callerClass, file);
+        policyChecker.checkFileWrite(callerClass, file);
     }
 
     @Override
     public void check$java_io_FileWriter$(Class<?> callerClass, FileDescriptor fd) {
-        policyManager.checkFileDescriptorWrite(callerClass);
+        policyChecker.checkFileDescriptorWrite(callerClass);
     }
 
     @Override
     public void check$java_io_FileWriter$(Class<?> callerClass, String name) {
-        policyManager.checkFileWrite(callerClass, new File(name));
+        policyChecker.checkFileWrite(callerClass, new File(name));
     }
 
     @Override
     public void check$java_io_FileWriter$(Class<?> callerClass, String name, boolean append) {
-        policyManager.checkFileWrite(callerClass, new File(name));
+        policyChecker.checkFileWrite(callerClass, new File(name));
     }
 
     @Override
     public void check$java_io_FileWriter$(Class<?> callerClass, String name, Charset charset) {
-        policyManager.checkFileWrite(callerClass, new File(name));
+        policyChecker.checkFileWrite(callerClass, new File(name));
     }
 
     @Override
     public void check$java_io_FileWriter$(Class<?> callerClass, String name, Charset charset, boolean append) {
-        policyManager.checkFileWrite(callerClass, new File(name));
+        policyChecker.checkFileWrite(callerClass, new File(name));
     }
 
     @Override
     public void check$java_io_RandomAccessFile$(Class<?> callerClass, String name, String mode) {
         if (mode.equals("r")) {
-            policyManager.checkFileRead(callerClass, new File(name));
+            policyChecker.checkFileRead(callerClass, new File(name));
         } else {
-            policyManager.checkFileWrite(callerClass, new File(name));
+            policyChecker.checkFileWrite(callerClass, new File(name));
         }
     }
 
     @Override
     public void check$java_io_RandomAccessFile$(Class<?> callerClass, File file, String mode) {
         if (mode.equals("r")) {
-            policyManager.checkFileRead(callerClass, file);
+            policyChecker.checkFileRead(callerClass, file);
         } else {
-            policyManager.checkFileWrite(callerClass, file);
+            policyChecker.checkFileWrite(callerClass, file);
         }
     }
 
     @Override
     public void check$java_security_KeyStore$$getInstance(Class<?> callerClass, File file, char[] password) {
-        policyManager.checkFileRead(callerClass, file);
+        policyChecker.checkFileRead(callerClass, file);
     }
 
     @Override
     public void check$java_security_KeyStore$$getInstance(Class<?> callerClass, File file, KeyStore.LoadStoreParameter param) {
-        policyManager.checkFileRead(callerClass, file);
+        policyChecker.checkFileRead(callerClass, file);
     }
 
     @Override
@@ -1701,7 +1603,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         File file,
         KeyStore.ProtectionParameter protection
     ) {
-        policyManager.checkFileRead(callerClass, file);
+        policyChecker.checkFileRead(callerClass, file);
     }
 
     @Override
@@ -1712,89 +1614,89 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         File file,
         KeyStore.ProtectionParameter protection
     ) {
-        policyManager.checkFileRead(callerClass, file);
+        policyChecker.checkFileRead(callerClass, file);
     }
 
     @Override
     public void check$java_util_Scanner$(Class<?> callerClass, File source) {
-        policyManager.checkFileRead(callerClass, source);
+        policyChecker.checkFileRead(callerClass, source);
     }
 
     @Override
     public void check$java_util_Scanner$(Class<?> callerClass, File source, String charsetName) {
-        policyManager.checkFileRead(callerClass, source);
+        policyChecker.checkFileRead(callerClass, source);
     }
 
     @Override
     public void check$java_util_Scanner$(Class<?> callerClass, File source, Charset charset) {
-        policyManager.checkFileRead(callerClass, source);
+        policyChecker.checkFileRead(callerClass, source);
     }
 
     @Override
     public void check$java_util_jar_JarFile$(Class<?> callerClass, String name) {
-        policyManager.checkFileRead(callerClass, new File(name));
+        policyChecker.checkFileRead(callerClass, new File(name));
     }
 
     @Override
     public void check$java_util_jar_JarFile$(Class<?> callerClass, String name, boolean verify) {
-        policyManager.checkFileRead(callerClass, new File(name));
+        policyChecker.checkFileRead(callerClass, new File(name));
     }
 
     @Override
     public void check$java_util_jar_JarFile$(Class<?> callerClass, File file) {
-        policyManager.checkFileRead(callerClass, file);
+        policyChecker.checkFileRead(callerClass, file);
     }
 
     @Override
     public void check$java_util_jar_JarFile$(Class<?> callerClass, File file, boolean verify) {
-        policyManager.checkFileRead(callerClass, file);
+        policyChecker.checkFileRead(callerClass, file);
     }
 
     @Override
     public void check$java_util_jar_JarFile$(Class<?> callerClass, File file, boolean verify, int mode) {
-        policyManager.checkFileWithZipMode(callerClass, file, mode);
+        policyChecker.checkFileWithZipMode(callerClass, file, mode);
     }
 
     @Override
     public void check$java_util_jar_JarFile$(Class<?> callerClass, File file, boolean verify, int mode, Runtime.Version version) {
-        policyManager.checkFileWithZipMode(callerClass, file, mode);
+        policyChecker.checkFileWithZipMode(callerClass, file, mode);
     }
 
     @Override
     public void check$java_util_zip_ZipFile$(Class<?> callerClass, String name) {
-        policyManager.checkFileRead(callerClass, new File(name));
+        policyChecker.checkFileRead(callerClass, new File(name));
     }
 
     @Override
     public void check$java_util_zip_ZipFile$(Class<?> callerClass, String name, Charset charset) {
-        policyManager.checkFileRead(callerClass, new File(name));
+        policyChecker.checkFileRead(callerClass, new File(name));
     }
 
     @Override
     public void check$java_util_zip_ZipFile$(Class<?> callerClass, File file) {
-        policyManager.checkFileRead(callerClass, file);
+        policyChecker.checkFileRead(callerClass, file);
     }
 
     @Override
     public void check$java_util_zip_ZipFile$(Class<?> callerClass, File file, int mode) {
-        policyManager.checkFileWithZipMode(callerClass, file, mode);
+        policyChecker.checkFileWithZipMode(callerClass, file, mode);
     }
 
     @Override
     public void check$java_util_zip_ZipFile$(Class<?> callerClass, File file, Charset charset) {
-        policyManager.checkFileRead(callerClass, file);
+        policyChecker.checkFileRead(callerClass, file);
     }
 
     @Override
     public void check$java_util_zip_ZipFile$(Class<?> callerClass, File file, int mode, Charset charset) {
-        policyManager.checkFileWithZipMode(callerClass, file, mode);
+        policyChecker.checkFileWithZipMode(callerClass, file, mode);
     }
 
     // nio
 
     @Override
     public void check$java_nio_channels_FileChannel$(Class<?> callerClass) {
-        policyManager.checkChangeFilesHandling(callerClass);
+        policyChecker.checkChangeFilesHandling(callerClass);
     }
 
     @Override
@@ -1805,24 +1707,24 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         FileAttribute<?>... attrs
     ) {
         if (isOpenForWrite(options)) {
-            policyManager.checkFileWrite(callerClass, path);
+            policyChecker.checkFileWrite(callerClass, path);
         } else {
-            policyManager.checkFileRead(callerClass, path);
+            policyChecker.checkFileRead(callerClass, path);
         }
     }
 
     @Override
     public void check$java_nio_channels_FileChannel$$open(Class<?> callerClass, Path path, OpenOption... options) {
         if (isOpenForWrite(options)) {
-            policyManager.checkFileWrite(callerClass, path);
+            policyChecker.checkFileWrite(callerClass, path);
         } else {
-            policyManager.checkFileRead(callerClass, path);
+            policyChecker.checkFileRead(callerClass, path);
         }
     }
 
     @Override
     public void check$java_nio_channels_AsynchronousFileChannel$(Class<?> callerClass) {
-        policyManager.checkChangeFilesHandling(callerClass);
+        policyChecker.checkChangeFilesHandling(callerClass);
     }
 
     @Override
@@ -1834,18 +1736,18 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         FileAttribute<?>... attrs
     ) {
         if (isOpenForWrite(options)) {
-            policyManager.checkFileWrite(callerClass, path);
+            policyChecker.checkFileWrite(callerClass, path);
         } else {
-            policyManager.checkFileRead(callerClass, path);
+            policyChecker.checkFileRead(callerClass, path);
         }
     }
 
     @Override
     public void check$java_nio_channels_AsynchronousFileChannel$$open(Class<?> callerClass, Path path, OpenOption... options) {
         if (isOpenForWrite(options)) {
-            policyManager.checkFileWrite(callerClass, path);
+            policyChecker.checkFileWrite(callerClass, path);
         } else {
-            policyManager.checkFileRead(callerClass, path);
+            policyChecker.checkFileRead(callerClass, path);
         }
     }
 
@@ -1855,32 +1757,32 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         FileDescriptor fd,
         Channels.SelectableChannelCloser closer
     ) {
-        policyManager.checkFileDescriptorWrite(callerClass);
+        policyChecker.checkFileDescriptorWrite(callerClass);
     }
 
     @Override
     public void check$java_nio_file_Files$$getOwner(Class<?> callerClass, Path path, LinkOption... options) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$probeContentType(Class<?> callerClass, Path path) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$setOwner(Class<?> callerClass, Path path, UserPrincipal principal) {
-        policyManager.checkFileWrite(callerClass, path);
+        policyChecker.checkFileWrite(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$newInputStream(Class<?> callerClass, Path path, OpenOption... options) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$newOutputStream(Class<?> callerClass, Path path, OpenOption... options) {
-        policyManager.checkFileWrite(callerClass, path);
+        policyChecker.checkFileWrite(callerClass, path);
     }
 
     @Override
@@ -1891,49 +1793,49 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         FileAttribute<?>... attrs
     ) {
         if (isOpenForWrite(options)) {
-            policyManager.checkFileWrite(callerClass, path);
+            policyChecker.checkFileWrite(callerClass, path);
         } else {
-            policyManager.checkFileRead(callerClass, path);
+            policyChecker.checkFileRead(callerClass, path);
         }
     }
 
     @Override
     public void check$java_nio_file_Files$$newByteChannel(Class<?> callerClass, Path path, OpenOption... options) {
         if (isOpenForWrite(options)) {
-            policyManager.checkFileWrite(callerClass, path);
+            policyChecker.checkFileWrite(callerClass, path);
         } else {
-            policyManager.checkFileRead(callerClass, path);
+            policyChecker.checkFileRead(callerClass, path);
         }
     }
 
     @Override
     public void check$java_nio_file_Files$$newDirectoryStream(Class<?> callerClass, Path dir) {
-        policyManager.checkFileRead(callerClass, dir);
+        policyChecker.checkFileRead(callerClass, dir);
     }
 
     @Override
     public void check$java_nio_file_Files$$newDirectoryStream(Class<?> callerClass, Path dir, String glob) {
-        policyManager.checkFileRead(callerClass, dir);
+        policyChecker.checkFileRead(callerClass, dir);
     }
 
     @Override
     public void check$java_nio_file_Files$$newDirectoryStream(Class<?> callerClass, Path dir, DirectoryStream.Filter<? super Path> filter) {
-        policyManager.checkFileRead(callerClass, dir);
+        policyChecker.checkFileRead(callerClass, dir);
     }
 
     @Override
     public void check$java_nio_file_Files$$createFile(Class<?> callerClass, Path path, FileAttribute<?>... attrs) {
-        policyManager.checkFileWrite(callerClass, path);
+        policyChecker.checkFileWrite(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$createDirectory(Class<?> callerClass, Path dir, FileAttribute<?>... attrs) {
-        policyManager.checkFileWrite(callerClass, dir);
+        policyChecker.checkFileWrite(callerClass, dir);
     }
 
     @Override
     public void check$java_nio_file_Files$$createDirectories(Class<?> callerClass, Path dir, FileAttribute<?>... attrs) {
-        policyManager.checkFileWrite(callerClass, dir);
+        policyChecker.checkFileWrite(callerClass, dir);
     }
 
     @Override
@@ -1944,22 +1846,22 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         String suffix,
         FileAttribute<?>... attrs
     ) {
-        policyManager.checkFileWrite(callerClass, dir);
+        policyChecker.checkFileWrite(callerClass, dir);
     }
 
     @Override
     public void check$java_nio_file_Files$$createTempFile(Class<?> callerClass, String prefix, String suffix, FileAttribute<?>... attrs) {
-        policyManager.checkCreateTempFile(callerClass);
+        policyChecker.checkCreateTempFile(callerClass);
     }
 
     @Override
     public void check$java_nio_file_Files$$createTempDirectory(Class<?> callerClass, Path dir, String prefix, FileAttribute<?>... attrs) {
-        policyManager.checkFileWrite(callerClass, dir);
+        policyChecker.checkFileWrite(callerClass, dir);
     }
 
     @Override
     public void check$java_nio_file_Files$$createTempDirectory(Class<?> callerClass, String prefix, FileAttribute<?>... attrs) {
-        policyManager.checkCreateTempFile(callerClass);
+        policyChecker.checkCreateTempFile(callerClass);
     }
 
     private static Path resolveLinkTarget(Path path, Path target) {
@@ -1969,63 +1871,63 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
 
     @Override
     public void check$java_nio_file_Files$$createSymbolicLink(Class<?> callerClass, Path link, Path target, FileAttribute<?>... attrs) {
-        policyManager.checkFileWrite(callerClass, link);
-        policyManager.checkFileRead(callerClass, resolveLinkTarget(link, target));
+        policyChecker.checkFileWrite(callerClass, link);
+        policyChecker.checkFileRead(callerClass, resolveLinkTarget(link, target));
     }
 
     @Override
     public void check$java_nio_file_Files$$createLink(Class<?> callerClass, Path link, Path existing) {
-        policyManager.checkFileWrite(callerClass, link);
-        policyManager.checkFileRead(callerClass, resolveLinkTarget(link, existing));
+        policyChecker.checkFileWrite(callerClass, link);
+        policyChecker.checkFileRead(callerClass, resolveLinkTarget(link, existing));
     }
 
     @Override
     public void check$java_nio_file_Files$$delete(Class<?> callerClass, Path path) {
-        policyManager.checkFileWrite(callerClass, path);
+        policyChecker.checkFileWrite(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$deleteIfExists(Class<?> callerClass, Path path) {
-        policyManager.checkFileWrite(callerClass, path);
+        policyChecker.checkFileWrite(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$copy(Class<?> callerClass, Path source, Path target, CopyOption... options) {
-        policyManager.checkFileRead(callerClass, source);
-        policyManager.checkFileWrite(callerClass, target);
+        policyChecker.checkFileRead(callerClass, source);
+        policyChecker.checkFileWrite(callerClass, target);
     }
 
     @Override
     public void check$java_nio_file_Files$$move(Class<?> callerClass, Path source, Path target, CopyOption... options) {
-        policyManager.checkFileWrite(callerClass, source);
-        policyManager.checkFileWrite(callerClass, target);
+        policyChecker.checkFileWrite(callerClass, source);
+        policyChecker.checkFileWrite(callerClass, target);
     }
 
     @Override
     public void check$java_nio_file_Files$$readSymbolicLink(Class<?> callerClass, Path link) {
-        policyManager.checkFileRead(callerClass, link);
+        policyChecker.checkFileRead(callerClass, link);
     }
 
     @Override
     public void check$java_nio_file_Files$$getFileStore(Class<?> callerClass, Path path) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$isSameFile(Class<?> callerClass, Path path, Path path2) {
-        policyManager.checkFileRead(callerClass, path);
-        policyManager.checkFileRead(callerClass, path2);
+        policyChecker.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path2);
     }
 
     @Override
     public void check$java_nio_file_Files$$mismatch(Class<?> callerClass, Path path, Path path2) {
-        policyManager.checkFileRead(callerClass, path);
-        policyManager.checkFileRead(callerClass, path2);
+        policyChecker.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path2);
     }
 
     @Override
     public void check$java_nio_file_Files$$isHidden(Class<?> callerClass, Path path) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
@@ -2035,7 +1937,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         Class<? extends FileAttributeView> type,
         LinkOption... options
     ) {
-        policyManager.checkGetFileAttributeView(callerClass);
+        policyChecker.checkGetFileAttributeView(callerClass);
     }
 
     @Override
@@ -2045,7 +1947,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         Class<? extends BasicFileAttributes> type,
         LinkOption... options
     ) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
@@ -2056,82 +1958,82 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         Object value,
         LinkOption... options
     ) {
-        policyManager.checkFileWrite(callerClass, path);
+        policyChecker.checkFileWrite(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$getAttribute(Class<?> callerClass, Path path, String attribute, LinkOption... options) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$readAttributes(Class<?> callerClass, Path path, String attributes, LinkOption... options) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$getPosixFilePermissions(Class<?> callerClass, Path path, LinkOption... options) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$setPosixFilePermissions(Class<?> callerClass, Path path, Set<PosixFilePermission> perms) {
-        policyManager.checkFileWrite(callerClass, path);
+        policyChecker.checkFileWrite(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$isSymbolicLink(Class<?> callerClass, Path path) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$isDirectory(Class<?> callerClass, Path path, LinkOption... options) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$isRegularFile(Class<?> callerClass, Path path, LinkOption... options) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$getLastModifiedTime(Class<?> callerClass, Path path, LinkOption... options) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$setLastModifiedTime(Class<?> callerClass, Path path, FileTime time) {
-        policyManager.checkFileWrite(callerClass, path);
+        policyChecker.checkFileWrite(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$size(Class<?> callerClass, Path path) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$exists(Class<?> callerClass, Path path, LinkOption... options) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$notExists(Class<?> callerClass, Path path, LinkOption... options) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$isReadable(Class<?> callerClass, Path path) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$isWritable(Class<?> callerClass, Path path) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$isExecutable(Class<?> callerClass, Path path) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
@@ -2142,72 +2044,72 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         int maxDepth,
         FileVisitor<? super Path> visitor
     ) {
-        policyManager.checkFileRead(callerClass, start);
+        policyChecker.checkFileRead(callerClass, start);
     }
 
     @Override
     public void check$java_nio_file_Files$$walkFileTree(Class<?> callerClass, Path start, FileVisitor<? super Path> visitor) {
-        policyManager.checkFileRead(callerClass, start);
+        policyChecker.checkFileRead(callerClass, start);
     }
 
     @Override
     public void check$java_nio_file_Files$$newBufferedReader(Class<?> callerClass, Path path, Charset cs) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$newBufferedReader(Class<?> callerClass, Path path) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$newBufferedWriter(Class<?> callerClass, Path path, Charset cs, OpenOption... options) {
-        policyManager.checkFileWrite(callerClass, path);
+        policyChecker.checkFileWrite(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$newBufferedWriter(Class<?> callerClass, Path path, OpenOption... options) {
-        policyManager.checkFileWrite(callerClass, path);
+        policyChecker.checkFileWrite(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$copy(Class<?> callerClass, InputStream in, Path target, CopyOption... options) {
-        policyManager.checkFileWrite(callerClass, target);
+        policyChecker.checkFileWrite(callerClass, target);
     }
 
     @Override
     public void check$java_nio_file_Files$$copy(Class<?> callerClass, Path source, OutputStream out) {
-        policyManager.checkFileRead(callerClass, source);
+        policyChecker.checkFileRead(callerClass, source);
     }
 
     @Override
     public void check$java_nio_file_Files$$readAllBytes(Class<?> callerClass, Path path) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$readString(Class<?> callerClass, Path path) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$readString(Class<?> callerClass, Path path, Charset cs) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$readAllLines(Class<?> callerClass, Path path, Charset cs) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$readAllLines(Class<?> callerClass, Path path) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$write(Class<?> callerClass, Path path, byte[] bytes, OpenOption... options) {
-        policyManager.checkFileWrite(callerClass, path);
+        policyChecker.checkFileWrite(callerClass, path);
     }
 
     @Override
@@ -2218,7 +2120,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         Charset cs,
         OpenOption... options
     ) {
-        policyManager.checkFileWrite(callerClass, path);
+        policyChecker.checkFileWrite(callerClass, path);
     }
 
     @Override
@@ -2228,12 +2130,12 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         Iterable<? extends CharSequence> lines,
         OpenOption... options
     ) {
-        policyManager.checkFileWrite(callerClass, path);
+        policyChecker.checkFileWrite(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$writeString(Class<?> callerClass, Path path, CharSequence csq, OpenOption... options) {
-        policyManager.checkFileWrite(callerClass, path);
+        policyChecker.checkFileWrite(callerClass, path);
     }
 
     @Override
@@ -2244,22 +2146,22 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         Charset cs,
         OpenOption... options
     ) {
-        policyManager.checkFileWrite(callerClass, path);
+        policyChecker.checkFileWrite(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$list(Class<?> callerClass, Path dir) {
-        policyManager.checkFileRead(callerClass, dir);
+        policyChecker.checkFileRead(callerClass, dir);
     }
 
     @Override
     public void check$java_nio_file_Files$$walk(Class<?> callerClass, Path start, int maxDepth, FileVisitOption... options) {
-        policyManager.checkFileRead(callerClass, start);
+        policyChecker.checkFileRead(callerClass, start);
     }
 
     @Override
     public void check$java_nio_file_Files$$walk(Class<?> callerClass, Path start, FileVisitOption... options) {
-        policyManager.checkFileRead(callerClass, start);
+        policyChecker.checkFileRead(callerClass, start);
     }
 
     @Override
@@ -2270,54 +2172,54 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         BiPredicate<Path, BasicFileAttributes> matcher,
         FileVisitOption... options
     ) {
-        policyManager.checkFileRead(callerClass, start);
+        policyChecker.checkFileRead(callerClass, start);
     }
 
     @Override
     public void check$java_nio_file_Files$$lines(Class<?> callerClass, Path path, Charset cs) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
     public void check$java_nio_file_Files$$lines(Class<?> callerClass, Path path) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     // file system providers
 
     @Override
     public void check$java_nio_file_spi_FileSystemProvider$(Class<?> callerClass) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void check$java_util_logging_FileHandler$(Class<?> callerClass) {
-        policyManager.checkLoggingFileHandler(callerClass);
+        policyChecker.checkLoggingFileHandler(callerClass);
     }
 
     @Override
     public void check$java_util_logging_FileHandler$(Class<?> callerClass, String pattern) {
-        policyManager.checkLoggingFileHandler(callerClass);
+        policyChecker.checkLoggingFileHandler(callerClass);
     }
 
     @Override
     public void check$java_util_logging_FileHandler$(Class<?> callerClass, String pattern, boolean append) {
-        policyManager.checkLoggingFileHandler(callerClass);
+        policyChecker.checkLoggingFileHandler(callerClass);
     }
 
     @Override
     public void check$java_util_logging_FileHandler$(Class<?> callerClass, String pattern, int limit, int count) {
-        policyManager.checkLoggingFileHandler(callerClass);
+        policyChecker.checkLoggingFileHandler(callerClass);
     }
 
     @Override
     public void check$java_util_logging_FileHandler$(Class<?> callerClass, String pattern, int limit, int count, boolean append) {
-        policyManager.checkLoggingFileHandler(callerClass);
+        policyChecker.checkLoggingFileHandler(callerClass);
     }
 
     @Override
     public void check$java_util_logging_FileHandler$(Class<?> callerClass, String pattern, long limit, int count, boolean append) {
-        policyManager.checkLoggingFileHandler(callerClass);
+        policyChecker.checkLoggingFileHandler(callerClass);
     }
 
     @Override
@@ -2325,22 +2227,22 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         // Note that there's no IT test for this one, because there's no way to create
         // a FileHandler. However, we have this check just in case someone does manage
         // to get their hands on a FileHandler and uses close() to cause its lock file to be deleted.
-        policyManager.checkLoggingFileHandler(callerClass);
+        policyChecker.checkLoggingFileHandler(callerClass);
     }
 
     @Override
     public void check$java_net_http_HttpRequest$BodyPublishers$$ofFile(Class<?> callerClass, Path path) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
     public void check$java_net_http_HttpResponse$BodyHandlers$$ofFile(Class<?> callerClass, Path path) {
-        policyManager.checkFileWrite(callerClass, path);
+        policyChecker.checkFileWrite(callerClass, path);
     }
 
     @Override
     public void check$java_net_http_HttpResponse$BodyHandlers$$ofFile(Class<?> callerClass, Path path, OpenOption... options) {
-        policyManager.checkFileWrite(callerClass, path);
+        policyChecker.checkFileWrite(callerClass, path);
     }
 
     @Override
@@ -2349,37 +2251,37 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         Path directory,
         OpenOption... openOptions
     ) {
-        policyManager.checkFileWrite(callerClass, directory);
+        policyChecker.checkFileWrite(callerClass, directory);
     }
 
     @Override
     public void check$java_net_http_HttpResponse$BodySubscribers$$ofFile(Class<?> callerClass, Path directory) {
-        policyManager.checkFileWrite(callerClass, directory);
+        policyChecker.checkFileWrite(callerClass, directory);
     }
 
     @Override
     public void check$java_net_http_HttpResponse$BodySubscribers$$ofFile(Class<?> callerClass, Path directory, OpenOption... openOptions) {
-        policyManager.checkFileWrite(callerClass, directory);
+        policyChecker.checkFileWrite(callerClass, directory);
     }
 
     @Override
     public void checkNewFileSystem(Class<?> callerClass, FileSystemProvider that, URI uri, Map<String, ?> env) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void checkNewFileSystem(Class<?> callerClass, FileSystemProvider that, Path path, Map<String, ?> env) {
-        policyManager.checkChangeJVMGlobalState(callerClass);
+        policyChecker.checkChangeJVMGlobalState(callerClass);
     }
 
     @Override
     public void checkNewInputStream(Class<?> callerClass, FileSystemProvider that, Path path, OpenOption... options) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
     public void checkNewOutputStream(Class<?> callerClass, FileSystemProvider that, Path path, OpenOption... options) {
-        policyManager.checkFileWrite(callerClass, path);
+        policyChecker.checkFileWrite(callerClass, path);
     }
 
     private static boolean isOpenForWrite(Set<? extends OpenOption> options) {
@@ -2410,9 +2312,9 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         FileAttribute<?>... attrs
     ) {
         if (isOpenForWrite(options)) {
-            policyManager.checkFileWrite(callerClass, path);
+            policyChecker.checkFileWrite(callerClass, path);
         } else {
-            policyManager.checkFileRead(callerClass, path);
+            policyChecker.checkFileRead(callerClass, path);
         }
     }
 
@@ -2426,9 +2328,9 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         FileAttribute<?>... attrs
     ) {
         if (isOpenForWrite(options)) {
-            policyManager.checkFileWrite(callerClass, path);
+            policyChecker.checkFileWrite(callerClass, path);
         } else {
-            policyManager.checkFileRead(callerClass, path);
+            policyChecker.checkFileRead(callerClass, path);
         }
     }
 
@@ -2441,9 +2343,9 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         FileAttribute<?>... attrs
     ) {
         if (isOpenForWrite(options)) {
-            policyManager.checkFileWrite(callerClass, path);
+            policyChecker.checkFileWrite(callerClass, path);
         } else {
-            policyManager.checkFileRead(callerClass, path);
+            policyChecker.checkFileRead(callerClass, path);
         }
     }
 
@@ -2454,87 +2356,87 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         Path dir,
         DirectoryStream.Filter<? super Path> filter
     ) {
-        policyManager.checkFileRead(callerClass, dir);
+        policyChecker.checkFileRead(callerClass, dir);
     }
 
     @Override
     public void checkCreateDirectory(Class<?> callerClass, FileSystemProvider that, Path dir, FileAttribute<?>... attrs) {
-        policyManager.checkFileWrite(callerClass, dir);
+        policyChecker.checkFileWrite(callerClass, dir);
     }
 
     @Override
     public void checkCreateSymbolicLink(Class<?> callerClass, FileSystemProvider that, Path link, Path target, FileAttribute<?>... attrs) {
-        policyManager.checkFileWrite(callerClass, link);
-        policyManager.checkFileRead(callerClass, resolveLinkTarget(link, target));
+        policyChecker.checkFileWrite(callerClass, link);
+        policyChecker.checkFileRead(callerClass, resolveLinkTarget(link, target));
     }
 
     @Override
     public void checkCreateLink(Class<?> callerClass, FileSystemProvider that, Path link, Path existing) {
-        policyManager.checkFileWrite(callerClass, link);
-        policyManager.checkFileRead(callerClass, resolveLinkTarget(link, existing));
+        policyChecker.checkFileWrite(callerClass, link);
+        policyChecker.checkFileRead(callerClass, resolveLinkTarget(link, existing));
     }
 
     @Override
     public void checkDelete(Class<?> callerClass, FileSystemProvider that, Path path) {
-        policyManager.checkFileWrite(callerClass, path);
+        policyChecker.checkFileWrite(callerClass, path);
     }
 
     @Override
     public void checkDeleteIfExists(Class<?> callerClass, FileSystemProvider that, Path path) {
-        policyManager.checkFileWrite(callerClass, path);
+        policyChecker.checkFileWrite(callerClass, path);
     }
 
     @Override
     public void checkReadSymbolicLink(Class<?> callerClass, FileSystemProvider that, Path link) {
-        policyManager.checkFileRead(callerClass, link);
+        policyChecker.checkFileRead(callerClass, link);
     }
 
     @Override
     public void checkCopy(Class<?> callerClass, FileSystemProvider that, Path source, Path target, CopyOption... options) {
-        policyManager.checkFileWrite(callerClass, target);
-        policyManager.checkFileRead(callerClass, source);
+        policyChecker.checkFileWrite(callerClass, target);
+        policyChecker.checkFileRead(callerClass, source);
     }
 
     @Override
     public void checkMove(Class<?> callerClass, FileSystemProvider that, Path source, Path target, CopyOption... options) {
-        policyManager.checkFileWrite(callerClass, target);
-        policyManager.checkFileWrite(callerClass, source);
+        policyChecker.checkFileWrite(callerClass, target);
+        policyChecker.checkFileWrite(callerClass, source);
     }
 
     @Override
     public void checkIsSameFile(Class<?> callerClass, FileSystemProvider that, Path path, Path path2) {
-        policyManager.checkFileRead(callerClass, path);
-        policyManager.checkFileRead(callerClass, path2);
+        policyChecker.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path2);
     }
 
     @Override
     public void checkIsHidden(Class<?> callerClass, FileSystemProvider that, Path path) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
     public void checkGetFileStore(Class<?> callerClass, FileSystemProvider that, Path path) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
     public void checkCheckAccess(Class<?> callerClass, FileSystemProvider that, Path path, AccessMode... modes) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
     public void checkGetFileAttributeView(Class<?> callerClass, FileSystemProvider that, Path path, Class<?> type, LinkOption... options) {
-        policyManager.checkGetFileAttributeView(callerClass);
+        policyChecker.checkGetFileAttributeView(callerClass);
     }
 
     @Override
     public void checkReadAttributes(Class<?> callerClass, FileSystemProvider that, Path path, Class<?> type, LinkOption... options) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
     public void checkReadAttributes(Class<?> callerClass, FileSystemProvider that, Path path, String attributes, LinkOption... options) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
@@ -2546,7 +2448,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         Object value,
         LinkOption... options
     ) {
-        policyManager.checkFileWrite(callerClass, path);
+        policyChecker.checkFileWrite(callerClass, path);
 
     }
 
@@ -2554,32 +2456,32 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
 
     @Override
     public void check$java_lang_Thread$start(Class<?> callerClass, Thread thread) {
-        policyManager.checkManageThreadsEntitlement(callerClass);
+        policyChecker.checkManageThreadsEntitlement(callerClass);
     }
 
     @Override
     public void check$java_lang_Thread$setDaemon(Class<?> callerClass, Thread thread, boolean on) {
-        policyManager.checkManageThreadsEntitlement(callerClass);
+        policyChecker.checkManageThreadsEntitlement(callerClass);
     }
 
     @Override
     public void check$java_lang_ThreadGroup$setDaemon(Class<?> callerClass, ThreadGroup threadGroup, boolean daemon) {
-        policyManager.checkManageThreadsEntitlement(callerClass);
+        policyChecker.checkManageThreadsEntitlement(callerClass);
     }
 
     @Override
     public void check$java_util_concurrent_ForkJoinPool$setParallelism(Class<?> callerClass, ForkJoinPool forkJoinPool, int size) {
-        policyManager.checkManageThreadsEntitlement(callerClass);
+        policyChecker.checkManageThreadsEntitlement(callerClass);
     }
 
     @Override
     public void check$java_lang_Thread$setName(Class<?> callerClass, Thread thread, String name) {
-        policyManager.checkManageThreadsEntitlement(callerClass);
+        policyChecker.checkManageThreadsEntitlement(callerClass);
     }
 
     @Override
     public void check$java_lang_Thread$setPriority(Class<?> callerClass, Thread thread, int newPriority) {
-        policyManager.checkManageThreadsEntitlement(callerClass);
+        policyChecker.checkManageThreadsEntitlement(callerClass);
     }
 
     @Override
@@ -2588,57 +2490,57 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         Thread thread,
         Thread.UncaughtExceptionHandler ueh
     ) {
-        policyManager.checkManageThreadsEntitlement(callerClass);
+        policyChecker.checkManageThreadsEntitlement(callerClass);
     }
 
     @Override
     public void check$java_lang_ThreadGroup$setMaxPriority(Class<?> callerClass, ThreadGroup threadGroup, int pri) {
-        policyManager.checkManageThreadsEntitlement(callerClass);
+        policyChecker.checkManageThreadsEntitlement(callerClass);
     }
 
     @Override
     public void checkGetFileStoreAttributeView(Class<?> callerClass, FileStore that, Class<?> type) {
-        policyManager.checkWriteStoreAttributes(callerClass);
+        policyChecker.checkWriteStoreAttributes(callerClass);
     }
 
     @Override
     public void checkGetAttribute(Class<?> callerClass, FileStore that, String attribute) {
-        policyManager.checkReadStoreAttributes(callerClass);
+        policyChecker.checkReadStoreAttributes(callerClass);
     }
 
     @Override
     public void checkGetBlockSize(Class<?> callerClass, FileStore that) {
-        policyManager.checkReadStoreAttributes(callerClass);
+        policyChecker.checkReadStoreAttributes(callerClass);
     }
 
     @Override
     public void checkGetTotalSpace(Class<?> callerClass, FileStore that) {
-        policyManager.checkReadStoreAttributes(callerClass);
+        policyChecker.checkReadStoreAttributes(callerClass);
     }
 
     @Override
     public void checkGetUnallocatedSpace(Class<?> callerClass, FileStore that) {
-        policyManager.checkReadStoreAttributes(callerClass);
+        policyChecker.checkReadStoreAttributes(callerClass);
     }
 
     @Override
     public void checkGetUsableSpace(Class<?> callerClass, FileStore that) {
-        policyManager.checkReadStoreAttributes(callerClass);
+        policyChecker.checkReadStoreAttributes(callerClass);
     }
 
     @Override
     public void checkIsReadOnly(Class<?> callerClass, FileStore that) {
-        policyManager.checkReadStoreAttributes(callerClass);
+        policyChecker.checkReadStoreAttributes(callerClass);
     }
 
     @Override
     public void checkName(Class<?> callerClass, FileStore that) {
-        policyManager.checkReadStoreAttributes(callerClass);
+        policyChecker.checkReadStoreAttributes(callerClass);
     }
 
     @Override
     public void checkType(Class<?> callerClass, FileStore that) {
-        policyManager.checkReadStoreAttributes(callerClass);
+        policyChecker.checkReadStoreAttributes(callerClass);
     }
 
     @Override
@@ -2649,12 +2551,12 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
                 followLinks = false;
             }
         }
-        policyManager.checkFileRead(callerClass, that, followLinks);
+        policyChecker.checkFileRead(callerClass, that, followLinks);
     }
 
     @Override
     public void checkPathRegister(Class<?> callerClass, Path that, WatchService watcher, WatchEvent.Kind<?>... events) {
-        policyManager.checkFileRead(callerClass, that);
+        policyChecker.checkFileRead(callerClass, that);
     }
 
     @Override
@@ -2665,26 +2567,17 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         WatchEvent.Kind<?>[] events,
         WatchEvent.Modifier... modifiers
     ) {
-        policyManager.checkFileRead(callerClass, that);
-    }
-
-    private void checkURLFileRead(Class<?> callerClass, URL url) {
-        try {
-            policyManager.checkFileRead(callerClass, Paths.get(url.toURI()));
-        } catch (URISyntaxException e) {
-            // We expect this method to be called only on File URLs; otherwise the underlying method would fail anyway
-            throw new RuntimeException(e);
-        }
+        policyChecker.checkFileRead(callerClass, that);
     }
 
     @Override
     public void check$sun_net_www_protocol_file_FileURLConnection$connect(Class<?> callerClass, java.net.URLConnection that) {
-        checkURLFileRead(callerClass, that.getURL());
+        policyChecker.checkURLFileRead(callerClass, that.getURL());
     }
 
     @Override
     public void check$sun_net_www_protocol_file_FileURLConnection$getHeaderFields(Class<?> callerClass, java.net.URLConnection that) {
-        checkURLFileRead(callerClass, that.getURL());
+        policyChecker.checkURLFileRead(callerClass, that.getURL());
     }
 
     @Override
@@ -2693,22 +2586,22 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         java.net.URLConnection that,
         String name
     ) {
-        checkURLFileRead(callerClass, that.getURL());
+        policyChecker.checkURLFileRead(callerClass, that.getURL());
     }
 
     @Override
     public void check$sun_net_www_protocol_file_FileURLConnection$getHeaderField(Class<?> callerClass, java.net.URLConnection that, int n) {
-        checkURLFileRead(callerClass, that.getURL());
+        policyChecker.checkURLFileRead(callerClass, that.getURL());
     }
 
     @Override
     public void check$sun_net_www_protocol_file_FileURLConnection$getContentLength(Class<?> callerClass, java.net.URLConnection that) {
-        checkURLFileRead(callerClass, that.getURL());
+        policyChecker.checkURLFileRead(callerClass, that.getURL());
     }
 
     @Override
     public void check$sun_net_www_protocol_file_FileURLConnection$getContentLengthLong(Class<?> callerClass, java.net.URLConnection that) {
-        checkURLFileRead(callerClass, that.getURL());
+        policyChecker.checkURLFileRead(callerClass, that.getURL());
     }
 
     @Override
@@ -2717,22 +2610,26 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
         java.net.URLConnection that,
         int n
     ) {
-        checkURLFileRead(callerClass, that.getURL());
+        policyChecker.checkURLFileRead(callerClass, that.getURL());
     }
 
     @Override
     public void check$sun_net_www_protocol_file_FileURLConnection$getLastModified(Class<?> callerClass, java.net.URLConnection that) {
-        checkURLFileRead(callerClass, that.getURL());
+        policyChecker.checkURLFileRead(callerClass, that.getURL());
     }
 
     @Override
     public void check$sun_net_www_protocol_file_FileURLConnection$getInputStream(Class<?> callerClass, java.net.URLConnection that) {
-        checkURLFileRead(callerClass, that.getURL());
+        policyChecker.checkURLFileRead(callerClass, that.getURL());
     }
 
     @Override
     public void check$java_net_JarURLConnection$getManifest(Class<?> callerClass, java.net.JarURLConnection that) {
         checkJarURLAccess(callerClass, that);
+    }
+
+    private void checkJarURLAccess(Class<?> callerClass, JarURLConnection connection) {
+        policyChecker.checkJarURLAccess(callerClass, connection);
     }
 
     @Override

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyChecker.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyChecker.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlement.runtime.policy;
+
+import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.entitlement.runtime.policy.entitlements.Entitlement;
+
+import java.io.File;
+import java.net.JarURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+
+/**
+ * Contains one "check" method for each distinct kind of check we do
+ * (as opposed to {@link org.elasticsearch.entitlement.bridge.EntitlementChecker},
+ * which has a method for each distinct <em>>method</em> we instrument).
+ */
+@SuppressForbidden(reason = "Explicitly checking APIs that are forbidden")
+public interface PolicyChecker {
+    void checkAllNetworkAccess(Class<?> callerClass);
+
+    void checkChangeFilesHandling(Class<?> callerClass);
+
+    void checkChangeJVMGlobalState(Class<?> callerClass);
+
+    void checkChangeNetworkHandling(Class<?> callerClass);
+
+    void checkCreateClassLoader(Class<?> callerClass);
+
+    void checkCreateTempFile(Class<?> callerClass);
+
+    void checkEntitlementPresent(Class<?> callerClass, Class<? extends Entitlement> entitlementClass);
+
+    void checkEntitlementForUrl(Class<?> callerClass, URL url);
+
+    void checkEntitlementForURLConnection(Class<?> callerClass, URLConnection urlConnection);
+
+    void checkExitVM(Class<?> callerClass);
+
+    void checkFileDescriptorRead(Class<?> callerClass);
+
+    void checkFileDescriptorWrite(Class<?> callerClass);
+
+    void checkFileRead(Class<?> callerClass, File file);
+
+    void checkFileRead(Class<?> callerClass, Path path, boolean followLinks) throws NoSuchFileException;
+
+    void checkFileRead(Class<?> callerClass, Path path);
+
+    void checkFileWithZipMode(Class<?> callerClass, File file, int zipMode);
+
+    void checkFileWrite(Class<?> callerClass, File file);
+
+    void checkFileWrite(Class<?> callerClass, Path path);
+
+    void checkGetFileAttributeView(Class<?> callerClass);
+
+    void checkInboundNetworkAccess(Class<?> callerClass);
+
+    void checkJarURLAccess(Class<?> callerClass, JarURLConnection connection);
+
+    void checkLoadingNativeLibraries(Class<?> callerClass);
+
+    void checkLoggingFileHandler(Class<?> callerClass);
+
+    void checkManageThreadsEntitlement(Class<?> callerClass);
+
+    void checkOutboundNetworkAccess(Class<?> callerClass);
+
+    void checkReadStoreAttributes(Class<?> callerClass);
+
+    void checkSetHttpsConnectionProperties(Class<?> callerClass);
+
+    void checkStartProcess(Class<?> callerClass);
+
+    void checkUnsupportedURLProtocolConnection(Class<?> callerClass, String protocol);
+
+    void checkURLFileRead(Class<?> callerClass, URL url);
+
+    void checkWriteProperty(Class<?> callerClass, String property);
+
+    void checkWriteStoreAttributes(Class<?> callerClass);
+}

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyCheckerImpl.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyCheckerImpl.java
@@ -1,0 +1,596 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlement.runtime.policy;
+
+import org.elasticsearch.core.PathUtils;
+import org.elasticsearch.core.Strings;
+import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.entitlement.instrumentation.InstrumentationService;
+import org.elasticsearch.entitlement.runtime.api.NotEntitledException;
+import org.elasticsearch.entitlement.runtime.policy.PolicyManager.ModuleEntitlements;
+import org.elasticsearch.entitlement.runtime.policy.entitlements.CreateClassLoaderEntitlement;
+import org.elasticsearch.entitlement.runtime.policy.entitlements.Entitlement;
+import org.elasticsearch.entitlement.runtime.policy.entitlements.ExitVMEntitlement;
+import org.elasticsearch.entitlement.runtime.policy.entitlements.InboundNetworkEntitlement;
+import org.elasticsearch.entitlement.runtime.policy.entitlements.LoadNativeLibrariesEntitlement;
+import org.elasticsearch.entitlement.runtime.policy.entitlements.ManageThreadsEntitlement;
+import org.elasticsearch.entitlement.runtime.policy.entitlements.OutboundNetworkEntitlement;
+import org.elasticsearch.entitlement.runtime.policy.entitlements.ReadStoreAttributesEntitlement;
+import org.elasticsearch.entitlement.runtime.policy.entitlements.SetHttpsConnectionPropertiesEntitlement;
+import org.elasticsearch.entitlement.runtime.policy.entitlements.WriteSystemPropertiesEntitlement;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.JarURLConnection;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static java.lang.StackWalker.Option.RETAIN_CLASS_REFERENCE;
+import static java.util.function.Predicate.not;
+import static java.util.zip.ZipFile.OPEN_DELETE;
+import static java.util.zip.ZipFile.OPEN_READ;
+import static org.elasticsearch.entitlement.runtime.policy.PathLookup.BaseDir.TEMP;
+
+/**
+ * Connects the {@link PolicyChecker} interface to a {@link PolicyManager}
+ * to perform the checks in accordance with the policy.
+ * Determines the caller class, queries {@link PolicyManager}
+ * to find what entitlements have been granted to that class,
+ * and finally checks whether the desired entitlements are present.
+ */
+@SuppressForbidden(reason = "Explicitly checking APIs that are forbidden")
+public class PolicyCheckerImpl implements PolicyChecker {
+    static final Class<?> DEFAULT_FILESYSTEM_CLASS = PathUtils.getDefaultFileSystem().getClass();
+    protected final Set<Package> suppressFailureLogPackages;
+    /**
+     * Frames originating from this module are ignored in the permission logic.
+     */
+    protected final Module entitlementsModule;
+
+    private final PolicyManager policyManager;
+
+    private final PathLookup pathLookup;
+
+    public PolicyCheckerImpl(
+        Set<Package> suppressFailureLogPackages,
+        Module entitlementsModule,
+        PolicyManager policyManager,
+        PathLookup pathLookup
+    ) {
+        this.suppressFailureLogPackages = suppressFailureLogPackages;
+        this.entitlementsModule = entitlementsModule;
+        this.policyManager = policyManager;
+        this.pathLookup = pathLookup;
+    }
+
+    private static boolean isPathOnDefaultFilesystem(Path path) {
+        var pathFileSystemClass = path.getFileSystem().getClass();
+        if (path.getFileSystem().getClass() != DEFAULT_FILESYSTEM_CLASS) {
+            PolicyManager.generalLogger.trace(
+                () -> Strings.format(
+                    "File entitlement trivially allowed: path [%s] is for a different FileSystem class [%s], default is [%s]",
+                    path.toString(),
+                    pathFileSystemClass.getName(),
+                    DEFAULT_FILESYSTEM_CLASS.getName()
+                )
+            );
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * @return the {@code requestingClass}'s module name as it would appear in an entitlement policy file
+     */
+    private static String getModuleName(Class<?> requestingClass) {
+        String name = requestingClass.getModule().getName();
+        return (name == null) ? PolicyManager.ALL_UNNAMED : name;
+    }
+
+    @Override
+    public void checkStartProcess(Class<?> callerClass) {
+        neverEntitled(callerClass, () -> "start process");
+    }
+
+    @Override
+    public void checkWriteStoreAttributes(Class<?> callerClass) {
+        neverEntitled(callerClass, () -> "change file store attributes");
+    }
+
+    @Override
+    public void checkReadStoreAttributes(Class<?> callerClass) {
+        checkEntitlementPresent(callerClass, ReadStoreAttributesEntitlement.class);
+    }
+
+    /**
+     * @param operationDescription is only called when the operation is not trivially allowed, meaning the check is about to fail;
+     *                            therefore, its performance is not a major concern.
+     */
+    private void neverEntitled(Class<?> callerClass, Supplier<String> operationDescription) {
+        var requestingClass = requestingClass(callerClass);
+        if (policyManager.isTriviallyAllowed(requestingClass)) {
+            return;
+        }
+
+        ModuleEntitlements entitlements = policyManager.getEntitlements(requestingClass);
+        notEntitled(
+            Strings.format(
+                "component [%s], module [%s], class [%s], operation [%s]",
+                entitlements.componentName(),
+                PolicyCheckerImpl.getModuleName(requestingClass),
+                requestingClass,
+                operationDescription.get()
+            ),
+            callerClass,
+            entitlements
+        );
+    }
+
+    @Override
+    public void checkExitVM(Class<?> callerClass) {
+        checkEntitlementPresent(callerClass, ExitVMEntitlement.class);
+    }
+
+    @Override
+    public void checkCreateClassLoader(Class<?> callerClass) {
+        checkEntitlementPresent(callerClass, CreateClassLoaderEntitlement.class);
+    }
+
+    @Override
+    public void checkSetHttpsConnectionProperties(Class<?> callerClass) {
+        checkEntitlementPresent(callerClass, SetHttpsConnectionPropertiesEntitlement.class);
+    }
+
+    @Override
+    public void checkChangeJVMGlobalState(Class<?> callerClass) {
+        neverEntitled(callerClass, () -> walkStackForCheckMethodName().orElse("change JVM global state"));
+    }
+
+    @Override
+    public void checkLoggingFileHandler(Class<?> callerClass) {
+        neverEntitled(callerClass, () -> walkStackForCheckMethodName().orElse("create logging file handler"));
+    }
+
+    private Optional<String> walkStackForCheckMethodName() {
+        // Look up the check$ method to compose an informative error message.
+        // This way, we don't need to painstakingly describe every individual global-state change.
+        return StackWalker.getInstance()
+            .walk(
+                frames -> frames.map(StackWalker.StackFrame::getMethodName)
+                    .dropWhile(not(methodName -> methodName.startsWith(InstrumentationService.CHECK_METHOD_PREFIX)))
+                    .findFirst()
+            )
+            .map(this::operationDescription);
+    }
+
+    /**
+     * Check for operations that can modify the way network operations are handled
+     */
+    @Override
+    public void checkChangeNetworkHandling(Class<?> callerClass) {
+        checkChangeJVMGlobalState(callerClass);
+    }
+
+    /**
+     * Check for operations that can modify the way file operations are handled
+     */
+    @Override
+    public void checkChangeFilesHandling(Class<?> callerClass) {
+        checkChangeJVMGlobalState(callerClass);
+    }
+
+    @SuppressForbidden(reason = "Explicitly checking File apis")
+    @Override
+    public void checkFileRead(Class<?> callerClass, File file) {
+        checkFileRead(callerClass, file.toPath());
+    }
+
+    @Override
+    public void checkFileRead(Class<?> callerClass, Path path) {
+        try {
+            checkFileRead(callerClass, path, false);
+        } catch (NoSuchFileException e) {
+            assert false : "NoSuchFileException should only be thrown when following links";
+            var notEntitledException = new NotEntitledException(e.getMessage());
+            notEntitledException.addSuppressed(e);
+            throw notEntitledException;
+        }
+    }
+
+    @Override
+    public void checkFileRead(Class<?> callerClass, Path path, boolean followLinks) throws NoSuchFileException {
+        if (PolicyCheckerImpl.isPathOnDefaultFilesystem(path) == false) {
+            return;
+        }
+        var requestingClass = requestingClass(callerClass);
+        if (policyManager.isTriviallyAllowed(requestingClass)) {
+            return;
+        }
+
+        ModuleEntitlements entitlements = policyManager.getEntitlements(requestingClass);
+
+        Path realPath = null;
+        boolean canRead = entitlements.fileAccess().canRead(path);
+        if (canRead && followLinks) {
+            try {
+                realPath = path.toRealPath();
+                if (realPath.equals(path) == false) {
+                    canRead = entitlements.fileAccess().canRead(realPath);
+                }
+            } catch (NoSuchFileException e) {
+                throw e; // rethrow
+            } catch (IOException e) {
+                canRead = false;
+            }
+        }
+
+        if (canRead == false) {
+            notEntitled(
+                Strings.format(
+                    "component [%s], module [%s], class [%s], entitlement [file], operation [read], path [%s]",
+                    entitlements.componentName(),
+                    PolicyCheckerImpl.getModuleName(requestingClass),
+                    requestingClass,
+                    realPath == null ? path : Strings.format("%s -> %s", path, realPath)
+                ),
+                callerClass,
+                entitlements
+            );
+        }
+    }
+
+    @SuppressForbidden(reason = "Explicitly checking File apis")
+    @Override
+    public void checkFileWrite(Class<?> callerClass, File file) {
+        checkFileWrite(callerClass, file.toPath());
+    }
+
+    @Override
+    public void checkFileWrite(Class<?> callerClass, Path path) {
+        if (PolicyCheckerImpl.isPathOnDefaultFilesystem(path) == false) {
+            return;
+        }
+        var requestingClass = requestingClass(callerClass);
+        if (policyManager.isTriviallyAllowed(requestingClass)) {
+            return;
+        }
+
+        ModuleEntitlements entitlements = policyManager.getEntitlements(requestingClass);
+        if (entitlements.fileAccess().canWrite(path) == false) {
+            notEntitled(
+                Strings.format(
+                    "component [%s], module [%s], class [%s], entitlement [file], operation [write], path [%s]",
+                    entitlements.componentName(),
+                    PolicyCheckerImpl.getModuleName(requestingClass),
+                    requestingClass,
+                    path
+                ),
+                callerClass,
+                entitlements
+            );
+        }
+    }
+
+    @SuppressForbidden(reason = "Explicitly checking File apis")
+    @Override
+    public void checkFileWithZipMode(Class<?> callerClass, File file, int zipMode) {
+        assert zipMode == OPEN_READ || zipMode == (OPEN_READ | OPEN_DELETE);
+        if ((zipMode & OPEN_DELETE) == OPEN_DELETE) {
+            // This needs both read and write, but we happen to know that checkFileWrite
+            // actually checks both.
+            checkFileWrite(callerClass, file);
+        } else {
+            checkFileRead(callerClass, file);
+        }
+    }
+
+    @Override
+    public void checkCreateTempFile(Class<?> callerClass) {
+        // in production there should only ever be a single temp directory
+        // so we can safely assume we only need to check the sole element in this stream
+        checkFileWrite(callerClass, pathLookup.getBaseDirPaths(TEMP).findFirst().get());
+    }
+
+    @Override
+    public void checkFileDescriptorRead(Class<?> callerClass) {
+        neverEntitled(callerClass, () -> "read file descriptor");
+    }
+
+    @Override
+    public void checkFileDescriptorWrite(Class<?> callerClass) {
+        neverEntitled(callerClass, () -> "write file descriptor");
+    }
+
+    /**
+     * Invoked when we try to get an arbitrary {@code FileAttributeView} class. Such a class can modify attributes, like owner etc.;
+     * we could think about introducing checks for each of the operations, but for now we over-approximate this and simply deny when it is
+     * used directly.
+     */
+    @Override
+    public void checkGetFileAttributeView(Class<?> callerClass) {
+        neverEntitled(callerClass, () -> "get file attribute view");
+    }
+
+    /**
+     * Check for operations that can access sensitive network information, e.g. secrets, tokens or SSL sessions
+     */
+    @Override
+    public void checkLoadingNativeLibraries(Class<?> callerClass) {
+        checkEntitlementPresent(callerClass, LoadNativeLibrariesEntitlement.class);
+    }
+
+    private String operationDescription(String methodName) {
+        // TODO: Use a more human-readable description. Perhaps share code with InstrumentationServiceImpl.parseCheckerMethodName
+        return methodName.substring(methodName.indexOf('$'));
+    }
+
+    @Override
+    public void checkInboundNetworkAccess(Class<?> callerClass) {
+        checkEntitlementPresent(callerClass, InboundNetworkEntitlement.class);
+    }
+
+    @Override
+    public void checkOutboundNetworkAccess(Class<?> callerClass) {
+        checkEntitlementPresent(callerClass, OutboundNetworkEntitlement.class);
+    }
+
+    @Override
+    public void checkAllNetworkAccess(Class<?> callerClass) {
+        var requestingClass = requestingClass(callerClass);
+        if (policyManager.isTriviallyAllowed(requestingClass)) {
+            return;
+        }
+
+        var classEntitlements = policyManager.getEntitlements(requestingClass);
+        checkFlagEntitlement(classEntitlements, InboundNetworkEntitlement.class, requestingClass, callerClass);
+        checkFlagEntitlement(classEntitlements, OutboundNetworkEntitlement.class, requestingClass, callerClass);
+    }
+
+    @Override
+    public void checkUnsupportedURLProtocolConnection(Class<?> callerClass, String protocol) {
+        neverEntitled(callerClass, () -> Strings.format("unsupported URL protocol [%s]", protocol));
+    }
+
+    @Override
+    public void checkWriteProperty(Class<?> callerClass, String property) {
+        var requestingClass = requestingClass(callerClass);
+        if (policyManager.isTriviallyAllowed(requestingClass)) {
+            return;
+        }
+
+        ModuleEntitlements entitlements = policyManager.getEntitlements(requestingClass);
+        if (entitlements.getEntitlements(WriteSystemPropertiesEntitlement.class).anyMatch(e -> e.properties().contains(property))) {
+            entitlements.logger()
+                .debug(
+                    () -> Strings.format(
+                        "Entitled: component [%s], module [%s], class [%s], entitlement [write_system_properties], property [%s]",
+                        entitlements.componentName(),
+                        PolicyCheckerImpl.getModuleName(requestingClass),
+                        requestingClass,
+                        property
+                    )
+                );
+            return;
+        }
+        notEntitled(
+            Strings.format(
+                "component [%s], module [%s], class [%s], entitlement [write_system_properties], property [%s]",
+                entitlements.componentName(),
+                PolicyCheckerImpl.getModuleName(requestingClass),
+                requestingClass,
+                property
+            ),
+            callerClass,
+            entitlements
+        );
+    }
+
+    @Override
+    public void checkManageThreadsEntitlement(Class<?> callerClass) {
+        checkEntitlementPresent(callerClass, ManageThreadsEntitlement.class);
+    }
+
+    /**
+     * Walks the stack to determine which class should be checked for entitlements.
+     *
+     * @param callerClass when non-null will be returned;
+     *                    this is a fast-path check that can avoid the stack walk
+     *                    in cases where the caller class is available.
+     * @return the requesting class, or {@code null} if the entire call stack
+     * comes from the entitlement library itself.
+     */
+    Class<?> requestingClass(Class<?> callerClass) {
+        if (callerClass != null) {
+            // fast path
+            return callerClass;
+        }
+        Optional<Class<?>> result = StackWalker.getInstance(RETAIN_CLASS_REFERENCE)
+            .walk(frames -> findRequestingFrame(frames).map(StackWalker.StackFrame::getDeclaringClass));
+        return result.orElse(null);
+    }
+
+    /**
+     * Given a stream of {@link StackWalker.StackFrame}s, identify the one whose entitlements should be checked.
+     */
+    Optional<StackWalker.StackFrame> findRequestingFrame(Stream<StackWalker.StackFrame> frames) {
+        return frames.filter(f -> f.getDeclaringClass().getModule() != entitlementsModule) // ignore entitlements library
+            .skip(1) // Skip the sensitive caller method
+            .findFirst();
+    }
+
+    private void checkFlagEntitlement(
+        ModuleEntitlements classEntitlements,
+        Class<? extends Entitlement> entitlementClass,
+        Class<?> requestingClass,
+        Class<?> callerClass
+    ) {
+        if (classEntitlements.hasEntitlement(entitlementClass) == false) {
+            notEntitled(
+                Strings.format(
+                    "component [%s], module [%s], class [%s], entitlement [%s]",
+                    classEntitlements.componentName(),
+                    PolicyCheckerImpl.getModuleName(requestingClass),
+                    requestingClass,
+                    PolicyParser.buildEntitlementNameFromClass(entitlementClass)
+                ),
+                callerClass,
+                classEntitlements
+            );
+        }
+        classEntitlements.logger()
+            .debug(
+                () -> Strings.format(
+                    "Entitled: component [%s], module [%s], class [%s], entitlement [%s]",
+                    classEntitlements.componentName(),
+                    PolicyCheckerImpl.getModuleName(requestingClass),
+                    requestingClass,
+                    PolicyParser.buildEntitlementNameFromClass(entitlementClass)
+                )
+            );
+    }
+
+    private void notEntitled(String message, Class<?> callerClass, ModuleEntitlements entitlements) {
+        var exception = new NotEntitledException(message);
+        // Don't emit a log for suppressed packages, e.g. packages containing self tests
+        if (suppressFailureLogPackages.contains(callerClass.getPackage()) == false) {
+            entitlements.logger().warn("Not entitled: {}", message, exception);
+        }
+        throw exception;
+    }
+
+    @Override
+    public void checkEntitlementPresent(Class<?> callerClass, Class<? extends Entitlement> entitlementClass) {
+        var requestingClass = requestingClass(callerClass);
+        if (policyManager.isTriviallyAllowed(requestingClass)) {
+            return;
+        }
+        checkFlagEntitlement(policyManager.getEntitlements(requestingClass), entitlementClass, requestingClass, callerClass);
+    }
+
+    @Override
+    public void checkEntitlementForUrl(Class<?> callerClass, URL url) {
+        if (handleNetworkOrFileUrlCheck(callerClass, url)) {
+            return;
+        }
+        if (isJarUrl(url)) {
+            var jarFileUrl = extractJarFileUrl(url);
+            if (jarFileUrl == null || handleNetworkOrFileUrlCheck(callerClass, jarFileUrl) == false) {
+                checkUnsupportedURLProtocolConnection(callerClass, "jar with unsupported inner protocol");
+            }
+        } else {
+            checkUnsupportedURLProtocolConnection(callerClass, url.getProtocol());
+        }
+    }
+
+    @Override
+    public void checkEntitlementForURLConnection(Class<?> callerClass, URLConnection urlConnection) {
+        if (isNetworkUrlConnection(urlConnection)) {
+            checkOutboundNetworkAccess(callerClass);
+        } else if (isFileUrlConnection(urlConnection)) {
+            checkURLFileRead(callerClass, urlConnection.getURL());
+        } else if (urlConnection instanceof JarURLConnection jarURLConnection) {
+            checkJarURLAccess(callerClass, jarURLConnection);
+        } else {
+            checkUnsupportedURLProtocolConnection(callerClass, urlConnection.getURL().getProtocol());
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    private URL extractJarFileUrl(URL jarUrl) {
+        String spec = jarUrl.getFile();
+        int separator = spec.indexOf("!/");
+
+        // URL does not handle nested JAR URLs (it would be a MalformedURLException upon connection)
+        if (separator == -1) {
+            return null;
+        }
+
+        try {
+            return new URL(spec.substring(0, separator));
+        } catch (MalformedURLException e) {
+            return null;
+        }
+    }
+
+    private boolean handleNetworkOrFileUrlCheck(Class<?> callerClass, URL url) {
+        if (isNetworkUrl(url)) {
+            checkOutboundNetworkAccess(callerClass);
+            return true;
+        }
+        if (isFileUrl(url)) {
+            checkURLFileRead(callerClass, url);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void checkJarURLAccess(Class<?> callerClass, JarURLConnection connection) {
+        var jarFileUrl = connection.getJarFileURL();
+        if (handleNetworkOrFileUrlCheck(callerClass, jarFileUrl)) {
+            return;
+        }
+        checkUnsupportedURLProtocolConnection(callerClass, jarFileUrl.getProtocol());
+    }
+
+    private static final Set<String> NETWORK_PROTOCOLS = Set.of("http", "https", "ftp", "mailto");
+
+    private static boolean isNetworkUrl(java.net.URL url) {
+        return NETWORK_PROTOCOLS.contains(url.getProtocol());
+    }
+
+    private static boolean isFileUrl(java.net.URL url) {
+        return "file".equals(url.getProtocol());
+    }
+
+    private static boolean isJarUrl(java.net.URL url) {
+        return "jar".equals(url.getProtocol());
+    }
+
+    // We have to use class names for sun.net.www classes as java.base does not export them
+    private static final List<String> ADDITIONAL_NETWORK_URL_CONNECT_CLASS_NAMES = List.of(
+        "sun.net.www.protocol.ftp.FtpURLConnection",
+        "sun.net.www.protocol.mailto.MailToURLConnection"
+    );
+
+    private static boolean isNetworkUrlConnection(java.net.URLConnection urlConnection) {
+        var connectionClass = urlConnection.getClass();
+        return HttpURLConnection.class.isAssignableFrom(connectionClass)
+            || ADDITIONAL_NETWORK_URL_CONNECT_CLASS_NAMES.contains(connectionClass.getName());
+    }
+
+    // We have to use class names for sun.net.www classes as java.base does not export them
+    private static boolean isFileUrlConnection(java.net.URLConnection urlConnection) {
+        var connectionClass = urlConnection.getClass();
+        return "sun.net.www.protocol.file.FileURLConnection".equals(connectionClass.getName());
+    }
+
+    @Override
+    public void checkURLFileRead(Class<?> callerClass, URL url) {
+        try {
+            checkFileRead(callerClass, Paths.get(url.toURI()));
+        } catch (URISyntaxException e) {
+            // We expect this method to be called only on File URLs; otherwise the underlying method would fail anyway
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
@@ -9,130 +9,47 @@
 
 package org.elasticsearch.entitlement.runtime.policy;
 
-import org.elasticsearch.core.PathUtils;
-import org.elasticsearch.core.Strings;
-import org.elasticsearch.core.SuppressForbidden;
-import org.elasticsearch.entitlement.instrumentation.InstrumentationService;
-import org.elasticsearch.entitlement.runtime.api.NotEntitledException;
 import org.elasticsearch.entitlement.runtime.policy.FileAccessTree.ExclusiveFileEntitlement;
 import org.elasticsearch.entitlement.runtime.policy.FileAccessTree.ExclusivePath;
-import org.elasticsearch.entitlement.runtime.policy.entitlements.CreateClassLoaderEntitlement;
 import org.elasticsearch.entitlement.runtime.policy.entitlements.Entitlement;
-import org.elasticsearch.entitlement.runtime.policy.entitlements.ExitVMEntitlement;
 import org.elasticsearch.entitlement.runtime.policy.entitlements.FilesEntitlement;
-import org.elasticsearch.entitlement.runtime.policy.entitlements.InboundNetworkEntitlement;
-import org.elasticsearch.entitlement.runtime.policy.entitlements.LoadNativeLibrariesEntitlement;
-import org.elasticsearch.entitlement.runtime.policy.entitlements.ManageThreadsEntitlement;
-import org.elasticsearch.entitlement.runtime.policy.entitlements.OutboundNetworkEntitlement;
-import org.elasticsearch.entitlement.runtime.policy.entitlements.ReadStoreAttributesEntitlement;
-import org.elasticsearch.entitlement.runtime.policy.entitlements.SetHttpsConnectionPropertiesEntitlement;
-import org.elasticsearch.entitlement.runtime.policy.entitlements.WriteSystemPropertiesEntitlement;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 
-import java.io.File;
-import java.io.IOException;
-import java.lang.StackWalker.StackFrame;
 import java.lang.module.ModuleFinder;
 import java.lang.module.ModuleReference;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static java.lang.StackWalker.Option.RETAIN_CLASS_REFERENCE;
 import static java.util.Objects.requireNonNull;
-import static java.util.function.Predicate.not;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toUnmodifiableMap;
-import static java.util.zip.ZipFile.OPEN_DELETE;
-import static java.util.zip.ZipFile.OPEN_READ;
 import static org.elasticsearch.entitlement.bridge.Util.NO_CLASS;
-import static org.elasticsearch.entitlement.runtime.policy.PathLookup.BaseDir.TEMP;
 import static org.elasticsearch.entitlement.runtime.policy.PolicyManager.ComponentKind.APM_AGENT;
 import static org.elasticsearch.entitlement.runtime.policy.PolicyManager.ComponentKind.PLUGIN;
 import static org.elasticsearch.entitlement.runtime.policy.PolicyManager.ComponentKind.SERVER;
 import static org.elasticsearch.entitlement.runtime.policy.PolicyManager.ComponentKind.UNKNOWN;
 
 /**
- * This class is responsible for finding the <strong>component</strong> (system, server, plugin, agent) for a caller class to check,
- * retrieve the policy and entitlements for that component, and check them against the action(s) the caller wants to perform.
- * <p>
- * To find a component:
- * <ul>
- * <li>
- * For plugins, we use the Module -> Plugin name (String) passed to the ctor
- * </li>
- * <li>
- * For the system component, we build a set ({@link PolicyManager#SYSTEM_LAYER_MODULES}) of references to modules that belong that
- * component, i.e. the component containing what we consider system modules. These are the modules that:
- * <ul>
- * <li>
- * are in the boot module layer ({@link ModuleLayer#boot()});
- * </li>
- * <li>
- * are defined in {@link ModuleFinder#ofSystem()};
- * </li>
- * <li>
- * are not in the ({@link PolicyManager#MODULES_EXCLUDED_FROM_SYSTEM_MODULES}) (currently: {@code java.desktop})
- * </li>
- * </ul>
- * </li>
- * <li>
- * For the server component, we build a set ({@link PolicyManager#SERVER_LAYER_MODULES}) as the set of modules that are in the boot module
- * layer but not in the system component.
- * </li>
- * </ul>
- * <p>
- * When a check is performed (e.g. {@link PolicyManager#checkExitVM(Class)}, we get the module the caller class belongs to via
- * {@link Class#getModule} and try (in order) to see if that class belongs to:
- * <ol>
- * <li>
- * The system component - if a module is contained in {@link PolicyManager#SYSTEM_LAYER_MODULES}
- * </li>
- * <li>
- * The server component - if a module is contained in {@link PolicyManager#SERVER_LAYER_MODULES}
- * </li>
- * <li>
- * One of the plugins or modules - if the module is present in the {@code PluginsResolver} map
- * </li>
- * <li>
- * A known agent (APM)
- * </li>
- * <li>
- * Something else
- * </li>
- * </ol>
- * <p>
- * Once it has a component, this class maps it to a policy and check the action performed by the caller class against its entitlements,
- * either allowing it to proceed or raising a {@link NotEntitledException} if the caller class is not entitled to perform the action.
- * </p>
- * <p>
- * All these methods start in the same way: the components identified in the previous section are used to establish if and how to check:
- * If the caller class belongs to {@link PolicyManager#SYSTEM_LAYER_MODULES}, no check is performed (the call is trivially allowed, see
- * {@link PolicyManager#isTriviallyAllowed}).
- * Otherwise, we lazily compute and create a {@link PolicyManager.ModuleEntitlements} record (see
- * {@link PolicyManager#computeEntitlements}). The record is cached so it can be used in following checks, stored in a
- * {@code Module -> ModuleEntitlement} map.
- * </p>
+ * Determines, from the specified policy information, which entitlements are granted to a given caller class,
+ * as well as whether certain caller classes (like those built into the JDK) should be <em>trivially allowed</em>,
+ * meaning they are always entitled regardless of policy.
  */
 public class PolicyManager {
+    public static final String ALL_UNNAMED = "ALL-UNNAMED";
     /**
      * Use this if you don't have a {@link ModuleEntitlements} in hand.
      */
-    private static final Logger generalLogger = LogManager.getLogger(PolicyManager.class);
-
-    static final Class<?> DEFAULT_FILESYSTEM_CLASS = PathUtils.getDefaultFileSystem().getClass();
+    static final Logger generalLogger = LogManager.getLogger(PolicyManager.class);
 
     static final Set<String> MODULES_EXCLUDED_FROM_SYSTEM_MODULES = Set.of("java.desktop");
 
@@ -207,7 +124,7 @@ public class PolicyManager {
         Logger logger
     ) {
 
-        ModuleEntitlements {
+        public ModuleEntitlements {
             entitlementsByType = Map.copyOf(entitlementsByType);
         }
 
@@ -256,9 +173,6 @@ public class PolicyManager {
     private final Map<String, Map<String, List<Entitlement>>> pluginsEntitlements;
     private final Function<Class<?>, PolicyScope> scopeResolver;
     private final PathLookup pathLookup;
-    private final Set<Package> suppressFailureLogPackages;
-
-    public static final String ALL_UNNAMED = "ALL-UNNAMED";
 
     private static final Set<Module> SYSTEM_LAYER_MODULES = findSystemLayerModules();
 
@@ -292,11 +206,6 @@ public class PolicyManager {
     private final Map<String, Path> sourcePaths;
 
     /**
-     * Frames originating from this module are ignored in the permission logic.
-     */
-    private final Module entitlementsModule;
-
-    /**
      * Paths that are only allowed for a single module. Used to generate
      * structures to indicate other modules aren't allowed to use these
      * files in {@link FileAccessTree}s.
@@ -309,9 +218,7 @@ public class PolicyManager {
         Map<String, Policy> pluginPolicies,
         Function<Class<?>, PolicyScope> scopeResolver,
         Map<String, Path> sourcePaths,
-        Module entitlementsModule,
-        PathLookup pathLookup,
-        Set<Package> suppressFailureLogPackages
+        PathLookup pathLookup
     ) {
         this.serverEntitlements = buildScopeEntitlementsMap(requireNonNull(serverPolicy));
         this.apmAgentEntitlements = apmAgentEntitlements;
@@ -320,9 +227,7 @@ public class PolicyManager {
             .collect(toUnmodifiableMap(Map.Entry::getKey, e -> buildScopeEntitlementsMap(e.getValue())));
         this.scopeResolver = scopeResolver;
         this.sourcePaths = sourcePaths;
-        this.entitlementsModule = entitlementsModule;
         this.pathLookup = requireNonNull(pathLookup);
-        this.suppressFailureLogPackages = suppressFailureLogPackages;
 
         List<ExclusiveFileEntitlement> exclusiveFileEntitlements = new ArrayList<>();
         for (var e : serverEntitlements.entrySet()) {
@@ -367,334 +272,6 @@ public class PolicyManager {
         }
     }
 
-    public void checkStartProcess(Class<?> callerClass) {
-        neverEntitled(callerClass, () -> "start process");
-    }
-
-    public void checkWriteStoreAttributes(Class<?> callerClass) {
-        neverEntitled(callerClass, () -> "change file store attributes");
-    }
-
-    public void checkReadStoreAttributes(Class<?> callerClass) {
-        checkEntitlementPresent(callerClass, ReadStoreAttributesEntitlement.class);
-    }
-
-    /**
-     * @param operationDescription is only called when the operation is not trivially allowed, meaning the check is about to fail;
-     *                            therefore, its performance is not a major concern.
-     */
-    private void neverEntitled(Class<?> callerClass, Supplier<String> operationDescription) {
-        var requestingClass = requestingClass(callerClass);
-        if (isTriviallyAllowed(requestingClass)) {
-            return;
-        }
-
-        ModuleEntitlements entitlements = getEntitlements(requestingClass);
-        notEntitled(
-            Strings.format(
-                "component [%s], module [%s], class [%s], operation [%s]",
-                entitlements.componentName(),
-                getModuleName(requestingClass),
-                requestingClass,
-                operationDescription.get()
-            ),
-            callerClass,
-            entitlements
-        );
-    }
-
-    public void checkExitVM(Class<?> callerClass) {
-        checkEntitlementPresent(callerClass, ExitVMEntitlement.class);
-    }
-
-    public void checkCreateClassLoader(Class<?> callerClass) {
-        checkEntitlementPresent(callerClass, CreateClassLoaderEntitlement.class);
-    }
-
-    public void checkSetHttpsConnectionProperties(Class<?> callerClass) {
-        checkEntitlementPresent(callerClass, SetHttpsConnectionPropertiesEntitlement.class);
-    }
-
-    public void checkChangeJVMGlobalState(Class<?> callerClass) {
-        neverEntitled(callerClass, () -> walkStackForCheckMethodName().orElse("change JVM global state"));
-    }
-
-    public void checkLoggingFileHandler(Class<?> callerClass) {
-        neverEntitled(callerClass, () -> walkStackForCheckMethodName().orElse("create logging file handler"));
-    }
-
-    private Optional<String> walkStackForCheckMethodName() {
-        // Look up the check$ method to compose an informative error message.
-        // This way, we don't need to painstakingly describe every individual global-state change.
-        return StackWalker.getInstance()
-            .walk(
-                frames -> frames.map(StackFrame::getMethodName)
-                    .dropWhile(not(methodName -> methodName.startsWith(InstrumentationService.CHECK_METHOD_PREFIX)))
-                    .findFirst()
-            )
-            .map(this::operationDescription);
-    }
-
-    /**
-     * Check for operations that can modify the way network operations are handled
-     */
-    public void checkChangeNetworkHandling(Class<?> callerClass) {
-        checkChangeJVMGlobalState(callerClass);
-    }
-
-    /**
-     * Check for operations that can modify the way file operations are handled
-     */
-    public void checkChangeFilesHandling(Class<?> callerClass) {
-        checkChangeJVMGlobalState(callerClass);
-    }
-
-    @SuppressForbidden(reason = "Explicitly checking File apis")
-    public void checkFileRead(Class<?> callerClass, File file) {
-        checkFileRead(callerClass, file.toPath());
-    }
-
-    private static boolean isPathOnDefaultFilesystem(Path path) {
-        var pathFileSystemClass = path.getFileSystem().getClass();
-        if (path.getFileSystem().getClass() != DEFAULT_FILESYSTEM_CLASS) {
-            generalLogger.trace(
-                () -> Strings.format(
-                    "File entitlement trivially allowed: path [%s] is for a different FileSystem class [%s], default is [%s]",
-                    path.toString(),
-                    pathFileSystemClass.getName(),
-                    DEFAULT_FILESYSTEM_CLASS.getName()
-                )
-            );
-            return false;
-        }
-        return true;
-    }
-
-    public void checkFileRead(Class<?> callerClass, Path path) {
-        try {
-            checkFileRead(callerClass, path, false);
-        } catch (NoSuchFileException e) {
-            assert false : "NoSuchFileException should only be thrown when following links";
-            var notEntitledException = new NotEntitledException(e.getMessage());
-            notEntitledException.addSuppressed(e);
-            throw notEntitledException;
-        }
-    }
-
-    public void checkFileRead(Class<?> callerClass, Path path, boolean followLinks) throws NoSuchFileException {
-        if (isPathOnDefaultFilesystem(path) == false) {
-            return;
-        }
-        var requestingClass = requestingClass(callerClass);
-        if (isTriviallyAllowed(requestingClass)) {
-            return;
-        }
-
-        ModuleEntitlements entitlements = getEntitlements(requestingClass);
-
-        Path realPath = null;
-        boolean canRead = entitlements.fileAccess().canRead(path);
-        if (canRead && followLinks) {
-            try {
-                realPath = path.toRealPath();
-                if (realPath.equals(path) == false) {
-                    canRead = entitlements.fileAccess().canRead(realPath);
-                }
-            } catch (NoSuchFileException e) {
-                throw e; // rethrow
-            } catch (IOException e) {
-                canRead = false;
-            }
-        }
-
-        if (canRead == false) {
-            notEntitled(
-                Strings.format(
-                    "component [%s], module [%s], class [%s], entitlement [file], operation [read], path [%s]",
-                    entitlements.componentName(),
-                    getModuleName(requestingClass),
-                    requestingClass,
-                    realPath == null ? path : Strings.format("%s -> %s", path, realPath)
-                ),
-                callerClass,
-                entitlements
-            );
-        }
-    }
-
-    @SuppressForbidden(reason = "Explicitly checking File apis")
-    public void checkFileWrite(Class<?> callerClass, File file) {
-        checkFileWrite(callerClass, file.toPath());
-    }
-
-    public void checkFileWrite(Class<?> callerClass, Path path) {
-        if (isPathOnDefaultFilesystem(path) == false) {
-            return;
-        }
-        var requestingClass = requestingClass(callerClass);
-        if (isTriviallyAllowed(requestingClass)) {
-            return;
-        }
-
-        ModuleEntitlements entitlements = getEntitlements(requestingClass);
-        if (entitlements.fileAccess().canWrite(path) == false) {
-            notEntitled(
-                Strings.format(
-                    "component [%s], module [%s], class [%s], entitlement [file], operation [write], path [%s]",
-                    entitlements.componentName(),
-                    getModuleName(requestingClass),
-                    requestingClass,
-                    path
-                ),
-                callerClass,
-                entitlements
-            );
-        }
-    }
-
-    public void checkCreateTempFile(Class<?> callerClass) {
-        // in production there should only ever be a single temp directory
-        // so we can safely assume we only need to check the sole element in this stream
-        checkFileWrite(callerClass, pathLookup.getBaseDirPaths(TEMP).findFirst().get());
-    }
-
-    @SuppressForbidden(reason = "Explicitly checking File apis")
-    public void checkFileWithZipMode(Class<?> callerClass, File file, int zipMode) {
-        assert zipMode == OPEN_READ || zipMode == (OPEN_READ | OPEN_DELETE);
-        if ((zipMode & OPEN_DELETE) == OPEN_DELETE) {
-            // This needs both read and write, but we happen to know that checkFileWrite
-            // actually checks both.
-            checkFileWrite(callerClass, file);
-        } else {
-            checkFileRead(callerClass, file);
-        }
-    }
-
-    public void checkFileDescriptorRead(Class<?> callerClass) {
-        neverEntitled(callerClass, () -> "read file descriptor");
-    }
-
-    public void checkFileDescriptorWrite(Class<?> callerClass) {
-        neverEntitled(callerClass, () -> "write file descriptor");
-    }
-
-    /**
-     * Invoked when we try to get an arbitrary {@code FileAttributeView} class. Such a class can modify attributes, like owner etc.;
-     * we could think about introducing checks for each of the operations, but for now we over-approximate this and simply deny when it is
-     * used directly.
-     */
-    public void checkGetFileAttributeView(Class<?> callerClass) {
-        neverEntitled(callerClass, () -> "get file attribute view");
-    }
-
-    /**
-     * Check for operations that can access sensitive network information, e.g. secrets, tokens or SSL sessions
-     */
-    public void checkLoadingNativeLibraries(Class<?> callerClass) {
-        checkEntitlementPresent(callerClass, LoadNativeLibrariesEntitlement.class);
-    }
-
-    private String operationDescription(String methodName) {
-        // TODO: Use a more human-readable description. Perhaps share code with InstrumentationServiceImpl.parseCheckerMethodName
-        return methodName.substring(methodName.indexOf('$'));
-    }
-
-    public void checkInboundNetworkAccess(Class<?> callerClass) {
-        checkEntitlementPresent(callerClass, InboundNetworkEntitlement.class);
-    }
-
-    public void checkOutboundNetworkAccess(Class<?> callerClass) {
-        checkEntitlementPresent(callerClass, OutboundNetworkEntitlement.class);
-    }
-
-    public void checkAllNetworkAccess(Class<?> callerClass) {
-        var requestingClass = requestingClass(callerClass);
-        if (isTriviallyAllowed(requestingClass)) {
-            return;
-        }
-
-        var classEntitlements = getEntitlements(requestingClass);
-        checkFlagEntitlement(classEntitlements, InboundNetworkEntitlement.class, requestingClass, callerClass);
-        checkFlagEntitlement(classEntitlements, OutboundNetworkEntitlement.class, requestingClass, callerClass);
-    }
-
-    public void checkUnsupportedURLProtocolConnection(Class<?> callerClass, String protocol) {
-        neverEntitled(callerClass, () -> Strings.format("unsupported URL protocol [%s]", protocol));
-    }
-
-    private void checkFlagEntitlement(
-        ModuleEntitlements classEntitlements,
-        Class<? extends Entitlement> entitlementClass,
-        Class<?> requestingClass,
-        Class<?> callerClass
-    ) {
-        if (classEntitlements.hasEntitlement(entitlementClass) == false) {
-            notEntitled(
-                Strings.format(
-                    "component [%s], module [%s], class [%s], entitlement [%s]",
-                    classEntitlements.componentName(),
-                    getModuleName(requestingClass),
-                    requestingClass,
-                    PolicyParser.buildEntitlementNameFromClass(entitlementClass)
-                ),
-                callerClass,
-                classEntitlements
-            );
-        }
-        classEntitlements.logger()
-            .debug(
-                () -> Strings.format(
-                    "Entitled: component [%s], module [%s], class [%s], entitlement [%s]",
-                    classEntitlements.componentName(),
-                    getModuleName(requestingClass),
-                    requestingClass,
-                    PolicyParser.buildEntitlementNameFromClass(entitlementClass)
-                )
-            );
-    }
-
-    public void checkWriteProperty(Class<?> callerClass, String property) {
-        var requestingClass = requestingClass(callerClass);
-        if (isTriviallyAllowed(requestingClass)) {
-            return;
-        }
-
-        ModuleEntitlements entitlements = getEntitlements(requestingClass);
-        if (entitlements.getEntitlements(WriteSystemPropertiesEntitlement.class).anyMatch(e -> e.properties().contains(property))) {
-            entitlements.logger()
-                .debug(
-                    () -> Strings.format(
-                        "Entitled: component [%s], module [%s], class [%s], entitlement [write_system_properties], property [%s]",
-                        entitlements.componentName(),
-                        getModuleName(requestingClass),
-                        requestingClass,
-                        property
-                    )
-                );
-            return;
-        }
-        notEntitled(
-            Strings.format(
-                "component [%s], module [%s], class [%s], entitlement [write_system_properties], property [%s]",
-                entitlements.componentName(),
-                getModuleName(requestingClass),
-                requestingClass,
-                property
-            ),
-            callerClass,
-            entitlements
-        );
-    }
-
-    private void notEntitled(String message, Class<?> callerClass, ModuleEntitlements entitlements) {
-        var exception = new NotEntitledException(message);
-        // Don't emit a log for suppressed packages, e.g. packages containing self tests
-        if (suppressFailureLogPackages.contains(callerClass.getPackage()) == false) {
-            entitlements.logger().warn("Not entitled: {}", message, exception);
-        }
-        throw exception;
-    }
-
     private static Logger getLogger(String componentName, String moduleName) {
         var loggerSuffix = "." + componentName + "." + ((moduleName == null) ? ALL_UNNAMED : moduleName);
         return MODULE_LOGGERS.computeIfAbsent(PolicyManager.class.getName() + loggerSuffix, LogManager::getLogger);
@@ -709,18 +286,6 @@ public class PolicyManager {
      * but here we are.
      */
     private static final ConcurrentHashMap<String, Logger> MODULE_LOGGERS = new ConcurrentHashMap<>();
-
-    public void checkManageThreadsEntitlement(Class<?> callerClass) {
-        checkEntitlementPresent(callerClass, ManageThreadsEntitlement.class);
-    }
-
-    private void checkEntitlementPresent(Class<?> callerClass, Class<? extends Entitlement> entitlementClass) {
-        var requestingClass = requestingClass(callerClass);
-        if (isTriviallyAllowed(requestingClass)) {
-            return;
-        }
-        checkFlagEntitlement(getEntitlements(requestingClass), entitlementClass, requestingClass, callerClass);
-    }
 
     ModuleEntitlements getEntitlements(Class<?> requestingClass) {
         return moduleEntitlementsMap.computeIfAbsent(requestingClass.getModule(), m -> computeEntitlements(requestingClass));
@@ -797,37 +362,9 @@ public class PolicyManager {
     }
 
     /**
-     * Walks the stack to determine which class should be checked for entitlements.
-     *
-     * @param callerClass when non-null will be returned;
-     *                    this is a fast-path check that can avoid the stack walk
-     *                    in cases where the caller class is available.
-     * @return the requesting class, or {@code null} if the entire call stack
-     * comes from the entitlement library itself.
-     */
-    Class<?> requestingClass(Class<?> callerClass) {
-        if (callerClass != null) {
-            // fast path
-            return callerClass;
-        }
-        Optional<Class<?>> result = StackWalker.getInstance(RETAIN_CLASS_REFERENCE)
-            .walk(frames -> findRequestingFrame(frames).map(StackFrame::getDeclaringClass));
-        return result.orElse(null);
-    }
-
-    /**
-     * Given a stream of {@link StackFrame}s, identify the one whose entitlements should be checked.
-     */
-    Optional<StackFrame> findRequestingFrame(Stream<StackFrame> frames) {
-        return frames.filter(f -> f.getDeclaringClass().getModule() != entitlementsModule) // ignore entitlements library
-            .skip(1) // Skip the sensitive caller method
-            .findFirst();
-    }
-
-    /**
      * @return true if permission is granted regardless of the entitlement
      */
-    private static boolean isTriviallyAllowed(Class<?> requestingClass) {
+    boolean isTriviallyAllowed(Class<?> requestingClass) {
         if (generalLogger.isTraceEnabled()) {
             generalLogger.trace("Stack trace for upcoming trivially-allowed check", new Exception());
         }
@@ -845,14 +382,6 @@ public class PolicyManager {
         }
         generalLogger.trace("Entitlement not trivially allowed");
         return false;
-    }
-
-    /**
-     * @return the {@code requestingClass}'s module name as it would appear in an entitlement policy file
-     */
-    private static String getModuleName(Class<?> requestingClass) {
-        String name = requestingClass.getModule().getName();
-        return (name == null) ? ALL_UNNAMED : name;
     }
 
     @Override

--- a/libs/entitlement/src/main19/java/org/elasticsearch/entitlement/runtime/api/Java19ElasticsearchEntitlementChecker.java
+++ b/libs/entitlement/src/main19/java/org/elasticsearch/entitlement/runtime/api/Java19ElasticsearchEntitlementChecker.java
@@ -10,7 +10,7 @@
 package org.elasticsearch.entitlement.runtime.api;
 
 import org.elasticsearch.entitlement.bridge.Java19EntitlementChecker;
-import org.elasticsearch.entitlement.runtime.policy.PolicyManager;
+import org.elasticsearch.entitlement.runtime.policy.PolicyChecker;
 
 import java.lang.foreign.Addressable;
 import java.lang.foreign.FunctionDescriptor;
@@ -22,8 +22,8 @@ import java.nio.file.Path;
 
 public class Java19ElasticsearchEntitlementChecker extends ElasticsearchEntitlementChecker implements Java19EntitlementChecker {
 
-    public Java19ElasticsearchEntitlementChecker(PolicyManager policyManager) {
-        super(policyManager);
+    public Java19ElasticsearchEntitlementChecker(PolicyChecker policyChecker) {
+        super(policyChecker);
     }
 
     @Override
@@ -32,7 +32,7 @@ public class Java19ElasticsearchEntitlementChecker extends ElasticsearchEntitlem
         Linker that,
         FunctionDescriptor function
     ) {
-        policyManager.checkLoadingNativeLibraries(callerClass);
+        policyChecker.checkLoadingNativeLibraries(callerClass);
     }
 
     @Override
@@ -42,7 +42,7 @@ public class Java19ElasticsearchEntitlementChecker extends ElasticsearchEntitlem
         Addressable address,
         FunctionDescriptor function
     ) {
-        policyManager.checkLoadingNativeLibraries(callerClass);
+        policyChecker.checkLoadingNativeLibraries(callerClass);
     }
 
     @Override
@@ -53,7 +53,7 @@ public class Java19ElasticsearchEntitlementChecker extends ElasticsearchEntitlem
         FunctionDescriptor function,
         MemorySession scope
     ) {
-        policyManager.checkLoadingNativeLibraries(callerClass);
+        policyChecker.checkLoadingNativeLibraries(callerClass);
     }
 
     @Override
@@ -63,17 +63,17 @@ public class Java19ElasticsearchEntitlementChecker extends ElasticsearchEntitlem
         long byteSize,
         MemorySession session
     ) {
-        policyManager.checkLoadingNativeLibraries(callerClass);
+        policyChecker.checkLoadingNativeLibraries(callerClass);
     }
 
     @Override
     public void check$java_lang_foreign_SymbolLookup$$libraryLookup(Class<?> callerClass, String name, MemorySession session) {
-        policyManager.checkLoadingNativeLibraries(callerClass);
+        policyChecker.checkLoadingNativeLibraries(callerClass);
     }
 
     @Override
     public void check$java_lang_foreign_SymbolLookup$$libraryLookup(Class<?> callerClass, Path path, MemorySession session) {
-        policyManager.checkFileRead(callerClass, path);
-        policyManager.checkLoadingNativeLibraries(callerClass);
+        policyChecker.checkFileRead(callerClass, path);
+        policyChecker.checkLoadingNativeLibraries(callerClass);
     }
 }

--- a/libs/entitlement/src/main20/java/org/elasticsearch/entitlement/runtime/api/Java20ElasticsearchEntitlementChecker.java
+++ b/libs/entitlement/src/main20/java/org/elasticsearch/entitlement/runtime/api/Java20ElasticsearchEntitlementChecker.java
@@ -10,7 +10,7 @@
 package org.elasticsearch.entitlement.runtime.api;
 
 import org.elasticsearch.entitlement.bridge.Java20EntitlementChecker;
-import org.elasticsearch.entitlement.runtime.policy.PolicyManager;
+import org.elasticsearch.entitlement.runtime.policy.PolicyChecker;
 
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.Linker;
@@ -24,8 +24,8 @@ import java.nio.file.spi.FileSystemProvider;
 
 public class Java20ElasticsearchEntitlementChecker extends ElasticsearchEntitlementChecker implements Java20EntitlementChecker {
 
-    public Java20ElasticsearchEntitlementChecker(PolicyManager policyManager) {
-        super(policyManager);
+    public Java20ElasticsearchEntitlementChecker(PolicyChecker policyChecker) {
+        super(policyChecker);
     }
 
     @Override
@@ -35,7 +35,7 @@ public class Java20ElasticsearchEntitlementChecker extends ElasticsearchEntitlem
         FunctionDescriptor function,
         Linker.Option... options
     ) {
-        policyManager.checkLoadingNativeLibraries(callerClass);
+        policyChecker.checkLoadingNativeLibraries(callerClass);
     }
 
     @Override
@@ -46,7 +46,7 @@ public class Java20ElasticsearchEntitlementChecker extends ElasticsearchEntitlem
         FunctionDescriptor function,
         Linker.Option... options
     ) {
-        policyManager.checkLoadingNativeLibraries(callerClass);
+        policyChecker.checkLoadingNativeLibraries(callerClass);
     }
 
     @Override
@@ -57,22 +57,22 @@ public class Java20ElasticsearchEntitlementChecker extends ElasticsearchEntitlem
         FunctionDescriptor function,
         SegmentScope scope
     ) {
-        policyManager.checkLoadingNativeLibraries(callerClass);
+        policyChecker.checkLoadingNativeLibraries(callerClass);
     }
 
     @Override
     public void check$java_lang_foreign_MemorySegment$$ofAddress(Class<?> callerClass, long address) {
-        policyManager.checkLoadingNativeLibraries(callerClass);
+        policyChecker.checkLoadingNativeLibraries(callerClass);
     }
 
     @Override
     public void check$java_lang_foreign_MemorySegment$$ofAddress(Class<?> callerClass, long address, long byteSize) {
-        policyManager.checkLoadingNativeLibraries(callerClass);
+        policyChecker.checkLoadingNativeLibraries(callerClass);
     }
 
     @Override
     public void check$java_lang_foreign_MemorySegment$$ofAddress(Class<?> callerClass, long address, long byteSize, SegmentScope scope) {
-        policyManager.checkLoadingNativeLibraries(callerClass);
+        policyChecker.checkLoadingNativeLibraries(callerClass);
     }
 
     @Override
@@ -83,23 +83,23 @@ public class Java20ElasticsearchEntitlementChecker extends ElasticsearchEntitlem
         SegmentScope scope,
         Runnable cleanupAction
     ) {
-        policyManager.checkLoadingNativeLibraries(callerClass);
+        policyChecker.checkLoadingNativeLibraries(callerClass);
     }
 
     @Override
     public void check$jdk_internal_foreign_layout_ValueLayouts$OfAddressImpl$asUnbounded(Class<?> callerClass, ValueLayout.OfAddress that) {
-        policyManager.checkLoadingNativeLibraries(callerClass);
+        policyChecker.checkLoadingNativeLibraries(callerClass);
     }
 
     @Override
     public void check$java_lang_foreign_SymbolLookup$$libraryLookup(Class<?> callerClass, String name, SegmentScope scope) {
-        policyManager.checkLoadingNativeLibraries(callerClass);
+        policyChecker.checkLoadingNativeLibraries(callerClass);
     }
 
     @Override
     public void check$java_lang_foreign_SymbolLookup$$libraryLookup(Class<?> callerClass, Path path, SegmentScope scope) {
-        policyManager.checkFileRead(callerClass, path);
-        policyManager.checkLoadingNativeLibraries(callerClass);
+        policyChecker.checkFileRead(callerClass, path);
+        policyChecker.checkLoadingNativeLibraries(callerClass);
     }
 
     @Override
@@ -110,11 +110,11 @@ public class Java20ElasticsearchEntitlementChecker extends ElasticsearchEntitlem
         Class<?> type,
         LinkOption... options
     ) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
     public void checkExists(Class<?> callerClass, FileSystemProvider that, Path path, LinkOption... options) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 }

--- a/libs/entitlement/src/main21/java/org/elasticsearch/entitlement/runtime/api/Java21ElasticsearchEntitlementChecker.java
+++ b/libs/entitlement/src/main21/java/org/elasticsearch/entitlement/runtime/api/Java21ElasticsearchEntitlementChecker.java
@@ -10,7 +10,7 @@
 package org.elasticsearch.entitlement.runtime.api;
 
 import org.elasticsearch.entitlement.bridge.Java21EntitlementChecker;
-import org.elasticsearch.entitlement.runtime.policy.PolicyManager;
+import org.elasticsearch.entitlement.runtime.policy.PolicyChecker;
 
 import java.lang.foreign.AddressLayout;
 import java.lang.foreign.Arena;
@@ -26,8 +26,8 @@ import java.util.function.Consumer;
 
 public class Java21ElasticsearchEntitlementChecker extends ElasticsearchEntitlementChecker implements Java21EntitlementChecker {
 
-    public Java21ElasticsearchEntitlementChecker(PolicyManager policyManager) {
-        super(policyManager);
+    public Java21ElasticsearchEntitlementChecker(PolicyChecker policyChecker) {
+        super(policyChecker);
     }
 
     @Override
@@ -36,7 +36,7 @@ public class Java21ElasticsearchEntitlementChecker extends ElasticsearchEntitlem
         AddressLayout that,
         MemoryLayout memoryLayout
     ) {
-        policyManager.checkLoadingNativeLibraries(callerClass);
+        policyChecker.checkLoadingNativeLibraries(callerClass);
     }
 
     @Override
@@ -47,7 +47,7 @@ public class Java21ElasticsearchEntitlementChecker extends ElasticsearchEntitlem
         FunctionDescriptor function,
         Linker.Option... options
     ) {
-        policyManager.checkLoadingNativeLibraries(callerClass);
+        policyChecker.checkLoadingNativeLibraries(callerClass);
     }
 
     @Override
@@ -57,7 +57,7 @@ public class Java21ElasticsearchEntitlementChecker extends ElasticsearchEntitlem
         FunctionDescriptor function,
         Linker.Option... options
     ) {
-        policyManager.checkLoadingNativeLibraries(callerClass);
+        policyChecker.checkLoadingNativeLibraries(callerClass);
     }
 
     @Override
@@ -69,12 +69,12 @@ public class Java21ElasticsearchEntitlementChecker extends ElasticsearchEntitlem
         Arena arena,
         Linker.Option... options
     ) {
-        policyManager.checkLoadingNativeLibraries(callerClass);
+        policyChecker.checkLoadingNativeLibraries(callerClass);
     }
 
     @Override
     public void check$jdk_internal_foreign_AbstractMemorySegmentImpl$reinterpret(Class<?> callerClass, MemorySegment that, long newSize) {
-        policyManager.checkLoadingNativeLibraries(callerClass);
+        policyChecker.checkLoadingNativeLibraries(callerClass);
     }
 
     @Override
@@ -85,7 +85,7 @@ public class Java21ElasticsearchEntitlementChecker extends ElasticsearchEntitlem
         Arena arena,
         Consumer<MemorySegment> cleanup
     ) {
-        policyManager.checkLoadingNativeLibraries(callerClass);
+        policyChecker.checkLoadingNativeLibraries(callerClass);
     }
 
     @Override
@@ -95,18 +95,18 @@ public class Java21ElasticsearchEntitlementChecker extends ElasticsearchEntitlem
         Arena arena,
         Consumer<MemorySegment> cleanup
     ) {
-        policyManager.checkLoadingNativeLibraries(callerClass);
+        policyChecker.checkLoadingNativeLibraries(callerClass);
     }
 
     @Override
     public void check$java_lang_foreign_SymbolLookup$$libraryLookup(Class<?> callerClass, String name, Arena arena) {
-        policyManager.checkLoadingNativeLibraries(callerClass);
+        policyChecker.checkLoadingNativeLibraries(callerClass);
     }
 
     @Override
     public void check$java_lang_foreign_SymbolLookup$$libraryLookup(Class<?> callerClass, Path path, Arena arena) {
-        policyManager.checkFileRead(callerClass, path);
-        policyManager.checkLoadingNativeLibraries(callerClass);
+        policyChecker.checkFileRead(callerClass, path);
+        policyChecker.checkLoadingNativeLibraries(callerClass);
     }
 
     @Override
@@ -117,11 +117,11 @@ public class Java21ElasticsearchEntitlementChecker extends ElasticsearchEntitlem
         Class<?> type,
         LinkOption... options
     ) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 
     @Override
     public void checkExists(Class<?> callerClass, FileSystemProvider that, Path path, LinkOption... options) {
-        policyManager.checkFileRead(callerClass, path);
+        policyChecker.checkFileRead(callerClass, path);
     }
 }

--- a/libs/entitlement/src/main22/java/org/elasticsearch/entitlement/runtime/api/Java22ElasticsearchEntitlementChecker.java
+++ b/libs/entitlement/src/main22/java/org/elasticsearch/entitlement/runtime/api/Java22ElasticsearchEntitlementChecker.java
@@ -10,11 +10,11 @@
 package org.elasticsearch.entitlement.runtime.api;
 
 import org.elasticsearch.entitlement.bridge.Java22EntitlementChecker;
-import org.elasticsearch.entitlement.runtime.policy.PolicyManager;
+import org.elasticsearch.entitlement.runtime.policy.PolicyChecker;
 
 public class Java22ElasticsearchEntitlementChecker extends Java21ElasticsearchEntitlementChecker implements Java22EntitlementChecker {
 
-    public Java22ElasticsearchEntitlementChecker(PolicyManager policyManager) {
-        super(policyManager);
+    public Java22ElasticsearchEntitlementChecker(PolicyChecker policyChecker) {
+        super(policyChecker);
     }
 }

--- a/libs/entitlement/src/main23/java/org/elasticsearch/entitlement/runtime/api/Java23ElasticsearchEntitlementChecker.java
+++ b/libs/entitlement/src/main23/java/org/elasticsearch/entitlement/runtime/api/Java23ElasticsearchEntitlementChecker.java
@@ -10,11 +10,11 @@
 package org.elasticsearch.entitlement.runtime.api;
 
 import org.elasticsearch.entitlement.bridge.Java23EntitlementChecker;
-import org.elasticsearch.entitlement.runtime.policy.PolicyManager;
+import org.elasticsearch.entitlement.runtime.policy.PolicyChecker;
 
 public class Java23ElasticsearchEntitlementChecker extends Java22ElasticsearchEntitlementChecker implements Java23EntitlementChecker {
 
-    public Java23ElasticsearchEntitlementChecker(PolicyManager policyManager) {
-        super(policyManager);
+    public Java23ElasticsearchEntitlementChecker(PolicyChecker policyChecker) {
+        super(policyChecker);
     }
 }

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyCheckerImplTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyCheckerImplTests.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlement.runtime.policy;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.elasticsearch.entitlement.runtime.policy.PolicyManagerTests.NO_ENTITLEMENTS_MODULE;
+import static org.elasticsearch.entitlement.runtime.policy.PolicyManagerTests.TEST_PATH_LOOKUP;
+import static org.elasticsearch.entitlement.runtime.policy.PolicyManagerTests.makeClassInItsOwnModule;
+
+public class PolicyCheckerImplTests extends ESTestCase {
+    public void testRequestingClassFastPath() throws IOException, ClassNotFoundException {
+        var callerClass = makeClassInItsOwnModule();
+        assertEquals(callerClass, checker(NO_ENTITLEMENTS_MODULE).requestingClass(callerClass));
+    }
+
+    public void testRequestingModuleWithStackWalk() throws IOException, ClassNotFoundException {
+        var entitlementsClass = makeClassInItsOwnModule();    // A class in the entitlements library itself
+        var instrumentedClass = makeClassInItsOwnModule();    // The class that called the check method
+        var requestingClass = makeClassInItsOwnModule();      // This guy is always the right answer
+        var ignorableClass = makeClassInItsOwnModule();
+
+        var checker = checker(entitlementsClass.getModule());
+
+        assertEquals(
+            "Skip entitlement library and the instrumented method",
+            requestingClass,
+            checker.findRequestingFrame(
+                Stream.of(entitlementsClass, instrumentedClass, requestingClass, ignorableClass).map(PolicyManagerTests.MockFrame::new)
+            ).map(StackWalker.StackFrame::getDeclaringClass).orElse(null)
+        );
+        assertEquals(
+            "Skip multiple library frames",
+            requestingClass,
+            checker.findRequestingFrame(
+                Stream.of(entitlementsClass, entitlementsClass, instrumentedClass, requestingClass).map(PolicyManagerTests.MockFrame::new)
+            ).map(StackWalker.StackFrame::getDeclaringClass).orElse(null)
+        );
+        assertThrows(
+            "Non-modular caller frames are not supported",
+            NullPointerException.class,
+            () -> checker.findRequestingFrame(Stream.of(entitlementsClass, null).map(PolicyManagerTests.MockFrame::new))
+        );
+    }
+
+    private static PolicyCheckerImpl checker(Module entitlementsModule) {
+        return new PolicyCheckerImpl(Set.of(), entitlementsModule, null, TEST_PATH_LOOKUP);
+    }
+
+}

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyManagerTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyManagerTests.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Stream;
 
 import static java.util.Map.entry;
 import static org.elasticsearch.entitlement.runtime.policy.PolicyManager.ComponentKind.SERVER;
@@ -56,11 +55,9 @@ public class PolicyManagerTests extends ESTestCase {
      * A module you can use for test cases that don't actually care about the
      * entitlement module.
      */
-    private static Module NO_ENTITLEMENTS_MODULE;
+    static Module NO_ENTITLEMENTS_MODULE;
 
-    private static Path TEST_BASE_DIR;
-
-    private static PathLookup TEST_PATH_LOOKUP;
+    static PathLookup TEST_PATH_LOOKUP;
 
     @BeforeClass
     public static void beforeClass() {
@@ -68,17 +65,17 @@ public class PolicyManagerTests extends ESTestCase {
             // Any old module will do for tests using NO_ENTITLEMENTS_MODULE
             NO_ENTITLEMENTS_MODULE = makeClassInItsOwnModule().getModule();
 
-            TEST_BASE_DIR = createTempDir().toAbsolutePath();
+            Path baseDir = createTempDir().toAbsolutePath();
             TEST_PATH_LOOKUP = new PathLookupImpl(
-                TEST_BASE_DIR.resolve("/user/home"),
-                TEST_BASE_DIR.resolve("/config"),
-                new Path[] { TEST_BASE_DIR.resolve("/data1/"), TEST_BASE_DIR.resolve("/data2") },
-                new Path[] { TEST_BASE_DIR.resolve("/shared1"), TEST_BASE_DIR.resolve("/shared2") },
-                TEST_BASE_DIR.resolve("/lib"),
-                TEST_BASE_DIR.resolve("/modules"),
-                TEST_BASE_DIR.resolve("/plugins"),
-                TEST_BASE_DIR.resolve("/logs"),
-                TEST_BASE_DIR.resolve("/tmp"),
+                baseDir.resolve("/user/home"),
+                baseDir.resolve("/config"),
+                new Path[] { baseDir.resolve("/data1/"), baseDir.resolve("/data2") },
+                new Path[] { baseDir.resolve("/shared1"), baseDir.resolve("/shared2") },
+                baseDir.resolve("/lib"),
+                baseDir.resolve("/modules"),
+                baseDir.resolve("/plugins"),
+                baseDir.resolve("/logs"),
+                baseDir.resolve("/tmp"),
                 null,
                 Settings.EMPTY::getValues
             );
@@ -100,9 +97,7 @@ public class PolicyManagerTests extends ESTestCase {
             Map.of("plugin1", new Policy("plugin1", List.of(new Scope("plugin.module1", List.of(new ExitVMEntitlement()))))),
             c -> policyScope.get(),
             Map.of("plugin1", plugin1SourcePath),
-            NO_ENTITLEMENTS_MODULE,
-            TEST_PATH_LOOKUP,
-            Set.of()
+            TEST_PATH_LOOKUP
         );
 
         // "Unspecified" below means that the module is not named in the policy
@@ -164,40 +159,6 @@ public class PolicyManagerTests extends ESTestCase {
         assertEquals("Map is unchanged", Map.of(requestingClass.getModule(), expectedEntitlements), policyManager.moduleEntitlementsMap);
     }
 
-    public void testRequestingClassFastPath() throws IOException, ClassNotFoundException {
-        var callerClass = makeClassInItsOwnModule();
-        assertEquals(callerClass, policyManager(NO_ENTITLEMENTS_MODULE).requestingClass(callerClass));
-    }
-
-    public void testRequestingModuleWithStackWalk() throws IOException, ClassNotFoundException {
-        var entitlementsClass = makeClassInItsOwnModule();    // A class in the entitlements library itself
-        var requestingClass = makeClassInItsOwnModule();      // This guy is always the right answer
-        var instrumentedClass = makeClassInItsOwnModule();    // The class that called the check method
-        var ignorableClass = makeClassInItsOwnModule();
-
-        var policyManager = policyManager(entitlementsClass.getModule());
-
-        assertEquals(
-            "Skip entitlement library and the instrumented method",
-            requestingClass,
-            policyManager.findRequestingFrame(
-                Stream.of(entitlementsClass, instrumentedClass, requestingClass, ignorableClass).map(MockFrame::new)
-            ).map(StackFrame::getDeclaringClass).orElse(null)
-        );
-        assertEquals(
-            "Skip multiple library frames",
-            requestingClass,
-            policyManager.findRequestingFrame(
-                Stream.of(entitlementsClass, entitlementsClass, instrumentedClass, requestingClass).map(MockFrame::new)
-            ).map(StackFrame::getDeclaringClass).orElse(null)
-        );
-        assertThrows(
-            "Non-modular caller frames are not supported",
-            NullPointerException.class,
-            () -> policyManager.findRequestingFrame(Stream.of(entitlementsClass, null).map(MockFrame::new))
-        );
-    }
-
     public void testAgentsEntitlements() throws IOException, ClassNotFoundException {
         Path home = createTempDir();
         Path unnamedJar = createMockPluginJarForUnnamedModule(home);
@@ -210,9 +171,7 @@ public class PolicyManagerTests extends ESTestCase {
                 ? PolicyScope.apmAgent("test.agent.module")
                 : PolicyScope.plugin("test", "test.plugin.module"),
             Map.of(),
-            NO_ENTITLEMENTS_MODULE,
-            TEST_PATH_LOOKUP,
-            Set.of()
+            TEST_PATH_LOOKUP
         );
         ModuleEntitlements agentsEntitlements = policyManager.getEntitlements(TestAgent.class);
         assertThat(agentsEntitlements.hasEntitlement(CreateClassLoaderEntitlement.class), is(true));
@@ -239,9 +198,7 @@ public class PolicyManagerTests extends ESTestCase {
                 Map.of(),
                 c -> PolicyScope.plugin("test", moduleName(c)),
                 Map.of(),
-                NO_ENTITLEMENTS_MODULE,
-                TEST_PATH_LOOKUP,
-                Set.of()
+                TEST_PATH_LOOKUP
             )
         );
         assertEquals(
@@ -257,9 +214,7 @@ public class PolicyManagerTests extends ESTestCase {
                 Map.of(),
                 c -> PolicyScope.plugin("test", moduleName(c)),
                 Map.of(),
-                NO_ENTITLEMENTS_MODULE,
-                TEST_PATH_LOOKUP,
-                Set.of()
+                TEST_PATH_LOOKUP
             )
         );
         assertEquals(
@@ -295,9 +250,7 @@ public class PolicyManagerTests extends ESTestCase {
                 ),
                 c -> PolicyScope.plugin("plugin1", moduleName(c)),
                 Map.of("plugin1", Path.of("modules", "plugin1")),
-                NO_ENTITLEMENTS_MODULE,
-                TEST_PATH_LOOKUP,
-                Set.of()
+                TEST_PATH_LOOKUP
             )
         );
         assertEquals(
@@ -347,9 +300,7 @@ public class PolicyManagerTests extends ESTestCase {
                 ),
                 c -> PolicyScope.plugin("", moduleName(c)),
                 Map.of("plugin1", Path.of("modules", "plugin1"), "plugin2", Path.of("modules", "plugin2")),
-                NO_ENTITLEMENTS_MODULE,
-                TEST_PATH_LOOKUP,
-                Set.of()
+                TEST_PATH_LOOKUP
             )
         );
         assertThat(
@@ -400,9 +351,7 @@ public class PolicyManagerTests extends ESTestCase {
                 ),
                 c -> PolicyScope.plugin("", moduleName(c)),
                 Map.of(),
-                NO_ENTITLEMENTS_MODULE,
-                TEST_PATH_LOOKUP,
-                Set.of()
+                TEST_PATH_LOOKUP
             )
         );
         assertEquals(
@@ -416,27 +365,14 @@ public class PolicyManagerTests extends ESTestCase {
         );
     }
 
-    private static Class<?> makeClassInItsOwnModule() throws IOException, ClassNotFoundException {
+    static Class<?> makeClassInItsOwnModule() throws IOException, ClassNotFoundException {
         final Path home = createTempDir();
         Path jar = createMockPluginJar(home);
         var layer = createLayerForJar(jar, "org.example.plugin");
         return layer.findLoader("org.example.plugin").loadClass("q.B");
     }
 
-    private static PolicyManager policyManager(Module entitlementsModule) {
-        return new PolicyManager(
-            createEmptyTestServerPolicy(),
-            List.of(),
-            Map.of(),
-            c -> PolicyScope.plugin("test", moduleName(c)),
-            Map.of(),
-            entitlementsModule,
-            TEST_PATH_LOOKUP,
-            Set.of()
-        );
-    }
-
-    private static Policy createEmptyTestServerPolicy() {
+    static Policy createEmptyTestServerPolicy() {
         return new Policy("server", List.of());
     }
 
@@ -518,7 +454,7 @@ public class PolicyManagerTests extends ESTestCase {
         }
     }
 
-    private static String moduleName(Class<?> c) {
+    static String moduleName(Class<?> c) {
         return ScopeResolver.getScopeName(c.getModule());
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Split PolicyChecker from PolicyManager (#128004)](https://github.com/elastic/elasticsearch/pull/128004)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)