### PR TITLE
Clarify quantization on semantic_text BBQ dense vector default

### DIFF
--- a/docs/reference/elasticsearch/mapping-reference/semantic-text.md
+++ b/docs/reference/elasticsearch/mapping-reference/semantic-text.md
@@ -35,7 +35,7 @@ the embedding generation, indexing, and query to use.
 
 {applies_to}`stack: ga 9.1`  Newly created indices with `semantic_text` fields using dense embeddings will be
 [quantized](/reference/elasticsearch/mapping-reference/dense-vector.md#dense-vector-quantization)
-to `bbq_hnsw` automatically.
+to `bbq_hnsw` automatically as long as they have a minimum of 64 dimensions.
 
 ## Default and custom endpoints
 


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/126629 sets the default quantization in `semantic_text` fields to `bbq_hnsw` for all compatible models. In practice this is 64 dimensions. This change clarifies this in our documentation. 