### PR TITLE
Use UTF strings in data generation

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/datageneration/datasource/DefaultObjectGenerationHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/datageneration/datasource/DefaultObjectGenerationHandler.java
@@ -49,7 +49,17 @@ public class DefaultObjectGenerationHandler implements DataSourceHandler {
 
             @Override
             public String generateFieldName() {
-                return randomRealisticUnicodeOfCodepointLengthBetween(1, 10);
+                while (true) {
+                    String fieldName = randomRealisticUnicodeOfCodepointLengthBetween(1, 10);
+                    if (fieldName.isBlank()) {
+                        continue;
+                    }
+                    if (fieldName.indexOf('.') != -1) {
+                        continue;
+                    }
+
+                    return fieldName;
+                }
             }
         };
     }

--- a/test/framework/src/main/java/org/elasticsearch/datageneration/datasource/DefaultObjectGenerationHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/datageneration/datasource/DefaultObjectGenerationHandler.java
@@ -15,9 +15,9 @@ import org.elasticsearch.test.ESTestCase;
 import java.util.Optional;
 import java.util.Set;
 
-import static org.elasticsearch.test.ESTestCase.randomAlphaOfLengthBetween;
 import static org.elasticsearch.test.ESTestCase.randomDouble;
 import static org.elasticsearch.test.ESTestCase.randomIntBetween;
+import static org.elasticsearch.test.ESTestCase.randomRealisticUnicodeOfCodepointLengthBetween;
 
 public class DefaultObjectGenerationHandler implements DataSourceHandler {
     @Override
@@ -49,7 +49,7 @@ public class DefaultObjectGenerationHandler implements DataSourceHandler {
 
             @Override
             public String generateFieldName() {
-                return randomAlphaOfLengthBetween(1, 10);
+                return randomRealisticUnicodeOfCodepointLengthBetween(1, 10);
             }
         };
     }

--- a/test/framework/src/main/java/org/elasticsearch/datageneration/datasource/DefaultPrimitiveTypesHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/datageneration/datasource/DefaultPrimitiveTypesHandler.java
@@ -59,7 +59,7 @@ public class DefaultPrimitiveTypesHandler implements DataSourceHandler {
 
     @Override
     public DataSourceResponse.StringGenerator handle(DataSourceRequest.StringGenerator request) {
-        return new DataSourceResponse.StringGenerator(() -> ESTestCase.randomAlphaOfLengthBetween(0, 50));
+        return new DataSourceResponse.StringGenerator(() -> ESTestCase.randomRealisticUnicodeOfCodepointLengthBetween(0, 50));
     }
 
     @Override


### PR DESCRIPTION
In #132018 we found an issue with non-ascii strings in ignored source. This issue was not exposed by the data generation tests because these tests use ascii-only strings. This patch updates the tests to instead use full unicode strings by default.