### PR TITLE
[9.1] [EIS] Rename the elser 2 default model and the default inference endpoint (#130336)

### DIFF
--- a/docs/changelog/130336.yaml
+++ b/docs/changelog/130336.yaml
@@ -1,0 +1,5 @@
+pr: 130336
+summary: "[EIS] Rename the elser 2 default model and the default inference endpoint"
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceGetModelsWithElasticInferenceServiceIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceGetModelsWithElasticInferenceServiceIT.java
@@ -41,7 +41,7 @@ public class InferenceGetModelsWithElasticInferenceServiceIT extends BaseMockEIS
         }
 
         assertInferenceIdTaskType(allModels, ".rainbow-sprinkles-elastic", TaskType.CHAT_COMPLETION);
-        assertInferenceIdTaskType(allModels, ".elser-v2-elastic", TaskType.SPARSE_EMBEDDING);
+        assertInferenceIdTaskType(allModels, ".elser-2-elastic", TaskType.SPARSE_EMBEDDING);
         assertInferenceIdTaskType(allModels, ".multilingual-embed-v1-elastic", TaskType.TEXT_EMBEDDING);
         assertInferenceIdTaskType(allModels, ".rerank-v1-elastic", TaskType.RERANK);
     }

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/MockElasticInferenceServiceAuthorizationServer.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/MockElasticInferenceServiceAuthorizationServer.java
@@ -39,7 +39,7 @@ public class MockElasticInferenceServiceAuthorizationServer implements TestRule 
                       "task_types": ["chat"]
                     },
                     {
-                      "model_name": "elser-v2",
+                      "model_name": "elser_model_2",
                       "task_types": ["embed/text/sparse"]
                     },
                     {

--- a/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/InferenceRevokeDefaultEndpointsIT.java
+++ b/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/InferenceRevokeDefaultEndpointsIT.java
@@ -195,7 +195,7 @@ public class InferenceRevokeDefaultEndpointsIT extends ESSingleNodeTestCase {
                 {
                     "models": [
                         {
-                          "model_name": "elser-v2",
+                          "model_name": "elser_model_2",
                           "task_types": ["embed/text/sparse"]
                         },
                         {
@@ -224,7 +224,7 @@ public class InferenceRevokeDefaultEndpointsIT extends ESSingleNodeTestCase {
                     service.defaultConfigIds(),
                     containsInAnyOrder(
                         new InferenceService.DefaultConfigId(
-                            ".elser-v2-elastic",
+                            ".elser-2-elastic",
                             MinimalServiceSettings.sparseEmbedding(ElasticInferenceService.NAME),
                             service
                         ),
@@ -257,7 +257,7 @@ public class InferenceRevokeDefaultEndpointsIT extends ESSingleNodeTestCase {
 
                 PlainActionFuture<List<Model>> listener = new PlainActionFuture<>();
                 service.defaultConfigs(listener);
-                assertThat(listener.actionGet(TIMEOUT).get(0).getConfigurations().getInferenceEntityId(), is(".elser-v2-elastic"));
+                assertThat(listener.actionGet(TIMEOUT).get(0).getConfigurations().getInferenceEntityId(), is(".elser-2-elastic"));
                 assertThat(
                     listener.actionGet(TIMEOUT).get(1).getConfigurations().getInferenceEntityId(),
                     is(".multilingual-embed-v1-elastic")
@@ -279,7 +279,7 @@ public class InferenceRevokeDefaultEndpointsIT extends ESSingleNodeTestCase {
                 {
                     "models": [
                         {
-                          "model_name": "elser-v2",
+                          "model_name": "elser_model_2",
                           "task_types": ["embed/text/sparse"]
                         },
                         {
@@ -304,7 +304,7 @@ public class InferenceRevokeDefaultEndpointsIT extends ESSingleNodeTestCase {
                     service.defaultConfigIds(),
                     containsInAnyOrder(
                         new InferenceService.DefaultConfigId(
-                            ".elser-v2-elastic",
+                            ".elser-2-elastic",
                             MinimalServiceSettings.sparseEmbedding(ElasticInferenceService.NAME),
                             service
                         ),

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceService.java
@@ -106,9 +106,9 @@ public class ElasticInferenceService extends SenderService {
     static final String DEFAULT_CHAT_COMPLETION_MODEL_ID_V1 = "rainbow-sprinkles";
     static final String DEFAULT_CHAT_COMPLETION_ENDPOINT_ID_V1 = defaultEndpointId(DEFAULT_CHAT_COMPLETION_MODEL_ID_V1);
 
-    // elser-v2
-    static final String DEFAULT_ELSER_MODEL_ID_V2 = "elser-v2";
-    static final String DEFAULT_ELSER_ENDPOINT_ID_V2 = defaultEndpointId(DEFAULT_ELSER_MODEL_ID_V2);
+    // elser-2
+    static final String DEFAULT_ELSER_2_MODEL_ID = "elser_model_2";
+    static final String DEFAULT_ELSER_ENDPOINT_ID_V2 = defaultEndpointId("elser-2");
 
     // multilingual-text-embed
     static final String DEFAULT_MULTILINGUAL_EMBED_MODEL_ID = "multilingual-embed-v1";
@@ -174,13 +174,13 @@ public class ElasticInferenceService extends SenderService {
                 ),
                 MinimalServiceSettings.chatCompletion(NAME)
             ),
-            DEFAULT_ELSER_MODEL_ID_V2,
+            DEFAULT_ELSER_2_MODEL_ID,
             new DefaultModelConfig(
                 new ElasticInferenceServiceSparseEmbeddingsModel(
                     DEFAULT_ELSER_ENDPOINT_ID_V2,
                     TaskType.SPARSE_EMBEDDING,
                     NAME,
-                    new ElasticInferenceServiceSparseEmbeddingsServiceSettings(DEFAULT_ELSER_MODEL_ID_V2, null, null),
+                    new ElasticInferenceServiceSparseEmbeddingsServiceSettings(DEFAULT_ELSER_2_MODEL_ID, null, null),
                     EmptyTaskSettings.INSTANCE,
                     EmptySecretSettings.INSTANCE,
                     elasticInferenceServiceComponents,
@@ -213,7 +213,6 @@ public class ElasticInferenceService extends SenderService {
                     DenseVectorFieldMapper.ElementType.FLOAT
                 )
             ),
-
             DEFAULT_RERANK_MODEL_ID_V1,
             new DefaultModelConfig(
                 new ElasticInferenceServiceRerankModel(

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElserModels.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElserModels.java
@@ -26,8 +26,4 @@ public class ElserModels {
         return model != null && VALID_ELSER_MODEL_IDS.contains(model);
     }
 
-    public static boolean isValidEisModel(String model) {
-        return ELSER_V2_MODEL.equals(model);
-    }
-
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
@@ -1243,7 +1243,7 @@ public class ElasticInferenceServiceTests extends ESSingleNodeTestCase {
                       "task_types": ["chat"]
                     },
                     {
-                      "model_name": "elser-v2",
+                      "model_name": "elser_model_2",
                       "task_types": ["embed/text/sparse"]
                     },
                     {
@@ -1270,7 +1270,7 @@ public class ElasticInferenceServiceTests extends ESSingleNodeTestCase {
                 is(
                     List.of(
                         new InferenceService.DefaultConfigId(
-                            ".elser-v2-elastic",
+                            ".elser-2-elastic",
                             MinimalServiceSettings.sparseEmbedding(ElasticInferenceService.NAME),
                             service
                         ),
@@ -1306,7 +1306,7 @@ public class ElasticInferenceServiceTests extends ESSingleNodeTestCase {
             service.defaultConfigs(listener);
             var models = listener.actionGet(TIMEOUT);
             assertThat(models.size(), is(4));
-            assertThat(models.get(0).getConfigurations().getInferenceEntityId(), is(".elser-v2-elastic"));
+            assertThat(models.get(0).getConfigurations().getInferenceEntityId(), is(".elser-2-elastic"));
             assertThat(models.get(1).getConfigurations().getInferenceEntityId(), is(".multilingual-embed-v1-elastic"));
             assertThat(models.get(2).getConfigurations().getInferenceEntityId(), is(".rainbow-sprinkles-elastic"));
             assertThat(models.get(3).getConfigurations().getInferenceEntityId(), is(".rerank-v1-elastic"));

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/authorization/ElasticInferenceServiceAuthorizationHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/authorization/ElasticInferenceServiceAuthorizationHandlerTests.java
@@ -188,13 +188,13 @@ public class ElasticInferenceServiceAuthorizationHandlerTests extends ESSingleNo
                 ),
                 MinimalServiceSettings.chatCompletion(ElasticInferenceService.NAME)
             ),
-            "elser-v2",
+            "elser-2",
             new DefaultModelConfig(
                 new ElasticInferenceServiceSparseEmbeddingsModel(
-                    defaultEndpointId("elser-v2"),
+                    defaultEndpointId("elser-2"),
                     TaskType.SPARSE_EMBEDDING,
                     "test",
-                    new ElasticInferenceServiceSparseEmbeddingsServiceSettings("elser-v2", null, null),
+                    new ElasticInferenceServiceSparseEmbeddingsServiceSettings("elser-2", null, null),
                     EmptyTaskSettings.INSTANCE,
                     EmptySecretSettings.INSTANCE,
                     ElasticInferenceServiceComponents.EMPTY_INSTANCE,

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElserModelsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElserModelsTests.java
@@ -19,21 +19,7 @@ public class ElserModelsTests extends ESTestCase {
         assertTrue(org.elasticsearch.xpack.inference.services.elasticsearch.ElserModels.isValidModel(randomElserModel()));
     }
 
-    public void testIsValidEisModel() {
-        assertTrue(
-            org.elasticsearch.xpack.inference.services.elasticsearch.ElserModels.isValidEisModel(
-                org.elasticsearch.xpack.inference.services.elasticsearch.ElserModels.ELSER_V2_MODEL
-            )
-        );
-    }
-
     public void testIsInvalidModel() {
         assertFalse(org.elasticsearch.xpack.inference.services.elasticsearch.ElserModels.isValidModel("invalid"));
-    }
-
-    public void testIsInvalidEisModel() {
-        assertFalse(
-            org.elasticsearch.xpack.inference.services.elasticsearch.ElserModels.isValidEisModel(ElserModels.ELSER_V2_MODEL_LINUX_X86)
-        );
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[EIS] Rename the elser 2 default model and the default inference endpoint (#130336)](https://github.com/elastic/elasticsearch/pull/130336)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)