### PR TITLE
Adding clarification for ilm troubleshooting-privileges

### DIFF
--- a/docs/reference/ilm/error-handling.asciidoc
+++ b/docs/reference/ilm/error-handling.asciidoc
@@ -246,5 +246,6 @@ For more information, see <<fix-watermark-errors,Fix watermark errors>>.
 [discrete]
 ==== security_exception: action [<action-name>] is unauthorized for user [<user-name>] with roles [<role-name>], this action is granted by the index privileges [manage_follow_index,manage,all]
 
-This indicates the ILM action cannot be executed because the user used by ILM to perform the action doesn't have the proper privileges. This can happen when user's privileges has been dropped after updating the ILM policy.
-ILM actions are run as though they were performed by the last user who modify the policy. The account used to create or modify the policy from should have permissions to perform all operations that are part of that policy.
+This indicates the ILM action cannot be executed because the user that ILM uses to perform the action doesn’t have the correct privileges.
+ILM actions are run as though they are performed by the last user who modified the policy with the privileges that user had at that time.
+The account used to create or modify the policy must have permissions to perform all operations that are part of that policy.


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/110662

I've made small adjustments to the text that clarifies how ILM runs actions as though they are performed by the user who last modified the policy.
