### PR TITLE
ESQL: Skip new ENRICH tests only on 8.14

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/enrich.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/enrich.csv-spec
@@ -664,7 +664,7 @@ Fyodor Dostoevsky     |1211           |null             |null          |null    
 ;
 
 
-statsAfterRemoteEnrich#[skip:-8.17.99]
+statsAfterRemoteEnrich#[skip:-8.14.99]
 required_capability: enrich_load
 
 FROM sample_data
@@ -680,7 +680,7 @@ messages:long | language_name:keyword
 ;
 
 
-enrichAfterRemoteEnrich#[skip:-8.17.99]
+enrichAfterRemoteEnrich#[skip:-8.14.99]
 required_capability: enrich_load
 
 FROM sample_data
@@ -697,7 +697,7 @@ Connected to 10.1.0.1 | 1                     | English                     | En
 ;
 
 
-coordinatorEnrichAfterRemoteEnrich#[skip:-8.17.99]
+coordinatorEnrichAfterRemoteEnrich#[skip:-8.14.99]
 required_capability: enrich_load
 
 FROM sample_data
@@ -714,7 +714,7 @@ Connected to 10.1.0.1 | 1                     | English                     | En
 ;
 
 
-doubleRemoteEnrich#[skip:-8.17.99]
+doubleRemoteEnrich#[skip:-8.14.99]
 required_capability: enrich_load
 
 FROM sample_data
@@ -731,7 +731,7 @@ Connected to 10.1.0.1 | 1                     | English                     | En
 ;
 
 
-enrichAfterCoordinatorEnrich#[skip:-8.17.99]
+enrichAfterCoordinatorEnrich#[skip:-8.14.99]
 required_capability: enrich_load
 
 FROM sample_data
@@ -748,7 +748,7 @@ Connected to 10.1.0.1 | 1                     | English                     | En
 ;
 
 
-doubleCoordinatorEnrich#[skip:-8.17.99]
+doubleCoordinatorEnrich#[skip:-8.14.99]
 required_capability: enrich_load
 
 FROM sample_data


### PR DESCRIPTION
They should work correctly on 8.15+.
https://github.com/elastic/elasticsearch/pull/131640 disabled them on 8.14-8.17.

Backporting this to 8.18 (+ unmuting!) will fix:
- https://github.com/elastic/elasticsearch/issues/131977
- https://github.com/elastic/elasticsearch/issues/131976
- https://github.com/elastic/elasticsearch/issues/131970
- https://github.com/elastic/elasticsearch/issues/131969
- https://github.com/elastic/elasticsearch/issues/131968
- https://github.com/elastic/elasticsearch/issues/131959
- https://github.com/elastic/elasticsearch/issues/131958
- https://github.com/elastic/elasticsearch/issues/131957
- https://github.com/elastic/elasticsearch/issues/131956
- https://github.com/elastic/elasticsearch/issues/131013