### PR TITLE
Expand javadoc on NodeInfo

### DIFF
--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/tree/Node.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/tree/Node.java
@@ -307,13 +307,11 @@ public abstract class Node<T extends Node<T>> implements NamedWriteable {
     }
 
     /**
-     * Return the information about this node.
-     * <p>
      * Normally, you want to use one of the static {@code create} methods to implement this.
      * <p>
      * For {@code QueryPlan}s, it is very important that
      * the properties contain all of the expressions and references relevant to this node, and
-     * that all of the properties are used in the provided constructor; otherwise query plan
+     * that all the properties are used in the provided constructor; otherwise query plan
      * transformations like
      * {@code QueryPlan#transformExpressionsOnly(Function)}
      * will not have an effect.

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/tree/NodeInfo.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/tree/NodeInfo.java
@@ -18,7 +18,10 @@ import static java.util.Collections.unmodifiableList;
 /**
  * All the information about a {@link Node} that is needed to recreate or modify it.
  * <p>
- * Allows us to perform traversals and transformations of query plans and expressions without resorting to reflection, e.g. via
+ * Generally, this will contain the longest constructor of the respective {@link Node} subclass; the non-{@link Source} arguments of that
+ * constructor are called "properties" of the node and are modified when transforming the node.
+ * <p>
+ * This allows us to perform traversals and transformations of query plans and expressions without resorting to reflection, e.g. via
  * {@link Node#transformNodeProps(Class, Function)}, which is used e.g. in {@code QueryPlan#transformExpressionsDown}.
  * <p>
  * All the uses of this are fairly non-OO and we're looking

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/tree/NodeInfo.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/tree/NodeInfo.java
@@ -16,7 +16,10 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableList;
 
 /**
- * Information about a {@link Node}.
+ * All the information about a {@link Node} that is needed to recreate or modify it.
+ * <p>
+ * Allows us to perform traversals and transformations of query plans and expressions without resorting to reflection, e.g. via
+ * {@link Node#transformNodeProps(Class, Function)}, which is used e.g. in {@code QueryPlan#transformExpressionsDown}.
  * <p>
  * All the uses of this are fairly non-OO and we're looking
  * for ways to use this less and less.


### PR DESCRIPTION
Move the javadoc from Node#info onto NodeInfo and make it clearer what it's used for.
