### PR TITLE
[9.1] Unmute #131803 (#132295)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -447,9 +447,6 @@ tests:
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test151MachineDependentHeapWithSizeOverride
   issue: https://github.com/elastic/elasticsearch/issues/123437
-- class: org.elasticsearch.xpack.stack.StackYamlIT
-  method: test {yaml=stack/10_basic/Test wrong data_stream type - logs from 9.2.0}
-  issue: https://github.com/elastic/elasticsearch/issues/131803
 - class: org.elasticsearch.index.engine.MergeWithLowDiskSpaceIT
   method: testRelocationWhileForceMerging
   issue: https://github.com/elastic/elasticsearch/issues/131789


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Unmute #131803 (#132295)](https://github.com/elastic/elasticsearch/pull/132295)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)