### PR TITLE
[Fleet] add privileges to `kibana_system` to read integrations data

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -328,6 +328,8 @@ class KibanaOwnedReservedRoleDescriptors {
                         "indices:admin/data_stream/lifecycle/put"
                     )
                     .build(),
+                // Read datasets for auto install content packages feature in Fleet
+                RoleDescriptor.IndicesPrivileges.builder().indices("logs-*", "metrics-*", "traces-*").privileges("read").build(),
                 // Endpoint specific action responses. Kibana reads and writes (for third party
                 // agents) to the index to display action responses to the user.
                 // `create_index`: is necessary in order to ensure that the DOT datastream index is

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1397,7 +1397,10 @@ public class ReservedRolesStoreTests extends ESTestCase {
                 || indexName.startsWith(".logs-endpoint.actions-")
                 || indexName.startsWith(".logs-endpoint.action.responses-")
                 || indexName.startsWith(".logs-endpoint.heartbeat-")
-                || indexName.startsWith(".logs-osquery_manager.actions-");
+                || indexName.startsWith(".logs-osquery_manager.actions-")
+                || indexName.startsWith("logs-")
+                || indexName.startsWith("metrics-")
+                || indexName.startsWith("traces-");
             assertThat(
                 kibanaRole.indices().allowedIndicesMatcher(TransportGetAction.TYPE.name()).test(indexAbstraction),
                 is(isAlsoReadIndex)


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? yes
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)? yes
- If submitting code, have you built your formula locally prior to submission with `gradle check`? yes
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed. yes
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)? yes
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that. yes

Relates https://github.com/elastic/kibana/pull/230369
Relates https://github.com/elastic/ingest-dev/issues/5685

`kibana_system` needs permission to read integrations data streams `logs-*,metrics-*,traces-*` to support the auto install content packages feature.
Fleet checks ingested `data_stream.dataset` values to see if any content packages match that can be auto installed.