### PR TITLE
Add the current count of vectors in a cluster in hierarchical k-means

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/CentroidAssignments.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/CentroidAssignments.java
@@ -9,11 +9,18 @@
 
 package org.elasticsearch.index.codec.vectors;
 
-record CentroidAssignments(int numCentroids, float[][] centroids, int[] assignments, int[] overspillAssignments) {
+record CentroidAssignments(
+    int numCentroids,
+    float[][] centroids,
+    int[] assignments,
+    int[] overspillAssignments,
+    int[] centroidVectorCount
+) {
 
-    CentroidAssignments(float[][] centroids, int[] assignments, int[] overspillAssignments) {
-        this(centroids.length, centroids, assignments, overspillAssignments);
+    CentroidAssignments(float[][] centroids, int[] assignments, int[] overspillAssignments, int[] centroidVectorCount) {
+        this(centroids.length, centroids, assignments, overspillAssignments, centroidVectorCount);
         assert assignments.length == overspillAssignments.length || overspillAssignments.length == 0
             : "assignments and overspillAssignments must have the same length";
+        assert centroids.length == centroidVectorCount.length : "centroids and counts must have the same length";
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/DefaultIVFVectorsWriter.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/DefaultIVFVectorsWriter.java
@@ -66,16 +66,9 @@ public class DefaultIVFVectorsWriter extends IVFVectorsWriter {
         IndexOutput postingsOutput,
         long fileOffset,
         int[] assignments,
-        int[] overspillAssignments
+        int[] overspillAssignments,
+        int[] centroidVectorCount
     ) throws IOException {
-        int[] centroidVectorCount = new int[centroidSupplier.size()];
-        for (int i = 0; i < assignments.length; i++) {
-            centroidVectorCount[assignments[i]]++;
-            // if soar assignments are present, count them as well
-            if (overspillAssignments.length > i && overspillAssignments[i] != -1) {
-                centroidVectorCount[overspillAssignments[i]]++;
-            }
-        }
 
         int maxPostingListSize = 0;
         int[][] assignmentsByCluster = new int[centroidSupplier.size()][];
@@ -146,7 +139,8 @@ public class DefaultIVFVectorsWriter extends IVFVectorsWriter {
         long fileOffset,
         MergeState mergeState,
         int[] assignments,
-        int[] overspillAssignments
+        int[] overspillAssignments,
+        int[] centroidVectorCount
     ) throws IOException {
         // first, quantize all the vectors into a temporary file
         String quantizedVectorsTempName = null;
@@ -192,14 +186,6 @@ public class DefaultIVFVectorsWriter extends IVFVectorsWriter {
         } finally {
             if (success == false && quantizedVectorsTemp != null) {
                 mergeState.segmentInfo.dir.deleteFile(quantizedVectorsTemp.getName());
-            }
-        }
-        int[] centroidVectorCount = new int[centroidSupplier.size()];
-        for (int i = 0; i < assignments.length; i++) {
-            centroidVectorCount[assignments[i]]++;
-            // if soar assignments are present, count them as well
-            if (overspillAssignments.length > i && overspillAssignments[i] != -1) {
-                centroidVectorCount[overspillAssignments[i]]++;
             }
         }
 
@@ -423,10 +409,7 @@ public class DefaultIVFVectorsWriter extends IVFVectorsWriter {
             HierarchicalKMeans.MAXK,
             -1 // disable SOAR assignments
         ).cluster(floatVectorValues, centroidsPerParentCluster);
-        final int[] centroidVectorCount = new int[kMeansResult.centroids().length];
-        for (int i = 0; i < kMeansResult.assignments().length; i++) {
-            centroidVectorCount[kMeansResult.assignments()[i]]++;
-        }
+        final int[] centroidVectorCount = kMeansResult.centroidCounts();
         final int[][] vectorsPerCentroid = new int[kMeansResult.centroids().length][];
         int maxVectorsPerCentroidLength = 0;
         for (int i = 0; i < kMeansResult.centroids().length; i++) {
@@ -481,10 +464,12 @@ public class DefaultIVFVectorsWriter extends IVFVectorsWriter {
 
     static CentroidAssignments buildCentroidAssignments(FloatVectorValues floatVectorValues, int vectorPerCluster) throws IOException {
         KMeansResult kMeansResult = new HierarchicalKMeans(floatVectorValues.dimension()).cluster(floatVectorValues, vectorPerCluster);
-        float[][] centroids = kMeansResult.centroids();
-        int[] assignments = kMeansResult.assignments();
-        int[] soarAssignments = kMeansResult.soarAssignments();
-        return new CentroidAssignments(centroids, assignments, soarAssignments);
+        return new CentroidAssignments(
+            kMeansResult.centroids(),
+            kMeansResult.assignments(),
+            kMeansResult.soarAssignments(),
+            kMeansResult.centroidCounts()
+        );
     }
 
     static void writeQuantizedValue(IndexOutput indexOutput, byte[] binaryValue, OptimizedScalarQuantizer.QuantizationResult corrections)

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/IVFVectorsWriter.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/IVFVectorsWriter.java
@@ -138,7 +138,8 @@ public abstract class IVFVectorsWriter extends KnnVectorsWriter {
         IndexOutput postingsOutput,
         long fileOffset,
         int[] assignments,
-        int[] overspillAssignments
+        int[] overspillAssignments,
+        int[] centroidVectorCount
     ) throws IOException;
 
     abstract LongValues buildAndWritePostingsLists(
@@ -149,7 +150,8 @@ public abstract class IVFVectorsWriter extends KnnVectorsWriter {
         long fileOffset,
         MergeState mergeState,
         int[] assignments,
-        int[] overspillAssignments
+        int[] overspillAssignments,
+        int[] centroidVectorCount
     ) throws IOException;
 
     abstract CentroidSupplier createCentroidSupplier(
@@ -179,7 +181,8 @@ public abstract class IVFVectorsWriter extends KnnVectorsWriter {
                 ivfClusters,
                 postingListOffset,
                 centroidAssignments.assignments(),
-                centroidAssignments.overspillAssignments()
+                centroidAssignments.overspillAssignments(),
+                centroidAssignments.centroidVectorCount()
             );
             final long postingListLength = ivfClusters.getFilePointer() - postingListOffset;
             // write centroids
@@ -306,6 +309,7 @@ public abstract class IVFVectorsWriter extends KnnVectorsWriter {
             final int numCentroids;
             final int[] assignments;
             final int[] overspillAssignments;
+            final int[] centroidVectorCount;
             final float[] calculatedGlobalCentroid = new float[fieldInfo.getVectorDimension()];
             String centroidTempName = null;
             IndexOutput centroidTemp = null;
@@ -327,6 +331,7 @@ public abstract class IVFVectorsWriter extends KnnVectorsWriter {
                 numCentroids = centroidAssignments.numCentroids();
                 assignments = centroidAssignments.assignments();
                 overspillAssignments = centroidAssignments.overspillAssignments();
+                centroidVectorCount = centroidAssignments.centroidVectorCount();
                 success = true;
             } finally {
                 if (success == false && centroidTempName != null) {
@@ -362,7 +367,8 @@ public abstract class IVFVectorsWriter extends KnnVectorsWriter {
                         postingListOffset,
                         mergeState,
                         assignments,
-                        overspillAssignments
+                        overspillAssignments,
+                        centroidVectorCount
                     );
                     postingListLength = ivfClusters.getFilePointer() - postingListOffset;
                     // write centroids

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/KMeansIntermediate.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/KMeansIntermediate.java
@@ -17,22 +17,28 @@ import org.apache.lucene.util.hnsw.IntToIntFunction;
 class KMeansIntermediate extends KMeansResult {
     private final IntToIntFunction assignmentOrds;
 
-    private KMeansIntermediate(float[][] centroids, int[] assignments, IntToIntFunction assignmentOrds, int[] soarAssignments) {
-        super(centroids, assignments, soarAssignments);
+    private KMeansIntermediate(
+        float[][] centroids,
+        int[] assignments,
+        int[] counts,
+        IntToIntFunction assignmentOrds,
+        int[] soarAssignments
+    ) {
+        super(centroids, assignments, soarAssignments, counts);
         assert assignmentOrds != null;
         this.assignmentOrds = assignmentOrds;
     }
 
-    KMeansIntermediate(float[][] centroids, int[] assignments, IntToIntFunction assignmentOrdinals) {
-        this(centroids, assignments, assignmentOrdinals, new int[0]);
+    KMeansIntermediate(float[][] centroids, int[] assignments, int[] counts, IntToIntFunction assignmentOrdinals) {
+        this(centroids, assignments, counts, assignmentOrdinals, new int[0]);
     }
 
     KMeansIntermediate() {
-        this(new float[0][0], new int[0], i -> i, new int[0]);
+        this(new float[0][0], new int[0], new int[0], i -> i, new int[0]);
     }
 
-    KMeansIntermediate(float[][] centroids, int[] assignments) {
-        this(centroids, assignments, i -> i, new int[0]);
+    KMeansIntermediate(float[][] centroids, int[] assignments, int[] counts) {
+        this(centroids, assignments, counts, i -> i, new int[0]);
     }
 
     public int ordToDoc(int ord) {

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/KMeansLocal.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/KMeansLocal.java
@@ -77,7 +77,6 @@ class KMeansLocal {
         NeighborHood[] neighborhoods
     ) throws IOException {
         boolean changed = false;
-        int dim = vectors.dimension();
         centroidChanged.clear();
         final float[] distances = new float[4];
         for (int idx = 0; idx < vectors.size(); idx++) {
@@ -92,42 +91,15 @@ class KMeansLocal {
             }
             if (assignment != bestCentroidOffset) {
                 if (assignment != -1) {
+                    centroidCounts[assignment]--;
                     centroidChanged.set(assignment);
                 }
+                centroidCounts[bestCentroidOffset]++;
                 centroidChanged.set(bestCentroidOffset);
                 assignments[vectorOrd] = bestCentroidOffset;
                 changed = true;
             }
         }
-        if (changed) {
-            Arrays.fill(centroidCounts, 0);
-            for (int idx = 0; idx < vectors.size(); idx++) {
-                final int assignment = assignments[translateOrd.apply(idx)];
-                if (centroidChanged.get(assignment)) {
-                    float[] centroid = centroids[assignment];
-                    if (centroidCounts[assignment]++ == 0) {
-                        Arrays.fill(centroid, 0.0f);
-                    }
-                    float[] vector = vectors.vectorValue(idx);
-                    for (int d = 0; d < dim; d++) {
-                        centroid[d] += vector[d];
-                    }
-                }
-            }
-
-            for (int clusterIdx = 0; clusterIdx < centroids.length; clusterIdx++) {
-                if (centroidChanged.get(clusterIdx)) {
-                    float count = (float) centroidCounts[clusterIdx];
-                    if (count > 0) {
-                        float[] centroid = centroids[clusterIdx];
-                        for (int d = 0; d < dim; d++) {
-                            centroid[d] /= count;
-                        }
-                    }
-                }
-            }
-        }
-
         return changed;
     }
 
@@ -276,6 +248,7 @@ class KMeansLocal {
         assert spilledAssignments != null;
         assert spilledAssignments.length == vectors.size();
         float[][] centroids = kmeansIntermediate.centroids();
+        int[] counts = kmeansIntermediate.centroidCounts();
 
         float[] diffs = new float[vectors.dimension()];
         final float[] distances = new float[4];
@@ -359,6 +332,7 @@ class KMeansLocal {
 
             assert bestAssignment != -1 : "Failed to assign soar vector to centroid";
             spilledAssignments[i] = bestAssignment;
+            counts[bestAssignment]++;
         }
     }
 
@@ -424,9 +398,11 @@ class KMeansLocal {
         int k = centroids.length;
         int n = vectors.size();
         int[] assignments = kMeansIntermediate.assignments();
+        int[] centroidCounts = kMeansIntermediate.centroidCounts();
 
         if (k == 1) {
             Arrays.fill(assignments, 0);
+            centroidCounts[0] = assignments.length;
             return;
         }
         IntToIntFunction translateOrd = i -> i;
@@ -438,33 +414,55 @@ class KMeansLocal {
 
         assert assignments.length == n;
         FixedBitSet centroidChanged = new FixedBitSet(centroids.length);
-        int[] centroidCounts = new int[centroids.length];
         for (int i = 0; i < maxIterations; i++) {
             // This is potentially sampled, so we need to translate ordinals
             if (stepLloyd(sampledVectors, translateOrd, centroids, centroidChanged, centroidCounts, assignments, neighborhoods) == false) {
                 break;
             }
+            updateCentroids(vectors, centroids, assignments, centroidCounts, centroidChanged);
         }
         // If we were sampled, do a once over the full set of vectors to finalize the centroids
         if (sampleSize < n || maxIterations == 0) {
             // No ordinal translation needed here, we are using the full set of vectors
-            stepLloyd(vectors, i -> i, centroids, centroidChanged, centroidCounts, assignments, neighborhoods);
+            if (stepLloyd(vectors, i -> i, centroids, centroidChanged, centroidCounts, assignments, neighborhoods)) {
+                updateCentroids(vectors, centroids, assignments, centroidCounts, centroidChanged);
+            }
         }
     }
 
-    /**
-     * helper that calls {@link KMeansLocal#cluster(FloatVectorValues, KMeansIntermediate)} given a set of initialized centroids,
-     * this call is not neighbor aware
-     *
-     * @param vectors the vectors to cluster
-     * @param centroids the initialized centroids to be shifted using k-means
-     * @param sampleSize the subset of vectors to use when shifting centroids
-     * @param maxIterations the max iterations to shift centroids
-     */
-    public static void cluster(FloatVectorValues vectors, float[][] centroids, int sampleSize, int maxIterations) throws IOException {
-        KMeansIntermediate kMeansIntermediate = new KMeansIntermediate(centroids, new int[vectors.size()], vectors::ordToDoc);
-        KMeansLocal kMeans = new KMeansLocal(sampleSize, maxIterations);
-        kMeans.cluster(vectors, kMeansIntermediate);
+    private void updateCentroids(
+        FloatVectorValues vectors,
+        float[][] centroids,
+        int[] assignments,
+        int[] centroidCounts,
+        FixedBitSet centroidChanged
+    ) throws IOException {
+        int dim = vectors.dimension();
+        for (int clusterIdx = 0; clusterIdx < centroids.length; clusterIdx++) {
+            if (centroidChanged.get(clusterIdx) && centroidCounts[clusterIdx] > 0) {
+                Arrays.fill(centroids[clusterIdx], 0.0f);
+            }
+        }
+        for (int idx = 0; idx < assignments.length; idx++) {
+            final int assignment = assignments[idx];
+            if (assignment != -1 && centroidChanged.get(assignment)) {
+                float[] centroid = centroids[assignment];
+                float[] vector = vectors.vectorValue(idx);
+                for (int d = 0; d < dim; d++) {
+                    centroid[d] += vector[d];
+                }
+            }
+        }
+        for (int clusterIdx = 0; clusterIdx < centroids.length; clusterIdx++) {
+            if (centroidChanged.get(clusterIdx)) {
+                float count = (float) centroidCounts[clusterIdx];
+                if (count > 0) {
+                    float[] centroid = centroids[clusterIdx];
+                    for (int d = 0; d < dim; d++) {
+                        centroid[d] /= count;
+                    }
+                }
+            }
+        }
     }
-
 }

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/KMeansResult.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/KMeansResult.java
@@ -14,24 +14,31 @@ package org.elasticsearch.index.codec.vectors.cluster;
  */
 public class KMeansResult {
     private float[][] centroids;
+    private int[] centroidCounts;
     private final int[] assignments;
     private int[] soarAssignments;
 
-    KMeansResult(float[][] centroids, int[] assignments, int[] soarAssignments) {
+    KMeansResult(float[][] centroids, int[] assignments, int[] soarAssignments, int[] centroidCounts) {
         assert centroids != null;
         assert assignments != null;
         assert soarAssignments != null;
         this.centroids = centroids;
         this.assignments = assignments;
         this.soarAssignments = soarAssignments;
+        this.centroidCounts = centroidCounts;
     }
 
     public float[][] centroids() {
         return centroids;
     }
 
-    void setCentroids(float[][] centroids) {
+    public int[] centroidCounts() {
+        return centroidCounts;
+    }
+
+    void setCentroidsAndCounts(float[][] centroids, int[] counts) {
         this.centroids = centroids;
+        this.centroidCounts = counts;
     }
 
     public int[] assignments() {

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/cluster/HierarchicalKMeansTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/cluster/HierarchicalKMeansTests.java
@@ -31,6 +31,7 @@ public class HierarchicalKMeansTests extends ESTestCase {
         HierarchicalKMeans hkmeans = new HierarchicalKMeans(dims, maxIterations, sampleSize, clustersPerNeighborhood, soarLambda);
 
         KMeansResult result = hkmeans.cluster(vectors, targetSize);
+        KMeansLocalTests.assertCounts(result);
 
         float[][] centroids = result.centroids();
         int[] assignments = result.assignments();


### PR DESCRIPTION
This commits adds a new parameter to the k-means result that contains the current count of vectors in a cluster. This array is always up-to-date so at anytime it contains the number of vectors assign to a cluster. This array is used in the places where we are counting the number of vectors assigned, both in the codec as well as in the algorithm itself.  But more important, this will allow us to limit the number of vectors in a cluster if we wish to, in order to build more balanced clusters.

I did not notice any performance regression or changes in recall after this change. The only difference with the previous version is that when we update the centroids after a assignment step, we update the centroids using all the assigned vectors, while before we were using only the sampled vectors.