### PR TITLE
Mute a couple of ValuesSourceReaderOperatorTests in lucene_snapshot

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -479,6 +479,12 @@ tests:
 - class: org.elasticsearch.compute.lucene.read.SortedSetOrdinalsBuilderTests
   method: testReader
   issue: https://github.com/elastic/elasticsearch/issues/131573
+- class: org.elasticsearch.compute.lucene.read.ValuesSourceReaderOperatorTests
+  method: testLoadLongShuffledManySegments
+  issue: https://github.com/elastic/elasticsearch/issues/132258
+- class: org.elasticsearch.compute.lucene.read.ValuesSourceReaderOperatorTests
+  method: testLoadLongManySegments
+  issue: https://github.com/elastic/elasticsearch/issues/132258
 - class: org.elasticsearch.search.SearchWithIndexBlocksIT
   method: testSearchShardsOnIndicesWithIndexRefreshBlocks
   issue: https://github.com/elastic/elasticsearch/issues/131662


### PR DESCRIPTION
The following tests fails consistently in the lucene_snapshot branch:
1. ValuesSourceReaderOperatorTests.testLoadLongShuffledManySegments
2. ValuesSourceReaderOperatorTests.testLoadLongManySegments

Mute these tests until the failures can be investigated.

relates #132258