### PR TITLE
Allow templates for `.chat-*` index template

### DIFF
--- a/modules/kibana/src/main/java/org/elasticsearch/kibana/KibanaPlugin.java
+++ b/modules/kibana/src/main/java/org/elasticsearch/kibana/KibanaPlugin.java
@@ -43,6 +43,7 @@ public class KibanaPlugin extends Plugin implements SystemIndexPlugin {
         .setDescription("Onechat system index")
         .setType(Type.EXTERNAL_UNMANAGED)
         .setAllowedElasticProductOrigins(KIBANA_PRODUCT_ORIGIN)
+        .setAllowsTemplates()
         .build();
 
     public static final SystemIndexDescriptor APM_AGENT_CONFIG_INDEX_DESCRIPTOR = SystemIndexDescriptor.builder()


### PR DESCRIPTION
Follow-up of https://github.com/elastic/elasticsearch/pull/131419

We need to allow templates for our `.chat-*` system indices. (similar to how it's done for Kibana's)