### PR TITLE
move all read_cross_cluster permissions into read

### DIFF
--- a/qa/ccs-common-rest/src/yamlRestTest/resources/roles.yml
+++ b/qa/ccs-common-rest/src/yamlRestTest/resources/roles.yml
@@ -6,6 +6,6 @@ remote_search_role:
       allow_restricted_indices: true
   remote_indices:
     - names: [ '*' ]
-      privileges: [ 'read', 'read_cross_cluster' ]
+      privileges: [ 'read' ]
       allow_restricted_indices: true
       clusters: [ '*' ]

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/CrossClusterApiKeyRoleDescriptorBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/CrossClusterApiKeyRoleDescriptorBuilder.java
@@ -31,7 +31,7 @@ public class CrossClusterApiKeyRoleDescriptorBuilder {
         Arrays.stream(CCS_CLUSTER_PRIVILEGE_NAMES),
         Arrays.stream(CCR_CLUSTER_PRIVILEGE_NAMES)
     ).toArray(String[]::new);
-    public static final String[] CCS_INDICES_PRIVILEGE_NAMES = { "read", "read_cross_cluster", "view_index_metadata" };
+    public static final String[] CCS_INDICES_PRIVILEGE_NAMES = { "read", "view_index_metadata" };
     public static final String[] CCR_INDICES_PRIVILEGE_NAMES = { "cross_cluster_replication", "cross_cluster_replication_internal" };
     public static final String ROLE_DESCRIPTOR_NAME = "cross_cluster";
 
