### PR TITLE
ESQL: Reenable INLINESTATS telemetry test

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/TelemetryIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/TelemetryIT.java
@@ -161,22 +161,20 @@ public class TelemetryIT extends AbstractEsqlIntegTestCase {
                         : Collections.emptyMap(),
                     Build.current().isSnapshot() ? Map.ofEntries(Map.entry("MAX", 1)) : Collections.emptyMap(),
                     Build.current().isSnapshot()
+                ) },
+            new Object[] {
+                new Test(
+                    """
+                        FROM idx
+                        | EVAL ip = TO_IP(host), x = TO_STRING(host), y = TO_STRING(host)
+                        | INLINESTATS MAX(id)
+                        """,
+                    Build.current().isSnapshot() ? Map.of("FROM", 1, "EVAL", 1, "INLINESTATS", 1) : Collections.emptyMap(),
+                    Build.current().isSnapshot()
+                        ? Map.ofEntries(Map.entry("MAX", 1), Map.entry("TO_IP", 1), Map.entry("TO_STRING", 2))
+                        : Collections.emptyMap(),
+                    Build.current().isSnapshot()
                 ) }
-            // awaits fix for https://github.com/elastic/elasticsearch/issues/116003
-            // ,
-            // new Object[] {
-            // new Test(
-            // """
-            // FROM idx
-            // | EVAL ip = to_ip(host), x = to_string(host), y = to_string(host)
-            // | INLINESTATS max(id)
-            // """,
-            // Build.current().isSnapshot() ? Map.of("FROM", 1, "EVAL", 1, "INLINESTATS", 1) : Collections.emptyMap(),
-            // Build.current().isSnapshot()
-            // ? Map.ofEntries(Map.entry("MAX", 1), Map.entry("TO_IP", 1), Map.entry("TO_STRING", 2))
-            // : Collections.emptyMap(),
-            // Build.current().isSnapshot()
-            // ) }
         );
     }
 


### PR DESCRIPTION
Reenable `INLINESTATS` telemetry test that was disabled in #116005. 
The test query is now planned and accounted for correctly.