### PR TITLE
[8.19] Mute failing packaging tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -415,3 +415,9 @@ tests:
   - class: org.elasticsearch.packaging.test.DockerTests
     method: test151MachineDependentHeapWithSizeOverride
     issue: https://github.com/elastic/elasticsearch/issues/123437
+  - class: org.elasticsearch.packaging.test.ArchiveTests
+    method: test61EsJavaHomeOverride
+    issue: https://github.com/elastic/elasticsearch/issues/131839
+  - class: org.elasticsearch.packaging.test.PackageTests
+    method: test32JavaHomeOverride
+    issue: https://github.com/elastic/elasticsearch/issues/131842


### PR DESCRIPTION
Mute org.elasticsearch.packaging.test.PackageTests test32JavaHomeOverride #131842 
Mute org.elasticsearch.packaging.test.ArchiveTests test61EsJavaHomeOverride #131839

These are also failing in the periodic packaging tests for 8.19.
https://buildkite.com/elastic/elasticsearch-periodic-packaging/builds/9250
