### PR TITLE
Handle special regex cases for version fields

### DIFF
--- a/docs/changelog/132511.yaml
+++ b/docs/changelog/132511.yaml
@@ -1,0 +1,5 @@
+pr: 132511
+summary: Handle special regex cases for version fields
+area: Search
+type: bug
+issues: []

--- a/x-pack/plugin/mapper-version/src/test/java/org/elasticsearch/xpack/versionfield/VersionStringFieldTests.java
+++ b/x-pack/plugin/mapper-version/src/test/java/org/elasticsearch/xpack/versionfield/VersionStringFieldTests.java
@@ -216,6 +216,35 @@ public class VersionStringFieldTests extends ESSingleNodeTestCase {
                 assertEquals("2.1.0-alpha.beta", response.getHits().getHits()[1].getSourceAsMap().get("version"));
             }
         );
+
+        assertResponse(
+            client().prepareSearch(indexName).setQuery(QueryBuilders.regexpQuery("version", ".*").caseInsensitive(true)),
+            response -> {
+                assertEquals(5, response.getHits().getTotalHits().value());
+            }
+        );
+
+        assertResponse(
+            client().prepareSearch(indexName).setQuery(QueryBuilders.regexpQuery("version", "2\\.1\\.0").caseInsensitive(false)),
+            response -> {
+                assertEquals(1, response.getHits().getTotalHits().value());
+            }
+        );
+
+        assertResponse(
+            client().prepareSearch(indexName).setQuery(QueryBuilders.regexpQuery("version", "2\\.1\\.1").caseInsensitive(false)),
+            response -> {
+                assertEquals(0, response.getHits().getTotalHits().value());
+            }
+        );
+
+        // empty regex should not match anything
+        assertResponse(
+            client().prepareSearch(indexName).setQuery(QueryBuilders.regexpQuery("version", "").caseInsensitive(false)),
+            response -> {
+                assertEquals(0, response.getHits().getTotalHits().value());
+            }
+        );
     }
 
     public void testFuzzyQuery() throws Exception {


### PR DESCRIPTION
It is possible that the runAutomaton created is `null` as its one of the following cases:

 - none: meaning no matches
 - all: meaning all matches
 - single: meaning its just a single term (not actually regex)

Each of these can be handled directly.