### PR TITLE
ESQL: Push filters on right hand-side of joins

### DIFF
--- a/docs/changelog/132635.yaml
+++ b/docs/changelog/132635.yaml
@@ -1,0 +1,6 @@
+pr: 132635
+summary: Push filters on right hand-side of joins
+area: ES|QL
+type: enhancement
+issues:
+ - 130024

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -359,6 +359,7 @@ public class TransportVersions {
     public static final TransportVersion TRANSPORT_NODE_USAGE_STATS_FOR_THREAD_POOLS_ACTION = def(9_135_0_00);
     public static final TransportVersion INDEX_TEMPLATE_TRACKING_INFO = def(9_136_0_00);
     public static final TransportVersion EXTENDED_SNAPSHOT_STATS_IN_NODE_INFO = def(9_137_0_00);
+    public static final TransportVersion ESQL_LOOKUP_JOIN_FILTER = def(9_138_0_00);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/QueryList.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/QueryList.java
@@ -37,7 +37,6 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.RangeFieldMapper;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.SearchExecutionContext;
-import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.search.internal.AliasFilter;
 
 import java.io.IOException;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/QueryList.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/QueryList.java
@@ -146,6 +146,7 @@ public abstract class QueryList {
         if (aliasFilter != null && aliasFilter != AliasFilter.EMPTY) {
             try {
                 builder.add(aliasFilter.getQueryBuilder().toQuery(searchExecutionContext), BooleanClause.Occur.FILTER);
+                builderHasClauses = true;
             } catch (IOException e) {
                 throw new UncheckedIOException("Error while building query for alias filter", e);
             }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/LookupFromIndexIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/LookupFromIndexIT.java
@@ -235,6 +235,7 @@ public class LookupFromIndexIT extends AbstractEsqlIntegTestCase {
                 "lookup",
                 new FieldAttribute.FieldName("key"),
                 List.of(new Alias(Source.EMPTY, "l", new ReferenceAttribute(Source.EMPTY, "l", DataType.LONG))),
+                null,
                 Source.EMPTY
             );
             DriverContext driverContext = driverContext();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/LookupFromIndexOperator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/LookupFromIndexOperator.java
@@ -21,6 +21,7 @@ import org.elasticsearch.compute.operator.Operator;
 import org.elasticsearch.compute.operator.lookup.RightChunkedLeftJoin;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
@@ -48,6 +49,7 @@ public final class LookupFromIndexOperator extends AsyncOperator<LookupFromIndex
         String lookupIndex,
         FieldAttribute.FieldName matchField,
         List<NamedExpression> loadFields,
+        QueryBuilder filterQueryBuilder,
         Source source
     ) implements OperatorFactory {
         @Override
@@ -62,6 +64,8 @@ public final class LookupFromIndexOperator extends AsyncOperator<LookupFromIndex
                 + loadFields
                 + " inputChannel="
                 + inputChannel
+                + " filterQueryBuilder="
+                + filterQueryBuilder
                 + "]";
         }
 
@@ -79,6 +83,7 @@ public final class LookupFromIndexOperator extends AsyncOperator<LookupFromIndex
                 lookupIndex,
                 matchField.string(),
                 loadFields,
+                filterQueryBuilder,
                 source
             );
         }
@@ -93,6 +98,7 @@ public final class LookupFromIndexOperator extends AsyncOperator<LookupFromIndex
     private final String lookupIndex;
     private final String matchField;
     private final List<NamedExpression> loadFields;
