### PR TITLE
DiskBBQ to dynamically adapt nProbe when centroids scores diff is large-ish (multi segment case)

### DIFF
--- a/qa/vector/src/main/java/org/elasticsearch/test/knn/CmdLineArgs.java
+++ b/qa/vector/src/main/java/org/elasticsearch/test/knn/CmdLineArgs.java
@@ -52,7 +52,8 @@ record CmdLineArgs(
     int quantizeBits,
     VectorEncoding vectorEncoding,
     int dimensions,
-    boolean earlyTermination
+    boolean earlyTermination,
+    String mergePolicy
 ) implements ToXContentObject {
 
     static final ParseField DOC_VECTORS_FIELD = new ParseField("doc_vectors");
@@ -79,6 +80,7 @@ record CmdLineArgs(
     static final ParseField EARLY_TERMINATION_FIELD = new ParseField("early_termination");
     static final ParseField FILTER_SELECTIVITY_FIELD = new ParseField("filter_selectivity");
     static final ParseField SEED_FIELD = new ParseField("seed");
+    static final ParseField MERGE_POLICY_FIELD = new ParseField("merge_policy");
 
     static CmdLineArgs fromXContent(XContentParser parser) throws IOException {
         Builder builder = PARSER.apply(parser, null);
@@ -112,6 +114,7 @@ record CmdLineArgs(
         PARSER.declareBoolean(Builder::setEarlyTermination, EARLY_TERMINATION_FIELD);
         PARSER.declareFloat(Builder::setFilterSelectivity, FILTER_SELECTIVITY_FIELD);
         PARSER.declareLong(Builder::setSeed, SEED_FIELD);
+        PARSER.declareString(Builder::setMergePolicy, MERGE_POLICY_FIELD);
     }
 
     @Override
@@ -179,6 +182,7 @@ record CmdLineArgs(
         private boolean earlyTermination;
         private float filterSelectivity = 1f;
         private long seed = 1751900822751L;
+        private String mergePolicy = null;
 
         public Builder setDocVectors(List<String> docVectors) {
             if (docVectors == null || docVectors.isEmpty()) {
@@ -304,6 +308,11 @@ record CmdLineArgs(
             return this;
         }
 
+        public Builder setMergePolicy(String mergePolicy) {
+            this.mergePolicy = mergePolicy;
+            return this;
+        }
+
         public CmdLineArgs build() {
             if (docVectors == null) {
                 throw new IllegalArgumentException("Document vectors path must be provided");
@@ -337,7 +346,8 @@ record CmdLineArgs(
                 quantizeBits,
                 vectorEncoding,
                 dimensions,
-                earlyTermination
+                earlyTermination,
+                mergePolicy
             );
         }
     }

--- a/qa/vector/src/main/java/org/elasticsearch/test/knn/KnnIndexer.java
+++ b/qa/vector/src/main/java/org/elasticsearch/test/knn/KnnIndexer.java
@@ -31,6 +31,7 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.MergePolicy;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.store.FSDirectory;
@@ -64,6 +65,7 @@ class KnnIndexer {
     private final List<Path> docsPath;
     private final Path indexPath;
     private final VectorEncoding vectorEncoding;
+    private final MergePolicy mergePolicy;
     private int dim;
     private final VectorSimilarityFunction similarityFunction;
     private final Codec codec;
@@ -78,7 +80,8 @@ class KnnIndexer {
         VectorEncoding vectorEncoding,
         int dim,
         VectorSimilarityFunction similarityFunction,
-        int numDocs
+        int numDocs,
+        MergePolicy mergePolicy
     ) {
         this.docsPath = docsPath;
         this.indexPath = indexPath;
@@ -88,6 +91,7 @@ class KnnIndexer {
         this.dim = dim;
         this.similarityFunction = similarityFunction;
         this.numDocs = numDocs;
+        this.mergePolicy = mergePolicy;
     }
 
     void numSegments(KnnIndexTester.Results result) {
@@ -104,6 +108,9 @@ class KnnIndexer {
         iwc.setRAMBufferSizeMB(WRITER_BUFFER_MB);
         iwc.setUseCompoundFile(false);
 
+        if (mergePolicy != null) {
+            iwc.setMergePolicy(mergePolicy);
+        }
         iwc.setMaxFullFlushMergeWaitMillis(0);
 
         iwc.setInfoStream(new PrintStreamInfoStream(System.out) {

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/DefaultIVFVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/DefaultIVFVectorsReader.java
@@ -24,10 +24,7 @@ import org.elasticsearch.simdvec.ES91OSQVectorsScorer;
 import org.elasticsearch.simdvec.ESVectorUtil;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.function.IntPredicate;
 

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/IVFVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/IVFVectorsReader.java
@@ -261,7 +261,7 @@ public abstract class IVFVectorsReader extends KnnVectorsReader {
             float lastCentroidScore = centroidScores.get(nProbe - 1);
             float scoreDifferencePercentage = Math.abs(firstCentroidScore - lastCentroidScore) / firstCentroidScore;
 
-            // If difference is small, increase nprobe to search more centroids
+            // If the difference is small, increase nprobe to search more centroids
             if (scoreDifferencePercentage < 0.001f) {
                 nProbe = Math.min(nProbe * 2, centroidQueryScorer.size());
             }

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/IVFVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/IVFVectorsReader.java
@@ -261,7 +261,7 @@ public abstract class IVFVectorsReader extends KnnVectorsReader {
         if (centroidQueue.size() > 2 && numCentroids > nProbe) {
             // If the difference is small, increase nprobe to search more centroids
             if (centroidQueryScorer.scoreRatioAtNprobe() < 0.001f) {
-                nProbe = (int) Math.min(nProbe * 1.1, centroidQueryScorer.size());
+                nProbe = (int) Math.min(nProbe * 2.0, numCentroids);
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/IVFVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/IVFVectorsReader.java
@@ -254,7 +254,6 @@ public abstract class IVFVectorsReader extends KnnVectorsReader {
         }
         final NeighborQueue centroidQueue = scorePostingLists(fieldInfo, knnCollector, centroidQueryScorer, nProbe);
 
-        // TODO : eval this
         List<Float> centroidScores = centroidQueryScorer.scores();
         if (centroidQueue.size() > 2 && centroidScores.size() > nProbe) {
             // Calculate distances between first and last centroids in queue

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/IVFVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/IVFVectorsReader.java
@@ -263,9 +263,10 @@ public abstract class IVFVectorsReader extends KnnVectorsReader {
 
             // If the difference is small, increase nprobe to search more centroids
             if (scoreDifferencePercentage < 0.001f) {
-                nProbe = Math.min(nProbe * 2, centroidQueryScorer.size());
+                nProbe = (int) Math.min(nProbe * 1.1, centroidQueryScorer.size());
             }
         }
+
 
         PostingVisitor scorer = getPostingVisitor(fieldInfo, ivfClusters, target, needsScoring);
         int centroidsVisited = 0;

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/IVFVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/IVFVectorsReader.java
@@ -260,10 +260,10 @@ public abstract class IVFVectorsReader extends KnnVectorsReader {
             // Calculate distances between first and last centroids in queue
             float firstCentroidScore = centroidScores.getFirst();
             float lastCentroidScore = centroidScores.get(nProbe - 1);
-            float scoreDifference = Math.abs(firstCentroidScore - lastCentroidScore);
+            float scoreDifferencePercentage = Math.abs(firstCentroidScore - lastCentroidScore) / firstCentroidScore;
 
             // If difference is small, increase nprobe to search more centroids
-            if (scoreDifference < 0.1f) {
+            if (scoreDifferencePercentage < 0.001f) {
                 nProbe = Math.min(nProbe * 2, centroidQueryScorer.size());
             }
         }

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/IVFVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/IVFVectorsReader.java
@@ -36,7 +36,6 @@ import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.search.vectors.IVFKnnSearchStrategy;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.function.IntPredicate;
 
 import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsReader.SIMILARITY_FUNCTIONS;
@@ -264,7 +263,6 @@ public abstract class IVFVectorsReader extends KnnVectorsReader {
                 nProbe = (int) Math.min(nProbe * 2.0, numCentroids);
             }
         }
-
 
         PostingVisitor scorer = getPostingVisitor(fieldInfo, ivfClusters, target, needsScoring);
         int centroidsVisited = 0;


### PR DESCRIPTION
This is a first attempt at dynamically adapt each segment's `nProbe` param to the distribution of the centroids wrt a specific query vector.
This seeks to detect if a specific query vector lies close to most of `nProbe` centroids, if so, it might be worth to explore more centroids. 
 
See https://github.com/elastic/elasticsearch/issues/129290.



this patch also adds a `merge_policy` param to `KnnIndexTester` so that we could better test differing numbers of merge policies (for this patch it was useful to set it to `"merge_policy" : "no", "forge_merge" : false`, to search with multiple segments).