### PR TITLE
Move ClusterApplierService assertion after logging exception

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplierService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplierService.java
@@ -469,9 +469,6 @@ public class ClusterApplierService extends AbstractLifecycleComponent implements
                 );
                 warnAboutSlowTaskIfNeeded(executionTime, source, stopWatch);
             } catch (Exception e) {
-                // failing to apply a cluster state with an exception indicates a bug in validation or in one of the appliers; if we
-                // continue we will retry with the same cluster state but that might not help.
-                assert applicationMayFail();
                 timedListener.onFailure(e);
                 TimeValue executionTime = getTimeSince(startTimeMillis);
                 if (logger.isTraceEnabled()) {
@@ -492,6 +489,9 @@ public class ClusterApplierService extends AbstractLifecycleComponent implements
                         e
                     );
                 }
+                // failing to apply a cluster state with an exception indicates a bug in validation or in one of the appliers; if we
+                // continue we will retry with the same cluster state but that might not help.
+                assert applicationMayFail();
             } finally {
                 clearIsApplyingClusterState();
             }


### PR DESCRIPTION
#120087 moved the assertion to the beginning of the catch block, before the warning log message.
To ease future development, this PR moves the assertion back, so the warning will be available in the logs if a dev unexpectedly runs into this assertion.
