### PR TITLE
[8.19] Use local segment fieldInfos to lookup tsdb merge stats (#132597)

### DIFF
--- a/docs/changelog/132597.yaml
+++ b/docs/changelog/132597.yaml
@@ -1,0 +1,5 @@
+pr: 132597
+summary: Use local segment `fieldInfos` to lookup tsdb merge stats
+area: Codec
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/DocValuesConsumerUtil.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/DocValuesConsumerUtil.java
@@ -24,7 +24,7 @@ class DocValuesConsumerUtil {
 
     record MergeStats(boolean supported, long sumNumValues, int sumNumDocsWithField, int minLength, int maxLength) {}
 
-    static MergeStats compatibleWithOptimizedMerge(boolean optimizedMergeEnabled, MergeState mergeState, FieldInfo fieldInfo) {
+    static MergeStats compatibleWithOptimizedMerge(boolean optimizedMergeEnabled, MergeState mergeState, FieldInfo mergedFieldInfo) {
         if (optimizedMergeEnabled == false || mergeState.needsIndexSort == false) {
             return UNSUPPORTED;
         }
@@ -42,6 +42,10 @@ class DocValuesConsumerUtil {
         int maxLength = 0;
 
         for (int i = 0; i < mergeState.docValuesProducers.length; i++) {
+            final FieldInfo fieldInfo = mergeState.fieldInfos[i].fieldInfo(mergedFieldInfo.name);
+            if (fieldInfo == null) {
+                continue;
+            }
             DocValuesProducer docValuesProducer = mergeState.docValuesProducers[i];
             if (docValuesProducer instanceof FilterDocValuesProducer filterDocValuesProducer) {
                 docValuesProducer = filterDocValuesProducer.getIn();

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesFormatTests.java
@@ -58,9 +58,9 @@ public class ES87TSDBDocValuesFormatTests extends BaseDocValuesFormatTestCase {
         LogConfigurator.configureESLogging();
     }
 
-    static class TestES87TSDBDocValuesFormat extends ES87TSDBDocValuesFormat {
+    public static class TestES87TSDBDocValuesFormat extends ES87TSDBDocValuesFormat {
 
-        TestES87TSDBDocValuesFormat() {
+        public TestES87TSDBDocValuesFormat() {
             super();
         }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Use local segment fieldInfos to lookup tsdb merge stats (#132597)](https://github.com/elastic/elasticsearch/pull/132597)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)