### PR TITLE
[ML] Adding internal input types

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceSparseEmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceSparseEmbeddingsRequest.java
@@ -108,10 +108,10 @@ public class ElasticInferenceServiceSparseEmbeddingsRequest extends ElasticInfer
     // visible for testing
     static ElasticInferenceServiceUsageContext inputTypeToUsageContext(InputType inputType) {
         switch (inputType) {
-            case SEARCH -> {
+            case SEARCH, INTERNAL_SEARCH -> {
                 return ElasticInferenceServiceUsageContext.SEARCH;
             }
-            case INGEST -> {
+            case INGEST, INTERNAL_INGEST -> {
                 return ElasticInferenceServiceUsageContext.INGEST;
             }
             default -> {


### PR DESCRIPTION
This PR adds the `internal` `InputType` values to the translation logic for EIS.

I'm backporting this because the internal values were added in 8.19 and 9.1 from this PR: https://github.com/elastic/elasticsearch/pull/122638

