### PR TITLE
Revert "[9.1] Standardize on docker image arch classifier (#130643)"

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/Architecture.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/Architecture.java
@@ -11,17 +11,15 @@ package org.elasticsearch.gradle;
 
 public enum Architecture {
 
-    X64("x86_64", "linux/amd64", "amd64"),
-    AARCH64("aarch64", "linux/arm64", "arm64");
+    X64("x86_64", "linux/amd64"),
+    AARCH64("aarch64", "linux/arm64");
 
     public final String classifier;
     public final String dockerPlatform;
-    public final String dockerClassifier;
 
-    Architecture(String classifier, String dockerPlatform, String dockerClassifier) {
+    Architecture(String classifier, String dockerPlatform) {
         this.classifier = classifier;
         this.dockerPlatform = dockerPlatform;
-        this.dockerClassifier = dockerClassifier;
     }
 
     public static Architecture current() {

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -659,7 +659,7 @@ subprojects { Project subProject ->
       it.setCompression(Compression.GZIP)
       it.getArchiveBaseName().set("elasticsearch${base.suffix}-${VersionProperties.elasticsearch}-docker-image")
       it.getArchiveVersion().set("")
-      it.getArchiveClassifier().set(architecture.dockerClassifier)
+      it.getArchiveClassifier().set(architecture == Architecture.AARCH64 ? 'aarch64' : '')
       it.getDestinationDirectory().set(new File(project.parent.buildDir, 'distributions'))
       it.dependsOn(exportTask)
     }


### PR DESCRIPTION
Reverts elastic/elasticsearch#131753
Changes in release-manager are not ready yet.