### PR TITLE
Make hierarchical k-means over centroids cheaper

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/DefaultIVFVectorsWriter.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/DefaultIVFVectorsWriter.java
@@ -405,9 +405,9 @@ public class DefaultIVFVectorsWriter extends IVFVectorsWriter {
         // this are small numbers so we run it wih all the centroids.
         final KMeansResult kMeansResult = new HierarchicalKMeans(
             fieldInfo.getVectorDimension(),
-            6,
-            floatVectorValues.size(),
-            floatVectorValues.size(),
+            HierarchicalKMeans.MAX_ITERATIONS_DEFAULT,
+            HierarchicalKMeans.SAMPLES_PER_CLUSTER_DEFAULT,
+            HierarchicalKMeans.MAXK,
             -1 // disable SOAR assignments
         ).cluster(floatVectorValues, centroidsPerParentCluster);
         final int[] centroidVectorCount = new int[kMeansResult.centroids().length];

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/HierarchicalKMeans.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/HierarchicalKMeans.java
@@ -19,10 +19,10 @@ import java.util.Arrays;
  */
 public class HierarchicalKMeans {
 
-    static final int MAXK = 128;
-    static final int MAX_ITERATIONS_DEFAULT = 6;
-    static final int SAMPLES_PER_CLUSTER_DEFAULT = 64;
-    static final float DEFAULT_SOAR_LAMBDA = 1.0f;
+    public static final int MAXK = 128;
+    public static final int MAX_ITERATIONS_DEFAULT = 6;
+    public static final int SAMPLES_PER_CLUSTER_DEFAULT = 64;
+    public static final float DEFAULT_SOAR_LAMBDA = 1.0f;
 
     final int dimension;
     final int maxIterations;


### PR DESCRIPTION
when adding hierarchical kmeans over centroids, we added very aggressive settings. This makes a noticeable slow down when the number of centroids increases and it provides little benefit. My checks shows no change on recall by changing the settings to the default ones.