### PR TITLE
[9.0] Fix TEST ThreadPoolMergeExecutorServiceDiskSpaceTests testUnavailableBudgetBlocksNewMergeTasksFromStartingExecution failing

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -232,9 +232,6 @@ tests:
 - class: org.elasticsearch.action.admin.cluster.node.tasks.CancellableTasksIT
   method: testChildrenTasksCancelledOnTimeout
   issue: https://github.com/elastic/elasticsearch/issues/123568
-- class: org.elasticsearch.index.engine.ThreadPoolMergeExecutorServiceDiskSpaceTests
-  method: testUnavailableBudgetBlocksNewMergeTasksFromStartingExecution
-  issue: https://github.com/elastic/elasticsearch/issues/130205
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test050BasicApiTests
   issue: https://github.com/elastic/elasticsearch/issues/120911

--- a/server/src/test/java/org/elasticsearch/index/engine/ThreadPoolMergeExecutorServiceDiskSpaceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/ThreadPoolMergeExecutorServiceDiskSpaceTests.java
@@ -771,16 +771,8 @@ public class ThreadPoolMergeExecutorServiceDiskSpaceTests extends ESTestCase {
             while (submittedMergesCount > 0 && expectedAvailableBudget.get() > 0L) {
                 ThreadPoolMergeScheduler.MergeTask mergeTask = mock(ThreadPoolMergeScheduler.MergeTask.class);
                 when(mergeTask.supportsIOThrottling()).thenReturn(randomBoolean());
-                doAnswer(mock -> {
-                    Schedule schedule = randomFrom(Schedule.values());
-                    if (schedule == BACKLOG) {
-                        testThreadPool.executor(ThreadPool.Names.GENERIC).execute(() -> {
-                            // re-enqueue backlogged merge task
-                            threadPoolMergeExecutorService.reEnqueueBackloggedMergeTask(mergeTask);
-                        });
-                    }
-                    return schedule;
-                }).when(mergeTask).schedule();
+                // avoid backlogging and re-enqueing merge tasks in this test because it makes the queue's available budget unsteady
+                when(mergeTask.schedule()).thenReturn(randomFrom(RUN, ABORT));
                 // let some task complete, which will NOT hold up any budget
                 if (randomBoolean()) {
                     // this task will NOT hold up any budget because it runs quickly (it is not blocked)


### PR DESCRIPTION
Avoid mocking merge tasks as backlogged (which are then re-enqueued) because it makes the merge task's queue available budget value unsteady, which breaks the test when it later schedules merge tasks that are under/over budget.

Closes https://github.com/elastic/elasticsearch/issues/130205 https://github.com/elastic/elasticsearch/issues/131982
Backport of https://github.com/elastic/elasticsearch/pull/132020