### PR TITLE
Removing a yaml test

### DIFF
--- a/x-pack/plugin/stack/src/yamlRestTest/resources/rest-api-spec/test/stack/10_basic.yml
+++ b/x-pack/plugin/stack/src/yamlRestTest/resources/rest-api-spec/test/stack/10_basic.yml
@@ -284,19 +284,3 @@ setup:
           data_stream.type: "synthetics"
           data_stream.dataset: "dataset0"
           data_stream.namespace: "namespace1"
-
----
-"Test wrong data_stream type - logs from 9.2.0":
-  - requires:
-      cluster_features: [ "gte_v9.1.99" ]
-      reason: "failure store is enabled by default for log data streams since 9.2.0"
-
-  - do:
-      index:
-        index: logs-dataset0-namespace1
-        body:
-          "@timestamp": "2020-01-01"
-          data_stream.type: "metrics"
-          data_stream.dataset: "dataset0"
-          data_stream.namespace: "namespace1"
-  - match: { failure_store: used }


### PR DESCRIPTION
@mark-vieira I (naively) added this test in https://github.com/elastic/elasticsearch/pull/131583 in addition to removing the broken test. This caused another [issue](https://github.com/elastic/elasticsearch/issues/131803) due to the usage of a synthetic [future version](https://github.com/elastic/elasticsearch/pull/131583/files#diff-cb1222649485b9efef450e33fe153e7331ae260a049a24e4831a7ffe8cfe5c18R291).

In order to fix it now we can add a test cluster feature to `8.19`, even though the feauture is not backported, just so we can use it to limit where the test runs instead of the version (as I [did](https://github.com/elastic/elasticsearch/commit/10af65e2a1ce4dfc5c301a96769184a1b3845cd7) in the new test I added to `main`), but this is weird and seems like an awful overkill.

I think the best thing to do now is remove this test altogether. The usage of wrong `data_stream.type` is still tested for the other two types (and it's not as if we test to all possible types anyway). In addition, this doesn't really verifies compatibility.
