### PR TITLE
[8.18] EQL: better error message for sequences with only one clause plus UNTIL (#132638)

### DIFF
--- a/docs/changelog/132638.yaml
+++ b/docs/changelog/132638.yaml
@@ -1,0 +1,5 @@
+pr: 132638
+summary: Better error message for sequences with only one clause plus UNTIL
+area: EQL
+type: bug
+issues: []

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/LogicalPlanBuilder.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/parser/LogicalPlanBuilder.java
@@ -330,6 +330,9 @@ public abstract class LogicalPlanBuilder extends ExpressionBuilder {
 
         // until is already parsed through sequenceTerm() above
         if (ctx.until != null) {
+            if (queries.size() == 2) {
+                throw new ParsingException(source, "A sequence requires a minimum of 2 queries (excluding UNTIL clause), found [1]");
+            }
             until = queries.remove(queries.size() - 1);
         } else {
             until = defaultUntil(source);

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/planner/QueryTranslatorFailTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/planner/QueryTranslatorFailTests.java
@@ -261,6 +261,17 @@ public class QueryTranslatorFailTests extends AbstractQueryTranslatorTestCase {
         assertEquals("1:2: A sequence requires a minimum of 2 queries, found [1]", s);
     }
 
+    public void testSequenceWithTooLittleQueriesWithUntil() throws Exception {
+        String s = errorParsing("sequence [any where true] until [any where true]");
+        assertEquals("1:2: A sequence requires a minimum of 2 queries (excluding UNTIL clause), found [1]", s);
+        plan("sequence [any where true] [any where true] until [any where true]");
+    }
+
+    public void testSequenceWithOnlyMissingEventsAndUntil() throws Exception {
+        String s = errorParsing("sequence with maxspan=1h ![process where true] until [process where true]");
+        assertEquals("1:2: A sequence requires a minimum of 2 queries (excluding UNTIL clause), found [1]", s);
+    }
+
     public void testSequenceWithIncorrectOption() throws Exception {
         EqlClientException e = expectThrows(EqlClientException.class, () -> plan("sequence [any where true] with repeat=123"));
         String msg = e.getMessage();


### PR DESCRIPTION
Backports the following commits to 8.18:
 - EQL: better error message for sequences with only one clause plus UNTIL (#132638)