### PR TITLE
SearchWithRandomDisconnectsIT testSearchWithRandomDisconnect test-failure

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -212,9 +212,6 @@ tests:
 - class: org.elasticsearch.action.RejectionActionIT
   method: testSimulatedSearchRejectionLoad
   issue: https://github.com/elastic/elasticsearch/issues/125901
-- class: org.elasticsearch.search.basic.SearchWithRandomDisconnectsIT
-  method: testSearchWithRandomDisconnects
-  issue: https://github.com/elastic/elasticsearch/issues/122707
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=transform/transforms_reset/Test force reseting a running transform}
   issue: https://github.com/elastic/elasticsearch/issues/126240

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -1618,6 +1618,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                 shardIterators.size(),
                 exc -> searchTransportService.cancelSearchTask(task, "failed to merge result [" + exc.getMessage() + "]")
             );
+            final ActionListener<SearchResponse> releasingListener = ActionListener.runAfter(listener, queryResultConsumer::close);
             boolean success = false;
             try {
                 final AbstractSearchAsyncAction<?> searchPhase;
@@ -1632,7 +1633,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                         executor,
                         queryResultConsumer,
                         searchRequest,
-                        listener,
+                        releasingListener,
                         shardIterators,
                         timeProvider,
                         clusterState,
@@ -1652,7 +1653,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                         executor,
                         queryResultConsumer,
                         searchRequest,
-                        listener,
+                        releasingListener,
                         shardIterators,
                         timeProvider,
                         clusterState,


### PR DESCRIPTION
In the [122707](https://github.com/elastic/elasticsearch/issues/122707) test-failure we get the error
```
Expected: an empty collection
         but: <[LEAK: resource was not cleaned up before it was garbage-collected.
    Recent access records: 
     #1:
        in [elasticsearch[node_s1][search][T#2]][testSearchWithRandomDisconnects {seed=[9C4F49EC3D6BE222:4BFA3E4DF9657D16]}]
        org.elasticsearch.action.ActionListener.respondAndRelease(ActionListener.java:388)
        org.elasticsearch.action.ActionRunnable$3.accept(ActionRunnable.java:79)
        org.elasticsearch.action.ActionRunnable$3.accept(ActionRunnable.java:76)
        org.elasticsearch.action.ActionRunnable$4.doRun(ActionRunnable.java:101)
        org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:27)
        org.elasticsearch.common.util.concurrent.TimedRunnable.doRun(TimedRunnable.java:34)
        org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:1044)
        org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:27)
        java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1095)
        java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:619)
        java.base/java.lang.Thread.run(Thread.java:1447)
    #2:
        in [elasticsearch[node_s1][search][T#2]][testSearchWithRandomDisconnects {seed=[9C4F49EC3D6BE222:4BFA3E4DF9657D16]}]
        org.elasticsearch.action.search.ArraySearchPhaseResults.consumeResult(ArraySearchPhaseResults.java:47)
        org.elasticsearch.action.search.QueryPhaseResultConsumer.consumeResult(QueryPhaseResultConsumer.java:159)
        org.elasticsearch.action.search.AbstractSearchAsyncAction.onShardResult(AbstractSearchAsyncAction.java:503)
        org.elasticsearch.action.search.SearchQueryThenFetchAsyncAction.onShardResult(SearchQueryThenFetchAsyncAction.java:180)
        org.elasticsearch.action.search.AbstractSearchAsyncAction$1.innerOnResponse(AbstractSearchAsyncAction.
```
This draft PR, addresses(?) the resource leak reported by the leak tracker, which indicates that a search-phase-related resource (likely ArraySearchPhaseResults or a similar buffer) is not being properly released before garbage collection.

To mitigate this, the existing listener is wrapped by `ActionListener.runAfter`, ensuring that `queryResultConsumer::close` is always invoked once the search operation completes — whether it succeeds or fails:

```
final ActionListener<SearchResponse> releasingListener = ActionListener.runAfter(listener, queryResultConsumer::close);
```
This hopefully ensures that the `queryResultConsumer` is reliably closed after the original listener is notified, preventing the resource leak and aligning with the expected lifecycle management.

This has not been extensively tested yet, but initial results suggest it resolves the issue in the `SearchWithRandomDisconnectsIT` test case.

cc @benchaplin (you are currently reviewing tests that disable batched execution)
