### PR TITLE
Resolve inference release tests failing due to missing feature flag 

### DIFF
--- a/x-pack/plugin/inference/src/yamlRestTest/java/org/elasticsearch/xpack/inference/InferenceRestIT.java
+++ b/x-pack/plugin/inference/src/yamlRestTest/java/org/elasticsearch/xpack/inference/InferenceRestIT.java
@@ -13,6 +13,7 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.FeatureFlag;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
@@ -31,6 +32,7 @@ public class InferenceRestIT extends ESClientYamlSuiteTestCase {
         .setting("xpack.security.enabled", "false")
         .setting("xpack.security.http.ssl.enabled", "false")
         .setting("xpack.license.self_generated.type", "trial")
+        .feature(FeatureFlag.RERANK_SNIPPETS)
         .plugin("inference-service-test")
         .distribution(DistributionType.DEFAULT)
         .build();

--- a/x-pack/plugin/inference/src/yamlRestTest/java/org/elasticsearch/xpack/inference/InferenceRestIT.java
+++ b/x-pack/plugin/inference/src/yamlRestTest/java/org/elasticsearch/xpack/inference/InferenceRestIT.java
@@ -23,6 +23,7 @@ import org.junit.ClassRule;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 public class InferenceRestIT extends ESClientYamlSuiteTestCase {
@@ -41,7 +42,7 @@ public class InferenceRestIT extends ESClientYamlSuiteTestCase {
     public InferenceRestIT(final ClientYamlTestCandidate testCandidate) {
         super(testCandidate);
         String testPath = testCandidate.getTestPath();
-        if (testPath.startsWith("inference/70_text_similarity_rank_retriever") && testPath.toLowerCase().contains("snippet")) {
+        if (testPath.startsWith("inference/70_text_similarity_rank_retriever") && testPath.toLowerCase(Locale.ROOT).contains("snippet")) {
             assumeTrue("Rerank snippets does not work in release builds", Build.current().isSnapshot());
         }
     }

--- a/x-pack/plugin/inference/src/yamlRestTest/java/org/elasticsearch/xpack/inference/InferenceRestIT.java
+++ b/x-pack/plugin/inference/src/yamlRestTest/java/org/elasticsearch/xpack/inference/InferenceRestIT.java
@@ -40,7 +40,10 @@ public class InferenceRestIT extends ESClientYamlSuiteTestCase {
 
     public InferenceRestIT(final ClientYamlTestCandidate testCandidate) {
         super(testCandidate);
-        assumeTrue("Rerank snippets does not work in release builds", Build.current().isSnapshot());
+        String testPath = testCandidate.getTestPath();
+        if (testPath.startsWith("inference/70_text_similarity_rank_retriever") && testPath.toLowerCase().contains("snippet")) {
+            assumeTrue("Rerank snippets does not work in release builds", Build.current().isSnapshot());
+        }
     }
 
     @Override

--- a/x-pack/plugin/inference/src/yamlRestTest/java/org/elasticsearch/xpack/inference/InferenceRestIT.java
+++ b/x-pack/plugin/inference/src/yamlRestTest/java/org/elasticsearch/xpack/inference/InferenceRestIT.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.inference;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.elasticsearch.Build;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
@@ -39,6 +40,7 @@ public class InferenceRestIT extends ESClientYamlSuiteTestCase {
 
     public InferenceRestIT(final ClientYamlTestCandidate testCandidate) {
         super(testCandidate);
+        assumeTrue("Rerank snippets does not work in release builds", Build.current().isSnapshot());
     }
 
     @Override


### PR DESCRIPTION
Resolves https://github.com/elastic/elasticsearch/issues/131838 

Fixes test issue introduced in https://github.com/elastic/elasticsearch/pull/129369 feature flags