### PR TITLE
[8.17] Revert "Remove 8.17 from branches.json"

### DIFF
--- a/branches.json
+++ b/branches.json
@@ -17,9 +17,12 @@
       "branch": "8.17"
     },
     {
+<<<<<<< HEAD
       "branch": "8.16"
     },
     {
+=======
+>>>>>>> 54d0e6f8e58 (Revert "Remove 8.17 from branches.json")
       "branch": "7.17"
     }
   ]

--- a/branches.json
+++ b/branches.json
@@ -17,12 +17,6 @@
       "branch": "8.17"
     },
     {
-<<<<<<< HEAD
-      "branch": "8.16"
-    },
-    {
-=======
->>>>>>> 54d0e6f8e58 (Revert "Remove 8.17 from branches.json")
       "branch": "7.17"
     }
   ]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - Revert &quot;Remove 8.17 from branches.json&quot; (54d0e6f8)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)