### PR TITLE
[9.1] Grant server read/write permissions on shared data path "path.shared_data". (#131680)

### DIFF
--- a/docs/changelog/131680.yaml
+++ b/docs/changelog/131680.yaml
@@ -1,0 +1,5 @@
+pr: 131680
+summary: Grant server module read/write entitlements for deprecated path setting "path.shared_data"
+area: Infra/Core
+type: bug
+issues: []

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/bootstrap/EntitlementBootstrap.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/bootstrap/EntitlementBootstrap.java
@@ -46,6 +46,7 @@ public class EntitlementBootstrap {
      * @param scopeResolver                a functor to map a Java Class to the component and module it belongs to.
      * @param settingResolver              a functor to resolve a setting name pattern for one or more Elasticsearch settings.
      * @param dataDirs                     data directories for Elasticsearch
+     * @param sharedDataDir                shared data directory for Elasticsearch (deprecated)
      * @param sharedRepoDirs               shared repository directories for Elasticsearch
      * @param configDir                    the config directory for Elasticsearch
      * @param libDir                       the lib directory for Elasticsearch
@@ -63,6 +64,7 @@ public class EntitlementBootstrap {
         Function<Class<?>, PolicyManager.PolicyScope> scopeResolver,
         Function<String, Stream<String>> settingResolver,
         Path[] dataDirs,
+        Path sharedDataDir,
         Path[] sharedRepoDirs,
         Path configDir,
         Path libDir,
@@ -82,6 +84,7 @@ public class EntitlementBootstrap {
             getUserHome(),
             configDir,
             dataDirs,
+            sharedDataDir,
             sharedRepoDirs,
             libDir,
             modulesDir,

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/bootstrap/HardcodedEntitlements.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/bootstrap/HardcodedEntitlements.java
@@ -37,6 +37,7 @@ import static org.elasticsearch.entitlement.runtime.policy.PathLookup.BaseDir.LI
 import static org.elasticsearch.entitlement.runtime.policy.PathLookup.BaseDir.LOGS;
 import static org.elasticsearch.entitlement.runtime.policy.PathLookup.BaseDir.MODULES;
 import static org.elasticsearch.entitlement.runtime.policy.PathLookup.BaseDir.PLUGINS;
+import static org.elasticsearch.entitlement.runtime.policy.PathLookup.BaseDir.SHARED_DATA;
 import static org.elasticsearch.entitlement.runtime.policy.PathLookup.BaseDir.SHARED_REPO;
 import static org.elasticsearch.entitlement.runtime.policy.Platform.LINUX;
 import static org.elasticsearch.entitlement.runtime.policy.entitlements.FilesEntitlement.Mode.READ;
@@ -57,6 +58,7 @@ class HardcodedEntitlements {
             FilesEntitlement.FileData.ofBaseDirPath(LOGS, READ_WRITE),
             FilesEntitlement.FileData.ofBaseDirPath(LIB, READ),
             FilesEntitlement.FileData.ofBaseDirPath(DATA, READ_WRITE),
+            FilesEntitlement.FileData.ofBaseDirPath(SHARED_DATA, READ_WRITE),
             FilesEntitlement.FileData.ofBaseDirPath(SHARED_REPO, READ_WRITE),
             // exclusive settings file
             FilesEntitlement.FileData.ofRelativePath(Path.of("operator/settings.json"), CONFIG, READ_WRITE).withExclusive(true),

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PathLookup.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PathLookup.java
@@ -24,6 +24,7 @@ public interface PathLookup {
         USER_HOME,
         CONFIG,
         DATA,
+        SHARED_DATA,
         SHARED_REPO,
         LIB,
         MODULES,

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PathLookupImpl.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PathLookupImpl.java
@@ -25,6 +25,7 @@ public record PathLookupImpl(
     Path homeDir,
     Path configDir,
     Path[] dataDirs,
+    Path sharedDataDir,
     Path[] sharedRepoDirs,
     Path libDir,
     Path modulesDir,
@@ -56,6 +57,7 @@ public record PathLookupImpl(
         return switch (baseDir) {
             case USER_HOME -> Stream.of(homeDir);
             case DATA -> Arrays.stream(dataDirs);
+            case SHARED_DATA -> Stream.ofNullable(sharedDataDir);
             case SHARED_REPO -> Arrays.stream(sharedRepoDirs);
             case CONFIG -> Stream.of(configDir);
             case LIB -> Stream.of(libDir);

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/bootstrap/FilesEntitlementsValidationTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/bootstrap/FilesEntitlementsValidationTests.java
@@ -48,6 +48,7 @@ public class FilesEntitlementsValidationTests extends ESTestCase {
                 testBaseDir.resolve("user/home"),
                 TEST_CONFIG_DIR,
                 new Path[] { testBaseDir.resolve("data1"), testBaseDir.resolve("data2") },
+                Path.of("/shareddata"),
                 new Path[] { testBaseDir.resolve("shared1"), testBaseDir.resolve("shared2") },
                 TEST_LIBS_DIR,
                 testBaseDir.resolve("modules"),

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTreeTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTreeTests.java
@@ -59,6 +59,7 @@ public class FileAccessTreeTests extends ESTestCase {
         Path.of("/home"),
         Path.of("/config"),
         new Path[] { Path.of("/data1"), Path.of("/data2") },
+        Path.of("/shareddata"),
         new Path[] { Path.of("/shared1"), Path.of("/shared2") },
         Path.of("/lib"),
         Path.of("/modules"),

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyManagerTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/PolicyManagerTests.java
@@ -71,6 +71,7 @@ public class PolicyManagerTests extends ESTestCase {
                 baseDir.resolve("/user/home"),
                 baseDir.resolve("/config"),
                 new Path[] { baseDir.resolve("/data1/"), baseDir.resolve("/data2") },
+                Path.of("/shareddata"),
                 new Path[] { baseDir.resolve("/shared1"), baseDir.resolve("/shared2") },
                 baseDir.resolve("/lib"),
                 baseDir.resolve("/modules"),

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/entitlements/FilesEntitlementTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/entitlements/FilesEntitlementTests.java
@@ -47,6 +47,7 @@ public class FilesEntitlementTests extends ESTestCase {
         Path.of("/home"),
         Path.of("/config"),
         new Path[] { Path.of("/data1"), Path.of("/data2") },
+        Path.of("/shareddata"),
         new Path[] { Path.of("/shared1"), Path.of("/shared2") },
         Path.of("/lib"),
         Path.of("/modules"),

--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -256,6 +256,7 @@ class Elasticsearch {
             scopeResolver::resolveClassToScope,
             nodeEnv.settings()::getValues,
             nodeEnv.dataDirs(),
+            nodeEnv.sharedDataDir(),
             nodeEnv.repoDirs(),
             nodeEnv.configDir(),
             nodeEnv.libDir(),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Grant server read/write permissions on shared data path "path.shared_data". (#131680)](https://github.com/elastic/elasticsearch/pull/131680)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)