### PR TITLE
Make KnnIndexTester option parser strict

### DIFF
--- a/qa/vector/src/main/java/org/elasticsearch/test/knn/CmdLineArgs.java
+++ b/qa/vector/src/main/java/org/elasticsearch/test/knn/CmdLineArgs.java
@@ -87,7 +87,7 @@ record CmdLineArgs(
         return builder.build();
     }
 
-    static final ObjectParser<CmdLineArgs.Builder, Void> PARSER = new ObjectParser<>("cmd_line_args", true, Builder::new);
+    static final ObjectParser<CmdLineArgs.Builder, Void> PARSER = new ObjectParser<>("cmd_line_args", false, Builder::new);
 
     static {
         PARSER.declareStringArray(Builder::setDocVectors, DOC_VECTORS_FIELD);


### PR DESCRIPTION
This commit changes the option parser to be strict - it will bork on unknown options (and even suggest an alternative). I'm suggesting this change as I fat fingered an option that took some time to determine why the recall was terrible!