### PR TITLE
ESQL: Remove removed param from EsqlSpec argument formatting

### DIFF
--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
@@ -97,7 +97,7 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
     protected final Mode mode;
     protected static Boolean supportsTook;
 
-    @ParametersFactory(argumentFormatting = "%2$s.%3$s %7$s")
+    @ParametersFactory(argumentFormatting = "%2$s.%3$s")
     public static List<Object[]> readScriptSpec() throws Exception {
         List<URL> urls = classpathResources("/*.csv-spec");
         assertTrue("Not enough specs found " + urls, urls.size() > 0);


### PR DESCRIPTION
Fix after https://github.com/elastic/elasticsearch/pull/131949

Initially, the test string was: `test {file.test SYNC/ASYNC}`
After the mentioned PR: `test {file.test [ABC0ABCA0:ABC0ABC0]}`
With this fix: `test {file.test}`