### PR TITLE
Remove 132597 as not affecting for 8.19.0 version

### DIFF
--- a/docs/reference/release-notes/8.19.0.asciidoc
+++ b/docs/reference/release-notes/8.19.0.asciidoc
@@ -539,17 +539,4 @@ Snapshot/Restore::
 * Upgrade AWS Java SDK to 2.31.78 {es-pull}131050[#131050]
 * Upgrade AWS SDK to v1.12.746 {es-pull}122431[#122431]
 
-[discrete]
-[[known-issues-8.19.0]]
-=== Known issues
-
-* An [optimization](https://github.com/elastic/elasticsearch/pull/125403) introduced in 8.19.0 contains a [bug](https://github.com/elastic/elasticsearch/pull/132597) that causes merges to fail for shrunk TSDB and LogsDB indices.
-  
-  Possible *temporary* workarounds include:
-  * Configure the ILM policy to not perform force merges after shrinking TSDB or LogsDB indices.
-  * Add `-Dorg.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesConsumer.enableOptimizedMerge=false` as a Java system property to all data nodes in the cluster and perform a rolling restart.
-    * *Important:* Remove this property when upgrading to the fixed version to re-enable merge optimization. Otherwise, merges will be slower.  
-
-The bug is addressed in version 8.19.2. 
-
 


### PR DESCRIPTION
Reverting [change](https://github.com/elastic/elasticsearch/pull/132683) based on the [comment](https://github.com/elastic/elasticsearch/pull/132683#discussion_r2268371884).

Due to a PR CI issue, the [optimization](https://github.com/elastic/elasticsearch/pull/125403) introduced in 8.19.0 that would have caused the [bug](https://github.com/elastic/elasticsearch/pull/132597) didn't actually get enabled in 8.19.x versions.  Therefore, 8.19.0 and 8.19.1 do not have either the optimization or the bug.  The optimization will be enabled in 8.19.2 and the bug will be fixed by then.  