### PR TITLE
Fixing handling of subobject mappings in simulate ingest API

### DIFF
--- a/docs/changelog/132046.yaml
+++ b/docs/changelog/132046.yaml
@@ -1,0 +1,6 @@
+pr: 132046
+summary: Fixing handling of subobject mappings in simulate ingest API
+area: Ingest Node
+type: bug
+issues:
+ - 131608

--- a/docs/changelog/132046.yaml
+++ b/docs/changelog/132046.yaml
@@ -2,5 +2,4 @@ pr: 132046
 summary: Fixing handling of subobject mappings in simulate ingest API
 area: Ingest Node
 type: bug
-issues:
- - 131608
+issues: []

--- a/qa/smoke-test-ingest-with-all-dependencies/src/yamlRestTest/resources/rest-api-spec/test/ingest/80_ingest_simulate.yml
+++ b/qa/smoke-test-ingest-with-all-dependencies/src/yamlRestTest/resources/rest-api-spec/test/ingest/80_ingest_simulate.yml
@@ -1740,3 +1740,52 @@ setup:
   - match: { docs.0.doc._source.abc: "sfdsfsfdsfsfdsfsfdsfsfdsfsfdsf" }
   - match: { docs.0.doc.ignored_fields: [ {"field": "abc"} ] }
   - not_exists: docs.0.doc.error
+
+---
+"Test ingest simulate with mapping addition on subobjects":
+
+  - skip:
+      features:
+        - headers
+        - allowed_warnings
+
+  - do:
+      indices.put_index_template:
+        name: subobject-template
+        body:
+          index_patterns: subobject-index*
+          template:
+            mappings:
+              properties:
+                a.b:
+                  type: match_only_text
+
+  # Here we provide a mapping_substitution to the subobject, and make sure that it is applied rather than throwing an
+  # exception.
+  - do:
+      headers:
+        Content-Type: application/json
+      simulate.ingest:
+        body: >
+          {
+            "docs": [
+              {
+                "_index": "subobject-index-1",
+                "_id": "AZgsHA0B41JjTOmNiBKC",
+                "_source": {
+                  "a.b": "some text"
+                }
+              }
+            ],
+            "mapping_addition": {
+              "properties": {
+                "a.b": {
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+  - length: { docs: 1 }
+  - match: { docs.0.doc._index: "subobject-index-1" }
+  - match: { docs.0.doc._source.a\.b: "some text" }
+  - not_exists: docs.0.doc.error

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportSimulateBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportSimulateBulkAction.java
@@ -351,7 +351,7 @@ public class TransportSimulateBulkAction extends TransportAbstractBulkAction {
             .putMapping(new MappingMetadata(updatedMappings))
             .build();
         Engine.Index result = indicesService.withTempIndexService(originalIndexMetadata, indexService -> {
-            indexService.mapperService().merge(updatedIndexMetadata, MapperService.MergeReason.MAPPING_UPDATE);
+            indexService.mapperService().merge(updatedIndexMetadata, MapperService.MergeReason.INDEX_TEMPLATE);
             return IndexShard.prepareIndex(
                 indexService.mapperService(),
                 sourceToParse,


### PR DESCRIPTION
This correctly replaces mappings for subobjects rather than attempting to merge them in the simulate ingest API. 
This fixes the problem in the description of #131608, but does not address the problem described in a comment in that issue, which appears to be different.