### PR TITLE
[DOCS] Explains that chunks stored as offsets in semantic_text

### DIFF
--- a/docs/reference/elasticsearch/mapping-reference/semantic-text.md
+++ b/docs/reference/elasticsearch/mapping-reference/semantic-text.md
@@ -243,7 +243,8 @@ stack: ga 9.1
 
 You can pre-chunk the input by sending it to Elasticsearch as an array of
 strings.
-Example:
+
+For example:
 
 ```console
 PUT test-index
@@ -545,7 +546,6 @@ POST test-index/_search
 
 This will return verbose chunked embeddings content that is used to perform
 semantic search for `semantic_text` fields.
-
 
 ## Limitations [limitations]
 

--- a/docs/reference/elasticsearch/mapping-reference/semantic-text.md
+++ b/docs/reference/elasticsearch/mapping-reference/semantic-text.md
@@ -107,7 +107,6 @@ PUT my-index-000003
 ```
 
 ### Using ELSER on EIS
-
 ```{applies_to}
 stack: preview 9.1
 serverless: preview
@@ -236,7 +235,6 @@ to [this tutorial](docs-content://solutions/search/semantic-search/semantic-sear
 to learn more about semantic search using `semantic_text`.
 
 ### Pre-chunking [pre-chunking]
-
 ```{applies_to}
 stack: ga 9.1
 ```
@@ -289,7 +287,6 @@ PUT test-index/_doc/1
       the input.
 
 ## Retrieving indexed chunks
-
 ```{applies_to}
 stack: ga 9.2
 serverless: ga

--- a/docs/reference/elasticsearch/mapping-reference/semantic-text.md
+++ b/docs/reference/elasticsearch/mapping-reference/semantic-text.md
@@ -223,6 +223,10 @@ generated from it. When querying, the individual passages will be automatically
 searched for each document, and the most relevant passage will be used to
 compute a score.
 
+Chunks are stored as start and end character offsets rather than as separate
+text strings. These offsets point to the exact location of each chunk within the
+original input text.
+
 For more details on chunking and how to configure chunking settings,
 see [Configuring chunking](https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-inference)
 in the Inference API documentation.
@@ -232,6 +236,7 @@ to [this tutorial](docs-content://solutions/search/semantic-search/semantic-sear
 to learn more about semantic search using `semantic_text`.
 
 ### Pre-chunking [pre-chunking]
+
 ```{applies_to}
 stack: ga 9.1
 ```
@@ -283,6 +288,7 @@ PUT test-index/_doc/1
       the input.
 
 ## Retrieving indexed chunks
+
 ```{applies_to}
 stack: ga 9.2
 serverless: ga


### PR DESCRIPTION
## Overview

Related to https://github.com/elastic/docs-content/issues/772

This PR adds a sentence about chunks being stored as start and end character offsets in semantic text.