### PR TITLE
ES|QL: Fix generative tests - exclude unsupported fields

### DIFF
--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/EsqlQueryGenerator.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/EsqlQueryGenerator.java
@@ -38,7 +38,11 @@ import static org.elasticsearch.test.ESTestCase.randomLongBetween;
 
 public class EsqlQueryGenerator {
 
-    public record Column(String name, String type) {}
+    public static final String COLUMN_NAME = "name";
+    public static final String COLUMN_TYPE = "type";
+    public static final String COLUMN_ORIGINAL_TYPES = "original_types";
+
+    public record Column(String name, String type, List<String> originalTypes) {}
 
     public record QueryExecuted(String query, int depth, List<Column> outputSchema, List<List<Object>> result, Exception exception) {}
 
@@ -331,7 +335,7 @@ public class EsqlQueryGenerator {
             || field.name().equals("<no-fields>")
             // no dense vectors for now, they are not supported in most commands
             || field.type().contains("vector")
-            || field.type().contains("unsupported")) == false;
+            || field.originalTypes.stream().anyMatch(x -> x.contains("vector"))) == false;
     }
 
     public static String unquote(String colName) {

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/EsqlQueryGenerator.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/EsqlQueryGenerator.java
@@ -330,7 +330,8 @@ public class EsqlQueryGenerator {
             // this is a known pathological case, no need to test it for now
             || field.name().equals("<no-fields>")
             // no dense vectors for now, they are not supported in most commands
-            || field.type().contains("vector")) == false;
+            || field.type().contains("vector")
+            || field.type().contains("unsupported")) == false;
     }
 
     public static String unquote(String colName) {

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
@@ -32,6 +32,9 @@ import static org.elasticsearch.xpack.esql.CsvTestsDataLoader.CSV_DATASET_MAP;
 import static org.elasticsearch.xpack.esql.CsvTestsDataLoader.ENRICH_POLICIES;
 import static org.elasticsearch.xpack.esql.CsvTestsDataLoader.availableDatasetsForEs;
 import static org.elasticsearch.xpack.esql.CsvTestsDataLoader.loadDataSetIntoEs;
+import static org.elasticsearch.xpack.esql.qa.rest.generative.EsqlQueryGenerator.COLUMN_NAME;
+import static org.elasticsearch.xpack.esql.qa.rest.generative.EsqlQueryGenerator.COLUMN_ORIGINAL_TYPES;
+import static org.elasticsearch.xpack.esql.qa.rest.generative.EsqlQueryGenerator.COLUMN_TYPE;
 
 public abstract class GenerativeRestTest extends ESRestTestCase {
 
@@ -212,11 +215,22 @@ public abstract class GenerativeRestTest extends ESRestTestCase {
 
     @SuppressWarnings("unchecked")
     private static List<EsqlQueryGenerator.Column> outputSchema(Map<String, Object> a) {
-        List<Map<String, String>> cols = (List<Map<String, String>>) a.get("columns");
+        List<Map<String, ?>> cols = (List<Map<String, ?>>) a.get("columns");
         if (cols == null) {
             return null;
         }
-        return cols.stream().map(x -> new EsqlQueryGenerator.Column(x.get("name"), x.get("type"))).collect(Collectors.toList());
+        return cols.stream()
+            .map(x -> new EsqlQueryGenerator.Column((String) x.get(COLUMN_NAME), (String) x.get(COLUMN_TYPE), originalTypes(x)))
+            .collect(Collectors.toList());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> originalTypes(Map<String, ?> x) {
+        List<String> originalTypes = (List<String>) x.get(COLUMN_ORIGINAL_TYPES);
+        if (originalTypes == null) {
+            return List.of();
+        }
+        return originalTypes;
     }
 
     private List<String> availableIndices() throws IOException {


### PR DESCRIPTION
Exclude `vector` fields from generative tests.

Fixes: https://github.com/elastic/elasticsearch/issues/132520