### PR TITLE
[9.0] [DOCS] Adds applies_to tag to semantic text and semantic query (#131804)

### DIFF
--- a/docs/reference/query-languages/query-dsl/query-dsl-semantic-query.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-semantic-query.md
@@ -2,6 +2,9 @@
 navigation_title: "Semantic"
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-semantic-query.html
+applies_to:
+  stack: ga 9.0
+  serverless: ga
 ---
 
 # Semantic query [query-dsl-semantic-query]


### PR DESCRIPTION
Backports the following commits to 9.0:
 - [DOCS] Adds applies_to tag to semantic text and semantic query (#131804)