### PR TITLE
[8.17] Update JDK base image for OIDC fixture (#131176)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -26,12 +26,6 @@ tests:
 - class: org.elasticsearch.nativeaccess.VectorSystemPropertyTests
   method: testSystemPropertyDisabled
   issue: https://github.com/elastic/elasticsearch/issues/110949
-- class: org.elasticsearch.xpack.security.authc.oidc.OpenIdConnectAuthIT
-  method: testAuthenticateWithImplicitFlow
-  issue: https://github.com/elastic/elasticsearch/issues/111191
-- class: org.elasticsearch.xpack.security.authc.oidc.OpenIdConnectAuthIT
-  method: testAuthenticateWithCodeFlowAndClientPost
-  issue: https://github.com/elastic/elasticsearch/issues/111396
 - class: org.elasticsearch.xpack.restart.FullClusterRestartIT
   method: testSingleDoc {cluster=UPGRADED}
   issue: https://github.com/elastic/elasticsearch/issues/111434
@@ -349,10 +343,6 @@ tests:
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test151MachineDependentHeapWithSizeOverride
   issue: https://github.com/elastic/elasticsearch/issues/123437
-- class: org.elasticsearch.xpack.security.authc.oidc.OpenIdConnectAuthIT
-  issue: https://github.com/elastic/elasticsearch/issues/124845
-- class: org.elasticsearch.xpack.security.authc.jwt.JwtWithOidcAuthIT
-  issue: https://github.com/elastic/elasticsearch/issues/131794
 - class: org.elasticsearch.packaging.test.DockerTests 
   issue: https://github.com/elastic/elasticsearch/issues/131586
 

--- a/x-pack/test/idp-fixture/src/main/resources/oidc/Dockerfile
+++ b/x-pack/test/idp-fixture/src/main/resources/oidc/Dockerfile
@@ -1,5 +1,5 @@
-FROM c2id/c2id-server-demo:12.18 AS c2id
-FROM openjdk:11.0.16-jre
+FROM c2id/c2id-server-demo:16.1.1 AS c2id
+FROM eclipse-temurin:17-noble
 
 # Using this to launch a fake server on container start; see `setup.sh`
 RUN apt-get update -qqy && apt-get install -qqy python3


### PR DESCRIPTION
This upgrades the JDK base image for the OIDC fixture.

The old image used Debian 10 (buster) which is no longer supported and it appears the APT repos have been shutdown

We now use a temurin supplied image based on Ubuntu 24 (Noble Numbat)


Backport of https://github.com/elastic/elasticsearch/pull/131176
