### PR TITLE
ESQL: Unmute multi_node generative tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -467,9 +467,6 @@ tests:
 - class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
   method: testCancellationViaTimeoutWithAllowPartialResultsSetToFalse
   issue: https://github.com/elastic/elasticsearch/issues/131248
-- class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/131508
 - class: org.elasticsearch.action.admin.cluster.node.tasks.CancellableTasksIT
   method: testRemoveBanParentsOnDisconnect
   issue: https://github.com/elastic/elasticsearch/issues/131562


### PR DESCRIPTION
Close https://github.com/elastic/elasticsearch/issues/131508

A partial mute was already put in place in
https://github.com/elastic/elasticsearch/pull/131515 and the bot just muted this after the fact for some reason. (C.f. my comment [here](https://github.com/elastic/elasticsearch/issues/131508#issuecomment-3127746620) for reference.)
