### PR TITLE
Adjust date docvalue formatting to return 4xx instead of 5xx

### DIFF
--- a/docs/changelog/132414.yaml
+++ b/docs/changelog/132414.yaml
@@ -1,0 +1,5 @@
+pr: 132414
+summary: Adjust date docvalue formatting to return 4xx instead of 5xx
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/DocValueFormat.java
+++ b/server/src/main/java/org/elasticsearch/search/DocValueFormat.java
@@ -34,6 +34,7 @@ import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.text.ParseException;
+import java.time.DateTimeException;
 import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Base64;
@@ -304,7 +305,14 @@ public interface DocValueFormat extends NamedWriteable {
 
         @Override
         public String format(long value) {
-            return formatter.format(resolution.toInstant(value).atZone(timeZone));
+            try {
+                return formatter.format(resolution.toInstant(value).atZone(timeZone));
+            } catch (DateTimeException dte) {
+                throw new IllegalArgumentException(
+                    "Failed formatting value [" + value + "] as date with pattern [" + formatter.pattern() + "]",
+                    dte
+                );
+            }
         }
 
         @Override


### PR DESCRIPTION
For the given format, if throwing a `DateTimeException`, it should be transformed into an IllegalArgumentException and provide better information.

related: https://github.com/elastic/elasticsearch/issues/81960