### PR TITLE
[ML] Add support for dimensions in google vertex ai request

### DIFF
--- a/docs/changelog/132689.yaml
+++ b/docs/changelog/132689.yaml
@@ -1,0 +1,5 @@
+pr: 132689
+summary: Add support for dimensions in google vertex ai request
+area: Machine Learning
+type: enhancement
+issues: []

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/embeddings/GoogleVertexAiEmbeddingsModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/embeddings/GoogleVertexAiEmbeddingsModel.java
@@ -67,7 +67,7 @@ public class GoogleVertexAiEmbeddingsModel extends GoogleVertexAiModel {
     }
 
     // Should only be used directly for testing
-    GoogleVertexAiEmbeddingsModel(
+    public GoogleVertexAiEmbeddingsModel(
         String inferenceEntityId,
         TaskType taskType,
         String service,

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/GoogleVertexAiEmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/GoogleVertexAiEmbeddingsRequest.java
@@ -49,8 +49,14 @@ public class GoogleVertexAiEmbeddingsRequest implements GoogleVertexAiRequest {
         HttpPost httpPost = new HttpPost(model.nonStreamingUri());
 
         ByteArrayEntity byteEntity = new ByteArrayEntity(
-            Strings.toString(new GoogleVertexAiEmbeddingsRequestEntity(truncationResult.input(), inputType, model.getTaskSettings()))
-                .getBytes(StandardCharsets.UTF_8)
+            Strings.toString(
+                new GoogleVertexAiEmbeddingsRequestEntity(
+                    truncationResult.input(),
+                    inputType,
+                    model.getTaskSettings(),
+                    model.getServiceSettings()
+                )
+            ).getBytes(StandardCharsets.UTF_8)
         );
 
         httpPost.setEntity(byteEntity);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/GoogleVertexAiEmbeddingsRequestEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/request/GoogleVertexAiEmbeddingsRequestEntity.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.inference.services.googlevertexai.request;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.inference.services.googlevertexai.embeddings.GoogleVertexAiEmbeddingsServiceSettings;
 import org.elasticsearch.xpack.inference.services.googlevertexai.embeddings.GoogleVertexAiEmbeddingsTaskSettings;
 
 import java.io.IOException;
@@ -21,13 +22,15 @@ import static org.elasticsearch.inference.InputType.invalidInputTypeMessage;
 public record GoogleVertexAiEmbeddingsRequestEntity(
     List<String> inputs,
     InputType inputType,
-    GoogleVertexAiEmbeddingsTaskSettings taskSettings
+    GoogleVertexAiEmbeddingsTaskSettings taskSettings,
+    GoogleVertexAiEmbeddingsServiceSettings serviceSettings
 ) implements ToXContentObject {
 
     private static final String INSTANCES_FIELD = "instances";
     private static final String CONTENT_FIELD = "content";
     private static final String PARAMETERS_FIELD = "parameters";
     private static final String AUTO_TRUNCATE_FIELD = "autoTruncate";
+    private static final String OUTPUT_DIMENSIONALITY_FIELD = "outputDimensionality";
     private static final String TASK_TYPE_FIELD = "task_type";
 
     private static final String CLASSIFICATION_TASK_TYPE = "CLASSIFICATION";
@@ -38,6 +41,7 @@ public record GoogleVertexAiEmbeddingsRequestEntity(
     public GoogleVertexAiEmbeddingsRequestEntity {
         Objects.requireNonNull(inputs);
         Objects.requireNonNull(taskSettings);
+        Objects.requireNonNull(serviceSettings);
     }
 
     @Override
@@ -62,13 +66,17 @@ public record GoogleVertexAiEmbeddingsRequestEntity(
 
         builder.endArray();
 
-        if (taskSettings.autoTruncate() != null) {
-            builder.startObject(PARAMETERS_FIELD);
-            {
+        builder.startObject(PARAMETERS_FIELD);
+        {
+            if (taskSettings.autoTruncate() != null) {
                 builder.field(AUTO_TRUNCATE_FIELD, taskSettings.autoTruncate());
             }
-            builder.endObject();
+            if (serviceSettings.dimensionsSetByUser()) {
+                builder.field(OUTPUT_DIMENSIONALITY_FIELD, serviceSettings.dimensions());
+            }
         }
+        builder.endObject();
+
         builder.endObject();
 
         return builder;


### PR DESCRIPTION
This PR adds support for passing the `dimensions` field through to the request to send to google vertex ai. We had included the field in the service settings but didn't send it in the request.

The `dimensions` field maps to `outputDimensionality` https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/text-embeddings-api

## Testing

```
PUT _inference/text_embedding/test
{
    "service": "googlevertexai",
    "service_settings": {
        "service_account_json": "<service_account>",
        "model_id": "gemini-embedding-001",
        "location": "us-central1",
        "project_id": "elastic-ml",
        "dimensions": 10
    }
}
```

Generate embeddings
```
POST _inference/text_embedding/test
{
    "input": ["The food was delicious"]
}
```

Response
```
{
    "text_embedding": [
        {
            "embedding": [
                0.0038749145,
                -0.0017926422,
                0.00781796,
                -0.06123169,
                -0.0026226782,
                -0.012737362,
                0.016699702,
                -0.016461374,
                -0.007187545,
                0.016607152
            ]
        }
    ]
}
```