### PR TITLE
Adjust exception wrapping logic when converting to ES exceptions

### DIFF
--- a/server/src/main/java/org/elasticsearch/ExceptionsHelper.java
+++ b/server/src/main/java/org/elasticsearch/ExceptionsHelper.java
@@ -54,8 +54,11 @@ public final class ExceptionsHelper {
     }
 
     public static ElasticsearchException convertToElastic(Exception e) {
-        if (e instanceof ElasticsearchException) {
-            return (ElasticsearchException) e;
+        if (e instanceof ElasticsearchException ese) {
+            return ese;
+        }
+        if (getInnerMostCause(e) instanceof ElasticsearchException ese) {
+            return ese;
         }
         return new ElasticsearchException(e);
     }
@@ -73,6 +76,24 @@ public final class ExceptionsHelper {
             }
         }
         return RestStatus.INTERNAL_SERVER_ERROR;
+    }
+
+    /**
+     * Unwraps while the throwable has a cause and the cause is not the same as the throwable itself.
+     * If you are wanting to unwrap an {@link ElasticsearchWrapperException} use {@link #unwrapCause(Throwable)} instead.
+     * @param t Throwable to unwrap
+     * @return the innermost cause of the given throwable, or the throwable itself if it has no cause
+     */
+    private static Throwable getInnerMostCause(Throwable t) {
+        int counter = 0;
+        Throwable result = t;
+        while (t.getCause() != null && t.getCause() != result) {
+            if (counter++ > 10) {
+                return result;
+            }
+            result = result.getCause();
+        }
+        return result;
     }
 
     public static Throwable unwrapCause(Throwable t) {


### PR DESCRIPTION
This is a broad brush to address https://github.com/elastic/elasticsearch/issues/131548

It seemed weird to only address strange wrapping in only one place (the bitset logic). However, I admit, this is a pretty huge change. 

There are many unknowns, so maybe this just isn't worth it. But it does seem weird that a Java Exception will have an ElasticsearchException as a cause and we would WANT to rather return the java exception rather than the inner ElasticsearchException...

//cc @javanna what do you think? Maybe we add a new "convertOrUnwrapToElastic" method and switch over good paths to that?