### PR TITLE
Test entitlements for shared data dir (MDP)

### DIFF
--- a/qa/multi-data-path/build.gradle
+++ b/qa/multi-data-path/build.gradle
@@ -1,0 +1,10 @@
+apply plugin: 'elasticsearch.internal-yaml-rest-test'
+
+// This subproject verifies MDP continues to work with entitlements.
+
+restResources {
+  restApi {
+    include '_common', 'capabilities', 'index', 'indices', 'indices.create'
+  }
+}
+

--- a/qa/multi-data-path/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/MDPYamlTestSuiteIT.java
+++ b/qa/multi-data-path/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/MDPYamlTestSuiteIT.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.test.rest.yaml;
+
+import com.carrotsearch.randomizedtesting.annotations.Name;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.junit.ClassRule;
+
+import java.io.IOException;
+import java.nio.file.Files;
+
+public class MDPYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
+
+    @ClassRule
+    public static ElasticsearchCluster cluster = ElasticsearchCluster.local().setting("path.shared_data", tempSharedDataPath()).build();
+
+    public MDPYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {
+        super(testCandidate);
+    }
+
+    @ParametersFactory
+    public static Iterable<Object[]> parameters() throws Exception {
+        return createParameters();
+    }
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
+
+    private static String tempSharedDataPath() {
+        try {
+            return Files.createTempDirectory("shared_data").toString();
+        } catch (IOException e) {
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/qa/multi-data-path/src/yamlRestTest/resources/rest-api-spec/test/mdp/10_basic.yml
+++ b/qa/multi-data-path/src/yamlRestTest/resources/rest-api-spec/test/mdp/10_basic.yml
@@ -1,0 +1,31 @@
+---
+"Index using shared data path":
+
+  - requires:
+      test_runner_features: ["warnings"]
+
+  - do:
+      warnings:
+        - "[index.data_path] setting was deprecated in Elasticsearch and will be removed in a future release. See the deprecation documentation for the next major version."
+      indices.create:
+        index: test_index
+        body:
+          settings:
+            data_path: "test_index_data_path"
+
+  - do:
+      index:
+        index:  test_index
+        id:     "1"
+        body:   { foo: bar }
+
+  - match:   { result: created }
+
+  - do:
+      index:
+        index:    test_index
+        id:       "1"
+        body:     { foo: bar }
+        op_type:  index
+
+  - match:   { result: updated }


### PR DESCRIPTION
Support for (the deprecated) `path.shared_data` was previously not covered in any REST test and broke unnoticed when we introduced entitlements. The problem only surfaced when eventually enabling entitlements on internalClusterTests.

This PR adds a basic test to check indexing using a relative (to `path.shared_data`) `data_path` index setting succeeds with sufficient entitlements for `path.shared_data`.

Relates to ES-12447