### PR TITLE
[8.19] Fix file entitlements for shared data dir (#131748)

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/bootstrap/HardcodedEntitlements.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/bootstrap/HardcodedEntitlements.java
@@ -92,8 +92,9 @@ class HardcodedEntitlements {
                     new CreateClassLoaderEntitlement(),
                     new FilesEntitlement(
                         List.of(
-                            // TODO: what in es.base is accessing shared repo?
+                            // necessary due to lack of delegation ES-12382
                             FilesEntitlement.FileData.ofBaseDirPath(SHARED_REPO, READ_WRITE),
+                            FilesEntitlement.FileData.ofBaseDirPath(SHARED_DATA, READ_WRITE),
                             FilesEntitlement.FileData.ofBaseDirPath(DATA, READ_WRITE)
                         )
                     )
@@ -122,6 +123,7 @@ class HardcodedEntitlements {
                     new FilesEntitlement(
                         List.of(
                             FilesEntitlement.FileData.ofBaseDirPath(CONFIG, READ),
+                            FilesEntitlement.FileData.ofBaseDirPath(SHARED_DATA, READ_WRITE),
                             FilesEntitlement.FileData.ofBaseDirPath(DATA, READ_WRITE)
                         )
                     )
@@ -130,7 +132,12 @@ class HardcodedEntitlements {
             new Scope(
                 "org.apache.lucene.misc",
                 List.of(
-                    new FilesEntitlement(List.of(FilesEntitlement.FileData.ofBaseDirPath(DATA, READ_WRITE))),
+                    new FilesEntitlement(
+                        List.of(
+                            FilesEntitlement.FileData.ofBaseDirPath(SHARED_DATA, READ_WRITE),
+                            FilesEntitlement.FileData.ofBaseDirPath(DATA, READ_WRITE)
+                        )
+                    ),
                     new ReadStoreAttributesEntitlement()
                 )
             ),
@@ -145,7 +152,12 @@ class HardcodedEntitlements {
                 "org.elasticsearch.nativeaccess",
                 List.of(
                     new LoadNativeLibrariesEntitlement(),
-                    new FilesEntitlement(List.of(FilesEntitlement.FileData.ofBaseDirPath(DATA, READ_WRITE)))
+                    new FilesEntitlement(
+                        List.of(
+                            FilesEntitlement.FileData.ofBaseDirPath(SHARED_DATA, READ_WRITE),
+                            FilesEntitlement.FileData.ofBaseDirPath(DATA, READ_WRITE)
+                        )
+                    )
                 )
             )
         );

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/entitlements/FilesEntitlement.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/entitlements/FilesEntitlement.java
@@ -182,8 +182,9 @@ public record FilesEntitlement(List<FileData> filesData) implements Entitlement 
             case "config" -> BaseDir.CONFIG;
             case "data" -> BaseDir.DATA;
             case "home" -> BaseDir.USER_HOME;
+            case "shared_data" -> BaseDir.SHARED_DATA;
             // it would be nice to limit this to just ES modules, but we don't have a way to plumb that through to here
-            // however, we still don't document in the error case below that shared_repo is valid
+            // however, we still don't document in the error case below that shared_repo and shared_data is valid
             case "shared_repo" -> BaseDir.SHARED_REPO;
             default -> throw new PolicyValidationException(
                 "invalid relative directory: " + baseDir + ", valid values: [config, data, home]"

--- a/plugins/store-smb/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/plugins/store-smb/src/main/plugin-metadata/entitlement-policy.yaml
@@ -3,3 +3,6 @@ ALL-UNNAMED:
       - relative_path: "indices/"
         relative_to: data
         mode: read_write
+      - relative_path: ""
+        relative_to: shared_data
+        mode: read_write

--- a/x-pack/plugin/searchable-snapshots/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/x-pack/plugin/searchable-snapshots/src/main/plugin-metadata/entitlement-policy.yaml
@@ -6,3 +6,6 @@ org.elasticsearch.searchablesnapshots:
       - relative_path: indices
         relative_to: data
         mode: read_write
+      - relative_path: ""
+        relative_to: shared_data
+        mode: read_write


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Fix file entitlements for shared data dir (#131748)