### PR TITLE
Add missing Kibana examples for bf vector dot_product and l1_norm functions

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/functions/examples/v_dot_product.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/examples/v_dot_product.md
@@ -3,7 +3,22 @@
 **Example**
 
 ```esql
-null
+ from colors
+ | eval similarity = v_dot_product(rgb_vector, [0, 255, 255])
+ | sort similarity desc, color asc
 ```
+
+| color:text | similarity:double |
+| --- | --- |
+| azure | 65025.5 |
+| cyan | 65025.5 |
+| white | 65025.5 |
+| mint cream | 64388.0 |
+| snow | 63750.5 |
+| honeydew | 63113.0 |
+| ivory | 63113.0 |
+| sea shell | 61583.0 |
+| lavender | 61200.5 |
+| old lace | 60563.0 |
 
 

--- a/docs/reference/query-languages/esql/_snippets/functions/examples/v_l1_norm.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/examples/v_l1_norm.md
@@ -3,7 +3,22 @@
 **Example**
 
 ```esql
-null
+ from colors
+ | eval similarity = v_l1_norm(rgb_vector, [0, 255, 255])
+ | sort similarity desc, color asc
 ```
+
+| color:text | similarity:double |
+| --- | --- |
+| red | 765.0 |
+| crimson | 650.0 |
+| maroon | 638.0 |
+| firebrick | 620.0 |
+| orange | 600.0 |
+| tomato | 595.0 |
+| brown | 591.0 |
+| chocolate | 585.0 |
+| coral | 558.0 |
+| gold | 550.0 |
 
 

--- a/docs/reference/query-languages/esql/kibana/definition/functions/v_dot_product.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/v_dot_product.json
@@ -5,7 +5,7 @@
   "description" : "Calculates the dot product between two dense_vectors.",
   "signatures" : [ ],
   "examples" : [
-    null
+    " from colors\n | eval similarity = v_dot_product(rgb_vector, [0, 255, 255])\n | sort similarity desc, color asc"
   ],
   "preview" : true,
   "snapshot_only" : true

--- a/docs/reference/query-languages/esql/kibana/definition/functions/v_l1_norm.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/v_l1_norm.json
@@ -5,7 +5,7 @@
   "description" : "Calculates the l1 norm between two dense_vectors.",
   "signatures" : [ ],
   "examples" : [
-    null
+    " from colors\n | eval similarity = v_l1_norm(rgb_vector, [0, 255, 255])\n | sort similarity desc, color asc"
   ],
   "preview" : true,
   "snapshot_only" : true

--- a/docs/reference/query-languages/esql/kibana/docs/functions/v_dot_product.md
+++ b/docs/reference/query-languages/esql/kibana/docs/functions/v_dot_product.md
@@ -4,5 +4,7 @@
 Calculates the dot product between two dense_vectors.
 
 ```esql
-null
+ from colors
+ | eval similarity = v_dot_product(rgb_vector, [0, 255, 255])
+ | sort similarity desc, color asc
 ```

--- a/docs/reference/query-languages/esql/kibana/docs/functions/v_l1_norm.md
+++ b/docs/reference/query-languages/esql/kibana/docs/functions/v_l1_norm.md
@@ -4,5 +4,7 @@
 Calculates the l1 norm between two dense_vectors.
 
 ```esql
-null
+ from colors
+ | eval similarity = v_l1_norm(rgb_vector, [0, 255, 255])
+ | sort similarity desc, color asc
 ```

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/vector-dot-product.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/vector-dot-product.csv-spec
@@ -3,16 +3,16 @@
  similarityWithVectorField
  required_capability: dot_product_vector_similarity_function
  
-// tag::vector-dot-product-similarity[]
+// tag::vector-dot-product[]
  from colors
  | eval similarity = v_dot_product(rgb_vector, [0, 255, 255]) 
  | sort similarity desc, color asc 
-// end::vector-dot-product-similarity[]
+// end::vector-dot-product[]
  | limit 10
  | keep color, similarity
  ;
  
-// tag::vector-dot-product-similarity-result[]
+// tag::vector-dot-product-result[]
 color:text | similarity:double
 azure      | 65025.5
 cyan       | 65025.5
@@ -24,7 +24,7 @@ ivory      | 63113.0
 sea shell  | 61583.0
 lavender   | 61200.5
 old lace   | 60563.0
-// end::vector-dot-product-similarity-result[] 
+// end::vector-dot-product-result[] 
 ;
 
  similarityAsPartOfExpression

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/vector-l1-norm.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/vector-l1-norm.csv-spec
@@ -3,16 +3,16 @@
  similarityWithVectorField
  required_capability: l1_norm_vector_similarity_function
  
-// tag::vector-l1-norm-similarity[]
+// tag::vector-l1-norm[]
  from colors
  | eval similarity = v_l1_norm(rgb_vector, [0, 255, 255]) 
  | sort similarity desc, color asc 
-// end::vector-l1-norm-similarity[]
+// end::vector-l1-norm[]
  | limit 10
  | keep color, similarity
  ;
  
-// tag::vector-l1-norm-similarity-result[]
+// tag::vector-l1-norm-result[]
 color:text | similarity:double
 red        | 765.0
 crimson    | 650.0
@@ -24,7 +24,7 @@ brown      | 591.0
 chocolate  | 585.0
 coral      | 558.0
 gold       | 550.0
-// end::vector-l1-norm-similarity-result[] 
+// end::vector-l1-norm-result[] 
 ;
 
  similarityAsPartOfExpression


### PR DESCRIPTION
Add missing example queries to `v_dot_product` and `v_l1_norm` functions for brute force dense vector search (ES|QL).