### PR TITLE
[8.18] Prevent auto-sharding for data streams in LOOKUP index mode (#131429)

### DIFF
--- a/docs/changelog/131429.yaml
+++ b/docs/changelog/131429.yaml
@@ -1,0 +1,5 @@
+pr: 131429
+summary: Prevent auto-sharding for data streams in LOOKUP index mode
+area: Data streams
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/datastreams/autosharding/DataStreamAutoShardingService.java
+++ b/server/src/main/java/org/elasticsearch/action/datastreams/autosharding/DataStreamAutoShardingService.java
@@ -26,6 +26,7 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexMode;
 
 import java.util.List;
 import java.util.Objects;
@@ -183,6 +184,11 @@ public class DataStreamAutoShardingService {
                 dataStream.getName(),
                 DATA_STREAMS_AUTO_SHARDING_EXCLUDES_SETTING.getKey()
             );
+            return NOT_APPLICABLE_RESULT;
+        }
+
+        if (dataStream.getIndexMode() == IndexMode.LOOKUP) {
+            logger.debug("Data stream [{}] has indexing mode LOOKUP; auto-sharding is not applicable.", dataStream.getName());
             return NOT_APPLICABLE_RESULT;
         }
 

--- a/server/src/test/java/org/elasticsearch/action/datastreams/autosharding/DataStreamAutoShardingServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/action/datastreams/autosharding/DataStreamAutoShardingServiceTests.java
@@ -819,4 +819,38 @@ public class DataStreamAutoShardingServiceTests extends ESTestCase {
         return builder.build();
     }
 
+    public void testCalculateReturnsNotApplicableForLookupIndexMode() {
+        Metadata.Builder builder = Metadata.builder();
+        DataStream dataStream = createLookupModeDataStream(builder);
+        ClusterState state = createClusterStateWithDataStream(builder);
+
+        AutoShardingResult autoShardingResult = service.calculate(state, dataStream, 1.0);
+        assertThat(autoShardingResult, is(NOT_APPLICABLE_RESULT));
+    }
+
+    public void testCalculateReturnsNotApplicableForLookupIndexModeWithNullWriteLoad() {
+        Metadata.Builder builder = Metadata.builder();
+        DataStream dataStream = createLookupModeDataStream(builder);
+        ClusterState state = createClusterStateWithDataStream(builder);
+
+        AutoShardingResult autoShardingResult = service.calculate(state, dataStream, null);
+        assertThat(autoShardingResult, is(NOT_APPLICABLE_RESULT));
+    }
+
+    private DataStream createLookupModeDataStream(Metadata.Builder builder) {
+        DataStream dataStream = DataStream.builder(dataStreamName, List.of(new Index("test-index", randomUUID())))
+            .setGeneration(1)
+            .setIndexMode(IndexMode.LOOKUP)
+            .build();
+        builder.put(dataStream);
+        return dataStream;
+    }
+
+    private ClusterState createClusterStateWithDataStream(Metadata.Builder builder) {
+        return ClusterState.builder(ClusterName.DEFAULT)
+            .nodes(DiscoveryNodes.builder().add(DiscoveryNodeUtils.create("n1")))
+            .metadata(builder.build())
+            .build();
+    }
+
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Prevent auto-sharding for data streams in LOOKUP index mode (#131429)](https://github.com/elastic/elasticsearch/pull/131429)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)