### PR TITLE
[DiskBBQ] Write the maximum posting list size to avoid resizing the docId array

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/DefaultIVFVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/DefaultIVFVectorsReader.java
@@ -369,7 +369,7 @@ public class DefaultIVFVectorsReader extends IVFVectorsReader implements OffHeap
             centroidDp = Float.intBitsToFloat(indexInput.readInt());
             vectors = indexInput.readVInt();
             // read the doc ids
-            assert vectors < docIdsScratch.length;
+            assert vectors <= docIdsScratch.length;
             docIdsWriter.readInts(indexInput, vectors, docIdsScratch);
             slicePos = indexInput.getFilePointer();
             return vectors;

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/DefaultIVFVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/DefaultIVFVectorsReader.java
@@ -297,7 +297,8 @@ public class DefaultIVFVectorsReader extends IVFVectorsReader implements OffHeap
     PostingVisitor getPostingVisitor(FieldInfo fieldInfo, IndexInput indexInput, float[] target, IntPredicate needsScoring)
         throws IOException {
         FieldEntry entry = fields.get(fieldInfo.number);
-        return new MemorySegmentPostingsVisitor(target, indexInput.clone(), entry, fieldInfo, needsScoring);
+        final int maxPostingListSize = indexInput.readVInt();
+        return new MemorySegmentPostingsVisitor(target, indexInput, entry, fieldInfo, maxPostingListSize, needsScoring);
     }
 
     @Override
@@ -318,8 +319,8 @@ public class DefaultIVFVectorsReader extends IVFVectorsReader implements OffHeap
         final float[] correctionsUpper = new float[BULK_SIZE];
         final int[] correctionsSum = new int[BULK_SIZE];
         final float[] correctionsAdd = new float[BULK_SIZE];
+        final int[] docIdsScratch;
 
-        int[] docIdsScratch = new int[0];
         int vectors;
         boolean quantized = false;
         float centroidDp;
@@ -340,6 +341,7 @@ public class DefaultIVFVectorsReader extends IVFVectorsReader implements OffHeap
             IndexInput indexInput,
             FieldEntry entry,
             FieldInfo fieldInfo,
+            int maxPostingListSize,
             IntPredicate needsScoring
         ) throws IOException {
             this.target = target;
@@ -356,6 +358,7 @@ public class DefaultIVFVectorsReader extends IVFVectorsReader implements OffHeap
             quantizedVectorByteSize = (discretizedDimensions / 8);
             quantizer = new OptimizedScalarQuantizer(fieldInfo.getVectorSimilarityFunction(), DEFAULT_LAMBDA, 1);
             osqVectorsScorer = ESVectorUtil.getES91OSQVectorsScorer(indexInput, fieldInfo.getVectorDimension());
+            this.docIdsScratch = new int[maxPostingListSize];
         }
 
         @Override
@@ -366,7 +369,7 @@ public class DefaultIVFVectorsReader extends IVFVectorsReader implements OffHeap
             centroidDp = Float.intBitsToFloat(indexInput.readInt());
             vectors = indexInput.readVInt();
             // read the doc ids
-            docIdsScratch = vectors > docIdsScratch.length ? new int[vectors] : docIdsScratch;
+            assert vectors < docIdsScratch.length;
             docIdsWriter.readInts(indexInput, vectors, docIdsScratch);
             slicePos = indexInput.getFilePointer();
             return vectors;


### PR DESCRIPTION
Instead of maybe resizing the docId array for every posting list, we should store the maximum posting list size and use that to size the array.  

This commit writes this info at the beginning of the posting lists. In order to read it, we will need to slice the posting lists the same way we are doing with the centroids, which means we need to add a postingListOffset and postingListSize to the meta file. I like this approach better for the symmetry with the centroids file.