### PR TITLE
[8.19] ESQL: Fix StdDev test for NaN results (#132195)

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/StdDevTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/StdDevTests.java
@@ -61,7 +61,7 @@ public class StdDevTests extends AbstractAggregationTestCase {
                 welfordAlgorithm.add(value);
             }
             var result = welfordAlgorithm.evaluate();
-            var expected = Double.isInfinite(result) ? null : result;
+            var expected = Double.isFinite(result) ? result : null;
             return new TestCaseSupplier.TestCase(
                 List.of(fieldTypedData),
                 "StdDev[field=Attribute[channel=0]]",


### PR DESCRIPTION
Backports the following commits to 8.19:
 - ESQL: Fix StdDev test for NaN results (#132195)