### PR TITLE
Add 8.17.9 Connectors release note (#131222)

### DIFF
--- a/docs/reference/connector/docs/connectors-release-notes.asciidoc
+++ b/docs/reference/connector/docs/connectors-release-notes.asciidoc
@@ -63,6 +63,12 @@ IMPORTANT: Users building custom docker images based on this Dockerfile may have
 See https://github.com/elastic/connectors/pull/3063[*PR 3063*].
 
 [discrete]
+[[es-connectors-release-notes-8-17-9]]
+=== 8.17.9
+
+No notable changes in this release.
+
+[discrete]
 [[es-connectors-release-notes-8-17-8]]
 === 8.17.8
 


### PR DESCRIPTION
Manual backport of https://github.com/elastic/elasticsearch/pull/131222
