### PR TITLE
Extend HTTP timeout in repo analysis tests

### DIFF
--- a/x-pack/plugin/snapshot-repo-test-kit/src/test/java/org/elasticsearch/repositories/blobstore/testkit/analyze/AbstractRepositoryAnalysisRestTestCase.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/test/java/org/elasticsearch/repositories/blobstore/testkit/analyze/AbstractRepositoryAnalysisRestTestCase.java
@@ -7,9 +7,12 @@
 
 package org.elasticsearch.repositories.blobstore.testkit.analyze;
 
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpPost;
 import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.rest.ESRestTestCase;
 
 public abstract class AbstractRepositoryAnalysisRestTestCase extends ESRestTestCase {
@@ -26,12 +29,18 @@ public abstract class AbstractRepositoryAnalysisRestTestCase extends ESRestTestC
         logger.info("creating repository [{}] of type [{}]", repository, repositoryType);
         registerRepository(repository, repositoryType, true, repositorySettings);
 
+        final TimeValue timeout = TimeValue.timeValueSeconds(120);
         final Request request = new Request(HttpPost.METHOD_NAME, "/_snapshot/" + repository + "/_analyze");
         request.addParameter("blob_count", "10");
         request.addParameter("concurrency", "4");
         request.addParameter("max_blob_size", "1mb");
-        request.addParameter("timeout", "120s");
+        request.addParameter("timeout", timeout.getStringRep());
         request.addParameter("seed", Long.toString(randomLong()));
+        request.setOptions(
+            RequestOptions.DEFAULT.toBuilder()
+                .setRequestConfig(RequestConfig.custom().setSocketTimeout(Math.toIntExact(timeout.millis() + 10_000)).build())
+        );
+
         assertOK(client().performRequest(request));
     }
 


### PR DESCRIPTION
We set a 120s timeout on the repo analysis that runs in these tests, but
the REST client in use has a read timeout of 60s so any analysis that
lasts longer than that will yield an HTTP timeout that contains very
limited information to help further investigation. With this commit we
extend the HTTP timeout to be a few seconds longer than the analysis
timeout so we should get a proper response in these cases.

Backport of #131744 to 8.18