### PR TITLE
[8.18] Log system information early during startup (#124926)

### DIFF
--- a/distribution/src/bin/elasticsearch-cli
+++ b/distribution/src/bin/elasticsearch-cli
@@ -19,6 +19,7 @@ exec \
   -Des.path.home="$ES_HOME" \
   -Des.path.conf="$ES_PATH_CONF" \
   -Des.distribution.type="$ES_DISTRIBUTION_TYPE" \
+  -Des.java.type="$JAVA_TYPE" \
   -cp "$LAUNCHER_CLASSPATH" \
   org.elasticsearch.launcher.CliToolLauncher \
   "$@"

--- a/distribution/src/bin/elasticsearch-cli.bat
+++ b/distribution/src/bin/elasticsearch-cli.bat
@@ -18,6 +18,7 @@ set LAUNCHER_CLASSPATH=%ES_HOME%/lib/*;%ES_HOME%/lib/cli-launcher/*
   -Des.path.home="%ES_HOME%" ^
   -Des.path.conf="%ES_PATH_CONF%" ^
   -Des.distribution.type="%ES_DISTRIBUTION_TYPE%" ^
+  -Des.java.type="%JAVA_TYPE%" ^
   -cp "%LAUNCHER_CLASSPATH%" ^
   org.elasticsearch.launcher.CliToolLauncher ^
   %*

--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.lucene.util.Constants;
 import org.apache.lucene.util.StringHelper;
 import org.apache.lucene.util.VectorUtil;
 import org.elasticsearch.Build;
@@ -55,6 +56,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.lang.invoke.MethodHandles;
+import java.lang.management.ManagementFactory;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -64,6 +66,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -176,6 +179,9 @@ class Elasticsearch {
      * <p> Phase 2 consists of everything that must occur up to and including security manager initialization.
      */
     private static void initPhase2(Bootstrap bootstrap) throws IOException {
+        // always start by dumping what we know about the process to the log
+        logSystemInfo();
+
         final ServerArgs args = bootstrap.args();
         final SecureSettings secrets = args.secrets();
         bootstrap.setSecureSettings(secrets);
@@ -287,6 +293,35 @@ class Elasticsearch {
         }
 
         bootstrap.setPluginsLoader(pluginsLoader);
+    }
+
+    private static void logSystemInfo() {
+        final Logger logger = LogManager.getLogger(Elasticsearch.class);
+        logger.info(
+            "version[{}], pid[{}], build[{}/{}/{}], OS[{}/{}/{}], JVM[{}/{}/{}/{}]",
+            Build.current().qualifiedVersion(),
+            ProcessHandle.current().pid(),
+            Build.current().type().displayName(),
+            Build.current().hash(),
+            Build.current().date(),
+            Constants.OS_NAME,
+            Constants.OS_VERSION,
+            Constants.OS_ARCH,
+            Constants.JVM_VENDOR,
+            Constants.JVM_NAME,
+            System.getProperty("java.version"),
+            Runtime.version().toString()
+        );
+        boolean isBundledJdk = System.getProperty("es.java.type", "").equals("bundled JDK");
+        logger.info("JVM home [{}], using bundled JDK [{}]", System.getProperty("java.home"), isBundledJdk);
+        logger.info("JVM arguments {}", ManagementFactory.getRuntimeMXBean().getInputArguments());
+        logger.info("Default Locale [{}]", Locale.getDefault());
+        if (Build.current().isProductionRelease() == false) {
+            logger.warn(
+                "version [{}] is a pre-release version of Elasticsearch and is not suitable for production",
+                Build.current().qualifiedVersion()
+            );
+        }
     }
 
     private static Map<String, String> collectPluginPolicyPatches(

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
@@ -9,14 +9,11 @@
 
 package org.elasticsearch.monitor.jvm;
 
-import org.apache.lucene.util.Constants;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.core.PathUtils;
-import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.node.ReportingService;
 import org.elasticsearch.xcontent.XContentBuilder;
 
@@ -168,19 +165,8 @@ public class JvmInfo implements ReportingService.Info {
         );
     }
 
-    @SuppressForbidden(reason = "PathUtils#get")
     private static boolean usingBundledJdk() {
-        /*
-         * We are using the bundled JDK if java.home is the jdk sub-directory of our working directory. This is because we always set
-         * the working directory of Elasticsearch to home, and the bundled JDK is in the jdk sub-directory there.
-         */
-        final String javaHome = System.getProperty("java.home");
-        final String userDir = System.getProperty("user.dir");
-        if (Constants.MAC_OS_X) {
-            return PathUtils.get(javaHome).equals(PathUtils.get(userDir).resolve("jdk.app/Contents/Home").toAbsolutePath());
-        } else {
-            return PathUtils.get(javaHome).equals(PathUtils.get(userDir).resolve("jdk").toAbsolutePath());
-        }
+        return System.getProperty("es.java.type", "").equals("bundled JDK");
     }
 
     public static JvmInfo jvmInfo() {

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -12,9 +12,7 @@ package org.elasticsearch.node;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.util.Constants;
 import org.apache.lucene.util.SetOnce;
-import org.elasticsearch.Build;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionModule;
@@ -229,7 +227,6 @@ import java.util.Collection;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -410,30 +407,6 @@ class NodeConstruction {
         DeprecationLogger.initialize(envSettings);
 
         JvmInfo jvmInfo = JvmInfo.jvmInfo();
-        logger.info(
-            "version[{}], pid[{}], build[{}/{}/{}], OS[{}/{}/{}], JVM[{}/{}/{}/{}]",
-            Build.current().qualifiedVersion(),
-            jvmInfo.pid(),
-            Build.current().type().displayName(),
-            Build.current().hash(),
-            Build.current().date(),
-            Constants.OS_NAME,
-            Constants.OS_VERSION,
-            Constants.OS_ARCH,
-            Constants.JVM_VENDOR,
-            Constants.JVM_NAME,
-            Constants.JAVA_VERSION,
-            Constants.JVM_VERSION
-        );
-        logger.info("JVM home [{}], using bundled JDK [{}]", System.getProperty("java.home"), jvmInfo.getUsingBundledJdk());
-        logger.info("JVM arguments {}", Arrays.toString(jvmInfo.getInputArguments()));
-        logger.info("Default Locale [{}]", Locale.getDefault());
-        if (Build.current().isProductionRelease() == false) {
-            logger.warn(
-                "version [{}] is a pre-release version of Elasticsearch and is not suitable for production",
-                Build.current().qualifiedVersion()
-            );
-        }
         if (Environment.PATH_SHARED_DATA_SETTING.exists(envSettings)) {
             // NOTE: this must be done with an explicit check here because the deprecation property on a path setting will
             // cause ES to fail to start since logging is not yet initialized on first read of the setting


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Log system information early during startup (#124926)](https://github.com/elastic/elasticsearch/pull/124926)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)