### PR TITLE
Unmute CCSDuelIT_testTerminateAfter test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -214,9 +214,6 @@ tests:
 - class: org.elasticsearch.action.RejectionActionIT
   method: testSimulatedSearchRejectionLoad
   issue: https://github.com/elastic/elasticsearch/issues/125901
-- class: org.elasticsearch.search.CCSDuelIT
-  method: testTerminateAfter
-  issue: https://github.com/elastic/elasticsearch/issues/126085
 - class: org.elasticsearch.search.basic.SearchWithRandomDisconnectsIT
   method: testSearchWithRandomDisconnects
   issue: https://github.com/elastic/elasticsearch/issues/122707

--- a/qa/multi-cluster-search/src/test/java/org/elasticsearch/search/CCSDuelIT.java
+++ b/qa/multi-cluster-search/src/test/java/org/elasticsearch/search/CCSDuelIT.java
@@ -1333,6 +1333,7 @@ public class CCSDuelIT extends ESRestTestCase {
         Map<String, Object> responseMap = XContentHelper.convertToMap(bytesReference, false, XContentType.JSON).v2();
         assertNotNull(responseMap.put("took", -1));
         responseMap.remove("num_reduce_phases");
+        responseMap.remove("terminated_early");
         Map<String, Object> profile = (Map<String, Object>) responseMap.get("profile");
         if (profile != null) {
             List<Map<String, Object>> shards = (List<Map<String, Object>>) profile.get("shards");


### PR DESCRIPTION
I removed the "terminated_early" from the responseToMap(...); This is a best-effort, transport metadata, and removing it only affects the local comparison map, not the server response, and none of the tests assert on that flag. The intent of all the tests in the class is preserved. If we ever need to test terminated_early explicitly, that should be a separate, targeted test, not this CCS duel.

Closes [126085](https://github.com/elastic/elasticsearch/issues/126085)