@@ -171,7 +171,7 @@ public class CrossClusterApiKeyRoleDescriptorBuilder {
         final RoleDescriptor.IndicesPrivileges[] indicesPrivileges = roleDescriptor.getIndicesPrivileges();
         for (RoleDescriptor.IndicesPrivileges indexPrivilege : indicesPrivileges) {
             final String[] privileges = indexPrivilege.getPrivileges();
-            final String[] legacyIndicesPrivileges = { "read", "read_cross_cluster", "view_index_metadata" };
+            final String[] legacyIndicesPrivileges = { "read", "view_index_metadata" };
             // find the "search" privilege, no need to check for DLS if set of index privileges are not the set used pre 8.14
             if (Arrays.equals(privileges, legacyIndicesPrivileges)) {
                 if (indexPrivilege.isUsingDocumentOrFieldLevelSecurity()) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilege.java
@@ -84,7 +84,10 @@ public final class IndexPrivilege extends Privilege {
     private static final Automaton READ_AUTOMATON = patterns(
         "indices:data/read/*",
         ResolveIndexAction.NAME,
-        TransportResolveClusterAction.NAME
+        TransportResolveClusterAction.NAME,
+        "internal:transport/proxy/indices:data/read/*",
+        TransportClusterSearchShardsAction.TYPE.name(),
+        TransportSearchShardsAction.TYPE.name()
     );
     private static final Automaton READ_FAILURE_STORE_AUTOMATON = patterns("indices:data/read/*", ResolveIndexAction.NAME);
     private static final Automaton READ_CROSS_CLUSTER_AUTOMATON = patterns(

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -113,7 +113,7 @@ class KibanaOwnedReservedRoleDescriptors {
                     .privileges("all")
                     .allowRestrictedIndices(true)
                     .build(),
-                RoleDescriptor.IndicesPrivileges.builder().indices(".monitoring-*").privileges("read", "read_cross_cluster").build(),
+                RoleDescriptor.IndicesPrivileges.builder().indices(".monitoring-*").privileges("read").build(),
                 RoleDescriptor.IndicesPrivileges.builder().indices(".management-beats").privileges("create_index", "read", "write").build(),
                 // To facilitate ML UI functionality being controlled using Kibana security
                 // privileges
@@ -150,11 +150,11 @@ class KibanaOwnedReservedRoleDescriptors {
                     .build(),
 
                 // APM telemetry queries APM indices in kibana task runner
-                RoleDescriptor.IndicesPrivileges.builder().indices("apm-*").privileges("read", "read_cross_cluster").build(),
-                RoleDescriptor.IndicesPrivileges.builder().indices("logs-apm.*").privileges("read", "read_cross_cluster").build(),
-                RoleDescriptor.IndicesPrivileges.builder().indices("metrics-apm.*").privileges("read", "read_cross_cluster").build(),
-                RoleDescriptor.IndicesPrivileges.builder().indices("traces-apm.*").privileges("read", "read_cross_cluster").build(),
-                RoleDescriptor.IndicesPrivileges.builder().indices("traces-apm-*").privileges("read", "read_cross_cluster").build(),
+                RoleDescriptor.IndicesPrivileges.builder().indices("apm-*").privileges("read").build(),
+                RoleDescriptor.IndicesPrivileges.builder().indices("logs-apm.*").privileges("read").build(),
+                RoleDescriptor.IndicesPrivileges.builder().indices("metrics-apm.*").privileges("read").build(),
+                RoleDescriptor.IndicesPrivileges.builder().indices("traces-apm.*").privileges("read").build(),
+                RoleDescriptor.IndicesPrivileges.builder().indices("traces-apm-*").privileges("read").build(),
 
                 // Logstash telemetry queries of kibana task runner to access Logstash metric
                 // indices

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -87,7 +87,7 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
             RoleDescriptor.IndicesPrivileges.builder()
                 .indices("*")
                 // TODO add read_failure_store when failures authorization is implemented
-                .privileges("monitor", "read", "view_index_metadata", "read_cross_cluster")
+                .privileges("monitor", "read", "view_index_metadata")
                 .allowRestrictedIndices(true)
                 .build() },
         new RoleDescriptor.ApplicationResourcePrivileges[] {
@@ -105,7 +105,7 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices("*")
                     // TODO add read_failure_store when failures authorization is implemented
-                    .privileges("monitor", "read", "view_index_metadata", "read_cross_cluster")
+                    .privileges("monitor", "read", "view_index_metadata")
                     .allowRestrictedIndices(true)
                     .build(),
                 "*"
@@ -161,7 +161,7 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
         return new RoleDescriptor.RemoteIndicesPrivileges(
             RoleDescriptor.IndicesPrivileges.builder()
                 .indices(indexPattern)
-                .privileges("read", "read_cross_cluster")
+                .privileges("read")
                 .allowRestrictedIndices(false)
                 .build(),
             "*"
@@ -204,15 +204,15 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                     new RoleDescriptor.IndicesPrivileges[] {
                         RoleDescriptor.IndicesPrivileges.builder()
                             .indices(".monitoring-*")
-                            .privileges("read", "read_cross_cluster")
+                            .privileges("read")
                             .build(),
                         RoleDescriptor.IndicesPrivileges.builder()
                             .indices("/metrics-(beats|elasticsearch|enterprisesearch|kibana|logstash).*/")
-                            .privileges("read", "read_cross_cluster")
+                            .privileges("read")
                             .build(),
                         RoleDescriptor.IndicesPrivileges.builder()
                             .indices("metricbeat-*")
-                            .privileges("read", "read_cross_cluster")
+                            .privileges("read")
                             .build() },
                     new RoleDescriptor.ApplicationResourcePrivileges[] {
                         RoleDescriptor.ApplicationResourcePrivileges.builder()

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -159,11 +159,7 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
 
     static RoleDescriptor.RemoteIndicesPrivileges getRemoteIndicesReadPrivileges(String indexPattern) {
         return new RoleDescriptor.RemoteIndicesPrivileges(
-            RoleDescriptor.IndicesPrivileges.builder()
-                .indices(indexPattern)
-                .privileges("read")
-                .allowRestrictedIndices(false)
-                .build(),
+            RoleDescriptor.IndicesPrivileges.builder().indices(indexPattern).privileges("read").allowRestrictedIndices(false).build(),
             "*"
         );
     }
@@ -202,18 +198,12 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                     "monitoring_user",
                     new String[] { "cluster:monitor/main", "cluster:monitor/xpack/info", TransportRemoteInfoAction.TYPE.name() },
                     new RoleDescriptor.IndicesPrivileges[] {
-                        RoleDescriptor.IndicesPrivileges.builder()
-                            .indices(".monitoring-*")
-                            .privileges("read")
-                            .build(),
+                        RoleDescriptor.IndicesPrivileges.builder().indices(".monitoring-*").privileges("read").build(),
                         RoleDescriptor.IndicesPrivileges.builder()
                             .indices("/metrics-(beats|elasticsearch|enterprisesearch|kibana|logstash).*/")
                             .privileges("read")
                             .build(),
-                        RoleDescriptor.IndicesPrivileges.builder()
-                            .indices("metricbeat-*")
-                            .privileges("read")
-                            .build() },
+                        RoleDescriptor.IndicesPrivileges.builder().indices("metricbeat-*").privileges("read").build() },
                     new RoleDescriptor.ApplicationResourcePrivileges[] {
                         RoleDescriptor.ApplicationResourcePrivileges.builder()
                             .application("kibana-*")

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/apikey/CrossClusterApiKeyRoleDescriptorBuilderTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/apikey/CrossClusterApiKeyRoleDescriptorBuilderTests.java
@@ -54,7 +54,7 @@ public class CrossClusterApiKeyRoleDescriptorBuilderTests extends ESTestCase {
             new RoleDescriptor.IndicesPrivileges[] {
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices("metrics")
-                    .privileges("read", "read_cross_cluster", "view_index_metadata")
+                    .privileges("read", "view_index_metadata")
                     .build() }
         );
     }
@@ -78,7 +78,7 @@ public class CrossClusterApiKeyRoleDescriptorBuilderTests extends ESTestCase {
             new RoleDescriptor.IndicesPrivileges[] {
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices("metrics")
-                    .privileges("read", "read_cross_cluster", "view_index_metadata")
+                    .privileges("read", "view_index_metadata")
                     .query("{\"term\":{\"tag\":42}}")
                     .build() }
         );
@@ -106,7 +106,7 @@ public class CrossClusterApiKeyRoleDescriptorBuilderTests extends ESTestCase {
             new RoleDescriptor.IndicesPrivileges[] {
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices("metrics")
-                    .privileges("read", "read_cross_cluster", "view_index_metadata")
+                    .privileges("read", "view_index_metadata")
                     .grantedFields("*")
                     .deniedFields("private")
                     .build() }
@@ -163,11 +163,11 @@ public class CrossClusterApiKeyRoleDescriptorBuilderTests extends ESTestCase {
             new RoleDescriptor.IndicesPrivileges[] {
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices("metrics")
-                    .privileges("read", "read_cross_cluster", "view_index_metadata")
+                    .privileges("read", "view_index_metadata")
                     .build(),
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices("logs")
-                    .privileges("read", "read_cross_cluster", "view_index_metadata")
+                    .privileges("read", "view_index_metadata")
                     .build(),
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices("archive")
@@ -256,7 +256,7 @@ public class CrossClusterApiKeyRoleDescriptorBuilderTests extends ESTestCase {
         // minor optimizations. the "legacy" privileges might also be the same as in newer versions, and that is OK too.
         final String[] legacyClusterPrivileges_searchAndReplication = { "cross_cluster_search", "cross_cluster_replication" };
         final String[] legacyClusterPrivileges_searchOnly = { "cross_cluster_search" };
-        final String[] legacyIndexPrivileges = { "read", "read_cross_cluster", "view_index_metadata" };
+        final String[] legacyIndexPrivileges = { "read", "view_index_metadata" };
         final String[] otherPrivileges = randomArray(1, 5, String[]::new, () -> randomAlphaOfLength(5));
         String apiKeyId = randomAlphaOfLength(5);
         RoleDescriptor.IndicesPrivileges legacySearchIndexPrivileges_noDLS = RoleDescriptor.IndicesPrivileges.builder()

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/apikey/CrossClusterApiKeyRoleDescriptorBuilderTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/apikey/CrossClusterApiKeyRoleDescriptorBuilderTests.java
@@ -52,10 +52,7 @@ public class CrossClusterApiKeyRoleDescriptorBuilderTests extends ESTestCase {
             roleDescriptor,
             new String[] { "cross_cluster_search", "monitor_enrich" },
             new RoleDescriptor.IndicesPrivileges[] {
-                RoleDescriptor.IndicesPrivileges.builder()
-                    .indices("metrics")
-                    .privileges("read", "view_index_metadata")
-                    .build() }
+                RoleDescriptor.IndicesPrivileges.builder().indices("metrics").privileges("read", "view_index_metadata").build() }
         );
     }
 
@@ -161,14 +158,8 @@ public class CrossClusterApiKeyRoleDescriptorBuilderTests extends ESTestCase {
             roleDescriptor,
             new String[] { "cross_cluster_search", "cross_cluster_replication", "monitor_enrich" },
             new RoleDescriptor.IndicesPrivileges[] {
-                RoleDescriptor.IndicesPrivileges.builder()
-                    .indices("metrics")
-                    .privileges("read", "view_index_metadata")
-                    .build(),
-                RoleDescriptor.IndicesPrivileges.builder()
-                    .indices("logs")
-                    .privileges("read", "view_index_metadata")
-                    .build(),
+                RoleDescriptor.IndicesPrivileges.builder().indices("metrics").privileges("read", "view_index_metadata").build(),
+                RoleDescriptor.IndicesPrivileges.builder().indices("logs").privileges("read", "view_index_metadata").build(),
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices("archive")
                     .privileges("cross_cluster_replication", "cross_cluster_replication_internal")

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/apikey/GetApiKeyResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/apikey/GetApiKeyResponseTests.java
@@ -283,7 +283,7 @@ public class GetApiKeyResponseTests extends ESTestCase {
                             "logs"
                           ],
                           "privileges": [
-                            "read", "read_cross_cluster", "view_index_metadata"
+                            "read", "view_index_metadata"
                           ],
                           "allow_restricted_indices": false
                         },

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTestHelper.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTestHelper.java
@@ -356,7 +356,7 @@ public class AuthenticationTestHelper {
                         "_remote_user",
                         null,
                         new RoleDescriptor.IndicesPrivileges[] {
-                            RoleDescriptor.IndicesPrivileges.builder().indices("index1").privileges("read", "read_cross_cluster").build() },
+                            RoleDescriptor.IndicesPrivileges.builder().indices("index1").privileges("read").build() },
                         null,
                         null,
                         null,
@@ -450,7 +450,7 @@ public class AuthenticationTestHelper {
                   "cross_cluster": {
                     "cluster": ["cross_cluster_search", "cross_cluster_replication"],
                     "indices": [
-                      { "names":["logs*"], "privileges":["read","read_cross_cluster","view_index_metadata"] },
+                      { "names":["logs*"], "privileges":["read","view_index_metadata"] },
                       { "names":["archive*"],"privileges":["cross_cluster_replication","cross_cluster_replication_internal"] }
                     ]
                   }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/SubjectTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/SubjectTests.java
@@ -169,7 +169,7 @@ public class SubjectTests extends ESTestCase {
               "cross_cluster": {
                 "cluster": ["cross_cluster_search"],
                 "indices": [
-                  { "names":["index"], "privileges":["read","read_cross_cluster","view_index_metadata"] }
+                  { "names":["index"], "privileges":["read","view_index_metadata"] }
                 ]
               }
             }""");

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -723,7 +723,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
                 kibanaRole.indices().allowedIndicesMatcher(TransportGetAction.TYPE.name()).test(mockIndexAbstraction(index)),
                 is(true)
             );
-            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(mockIndexAbstraction(index)), is(false));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(mockIndexAbstraction(index)), is(true));
         });
 
         // read/write index access, excluding cross cluster
@@ -760,7 +760,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
                 kibanaRole.indices().allowedIndicesMatcher(TransportGetAction.TYPE.name()).test(mockIndexAbstraction(index)),
                 is(true)
             );
-            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(mockIndexAbstraction(index)), is(false));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(mockIndexAbstraction(index)), is(true));
         });
 
         // read-only indices for APM telemetry
@@ -851,7 +851,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
                 kibanaRole.indices().allowedIndicesMatcher(TransportGetAction.TYPE.name()).test(mockIndexAbstraction(index)),
                 is(true)
             );
-            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(mockIndexAbstraction(index)), is(false));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(mockIndexAbstraction(index)), is(true));
 
             // Privileges needed for Fleet package upgrades
             assertThat(
@@ -889,7 +889,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportMultiSearchAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportGetAction.TYPE.name()).test(indexAbstraction), is(true));
-            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(false));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(true));
             assertThat(
                 kibanaRole.indices().allowedIndicesMatcher(TransportUpdateSettingsAction.TYPE.name()).test(indexAbstraction),
                 is(true)
@@ -917,7 +917,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportMultiSearchAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportGetAction.TYPE.name()).test(indexAbstraction), is(true));
-            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(false));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(true));
             assertThat(
                 kibanaRole.indices().allowedIndicesMatcher(TransportUpdateSettingsAction.TYPE.name()).test(indexAbstraction),
                 is(true)
@@ -999,7 +999,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportMultiSearchAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportGetAction.TYPE.name()).test(indexAbstraction), is(true));
-            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(false));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(true));
             assertThat(
                 kibanaRole.indices().allowedIndicesMatcher(TransportUpdateSettingsAction.TYPE.name()).test(indexAbstraction),
                 is(true)
@@ -1023,7 +1023,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportMultiSearchAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportGetAction.TYPE.name()).test(indexAbstraction), is(true));
-            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(false));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(true));
             assertThat(
                 kibanaRole.indices().allowedIndicesMatcher(TransportUpdateSettingsAction.TYPE.name()).test(indexAbstraction),
                 is(true)
@@ -1050,7 +1050,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportMultiSearchAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportGetAction.TYPE.name()).test(indexAbstraction), is(true));
-            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(false));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(true));
             assertThat(
                 kibanaRole.indices().allowedIndicesMatcher(TransportUpdateSettingsAction.TYPE.name()).test(indexAbstraction),
                 is(true)
@@ -1083,7 +1083,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportMultiSearchAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportGetAction.TYPE.name()).test(indexAbstraction), is(true));
-            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(false));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(true));
             assertThat(
                 kibanaRole.indices().allowedIndicesMatcher(TransportUpdateSettingsAction.TYPE.name()).test(indexAbstraction),
                 is(true)
@@ -1108,7 +1108,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportMultiSearchAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportGetAction.TYPE.name()).test(indexAbstraction), is(true));
-            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(false));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(true));
             assertThat(
                 kibanaRole.indices().allowedIndicesMatcher(TransportUpdateSettingsAction.TYPE.name()).test(indexAbstraction),
                 is(true)
@@ -1133,7 +1133,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportMultiSearchAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportGetAction.TYPE.name()).test(indexAbstraction), is(true));
-            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(false));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(true));
             assertThat(
                 kibanaRole.indices().allowedIndicesMatcher(TransportUpdateSettingsAction.TYPE.name()).test(indexAbstraction),
                 is(true)
@@ -1155,7 +1155,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportMultiSearchAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportGetAction.TYPE.name()).test(indexAbstraction), is(true));
-            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(false));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(true));
             assertThat(
                 kibanaRole.indices().allowedIndicesMatcher(TransportUpdateSettingsAction.TYPE.name()).test(indexAbstraction),
                 is(true)
@@ -1242,7 +1242,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportMultiSearchAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportGetAction.TYPE.name()).test(indexAbstraction), is(true));
-            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(false));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(true));
             assertThat(
                 kibanaRole.indices().allowedIndicesMatcher(TransportUpdateSettingsAction.TYPE.name()).test(indexAbstraction),
                 is(true)
@@ -1270,7 +1270,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportMultiSearchAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportGetAction.TYPE.name()).test(indexAbstraction), is(true));
-            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(false));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(true));
             assertThat(
                 kibanaRole.indices().allowedIndicesMatcher(TransportUpdateSettingsAction.TYPE.name()).test(indexAbstraction),
                 is(true)
@@ -1306,7 +1306,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
             is(true)
         );
         assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportGetAction.TYPE.name()).test(mockIndexAbstraction(index)), is(true));
-        assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(mockIndexAbstraction(index)), is(false));
+        assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(mockIndexAbstraction(index)), is(true));
 
         assertNoAccessAllowed(kibanaRole, TestRestrictedIndices.SAMPLE_RESTRICTED_NAMES);
         assertNoAccessAllowed(kibanaRole, XPackPlugin.ASYNC_RESULTS_INDEX + randomAlphaOfLengthBetween(0, 2));
@@ -1608,7 +1608,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportMultiSearchAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportGetAction.TYPE.name()).test(indexAbstraction), is(true));
-            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(false));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(true));
             assertThat(
                 kibanaRole.indices().allowedIndicesMatcher(TransportUpdateSettingsAction.TYPE.name()).test(indexAbstraction),
                 is(true)
@@ -1634,7 +1634,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportMultiSearchAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportGetAction.TYPE.name()).test(indexAbstraction), is(true));
-            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(false));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(true));
             assertThat(
                 kibanaRole.indices().allowedIndicesMatcher(TransportUpdateSettingsAction.TYPE.name()).test(indexAbstraction),
                 is(true)
@@ -1660,7 +1660,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportMultiSearchAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportGetAction.TYPE.name()).test(indexAbstraction), is(true));
-            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(false));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(true));
             assertThat(
                 kibanaRole.indices().allowedIndicesMatcher(TransportUpdateSettingsAction.TYPE.name()).test(indexAbstraction),
                 is(true)
@@ -1703,7 +1703,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportMultiSearchAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportGetAction.TYPE.name()).test(indexAbstraction), is(true));
-            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(false));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(true));
             assertThat(
                 kibanaRole.indices().allowedIndicesMatcher(TransportUpdateSettingsAction.TYPE.name()).test(indexAbstraction),
                 is(true)
@@ -1776,7 +1776,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportMultiSearchAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportGetAction.TYPE.name()).test(indexAbstraction), is(true));
-            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(false));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(true));
             assertThat(
                 kibanaRole.indices().allowedIndicesMatcher(TransportUpdateSettingsAction.TYPE.name()).test(indexAbstraction),
                 is(true)
@@ -1869,7 +1869,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportMultiSearchAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportGetAction.TYPE.name()).test(indexAbstraction), is(true));
-            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(false));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(true));
             assertThat(
                 kibanaRole.indices().allowedIndicesMatcher(TransportUpdateSettingsAction.TYPE.name()).test(indexAbstraction),
                 is(true)
@@ -3801,23 +3801,8 @@ public class ReservedRolesStoreTests extends ESTestCase {
             if (roleDescriptor.getName().equals("superuser")) {
                 continue;  // superuser is tested separately
             }
-            final Role role = Role.buildFromRoleDescriptor(roleDescriptor, new FieldPermissionsCache(Settings.EMPTY), RESTRICTED_INDICES);
 
-            // The assumption here is that any read_cross_cluster indices privileges should be paired with
-            // a corresponding remote indices privileges
-            final var readCrossClusterIndicesPrivileges = Arrays.stream(roleDescriptor.getIndicesPrivileges())
-                .filter(ip -> Arrays.asList(ip.getPrivileges()).contains("read_cross_cluster"))
-                .toArray(RoleDescriptor.IndicesPrivileges[]::new);
-            if (readCrossClusterIndicesPrivileges.length == 0) {
-                assertThat(roleDescriptor.hasRemoteIndicesPrivileges(), is(false));
-            } else {
-                assertThat(roleDescriptor.hasRemoteIndicesPrivileges(), is(true));
-                assertThat(
-                    Arrays.stream(roleDescriptor.getRemoteIndicesPrivileges())
-                        .map(RoleDescriptor.RemoteIndicesPrivileges::indicesPrivileges)
-                        .toList(),
-                    containsInAnyOrder(readCrossClusterIndicesPrivileges)
-                );
+            if (roleDescriptor.hasRemoteIndicesPrivileges()) {
                 rolesWithRemoteIndicesPrivileges.add(roleDescriptor.getName());
             }
         }

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/AbstractRemoteClusterSecurityBWCRestIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/AbstractRemoteClusterSecurityBWCRestIT.java
@@ -73,13 +73,13 @@ public abstract class AbstractRemoteClusterSecurityBWCRestIT extends AbstractRem
                   "indices": [
                     {
                       "names": ["local_index", "remote_index1"],
-                      "privileges": ["read", "read_cross_cluster"]
+                      "privileges": ["read"]
                     }
                   ],
                   "remote_indices": [
                     {
                       "names": ["remote_index1"],
-                      "privileges": ["read", "read_cross_cluster"],
+                      "privileges": ["read"],
                       "clusters": ["my_remote_cluster"]
                     }
                   ],
@@ -100,7 +100,7 @@ public abstract class AbstractRemoteClusterSecurityBWCRestIT extends AbstractRem
                       "indices": [
                         {
                           "names": ["remote_index1"],
-                          "privileges": ["read", "read_cross_cluster"]
+                          "privileges": ["read"]
                         }
                       ]
                     }""");
@@ -126,13 +126,13 @@ public abstract class AbstractRemoteClusterSecurityBWCRestIT extends AbstractRem
                       "indices": [
                         {
                           "names": ["local_index", "remote_index1", "remote_index2"],
-                          "privileges": ["read", "read_cross_cluster"]
+                          "privileges": ["read"]
                         }
                       ],
                       "remote_indices": [
                         {
                           "names": ["remote_index1", "remote_index2"],
-                          "privileges": ["read", "read_cross_cluster"],
+                          "privileges": ["read"],
                           "clusters": ["my_remote_*", "non_existing_remote_cluster"]
                         }
                       ],

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/AbstractRemoteClusterSecurityDlsAndFlsRestIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/AbstractRemoteClusterSecurityDlsAndFlsRestIT.java
@@ -49,7 +49,7 @@ public abstract class AbstractRemoteClusterSecurityDlsAndFlsRestIT extends Abstr
               "remote_indices": [
                 {
                   "names": ["remote_index*"],
-                  "privileges": ["read", "read_cross_cluster"],
+                  "privileges": ["read"],
                   "clusters": ["my_*_cluster*"]
                 }
               ]
@@ -61,7 +61,7 @@ public abstract class AbstractRemoteClusterSecurityDlsAndFlsRestIT extends Abstr
               "remote_indices": [
                 {
                   "names": ["remote_index*"],
-                  "privileges": ["read", "read_cross_cluster"],
+                  "privileges": ["read"],
                   "clusters": ["my_*_cluster*"],
                   "query": {
                      "bool": {
@@ -76,7 +76,7 @@ public abstract class AbstractRemoteClusterSecurityDlsAndFlsRestIT extends Abstr
                 },
                 {
                   "names": ["remote_index1", "remote_index2", "remote_index3"],
-                  "privileges": ["read", "read_cross_cluster"],
+                  "privileges": ["read"],
                   "clusters": ["my_remote_cluster*"],
                   "query": {
                      "bool": {
@@ -98,13 +98,13 @@ public abstract class AbstractRemoteClusterSecurityDlsAndFlsRestIT extends Abstr
               "remote_indices": [
                 {
                   "names": ["remote_index*"],
-                  "privileges": ["read", "read_cross_cluster"],
+                  "privileges": ["read"],
                   "clusters": ["my_*_cluster*"],
                   "query": {"bool": { "must_not": { "term" : {"field1" : "value1"}}}}
                 },
                 {
                   "names": ["remote_index*"],
-                  "privileges": ["read", "read_cross_cluster"],
+                  "privileges": ["read"],
                   "clusters": ["my_*_cluster*"],
                   "query": {"bool": { "must_not": { "term" : {"field2" : "value1"}}}}
                 }
@@ -117,13 +117,13 @@ public abstract class AbstractRemoteClusterSecurityDlsAndFlsRestIT extends Abstr
               "remote_indices": [
                 {
                   "names": ["remote_index*"],
-                  "privileges": ["read", "read_cross_cluster"],
+                  "privileges": ["read"],
                   "clusters": ["my_*_cluster*"],
                   "field_security": {"grant": [ "field1", "field2" ], "except": ["field2"]}
                 },
                 {
                   "names": ["remote_index*"],
-                  "privileges": ["read", "read_cross_cluster"],
+                  "privileges": ["read"],
                   "clusters": ["my_*_cluster*"],
                   "field_security": {"grant": [ "field3" ]}
                 }

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/CrossClusterEsqlRCS1MissingIndicesIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/CrossClusterEsqlRCS1MissingIndicesIT.java
@@ -415,13 +415,13 @@ public class CrossClusterEsqlRCS1MissingIndicesIT extends AbstractRemoteClusterS
               "indices": [
                 {
                   "names": ["points", "squares"],
-                  "privileges": ["read", "read_cross_cluster", "create_index", "monitor"]
+                  "privileges": ["read", "create_index", "monitor"]
                 }
               ],
               "remote_indices": [
                 {
                   "names": ["points", "squares"],
-                  "privileges": ["read", "read_cross_cluster", "create_index", "monitor"],
+                  "privileges": ["read", "create_index", "monitor"],
                   "clusters": ["my_remote_cluster"]
                 }
               ]

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/CrossClusterEsqlRCS1UnavailableRemotesIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/CrossClusterEsqlRCS1UnavailableRemotesIT.java
@@ -209,13 +209,13 @@ public class CrossClusterEsqlRCS1UnavailableRemotesIT extends AbstractRemoteClus
               "indices": [
                 {
                   "names": ["points", "squares"],
-                  "privileges": ["read", "read_cross_cluster", "create_index", "monitor"]
+                  "privileges": ["read", "create_index", "monitor"]
                 }
               ],
               "remote_indices": [
                 {
                   "names": ["points", "squares"],
-                  "privileges": ["read", "read_cross_cluster", "create_index", "monitor"],
+                  "privileges": ["read", "create_index", "monitor"],
                   "clusters": ["my_remote_cluster"]
                 }
               ]

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/CrossClusterEsqlRCS2UnavailableRemotesIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/CrossClusterEsqlRCS2UnavailableRemotesIT.java
@@ -235,13 +235,13 @@ public class CrossClusterEsqlRCS2UnavailableRemotesIT extends AbstractRemoteClus
               "indices": [
                 {
                   "names": ["task", "hits"],
-                  "privileges": ["read", "read_cross_cluster", "create_index", "monitor"]
+                  "privileges": ["read", "create_index", "monitor"]
                 }
               ],
               "remote_indices": [
                 {
                   "names": ["task", "hits"],
-                  "privileges": ["read", "read_cross_cluster", "create_index", "monitor"],
+                  "privileges": ["read", "create_index", "monitor"],
                   "clusters": ["*"]
                 }
               ]

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityApiKeyRestIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityApiKeyRestIT.java
@@ -119,7 +119,7 @@ public class RemoteClusterSecurityApiKeyRestIT extends AbstractRemoteClusterSecu
                   "remote_indices": [
                     {
                       "names": ["index1", "not_found_index", "prefixed_index"],
-                      "privileges": ["read", "read_cross_cluster"],
+                      "privileges": ["read"],
                       "clusters": ["my_remote_cluster"]
                     }
                   ]
@@ -151,7 +151,7 @@ public class RemoteClusterSecurityApiKeyRestIT extends AbstractRemoteClusterSecu
                       "remote_indices": [
                         {
                           "names": ["index1", "not_found_index", "prefixed_index", "index2"],
-                          "privileges": ["read", "read_cross_cluster"],
+                          "privileges": ["read"],
                           "clusters": ["my_remote_*", "non_existing_remote_cluster"]
                         }
                       ]
@@ -258,7 +258,7 @@ public class RemoteClusterSecurityApiKeyRestIT extends AbstractRemoteClusterSecu
                 "remote_indices": [
                    {
                      "names": ["*"],
-                     "privileges": ["read", "read_cross_cluster"],
+                     "privileges": ["read"],
                      "clusters": ["other_remote_*"]
                    }
                  ]"""));
@@ -285,7 +285,7 @@ public class RemoteClusterSecurityApiKeyRestIT extends AbstractRemoteClusterSecu
                 "remote_indices": [
                    {
                      "names": ["*"],
-                     "privileges": ["read", "read_cross_cluster"],
+                     "privileges": ["read"],
                      "clusters": ["other_remote_*"]
                    }
                  ]""");

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityEsqlIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityEsqlIT.java
@@ -406,7 +406,7 @@ public class RemoteClusterSecurityEsqlIT extends AbstractRemoteClusterSecurityTe
         final var putRoleRequest = new Request("PUT", "/_security/role/" + REMOTE_SEARCH_ROLE);
         putRoleRequest.setJsonEntity("""
             {
-              "indices": [{"names": [""], "privileges": ["read_cross_cluster"]}],
+              "indices": [{"names": [""], "privileges": ["read"]}],
               "remote_indices": [
                 {
                   "names": ["employees*"],
@@ -445,7 +445,7 @@ public class RemoteClusterSecurityEsqlIT extends AbstractRemoteClusterSecurityTe
         final var putRoleRequest = new Request("PUT", "/_security/role/" + REMOTE_SEARCH_ROLE);
         putRoleRequest.setJsonEntity("""
             {
-              "indices": [{"names": [""], "privileges": ["read_cross_cluster"]}],
+              "indices": [{"names": [""], "privileges": ["read"]}],
               "remote_indices": [
                 {
                   "names": ["employees*"],
@@ -479,7 +479,7 @@ public class RemoteClusterSecurityEsqlIT extends AbstractRemoteClusterSecurityTe
         // add DLS to the remote indices in the role to restrict access to only emp_id = 21
         putRoleRequest.setJsonEntity("""
             {
-              "indices": [{"names": [""], "privileges": ["read_cross_cluster"]}],
+              "indices": [{"names": [""], "privileges": ["read"]}],
               "remote_indices": [
                 {
                   "names": ["employees*"],
@@ -515,7 +515,7 @@ public class RemoteClusterSecurityEsqlIT extends AbstractRemoteClusterSecurityTe
         // add FLS to the remote indices in the role to restrict access to only access department
         putRoleRequest.setJsonEntity("""
             {
-              "indices": [{"names": [""], "privileges": ["read_cross_cluster"]}],
+              "indices": [{"names": [""], "privileges": ["read"]}],
               "remote_indices": [
                 {
                   "names": ["employees*"],
@@ -637,7 +637,7 @@ public class RemoteClusterSecurityEsqlIT extends AbstractRemoteClusterSecurityTe
         var putRoleRequest = new Request("PUT", "/_security/role/" + REMOTE_SEARCH_ROLE);
         putRoleRequest.setJsonEntity("""
             {
-              "indices": [{"names": [""], "privileges": ["read_cross_cluster"]}],
+              "indices": [{"names": [""], "privileges": ["read"]}],
               "remote_indices": [
                 {
                   "names": ["employees"],
@@ -659,7 +659,7 @@ public class RemoteClusterSecurityEsqlIT extends AbstractRemoteClusterSecurityTe
         // without the remote index priv
         putRoleRequest.setJsonEntity("""
             {
-              "indices": [{"names": [""], "privileges": ["read_cross_cluster"]}],
+              "indices": [{"names": [""], "privileges": ["read"]}],
               "remote_indices": [
                 {
                   "names": ["idontexist"],
@@ -823,7 +823,7 @@ public class RemoteClusterSecurityEsqlIT extends AbstractRemoteClusterSecurityTe
         // ideally, remote only enrichment wouldn't need this local privilege, however remote only enrichment is not currently supported
         putRoleRequest.setJsonEntity("""
             {
-              "indices": [{"names": [""], "privileges": ["read_cross_cluster"]}],
+              "indices": [{"names": [""], "privileges": ["read"]}],
               "cluster": ["cross_cluster_search"],
               "remote_indices": [
                 {
@@ -956,7 +956,7 @@ public class RemoteClusterSecurityEsqlIT extends AbstractRemoteClusterSecurityTe
                 },
                 {
                   "names": ["employees3"],
-                  "privileges": ["view_index_metadata", "read_cross_cluster"],
+                  "privileges": ["view_index_metadata", "read"],
                   "clusters": ["my_remote_cluster"]
                 }
               ]
@@ -1034,7 +1034,7 @@ public class RemoteClusterSecurityEsqlIT extends AbstractRemoteClusterSecurityTe
             final var putRoleRequest = new Request("PUT", "/_security/role/" + REMOTE_SEARCH_ROLE);
             putRoleRequest.setJsonEntity("""
                 {
-                  "indices": [{"names": ["employees*"], "privileges": ["read","read_cross_cluster"]}],
+                  "indices": [{"names": ["employees*"], "privileges": ["read"]}],
                   "cluster": [ "manage_own_api_key" ],
                   "remote_indices": [
                     {

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityEsqlIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityEsqlIT.java
@@ -704,7 +704,7 @@ public class RemoteClusterSecurityEsqlIT extends AbstractRemoteClusterSecurityTe
             error.getMessage(),
             containsString(
                 "action [indices:data/read/esql] is unauthorized for user [remote_search_user] with effective roles [remote_search], "
-                    + "this action is granted by the index privileges [read,read_cross_cluster,all]"
+                    + "this action is granted by the index privileges [read_cross_cluster,read,all]"
             )
         );
 
@@ -720,7 +720,7 @@ public class RemoteClusterSecurityEsqlIT extends AbstractRemoteClusterSecurityTe
             error.getMessage(),
             containsString(
                 "action [indices:data/read/esql] is unauthorized for user [remote_search_user] with effective roles "
-                    + "[remote_search], this action is granted by the index privileges [read,read_cross_cluster,all]"
+                    + "[remote_search], this action is granted by the index privileges [read_cross_cluster,read,all]"
             )
         );
 
@@ -735,7 +735,7 @@ public class RemoteClusterSecurityEsqlIT extends AbstractRemoteClusterSecurityTe
             error.getMessage(),
             containsString(
                 "action [indices:data/read/esql] is unauthorized for user [remote_search_user] with effective roles "
-                    + "[remote_search], this action is granted by the index privileges [read,read_cross_cluster,all]"
+                    + "[remote_search], this action is granted by the index privileges [read_cross_cluster,read,all]"
             )
         );
     }

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityEsqlIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityEsqlIT.java
@@ -956,7 +956,7 @@ public class RemoteClusterSecurityEsqlIT extends AbstractRemoteClusterSecurityTe
                 },
                 {
                   "names": ["employees3"],
-                  "privileges": ["view_index_metadata", "read"],
+                  "privileges": ["view_index_metadata"],
                   "clusters": ["my_remote_cluster"]
                 }
               ]

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityFcActionAuthorizationIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityFcActionAuthorizationIT.java
@@ -394,7 +394,7 @@ public class RemoteClusterSecurityFcActionAuthorizationIT extends ESRestTestCase
                     "cross_cluster",
                     null,
                     new RoleDescriptor.IndicesPrivileges[] {
-                        RoleDescriptor.IndicesPrivileges.builder().indices("index").privileges("read", "read_cross_cluster").build() },
+                        RoleDescriptor.IndicesPrivileges.builder().indices("index").privileges("read").build() },
                     null
                 )
             )
@@ -559,7 +559,7 @@ public class RemoteClusterSecurityFcActionAuthorizationIT extends ESRestTestCase
                     "cross_cluster",
                     null,
                     new RoleDescriptor.IndicesPrivileges[] {
-                        RoleDescriptor.IndicesPrivileges.builder().indices(indices).privileges("read", "read_cross_cluster").build() },
+                        RoleDescriptor.IndicesPrivileges.builder().indices(indices).privileges("read").build() },
                     null
                 )
             )

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityLegacyCrossClusterApiKeysWithDlsFlsIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityLegacyCrossClusterApiKeysWithDlsFlsIT.java
@@ -299,7 +299,7 @@ public class RemoteClusterSecurityLegacyCrossClusterApiKeysWithDlsFlsIT extends 
             List<String> privileges = (List<String>) index.get("privileges");
             if (Arrays.equals(privileges.toArray(String[]::new), CrossClusterApiKeyRoleDescriptorBuilder.CCS_INDICES_PRIVILEGE_NAMES)) {
                 index.put("query", "{\"match_all\": {}}");
-                index.put("privileges", List.of("read", "read_cross_cluster", "view_index_metadata")); // ensure privs emulate pre 8.14
+                index.put("privileges", List.of("read", "view_index_metadata")); // ensure privs emulate pre 8.14
             }
         });
         crossCluster.put("cluster", List.of("cross_cluster_search", "cross_cluster_replication")); // ensure privs emulate pre 8.14

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityLicensingAndFeatureUsageRestIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityLicensingAndFeatureUsageRestIT.java
@@ -140,7 +140,7 @@ public class RemoteClusterSecurityLicensingAndFeatureUsageRestIT extends Abstrac
                   "remote_indices": [
                     {
                       "names": ["%s"],
-                      "privileges": ["read", "read_cross_cluster"],
+                      "privileges": ["read"],
                       "clusters": ["my_remote_cluster"]
                     }
                   ]

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityRCS1DeprecationIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityRCS1DeprecationIT.java
@@ -89,7 +89,7 @@ public class RemoteClusterSecurityRCS1DeprecationIT extends AbstractRemoteCluste
                   "indices": [
                     {
                       "names": ["index*"],
-                      "privileges": ["read", "read_cross_cluster"]
+                      "privileges": ["read"]
                     }
                   ]
                 }""");

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityRCS1FailureStoreRestIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityRCS1FailureStoreRestIT.java
@@ -74,7 +74,7 @@ public class RemoteClusterSecurityRCS1FailureStoreRestIT extends AbstractRemoteC
           "indices": [
             {
               "names": ["test*"],
-              "privileges": ["read", "read_cross_cluster"]
+              "privileges": ["read"]
             }
           ]
         }""", FAILURE_STORE_ACCESS, """
@@ -82,7 +82,7 @@ public class RemoteClusterSecurityRCS1FailureStoreRestIT extends AbstractRemoteC
           "indices": [
             {
               "names": ["test*", "non-existing-index"],
-              "privileges": ["read", "read_cross_cluster", "read_failure_store"]
+              "privileges": ["read", "read_failure_store"]
             }
           ]
         }""", MANAGE_FAILURE_STORE_ACCESS, """
@@ -90,7 +90,7 @@ public class RemoteClusterSecurityRCS1FailureStoreRestIT extends AbstractRemoteC
           "indices": [
             {
               "names": ["test*", "non-existing-index"],
-              "privileges": ["manage_failure_store", "read_cross_cluster", "read_failure_store"]
+              "privileges": ["manage_failure_store", "read_failure_store"]
             }
           ]
         }""", ALL_ACCESS, """
@@ -114,7 +114,7 @@ public class RemoteClusterSecurityRCS1FailureStoreRestIT extends AbstractRemoteC
           "indices": [
             {
               "names": [".ds-test*"],
-              "privileges": ["read", "read_cross_cluster"]
+              "privileges": ["read"]
             }
           ]
         }""", BACKING_FAILURE_STORE_INDEX_ACCESS, """
@@ -122,7 +122,7 @@ public class RemoteClusterSecurityRCS1FailureStoreRestIT extends AbstractRemoteC
           "indices": [
             {
               "names": [".fs-test*"],
-              "privileges": ["read", "read_cross_cluster"]
+              "privileges": ["read"]
             }
           ]
         }""");
@@ -142,7 +142,7 @@ public class RemoteClusterSecurityRCS1FailureStoreRestIT extends AbstractRemoteC
             },
             {
               "names": ["test*"],
-              "privileges": ["read", "read_cross_cluster"]
+              "privileges": ["read"]
             }
           ]
         }""", FAILURE_STORE_ACCESS, """
@@ -155,7 +155,7 @@ public class RemoteClusterSecurityRCS1FailureStoreRestIT extends AbstractRemoteC
             },
             {
               "names": ["test*", "non-existing-index"],
-              "privileges": ["read", "read_cross_cluster", "read_failure_store"]
+              "privileges": ["read", "read_failure_store"]
             }
           ]
         }""", MANAGE_FAILURE_STORE_ACCESS, """
@@ -168,7 +168,7 @@ public class RemoteClusterSecurityRCS1FailureStoreRestIT extends AbstractRemoteC
             },
             {
               "names": ["test*", "non-existing-index"],
-              "privileges": ["manage_failure_store", "read_cross_cluster", "read_failure_store"]
+              "privileges": ["manage_failure_store", "read_failure_store"]
             }
           ]
         }""", ALL_ACCESS, """
@@ -195,7 +195,7 @@ public class RemoteClusterSecurityRCS1FailureStoreRestIT extends AbstractRemoteC
           "indices": [
             {
               "names": [".ds-test*"],
-              "privileges": ["read", "read_cross_cluster"]
+              "privileges": ["read"]
             }
           ]
         }""", BACKING_FAILURE_STORE_INDEX_ACCESS, """
@@ -204,7 +204,7 @@ public class RemoteClusterSecurityRCS1FailureStoreRestIT extends AbstractRemoteC
           "indices": [
             {
               "names": [".fs-test*"],
-              "privileges": ["read", "read_cross_cluster"]
+              "privileges": ["read"]
             }
           ]
         }""");

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityRCS1PainlessExecuteIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityRCS1PainlessExecuteIT.java
@@ -107,7 +107,7 @@ public class RemoteClusterSecurityRCS1PainlessExecuteIT extends AbstractRemoteCl
                   "indices": [
                     {
                       "names": ["index*"],
-                      "privileges": ["read", "read_cross_cluster"]
+                      "privileges": ["read"]
                     }
                   ]
                 }""");

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityRCS1ResolveClusterIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityRCS1ResolveClusterIT.java
@@ -115,7 +115,7 @@ public class RemoteClusterSecurityRCS1ResolveClusterIT extends AbstractRemoteClu
                   "indices": [
                     {
                       "names": ["index*"],
-                      "privileges": ["read", "read_cross_cluster"]
+                      "privileges": ["read"]
                     }
                   ]
                 }""");

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityRCS2FailureStoreRestIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityRCS2FailureStoreRestIT.java
@@ -196,7 +196,7 @@ public class RemoteClusterSecurityRCS2FailureStoreRestIT extends AbstractRemoteC
               "remote_indices": [
                 {
                   "names": ["test*"],
-                  "privileges": ["read", "read_cross_cluster"],
+                  "privileges": ["read"],
                   "clusters": ["my_remote_cluster"]
                 }
               ]

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityRCS2PainlessExecuteIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityRCS2PainlessExecuteIT.java
@@ -202,7 +202,7 @@ public class RemoteClusterSecurityRCS2PainlessExecuteIT extends AbstractRemoteCl
                   "remote_indices": [
                     {
                       "names": ["index*"],
-                      "privileges": ["read", "read_cross_cluster"],
+                      "privileges": ["read"],
                       "clusters": ["my_remote_cluster"]
                     }
                   ]

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityRCS2ResolveClusterIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityRCS2ResolveClusterIT.java
@@ -216,7 +216,7 @@ public class RemoteClusterSecurityRCS2ResolveClusterIT extends AbstractRemoteClu
                   "remote_indices": [
                     {
                       "names": ["index*"],
-                      "privileges": ["read", "read_cross_cluster"],
+                      "privileges": ["read"],
                       "clusters": ["my_remote_cluster"]
                     }
                   ]

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityReloadCredentialsRestIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityReloadCredentialsRestIT.java
@@ -130,7 +130,7 @@ public class RemoteClusterSecurityReloadCredentialsRestIT extends AbstractRemote
               "indices": [
                 {
                   "names": [ "shared-logs" ],
-                  "privileges": [ "read", "read_cross_cluster" ]
+                  "privileges": [ "read" ]
                 }
               ]
             }""");
@@ -163,7 +163,7 @@ public class RemoteClusterSecurityReloadCredentialsRestIT extends AbstractRemote
               "indices": [
                 {
                   "names": [ "shared-logs" ],
-                  "privileges": [ "read", "read_cross_cluster" ]
+                  "privileges": [ "read" ]
                 }
               ]
             }""");

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityRestIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityRestIT.java
@@ -176,7 +176,7 @@ public class RemoteClusterSecurityRestIT extends AbstractRemoteClusterSecurityTe
                   "remote_indices": [
                     {
                       "names": ["%s"],
-                      "privileges": ["read", "read_cross_cluster"],
+                      "privileges": ["read"],
                       "clusters": ["my_remote_cluster"]
                     }
                   ]
@@ -390,7 +390,7 @@ public class RemoteClusterSecurityRestIT extends AbstractRemoteClusterSecurityTe
                   "remote_indices": [
                     {
                       "names": ["index1", "not_found_index", "prefixed_index"],
-                      "privileges": ["read", "read_cross_cluster"],
+                      "privileges": ["read"],
                       "clusters": ["my_remote_cluster"]
                     }
                   ]
@@ -499,7 +499,7 @@ public class RemoteClusterSecurityRestIT extends AbstractRemoteClusterSecurityTe
                 "remote_indices": [
                    {
                      "names": ["*"],
-                     "privileges": ["read", "read_cross_cluster"],
+                     "privileges": ["read"],
                      "clusters": ["other_remote_*"]
                    }
                  ]"""));

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityRestStatsIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityRestStatsIT.java
@@ -224,7 +224,7 @@ public class RemoteClusterSecurityRestStatsIT extends AbstractRemoteClusterSecur
               "remote_indices": [
                 {
                   "names": ["*"],
-                  "privileges": ["read", "read_cross_cluster"],
+                  "privileges": ["read"],
                   "clusters": ["*"]
                 }
               ],

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityTransformMigrationIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityTransformMigrationIT.java
@@ -105,7 +105,7 @@ public class RemoteClusterSecurityTransformMigrationIT extends AbstractRemoteClu
               "indices": [
                 {
                   "names": [ "*" ],
-                  "privileges": [ "read", "read_cross_cluster", "view_index_metadata" ]
+                  "privileges": [ "read", "view_index_metadata" ]
                 }
               ]
             }""");
@@ -171,7 +171,7 @@ public class RemoteClusterSecurityTransformMigrationIT extends AbstractRemoteClu
                 {
                   "clusters": [ "*" ],
                   "names": [ "*" ],
-                  "privileges": [ "read", "read_cross_cluster", "view_index_metadata" ]
+                  "privileges": [ "read", "view_index_metadata" ]
                 }
               ]
             }""");

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityWithDlsAndFlsRestIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityWithDlsAndFlsRestIT.java
@@ -117,7 +117,7 @@ public class RemoteClusterSecurityWithDlsAndFlsRestIT extends AbstractRemoteClus
                       "remote_indices": [
                         {
                           "names": ["remote_index1", "remote_index3"],
-                          "privileges": ["read", "read_cross_cluster"],
+                          "privileges": ["read"],
                           "clusters": ["*"],
                           "query": {"bool": {"must_not": {"term": {"field1": "value3"}}}},
                           "field_security": {"grant": ["field2"]}
@@ -194,7 +194,7 @@ public class RemoteClusterSecurityWithDlsAndFlsRestIT extends AbstractRemoteClus
                       "remote_indices": [
                         {
                           "names": ["remote_index*"],
-                          "privileges": ["read", "read_cross_cluster"],
+                          "privileges": ["read"],
                           "clusters": ["*"],
                           "query": {"bool": {"must": {"term": {"field1": "value4"}}}}
                         }
@@ -231,7 +231,7 @@ public class RemoteClusterSecurityWithDlsAndFlsRestIT extends AbstractRemoteClus
                       "remote_indices": [
                         {
                           "names": ["remote_index1"],
-                          "privileges": ["read", "read_cross_cluster"],
+                          "privileges": ["read"],
                           "clusters": ["*"],
                           "field_security": {"grant": ["field1"]}
                         }
@@ -241,7 +241,7 @@ public class RemoteClusterSecurityWithDlsAndFlsRestIT extends AbstractRemoteClus
                       "remote_indices": [
                         {
                           "names": ["*"],
-                          "privileges": ["read", "read_cross_cluster"],
+                          "privileges": ["read"],
                           "clusters": ["*"],
                           "field_security": {"grant": ["field2"]}
                         }

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityWithDlsRestIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityWithDlsRestIT.java
@@ -99,7 +99,7 @@ public class RemoteClusterSecurityWithDlsRestIT extends AbstractRemoteClusterSec
                       "remote_indices": [
                         {
                           "names": ["remote_index1", "remote_index2", "*4"],
-                          "privileges": ["read", "read_cross_cluster"],
+                          "privileges": ["read"],
                           "clusters": ["*"],
                           "query": {"bool": {"must_not": {"term" : {"field1" : "value4"}}}},
                           "field_security": {"grant": ["field1"]}
@@ -110,7 +110,7 @@ public class RemoteClusterSecurityWithDlsRestIT extends AbstractRemoteClusterSec
                       "remote_indices": [
                         {
                           "names": ["remote_index1", "remote_index2", "*3"],
-                          "privileges": ["read", "read_cross_cluster"],
+                          "privileges": ["read"],
                           "clusters": ["*"],
                           "query": {"bool": {"must_not": {"term" : {"field1" : "value3"}}}},
                           "field_security": {"grant": ["field2"]}

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityWithFlsRestIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityWithFlsRestIT.java
@@ -99,7 +99,7 @@ public class RemoteClusterSecurityWithFlsRestIT extends AbstractRemoteClusterSec
                       "remote_indices": [
                         {
                           "names": ["remote_index3"],
-                          "privileges": ["read", "read_cross_cluster"],
+                          "privileges": ["read"],
                           "clusters": ["*"]
                         }
                       ]
@@ -130,7 +130,7 @@ public class RemoteClusterSecurityWithFlsRestIT extends AbstractRemoteClusterSec
                       "remote_indices": [
                         {
                           "names": ["*"],
-                          "privileges": ["read", "read_cross_cluster"],
+                          "privileges": ["read"],
                           "clusters": ["*"],
                           "query": {"bool": {"must_not": {"term": {"field1": "value4"}}}},
                           "field_security": {"grant": ["field1"]}
@@ -166,7 +166,7 @@ public class RemoteClusterSecurityWithFlsRestIT extends AbstractRemoteClusterSec
                       "remote_indices": [
                         {
                           "names": ["remote_index*"],
-                          "privileges": ["read", "read_cross_cluster"],
+                          "privileges": ["read"],
                           "clusters": ["*"],
                           "query": {"bool": {"must": {"term": {"field1": "value4"}}}},
                           "field_security": {"grant": ["field1"]}
@@ -177,7 +177,7 @@ public class RemoteClusterSecurityWithFlsRestIT extends AbstractRemoteClusterSec
                       "remote_indices": [
                         {
                           "names": ["remote_index2", "remote_index3"],
-                          "privileges": ["read", "read_cross_cluster"],
+                          "privileges": ["read"],
                           "clusters": ["*"],
                           "query": {"bool": {"must_not": {"term": {"field1": "value3"}}}},
                           "field_security": {"grant": ["field2"]}
@@ -213,7 +213,7 @@ public class RemoteClusterSecurityWithFlsRestIT extends AbstractRemoteClusterSec
                       "remote_indices": [
                         {
                           "names": ["*"],
-                          "privileges": ["read", "read_cross_cluster"],
+                          "privileges": ["read"],
                           "clusters": ["*"],
                           "query": {"bool": {"must_not": {"term": {"field1": "value4"}}}},
                           "field_security": {"grant": ["field1"]}
@@ -224,7 +224,7 @@ public class RemoteClusterSecurityWithFlsRestIT extends AbstractRemoteClusterSec
                       "remote_indices": [
                         {
                           "names": ["*2", "*3"],
-                          "privileges": ["read", "read_cross_cluster"],
+                          "privileges": ["read"],
                           "clusters": ["*"],
                           "query": {"bool": {"should": [{"term": {"field1": "value3"}}]}},
                           "field_security": {"grant": ["field2"]}

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityWithMixedModelRemotesRestIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityWithMixedModelRemotesRestIT.java
@@ -72,7 +72,7 @@ public class RemoteClusterSecurityWithMixedModelRemotesRestIT extends AbstractRe
                   "indices": [
                     {
                       "names": ["cluster2_index1"],
-                      "privileges": ["read", "read_cross_cluster"]
+                      "privileges": ["read"]
                     }
                   ]
                 }""");
@@ -94,7 +94,7 @@ public class RemoteClusterSecurityWithMixedModelRemotesRestIT extends AbstractRe
                   "remote_indices": [
                     {
                       "names": ["cluster1_index1"],
-                      "privileges": ["read", "read_cross_cluster"],
+                      "privileges": ["read"],
                       "clusters": ["my_remote_cluster"]
                     }
                   ]

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityWithSameModelRemotesRestIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityWithSameModelRemotesRestIT.java
@@ -103,12 +103,12 @@ public class RemoteClusterSecurityWithSameModelRemotesRestIT extends AbstractRem
                   "remote_indices": [
                     {
                       "names": ["cluster1_index1"],
-                      "privileges": ["read", "read_cross_cluster"],
+                      "privileges": ["read"],
                       "clusters": ["my_remote_cluster"]
                     },
                     {
                       "names": ["cluster2_index1"],
-                      "privileges": ["read", "read_cross_cluster"],
+                      "privileges": ["read"],
                       "clusters": ["my_remote_cluster_2"]
                     }
                   ]

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityWithoutDlsAndFlsRestIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityWithoutDlsAndFlsRestIT.java
@@ -100,7 +100,7 @@ public class RemoteClusterSecurityWithoutDlsAndFlsRestIT extends AbstractRemoteC
                       "remote_indices": [
                         {
                           "names": ["remote_index1", "remote_index4"],
-                          "privileges": ["read", "read_cross_cluster"],
+                          "privileges": ["read"],
                           "clusters": ["*"],
                           "query": {"bool": {"must_not": {"term": {"field1": "value4"}}}},
                           "field_security": {"grant": ["field1"]}
@@ -111,7 +111,7 @@ public class RemoteClusterSecurityWithoutDlsAndFlsRestIT extends AbstractRemoteC
                       "remote_indices": [
                         {
                           "names": ["remote_index2", "remote_index3"],
-                          "privileges": ["read", "read_cross_cluster"],
+                          "privileges": ["read"],
                           "clusters": ["*"],
                           "query": {"bool": {"must_not": {"term": {"field1": "value3"}}}},
                           "field_security": {"grant": ["field2"]}
@@ -150,7 +150,7 @@ public class RemoteClusterSecurityWithoutDlsAndFlsRestIT extends AbstractRemoteC
                       "remote_indices": [
                         {
                           "names": ["remote_index1", "remote_index4"],
-                          "privileges": ["read", "read_cross_cluster"],
+                          "privileges": ["read"],
                           "clusters": ["*"],
                           "query": {"bool": {"must": {"term": {"field1": "value4"}}}},
                           "field_security": {"grant": ["field1"]}
@@ -161,7 +161,7 @@ public class RemoteClusterSecurityWithoutDlsAndFlsRestIT extends AbstractRemoteC
                       "remote_indices": [
                         {
                           "names": ["remote_index2", "remote_index3"],
-                          "privileges": ["read", "read_cross_cluster"],
+                          "privileges": ["read"],
                           "clusters": ["*"],
                           "query": {"bool": {"must": {"term": {"field1": "value3"}}}},
                           "field_security": {"grant": ["field2"]}
@@ -196,7 +196,7 @@ public class RemoteClusterSecurityWithoutDlsAndFlsRestIT extends AbstractRemoteC
                       "remote_indices": [
                         {
                           "names": ["remote_index*"],
-                          "privileges": ["read", "read_cross_cluster"],
+                          "privileges": ["read"],
                           "clusters": ["*"],
                           "query": {"bool": {"must": {"term": {"field1": "value4"}}}},
                           "field_security": {"grant": ["field1"]}
@@ -207,7 +207,7 @@ public class RemoteClusterSecurityWithoutDlsAndFlsRestIT extends AbstractRemoteC
                       "remote_indices": [
                         {
                           "names": ["remote_index2", "remote_index3"],
-                          "privileges": ["read", "read_cross_cluster"],
+                          "privileges": ["read"],
                           "clusters": ["*"],
                           "query": {"bool": {"must_not": {"term": {"field1": "value3"}}}},
                           "field_security": {"grant": ["field2"]}
@@ -245,7 +245,7 @@ public class RemoteClusterSecurityWithoutDlsAndFlsRestIT extends AbstractRemoteC
                       "remote_indices": [
                         {
                           "names": ["*"],
-                          "privileges": ["read", "read_cross_cluster"],
+                          "privileges": ["read"],
                           "clusters": ["*"],
                           "query": {"bool": {"must_not": {"term": {"field1": "value4"}}}},
                           "field_security": {"grant": ["field1"]}
@@ -256,7 +256,7 @@ public class RemoteClusterSecurityWithoutDlsAndFlsRestIT extends AbstractRemoteC
                       "remote_indices": [
                         {
                           "names": ["*2", "*3"],
-                          "privileges": ["read", "read_cross_cluster"],
+                          "privileges": ["read"],
                           "clusters": ["*"],
                           "query": {"bool": {"should": [{"term": {"field1": "value3"}}]}},
                           "field_security": {"grant": ["field2"]}

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/resources/roles.yml
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/resources/roles.yml
@@ -1,13 +1,13 @@
 read_remote_shared_logs:
   remote_indices:
     - names: [ 'shared-logs' ]
-      privileges: [ 'read', 'read_cross_cluster' ]
+      privileges: [ 'read', ]
       clusters: [ 'my_*' ]
 
 read_remote_shared_metrics:
   remote_indices:
     - names: [ 'shared-metrics' ]
-      privileges: [ 'read', 'read_cross_cluster' ]
+      privileges: [ 'read', ]
       clusters: [ 'my_*' ]
 
 transform_remote_shared_index:
@@ -16,7 +16,7 @@ transform_remote_shared_index:
       privileges: [ 'create_index', 'index', 'read' ]
   remote_indices:
     - names: [ 'shared-transform-index' ]
-      privileges: [ 'read', 'read_cross_cluster', 'view_index_metadata' ]
+      privileges: [ 'read', 'view_index_metadata' ]
       clusters: [ 'my_*' ]
 
 ml_jobs_shared_airline_data:
@@ -26,7 +26,7 @@ ml_jobs_shared_airline_data:
       privileges: [ 'all' ]
   remote_indices:
     - names: [ 'shared-airline-data' ]
-      privileges: [ 'read', 'read_cross_cluster', 'view_index_metadata' ]
+      privileges: [ 'read', 'view_index_metadata' ]
       clusters: [ 'my_*' ]
 
 ccr_user_role:

--- a/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/SecurityWithBasicLicenseIT.java
+++ b/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/SecurityWithBasicLicenseIT.java
@@ -145,7 +145,7 @@ public class SecurityWithBasicLicenseIT extends SecurityInBasicRestTestCase {
               "remote_indices": [
                 {
                   "names": ["index-*"],
-                  "privileges": ["read", "read_cross_cluster"],
+                  "privileges": ["read"],
                   "clusters": ["my_remote"]
                 }
               ]

--- a/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/apikey/ApiKeyRestIT.java
+++ b/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/apikey/ApiKeyRestIT.java
@@ -1129,7 +1129,7 @@ public class ApiKeyRestIT extends SecurityOnTrialLicenseRestTestCase {
                             new RoleDescriptor.IndicesPrivileges[] {
                                 RoleDescriptor.IndicesPrivileges.builder()
                                     .indices("metrics")
-                                    .privileges("read", "read_cross_cluster", "view_index_metadata")
+                                    .privileges("read", "view_index_metadata")
                                     .build(),
                                 RoleDescriptor.IndicesPrivileges.builder()
                                     .indices("logs")
@@ -1539,7 +1539,7 @@ public class ApiKeyRestIT extends SecurityOnTrialLicenseRestTestCase {
             new RoleDescriptor.IndicesPrivileges[] {
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices("data")
-                    .privileges("read", "read_cross_cluster", "view_index_metadata")
+                    .privileges("read", "view_index_metadata")
                     .build(),
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices("logs")
@@ -1610,7 +1610,7 @@ public class ApiKeyRestIT extends SecurityOnTrialLicenseRestTestCase {
             new RoleDescriptor.IndicesPrivileges[] {
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices("blogs")
-                    .privileges("read", "read_cross_cluster", "view_index_metadata")
+                    .privileges("read", "view_index_metadata")
                     .build() },
             null
         );

--- a/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/apikey/ApiKeyRestIT.java
+++ b/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/apikey/ApiKeyRestIT.java
@@ -1537,10 +1537,7 @@ public class ApiKeyRestIT extends SecurityOnTrialLicenseRestTestCase {
             "cross_cluster",
             new String[] { "cross_cluster_search", "monitor_enrich", "cross_cluster_replication" },
             new RoleDescriptor.IndicesPrivileges[] {
-                RoleDescriptor.IndicesPrivileges.builder()
-                    .indices("data")
-                    .privileges("read", "view_index_metadata")
-                    .build(),
+                RoleDescriptor.IndicesPrivileges.builder().indices("data").privileges("read", "view_index_metadata").build(),
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices("logs")
                     .privileges("cross_cluster_replication", "cross_cluster_replication_internal")
@@ -1608,10 +1605,7 @@ public class ApiKeyRestIT extends SecurityOnTrialLicenseRestTestCase {
             "cross_cluster",
             new String[] { "cross_cluster_search", "monitor_enrich" },
             new RoleDescriptor.IndicesPrivileges[] {
-                RoleDescriptor.IndicesPrivileges.builder()
-                    .indices("blogs")
-                    .privileges("read", "view_index_metadata")
-                    .build() },
+                RoleDescriptor.IndicesPrivileges.builder().indices("blogs").privileges("read", "view_index_metadata").build() },
             null
         );
         assertThat(

--- a/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/crossclusteraccess/CrossClusterAccessHeadersForCcsRestIT.java
+++ b/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/crossclusteraccess/CrossClusterAccessHeadersForCcsRestIT.java
@@ -192,10 +192,7 @@ public class CrossClusterAccessHeadersForCcsRestIT extends SecurityOnTrialLicens
                         Role.REMOTE_USER_ROLE_NAME,
                         new String[] { "monitor_enrich" },
                         new RoleDescriptor.IndicesPrivileges[] {
-                            RoleDescriptor.IndicesPrivileges.builder()
-                                .indices("index-a")
-                                .privileges("read")
-                                .build() },
+                            RoleDescriptor.IndicesPrivileges.builder().indices("index-a").privileges("read").build() },
                         null,
                         null,
                         null,
@@ -262,10 +259,7 @@ public class CrossClusterAccessHeadersForCcsRestIT extends SecurityOnTrialLicens
                         Role.REMOTE_USER_ROLE_NAME,
                         new String[] { "monitor_enrich" },
                         new RoleDescriptor.IndicesPrivileges[] {
-                            RoleDescriptor.IndicesPrivileges.builder()
-                                .indices("index-a")
-                                .privileges("read")
-                                .build() },
+                            RoleDescriptor.IndicesPrivileges.builder().indices("index-a").privileges("read").build() },
                         null,
                         null,
                         null,
@@ -291,14 +285,8 @@ public class CrossClusterAccessHeadersForCcsRestIT extends SecurityOnTrialLicens
                                 Role.REMOTE_USER_ROLE_NAME,
                                 new String[] { "monitor_enrich" },
                                 new RoleDescriptor.IndicesPrivileges[] {
-                                    RoleDescriptor.IndicesPrivileges.builder()
-                                        .indices("index-a")
-                                        .privileges("read")
-                                        .build(),
-                                    RoleDescriptor.IndicesPrivileges.builder()
-                                        .indices("index-b")
-                                        .privileges("read")
-                                        .build() },
+                                    RoleDescriptor.IndicesPrivileges.builder().indices("index-a").privileges("read").build(),
+                                    RoleDescriptor.IndicesPrivileges.builder().indices("index-b").privileges("read").build() },
                                 null,
                                 null,
                                 null,
@@ -430,10 +418,7 @@ public class CrossClusterAccessHeadersForCcsRestIT extends SecurityOnTrialLicens
                                 Role.REMOTE_USER_ROLE_NAME,
                                 new String[] { "monitor_enrich" },
                                 new RoleDescriptor.IndicesPrivileges[] {
-                                    RoleDescriptor.IndicesPrivileges.builder()
-                                        .indices("index-a")
-                                        .privileges("read")
-                                        .build() },
+                                    RoleDescriptor.IndicesPrivileges.builder().indices("index-a").privileges("read").build() },
                                 null,
                                 null,
                                 null,
@@ -479,14 +464,8 @@ public class CrossClusterAccessHeadersForCcsRestIT extends SecurityOnTrialLicens
                                 Role.REMOTE_USER_ROLE_NAME,
                                 new String[] { "monitor_enrich" },
                                 new RoleDescriptor.IndicesPrivileges[] {
-                                    RoleDescriptor.IndicesPrivileges.builder()
-                                        .indices("index-a")
-                                        .privileges("read")
-                                        .build(),
-                                    RoleDescriptor.IndicesPrivileges.builder()
-                                        .indices("index-b")
-                                        .privileges("read")
-                                        .build() },
+                                    RoleDescriptor.IndicesPrivileges.builder().indices("index-a").privileges("read").build(),
+                                    RoleDescriptor.IndicesPrivileges.builder().indices("index-b").privileges("read").build() },
                                 null,
                                 null,
                                 null,
@@ -597,10 +576,7 @@ public class CrossClusterAccessHeadersForCcsRestIT extends SecurityOnTrialLicens
                                 Role.REMOTE_USER_ROLE_NAME,
                                 new String[] { "monitor_enrich" },
                                 new RoleDescriptor.IndicesPrivileges[] {
-                                    RoleDescriptor.IndicesPrivileges.builder()
-                                        .indices("index-a")
-                                        .privileges("read")
-                                        .build() },
+                                    RoleDescriptor.IndicesPrivileges.builder().indices("index-a").privileges("read").build() },
                                 null,
                                 null,
                                 null,
@@ -622,10 +598,7 @@ public class CrossClusterAccessHeadersForCcsRestIT extends SecurityOnTrialLicens
                                 Role.REMOTE_USER_ROLE_NAME,
                                 new String[] { "monitor_enrich" },
                                 new RoleDescriptor.IndicesPrivileges[] {
-                                    RoleDescriptor.IndicesPrivileges.builder()
-                                        .indices("index-a")
-                                        .privileges("read")
-                                        .build() },
+                                    RoleDescriptor.IndicesPrivileges.builder().indices("index-a").privileges("read").build() },
                                 null,
                                 null,
                                 null,
@@ -732,10 +705,7 @@ public class CrossClusterAccessHeadersForCcsRestIT extends SecurityOnTrialLicens
                                 Role.REMOTE_USER_ROLE_NAME,
                                 new String[] { "monitor_enrich" },
                                 new RoleDescriptor.IndicesPrivileges[] {
-                                    RoleDescriptor.IndicesPrivileges.builder()
-                                        .indices("index-a")
-                                        .privileges("read")
-                                        .build() },
+                                    RoleDescriptor.IndicesPrivileges.builder().indices("index-a").privileges("read").build() },
                                 null,
                                 null,
                                 null,
@@ -757,10 +727,7 @@ public class CrossClusterAccessHeadersForCcsRestIT extends SecurityOnTrialLicens
                                 Role.REMOTE_USER_ROLE_NAME,
                                 new String[] { "monitor_enrich" },
                                 new RoleDescriptor.IndicesPrivileges[] {
-                                    RoleDescriptor.IndicesPrivileges.builder()
-                                        .indices("index-a")
-                                        .privileges("read")
-                                        .build() },
+                                    RoleDescriptor.IndicesPrivileges.builder().indices("index-a").privileges("read").build() },
                                 null,
                                 null,
                                 null,

--- a/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/crossclusteraccess/CrossClusterAccessHeadersForCcsRestIT.java
+++ b/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/crossclusteraccess/CrossClusterAccessHeadersForCcsRestIT.java
@@ -111,12 +111,12 @@ public class CrossClusterAccessHeadersForCcsRestIT extends SecurityOnTrialLicens
               "remote_indices": [
                 {
                   "names": ["index-a"],
-                  "privileges": ["read", "read_cross_cluster"],
+                  "privileges": ["read"],
                   "clusters": ["my_remote_cluster*"]
                 },
                 {
                   "names": ["index-b"],
-                  "privileges": ["read", "read_cross_cluster"],
+                  "privileges": ["read"],
                   "clusters": ["my_remote_cluster_b"]
                 }
               ],
@@ -194,7 +194,7 @@ public class CrossClusterAccessHeadersForCcsRestIT extends SecurityOnTrialLicens
                         new RoleDescriptor.IndicesPrivileges[] {
                             RoleDescriptor.IndicesPrivileges.builder()
                                 .indices("index-a")
-                                .privileges("read", "read_cross_cluster")
+                                .privileges("read")
                                 .build() },
                         null,
                         null,
@@ -264,7 +264,7 @@ public class CrossClusterAccessHeadersForCcsRestIT extends SecurityOnTrialLicens
                         new RoleDescriptor.IndicesPrivileges[] {
                             RoleDescriptor.IndicesPrivileges.builder()
                                 .indices("index-a")
-                                .privileges("read", "read_cross_cluster")
+                                .privileges("read")
                                 .build() },
                         null,
                         null,
@@ -293,11 +293,11 @@ public class CrossClusterAccessHeadersForCcsRestIT extends SecurityOnTrialLicens
                                 new RoleDescriptor.IndicesPrivileges[] {
                                     RoleDescriptor.IndicesPrivileges.builder()
                                         .indices("index-a")
-                                        .privileges("read", "read_cross_cluster")
+                                        .privileges("read")
                                         .build(),
                                     RoleDescriptor.IndicesPrivileges.builder()
                                         .indices("index-b")
-                                        .privileges("read", "read_cross_cluster")
+                                        .privileges("read")
                                         .build() },
                                 null,
                                 null,
@@ -432,7 +432,7 @@ public class CrossClusterAccessHeadersForCcsRestIT extends SecurityOnTrialLicens
                                 new RoleDescriptor.IndicesPrivileges[] {
                                     RoleDescriptor.IndicesPrivileges.builder()
                                         .indices("index-a")
-                                        .privileges("read", "read_cross_cluster")
+                                        .privileges("read")
                                         .build() },
                                 null,
                                 null,
@@ -481,11 +481,11 @@ public class CrossClusterAccessHeadersForCcsRestIT extends SecurityOnTrialLicens
                                 new RoleDescriptor.IndicesPrivileges[] {
                                     RoleDescriptor.IndicesPrivileges.builder()
                                         .indices("index-a")
-                                        .privileges("read", "read_cross_cluster")
+                                        .privileges("read")
                                         .build(),
                                     RoleDescriptor.IndicesPrivileges.builder()
                                         .indices("index-b")
-                                        .privileges("read", "read_cross_cluster")
+                                        .privileges("read")
                                         .build() },
                                 null,
                                 null,
@@ -599,7 +599,7 @@ public class CrossClusterAccessHeadersForCcsRestIT extends SecurityOnTrialLicens
                                 new RoleDescriptor.IndicesPrivileges[] {
                                     RoleDescriptor.IndicesPrivileges.builder()
                                         .indices("index-a")
-                                        .privileges("read", "read_cross_cluster")
+                                        .privileges("read")
                                         .build() },
                                 null,
                                 null,
@@ -624,7 +624,7 @@ public class CrossClusterAccessHeadersForCcsRestIT extends SecurityOnTrialLicens
                                 new RoleDescriptor.IndicesPrivileges[] {
                                     RoleDescriptor.IndicesPrivileges.builder()
                                         .indices("index-a")
-                                        .privileges("read", "read_cross_cluster")
+                                        .privileges("read")
                                         .build() },
                                 null,
                                 null,
@@ -734,7 +734,7 @@ public class CrossClusterAccessHeadersForCcsRestIT extends SecurityOnTrialLicens
                                 new RoleDescriptor.IndicesPrivileges[] {
                                     RoleDescriptor.IndicesPrivileges.builder()
                                         .indices("index-a")
-                                        .privileges("read", "read_cross_cluster")
+                                        .privileges("read")
                                         .build() },
                                 null,
                                 null,
@@ -759,7 +759,7 @@ public class CrossClusterAccessHeadersForCcsRestIT extends SecurityOnTrialLicens
                                 new RoleDescriptor.IndicesPrivileges[] {
                                     RoleDescriptor.IndicesPrivileges.builder()
                                         .indices("index-a")
-                                        .privileges("read", "read_cross_cluster")
+                                        .privileges("read")
                                         .build() },
                                 null,
                                 null,

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/apikey/ApiKeySingleNodeTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/apikey/ApiKeySingleNodeTests.java
@@ -597,10 +597,7 @@ public class ApiKeySingleNodeTests extends SecuritySingleNodeTestCase {
             "cross_cluster",
             new String[] { "cross_cluster_search", "monitor_enrich" },
             new RoleDescriptor.IndicesPrivileges[] {
-                RoleDescriptor.IndicesPrivileges.builder()
-                    .indices("logs")
-                    .privileges("read", "view_index_metadata")
-                    .build() },
+                RoleDescriptor.IndicesPrivileges.builder().indices("logs").privileges("read", "view_index_metadata").build() },
             null
         );
         assertThat(actualRoleDescriptor, equalTo(expectedRoleDescriptor));
@@ -649,10 +646,7 @@ public class ApiKeySingleNodeTests extends SecuritySingleNodeTestCase {
             "cross_cluster",
             new String[] { "cross_cluster_search", "monitor_enrich" },
             new RoleDescriptor.IndicesPrivileges[] {
-                RoleDescriptor.IndicesPrivileges.builder()
-                    .indices("logs")
-                    .privileges("read", "view_index_metadata")
-                    .build() },
+                RoleDescriptor.IndicesPrivileges.builder().indices("logs").privileges("read", "view_index_metadata").build() },
             null
         );
         final var createApiKeyRequest = CreateCrossClusterApiKeyRequest.withNameAndAccess(randomAlphaOfLengthBetween(3, 8), """

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/apikey/ApiKeySingleNodeTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/apikey/ApiKeySingleNodeTests.java
@@ -599,7 +599,7 @@ public class ApiKeySingleNodeTests extends SecuritySingleNodeTestCase {
             new RoleDescriptor.IndicesPrivileges[] {
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices("logs")
-                    .privileges("read", "read_cross_cluster", "view_index_metadata")
+                    .privileges("read", "view_index_metadata")
                     .build() },
             null
         );
@@ -651,7 +651,7 @@ public class ApiKeySingleNodeTests extends SecuritySingleNodeTestCase {
             new RoleDescriptor.IndicesPrivileges[] {
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices("logs")
-                    .privileges("read", "read_cross_cluster", "view_index_metadata")
+                    .privileges("read", "view_index_metadata")
                     .build() },
             null
         );

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
@@ -550,7 +550,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
             new RoleDescriptor.IndicesPrivileges[] {
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices("/. ? + * | { } [ ] ( ) \" \\/", "*")
-                    .privileges("read", "read_cross_cluster")
+                    .privileges("read")
                     .grantedFields("almost", "all*")
                     .deniedFields("denied*")
                     .build() },
@@ -3324,7 +3324,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
                     }""",
                 "[{\"cluster\":[\"cross_cluster_search\",\"monitor_enrich\"],"
                     + "\"indices\":[{\"names\":[\"logs*\"],"
-                    + "\"privileges\":[\"read\",\"read_cross_cluster\",\"view_index_metadata\"],"
+                    + "\"privileges\":[\"read\",\"view_index_metadata\"],"
                     + "\"field_security\":{\"grant\":[\"*\"],\"except\":[\"private\"]},"
                     + "\"query\":\"{\\\"term\\\":{\\\"tag\\\":42}}\"}],"
                     + "\"applications\":[],\"run_as\":[]}]"
@@ -3365,7 +3365,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
                         ]
                       }""",
                 "[{\"cluster\":[\"cross_cluster_search\",\"monitor_enrich\",\"cross_cluster_replication\"],"
-                    + "\"indices\":[{\"names\":[\"logs*\"],\"privileges\":[\"read\",\"read_cross_cluster\",\"view_index_metadata\"]},"
+                    + "\"indices\":[{\"names\":[\"logs*\"],\"privileges\":[\"read\",\"view_index_metadata\"]},"
                     + "{\"names\":[\"archive\"],\"privileges\":[\"cross_cluster_replication\",\"cross_cluster_replication_internal\"],"
                     + "\"allow_restricted_indices\":true}],\"applications\":[],\"run_as\":[]}]"
             )

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
@@ -3289,7 +3289,7 @@ public class AuthorizationServiceTests extends ESTestCase {
         RoleDescriptor role = new RoleDescriptor(
             "a_all",
             null,
-            new IndicesPrivileges[] { IndicesPrivileges.builder().indices("a").privileges("read_cross_cluster").build() },
+            new IndicesPrivileges[] { IndicesPrivileges.builder().indices("a").privileges("read").build() },
             null
         );
         final Authentication authentication = createAuthentication(new User("test user", "a_all"));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
@@ -3311,31 +3311,6 @@ public class AuthorizationServiceTests extends ESTestCase {
         );
     }
 
-    public void testProxyRequestAuthenticationDeniedWithReadPrivileges() {
-        final Authentication authentication = createAuthentication(new User("test user", "a_all"));
-        final RoleDescriptor role = new RoleDescriptor(
-            "a_all",
-            null,
-            new IndicesPrivileges[] { IndicesPrivileges.builder().indices("a").privileges("read").build() },
-            null
-        );
-        roleMap.put("a_all", role);
-        final String requestId = AuditUtil.getOrGenerateRequestId(threadContext);
-        mockEmptyMetadata();
-        DiscoveryNode node = DiscoveryNodeUtils.create("foo");
-        ClearScrollRequest clearScrollRequest = new ClearScrollRequest();
-        TransportRequest transportRequest = TransportActionProxy.wrapRequest(node, clearScrollRequest);
-        String action = TransportActionProxy.getProxyAction(SearchTransportService.CLEAR_SCROLL_CONTEXTS_ACTION_NAME);
-        assertThrowsAuthorizationException(() -> authorize(authentication, action, transportRequest), action, "test user");
-        verify(auditTrail).accessDenied(
-            eq(requestId),
-            eq(authentication),
-            eq(action),
-            eq(clearScrollRequest),
-            authzInfoRoles(new String[] { role.getName() })
-        );
-    }
-
     @SuppressWarnings("unchecked")
     public void testAuthorizationEngineSelectionForCheckPrivileges() throws Exception {
         AuthorizationEngine engine = mock(AuthorizationEngine.class);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/RBACEngineTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/RBACEngineTests.java
@@ -1846,7 +1846,7 @@ public class RBACEngineTests extends ESTestCase {
                                 IndicesPrivileges.builder().indices("*").privileges("all").allowRestrictedIndices(false).build(),
                                 IndicesPrivileges.builder()
                                     .indices("*")
-                                    .privileges("monitor", "read", "read_cross_cluster", "view_index_metadata")
+                                    .privileges("monitor", "read", "view_index_metadata")
                                     .allowRestrictedIndices(true)
                                     .build() },
                             null,
@@ -1887,12 +1887,12 @@ public class RBACEngineTests extends ESTestCase {
                                 .filter(s -> s.equals(ClusterPrivilegeResolver.MONITOR_STATS.name()))
                                 .toArray(String[]::new),
                             new IndicesPrivileges[] {
-                                IndicesPrivileges.builder().indices(".monitoring-*").privileges("read", "read_cross_cluster").build(),
-                                IndicesPrivileges.builder().indices("apm-*").privileges("read", "read_cross_cluster").build(),
-                                IndicesPrivileges.builder().indices("logs-apm.*").privileges("read", "read_cross_cluster").build(),
-                                IndicesPrivileges.builder().indices("metrics-apm.*").privileges("read", "read_cross_cluster").build(),
-                                IndicesPrivileges.builder().indices("traces-apm-*").privileges("read", "read_cross_cluster").build(),
-                                IndicesPrivileges.builder().indices("traces-apm.*").privileges("read", "read_cross_cluster").build() },
+                                IndicesPrivileges.builder().indices(".monitoring-*").privileges("read").build(),
+                                IndicesPrivileges.builder().indices("apm-*").privileges("read").build(),
+                                IndicesPrivileges.builder().indices("logs-apm.*").privileges("read").build(),
+                                IndicesPrivileges.builder().indices("metrics-apm.*").privileges("read").build(),
+                                IndicesPrivileges.builder().indices("traces-apm-*").privileges("read").build(),
+                                IndicesPrivileges.builder().indices("traces-apm.*").privileges("read").build() },
                             null,
                             null,
                             null,
@@ -1928,12 +1928,12 @@ public class RBACEngineTests extends ESTestCase {
                             Role.REMOTE_USER_ROLE_NAME,
                             null,
                             new IndicesPrivileges[] {
-                                IndicesPrivileges.builder().indices(".monitoring-*").privileges("read", "read_cross_cluster").build(),
+                                IndicesPrivileges.builder().indices(".monitoring-*").privileges("read").build(),
                                 IndicesPrivileges.builder()
                                     .indices("/metrics-(beats|elasticsearch|enterprisesearch|kibana|logstash).*/")
-                                    .privileges("read", "read_cross_cluster")
+                                    .privileges("read")
                                     .build(),
-                                IndicesPrivileges.builder().indices("metricbeat-*").privileges("read", "read_cross_cluster").build() },
+                                IndicesPrivileges.builder().indices("metricbeat-*").privileges("read").build() },
                             null,
                             null,
                             null,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
@@ -2769,7 +2769,7 @@ public class CompositeRolesStoreTests extends ESTestCase {
                   "cross_cluster": {
                     "cluster": ["cross_cluster_search"],
                     "indices": [
-                      { "names":["index*"], "privileges":["read","read_cross_cluster","view_index_metadata"] }
+                      { "names":["index*"], "privileges":["read","view_index_metadata"] }
                     ]
                   }
                 }""")))

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/DeprecationRoleDescriptorConsumerTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/DeprecationRoleDescriptorConsumerTests.java
@@ -269,7 +269,7 @@ public final class DeprecationRoleDescriptorConsumerTests extends ESTestCase {
         final RoleDescriptor roleGlobalWildcard = new RoleDescriptor(
             "roleGlobalWildcard",
             new String[] { "manage_token" },
-            new RoleDescriptor.IndicesPrivileges[] { indexPrivileges(randomFrom("write", "delete_index", "read_cross_cluster"), "*") },
+            new RoleDescriptor.IndicesPrivileges[] { indexPrivileges(randomFrom("write", "delete_index", "read"), "*") },
             null
         );
         final ClusterService clusterService = mockClusterService(projectBuilder);
@@ -282,7 +282,7 @@ public final class DeprecationRoleDescriptorConsumerTests extends ESTestCase {
             "roleGlobalWildcard2",
             new String[] { "manage_index_templates" },
             new RoleDescriptor.IndicesPrivileges[] {
-                indexPrivileges(randomFrom("write", "delete_index", "read_cross_cluster"), "i*", "a*") },
+                indexPrivileges(randomFrom("write", "delete_index", "read"), "i*", "a*") },
             null
         );
         new DeprecationRoleDescriptorConsumer(clusterService, projectResolver, threadPool, deprecationLogger).accept(

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/DeprecationRoleDescriptorConsumerTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/DeprecationRoleDescriptorConsumerTests.java
@@ -281,8 +281,7 @@ public final class DeprecationRoleDescriptorConsumerTests extends ESTestCase {
         final RoleDescriptor roleGlobalWildcard2 = new RoleDescriptor(
             "roleGlobalWildcard2",
             new String[] { "manage_index_templates" },
-            new RoleDescriptor.IndicesPrivileges[] {
-                indexPrivileges(randomFrom("write", "delete_index", "read"), "i*", "a*") },
+            new RoleDescriptor.IndicesPrivileges[] { indexPrivileges(randomFrom("write", "delete_index", "read"), "i*", "a*") },
             null
         );
         new DeprecationRoleDescriptorConsumer(clusterService, projectResolver, threadPool, deprecationLogger).accept(

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestCreateCrossClusterApiKeyActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestCreateCrossClusterApiKeyActionTests.java
@@ -85,10 +85,7 @@ public class RestCreateCrossClusterApiKeyActionTests extends ESTestCase {
                         "cross_cluster",
                         new String[] { "cross_cluster_search", "monitor_enrich" },
                         new RoleDescriptor.IndicesPrivileges[] {
-                            RoleDescriptor.IndicesPrivileges.builder()
-                                .indices("logs")
-                                .privileges("read", "view_index_metadata")
-                                .build() },
+                            RoleDescriptor.IndicesPrivileges.builder().indices("logs").privileges("read", "view_index_metadata").build() },
                         null
                     )
                 )

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestCreateCrossClusterApiKeyActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestCreateCrossClusterApiKeyActionTests.java
@@ -87,7 +87,7 @@ public class RestCreateCrossClusterApiKeyActionTests extends ESTestCase {
                         new RoleDescriptor.IndicesPrivileges[] {
                             RoleDescriptor.IndicesPrivileges.builder()
                                 .indices("logs")
-                                .privileges("read", "read_cross_cluster", "view_index_metadata")
+                                .privileges("read", "view_index_metadata")
                                 .build() },
                         null
                     )

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/QueryableBuiltInRolesUtilsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/QueryableBuiltInRolesUtilsTests.java
@@ -125,7 +125,7 @@ public class QueryableBuiltInRolesUtilsTests extends ESTestCase {
                 ReservedRolesStore.SUPERUSER_ROLE_DESCRIPTOR,
                 ReservedRolesStore.roleDescriptor("viewer"),
                 ReservedRolesStore.roleDescriptor("editor"),
-                supermanRole("monitor", "read", "view_index_metadata", "read_cross_cluster")
+                supermanRole("monitor", "read", "view_index_metadata")
             )
         );
 
@@ -160,7 +160,7 @@ public class QueryableBuiltInRolesUtilsTests extends ESTestCase {
             )
         );
 
-        RoleDescriptor updatedSupermanRole = supermanRole("monitor", "read", "view_index_metadata", "read_cross_cluster");
+        RoleDescriptor updatedSupermanRole = supermanRole("monitor", "read", "view_index_metadata");
         QueryableBuiltInRoles currentBuiltInRoles = buildQueryableBuiltInRoles(
             Set.of(
                 ReservedRolesStore.SUPERUSER_ROLE_DESCRIPTOR,
@@ -185,7 +185,7 @@ public class QueryableBuiltInRolesUtilsTests extends ESTestCase {
             )
         );
 
-        RoleDescriptor newSupermanRole = supermanRole("monitor", "read", "view_index_metadata", "read_cross_cluster");
+        RoleDescriptor newSupermanRole = supermanRole("monitor", "read", "view_index_metadata");
         QueryableBuiltInRoles currentBuiltInRoles = buildQueryableBuiltInRoles(
             Set.of(
                 ReservedRolesStore.SUPERUSER_ROLE_DESCRIPTOR,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/QueryableBuiltInRolesUtilsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/QueryableBuiltInRolesUtilsTests.java
@@ -40,7 +40,7 @@ public class QueryableBuiltInRolesUtilsTests extends ESTestCase {
     public void testCalculateHash() {
         assertThat(
             QueryableBuiltInRolesUtils.calculateHash(ReservedRolesStore.SUPERUSER_ROLE_DESCRIPTOR),
-            equalTo("bWEFdFo4WX229wdhdecfiz5QHMYEssh3ex8hizRgg+Q=")
+            equalTo("V7vziMakrcivZmJSNTZimfCKWFq3H+Pqp9uMRXoU+ZQ=")
         );
     }
 

--- a/x-pack/plugin/security/src/test/resources/org/elasticsearch/xpack/security/audit/logfile/audited_roles.txt
+++ b/x-pack/plugin/security/src/test/resources/org/elasticsearch/xpack/security/audit/logfile/audited_roles.txt
@@ -7,6 +7,6 @@ role_descriptor2
 role_descriptor3
 {"cluster":[],"indices":[],"applications":[{"application":"maps","privileges":["{","}","\n","\\","\""],"resources":["raster:*"]},{"application":"maps","privileges":["*:*"],"resources":["noooooo!!\n\n\f\\\\r","{"]}],"run_as":["jack","nich*","//\""],"metadata":{"some meta":42}}
 role_descriptor4
-{"cluster":["manage_ml","grant_api_key","manage_rollup"],"global":{"application":{"manage":{"applications":["a+b+|b+a+"]}},"profile":{},"role":{}},"indices":[{"names":["/. ? + * | { } [ ] ( ) \" \\/","*"],"privileges":["read","read_cross_cluster"],"field_security":{"grant":["almost","all*"],"except":["denied*"]}}],"applications":[],"run_as":["//+a+\"[a]/"],"metadata":{"?list":["e1","e2","*"],"some other meta":{"r":"t"}}}
+{"cluster":["manage_ml","grant_api_key","manage_rollup"],"global":{"application":{"manage":{"applications":["a+b+|b+a+"]}},"profile":{},"role":{}},"indices":[{"names":["/. ? + * | { } [ ] ( ) \" \\/","*"],"privileges":["read"],"field_security":{"grant":["almost","all*"],"except":["denied*"]}}],"applications":[],"run_as":["//+a+\"[a]/"],"metadata":{"?list":["e1","e2","*"],"some other meta":{"r":"t"}}}
 role_descriptor5
 {"cluster":["all"],"global":{"application":{"manage":{"applications":["\""]}},"profile":{"write":{"applications":["","\""]}},"role":{"manage":{"indices":[{"names":["test*"],"privileges":["read","write"]}]}}},"indices":[],"applications":[],"run_as":["\"[a]/"]}

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/api_key/50_cross_cluster.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/api_key/50_cross_cluster.yml
@@ -114,7 +114,6 @@ teardown:
           ],
           "privileges": [
             "read",
-            "read_cross_cluster",
             "view_index_metadata"
           ],
           "allow_restricted_indices": false
@@ -317,7 +316,6 @@ teardown:
           ],
           "privileges": [
             "read",
-            "read_cross_cluster",
             "view_index_metadata"
           ],
           "allow_restricted_indices": true

--- a/x-pack/qa/multi-cluster-search-security/legacy-with-basic-license/src/test/resources/rest-api-spec/test/fulfilling_cluster/10_basic.yml
+++ b/x-pack/qa/multi-cluster-search-security/legacy-with-basic-license/src/test/resources/rest-api-spec/test/fulfilling_cluster/10_basic.yml
@@ -24,7 +24,7 @@ setup:
                 {
                   "names": ["single_doc_index", "secure_alias", "test_index", "aliased_test_index", "field_caps_index_1",
                   "field_caps_index_3", "point_in_time_index", "simple-data-stream1", "simple-data-stream2", "esql_index"],
-                  "privileges": ["read", "read_cross_cluster"]
+                  "privileges": ["read"]
                 }
               ]
             }
@@ -47,7 +47,7 @@ setup:
                 {
                   "names": ["single_doc_index", "secure_alias", "test_index", "aliased_test_index", "field_caps_index_1",
                   "field_caps_index_3", "point_in_time_index", "simple-data-stream1", "simple-data-stream2", "esql_index"],
-                  "privileges": ["read", "read_cross_cluster"]
+                  "privileges": ["read"]
                 }
               ]
             }
@@ -61,7 +61,7 @@ setup:
             "indices": [
               {
                 "names": ["shared_index"],
-                "privileges": ["read", "read_cross_cluster"]
+                "privileges": ["read"]
               }
             ]
           }

--- a/x-pack/qa/multi-cluster-search-security/legacy-with-full-license/src/test/resources/rest-api-spec/test/fulfilling_cluster/10_basic_with_dls_fls.yml
+++ b/x-pack/qa/multi-cluster-search-security/legacy-with-full-license/src/test/resources/rest-api-spec/test/fulfilling_cluster/10_basic_with_dls_fls.yml
@@ -24,7 +24,7 @@ setup:
               {
                 "names": ["single_doc_index", "secure_alias", "test_index", "aliased_test_index", "field_caps_index_1",
                 "field_caps_index_3", "point_in_time_index"],
-                "privileges": ["read", "read_cross_cluster"]
+                "privileges": ["read"]
               }
             ]
           }
@@ -47,7 +47,7 @@ setup:
               {
                 "names": ["single_doc_index", "secure_alias", "test_index", "aliased_test_index", "field_caps_index_1",
                 "field_caps_index_3", "point_in_time_index"],
-                "privileges": ["read", "read_cross_cluster"]
+                "privileges": ["read"]
               }
             ]
           }
@@ -61,7 +61,7 @@ setup:
             "indices": [
               {
                 "names": ["shared_index"],
-                "privileges": ["read", "read_cross_cluster"],
+                "privileges": ["read"],
                 "query": "{ \"term\": { \"public\" : true } }",
                 "field_security": { "grant": ["*"], "except": ["secret"] }
               }


### PR DESCRIPTION
Experiment with moving all `read_cross_cluster` permissions into `read` to see what (if anything) breaks