### PR TITLE
Add _data_stream metadata to SearchHit for _search response

### DIFF
--- a/docs/changelog/132476.yaml
+++ b/docs/changelog/132476.yaml
@@ -1,0 +1,5 @@
+pr: 132476
+summary: Add `_data_stream` metadata to `SearchHit` for `_search` response
+area: Data streams
+type: feature
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
@@ -100,7 +100,7 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
     public static final DateFormatter DATE_FORMATTER = DateFormatter.forPattern("uuuu.MM.dd");
     public static final String TIMESTAMP_FIELD_NAME = "@timestamp";
     public static final Pattern DS_BACKING_PATTERN = Pattern.compile(
-        "^(.*?" + BACKING_INDEX_PREFIX + ")(.+)-(\\d{4}.\\d{2}.\\d{2})(-[\\d]+)?$"
+        "^(.*?" + BACKING_INDEX_PREFIX + ")(.+)-(\\d{4}.\\d{2}.\\d{2})(-[\\d]+)$"
     );
 
     // Timeseries indices' leaf readers should be sorted by desc order of their timestamp field, as it allows search time optimizations

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTests.java
@@ -2715,6 +2715,36 @@ public class DataStreamTests extends AbstractXContentSerializingTestCase<DataStr
         assertThat(dataStream.getEffectiveIndexTemplate(projectMetadataBuilder.build()), equalTo(expectedEffectiveTemplate));
     }
 
