### PR TITLE
Skip indices with INDEX_REFRESH_BLOCK in field caps

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
@@ -372,7 +372,7 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
         );
     }
 
-    private static String[] checkBlocksAndFilterIndices(ProjectState projectState, String[] concreteIndices) {
+    static String[] checkBlocksAndFilterIndices(ProjectState projectState, String[] concreteIndices) {
         var blocks = projectState.blocks();
         var projectId = projectState.projectId();
         if (blocks.global(projectId).isEmpty() && blocks.indices(projectId).isEmpty()) {

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesActionTests.java
@@ -138,7 +138,7 @@ public class TransportFieldCapabilitiesActionTests extends ESTestCase {
             assertArrayEquals(concreteIndices, result);
         }
 
-        // Global block
+        // Global READ block
         {
             final ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
                 .putProjectMetadata(ProjectMetadata.builder(projectId).build())

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesActionTests.java
@@ -41,17 +41,11 @@ import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
 import java.util.EnumSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.action.fieldcaps.TransportFieldCapabilitiesAction.checkBlocksAndFilterIndices;
 import static org.hamcrest.Matchers.containsString;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class TransportFieldCapabilitiesActionTests extends ESTestCase {


### PR DESCRIPTION
INDEX_REFRESH_BLOCK: a cluster block added to newly created indices with replicas in serverless, and removed once at least one search shard is started.

Since https://github.com/elastic/elasticsearch/pull/129132, we began skipping indices with INDEX_REFRESH_BLOCK during searches. 

We should do the same in field caps, which will allow us to skip these indices in ESQL queries as ESQL uses field caps to resolve indices (ITs for field caps and ESQL are in the linked PR - INDEX_REFRESH_BLOCK can only be ITed in serverless).