### PR TITLE
[8.18] Remove allow_no_datafeeds from ml.stop_datafeed rest-api-spec (#131930)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.stop_datafeed.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.stop_datafeed.json
@@ -32,12 +32,6 @@
         "required":false,
         "description":"Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)"
       },
-      "allow_no_datafeeds":{
-        "type":"boolean",
-        "required":false,
-        "description":"Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)",
-        "deprecated":true
-      },
       "force":{
         "type":"boolean",
         "required":false,


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Remove allow_no_datafeeds from ml.stop_datafeed rest-api-spec (#131930)