### PR TITLE
Use local segment fieldInfos to lookup tsdb merge stats

### DIFF
--- a/docs/changelog/132597.yaml
+++ b/docs/changelog/132597.yaml
@@ -1,0 +1,5 @@
+pr: 132597
+summary: Use local segment `fieldInfos` to lookup tsdb merge stats
+area: Codec
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/DocValuesConsumerUtil.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/DocValuesConsumerUtil.java
@@ -24,7 +24,7 @@ class DocValuesConsumerUtil {
 
     record MergeStats(boolean supported, long sumNumValues, int sumNumDocsWithField, int minLength, int maxLength) {}
 
-    static MergeStats compatibleWithOptimizedMerge(boolean optimizedMergeEnabled, MergeState mergeState, FieldInfo fieldInfo) {
+    static MergeStats compatibleWithOptimizedMerge(boolean optimizedMergeEnabled, MergeState mergeState, FieldInfo mergedFieldInfo) {
         if (optimizedMergeEnabled == false || mergeState.needsIndexSort == false) {
             return UNSUPPORTED;
         }
@@ -42,6 +42,10 @@ class DocValuesConsumerUtil {
         int maxLength = 0;
 
         for (int i = 0; i < mergeState.docValuesProducers.length; i++) {
+            final FieldInfo fieldInfo = mergeState.fieldInfos[i].fieldInfo(mergedFieldInfo.name);
+            if (fieldInfo == null) {
+                continue;
+            }
             DocValuesProducer docValuesProducer = mergeState.docValuesProducers[i];
             if (docValuesProducer instanceof FilterDocValuesProducer filterDocValuesProducer) {
                 docValuesProducer = filterDocValuesProducer.getIn();

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesFormatTests.java
@@ -58,13 +58,13 @@ public class ES87TSDBDocValuesFormatTests extends BaseDocValuesFormatTestCase {
         LogConfigurator.configureESLogging();
     }
 
-    static class TestES87TSDBDocValuesFormat extends ES87TSDBDocValuesFormat {
+    public static class TestES87TSDBDocValuesFormat extends ES87TSDBDocValuesFormat {
 
         TestES87TSDBDocValuesFormat() {
             super();
         }
 
-        TestES87TSDBDocValuesFormat(int skipIndexIntervalSize) {
+        public TestES87TSDBDocValuesFormat(int skipIndexIntervalSize) {
             super(skipIndexIntervalSize);
         }
 

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesFormatTests.java
@@ -546,11 +546,11 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
             });
             return config;
         };
-        List<String> allNumericFields = IntStream.range(0, 5).mapToObj(n -> "numeric_" + n).toList();
-        List<String> allSortedNumericFields = IntStream.range(0, 5).mapToObj(n -> "sorted_numeric_" + n).toList();
-        List<String> allSortedFields = IntStream.range(0, 5).mapToObj(n -> "sorted_" + n).toList();
-        List<String> allSortedSetFields = IntStream.range(0, 5).mapToObj(n -> "sorted_set" + n).toList();
-        List<String> allBinaryFields = IntStream.range(0, 5).mapToObj(n -> "binary_" + n).toList();
+        var allNumericFields = IntStream.range(0, ESTestCase.between(1, 10)).mapToObj(n -> "numeric_" + n).toList();
+        var allSortedNumericFields = IntStream.range(0, ESTestCase.between(1, 10)).mapToObj(n -> "sorted_numeric_" + n).toList();
+        var allSortedFields = IntStream.range(0, ESTestCase.between(1, 10)).mapToObj(n -> "sorted_" + n).toList();
+        var allSortedSetFields = IntStream.range(0, ESTestCase.between(1, 10)).mapToObj(n -> "sorted_set" + n).toList();
+        var allBinaryFields = IntStream.range(0, ESTestCase.between(1, 10)).mapToObj(n -> "binary_" + n).toList();
         try (var source1 = newDirectory(); var source2 = newDirectory(); var singleDir = newDirectory(); var mergeDir = newDirectory()) {
             try (
                 var writer1 = new IndexWriter(source1, indexConfigWithRandomDVFormat.get());
@@ -565,7 +565,6 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                     timestamp += 1 + random().nextInt(1_000);
                     fields.add(new SortedDocValuesField(hostnameField, new BytesRef(hostName)));
                     fields.add(new SortedNumericDocValuesField(timestampField, timestamp));
-                    final IndexWriter splitWriter = random().nextBoolean() ? writer1 : writer2;
                     var numericFields = ESTestCase.randomSubsetOf(allNumericFields);
                     for (String f : numericFields) {
                         fields.add(new NumericDocValuesField(f, random().nextLong(1000L)));
@@ -579,20 +578,20 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                     }
                     var sortedFields = ESTestCase.randomSubsetOf(allSortedFields);
                     for (String field : sortedFields) {
-                        fields.add(new SortedDocValuesField(field, new BytesRef("v" + random().nextInt(100))));
+                        fields.add(new SortedDocValuesField(field, new BytesRef("s" + random().nextInt(100))));
                     }
                     var sortedSetFields = ESTestCase.randomSubsetOf(allSortedSetFields);
                     for (String field : sortedSetFields) {
                         int valueCount = 1 + random().nextInt(3);
                         for (int v = 0; v < valueCount; v++) {
-                            fields.add(new SortedSetDocValuesField(field, new BytesRef("v" + random().nextInt(100))));
+                            fields.add(new SortedSetDocValuesField(field, new BytesRef("ss" + random().nextInt(100))));
                         }
                     }
                     List<String> binaryFields = ESTestCase.randomSubsetOf(allBinaryFields);
                     for (String field : binaryFields) {
                         fields.add(new BinaryDocValuesField(field, new BytesRef("b" + random().nextInt(100))));
                     }
-                    for (IndexWriter writer : List.of(splitWriter, singleWriter)) {
+                    for (IndexWriter writer : List.of(ESTestCase.randomFrom(writer1, writer2), singleWriter)) {
                         Randomness.shuffle(fields);
                         writer.addDocument(fields);
                         if (random().nextInt(100) <= 5) {


### PR DESCRIPTION
Merging shrink TSDB or LogsDB indices can fail in versions 8.19 or 9.1+. 
When shrinking an index to a single shard, we use addIndexes, which can
add Lucene segments directly. In this case, FieldInfos can differ
between shards and the new segment. We should use the FieldInfos from
each segment to retrieve the merge stats, instead of the FieldInfos of
the merged segment.

Relates #125403