### PR TITLE
modules: add slf4j-nop where it is missing

### DIFF
--- a/modules/repository-gcs/build.gradle
+++ b/modules/repository-gcs/build.gradle
@@ -29,6 +29,7 @@ dependencies {
   runtimeOnly 'com.google.guava:guava:33.4.0-jre'
   runtimeOnly 'com.google.guava:failureaccess:1.0.2'
   runtimeOnly "org.slf4j:slf4j-api:${versions.slf4j}" // 2.0.16 in bom
+  runtimeOnly "org.slf4j:slf4j-nop:${versions.slf4j}"
   runtimeOnly "commons-codec:commons-codec:${versions.commonscodec}" // 1.18.0 in bom
   implementation 'com.google.api:api-common:2.46.1'
   implementation 'com.google.api:gax:2.63.1'

--- a/modules/repository-s3/build.gradle
+++ b/modules/repository-s3/build.gradle
@@ -45,6 +45,7 @@ dependencies {
   runtimeOnly "org.apache.logging.log4j:log4j-1.2-api:${versions.log4j}"
   runtimeOnly "org.reactivestreams:reactive-streams:${versions.reactive_streams}"
   runtimeOnly "org.slf4j:slf4j-api:${versions.slf4j}"
+  runtimeOnly "org.slf4j:slf4j-nop:${versions.slf4j}"
   runtimeOnly "software.amazon.awssdk:arns:${versions.awsv2sdk}"
   runtimeOnly "software.amazon.awssdk:aws-query-protocol:${versions.awsv2sdk}"
   runtimeOnly "software.amazon.awssdk:checksums-spi:${versions.awsv2sdk}"

--- a/x-pack/plugin/ent-search/build.gradle
+++ b/x-pack/plugin/ent-search/build.gradle
@@ -26,6 +26,7 @@ dependencies {
   implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
   implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}"
   implementation "org.slf4j:slf4j-api:${versions.slf4j}"
+  runtimeOnly "org.slf4j:slf4j-nop:${versions.slf4j}"
   implementation "org.apache.logging.log4j:log4j-slf4j-impl:${versions.log4j}"
   implementation "com.networknt:json-schema-validator:${versions.networknt_json_schema_validator}"
 


### PR DESCRIPTION
Default startup of elasticsearch results in warnings:

> [WARN ][stderr ] [es] SLF4J: No SLF4J providers were found.
> [WARN ][stderr ] [es] SLF4J: Defaulting to no-operation (NOP) logger implementation
> [WARN ][stderr ] [es] SLF4J: See https://www.slf4j.org/codes.html#noProviders for further details.

It seems like most modules and plugins install nop logger, but some don't. If one installs them everywhere, these warnings seem to go away.