### PR TITLE
Fix `InboundDecoderTests.testDecodePreHeaderSizeVariableInt()`

### DIFF
--- a/server/src/test/java/org/elasticsearch/transport/InboundDecoderTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundDecoderTests.java
@@ -161,6 +161,8 @@ public class InboundDecoderTests extends ESTestCase {
                 assertEquals(2, fragments.size());
             } else {
                 assertEquals(3, fragments.size());
+                final Object body = fragments.get(1);
+                assertThat(body, instanceOf(ReleasableBytesReference.class));
             }
             assertEquals(InboundDecoder.END_CONTENT, fragments.get(fragments.size() - 1));
             assertEquals(totalBytes.length() - bytesConsumed, bytesConsumed2);

--- a/server/src/test/java/org/elasticsearch/transport/InboundDecoderTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundDecoderTests.java
@@ -161,9 +161,6 @@ public class InboundDecoderTests extends ESTestCase {
                 assertEquals(2, fragments.size());
             } else {
                 assertEquals(3, fragments.size());
-                final Object body = fragments.get(1);
-                assertThat(body, instanceOf(ReleasableBytesReference.class));
-                ((ReleasableBytesReference) body).close();
             }
             assertEquals(InboundDecoder.END_CONTENT, fragments.get(fragments.size() - 1));
             assertEquals(totalBytes.length() - bytesConsumed, bytesConsumed2);


### PR DESCRIPTION
This test needed to be updated when #123390 was backported to 8.19 in #123554 since the test didn't exist on main when #123390 was merged.  Note that CI had failures for this test in #123554.

Closes: #132203, #132281