### PR TITLE
[ExtraHop][Qualys GAV] - Fix Cannot execute ILM policy delete step

### DIFF
--- a/docs/changelog/132387.yaml
+++ b/docs/changelog/132387.yaml
@@ -1,0 +1,6 @@
+pr: 132387
+summary: "[ExtraHop & QualysGAV] Add `manage`, `create_index`, `read`, `index`, `write`, `delete`, permission for third party agent indices `kibana_system`"
+area: Authorization
+type: enhancement
+issues:
+  - 131825

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -515,7 +515,9 @@ class KibanaOwnedReservedRoleDescriptors {
                         "logs-tenable_io.vulnerability-*",
                         "logs-rapid7_insightvm.vulnerability-*",
                         "logs-rapid7_insightvm.asset_vulnerability-*",
-                        "logs-carbon_black_cloud.asset_vulnerability_summary-*"
+                        "logs-carbon_black_cloud.asset_vulnerability_summary-*",
+                        "logs-extrahop.investigation-*",
+                        "logs-qualys_gav.asset-*"
                     )
                     .privileges("read", "view_index_metadata")
                     .build(),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -536,7 +536,6 @@ class KibanaOwnedReservedRoleDescriptors {
                         // Require "delete_index" to perform ILM policy actions
                         TransportDeleteIndexAction.TYPE.name(),
                         TransportIndicesAliasesAction.NAME,
-                        TransportUpdateSettingsAction.TYPE.name(),
                         TransportAutoPutMappingAction.TYPE.name()
                     )
                     .build(),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -522,10 +522,7 @@ class KibanaOwnedReservedRoleDescriptors {
                 // For ExtraHop and QualysGAV specific actions. Kibana reads, writes and manages this index
                 // for configured ILM policies.
                 RoleDescriptor.IndicesPrivileges.builder()
-                    .indices(
-                        "logs-extrahop.investigation-*",
-                        "logs-qualys_gav.asset-*"
-                    )
+                    .indices("logs-extrahop.investigation-*", "logs-qualys_gav.asset-*")
                     .privileges(
                         "manage",
                         "create_index",

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -515,11 +515,30 @@ class KibanaOwnedReservedRoleDescriptors {
                         "logs-tenable_io.vulnerability-*",
                         "logs-rapid7_insightvm.vulnerability-*",
                         "logs-rapid7_insightvm.asset_vulnerability-*",
-                        "logs-carbon_black_cloud.asset_vulnerability_summary-*",
+                        "logs-carbon_black_cloud.asset_vulnerability_summary-*"
+                    )
+                    .privileges("read", "view_index_metadata")
+                    .build(),
+                // For ExtraHop and QualysGAV specific actions. Kibana reads, writes and manages this index
+                // for configured ILM policies.
+                RoleDescriptor.IndicesPrivileges.builder()
+                    .indices(
                         "logs-extrahop.investigation-*",
                         "logs-qualys_gav.asset-*"
                     )
-                    .privileges("read", "view_index_metadata")
+                    .privileges(
+                        "manage",
+                        "create_index",
+                        "read",
+                        "index",
+                        "write",
+                        "delete",
+                        // Require "delete_index" to perform ILM policy actions
+                        TransportDeleteIndexAction.TYPE.name(),
+                        TransportIndicesAliasesAction.NAME,
+                        TransportUpdateSettingsAction.TYPE.name(),
+                        TransportAutoPutMappingAction.TYPE.name()
+                    )
                     .build(),
                 // For alias indices of the Cloud Detection & Response (CDR) packages that ships a
                 // transform

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1890,8 +1890,8 @@ public class ReservedRolesStoreTests extends ESTestCase {
         Arrays.asList(
             "logs-extrahop.investigation-" + randomAlphaOfLength(randomIntBetween(1, 10)),
             "logs-qualys_gav.asset-" + randomAlphaOfLength(randomIntBetween(1, 10))
-        ).forEach((index) -> {
-            final IndexAbstraction indexAbstraction = mockIndexAbstraction(index);
+        ).forEach((index_qualys_extra_hop) -> {
+            final IndexAbstraction indexAbstraction = mockIndexAbstraction(index_qualys_extra_hop);
 
             // Assert Read Actions (Allowed by "read")
             assertThat(kibanaRole.indices().allowedIndicesMatcher(GetIndexAction.NAME).test(indexAbstraction), is(true));
@@ -1906,29 +1906,16 @@ public class ReservedRolesStoreTests extends ESTestCase {
 
             // Assert Index Management Actions (Allowed by "create_index", "delete_index", and "manage")
             // Allowed by the explicit "create_index" privilege
-            assertThat(
-                kibanaRole.indices().allowedIndicesMatcher(TransportCreateIndexAction.TYPE.name()).test(indexAbstraction),
-                is(true)
-            );
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportCreateIndexAction.TYPE.name()).test(indexAbstraction), is(true));
             // Allowed by the explicit TransportDeleteIndexAction
-            assertThat(
-                kibanaRole.indices().allowedIndicesMatcher(TransportDeleteIndexAction.TYPE.name()).test(indexAbstraction),
-                is(true)
-            );
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportDeleteIndexAction.TYPE.name()).test(indexAbstraction), is(true));
 
             // Allowed due to the "manage" privilege and explicit TransportAutoPutMappingAction
-            assertThat(
-                kibanaRole.indices().allowedIndicesMatcher(TransportPutMappingAction.TYPE.name()).test(indexAbstraction),
-                is(true)
-            );
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportPutMappingAction.TYPE.name()).test(indexAbstraction), is(true));
             // Allowed due to the explicit TransportIndicesAliasesAction
-            assertThat(
-                kibanaRole.indices().allowedIndicesMatcher(TransportIndicesAliasesAction.NAME).test(indexAbstraction),
-                is(true)
-            );
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportIndicesAliasesAction.NAME).test(indexAbstraction), is(true));
             // Rollover requires 'manage' on the alias and 'create_index', both of which are granted.
             assertThat(kibanaRole.indices().allowedIndicesMatcher(RolloverAction.NAME).test(indexAbstraction), is(true));
