### PR TITLE
[8.18] Update docs for semantic chunking in 8.x (#132075)

### DIFF
--- a/docs/reference/mapping/types/semantic-text.asciidoc
+++ b/docs/reference/mapping/types/semantic-text.asciidoc
@@ -149,6 +149,28 @@ POST test-index/_search
 <1> Specifies the maximum number of fragments to return.
 <2> Sorts highlighted fragments by score when set to `score`. By default, fragments will be output in the order they appear in the field (order: none).
 
+To use the semantic highlighter to view chunks in the order which they were indexed with no scoring, use the match_all query to retrieve them in the order they appear in the document:
+
+[source,console]
+------------------------------------------------------------
+POST test-index/_search
+{
+    "query": {
+        "match_all": {}
+    },
+    "highlight": {
+        "fields": {
+            "my_semantic_field": {
+                "number_of_fragments": 5  <1>
+            }
+        }
+    }
+}
+------------------------------------------------------------
+// TEST[skip:Requires inference endpoint]
+
+<1> This will return the first 5 chunks, set this number higher to retrieve more chunks.
+
 Highlighting is supported on fields other than semantic_text.
 However, if you want to restrict highlighting to the semantic highlighter and return no fragments when the field is not of type semantic_text,
 you can explicitly enforce the `semantic` highlighter in the query:

--- a/docs/reference/search/search-your-data/highlighting.asciidoc
+++ b/docs/reference/search/search-your-data/highlighting.asciidoc
@@ -1,7 +1,7 @@
 [[highlighting]]
 === Highlighting
 
-Highlighters enable you to get highlighted snippets from one or more fields
+Highlighters enable you to retrieve the best-matching highlighted snippets from one or more fields
 in your search results so you can show users where the query matches are.
 When you request highlights, the response contains an additional `highlight`
 element for each search hit that includes the highlighted fields and the


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Update docs for semantic chunking in 8.x (#132075)