### PR TITLE
Pass project ID to trialRun

### DIFF
--- a/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedClusterStateService.java
@@ -461,7 +461,7 @@ public class ReservedClusterStateService {
         }
 
         // We trial run all handler validations to ensure that we can process all of the cluster state error free.
-        var trialRunErrors = trialRun(namespace, state, reservedStateChunk, orderedHandlers);
+        var trialRunErrors = trialRun(projectId, namespace, state, reservedStateChunk, orderedHandlers);
         // this is not using the modified trial state above, but that doesn't matter, we're just setting errors here
         var error = checkAndReportError(Optional.of(projectId), namespace, trialRunErrors, reservedStateVersion, versionCheck);
 


### PR DESCRIPTION
My serverless PR (linked) fails because it seems in `trialRun` we're not passing the project ID so it ends up always calling the soft-deletion handler with the `default` project which trips an assertion when applying the block. The actual application (the cluster state update task that is submitted after the trial run passes) correctly uses the project ID. 