### PR TITLE
KnnIndexer: update index count to not appear as if it has indexed more docs than it has

### DIFF
--- a/qa/vector/src/main/java/org/elasticsearch/test/knn/KnnIndexer.java
+++ b/qa/vector/src/main/java/org/elasticsearch/test/knn/KnnIndexer.java
@@ -280,9 +280,11 @@ class KnnIndexer {
 
         private void _run() throws IOException {
             while (true) {
-                int id = numDocsIndexed.getAndIncrement();
-                if (id >= numDocsToIndex) {
+                int id = numDocsIndexed.get();
+                if (id == numDocsToIndex) {
                     break;
+                } else if (numDocsIndexed.compareAndSet(id, id + 1) == false) {
+                    continue;
                 }
 
                 Document doc = new Document();


### PR DESCRIPTION
Currently each index thread updates the number of docs indexed before checking the configured number of docs to index, but can lead to an impression that more docs have been indexed than requested. The solution is to only update when there is head room.