### PR TITLE
Improve estimating live docs bytes

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/shard/ShardFieldStats.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/ShardFieldStats.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.index.shard;
 
+import org.apache.lucene.util.FixedBitSet;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.util.FeatureFlag;
 
 /**
@@ -25,5 +27,6 @@ import org.elasticsearch.common.util.FeatureFlag;
 public record ShardFieldStats(int numSegments, int totalFields, long fieldUsages, long postingsInMemoryBytes, long liveDocsBytes) {
 
     public static final FeatureFlag TRACK_LIVE_DOCS_IN_MEMORY_BYTES = new FeatureFlag("track_live_docs_in_memory_bytes");
+    public static final long FIXED_BITSET_BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(FixedBitSet.class);
 
 }

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -27,6 +27,7 @@ import org.apache.lucene.store.FilterDirectory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.Constants;
+import org.apache.lucene.util.FixedBitSet;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
@@ -77,6 +78,7 @@ import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.MergePolicyConfig;
 import org.elasticsearch.index.codec.CodecService;
 import org.elasticsearch.index.codec.TrackingPostingsInMemoryBytesCodec;
 import org.elasticsearch.index.engine.CommitStats;
@@ -1981,7 +1983,10 @@ public class IndexShardTests extends IndexShardTestCase {
     }
 
     public void testShardFieldStatsWithDeletes() throws IOException {
-        Settings settings = Settings.builder().put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), TimeValue.MINUS_ONE).build();
+        Settings settings = Settings.builder()
+            .put(MergePolicyConfig.INDEX_MERGE_ENABLED, false)
+            .put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), TimeValue.MINUS_ONE)
+            .build();
         IndexShard shard = newShard(true, settings);
         assertNull(shard.getShardFieldStats());
         recoverShardFromStore(shard);
@@ -2010,8 +2015,14 @@ public class IndexShardTests extends IndexShardTestCase {
         stats = shard.getShardFieldStats();
         // More segments because delete operation is stored in the new segment for replication purposes.
         assertThat(stats.numSegments(), equalTo(2));
-        // Delete op is stored in new segment, but marked as deleted. All segements have live docs:
-        assertThat(stats.liveDocsBytes(), equalTo(liveDocsTrackingEnabled ? 40L : 0L));
+        long expectedLiveDocsSize = 0;
+        if (liveDocsTrackingEnabled) {
+            // Delete op is stored in new segment, but marked as deleted. All segements have live docs:
+            expectedLiveDocsSize += new FixedBitSet(numDocs).ramBytesUsed();
+            // Second segment the delete operation that is marked as deleted:
+            expectedLiveDocsSize += new FixedBitSet(1).ramBytesUsed();
+        }
+        assertThat(stats.liveDocsBytes(), equalTo(expectedLiveDocsSize));
 
         // delete another doc:
         deleteDoc(shard, "first_1");
@@ -2022,8 +2033,16 @@ public class IndexShardTests extends IndexShardTestCase {
         stats = shard.getShardFieldStats();
         // More segments because delete operation is stored in the new segment for replication purposes.
         assertThat(stats.numSegments(), equalTo(3));
-        // Delete op is stored in new segment, but marked as deleted. All segements have live docs:
-        assertThat(stats.liveDocsBytes(), equalTo(liveDocsTrackingEnabled ? 56L : 0L));
+        expectedLiveDocsSize = 0;
+        if (liveDocsTrackingEnabled) {
+            // Delete op is stored in new segment, but marked as deleted. All segements have live docs:
+            // First segment with deletes
+            expectedLiveDocsSize += new FixedBitSet(numDocs).ramBytesUsed();
+            // Second and third segments the delete operation that is marked as deleted:
+            expectedLiveDocsSize += new FixedBitSet(1).ramBytesUsed();
+            expectedLiveDocsSize += new FixedBitSet(1).ramBytesUsed();
+        }
+        assertThat(stats.liveDocsBytes(), equalTo(expectedLiveDocsSize));
 
         closeShards(shard);
     }


### PR DESCRIPTION
By simulating what `FixedBitSet` exactly does.
This also improves testing because we can compare against `FixedBitSet#ramBytesUsed()`.

Follow up from #132232