### PR TITLE
Simulate API: Mute invalid processors BCC test

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/simulate.ingest/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/simulate.ingest/10_basic.yml
@@ -612,9 +612,9 @@ setup:
 
 ---
 "Test bad pipeline substitution":
-
   - skip:
       features: [headers, allowed_warnings]
+      cluster_features: [ "gte_v9.1.99" ]
 
   - do:
       headers:


### PR DESCRIPTION
- Bug being fixed in 9.2 which now returns 400 instead of a 500, so skipping this test for BWC when running against >9.2 cluster