### PR TITLE
Fix testLimitConcurrentNodes

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -521,9 +521,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
   method: test {csv-spec:lookup-join.MvJoinKeyFromRowExpanded}
   issue: https://github.com/elastic/elasticsearch/issues/132604
-- class: org.elasticsearch.xpack.esql.plugin.DataNodeRequestSenderTests
-  method: testLimitConcurrentNodes
-  issue: https://github.com/elastic/elasticsearch/issues/132607
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=esql/60_usage/Basic ESQL usage output (telemetry) non-snapshot version}
   issue: https://github.com/elastic/elasticsearch/issues/132608

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/DataNodeRequestSenderTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/DataNodeRequestSenderTests.java
@@ -306,13 +306,16 @@ public class DataNodeRequestSenderTests extends ComputeTestCase {
     }
 
     public void testLimitConcurrentNodes() {
-        var targetShards = List.of(
-            targetShard(shard1, node1),
-            targetShard(shard2, node2),
-            targetShard(shard3, node3),
-            targetShard(shard4, node4),
-            targetShard(shard5, node5)
-        );
+        final int shards = 10;
+        var targetShards = new ArrayList<DataNodeRequestSender.TargetShard>(shards);
+        for (int i = 0; i < shards; i++) {
+            targetShards.add(
+                targetShard(
+                    new ShardId("index", "n/a", i),
+                    DiscoveryNodeUtils.builder("node-" + i).roles(Set.of(DATA_HOT_NODE_ROLE)).build()
+                )
+            );
+        }
 
         var concurrency = randomIntBetween(1, 2);
         AtomicInteger maxConcurrentRequests = new AtomicInteger(0);
@@ -335,10 +338,10 @@ public class DataNodeRequestSenderTests extends ComputeTestCase {
                 listener.onResponse(new DataNodeComputeResponse(DriverCompletionInfo.EMPTY, Map.of()));
             });
         }));
-        assertThat(sent.size(), equalTo(5));
+        assertThat(sent.size(), equalTo(shards));
         assertThat(maxConcurrentRequests.get(), equalTo(concurrency));
-        assertThat(response.totalShards, equalTo(5));
-        assertThat(response.successfulShards, equalTo(5));
+        assertThat(response.totalShards, equalTo(shards));
+        assertThat(response.successfulShards, equalTo(shards));
         assertThat(response.failedShards, equalTo(0));
     }
 


### PR DESCRIPTION
The test is checking that we dispatch 5 requests 2 at the time, however some failures happened observing concurrency of 1.
This could rarely happen when request producer is slower than dispatcher. I was not able to reproduce this.
I think this is less likely to happen if we have more requests. Updating the test to send 10 requests instead of 5.

Closes: #132607