### PR TITLE
[8.19] Remove incorrectly added EsqlCapability

### DIFF
--- a/docs/changelog/131962.yaml
+++ b/docs/changelog/131962.yaml
@@ -1,5 +1,0 @@
-pr: 131962
-summary: "[8.19] Remove incorrectly added `EsqlCapability`"
-area: "ES|QL, TSDB"
-type: bug
-issues: []

--- a/docs/changelog/131962.yaml
+++ b/docs/changelog/131962.yaml
@@ -1,0 +1,5 @@
+pr: 131962
+summary: "[8.19] Remove incorrectly added `EsqlCapability`"
+area: "ES|QL, TSDB"
+type: bug
+issues: []

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -787,11 +787,6 @@ public class EsqlCapabilities {
         AGGREGATE_METRIC_DOUBLE_AVG(AGGREGATE_METRIC_DOUBLE_FEATURE_FLAG),
 
         /**
-         * Support for implicit casting of aggregate metric double when run in aggregations
-         */
-        AGGREGATE_METRIC_DOUBLE_IMPLICIT_CASTING_IN_AGGS(AGGREGATE_METRIC_DOUBLE_FEATURE_FLAG),
-
-        /**
          * Fixes bug when aggregate metric double is encoded as a single nul value but decoded as
          * AggregateMetricDoubleBlock (expecting 4 values) in TopN.
          */


### PR DESCRIPTION
Accidentally added this in when backporting #131955 which will break some of the tests, so I am removing it.
