### PR TITLE
Precompute the BitsetCacheKey hashCode

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCache.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCache.java
@@ -151,8 +151,8 @@ public final class DocumentSubsetBitsetCache implements IndexReader.ClosedListen
     }
 
     @Override
-    public void onClose(IndexReader.CacheKey ownerCoreCacheKey) {
-        final Set<BitsetCacheKey> keys = keysByIndex.remove(ownerCoreCacheKey);
+    public void onClose(IndexReader.CacheKey indexKey) {
+        final Set<BitsetCacheKey> keys = keysByIndex.remove(indexKey);
         if (keys != null) {
             // Because this Set has been removed from the map, and the only update to the set is performed in a
             // Map#compute call, it should not be possible to get a concurrent modification here.
@@ -164,10 +164,10 @@ public final class DocumentSubsetBitsetCache implements IndexReader.ClosedListen
      * Cleanup (synchronize) the internal state when an object is removed from the primary cache
      */
     private void onCacheEviction(RemovalNotification<BitsetCacheKey, BitSet> notification) {
-        final BitsetCacheKey bitsetKey = notification.getKey();
-        final IndexReader.CacheKey indexKey = bitsetKey.index;
-        if (keysByIndex.getOrDefault(indexKey, Set.of()).contains(bitsetKey) == false) {
-            // If the bitsetKey isn't in the lookup map, then there's nothing to synchronize
+        final BitsetCacheKey cacheKey = notification.getKey();
+        final IndexReader.CacheKey indexKey = cacheKey.indexKey;
+        if (keysByIndex.getOrDefault(indexKey, Set.of()).contains(cacheKey) == false) {
+            // If the cacheKey isn't in the lookup map, then there's nothing to synchronize
             return;
         }
         // We push this to a background thread, so that it reduces the risk of blocking searches, but also so that the lock management is
@@ -177,9 +177,9 @@ public final class DocumentSubsetBitsetCache implements IndexReader.ClosedListen
         cleanupExecutor.submit(() -> {
             try (ReleasableLock ignored = cacheEvictionLock.acquire()) {
                 // it's possible for the key to be back in the cache if it was immediately repopulated after it was evicted, so check
-                if (bitsetCache.get(bitsetKey) == null) {
+                if (bitsetCache.get(cacheKey) == null) {
                     // key is no longer in the cache, make sure it is no longer in the lookup map either.
-                    Optional.ofNullable(keysByIndex.get(indexKey)).ifPresent(set -> set.remove(bitsetKey));
+                    Optional.ofNullable(keysByIndex.get(indexKey)).ifPresent(set -> set.remove(cacheKey));
                 }
             }
         });
@@ -325,12 +325,12 @@ public final class DocumentSubsetBitsetCache implements IndexReader.ClosedListen
 
     private static final class BitsetCacheKey {
 
-        final IndexReader.CacheKey index;
+        final IndexReader.CacheKey indexKey;
         final Query query;
         final int hashCode;
 
-        private BitsetCacheKey(IndexReader.CacheKey index, Query query) {
-            this.index = index;
+        private BitsetCacheKey(IndexReader.CacheKey indexKey, Query query) {
+            this.indexKey = indexKey;
             this.query = query;
             // compute the hashCode eagerly, since it's used multiple times in the cache implementation anyway -- the query here will
             // be a ConstantScoreQuery around a BooleanQuery, and BooleanQuery already *lazily* caches the hashCode, so this isn't
@@ -347,11 +347,11 @@ public final class DocumentSubsetBitsetCache implements IndexReader.ClosedListen
                 return false;
             }
             final BitsetCacheKey that = (BitsetCacheKey) other;
-            return Objects.equals(this.index, that.index) && Objects.equals(this.query, that.query);
+            return Objects.equals(this.indexKey, that.indexKey) && Objects.equals(this.query, that.query);
         }
 
         private int computeHashCode() {
-            int result = index.hashCode();
+            int result = indexKey.hashCode();
             result = 31 * result + query.hashCode();
             return result;
         }
@@ -363,7 +363,7 @@ public final class DocumentSubsetBitsetCache implements IndexReader.ClosedListen
 
         @Override
         public String toString() {
-            return getClass().getSimpleName() + "(" + index + "," + query + ")";
+            return getClass().getSimpleName() + "(" + indexKey + "," + query + ")";
         }
     }
 
@@ -373,15 +373,15 @@ public final class DocumentSubsetBitsetCache implements IndexReader.ClosedListen
      */
     void verifyInternalConsistency() {
         this.bitsetCache.keys().forEach(bck -> {
-            final Set<BitsetCacheKey> set = this.keysByIndex.get(bck.index);
+            final Set<BitsetCacheKey> set = this.keysByIndex.get(bck.indexKey);
             if (set == null) {
                 throw new IllegalStateException(
-                    "Key [" + bck + "] is in the cache, but there is no entry for [" + bck.index + "] in the lookup map"
+                    "Key [" + bck + "] is in the cache, but there is no entry for [" + bck.indexKey + "] in the lookup map"
                 );
             }
             if (set.contains(bck) == false) {
                 throw new IllegalStateException(
-                    "Key [" + bck + "] is in the cache, but the lookup entry for [" + bck.index + "] does not contain that key"
+                    "Key [" + bck + "] is in the cache, but the lookup entry for [" + bck.indexKey + "] does not contain that key"
                 );
             }
         });


### PR DESCRIPTION
If you trace the `org.elasticsearch.common.cache.Cache`, you can see that it uses the `hashCode` of the key object pretty extenstively (see some of the discussion on https://github.com/elastic/elasticsearch/issues/96050). For example, in a `cache.evictEntry(entry)` call, we first `hashCode` to get the right segment, then within the segment we `hashCode` to do a `get`, then finally we do a `hashCode` in the `remove`. So that's three `hashCode` calls to remove an entry. And the latter two are done while holding the `writeLock`. This isn't the be-all-end-all of performance, but it's a tidy little speedup, and it's easy to write.

I also applied some renaming to name a couple of things more consistently all the time -- this is also not a huge deal, but it seems clearer this way to me.

As with #132416, I've added @tvernum as a reviewer just as an FYI to him that this PR exists, I don't actually need his +1 specifically (anybody the @elastic/es-security team is fine by me).

Note: this is mostly an extraction of part of #132418 into a new PR (I'll return to the question of accounting for the size of the key in the cost of an entry in the cache later on its own).