### PR TITLE
Add support for -Druntime.java in `:qa:vector:checkVec` task

### DIFF
--- a/qa/vector/build.gradle
+++ b/qa/vector/build.gradle
@@ -8,6 +8,8 @@
  */
 
 import org.elasticsearch.gradle.internal.test.TestUtil
+import org.elasticsearch.gradle.OS
+import org.elasticsearch.gradle.VersionProperties
 
 apply plugin: 'elasticsearch.java'
 apply plugin: 'elasticsearch.build'
@@ -48,6 +50,16 @@ tasks.register("checkVec", JavaExec) {
   }
   if (System.getenv("DO_PROFILING") != null) {
     jvmArgs '-XX:StartFlightRecording=dumponexit=true,maxsize=250M,filename=knn.jfr,settings=profile.jfc'
+  }
+  if (buildParams.getIsRuntimeJavaHomeSet()) {
+    executable = "${buildParams.runtimeJavaHome.get()}/bin/java" + (OS.current() == OS.WINDOWS ? '.exe' : '')
+  } else {
+    javaLauncher = javaToolchains.launcherFor {
+      languageVersion = JavaLanguageVersion.of(VersionProperties.bundledJdkMajorVersion)
+      vendor = VersionProperties.bundledJdkVendor == "openjdk" ?
+        JvmVendorSpec.ORACLE :
+        JvmVendorSpec.matching(VersionProperties.bundledJdkVendor)
+    }
   }
 }
 


### PR DESCRIPTION
I noticed that the argument option -Druntime.java dod not have any effect when running the gradle task `:qa:vector:checkVec`. More ever, it seemed to be always running the process usng java 21 regardless of the runtime announced by gradle.  

This commit adds proper support (I hope!).