### PR TITLE
Unmute testTermsQuery tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -515,15 +515,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.AutodetectMemoryLimitIT
   method: testTooManyByAndOverFields
   issue: https://github.com/elastic/elasticsearch/issues/132310
-- class: org.elasticsearch.xpack.logsdb.qa.LogsDbVersusLogsDbReindexedIntoStandardModeChallengeRestIT
-  method: testTermsQuery
-  issue: https://github.com/elastic/elasticsearch/issues/132335
-- class: org.elasticsearch.xpack.logsdb.qa.LogsDbVersusReindexedIntoStoredSourceChallengeRestIT
-  method: testTermsQuery
-  issue: https://github.com/elastic/elasticsearch/issues/132336
-- class: org.elasticsearch.xpack.logsdb.qa.LogsDbVersusReindexedLogsDbChallengeRestIT
-  method: testTermsQuery
-  issue: https://github.com/elastic/elasticsearch/issues/132337
 - class: org.elasticsearch.xpack.esql.action.CrossClusterAsyncQueryIT
   method: testBadAsyncId
   issue: https://github.com/elastic/elasticsearch/issues/132353


### PR DESCRIPTION
Unmute the following tests:
- LogsDbVersusReindexedIntoStoredSourceChallengeRestIT.testTermsQuery
- LogsDbVersusLogsDbReindexedIntoStandardModeChallengeRestIT.testTermsQuery
- LogsDbVersusReindexedLogsDbChallengeRestIT.testTermsQuery

The underlying issue was already fixed in https://github.com/elastic/elasticsearch/pull/132322

I've confirmed locally that all three tests fail locally on the last commit before the above fix (90990057f73e54c0aa079408ac5ec40d60a65e9c), but pass with the fix.

Fixes https://github.com/elastic/elasticsearch/issues/132335, https://github.com/elastic/elasticsearch/issues/132336, and https://github.com/elastic/elasticsearch/issues/132337