### PR TITLE
ESQL: Unmute CCS enrich test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -512,9 +512,6 @@ tests:
 - class: org.elasticsearch.xpack.restart.FullClusterRestartIT
   method: testWatcherWithApiKey {cluster=UPGRADED}
   issue: https://github.com/elastic/elasticsearch/issues/131964
-- class: org.elasticsearch.xpack.remotecluster.CrossClusterEsqlRCS2EnrichUnavailableRemotesIT
-  method: testEsqlEnrichWithSkipUnavailable
-  issue: https://github.com/elastic/elasticsearch/issues/131965
 - class: org.elasticsearch.test.rest.yaml.RcsCcsCommonYamlTestSuiteIT
   method: test {p0=search/600_flattened_ignore_above/flattened ignore_above multi-value field}
   issue: https://github.com/elastic/elasticsearch/issues/131967


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch/issues/131965

The muted test isn't really failing; the failure happened in some other tests setup too. It's not specific, so I'm unmuting that test for now.