### PR TITLE
[9.0] Skip update/100_synthetic_source tests in yamlRestCompatTests (#132296)

### DIFF
--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -110,4 +110,6 @@ tasks.named("yamlRestCompatTestTransform").configure ({ task ->
   )
   task.skipTest("cluster.info/30_info_thread_pool/Cluster HTTP Info", "The search_throttled thread pool has been removed")
   task.skipTest("synonyms/80_synonyms_from_index/Fail loading synonyms from index if synonyms_set doesn't exist", "Synonyms do no longer fail if the synonyms_set doesn't exist")
+  task.skipTest("update/100_synthetic_source/keyword", "synthetic recovery source means _recovery_source field will not be present")
+  task.skipTest("update/100_synthetic_source/stored text", "synthetic recovery source means _recovery_source field will not be present")
 })


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Skip update/100_synthetic_source tests in yamlRestCompatTests (#132296)](https://github.com/elastic/elasticsearch/pull/132296)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)