### PR TITLE
Wait for snapshot finalization in `testSnapshotAPMMetrics()`

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -504,9 +504,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.RevertModelSnapshotIT
   method: testRevertModelSnapshot
   issue: https://github.com/elastic/elasticsearch/issues/132733
-- class: org.elasticsearch.repositories.SnapshotMetricsIT
-  method: testSnapshotAPMMetrics
-  issue: https://github.com/elastic/elasticsearch/issues/132731
 
 # Examples:
 #


### PR DESCRIPTION
Adds an `assertBusy()` to `testSnapshotAPMMetrics()` to ensure the snapshot finalization code has had a chance to run and update the snapshot completed metrics.

The `awaitNumberOfSnapshotsInProgress(0)` call returns after it observes the expected `SnapshotsInProgress` cluster state update, but the snapshot finalization code may not have been executed yet.

The change in #132686 only reduced the race condition window.

Resolves: #132731