### PR TITLE
Small optimization in OptimizedScalarQuantizer by using mul instead of div

### DIFF
--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/DefaultESVectorUtilSupport.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/DefaultESVectorUtilSupport.java
@@ -80,10 +80,11 @@ final class DefaultESVectorUtilSupport implements ESVectorUtilSupport {
         float dbb = 0;
         float dax = 0;
         float dbx = 0;
+        float invPmOnes = 1f / (points - 1f);
         for (int i = 0; i < target.length; ++i) {
             float v = target[i];
             float k = quantize[i];
-            float s = k / (points - 1);
+            float s = k * invPmOnes;
             float ms = 1f - s;
             daa = fma(ms, ms, daa);
             dab = fma(ms, s, dab);

--- a/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/PanamaESVectorUtilSupport.java
+++ b/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/PanamaESVectorUtilSupport.java
@@ -810,8 +810,7 @@ public final class PanamaESVectorUtilSupport implements ESVectorUtilSupport {
             for (; i < limit; i += FLOAT_SPECIES.length()) {
                 FloatVector v = FloatVector.fromArray(FLOAT_SPECIES, vector, i);
                 FloatVector xi = v.max(lowVec).min(upperVec); // clamp
-                IntVector assignment = xi.sub(lowVec).mul(invStepVec).
-                    add(0.5f).convert(VectorOperators.F2I, 0).reinterpretAsInts(); // round
+                IntVector assignment = xi.sub(lowVec).mul(invStepVec).add(0.5f).convert(VectorOperators.F2I, 0).reinterpretAsInts(); // round
                 sumQuery += assignment.reduceLanes(ADD);
                 assignment.intoArray(destination, i);
             }

--- a/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/PanamaESVectorUtilSupport.java
+++ b/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/PanamaESVectorUtilSupport.java
@@ -132,7 +132,7 @@ public final class PanamaESVectorUtilSupport implements ESVectorUtilSupport {
                 FloatVector centeredVec = v.sub(c);
                 FloatVector deltaVec = centeredVec.sub(vecMeanVec);
                 norm2Vec = fma(centeredVec, centeredVec, norm2Vec);
-                vecMeanVec = vecMeanVec.add(deltaVec.div(count));
+                vecMeanVec = vecMeanVec.add(deltaVec.mul(1f / count));
                 FloatVector delta2Vec = centeredVec.sub(vecMeanVec);
                 m2Vec = fma(deltaVec, delta2Vec, m2Vec);
                 minVec = minVec.min(centeredVec);
@@ -214,7 +214,7 @@ public final class PanamaESVectorUtilSupport implements ESVectorUtilSupport {
                 FloatVector centeredVec = v.sub(c);
                 FloatVector deltaVec = centeredVec.sub(vecMeanVec);
                 norm2Vec = fma(centeredVec, centeredVec, norm2Vec);
-                vecMeanVec = vecMeanVec.add(deltaVec.div(count));
+                vecMeanVec = vecMeanVec.add(deltaVec.mul(1f / count));
                 FloatVector delta2Vec = centeredVec.sub(vecMeanVec);
                 m2Vec = fma(deltaVec, delta2Vec, m2Vec);
                 minVec = minVec.min(centeredVec);
@@ -278,6 +278,7 @@ public final class PanamaESVectorUtilSupport implements ESVectorUtilSupport {
         float dbb = 0;
         float dax = 0;
         float dbx = 0;
+        float invPmOnes = 1f / (points - 1f);
         // if the array size is large (> 2x platform vector size), it's worth the overhead to vectorize
         if (target.length > 2 * FLOAT_SPECIES.length()) {
             FloatVector daaVec = FloatVector.zero(FLOAT_SPECIES);
@@ -286,11 +287,11 @@ public final class PanamaESVectorUtilSupport implements ESVectorUtilSupport {
             FloatVector daxVec = FloatVector.zero(FLOAT_SPECIES);
             FloatVector dbxVec = FloatVector.zero(FLOAT_SPECIES);
             FloatVector ones = FloatVector.broadcast(FLOAT_SPECIES, 1f);
-            FloatVector pmOnes = FloatVector.broadcast(FLOAT_SPECIES, points - 1f);
+            FloatVector invPmOnesVec = FloatVector.broadcast(FLOAT_SPECIES, invPmOnes);
             for (; i < FLOAT_SPECIES.loopBound(target.length); i += FLOAT_SPECIES.length()) {
                 FloatVector v = FloatVector.fromArray(FLOAT_SPECIES, target, i);
                 FloatVector oVec = IntVector.fromArray(INTEGER_SPECIES, quantize, i).convert(VectorOperators.I2F, 0).reinterpretAsFloats();
-                FloatVector sVec = oVec.div(pmOnes);
+                FloatVector sVec = oVec.mul(invPmOnesVec);
                 FloatVector smVec = ones.sub(sVec);
                 daaVec = fma(smVec, smVec, daaVec);
                 dabVec = fma(smVec, sVec, dabVec);
@@ -307,7 +308,7 @@ public final class PanamaESVectorUtilSupport implements ESVectorUtilSupport {
 
         for (; i < target.length; i++) {
             float k = quantize[i];
-            float s = k / (points - 1);
+            float s = k * invPmOnes;
             float ms = 1f - s;
             daa = fma(ms, ms, daa);
             dab = fma(ms, s, dab);
@@ -798,25 +799,25 @@ public final class PanamaESVectorUtilSupport implements ESVectorUtilSupport {
     @Override
     public int quantizeVectorWithIntervals(float[] vector, int[] destination, float lowInterval, float upperInterval, byte bits) {
         float nSteps = ((1 << bits) - 1);
-        float step = (upperInterval - lowInterval) / nSteps;
+        float invStep = nSteps / (upperInterval - lowInterval);
         int sumQuery = 0;
         int i = 0;
         if (vector.length > 2 * FLOAT_SPECIES.length()) {
             int limit = FLOAT_SPECIES.loopBound(vector.length);
             FloatVector lowVec = FloatVector.broadcast(FLOAT_SPECIES, lowInterval);
             FloatVector upperVec = FloatVector.broadcast(FLOAT_SPECIES, upperInterval);
-            FloatVector stepVec = FloatVector.broadcast(FLOAT_SPECIES, step);
+            FloatVector invStepVec = FloatVector.broadcast(FLOAT_SPECIES, invStep);
             for (; i < limit; i += FLOAT_SPECIES.length()) {
                 FloatVector v = FloatVector.fromArray(FLOAT_SPECIES, vector, i);
                 FloatVector xi = v.max(lowVec).min(upperVec); // clamp
-                IntVector assignment = xi.sub(lowVec).div(stepVec).add(0.5f).convert(VectorOperators.F2I, 0).reinterpretAsInts(); // round
+                IntVector assignment = xi.sub(lowVec).mul(invStepVec).add(0.5f).convert(VectorOperators.F2I, 0).reinterpretAsInts(); // round
                 sumQuery += assignment.reduceLanes(ADD);
                 assignment.intoArray(destination, i);
             }
         }
         for (; i < vector.length; i++) {
             float xi = Math.min(Math.max(vector[i], lowInterval), upperInterval);
-            int assignment = Math.round((xi - lowInterval) / step);
+            int assignment = Math.round((xi - lowInterval) * invStep);
             sumQuery += assignment;
             destination[i] = assignment;
         }

--- a/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/PanamaESVectorUtilSupport.java
+++ b/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/PanamaESVectorUtilSupport.java
@@ -810,7 +810,8 @@ public final class PanamaESVectorUtilSupport implements ESVectorUtilSupport {
             for (; i < limit; i += FLOAT_SPECIES.length()) {
                 FloatVector v = FloatVector.fromArray(FLOAT_SPECIES, vector, i);
                 FloatVector xi = v.max(lowVec).min(upperVec); // clamp
-                IntVector assignment = xi.sub(lowVec).mul(invStepVec).add(0.5f).convert(VectorOperators.F2I, 0).reinterpretAsInts(); // round
+                IntVector assignment = xi.sub(lowVec).mul(invStepVec).
+                    add(0.5f).convert(VectorOperators.F2I, 0).reinterpretAsInts(); // round
                 sumQuery += assignment.reduceLanes(ADD);
                 assignment.intoArray(destination, i);
             }

--- a/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/PanamaESVectorUtilSupport.java
+++ b/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/PanamaESVectorUtilSupport.java
@@ -810,7 +810,8 @@ public final class PanamaESVectorUtilSupport implements ESVectorUtilSupport {
             for (; i < limit; i += FLOAT_SPECIES.length()) {
                 FloatVector v = FloatVector.fromArray(FLOAT_SPECIES, vector, i);
                 FloatVector xi = v.max(lowVec).min(upperVec); // clamp
-                IntVector assignment = xi.sub(lowVec).mul(invStepVec).add(0.5f).convert(VectorOperators.F2I, 0).reinterpretAsInts(); // round
+                // round
+                IntVector assignment = xi.sub(lowVec).mul(invStepVec).add(0.5f).convert(VectorOperators.F2I, 0).reinterpretAsInts();
                 sumQuery += assignment.reduceLanes(ADD);
                 assignment.intoArray(destination, i);
             }


### PR DESCRIPTION
I read somewhere that it is generally faster to perform multiplication than divisions when using SIMD instructions. I had a go and change those operations in the panamized methods used by OptimizedScalarQuantizer and we get a measurable speed up!

Before:
```
Benchmark                                 (bits)  (dims)   Mode  Cnt    Score     Error   Units
OptimizedScalarQuantizerBenchmark.scalar       1     384  thrpt   15  168.238 ±  23.585  ops/ms
OptimizedScalarQuantizerBenchmark.scalar       1     702  thrpt   15   93.736 ±  14.887  ops/ms
OptimizedScalarQuantizerBenchmark.scalar       1    1024  thrpt   15   62.421 ±   5.945  ops/ms
OptimizedScalarQuantizerBenchmark.scalar       4     384  thrpt   15  173.864 ±  35.138  ops/ms
OptimizedScalarQuantizerBenchmark.scalar       4     702  thrpt   15   88.646 ±  19.756  ops/ms
OptimizedScalarQuantizerBenchmark.scalar       4    1024  thrpt   15   57.225 ±   8.842  ops/ms
OptimizedScalarQuantizerBenchmark.scalar       7     384  thrpt   15  173.472 ±  16.121  ops/ms
OptimizedScalarQuantizerBenchmark.scalar       7     702  thrpt   15   93.513 ±   9.126  ops/ms
OptimizedScalarQuantizerBenchmark.scalar       7    1024  thrpt   15   68.805 ±  10.624  ops/ms
OptimizedScalarQuantizerBenchmark.vector       1     384  thrpt   15  656.885 ± 114.497  ops/ms
OptimizedScalarQuantizerBenchmark.vector       1     702  thrpt   15  357.374 ±  66.247  ops/ms
OptimizedScalarQuantizerBenchmark.vector       1    1024  thrpt   15  234.931 ±  30.954  ops/ms
OptimizedScalarQuantizerBenchmark.vector       4     384  thrpt   15  596.822 ±  86.150  ops/ms
OptimizedScalarQuantizerBenchmark.vector       4     702  thrpt   15  314.400 ±  30.220  ops/ms
OptimizedScalarQuantizerBenchmark.vector       4    1024  thrpt   15  218.100 ±  15.042  ops/ms
OptimizedScalarQuantizerBenchmark.vector       7     384  thrpt   15  647.844 ±  41.396  ops/ms
OptimizedScalarQuantizerBenchmark.vector       7     702  thrpt   15  358.260 ±  20.754  ops/ms
OptimizedScalarQuantizerBenchmark.vector       7    1024  thrpt   15  250.937 ±  20.001  ops/ms
```

After:
```
Benchmark                                 (bits)  (dims)   Mode  Cnt    Score     Error   Units
OptimizedScalarQuantizerBenchmark.scalar       1     384  thrpt   15  181.036 ±  32.714  ops/ms
OptimizedScalarQuantizerBenchmark.scalar       1     702  thrpt   15   91.953 ±  10.118  ops/ms
OptimizedScalarQuantizerBenchmark.scalar       1    1024  thrpt   15   64.169 ±   9.674  ops/ms
OptimizedScalarQuantizerBenchmark.scalar       4     384  thrpt   15  177.412 ±  38.977  ops/ms
OptimizedScalarQuantizerBenchmark.scalar       4     702  thrpt   15   89.876 ±  14.582  ops/ms
OptimizedScalarQuantizerBenchmark.scalar       4    1024  thrpt   15   60.455 ±  13.816  ops/ms
OptimizedScalarQuantizerBenchmark.scalar       7     384  thrpt   15  192.380 ±  21.849  ops/ms
OptimizedScalarQuantizerBenchmark.scalar       7     702  thrpt   15   96.493 ±   8.962  ops/ms
OptimizedScalarQuantizerBenchmark.scalar       7    1024  thrpt   15   69.664 ±   5.691  ops/ms
OptimizedScalarQuantizerBenchmark.vector       1     384  thrpt   15  735.320 ±  87.558  ops/ms
OptimizedScalarQuantizerBenchmark.vector       1     702  thrpt   15  397.016 ±  48.072  ops/ms
OptimizedScalarQuantizerBenchmark.vector       1    1024  thrpt   15  278.980 ±  31.580  ops/ms
OptimizedScalarQuantizerBenchmark.vector       4     384  thrpt   15  721.900 ± 117.902  ops/ms
OptimizedScalarQuantizerBenchmark.vector       4     702  thrpt   15  359.691 ±  49.942  ops/ms
OptimizedScalarQuantizerBenchmark.vector       4    1024  thrpt   15  230.584 ±   9.912  ops/ms
OptimizedScalarQuantizerBenchmark.vector       7     384  thrpt   15  725.781 ±  49.995  ops/ms
OptimizedScalarQuantizerBenchmark.vector       7     702  thrpt   15  419.100 ±  42.762  ops/ms
OptimizedScalarQuantizerBenchmark.vector       7    1024  thrpt   15  278.497 ±  26.565  ops/ms
```