### PR TITLE
[9.1] Restrict remote ENRICH after FORK (#131945)

### DIFF
--- a/docs/changelog/131945.yaml
+++ b/docs/changelog/131945.yaml
@@ -1,0 +1,6 @@
+pr: 131945
+summary: Restrict remote ENRICH after FORK
+area: ES|QL
+type: bug
+issues:
+ - 131445

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Fork.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Fork.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
  * A Fork is a n-ary {@code Plan} where each child is a sub plan, e.g.
  * {@code FORK [WHERE content:"fox" ] [WHERE content:"dog"] }
  */
-public class Fork extends LogicalPlan implements PostAnalysisPlanVerificationAware, TelemetryAware {
+public class Fork extends LogicalPlan implements PostAnalysisPlanVerificationAware, TelemetryAware, PipelineBreaker {
 
     public static final String FORK_FIELD = "_fork";
     public static final int MAX_BRANCHES = 8;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Fork.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Fork.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
  * A Fork is a n-ary {@code Plan} where each child is a sub plan, e.g.
  * {@code FORK [WHERE content:"fox" ] [WHERE content:"dog"] }
  */
-public class Fork extends LogicalPlan implements PostAnalysisPlanVerificationAware, TelemetryAware, PipelineBreaker {
+public class Fork extends LogicalPlan implements PostAnalysisPlanVerificationAware, TelemetryAware {
 
     public static final String FORK_FIELD = "_fork";
     public static final int MAX_BRANCHES = 8;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
@@ -120,6 +120,8 @@ public class PlannerUtils {
         }
         final FragmentExec fragment = (FragmentExec) fragments.getFirst();
 
+        // Though FORK is technically a pipeline breaker, it should never show up here.
+        // See also: https://github.com/elastic/elasticsearch/pull/131945/files#r2235572935
         final var pipelineBreakers = fragment.fragment().collectFirstChildren(Mapper::isPipelineBreaker);
         if (pipelineBreakers.isEmpty()) {
             return null;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -2357,6 +2357,14 @@ public class VerifierTests extends ESTestCase {
             | ENRICH _remote:languages ON language_code
             """, analyzer);
         assertThat(err, containsString("7:3: ENRICH with remote policy can't be executed after another ENRICH with coordinator policy"));
+
+        err = error("""
+            FROM test
+            | FORK (WHERE languages == 1) (WHERE languages == 2)
+            | EVAL language_code = languages
+            | ENRICH _remote:languages ON language_code
+            """, analyzer);
+        assertThat(err, containsString("4:3: ENRICH with remote policy can't be executed after FORK"));
     }
 
     private void checkFullTextFunctionsInStats(String functionInvocation) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Restrict remote ENRICH after FORK (#131945)](https://github.com/elastic/elasticsearch/pull/131945)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)