### PR TITLE
Register a blob cache long counter metric for total evicted regions

### DIFF
--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/BlobCacheMetrics.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/BlobCacheMetrics.java
@@ -27,9 +27,11 @@ public class BlobCacheMetrics {
     public static final String CACHE_POPULATION_SOURCE_ATTRIBUTE_KEY = "source";
     public static final String LUCENE_FILE_EXTENSION_ATTRIBUTE_KEY = "file_extension";
     public static final String NON_LUCENE_EXTENSION_TO_RECORD = "other";
+    public static final String BLOB_CACHE_COUNT_OF_EVICTED_REGIONS_TOTAL = "es.blob_cache.count_of_evicted_regions.total";
 
     private final LongCounter cacheMissCounter;
     private final LongCounter evictedCountNonZeroFrequency;
+    private final LongCounter totalEvictedCount;
     private final LongHistogram cacheMissLoadTimes;
     private final DoubleHistogram cachePopulationThroughput;
     private final LongCounter cachePopulationBytes;
@@ -66,6 +68,11 @@ public class BlobCacheMetrics {
                 "The number of times a cache entry was evicted where the frequency was not zero",
                 "entries"
             ),
+            meterRegistry.registerLongCounter(
+                BLOB_CACHE_COUNT_OF_EVICTED_REGIONS_TOTAL,
+                "The number of times a cache entry was evicted, irrespective of the frequency",
+                "entries"
+            ),
             meterRegistry.registerLongHistogram(
                 "es.blob_cache.cache_miss_load_times.histogram",
                 "The time in milliseconds for populating entries in the blob store resulting from a cache miss, expressed as a histogram.",
@@ -92,6 +99,7 @@ public class BlobCacheMetrics {
     BlobCacheMetrics(
         LongCounter cacheMissCounter,
         LongCounter evictedCountNonZeroFrequency,
+        LongCounter totalEvictedCount,
         LongHistogram cacheMissLoadTimes,
         DoubleHistogram cachePopulationThroughput,
         LongCounter cachePopulationBytes,
@@ -99,6 +107,7 @@ public class BlobCacheMetrics {
     ) {
         this.cacheMissCounter = cacheMissCounter;
         this.evictedCountNonZeroFrequency = evictedCountNonZeroFrequency;
+        this.totalEvictedCount = totalEvictedCount;
         this.cacheMissLoadTimes = cacheMissLoadTimes;
         this.cachePopulationThroughput = cachePopulationThroughput;
         this.cachePopulationBytes = cachePopulationBytes;
@@ -113,6 +122,10 @@ public class BlobCacheMetrics {
 
     public LongCounter getEvictedCountNonZeroFrequency() {
         return evictedCountNonZeroFrequency;
+    }
+
+    public LongCounter getTotalEvictedCount() {
+        return totalEvictedCount;
     }
 
     public LongHistogram getCacheMissLoadTimes() {

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -922,6 +922,7 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
             if (refCount() <= 1 && evict()) {
                 logger.trace("evicted {} with channel offset {}", regionKey, physicalStartOffset());
                 blobCacheService.evictCount.increment();
+                blobCacheService.blobCacheMetrics.getTotalEvictedCount().increment();
                 decRef();
                 return true;
             }
@@ -933,6 +934,7 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
             if (refCount() <= 1 && evict()) {
                 logger.trace("evicted and take {} with channel offset {}", regionKey, physicalStartOffset());
                 blobCacheService.evictCount.increment();
+                blobCacheService.blobCacheMetrics.getTotalEvictedCount().increment();
                 return true;
             }
 
@@ -944,6 +946,7 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
             if (evict()) {
                 logger.trace("force evicted {} with channel offset {}", regionKey, physicalStartOffset());
                 blobCacheService.evictCount.increment();
+                blobCacheService.blobCacheMetrics.getTotalEvictedCount().increment();
                 decRef();
                 return true;
             }


### PR DESCRIPTION
Currently we only track the number of evicted _used_ regions (i.e. freq > 1). 

This adds another metric, `es.blob_cache.count_of_evicted_regions.total`, that tracks the 
total number of evicted regions, irrespective of frequency.
