### PR TITLE
[8.18] ESQL: Fix NPE on empty to_lower/to_upper call (#131917)

### DIFF
--- a/docs/changelog/131917.yaml
+++ b/docs/changelog/131917.yaml
@@ -1,0 +1,6 @@
+pr: 131917
+summary: Fix NPE on empty to_lower/to_upper call
+area: ES|QL
+type: bug
+issues:
+ - 131913

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
@@ -1042,10 +1042,10 @@ public class EsqlFunctionRegistry {
         String... names
     ) {
         FunctionBuilder builder = (source, children, cfg) -> {
-            if (children.size() > 1) {
+            if (children.size() != 1) {
                 throw new QlIllegalArgumentException("expects exactly one argument");
             }
-            Expression ex = children.size() == 1 ? children.get(0) : null;
+            Expression ex = children.get(0);
             return ctorRef.build(source, ex, cfg);
         };
         return def(function, builder, names);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistryTests.java
@@ -29,6 +29,7 @@ import static java.util.Collections.emptyList;
 import static org.elasticsearch.xpack.esql.ConfigurationTestUtils.randomConfiguration;
 import static org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry.def;
 import static org.elasticsearch.xpack.esql.expression.function.FunctionResolutionStrategy.DEFAULT;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
@@ -159,6 +160,9 @@ public class EsqlFunctionRegistryTests extends ESTestCase {
         );
         def = r.resolveFunction(r.resolveAlias("DUMMY"));
         assertEquals(ur.source(), ur.buildResolved(randomConfiguration(), def).source());
+
+        ParsingException e = expectThrows(ParsingException.class, () -> uf(DEFAULT).buildResolved(randomConfiguration(), def));
+        assertThat(e.getMessage(), containsString("expects exactly one argument"));
     }
 
     private static UnresolvedFunction uf(FunctionResolutionStrategy resolutionStrategy, Expression... children) {


### PR DESCRIPTION
Backports the following commits to 8.18:
 - ESQL: Fix NPE on empty to_lower/to_upper call (#131917)