### PR TITLE
ESQL: Fix skipping of generative ESQL tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -509,9 +509,6 @@ tests:
 - class: org.elasticsearch.xpack.sql.qa.mixed_node.SqlCompatIT
   method: testNullsOrderWithMissingOrderSupportQueryingNewNode
   issue: https://github.com/elastic/elasticsearch/issues/132249
-- class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/132273
 - class: org.elasticsearch.common.logging.JULBridgeTests
   method: testThrowable
   issue: https://github.com/elastic/elasticsearch/issues/132280

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
@@ -160,7 +160,7 @@ public abstract class GenerativeRestTest extends ESRestTestCase {
         );
         if (outputValidation.success() == false) {
             for (Pattern allowedError : ALLOWED_ERROR_PATTERNS) {
-                if (allowedError.matcher(outputValidation.errorMessage()).matches()) {
+                if (isAllowedError(outputValidation.errorMessage(), allowedError)) {
                     return outputValidation;
                 }
             }
@@ -171,11 +171,22 @@ public abstract class GenerativeRestTest extends ESRestTestCase {
 
     private void checkException(EsqlQueryGenerator.QueryExecuted query) {
         for (Pattern allowedError : ALLOWED_ERROR_PATTERNS) {
-            if (allowedError.matcher(query.exception().getMessage()).matches()) {
+            if (isAllowedError(query.exception().getMessage(), allowedError)) {
                 return;
             }
         }
         fail("query: " + query.query() + "\nexception: " + query.exception().getMessage());
+    }
+
+    /**
+     * Long lines in exceptions can be split across several lines. When a newline is inserted, the end of the current line and the beginning
+     * of the new line are marked with a backslash {@code \}; the new line will also have whitespace before the backslash for aligning.
+     */
+    private static final Pattern ERROR_MESSAGE_LINE_BREAK = Pattern.compile("\\\\\n\\s*\\\\");
+
+    private static boolean isAllowedError(String errorMessage, Pattern allowedPattern) {
+        String errorWithoutLineBreaks = ERROR_MESSAGE_LINE_BREAK.matcher(errorMessage).replaceAll("");
+        return allowedPattern.matcher(errorWithoutLineBreaks).matches();
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Fix https://github.com/elastic/elasticsearch/issues/132273

Our generative tests skip some faulty queries based on the returned error message.

The error message can sometimes be split into multiple lines with backslashes marking the line boundaries, like in the following example:
```
error:	
  root_cause:	
  - type: "illegal_state_exception"	
    reason: "Found 1 problem\nline 1:960: Plan [Grok[message{r}#72141,Parser[pattern=%{WORD:wuHEnnQxDWJ}\	
      \ %{WORD:language_code_long} %{WORD:color}, grok=org.elastics\nearch.grok.Grok@2a38e4e2],[color{r}#72147,\	
      \ language_code_long{r}#72148, wuHEnnQxDWJ{r}#72149]]] optimized incorrectly\	
      \ due to missing references [message{r}#72141]"	
    stack_trace: "org.elasticsearch.ElasticsearchException$1: Found 1 problem\nline\	
      \ 1:960: Plan [Grok[message{r}#72141,Parser[pattern=%{WORD:wuHEnnQxDWJ} %{WORD:language_code_long}\	
      \ %{WORD:color}, grok=org.elastics\nearch.grok.Grok@2a38e4e2],[color{r}#72147,\	
      \ language_code_long{r}#72148, wuHEnnQxDWJ{r}#72149]]] optimized incorrectly\	
      \ due to missing references [message{r}#72141]\r\n\tat org.elasticsea
```
This should have been [skipped](https://github.com/elastic/elasticsearch/blob/829fb56b986acb0b47b9be7aabc5c7b6e6d7f59d/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java#L59) based on the string `optimized incorrectly due to missing references`, but this skip was prevented because this string was split across multiple lines.

Let's stitch the error message back together before we check if it should be ignored, so that such line splits don't prevent skips.