### PR TITLE
Fix comment of REINITIALIZED unassigned reason.

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
@@ -139,7 +139,7 @@ public record UnassignedInfo(
          */
         REROUTE_CANCELLED,
         /**
-         * When a shard moves from started back to initializing.
+         * Unassigned as a result of the recovery source (the primary shard) changed during initialization.
          */
         REINITIALIZED,
         /**


### PR DESCRIPTION
Fixes the comment for REINITIALIZED to accurately describe unassignment due to primary recovery source changes.