### PR TITLE
Unmute `CrossClusterEsqlRCS2EnrichUnavailableRemotesIT`

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -274,9 +274,6 @@ tests:
 - class: org.elasticsearch.cli.keystore.AddStringKeyStoreCommandTests
   method: testStdinWithMultipleValues
   issue: https://github.com/elastic/elasticsearch/issues/126882
-- class: org.elasticsearch.xpack.remotecluster.CrossClusterEsqlRCS2EnrichUnavailableRemotesIT
-  method: testEsqlEnrichWithSkipUnavailable
-  issue: https://github.com/elastic/elasticsearch/issues/127368
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=ml/data_frame_analytics_cat_apis/Test cat data frame analytics all jobs with header}
   issue: https://github.com/elastic/elasticsearch/issues/127625


### PR DESCRIPTION
This test got muted due to a build where there were other ES|QL test failures as well. I believe something systematic went wrong with the ES|QL tests and hence the failures -- where the data received was 0/empty/null across the failures. This test itself has been reliable with very few failures and I see no immediate fixes that can be applied. I'd like to unmute it and see what happens.