### PR TITLE
[8.18] [8.19] Remove type from bulk rest-api-spec (#131929)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/bulk.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/bulk.json
@@ -56,10 +56,6 @@
         "type":"time",
         "description":"Explicit operation timeout"
       },
-      "type":{
-        "type":"string",
-        "description":"Default document type for items which don't provide one"
-      },
       "_source":{
         "type":"list",
         "description":"True or false to return the _source field or not, or default list of fields to return, can be overridden on each sub-request"


### PR DESCRIPTION
Backports the following commits to 8.18:
 - [8.19] Remove type from bulk rest-api-spec (#131929)