### PR TITLE
Adjust testHKmeans assertion after #132706

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -504,9 +504,6 @@ tests:
 - class: org.elasticsearch.repositories.SnapshotMetricsIT
   method: testSnapshotAPMMetrics
   issue: https://github.com/elastic/elasticsearch/issues/132731
-- class: org.elasticsearch.index.codec.vectors.cluster.HierarchicalKMeansTests
-  method: testHKmeans
-  issue: https://github.com/elastic/elasticsearch/issues/132771
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeForkIT
   method: test {csv-spec:lookup-join.MvJoinKeyFromRowExpanded}
   issue: https://github.com/elastic/elasticsearch/issues/132778

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/cluster/HierarchicalKMeansTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/cluster/HierarchicalKMeansTests.java
@@ -46,8 +46,9 @@ public class HierarchicalKMeansTests extends ESTestCase {
             assertEquals(nVectors, soarAssignments.length);
             // verify no duplicates exist
             for (int i = 0; i < assignments.length; i++) {
-                assertTrue(soarAssignments[i] >= 0 && soarAssignments[i] < centroids.length);
-                assertNotEquals(assignments[i], soarAssignments[i]);
+                int soarAssignment = soarAssignments[i];
+                assertTrue(soarAssignment == -1 || (soarAssignment >= 0 && soarAssignment < centroids.length));
+                assertNotEquals(assignments[i], soarAssignment);
             }
         } else {
             assertEquals(0, soarAssignments.length);


### PR DESCRIPTION
We are not spilling vectors that are numerically equivalent to the centroid so we need to adjust the assertion in the tests because we can have unassigned soar vectors.

fixes https://github.com/elastic/elasticsearch/issues/132771