### PR TITLE
Correct exception for missing nested path

### DIFF
--- a/docs/changelog/132408.yaml
+++ b/docs/changelog/132408.yaml
@@ -1,0 +1,5 @@
+pr: 132408
+summary: Correct exception for missing nested path
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java
@@ -300,7 +300,7 @@ public class NestedQueryBuilder extends AbstractQueryBuilder<NestedQueryBuilder>
             if (ignoreUnmapped) {
                 return new MatchNoDocsQuery();
             } else {
-                throw new IllegalStateException("[" + NAME + "] failed to find nested object under path [" + path + "]");
+                throw new QueryShardException(context, "[" + NAME + "] failed to find nested object under path [" + path + "]");
             }
         }
         final BitSetProducer parentFilter;

--- a/server/src/test/java/org/elasticsearch/index/query/NestedQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/NestedQueryBuilderTests.java
@@ -294,10 +294,7 @@ public class NestedQueryBuilderTests extends AbstractQueryTestCase<NestedQueryBu
 
         final NestedQueryBuilder failingQueryBuilder = new NestedQueryBuilder("unmapped", new MatchAllQueryBuilder(), ScoreMode.None);
         failingQueryBuilder.ignoreUnmapped(false);
-        IllegalStateException e = expectThrows(
-            IllegalStateException.class,
-            () -> failingQueryBuilder.toQuery(createSearchExecutionContext())
-        );
+        QueryShardException e = expectThrows(QueryShardException.class, () -> failingQueryBuilder.toQuery(createSearchExecutionContext()));
         assertThat(e.getMessage(), containsString("[" + NestedQueryBuilder.NAME + "] failed to find nested object under path [unmapped]"));
     }
 


### PR DESCRIPTION
closes: https://github.com/elastic/elasticsearch/issues/132407