### PR TITLE
Unmute `CrossClusterEsqlRCS1EnrichUnavailableRemotesIT`

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -461,9 +461,6 @@ tests:
 - class: org.elasticsearch.test.rest.yaml.RcsCcsCommonYamlTestSuiteIT
   method: test {p0=search/600_flattened_ignore_above/flattened ignore_above multi-value field}
   issue: https://github.com/elastic/elasticsearch/issues/131967
-- class: org.elasticsearch.xpack.remotecluster.CrossClusterEsqlRCS1EnrichUnavailableRemotesIT
-  method: testEsqlEnrichWithSkipUnavailable
-  issue: https://github.com/elastic/elasticsearch/issues/132078
 - class: org.elasticsearch.index.engine.MergeWithLowDiskSpaceIT
   method: testRelocationWhileForceMerging
   issue: https://github.com/elastic/elasticsearch/issues/131789


### PR DESCRIPTION
This test got muted due to an issue with the CI and there's nothing inherently wrong with the test itself. Ref https://github.com/elastic/elasticsearch/issues/132078#issuecomment-3174524984 for exact details.

Fixes https://github.com/elastic/elasticsearch/issues/132078.