-
 
             // Assert Denied Actions
             // This role should not have cross-cluster permissions on these indices

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1884,6 +1884,66 @@ public class ReservedRolesStoreTests extends ESTestCase {
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportPutMappingAction.TYPE.name()).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(RolloverAction.NAME).test(indexAbstraction), is(true));
         });
+
+        // Tests for third-party agent indices (ExtraHop, QualysGAV) that `kibana_system` has full management access to
+        // This includes read, write, create, delete, and all ILM-related management actions.
+        Arrays.asList(
+            "logs-extrahop.investigation-" + randomAlphaOfLength(randomIntBetween(1, 10)),
+            "logs-qualys_gav.asset-" + randomAlphaOfLength(randomIntBetween(1, 10))
+        ).forEach((index) -> {
+            final IndexAbstraction indexAbstraction = mockIndexAbstraction(index);
+
+            // Assert Read Actions (Allowed by "read")
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(GetIndexAction.NAME).test(indexAbstraction), is(true));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(indexAbstraction), is(true));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportGetAction.TYPE.name()).test(indexAbstraction), is(true));
+
+            // Assert Write & Delete Document Actions (Allowed by "write", "index", "delete")
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportIndexAction.NAME).test(indexAbstraction), is(true));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportDeleteAction.NAME).test(indexAbstraction), is(true));
+            // The "update" action is also implicitly part of "write"
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(UpdateAction.NAME).test(indexAbstraction), is(true));
+
+            // Assert Index Management Actions (Allowed by "create_index", "delete_index", and "manage")
+            // Allowed by the explicit "create_index" privilege
+            assertThat(
+                kibanaRole.indices().allowedIndicesMatcher(TransportCreateIndexAction.TYPE.name()).test(indexAbstraction),
+                is(true)
+            );
+            // Allowed by the explicit TransportDeleteIndexAction
+            assertThat(
+                kibanaRole.indices().allowedIndicesMatcher(TransportDeleteIndexAction.TYPE.name()).test(indexAbstraction),
+                is(true)
+            );
+
+            // Assert ILM Actions (Allowed by "manage" and explicit transport actions)
+            // Allowed due to the "manage" privilege and explicit TransportUpdateSettingsAction
+            assertThat(
+                kibanaRole.indices().allowedIndicesMatcher(TransportUpdateSettingsAction.TYPE.name()).test(indexAbstraction),
+                is(true)
+            );
+            // Allowed due to the "manage" privilege and explicit TransportAutoPutMappingAction
+            assertThat(
+                kibanaRole.indices().allowedIndicesMatcher(TransportPutMappingAction.TYPE.name()).test(indexAbstraction),
+                is(true)
+            );
+            // Allowed due to the explicit TransportIndicesAliasesAction
+            assertThat(
+                kibanaRole.indices().allowedIndicesMatcher(TransportIndicesAliasesAction.NAME).test(indexAbstraction),
+                is(true)
+            );
+            // Rollover requires 'manage' on the alias and 'create_index', both of which are granted.
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(RolloverAction.NAME).test(indexAbstraction), is(true));
+
+
+            // Assert Denied Actions
+            // This role should not have cross-cluster permissions on these indices
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(READ_CROSS_CLUSTER_NAME).test(indexAbstraction), is(false));
+
+            // A check against a completely different index should fail
+            final IndexAbstraction otherIndex = mockIndexAbstraction("some-unrelated-index");
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportSearchAction.TYPE.name()).test(otherIndex), is(false));
+        });
     }
 
     public void testKibanaAdminRole() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1902,7 +1902,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportIndexAction.NAME).test(indexAbstraction), is(true));
             assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportDeleteAction.NAME).test(indexAbstraction), is(true));
             // The "update" action is also implicitly part of "write"
