### PR TITLE
[8.19] Update IronBank base image to 9.6 (#131302)

### DIFF
--- a/distribution/docker/src/docker/iron_bank/hardening_manifest.yaml
+++ b/distribution/docker/src/docker/iron_bank/hardening_manifest.yaml
@@ -11,7 +11,7 @@ tags:
 # Build args passed to Dockerfile ARGs
 args:
   BASE_IMAGE: "redhat/ubi/ubi9"
-  BASE_TAG: "9.5"
+  BASE_TAG: "9.6"
 # Docker image labels
 labels:
   org.opencontainers.image.title: "elasticsearch"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Update IronBank base image to 9.6 (#131302)](https://github.com/elastic/elasticsearch/pull/131302)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)