### PR TITLE
[8.19] ESQL: Fix AbstractPageMappingOperator Status deserialization (#131820)

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/AbstractPageMappingToIteratorOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/AbstractPageMappingToIteratorOperator.java
@@ -202,7 +202,7 @@ public abstract class AbstractPageMappingToIteratorOperator implements Operator 
         public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
             Operator.Status.class,
             "page_mapping_to_iterator",
-            AbstractPageMappingOperator.Status::new
+            Status::new
         );
 
         private final long processNanos;


### PR DESCRIPTION
Backports the following commits to 8.19:
 - ESQL: Fix AbstractPageMappingOperator Status deserialization (#131820)