### PR TITLE
[DRAFT] Dont track source for keyworld fields that are multi-field, unless specifically designated so

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -625,8 +625,7 @@ public abstract class FieldMapper extends Mapper {
              * track source in some way, whether that be via the "store" param or using doc values.
              */
             private boolean isSyntheticSourceCompatible(KeywordFieldMapper.Builder keywordBuilder) {
-                return keywordBuilder.hasNormalizer() == false &&
-                        (keywordBuilder.hasDocValues() || keywordBuilder.isStored());
+                return keywordBuilder.hasNormalizer() == false && (keywordBuilder.hasDocValues() || keywordBuilder.isStored());
             }
 
             /**
@@ -642,8 +641,8 @@ public abstract class FieldMapper extends Mapper {
              * {@link KeywordFieldMapper} instead.
              */
             private boolean isSyntheticSourceCompatible(KeywordFieldMapper keyworddMapper) {
-                return keyworddMapper.hasNormalizer() == false &&
-                        (keyworddMapper.fieldType().hasDocValues() || keyworddMapper.fieldType().isStored());
+                return keyworddMapper.hasNormalizer() == false
+                    && (keyworddMapper.fieldType().hasDocValues() || keyworddMapper.fieldType().isStored());
             }
 
             public Builder add(FieldMapper.Builder builder) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -612,12 +612,47 @@ public abstract class FieldMapper extends Mapper {
 
             private boolean hasSyntheticSourceCompatibleKeywordField;
 
+            /**
+             * Returns whether the given builder should be used to track source for synthetic source purposes.
+             */
+            private boolean shouldTrackSource(KeywordFieldMapper.Builder keywordBuilder) {
+                // we only need one compatible keyword multi-field, so if one was already found, ignore the rest
+                return hasSyntheticSourceCompatibleKeywordField == false && isSyntheticSourceCompatible(keywordBuilder);
+            }
+
+            /**
+             * Returns whether the given builder is synthetic source compatible. To be compatible, the builder must
+             * track source in some way, whether that be via the "store" param or using doc values.
+             */
+            private boolean isSyntheticSourceCompatible(KeywordFieldMapper.Builder keywordBuilder) {
+                return keywordBuilder.hasNormalizer() == false &&
+                        (keywordBuilder.hasDocValues() || keywordBuilder.isStored());
+            }
+
+            /**
+             * Same as {@link #shouldTrackSource(KeywordFieldMapper.Builder)} but with a
+             * {@link KeywordFieldMapper} instead.
+             */
+            private boolean shouldTrackSource(KeywordFieldMapper keywordMapper) {
+                return hasSyntheticSourceCompatibleKeywordField == false && isSyntheticSourceCompatible(keywordMapper);
+            }
+
+            /**
+             * Same as {@link #isSyntheticSourceCompatible(KeywordFieldMapper.Builder)} but with a
+             * {@link KeywordFieldMapper} instead.
+             */
+            private boolean isSyntheticSourceCompatible(KeywordFieldMapper keyworddMapper) {
+                return keyworddMapper.hasNormalizer() == false &&
+                        (keyworddMapper.fieldType().hasDocValues() || keyworddMapper.fieldType().isStored());
+            }
+
             public Builder add(FieldMapper.Builder builder) {
                 mapperBuilders.put(builder.leafName(), builder::build);
 
                 if (builder instanceof KeywordFieldMapper.Builder kwd) {
-                    if (kwd.hasNormalizer() == false && (kwd.hasDocValues() || kwd.isStored())) {
+                    if (shouldTrackSource(kwd)) {
                         hasSyntheticSourceCompatibleKeywordField = true;
+                        kwd.shouldTrackSourceForSyntheticSource(true);
                     }
                 }
 
@@ -628,8 +663,9 @@ public abstract class FieldMapper extends Mapper {
                 mapperBuilders.put(mapper.leafName(), context -> mapper);
 
                 if (mapper instanceof KeywordFieldMapper kwd) {
-                    if (kwd.hasNormalizer() == false && (kwd.fieldType().hasDocValues() || kwd.fieldType().isStored())) {
+                    if (shouldTrackSource(kwd)) {
                         hasSyntheticSourceCompatibleKeywordField = true;
+                        kwd.setTracksSourceForSyntheticSource(true);
                     }
                 }
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -213,6 +213,11 @@ public final class KeywordFieldMapper extends FieldMapper {
         private final boolean forceDocValuesSkipper;
         private final SourceKeepMode indexSourceKeepMode;
 
+        private boolean withinMultiField;
+
+        // used when in a multi-field - indicates whether this keyword field should store source for synthetic source purposes
+        private boolean tracksSourceForSyntheticSource = false;
+
         public Builder(final String name, final MappingParserContext mappingParserContext) {
             this(
                 name,
@@ -325,6 +330,11 @@ public final class KeywordFieldMapper extends FieldMapper {
                 true,
                 SourceKeepMode.NONE
             );
+        }
+
+        public Builder shouldTrackSourceForSyntheticSource(boolean shouldTrackSourceForSyntheticSource) {
+            this.tracksSourceForSyntheticSource = shouldTrackSourceForSyntheticSource;
+            return this;
         }
 
         public Builder ignoreAbove(int ignoreAbove) {
@@ -1117,6 +1127,9 @@ public final class KeywordFieldMapper extends FieldMapper {
     private final ScriptCompiler scriptCompiler;
     private final IndexVersion indexCreatedVersion;
     private final boolean isSyntheticSource;
+    private final boolean isWithinMultiField;
+
+    private boolean tracksSourceForSyntheticSource;
 
     private final IndexAnalyzers indexAnalyzers;
     private final int ignoreAboveDefault;
@@ -1159,6 +1172,8 @@ public final class KeywordFieldMapper extends FieldMapper {
         this.offsetsFieldName = offsetsFieldName;
         this.indexSourceKeepMode = indexSourceKeepMode;
         this.originalName = mappedFieldType.originalName();
+        this.isWithinMultiField = builder.withinMultiField;
+        this.tracksSourceForSyntheticSource = builder.tracksSourceForSyntheticSource;
     }
 
     @Override
@@ -1202,6 +1217,14 @@ public final class KeywordFieldMapper extends FieldMapper {
         return indexValue(context, new Text(value));
     }
 
+    /**
+     * Returns whether this field should be stored separately as a {@link StoredField} for supporting synthetic source.
+     */
+    private boolean shouldStoreThisFieldForSyntheticSource() {
+        // skip all fields that are multi-fields unless they've been explicitly designated as a source tracker
+        return isSyntheticSource && (isWithinMultiField == false || tracksSourceForSyntheticSource);
+    }
+
     private boolean indexValue(DocumentParserContext context, XContentString value) {
         if (value == null) {
             return false;
@@ -1212,10 +1235,11 @@ public final class KeywordFieldMapper extends FieldMapper {
             return false;
         }
 
+        // if this field's value exceeds ignore_above, then don't index this field
         if (value.stringLength() > fieldType().ignoreAbove()) {
             context.addIgnoredField(fullPath());
-            if (isSyntheticSource) {
-                // Save a copy of the field so synthetic source can load it
+            // unless synthetic source is enabled, then we need to save a copy of the field so synthetic source can load it
+            if (shouldStoreThisFieldForSyntheticSource()) {
                 var utfBytes = value.bytes();
                 var bytesRef = new BytesRef(utfBytes.bytes(), utfBytes.offset(), utfBytes.length());
                 context.doc().add(new StoredField(originalName, bytesRef));
@@ -1332,6 +1356,10 @@ public final class KeywordFieldMapper extends FieldMapper {
 
     boolean hasNormalizer() {
         return normalizerName != null;
+    }
+
+    void setTracksSourceForSyntheticSource(boolean tracksSourceForSyntheticSource) {
+        this.tracksSourceForSyntheticSource = tracksSourceForSyntheticSource;
     }
 
     @Override


### PR DESCRIPTION
[DRAFT] (no tests yet)

Consider the following edge case:

```
"os": {
  "properties": {
    "name": {
      "type": "text",
      "fields": {
        "foo": {
          "type": "keyword",
          "ignore_above": 100
        }
      }
    }
```

If synthetic source is enabled, we'll have `name.foo` track source (current behavior). And if `name.foo` trips `ignore_above`, we'll create an extra [StoredField](https://github.com/elastic/elasticsearch/blob/321b1065969b2244f1e9db457c796c2b5582bfa7/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java#L1221) to continue tracking source within the `name.foo`. 

This however becomes a problem if there are multiple `keyword` multi fields, all of which trip `ignore_above`. In such a case, they'll all create an additional `StoredField` and we'll be storing the source multiple times, which is not space efficient.

This change designates one of the `keyword` multi fields as the one responsible for tracking source. Upon tripping `ignore_above`, this field will create a `StoredField` (same behavior as now), while the remaining `keyword` multi fields will not (new behavior).