### PR TITLE
Push compute engine value loading for dense singleton ordinals down to tsdb codec.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/BulkNumericDocValues.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/BulkNumericDocValues.java
@@ -24,4 +24,7 @@ public abstract class BulkNumericDocValues extends NumericDocValues {
      */
     public abstract BlockLoader.Block read(BlockLoader.BlockFactory factory, BlockLoader.Docs docs, int offset) throws IOException;
 
+    public abstract BlockLoader.Block readOrdinals(BlockLoader.SingletonOrdinalsBuilder builder, BlockLoader.Docs docs, int offset)
+        throws IOException;
+
 }

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/BulkSortedDocValues.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/BulkSortedDocValues.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.tsdb.es819;
+
+import org.apache.lucene.index.SortedDocValues;
+import org.elasticsearch.index.mapper.BlockLoader;
+
+import java.io.IOException;
+
+public abstract class BulkSortedDocValues extends SortedDocValues {
+
+    public BlockLoader.Block read(BlockLoader.BlockFactory factory, BlockLoader.Docs docs, int offset) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    public boolean supportsBlockRead() {
+        return false;
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesProducer.java
@@ -373,7 +373,7 @@ final class ES819TSDBDocValuesProducer extends DocValuesProducer {
             @Override
             public BlockLoader.Block read(BlockLoader.BlockFactory factory, BlockLoader.Docs docs, int offset) throws IOException {
                 if (ords instanceof BulkNumericDocValues b) {
-                    try (var builder = factory.singletonOrdinalsBuilder(this, docs.count() - offset)) {
+                    try (var builder = factory.singletonOrdinalsBuilder(this, docs.count() - offset, true)) {
                         return b.readOrdinals(builder, docs, offset);
                     }
                 } else {

--- a/server/src/main/java/org/elasticsearch/index/mapper/BlockDocValuesReader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BlockDocValuesReader.java
@@ -22,6 +22,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.ByteArrayStreamInput;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.codec.tsdb.es819.BulkNumericDocValues;
+import org.elasticsearch.index.codec.tsdb.es819.BulkSortedDocValues;
 import org.elasticsearch.index.mapper.BlockLoader.BlockFactory;
 import org.elasticsearch.index.mapper.BlockLoader.BooleanBuilder;
 import org.elasticsearch.index.mapper.BlockLoader.Builder;
@@ -658,6 +659,9 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
         public BlockLoader.Block read(BlockFactory factory, Docs docs, int offset) throws IOException {
             if (docs.count() - offset == 1) {
                 return readSingleDoc(factory, docs.get(offset));
+            }
+            if (ordinals instanceof BulkSortedDocValues bulkDv && bulkDv.supportsBlockRead()) {
+                return bulkDv.read(factory, docs, offset);
             }
             try (var builder = factory.singletonOrdinalsBuilder(ordinals, docs.count() - offset)) {
                 for (int i = offset; i < docs.count(); i++) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/BlockDocValuesReader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BlockDocValuesReader.java
@@ -663,7 +663,7 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
             if (ordinals instanceof BulkSortedDocValues bulkDv && bulkDv.supportsBlockRead()) {
                 return bulkDv.read(factory, docs, offset);
             }
-            try (var builder = factory.singletonOrdinalsBuilder(ordinals, docs.count() - offset)) {
+            try (var builder = factory.singletonOrdinalsBuilder(ordinals, docs.count() - offset, false)) {
                 for (int i = offset; i < docs.count(); i++) {
                     int doc = docs.get(i);
                     if (doc < ordinals.docID()) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/BlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BlockLoader.java
@@ -531,6 +531,8 @@ public interface BlockLoader {
          * Appends an ordinal to the builder.
          */
         SingletonOrdinalsBuilder appendOrd(int value);
+
+        SingletonOrdinalsBuilder appendOrds(int[] values, int from, int length, int minOrd, int maxOrd);
     }
 
     interface SortedSetOrdinalsBuilder extends Builder {

--- a/server/src/main/java/org/elasticsearch/index/mapper/BlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BlockLoader.java
@@ -430,7 +430,7 @@ public interface BlockLoader {
         /**
          * Build a reader for reading {@link SortedDocValues}
          */
-        SingletonOrdinalsBuilder singletonOrdinalsBuilder(SortedDocValues ordinals, int count);
+        SingletonOrdinalsBuilder singletonOrdinalsBuilder(SortedDocValues ordinals, int count, boolean isDense);
 
         /**
          * Build a reader for reading {@link SortedSetDocValues}

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/TestBlock.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/TestBlock.java
@@ -268,7 +268,11 @@ public class TestBlock implements BlockLoader.Block {
             }
 
             @Override
-            public BlockLoader.SingletonOrdinalsBuilder singletonOrdinalsBuilder(SortedDocValues ordinals, int expectedCount) {
+            public BlockLoader.SingletonOrdinalsBuilder singletonOrdinalsBuilder(
+                SortedDocValues ordinals,
+                int expectedCount,
+                boolean isDense
+            ) {
                 class SingletonOrdsBuilder extends TestBlock.Builder implements BlockLoader.SingletonOrdinalsBuilder {
                     private SingletonOrdsBuilder() {
                         super(expectedCount);

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/TestBlock.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/TestBlock.java
@@ -283,6 +283,14 @@ public class TestBlock implements BlockLoader.Block {
                             throw new UncheckedIOException(e);
                         }
                     }
+
+                    @Override
+                    public BlockLoader.SingletonOrdinalsBuilder appendOrds(int[] values, int from, int length, int minOrd, int maxOrd) {
+                        for (int i = from; i < from + length; i++) {
+                            appendOrd(values[i]);
+                        }
+                        return this;
+                    }
                 }
                 return new SingletonOrdsBuilder();
             }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/DelegatingBlockLoaderFactory.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/DelegatingBlockLoaderFactory.java
@@ -87,8 +87,8 @@ public abstract class DelegatingBlockLoaderFactory implements BlockLoader.BlockF
     }
 
     @Override
-    public BlockLoader.SingletonOrdinalsBuilder singletonOrdinalsBuilder(SortedDocValues ordinals, int count) {
-        return new SingletonOrdinalsBuilder(factory, ordinals, count);
+    public BlockLoader.SingletonOrdinalsBuilder singletonOrdinalsBuilder(SortedDocValues ordinals, int count, boolean isDense) {
+        return new SingletonOrdinalsBuilder(factory, ordinals, count, isDense);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/SingletonOrdinalsBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/SingletonOrdinalsBuilder.java
@@ -56,6 +56,15 @@ public class SingletonOrdinalsBuilder implements BlockLoader.SingletonOrdinalsBu
     }
 
     @Override
+    public BlockLoader.SingletonOrdinalsBuilder appendOrds(int[] values, int from, int length, int minOrd, int maxOrd) {
+        System.arraycopy(values, from, ords, count, length);
+        this.count += length;
+        this.minOrd = Math.min(this.minOrd, minOrd);
+        this.maxOrd = Math.max(this.maxOrd, maxOrd);
+        return this;
+    }
+
+    @Override
     public SingletonOrdinalsBuilder beginPositionEntry() {
         throw new UnsupportedOperationException("should only have one value per doc");
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/SingletonOrdinalsBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/SingletonOrdinalsBuilder.java
@@ -33,16 +33,23 @@ public class SingletonOrdinalsBuilder implements BlockLoader.SingletonOrdinalsBu
     private int maxOrd = Integer.MIN_VALUE;
     private final int[] ords;
     private int count;
+    private final boolean isDense;
 
     public SingletonOrdinalsBuilder(BlockFactory blockFactory, SortedDocValues docValues, int count) {
+        this(blockFactory, docValues, count, false);
+    }
+
+    public SingletonOrdinalsBuilder(BlockFactory blockFactory, SortedDocValues docValues, int count, boolean isDense) {
         this.blockFactory = blockFactory;
         this.docValues = docValues;
         blockFactory.adjustBreaker(ordsSize(count));
         this.ords = new int[count];
+        this.isDense = isDense;
     }
 
     @Override
     public SingletonOrdinalsBuilder appendNull() {
+        assert isDense == false;
         ords[count++] = -1; // real ords can't be < 0, so we use -1 as null
         return this;
     }
@@ -78,9 +85,11 @@ public class SingletonOrdinalsBuilder implements BlockLoader.SingletonOrdinalsBu
         if (minOrd != maxOrd) {
             return null;
         }
-        for (int ord : ords) {
-            if (ord == -1) {
-                return null;
+        if (isDense == false) {
+            for (int ord : ords) {
+                if (ord == -1) {
+                    return null;
+                }
             }
         }
         final BytesRef v;
@@ -116,33 +125,61 @@ public class SingletonOrdinalsBuilder implements BlockLoader.SingletonOrdinalsBu
         try {
             int[] newOrds = new int[valueCount];
             Arrays.fill(newOrds, -1);
-            for (int ord : ords) {
-                if (ord != -1) {
+            // Re-mapping ordinals to be more space-efficient:
+            if (isDense) {
+                for (int ord : ords) {
                     newOrds[ord - minOrd] = 0;
+                }
+            } else {
+                for (int ord : ords) {
+                    if (ord != -1) {
+                        newOrds[ord - minOrd] = 0;
+                    }
                 }
             }
             // resolve the ordinals and remaps the ordinals
-            int nextOrd = -1;
-            try (BytesRefVector.Builder bytesBuilder = blockFactory.newBytesRefVectorBuilder(Math.min(valueCount, ords.length))) {
-                for (int i = 0; i < newOrds.length; i++) {
-                    if (newOrds[i] != -1) {
-                        newOrds[i] = ++nextOrd;
-                        bytesBuilder.appendBytesRef(docValues.lookupOrd(i + minOrd));
-                    }
+            try {
+                int nextOrd = -1;
+                BytesRef firstTerm = minOrd != Integer.MAX_VALUE ? docValues.lookupOrd(minOrd) : null;
+                int estimatedSize;
+                if (firstTerm != null) {
+                    estimatedSize = Math.min(valueCount, ords.length) * firstTerm.length;
+                } else {
+                    estimatedSize = Math.min(valueCount, ords.length);
                 }
-                bytesVector = bytesBuilder.build();
+                try (BytesRefVector.Builder bytesBuilder = blockFactory.newBytesRefVectorBuilder(estimatedSize)) {
+                    if (firstTerm != null) {
+                        newOrds[0] = ++nextOrd;
+                        bytesBuilder.appendBytesRef(firstTerm);
+                    }
+                    for (int i = firstTerm != null ? 1 : 0; i < newOrds.length; i++) {
+                        if (newOrds[i] != -1) {
+                            newOrds[i] = ++nextOrd;
+                            bytesBuilder.appendBytesRef(docValues.lookupOrd(i + minOrd));
+                        }
+                    }
+                    bytesVector = bytesBuilder.build();
+                }
             } catch (IOException e) {
                 throw new UncheckedIOException("error resolving ordinals", e);
             }
-            try (IntBlock.Builder ordinalsBuilder = blockFactory.newIntBlockBuilder(ords.length)) {
-                for (int ord : ords) {
-                    if (ord == -1) {
-                        ordinalsBuilder.appendNull();
-                    } else {
-                        ordinalsBuilder.appendInt(newOrds[ord - minOrd]);
-                    }
+            if (isDense) {
+                // Reusing ords array and overwrite all slots with re-mapped ordinals
+                for (int i = 0; i < ords.length; i++) {
+                    ords[i] = newOrds[ords[i] - minOrd];
                 }
-                ordinalBlock = ordinalsBuilder.build();
+                ordinalBlock = blockFactory.newIntArrayVector(ords, ords.length).asBlock();
+            } else {
+                try (IntBlock.Builder ordinalsBuilder = blockFactory.newIntBlockBuilder(ords.length)) {
+                    for (int ord : ords) {
+                        if (ord == -1) {
+                            ordinalsBuilder.appendNull();
+                        } else {
+                            ordinalsBuilder.appendInt(newOrds[ord - minOrd]);
+                        }
+                    }
+                    ordinalBlock = ordinalsBuilder.build();
+                }
             }
             final OrdinalBytesRefBlock result = new OrdinalBytesRefBlock(ordinalBlock, bytesVector);
             bytesVector = null;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/TimeSeriesExtractFieldOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/TimeSeriesExtractFieldOperator.java
@@ -208,7 +208,7 @@ public class TimeSeriesExtractFieldOperator extends AbstractPageMappingOperator 
         }
 
         @Override
-        public BlockLoader.SingletonOrdinalsBuilder singletonOrdinalsBuilder(SortedDocValues ordinals, int count) {
+        public BlockLoader.SingletonOrdinalsBuilder singletonOrdinalsBuilder(SortedDocValues ordinals, int count, boolean isDense) {
             throw new UnsupportedOperationException("must not be used by column readers");
         }
     }


### PR DESCRIPTION
WIP Note: no tests yet, exploring how to implement bulk loading of dense singleton sorted (set) doc values.

This change targets reading field values in bulk mode at codec level when doc values type is sorted doc values or sorted set doc values, there is only one value per document, and the field is dense (all documents have a value).

Relates to #128445