+    private final QueryBuilder filterQueryBuilder;
     private final Source source;
     private long totalTerms = 0L;
     /**
@@ -116,6 +122,7 @@ public final class LookupFromIndexOperator extends AsyncOperator<LookupFromIndex
         String lookupIndex,
         String matchField,
         List<NamedExpression> loadFields,
+        QueryBuilder filterQueryBuilder,
         Source source
     ) {
         super(driverContext, lookupService.getThreadContext(), maxOutstandingRequests);
@@ -128,6 +135,7 @@ public final class LookupFromIndexOperator extends AsyncOperator<LookupFromIndex
         this.lookupIndex = lookupIndex;
         this.matchField = matchField;
         this.loadFields = loadFields;
+        this.filterQueryBuilder = filterQueryBuilder;
         this.source = source;
     }
 
@@ -143,6 +151,7 @@ public final class LookupFromIndexOperator extends AsyncOperator<LookupFromIndex
             matchField,
             new Page(inputBlock),
             loadFields,
+            filterQueryBuilder,
             source
         );
         lookupService.lookupAsync(
@@ -200,6 +209,8 @@ public final class LookupFromIndexOperator extends AsyncOperator<LookupFromIndex
             + loadFields
             + " inputChannel="
             + inputChannel
+            + " filterQueryBuilder="
+            + filterQueryBuilder
             + "]";
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizer.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceStringCasingW
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.local.InferIsNotNull;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.local.InferNonNullAggConstraint;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.local.LocalPropagateEmptyRelation;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.local.LocalPushDownFiltersRightPastJoin;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.local.ReplaceDateTruncBucketWithRoundTo;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.local.ReplaceFieldWithConstantOrNull;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.local.ReplaceTopNWithLimitAndSort;
@@ -82,6 +83,7 @@ public class LocalLogicalPlanOptimizer extends ParameterizedRuleExecutor<Logical
 
         // add rule that should only apply locally
         newRules.add(new ReplaceStringCasingWithInsensitiveRegexMatch());
+        newRules.add(new LocalPushDownFiltersRightPastJoin());
 
         return operators.with(newRules.toArray(Rule[]::new));
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/local/LocalPushDownFiltersRightPastJoin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/local/LocalPushDownFiltersRightPastJoin.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer.rules.logical.local;
+
+import org.elasticsearch.xpack.esql.capabilities.TranslationAware;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.util.CollectionUtils;
+import org.elasticsearch.xpack.esql.expression.predicate.Predicates;
+import org.elasticsearch.xpack.esql.optimizer.LocalLogicalOptimizerContext;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.OptimizerRules;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.PushDownAndCombineFilters;
+import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.LucenePushdownPredicates;
+import org.elasticsearch.xpack.esql.plan.logical.Filter;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.join.InlineJoin;
+import org.elasticsearch.xpack.esql.plan.logical.join.Join;
+import org.elasticsearch.xpack.esql.plan.logical.join.JoinTypes;
+import org.elasticsearch.xpack.esql.plugin.EsqlFlags;
+
+import java.util.List;
+
+import static org.elasticsearch.xpack.esql.optimizer.rules.logical.PushDownAndCombineFilters.scopeFilter;
+
+public final class LocalPushDownFiltersRightPastJoin extends OptimizerRules.ParameterizedOptimizerRule<
+    Filter,
+    LocalLogicalOptimizerContext> {
+
+    public LocalPushDownFiltersRightPastJoin() {
+        super(OptimizerRules.TransformDirection.DOWN);
+    }
+
+    @Override
+    protected LogicalPlan rule(Filter filter, LocalLogicalOptimizerContext context) {
+        LogicalPlan child = filter.child();
+        // TODO: see note in PushDownAndCombineFilters about InlineJoin
+        return child instanceof Join join && child instanceof InlineJoin == false ? pushDownRightPastJoin(filter, join, context) : filter;
+    }
+
+    private static LogicalPlan pushDownRightPastJoin(Filter filter, Join join, LocalLogicalOptimizerContext context) {
+        LogicalPlan plan = filter;
+        // pushdown only through LEFT joins
+        // TODO: generalize this for other join types
+        if (join.config().type() == JoinTypes.LEFT) {
+            LogicalPlan left = join.left();
+            LogicalPlan right = join.right();
+
+            PushDownAndCombineFilters.ScopedFilter scoped = scopeFilter(Predicates.splitAnd(filter.condition()), left, right);
+            // Only push down right if the filter can be merged; it would otherwise generate extra work, as the filter's kept before the
+            // join too. This is needed since the join produces `null`s for the fields corresponding to the rows that the pushed condition
+            // filters out.
+            if (areRightFiltersPushable(scoped.rightFilters(), context)) {
+                var combinedRightFilters = Predicates.combineAnd(scoped.rightFilters());
+                // avoid re-injecting the same filter if the rule applied already before.
+                if (right instanceof Filter == false || ((Filter) right).condition().semanticEquals(combinedRightFilters) == false) {
+                    // push the right scoped filter down to the right child
+                    right = new Filter(right.source(), right, combinedRightFilters);
+                    // update the join with the new right child
+                    join = (Join) join.replaceRight(right);
+                }
+            }
+            // keep the remaining filters in place, otherwise return the new join;
+            Expression remainingFilter = Predicates.combineAnd(CollectionUtils.combine(scoped.commonFilters(), scoped.rightFilters()));
+            plan = remainingFilter != null ? filter.with(join, remainingFilter) : join;
+        }
+        // ignore the rest of the join
+        return plan;
+    }
+
+    private static boolean areRightFiltersPushable(List<Expression> filters, LocalLogicalOptimizerContext ctx) {
+        if (filters.isEmpty()) {
+            return false;
+        }
+        // TODO: the flag isn't relevant for the pushdown decision?
+        LucenePushdownPredicates pushdownPredicates = LucenePushdownPredicates.from(ctx.searchStats(), new EsqlFlags(true));
+        for (Expression filter : filters) {
+            // the rigth filters will remain on top of the join, so any not-NO value is acceptable for "is it pushable?"
+            if (TranslationAware.translatable(filter, pushdownPredicates) == TranslationAware.Translatable.NO) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -731,10 +731,11 @@ public class LocalExecutionPlanner {
         }
         Layout layout = layoutBuilder.build();
 
-        EsQueryExec localSourceExec = (EsQueryExec) join.lookup();
-        if (localSourceExec.indexMode() != IndexMode.LOOKUP) {
+        var lookup = join.lookup();
+        if (lookup instanceof EsQueryExec == false || ((EsQueryExec) lookup).indexMode() != IndexMode.LOOKUP) {
             throw new IllegalArgumentException("can't plan [" + join + "]");
         }
+        EsQueryExec localSourceExec = (EsQueryExec) lookup;
 
         // After enabling remote joins, we can have one of the two situations here:
         // 1. We've just got one entry - this should be the one relevant to the join, and it should be for this cluster
@@ -797,6 +798,7 @@ public class LocalExecutionPlanner {
                 indexName,
                 matchConfig.fieldName(),
                 join.addedFields().stream().map(f -> (NamedExpression) f).toList(),
+                localSourceExec.query(),
                 join.source()
             ),
             layout

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/mapper/LocalMapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/mapper/LocalMapper.java
@@ -111,7 +111,8 @@ public class LocalMapper {
                     join.rightOutputFields()
                 );
             }
-            if (right instanceof EsSourceExec source && source.indexMode() == IndexMode.LOOKUP) {
+            var leaves = right.collectLeaves();
+            if (leaves.size() == 1 && leaves.get(0) instanceof EsSourceExec source && source.indexMode() == IndexMode.LOOKUP) {
                 return new LookupJoinExec(join.source(), left, right, config.leftFields(), config.rightFields(), join.rightOutputFields());
             }
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/mapper/Mapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/mapper/Mapper.java
@@ -226,10 +226,18 @@ public class Mapper {
                     join.rightOutputFields()
                 );
             }
-            if (right instanceof FragmentExec fragment
-                && fragment.fragment() instanceof EsRelation relation
-                && relation.indexMode() == IndexMode.LOOKUP) {
-                return new LookupJoinExec(join.source(), left, right, config.leftFields(), config.rightFields(), join.rightOutputFields());
+            if (right instanceof FragmentExec fragment) {
+                var leaves = fragment.fragment().collectLeaves();
+                if (leaves.size() == 1 && leaves.get(0) instanceof EsRelation relation && relation.indexMode() == IndexMode.LOOKUP) {
+                    return new LookupJoinExec(
+                        join.source(),
+                        left,
+                        right,
+                        config.leftFields(),
+                        config.rightFields(),
+                        join.rightOutputFields()
+                    );
+                }
             }
         }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/enrich/LookupFromIndexOperatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/enrich/LookupFromIndexOperatorTests.java
@@ -153,6 +153,7 @@ public class LookupFromIndexOperatorTests extends OperatorTestCase {
             lookupIndex,
             matchField,
             loadFields,
+            null,
             Source.EMPTY
         );
     }
@@ -165,7 +166,8 @@ public class LookupFromIndexOperatorTests extends OperatorTestCase {
     @Override
     protected Matcher<String> expectedToStringOfSimple() {
         return matchesPattern(
-            "LookupOperator\\[index=idx input_type=LONG match_field=match load_fields=\\[lkwd\\{r}#\\d+, lint\\{r}#\\d+] inputChannel=0]"
+            "LookupOperator\\[index=idx input_type=LONG match_field=match load_fields=\\[lkwd\\{r}#\\d+, lint\\{r}#\\d+] "
+                + "inputChannel=0 filterQueryBuilder=null]"
         );
     }
 


### PR DESCRIPTION
This adds the logic to push filters down the right hand-side of joins (excepting `InlineJoin`). This is done for those filters that can be pushed down all the way to Lucene only.

Closes #130024