### PR TITLE
Remove `RemoteClusterService.getConnections()` method

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
@@ -40,7 +40,6 @@ import org.elasticsearch.transport.RemoteClusterCredentialsManager.UpdateRemoteC
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -651,10 +650,6 @@ public final class RemoteClusterService extends RemoteClusterAware
             case FAIL_IF_DISCONNECTED -> false;
             case RECONNECT_UNLESS_SKIP_UNAVAILABLE -> transportService.getRemoteClusterService().isSkipUnavailable(clusterAlias) == false;
         });
-    }
-
-    Collection<RemoteClusterConnection> getConnections() {
-        return remoteClusters.values();
     }
 
     static void registerRemoteClusterHandshakeRequestHandler(TransportService transportService) {

--- a/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
@@ -838,14 +838,18 @@ public class TransportSearchActionTests extends ESTestCase {
             }
 
             CountDownLatch disconnectedLatch = new CountDownLatch(numDisconnectedClusters);
-            RemoteClusterServiceTests.addConnectionListener(remoteClusterService, new TransportConnectionListener() {
-                @Override
-                public void onNodeDisconnected(DiscoveryNode node, @Nullable Exception closeException) {
-                    if (disconnectedNodes.remove(node)) {
-                        disconnectedLatch.countDown();
+            RemoteClusterServiceTests.addConnectionListener(
+                remoteClusterService,
+                remoteIndicesByCluster.keySet(),
+                new TransportConnectionListener() {
+                    @Override
+                    public void onNodeDisconnected(DiscoveryNode node, @Nullable Exception closeException) {
+                        if (disconnectedNodes.remove(node)) {
+                            disconnectedLatch.countDown();
+                        }
                     }
                 }
-            });
+            );
             for (DiscoveryNode disconnectedNode : disconnectedNodes) {
                 service.addFailToSendNoConnectRule(disconnectedNode.getAddress());
             }
@@ -1149,14 +1153,18 @@ public class TransportSearchActionTests extends ESTestCase {
             }
 
             CountDownLatch disconnectedLatch = new CountDownLatch(numDisconnectedClusters);
-            RemoteClusterServiceTests.addConnectionListener(remoteClusterService, new TransportConnectionListener() {
-                @Override
-                public void onNodeDisconnected(DiscoveryNode node, @Nullable Exception closeException) {
-                    if (disconnectedNodes.remove(node)) {
-                        disconnectedLatch.countDown();
+            RemoteClusterServiceTests.addConnectionListener(
+                remoteClusterService,
+                remoteIndicesByCluster.keySet(),
+                new TransportConnectionListener() {
+                    @Override
+                    public void onNodeDisconnected(DiscoveryNode node, @Nullable Exception closeException) {
+                        if (disconnectedNodes.remove(node)) {
+                            disconnectedLatch.countDown();
+                        }
                     }
                 }
-            });
+            );
             for (DiscoveryNode disconnectedNode : disconnectedNodes) {
                 service.addFailToSendNoConnectRule(disconnectedNode.getAddress());
             }

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
@@ -1250,7 +1250,11 @@ public class RemoteClusterServiceTests extends ESTestCase {
         connection.setSkipUnavailable(skipUnavailable);
     }
 
-    public static void addConnectionListener(RemoteClusterService service, Set<String> clusterAliases, TransportConnectionListener listener) {
+    public static void addConnectionListener(
+        RemoteClusterService service,
+        Set<String> clusterAliases,
+        TransportConnectionListener listener
+    ) {
         for (final var clusterAlias : clusterAliases) {
             final var connection = service.getRemoteClusterConnection(clusterAlias);
             ConnectionManager connectionManager = connection.getConnectionManager();

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
@@ -1250,8 +1250,9 @@ public class RemoteClusterServiceTests extends ESTestCase {
         connection.setSkipUnavailable(skipUnavailable);
     }
 
-    public static void addConnectionListener(RemoteClusterService service, TransportConnectionListener listener) {
-        for (RemoteClusterConnection connection : service.getConnections()) {
+    public static void addConnectionListener(RemoteClusterService service, Set<String> clusterAliases, TransportConnectionListener listener) {
+        for (final var clusterAlias : clusterAliases) {
+            final var connection = service.getRemoteClusterConnection(clusterAlias);
             ConnectionManager connectionManager = connection.getConnectionManager();
             connectionManager.addListener(listener);
         }


### PR DESCRIPTION
This method is only used in unit tests.
In an effort to reduce the API surface area and ease the analysis for making `RemoteClusterService` multi-project aware, this change refactors the test code to use other existing methods to achieve the same functionality.

Relates: ES-11576, #131894