### PR TITLE
Test fix: reduce the number of fields per document in StandardVersusLogsIndexModeChallengeRestIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -515,12 +515,6 @@ tests:
 - class: org.elasticsearch.test.rest.yaml.MDPYamlTestSuiteIT
   method: test {yaml=mdp/10_basic/Index using shared data path}
   issue: https://github.com/elastic/elasticsearch/issues/132223
-- class: org.elasticsearch.xpack.logsdb.qa.StandardVersusStandardReindexedIntoLogsDbChallengeRestIT
-  method: testTermsQuery
-  issue: https://github.com/elastic/elasticsearch/issues/132225
-- class: org.elasticsearch.xpack.logsdb.qa.StoredSourceLogsDbVersusReindexedLogsDbChallengeRestIT
-  method: testTermsQuery
-  issue: https://github.com/elastic/elasticsearch/issues/132226
 - class: org.elasticsearch.xpack.sql.qa.mixed_node.SqlCompatIT
   method: testNullsOrderWithMissingOrderSupportQueryingNewNode
   issue: https://github.com/elastic/elasticsearch/issues/132249

--- a/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/qa/StandardVersusLogsIndexModeChallengeRestIT.java
+++ b/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/qa/StandardVersusLogsIndexModeChallengeRestIT.java
@@ -60,7 +60,7 @@ public abstract class StandardVersusLogsIndexModeChallengeRestIT extends Abstrac
     protected final DataGenerationHelper dataGenerationHelper;
 
     public StandardVersusLogsIndexModeChallengeRestIT() {
-        this(new DataGenerationHelper());
+        this(new DataGenerationHelper(builder -> builder.withMaxFieldCountPerLevel(30)));
     }
 
     protected StandardVersusLogsIndexModeChallengeRestIT(DataGenerationHelper dataGenerationHelper) {


### PR DESCRIPTION
Both test failed because the test was indexing very large documents and triggered the indexing pressure monitor. We considered adding throttling but we did not succeed so we reduced max the number of fields a document can have. This fixed the issue.

Fixes #132225 
Fixes #132226 