### PR TITLE
Allow setting default_metric for numerics

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/_nightly/esql/ValuesSourceReaderBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/_nightly/esql/ValuesSourceReaderBenchmark.java
@@ -285,6 +285,7 @@ public class ValuesSourceReaderBenchmark {
             false,
             null,
             null,
+            null,
             false
         ).blockLoader(new MappedFieldType.BlockLoaderContext() {
             @Override

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/script/ScriptScoreBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/script/ScriptScoreBenchmark.java
@@ -85,7 +85,10 @@ public class ScriptScoreBenchmark {
     private final ScriptModule scriptModule = new ScriptModule(Settings.EMPTY, pluginsService.filterPlugins(ScriptPlugin.class).toList());
 
     private final Map<String, MappedFieldType> fieldTypes = Map.ofEntries(
-        Map.entry("n", new NumberFieldType("n", NumberType.LONG, false, false, true, true, null, Map.of(), null, false, null, null, false))
+        Map.entry(
+            "n",
+            new NumberFieldType("n", NumberType.LONG, false, false, true, true, null, Map.of(), null, false, null, null, null, false)
+        )
     );
     private final IndexFieldDataCache fieldDataCache = new IndexFieldDataCache.None();
     private final CircuitBreakerService breakerService = new NoneCircuitBreakerService();

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamFeatures.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamFeatures.java
@@ -30,6 +30,10 @@ public class DataStreamFeatures implements FeatureSpecification {
 
     public static final NodeFeature FAILURE_STORE_IN_LOG_DATA_STREAMS = new NodeFeature("logs_data_streams.failure_store.enabled");
 
+    public static final NodeFeature DOWNSAMPLE_DEFAULT_METRIC_FOR_NUMERICS_FIX = new NodeFeature(
+        "data_stream.downsample.default_metric_for_numerics_fix"
+    );
+
     @Override
     public Set<NodeFeature> getFeatures() {
         return Set.of(DataStream.DATA_STREAM_FAILURE_STORE_FEATURE);
@@ -41,7 +45,8 @@ public class DataStreamFeatures implements FeatureSpecification {
             DATA_STREAM_FAILURE_STORE_TSDB_FIX,
             DOWNSAMPLE_AGGREGATE_DEFAULT_METRIC_FIX,
             LOGS_STREAM_FEATURE,
-            FAILURE_STORE_IN_LOG_DATA_STREAMS
+            FAILURE_STORE_IN_LOG_DATA_STREAMS,
+            DOWNSAMPLE_DEFAULT_METRIC_FOR_NUMERICS_FIX
         );
     }
 }

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/TokenCountFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/TokenCountFieldMapper.java
@@ -117,6 +117,7 @@ public class TokenCountFieldMapper extends FieldMapper {
                 false,
                 null,
                 null,
+                null,
                 isSyntheticSource
             );
         }

--- a/plugins/mapper-size/src/main/java/org/elasticsearch/index/mapper/size/SizeFieldMapper.java
+++ b/plugins/mapper-size/src/main/java/org/elasticsearch/index/mapper/size/SizeFieldMapper.java
@@ -50,7 +50,7 @@ public class SizeFieldMapper extends MetadataFieldMapper {
 
     private static class SizeFieldType extends NumberFieldType {
         SizeFieldType() {
-            super(NAME, NumberType.INTEGER, true, true, true, false, null, Collections.emptyMap(), null, false, null, null, false);
+            super(NAME, NumberType.INTEGER, true, true, true, false, null, Collections.emptyMap(), null, false, null, null, null, false);
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/index/fielddata/IndexFieldDataServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/IndexFieldDataServiceTests.java
@@ -337,6 +337,7 @@ public class IndexFieldDataServiceTests extends ESSingleNodeTestCase {
                 false,
                 null,
                 null,
+                null,
                 false
             )
         );
@@ -356,6 +357,7 @@ public class IndexFieldDataServiceTests extends ESSingleNodeTestCase {
                 Collections.emptyMap(),
                 null,
                 false,
+                null,
                 null,
                 null,
                 false

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
@@ -141,6 +141,7 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
             false,
             null,
             null,
+            null,
             false
         );
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/AggregatorBaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/AggregatorBaseTests.java
@@ -93,6 +93,7 @@ public class AggregatorBaseTests extends MapperServiceTestCase {
             false,
             null,
             null,
+            null,
             false
         );
         return ValuesSourceConfig.resolveFieldOnly(ft, context);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregatorTests.java
@@ -1495,6 +1495,7 @@ public class FiltersAggregatorTests extends AggregatorTestCase {
             false,
             null,
             null,
+            null,
             false
         );
         docValuesFieldExistsTestCase(new ExistsQueryBuilder("f"), ft, true, i -> {
@@ -1517,6 +1518,7 @@ public class FiltersAggregatorTests extends AggregatorTestCase {
                 Map.of(),
                 null,
                 false,
+                null,
                 null,
                 null,
                 false

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregatorTests.java
@@ -312,6 +312,7 @@ public class RangeAggregatorTests extends AggregatorTestCase {
                     false,
                     null,
                     null,
+                    null,
                     false
                 )
             )
@@ -426,6 +427,7 @@ public class RangeAggregatorTests extends AggregatorTestCase {
             Collections.emptyMap(),
             null,
             false,
+            null,
             null,
             null,
             false
@@ -708,6 +710,7 @@ public class RangeAggregatorTests extends AggregatorTestCase {
             Collections.emptyMap(),
             null,
             false,
+            null,
             null,
             null,
             false

--- a/server/src/test/java/org/elasticsearch/search/collapse/CollapseBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/collapse/CollapseBuilderTests.java
@@ -155,6 +155,7 @@ public class CollapseBuilderTests extends AbstractXContentSerializingTestCase<Co
                 false,
                 null,
                 null,
+                null,
                 false
             );
             when(searchExecutionContext.getFieldType("field")).thenReturn(numberFieldType);
@@ -172,6 +173,7 @@ public class CollapseBuilderTests extends AbstractXContentSerializingTestCase<Co
                 Collections.emptyMap(),
                 null,
                 false,
+                null,
                 null,
                 null,
                 false

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/rate/TimeSeriesRateAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/rate/TimeSeriesRateAggregatorTests.java
@@ -210,6 +210,7 @@ public class TimeSeriesRateAggregatorTests extends AggregatorTestCase {
             null,
             false,
             TimeSeriesParams.MetricType.COUNTER,
+            null,
             IndexMode.TIME_SERIES,
             false
         );

--- a/x-pack/plugin/downsample/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/downsample/80_downsample_aggregate.yml
+++ b/x-pack/plugin/downsample/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/downsample/80_downsample_aggregate.yml
@@ -77,3 +77,80 @@
         metrics: [min, sum, value_count]
         default_metric: sum
         time_series_metric: gauge
+
+---
+"downsample numeric field":
+  - requires:
+      cluster_features: ["data_stream.downsample.default_metric_for_numerics_fix"]
+      reason: "Specify default metric to be used when downsampling numerics"
+
+  - do:
+      indices.create:
+        index: test
+        body:
+          settings:
+            number_of_shards: 1
+            index:
+              mode: time_series
+              routing_path: [sensor_id]
+              time_series:
+                start_time: 2021-04-28T00:00:00Z
+                end_time: 2021-04-29T00:00:00Z
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+              sensor_id:
+                type: keyword
+                time_series_dimension: true
+              temperature:
+                type: double
+                default_metric: sum
+                time_series_metric: gauge
+
+  - do:
+      bulk:
+        refresh: true
+        index: test
+        body:
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T17:34:00Z", "sensor_id": "1", "temperature": 24.1}'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T17:39:00Z", "sensor_id": "1", "temperature": 25.3}'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T17:45:00Z", "sensor_id": "1", "temperature": 24.8}'
+
+  - do:
+      indices.put_settings:
+        index: test
+        body:
+          index.blocks.write: true
+
+  - do:
+      indices.downsample:
+        index: test
+        target_index: test-downsample
+        body:  >
+          {
+            "fixed_interval": "30m"
+          }
+  - is_true: acknowledged
+
+  - do:
+      search:
+        index: test-downsample
+        body:
+          size: 0
+
+  - match:
+      hits.total.value: 1
+
+  - do:
+      indices.get_mapping:
+        index: test-downsample
+  - match:
+      test-downsample.mappings.properties.temperature:
+        type: aggregate_metric_double
+        metrics: [min, max, sum, value_count]
+        default_metric: sum
+        time_series_metric: gauge

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/TransportDownsampleAction.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/TransportDownsampleAction.java
@@ -783,6 +783,11 @@ public class TransportDownsampleAction extends AcknowledgedTransportMasterNodeAc
                 (String) fieldProperties.get(AggregateMetricDoubleFieldMapper.Names.DEFAULT_METRIC),
                 defaultMetric
             );
+        } else {
+            defaultMetric = Objects.requireNonNullElse(
+                (String) fieldProperties.get(TimeSeriesParams.TIME_SERIES_DEFAULT_METRIC_PARAM),
+                defaultMetric
+            );
         }
 
         return new AggregateMetricDoubleFieldSupportedMetrics(defaultMetric, supportedAggs);


### PR DESCRIPTION
This commit adds in an option in the field mapping for numerics where, if the numeric has `time_series_metric` set to `gauge`, you can set a `default_metric`, so when the field is downsampled, the resulting aggregate_metric_double gets that specified field as its `default_metric`. If no `default_metric` is specified, the resulting aggregate_metric_double will have `max` as its default, as was before.

Example mappings:
```
"my-default-min-metric": {
    "time_series_metric": "gauge",
    "type": "integer",
    "default_metric": "min"
},
"my-other-metric": {
    "time_series_metric": "gauge",
    "type": "integer"
}
```
becomes this after downsampling:
```
"my-default-min-metric": {
    "type": "aggregate_metric_double",
    "metrics": [
        "min",
        "max",
        "sum",
        "value_count"
    ],
    "default_metric": "min",
    "time_series_metric": "gauge"
},
"my-other-metric": {
    "type": "aggregate_metric_double",
    "metrics": [
        "min",
        "max",
        "sum",
        "value_count"
    ],
    "default_metric": "max",
    "time_series_metric": "gauge"
}