-            assertThat(kibanaRole.indices().allowedIndicesMatcher(UpdateAction.NAME).test(indexAbstraction), is(true));
+            assertThat(kibanaRole.indices().allowedIndicesMatcher(TransportUpdateAction.NAME).test(indexAbstraction), is(true));
 
             // Assert Index Management Actions (Allowed by "create_index", "delete_index", and "manage")
             // Allowed by the explicit "create_index" privilege
@@ -1916,12 +1916,6 @@ public class ReservedRolesStoreTests extends ESTestCase {
                 is(true)
             );
 
-            // Assert ILM Actions (Allowed by "manage" and explicit transport actions)
-            // Allowed due to the "manage" privilege and explicit TransportUpdateSettingsAction
-            assertThat(
-                kibanaRole.indices().allowedIndicesMatcher(TransportUpdateSettingsAction.TYPE.name()).test(indexAbstraction),
-                is(true)
-            );
             // Allowed due to the "manage" privilege and explicit TransportAutoPutMappingAction
             assertThat(
                 kibanaRole.indices().allowedIndicesMatcher(TransportPutMappingAction.TYPE.name()).test(indexAbstraction),


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

 This PR focuses on the short term solution which add the `logs-extrahop.investigation-*` and `logs-qualys_gav.asset-*` indices under the `kibana_system` role with deletion privileges to prevent a failed deletion error when the index enters the [deletion phase for the ILM lifecycle](https://github.com/elastic/integrations/pull/14644/files), in upcoming PRs.


**Current behavior:**
- It shows permission issue while deleting the index

For Qualys GAV:

```
{
  "failed_step": "delete",
  "step_info": {
    "type": "security_exception",
    "reason": "action [indices:admin/delete] is unauthorized for user [found-internal-kibana4-server] with effective roles [found-internal-kibana4-server,kibana_system] on indices [.ds-logs-qualys_gav.asset-default-2025.07.24-000001], this action is granted by the index privileges [delete_index,manage,all]"
  }
}
```

For ExtraHop:

```
{
  "failed_step": "delete",
  "step_info": {
    "type": "security_exception",
    "reason": "action [indices:admin/delete] is unauthorized for user [found-internal-kibana4-server] with effective roles [found-internal-kibana4-server, kibana_system] on indices [.ds-logs-extrahop.investigation-default-2025.07.23-000001], this action is granted by the index privileges [delete_index, manage, all]"
  }
}
```

Closes - https://github.com/elastic/elasticsearch/issues/131825
Similar Issues : https://github.com/elastic/kibana/issues/197390, https://github.com/elastic/elasticsearch/pull/116982