### PR TITLE
Clarify highlighting docs for semantic_text and interacting with chunks

### DIFF
--- a/docs/reference/elasticsearch/mapping-reference/semantic-text.md
+++ b/docs/reference/elasticsearch/mapping-reference/semantic-text.md
@@ -270,10 +270,8 @@ POST test-index/_search
 2. Sorts the most relevant highlighted fragments by score when set to `score`. By default,
    fragments will be output in the order they appear in the field (order: none).
 
-To use the `semantic` highlighter to view indexed chunks in the order which they
-were indexed and no scoring,
-use the `match_all` query to retrieve each chunk in the order which it appears
-in the document:
+To use the `semantic` highlighter to view chunks in the order which they were indexed with no scoring,
+use the `match_all` query to retrieve them in the order they appear in the document:
 
 ```console
 POST test-index/_search

--- a/docs/reference/elasticsearch/mapping-reference/semantic-text.md
+++ b/docs/reference/elasticsearch/mapping-reference/semantic-text.md
@@ -267,8 +267,28 @@ POST test-index/_search
 ```
 
 1. Specifies the maximum number of fragments to return.
-2. Sorts highlighted fragments by score when set to `score`. By default,
+2. Sorts returned most relevant highlighted fragments by score when set to `score`. By default,
    fragments will be output in the order they appear in the field (order: none).
+
+To use the `semantic` highlighter to view indexed chunks in the order which they
+were indexed and no scoring,
+use the `match_all` query to retrieve each chunk in the order which it appears
+in the document:
+
+```console
+POST test-index/_search
+{
+    "query": {
+        "match_all": {}
+    },
+    "highlight": {
+        "fields": {
+            "my_semantic_field": {
+                "number_of_fragments": 5
+            }
+        }
+    }
+}
 
 Highlighting is supported on fields other than semantic_text. However, if you
 want to restrict highlighting to the semantic highlighter and return no

--- a/docs/reference/elasticsearch/mapping-reference/semantic-text.md
+++ b/docs/reference/elasticsearch/mapping-reference/semantic-text.md
@@ -282,11 +282,14 @@ POST test-index/_search
     "highlight": {
         "fields": {
             "my_semantic_field": {
-                "number_of_fragments": 5
+                "number_of_fragments": 5  <1>
             }
         }
     }
 }
+```
+
+1. This will return the first 5 chunks, set this number higher to retrieve more chunks.
 
 Highlighting is supported on fields other than semantic_text. However, if you
 want to restrict highlighting to the semantic highlighter and return no

--- a/docs/reference/elasticsearch/mapping-reference/semantic-text.md
+++ b/docs/reference/elasticsearch/mapping-reference/semantic-text.md
@@ -267,7 +267,7 @@ POST test-index/_search
 ```
 
 1. Specifies the maximum number of fragments to return.
-2. Sorts returned most relevant highlighted fragments by score when set to `score`. By default,
+2. Sorts the most relevant highlighted fragments by score when set to `score`. By default,
    fragments will be output in the order they appear in the field (order: none).
 
 To use the `semantic` highlighter to view indexed chunks in the order which they

--- a/docs/reference/elasticsearch/rest-apis/highlighting.md
+++ b/docs/reference/elasticsearch/rest-apis/highlighting.md
@@ -7,7 +7,7 @@ applies_to:
 
 # Highlighting [highlighting]
 
-Highlighters enable you to get highlighted snippets from one or more fields in your search results so you can show users where the query matches are. When you request highlights, the response contains an additional `highlight` element for each search hit that includes the highlighted fields and the highlighted fragments.
+Highlighters enable you to retrieve the best-matching highlighted snippets from one or more fields in your search results so you can show users where the query matches are. When you request highlights, the response contains an additional `highlight` element for each search hit that includes the highlighted fields and the highlighted fragments.
 
 ::::{note}
 Highlighters don’t reflect the boolean logic of a query when extracting terms to highlight. Thus, for some complex boolean queries (e.g nested boolean queries, queries using `minimum_should_match` etc.), parts of documents may be highlighted that don’t correspond to query matches.


### PR DESCRIPTION
We ran into a confusing use case with the `semantic` highlighter. 

```
PUT my-test-index
{
  "mappings": {
    "properties": {
      "text": {
        "type": "semantic_text"
      }
    }
  }
}

PUT my-test-index/_doc/1
{
  "text": [
    "puggles are pugs and beagles",
    "chiweenies are chihuahuas and dachshunds"
  ]
}

GET my-test-index/_search
{
  "query": {
    "match_all": {}
  },
  "highlight": {
    "fields": {
      "text": {
        "number_of_fragments": 1
      }
    }
  }
}
```

With the above search, the expectation was that the first snippet would be returned as order was not specified, but in fact the second snippet was returned. This is because we had only asked for one snippet, so only the top scoring snippet was returned. 

This clarifies the documentation to show an alternate way to get `semantic` highlighter chunks, in the order in which they appear in the document: 

```
GET my-test-index/_search
{
  "query": {
    "match_all": {}
  },
  "highlight": {
    "fields": {
      "text": {
        "number_of_fragments": 1
      }
    },
    "highlight_query": {
      "match": {
        "text": "chihuahua"
      }
    }
  }
}
```