### PR TITLE
Reduce logging frequency for GCS per project clients

### DIFF
--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageService.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageService.java
@@ -369,19 +369,18 @@ public class GoogleCloudStorageService {
                     .filter(entry -> entry.getValue().getCredential() != null)
                     .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
 
-                if (allClientSettings.size() != clientSettings.size()) {
-                    logger.warn(
-                        "Project [{}] has [{}] GCS client settings, but [{}] is usable due to missing credentials for clients {}",
-                        project.id(),
-                        allClientSettings.size(),
-                        clientSettings.size(),
-                        Sets.difference(allClientSettings.keySet(), clientSettings.keySet())
-                    );
-                }
-
                 // TODO: If performance is an issue, we may consider comparing just the relevant project secrets for new or updated clients
                 // and avoid building the clientSettings
                 if (newOrUpdated(project.id(), clientSettings)) {
+                    if (allClientSettings.size() != clientSettings.size()) {
+                        logger.warn(
+                            "Project [{}] has [{}] GCS client settings, but [{}] is usable due to missing credentials for clients {}",
+                            project.id(),
+                            allClientSettings.size(),
+                            clientSettings.size(),
+                            Sets.difference(allClientSettings.keySet(), clientSettings.keySet())
+                        );
+                    }
                     updatedPerProjectClients.put(project.id(), new PerProjectClientsHolder(clientSettings));
                 }
             }

--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageService.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageService.java
@@ -364,24 +364,24 @@ public class GoogleCloudStorageService {
                 // Skip project clients that have no credentials configured. This should not happen in serverless.
                 // But it is safer to skip them and is also a more consistent behaviour with the cases when
                 // project secrets are not present.
-                final var clientSettings = allClientSettings.entrySet()
+                final var clientSettingsWithCredentials = allClientSettings.entrySet()
                     .stream()
                     .filter(entry -> entry.getValue().getCredential() != null)
                     .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
 
                 // TODO: If performance is an issue, we may consider comparing just the relevant project secrets for new or updated clients
                 // and avoid building the clientSettings
-                if (newOrUpdated(project.id(), clientSettings)) {
-                    if (allClientSettings.size() != clientSettings.size()) {
+                if (newOrUpdated(project.id(), clientSettingsWithCredentials)) {
+                    if (allClientSettings.size() != clientSettingsWithCredentials.size()) {
                         logger.warn(
                             "Project [{}] has [{}] GCS client settings, but [{}] is usable due to missing credentials for clients {}",
                             project.id(),
                             allClientSettings.size(),
-                            clientSettings.size(),
-                            Sets.difference(allClientSettings.keySet(), clientSettings.keySet())
+                            clientSettingsWithCredentials.size(),
+                            Sets.difference(allClientSettings.keySet(), clientSettingsWithCredentials.keySet())
                         );
                     }
-                    updatedPerProjectClients.put(project.id(), new PerProjectClientsHolder(clientSettings));
+                    updatedPerProjectClients.put(project.id(), new PerProjectClientsHolder(clientSettingsWithCredentials));
                 }
             }
 


### PR DESCRIPTION
Log a message only when the client settings have actual changes.

Relates: #131899
