### PR TITLE
[Docs] Forward port (8.19) Fix broken anchors (#125589)

### DIFF
--- a/docs/reference/index-modules/slowlog.asciidoc
+++ b/docs/reference/index-modules/slowlog.asciidoc
@@ -107,6 +107,7 @@ GET _all/_settings?expand_wildcards=all&filter_path=*.settings.index.*.slowlog
 [[search-slow-log]]
 ==== Enable slow logging for search events
 
+[[_identifying_search_slow_log_origin]]
 Search slow logs emit per shard. They must be enabled separately for the shard's link:https://www.elastic.co/blog/understanding-query-then-fetch-vs-dfs-query-then-fetch[query and fetch search phases].
 
 You can use the `index.search.slowlog.include.user` setting to append `user.*` and `auth.type` fields to slow log entries. These fields contain information about the user who triggered the request.

--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -46,6 +46,29 @@ The following additional roles are available:
 
 * `voting_only`
 
+[NOTE]
+[[coordinating-only-node]]
+.Coordinating node
+===============================================
+
+Requests like search requests or bulk-indexing requests may involve data held
+on different data nodes. A search request, for example, is executed in two
+phases which are coordinated by the node which receives the client request --
+the _coordinating node_.
+
+In the _scatter_ phase, the coordinating node forwards the request to the data
+nodes which hold the data. Each data node executes the request locally and
+returns its results to the coordinating node. In the _gather_ phase, the
+coordinating node reduces each data node's results into a single global
+result set.
+
+Every node is implicitly a coordinating node. This means that a node that has
+an explicit empty list of roles in the `node.roles` setting will only act as a coordinating
+node, which cannot be disabled. As a result, such a node needs to have enough
+memory and CPU in order to deal with the gather phase.
+
+===============================================
+
 [IMPORTANT]
 ====
 If you set `node.roles`, ensure you specify every node role your cluster needs.

--- a/docs/reference/node-roles.asciidoc
+++ b/docs/reference/node-roles.asciidoc
@@ -359,7 +359,7 @@ node.roles: [ ingest ]
 ----
 
 [discrete]
-[[coordinating-only-node]]
+[[coordinating-only-node-role]]
 ==== Coordinating only node
 
 If you take away the ability to be able to handle master duties, to hold data,

--- a/docs/reference/setup/advanced-configuration.asciidoc
+++ b/docs/reference/setup/advanced-configuration.asciidoc
@@ -153,7 +153,6 @@ options. We do not recommend using `ES_JAVA_OPTS` in production.
 NOTE: If you are running {es} as a Windows service, you can change the heap size
 using the service manager. See <<windows-service>>.
 
-[[heap-dump-path]]
 include::important-settings/heap-dump-path.asciidoc[leveloffset=-1]
 
 [[gc-logging]]

--- a/docs/reference/setup/important-settings.asciidoc
+++ b/docs/reference/setup/important-settings.asciidoc
@@ -41,6 +41,7 @@ include::important-settings/discovery-settings.asciidoc[]
 
 include::important-settings/heap-size.asciidoc[]
 
+[[heap-dump-path]]
 include::important-settings/heap-dump-path.asciidoc[]
 
 include::important-settings/gc-logging.asciidoc[]


### PR DESCRIPTION
Forward port of https://github.com/elastic/elasticsearch/pull/125589 to fix broken links in docs [8.19 version bump PR](https://github.com/elastic/docs/pull/3239).
