### PR TITLE
[8.19] Fix MixedClusterEsqlSpecIT class failing

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -348,8 +348,8 @@ public class CsvTestsDataLoader {
 
         try (InputStream content = response.getEntity().getContent()) {
             XContentType xContentType = XContentType.fromMediaType(response.getEntity().getContentType().getValue());
-            Map<String, ?> responseMap = XContentHelper.convertToMap(xContentType.xContent(), content, false);
-            List<Map<String, ?>> endpoints = (List<Map<String, ?>>) responseMap.get("endpoints");
+            Map<String, Object> responseMap = XContentHelper.convertToMap(xContentType.xContent(), content, false);
+            List<Map<String, ?>> endpoints = (List<Map<String, ?>>) responseMap.getOrDefault("endpoints", List.of());
             for (Map<String, ?> endpoint : endpoints) {
                 String inferenceId = (String) endpoint.get("inference_id");
                 String taskType = (String) endpoint.get("task_type");


### PR DESCRIPTION
Fixes #132118
Fixes #131152

An exception was raised because because in 8.14 and previous version the endpoints entry was absent in the map when no endpoint have been created (was an empty list in 8.15+).

```
java.lang.NullPointerException: Cannot invoke "java.util.List.iterator()" because "endpoints" is null	
at __randomizedtesting.SeedInfo.seed([AB516635CA0719A4]:0)	
at org.elasticsearch.xpack.esql.CsvTestsDataLoader.deleteInferenceEndpoints(CsvTestsDataLoader.java:353)	
at org.elasticsearch.xpack.esql.qa.rest.EsqlSpecTestCase.wipeTestData(EsqlSpecTestCase.java:165)	
at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
```