+    public void testGetDataStreamNameFromValidBackingIndex() {
+        // Test a valid backing index name with correct format: .ds-<data-stream>-<yyyy.MM.dd>-<generation>
+        String indexName = ".ds-my-service-logs-2024.02.05-000001";
+        String dataStreamName = DataStream.getDataStreamNameFromIndex(indexName);
+
+        assertEquals("my-service-logs", dataStreamName);
+    }
+
+    public void testGetDataStreamNameFromInvalidBackingIndex() {
+        // Test cases that should not be recognized as valid backing indices
+        String[] invalidNames = {
+            "not-a-backing-index", // No .ds- prefix
+            ".ds-", // Missing data stream name
+            ".ds-logs", // Missing date and generation
+            ".ds-logs-2024.02.05", // Missing generation
+        };
+
+        for (String invalidName : invalidNames) {
+            assertNull(
+                "Should return null for invalid backing index name: " + invalidName,
+                DataStream.getDataStreamNameFromIndex(invalidName)
+            );
+        }
+    }
+
+    public void testGetDataStreamNameFromNullIndex() {
+        // should return null given null index name
+        assertNull(DataStream.getDataStreamNameFromIndex(null));
+    }
+
     private static CompressedXContent randomMappings() {
         try {
             return new CompressedXContent("{\"_doc\": {\"properties\":{\"" + randomAlphaOfLength(5) + "\":{\"type\":\"keyword\"}}}}");

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTests.java
@@ -2715,12 +2715,19 @@ public class DataStreamTests extends AbstractXContentSerializingTestCase<DataStr
         assertThat(dataStream.getEffectiveIndexTemplate(projectMetadataBuilder.build()), equalTo(expectedEffectiveTemplate));
     }
 
-    public void testGetDataStreamNameFromValidBackingIndex() {
+    public void testGetDataStreamNameFromValidBackingIndices() {
         // Test a valid backing index name with correct format: .ds-<data-stream>-<yyyy.MM.dd>-<generation>
         String indexName = ".ds-my-service-logs-2024.02.05-000001";
         String dataStreamName = DataStream.getDataStreamNameFromIndex(indexName);
 
         assertEquals("my-service-logs", dataStreamName);
+
+        // Test valid backing index with extra '-' dash in the name
+        indexName = ".ds-my-service-logs-two-2024.02.05-000001";
+        dataStreamName = DataStream.getDataStreamNameFromIndex(indexName);
+
+        assertEquals("my-service-logs-two", dataStreamName);
+
     }
 
     public void testGetDataStreamNameFromInvalidBackingIndex() {
@@ -2728,8 +2735,8 @@ public class DataStreamTests extends AbstractXContentSerializingTestCase<DataStr
         String[] invalidNames = {
             "not-a-backing-index", // No .ds- prefix
             ".ds-", // Missing data stream name
-            ".ds-logs", // Missing date and generation
-            ".ds-logs-2024.02.05", // Missing generation
+            ".ds-my-service-logs", // Missing date and generation
+            ".ds-my-service-logs-2024.02.05", // Missing generation
         };
 
         for (String invalidName : invalidNames) {

--- a/server/src/test/java/org/elasticsearch/search/SearchHitTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchHitTests.java
@@ -12,6 +12,7 @@ package org.elasticsearch.search;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -476,4 +477,57 @@ public class SearchHitTests extends AbstractWireSerializingTestCase<SearchHit> {
         }
         return Explanation.match(value, description, details);
     }
+
+    public void testShardTargetSetsDataStreamName() {
+        // Create a SearchHit
+        SearchHit hit = new SearchHit(1);
+
+        // Create a backing index name following the pattern: .ds-<data-stream>-<yyyy.MM.dd>-<generation>
+        String backingIndexName = ".ds-my-service-logs-2024.02.05-000001";
+        String nodeId = "node1";
+        int shardId = 0;
+        String clusterAlias = null;
+
+        // Create SearchShardTarget with the backing index name
+        SearchShardTarget target = new SearchShardTarget(
+            nodeId,
+            new ShardId(new Index(backingIndexName, IndexMetadata.INDEX_UUID_NA_VALUE), shardId),
+            clusterAlias
+        );
+
+        // Set the shard target
+        hit.shard(target);
+
+        // Verify the data-stream field is set correctly
+        assertEquals("my-service-logs", hit.getDataStream());
+        assertEquals(backingIndexName, hit.getIndex());
+        assertNull(hit.getClusterAlias());
+    }
+
+    public void testShardTargetWithNonDataStreamIndex() {
+        // Create a SearchHit
+        SearchHit hit = new SearchHit(1);
+
+        // Create a regular index name (not a backing index)
+        String regularIndexName = "regular-index";
+        String nodeId = "node1";
+        int shardId = 0;
+        String clusterAlias = null;
+
+        // Create SearchShardTarget with a non-data-stream-backed index name
+        SearchShardTarget target = new SearchShardTarget(
+            nodeId,
+            new ShardId(new Index(regularIndexName, IndexMetadata.INDEX_UUID_NA_VALUE), shardId),
+            clusterAlias
+        );
+
+        // Set the shard target
+        hit.shard(target);
+
+        // Verify the data-stream field is null for non-backing indices
+        assertNull(hit.getDataStream());
+        assertEquals(regularIndexName, hit.getIndex());
+        assertNull(hit.getClusterAlias());
+    }
+
 }

--- a/server/src/test/java/org/elasticsearch/search/SearchHitTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchHitTests.java
@@ -482,52 +482,60 @@ public class SearchHitTests extends AbstractWireSerializingTestCase<SearchHit> {
         // Create a SearchHit
         SearchHit hit = new SearchHit(1);
 
-        // Create a backing index name following the pattern: .ds-<data-stream>-<yyyy.MM.dd>-<generation>
-        String backingIndexName = ".ds-my-service-logs-2024.02.05-000001";
-        String nodeId = "node1";
-        int shardId = 0;
-        String clusterAlias = null;
+        try {
+            // Create a backing index name following the pattern: .ds-<data-stream>-<yyyy.MM.dd>-<generation>
+            String backingIndexName = ".ds-my-service-logs-2024.02.05-000001";
+            String nodeId = "node1";
+            int shardId = 0;
+            String clusterAlias = null;
 
-        // Create SearchShardTarget with the backing index name
-        SearchShardTarget target = new SearchShardTarget(
-            nodeId,
-            new ShardId(new Index(backingIndexName, IndexMetadata.INDEX_UUID_NA_VALUE), shardId),
-            clusterAlias
-        );
+            // Create SearchShardTarget with the backing index name
+            SearchShardTarget target = new SearchShardTarget(
+                nodeId,
+                new ShardId(new Index(backingIndexName, IndexMetadata.INDEX_UUID_NA_VALUE), shardId),
+                clusterAlias
+            );
 
-        // Set the shard target
-        hit.shard(target);
+            // Set the shard target
+            hit.shard(target);
 
-        // Verify the data-stream field is set correctly
-        assertEquals("my-service-logs", hit.getDataStream());
-        assertEquals(backingIndexName, hit.getIndex());
-        assertNull(hit.getClusterAlias());
+            // Verify the data-stream field is set correctly
+            assertEquals("my-service-logs", hit.getDataStream());
+            assertEquals(backingIndexName, hit.getIndex());
+            assertNull(hit.getClusterAlias());
+        } finally {
+            hit.decRef();
+        }
     }
 
     public void testShardTargetWithNonDataStreamIndex() {
         // Create a SearchHit
         SearchHit hit = new SearchHit(1);
 
-        // Create a regular index name (not a backing index)
-        String regularIndexName = "regular-index";
-        String nodeId = "node1";
-        int shardId = 0;
-        String clusterAlias = null;
+        try {
+            // Create a regular index name (not a backing index)
+            String regularIndexName = "regular-index";
+            String nodeId = "node1";
+            int shardId = 0;
+            String clusterAlias = null;
 
-        // Create SearchShardTarget with a non-data-stream-backed index name
-        SearchShardTarget target = new SearchShardTarget(
-            nodeId,
-            new ShardId(new Index(regularIndexName, IndexMetadata.INDEX_UUID_NA_VALUE), shardId),
-            clusterAlias
-        );
+            // Create SearchShardTarget with a non-data-stream-backed index name
+            SearchShardTarget target = new SearchShardTarget(
+                nodeId,
+                new ShardId(new Index(regularIndexName, IndexMetadata.INDEX_UUID_NA_VALUE), shardId),
+                clusterAlias
+            );
 
-        // Set the shard target
-        hit.shard(target);
+            // Set the shard target
+            hit.shard(target);
 
-        // Verify the data-stream field is null for non-backing indices
-        assertNull(hit.getDataStream());
-        assertEquals(regularIndexName, hit.getIndex());
-        assertNull(hit.getClusterAlias());
+            // Verify the data-stream field is null for non-backing indices
+            assertNull(hit.getDataStream());
+            assertEquals(regularIndexName, hit.getIndex());
+            assertNull(hit.getClusterAlias());
+        } finally {
+            hit.decRef();
+        }
     }
 
 }

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
@@ -64,7 +64,6 @@ import java.util.function.Function;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.core.Strings.format;
@@ -89,10 +88,6 @@ public class AutoFollowCoordinator extends AbstractLifecycleComponent implements
 
     private static final Logger LOGGER = LogManager.getLogger(AutoFollowCoordinator.class);
     private static final int MAX_AUTO_FOLLOW_ERRORS = 256;
-
-    private static final Pattern DS_BACKING_PATTERN = Pattern.compile(
-        "^(.*?" + DataStream.BACKING_INDEX_PREFIX + ")(.+)-(\\d{4}.\\d{2}.\\d{2})(-[\\d]+)?$"
-    );
 
     private final Client client;
     private final ClusterService clusterService;
@@ -852,7 +847,7 @@ public class AutoFollowCoordinator extends AbstractLifecycleComponent implements
                     // follow a parseable pattern. Instead it would be better to rename it as though
                     // the data stream name was the leader index name, ending up with
                     // ".ds-logs-foo-bar_copy-2022-02-02-000001" as the final index name.
-                    Matcher m = DS_BACKING_PATTERN.matcher(leaderIndexName);
+                    Matcher m = DataStream.DS_BACKING_PATTERN.matcher(leaderIndexName);
                     if (m.find()) {
                         return m.group(1) + // Prefix including ".ds-"
                             followPattern.replace(AUTO_FOLLOW_PATTERN_REPLACEMENT, m.group(2)) + // Data stream name changed


### PR DESCRIPTION
Per https://github.com/elastic/elasticsearch/issues/112750 , this PR adds the _data_stream metadata field to the Search Hit class and displays it in the response for _search

e.g.
```
{
    "took": 47,
    "timed_out": false,
    "_shards": {
        "total": 1,
        "successful": 1,
        "skipped": 0,
        "failed": 0
    },
    "hits": {
        "total": {
            "value": 1,
            "relation": "eq"
        },
        "max_score": 1.0,
        "hits": [
            {
                "_index": ".ds-logs-myapp-default-2025.08.05-000001",
                "_data_stream": "logs-myapp-default",
                "_id": "AZh64tcIiR68mRpOTMUC",
                "_score": 1.0,
                "_source": {
                    "@timestamp": "2099-05-06T16:21:15.000Z",
                    "message": "192.0.2.42 -[06/May/2099:16:21:15] \"GET /images/bg.jp..."
                }
            }
        ]
    }
}
```