### PR TITLE
Move inner records out of TransportVersionUtils (#132872)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/CollectTransportVersionReferencesTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/CollectTransportVersionReferencesTask.java
@@ -61,7 +61,7 @@ public abstract class CollectTransportVersionReferencesTask extends DefaultTask 
 
     @TaskAction
     public void checkTransportVersion() throws IOException {
-        var results = new HashSet<TransportVersionUtils.TransportVersionReference>();
+        var results = new HashSet<TransportVersionReference>();
 
         for (var cpElement : getClassPath()) {
             Path file = cpElement.toPath();
@@ -74,8 +74,7 @@ public abstract class CollectTransportVersionReferencesTask extends DefaultTask 
         Files.writeString(outputFile, String.join("\n", results.stream().map(Object::toString).sorted().toList()));
     }
 
-    private void addNamesFromClassesDirectory(Set<TransportVersionUtils.TransportVersionReference> results, Path basePath)
-        throws IOException {
+    private void addNamesFromClassesDirectory(Set<TransportVersionReference> results, Path basePath) throws IOException {
         Files.walkFileTree(basePath, new SimpleFileVisitor<>() {
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
@@ -90,8 +89,7 @@ public abstract class CollectTransportVersionReferencesTask extends DefaultTask 
         });
     }
 
-    private void addNamesFromClass(Set<TransportVersionUtils.TransportVersionReference> results, InputStream classBytes, String classname)
-        throws IOException {
+    private void addNamesFromClass(Set<TransportVersionReference> results, InputStream classBytes, String classname) throws IOException {
         ClassVisitor classVisitor = new ClassVisitor(Opcodes.ASM9) {
             @Override
             public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
@@ -111,7 +109,7 @@ public abstract class CollectTransportVersionReferencesTask extends DefaultTask 
                             if (abstractInstruction instanceof LdcInsnNode ldcInsnNode
                                 && ldcInsnNode.cst instanceof String tvName
                                 && tvName.isEmpty() == false) {
-                                results.add(new TransportVersionUtils.TransportVersionReference(tvName, location));
+                                results.add(new TransportVersionReference(tvName, location));
                             } else {
                                 // The instruction is not a LDC with a String constant (or an empty String), which is not allowed.
                                 throw new RuntimeException(

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/GlobalTransportVersionManagementPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/GlobalTransportVersionManagementPlugin.java
@@ -33,7 +33,7 @@ public class GlobalTransportVersionManagementPlugin implements Plugin<Project> {
         Configuration tvReferencesConfig = project.getConfigurations().create("globalTvReferences");
         tvReferencesConfig.setCanBeConsumed(false);
         tvReferencesConfig.setCanBeResolved(true);
-        tvReferencesConfig.attributes(TransportVersionUtils::addTransportVersionReferencesAttribute);
+        tvReferencesConfig.attributes(TransportVersionReference::addArtifactAttribute);
 
         // iterate through all projects, and if the management plugin is applied, add that project back as a dep to check
         for (Project subProject : project.getRootProject().getSubprojects()) {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionDefinition.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionDefinition.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.gradle.internal.transport;
+
+import java.util.ArrayList;
+import java.util.List;
+
+record TransportVersionDefinition(String name, List<TransportVersionId> ids) {
+    public static TransportVersionDefinition fromString(String filename, String contents) {
+        assert filename.endsWith(".csv");
+        String name = filename.substring(0, filename.length() - 4);
+        List<TransportVersionId> ids = new ArrayList<>();
+
+        if (contents.isEmpty() == false) {
+            for (String rawId : contents.split(",")) {
+                try {
+                    ids.add(TransportVersionId.fromString(rawId));
+                } catch (NumberFormatException e) {
+                    throw new IllegalStateException("Failed to parse id " + rawId + " in " + filename, e);
+                }
+            }
+        }
+
+        return new TransportVersionDefinition(name, ids);
+    }
+}

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionId.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionId.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.gradle.internal.transport;
+
+record TransportVersionId(int complete, int major, int server, int subsidiary, int patch) implements Comparable<TransportVersionId> {
+
+    static TransportVersionId fromString(String s) {
+        int complete = Integer.parseInt(s);
+        int patch = complete % 100;
+        int subsidiary = (complete / 100) % 10;
+        int server = (complete / 1000) % 1000;
+        int major = complete / 1000000;
+        return new TransportVersionId(complete, major, server, subsidiary, patch);
+    }
+
+    @Override
+    public int compareTo(TransportVersionId o) {
+        return Integer.compare(complete, o.complete);
+    }
+
+    @Override
+    public String toString() {
+        return Integer.toString(complete);
+    }
+
+    public int base() {
+        return (complete / 1000) * 1000;
+    }
+}

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionLatest.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionLatest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.gradle.internal.transport;
+
+record TransportVersionLatest(String branch, String name, TransportVersionId id) {
+    public static TransportVersionLatest fromString(String filename, String contents) {
+        assert filename.endsWith(".csv");
+        String branch = filename.substring(0, filename.length() - 4);
+
+        String[] parts = contents.split(",");
+        if (parts.length != 2) {
+            throw new IllegalStateException("Invalid transport version latest file [" + filename + "]: " + contents);
+        }
+
+        return new TransportVersionLatest(branch, parts[0], TransportVersionId.fromString(parts[1]));
+    }
+}

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionManagementPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionManagementPlugin.java
@@ -38,7 +38,7 @@ public class TransportVersionManagementPlugin implements Plugin<Project> {
         Configuration tvReferencesConfig = project.getConfigurations().create("transportVersionReferences", c -> {
             c.setCanBeConsumed(true);
             c.setCanBeResolved(false);
-            c.attributes(TransportVersionUtils::addTransportVersionReferencesAttribute);
+            c.attributes(TransportVersionReference::addArtifactAttribute);
         });
         project.getArtifacts().add(tvReferencesConfig.getName(), collectTask);
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionReference.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionReference.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.gradle.internal.transport;
+
+import org.gradle.api.attributes.Attribute;
+import org.gradle.api.attributes.AttributeContainer;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.gradle.api.artifacts.type.ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE;
+
+record TransportVersionReference(String name, String location) {
+
+    private static final Attribute<Boolean> REFERENCES_ATTRIBUTE = Attribute.of("transport-version-references", Boolean.class);
+
+    static List<TransportVersionReference> listFromFile(Path file) throws IOException {
+        assert file.endsWith(".csv");
+        List<TransportVersionReference> results = new ArrayList<>();
+        for (String line : Files.readAllLines(file, StandardCharsets.UTF_8)) {
+            String[] parts = line.split(",", 2);
+            if (parts.length != 2) {
+                throw new IOException("Invalid transport version data file [" + file + "]: " + line);
+            }
+            results.add(new TransportVersionReference(parts[0], parts[1]));
+        }
+        return results;
+    }
+
+    static void addArtifactAttribute(AttributeContainer attributes) {
+        attributes.attribute(ARTIFACT_TYPE_ATTRIBUTE, "csv");
+        attributes.attribute(REFERENCES_ATTRIBUTE, true);
+    }
+
+    @Override
+    public String toString() {
+        return name + "," + location;
+    }
+}

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionUtils.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionUtils.java
@@ -10,89 +10,14 @@
 package org.elasticsearch.gradle.internal.transport;
 
 import org.gradle.api.Project;
-import org.gradle.api.attributes.Attribute;
-import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.file.Directory;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.gradle.api.artifacts.type.ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE;
 
 class TransportVersionUtils {
-
-    static final Attribute<Boolean> TRANSPORT_VERSION_REFERENCES_ATTRIBUTE = Attribute.of("transport-version-references", Boolean.class);
-
-    record TransportVersionReference(String name, String location) {
-        @Override
-        public String toString() {
-            return name + "," + location;
-        }
-    }
-
-    record TransportVersionDefinition(String name, List<TransportVersionId> ids) {
-        public static TransportVersionDefinition fromString(String filename, String contents) {
-            assert filename.endsWith(".csv");
-            String name = filename.substring(0, filename.length() - 4);
-            List<TransportVersionId> ids = new ArrayList<>();
-
-            if (contents.isEmpty() == false) {
-                for (String rawId : contents.split(",")) {
-                    try {
-                        ids.add(parseId(rawId));
-                    } catch (NumberFormatException e) {
-                        throw new IllegalStateException("Failed to parse id " + rawId + " in " + filename, e);
-                    }
-                }
-            }
-
-            return new TransportVersionDefinition(name, ids);
-        }
-    }
-
-    record TransportVersionLatest(String branch, String name, TransportVersionId id) {
-        public static TransportVersionLatest fromString(String filename, String contents) {
-            assert filename.endsWith(".csv");
-            String branch = filename.substring(0, filename.length() - 4);
-
-            String[] parts = contents.split(",");
-            if (parts.length != 2) {
-                throw new IllegalStateException("Invalid transport version latest file [" + filename + "]: " + contents);
-            }
-
-            return new TransportVersionLatest(branch, parts[0], parseId(parts[1]));
-        }
-    }
-
-    record TransportVersionId(int complete, int major, int server, int subsidiary, int patch) implements Comparable<TransportVersionId> {
-
-        static TransportVersionId fromString(String s) {
-            int complete = Integer.parseInt(s);
-            int patch = complete % 100;
-            int subsidiary = (complete / 100) % 10;
-            int server = (complete / 1000) % 1000;
-            int major = complete / 1000000;
-            return new TransportVersionId(complete, major, server, subsidiary, patch);
-        }
-
-        @Override
-        public int compareTo(TransportVersionId o) {
-            return Integer.compare(complete, o.complete);
-        }
-
-        @Override
-        public String toString() {
-            return Integer.toString(complete);
-        }
-
-        public int base() {
-            return (complete / 1000) * 1000;
-        }
-    }
 
     static Path definitionFilePath(Directory resourcesDirectory, String name) {
         return getDefinitionsDirectory(resourcesDirectory).getAsFile().toPath().resolve(name + ".csv");
@@ -112,28 +37,6 @@ class TransportVersionUtils {
         return TransportVersionLatest.fromString(file.getFileName().toString(), contents);
     }
 
-    static List<TransportVersionReference> readReferencesFile(Path file) throws IOException {
-        assert file.endsWith(".txt");
-        List<TransportVersionReference> results = new ArrayList<>();
-        for (String line : Files.readAllLines(file, StandardCharsets.UTF_8)) {
-            String[] parts = line.split(",", 2);
-            if (parts.length != 2) {
-                throw new IOException("Invalid transport version data file [" + file + "]: " + line);
-            }
-            results.add(new TransportVersionReference(parts[0], parts[1]));
-        }
-        return results;
-    }
-
-    private static TransportVersionId parseId(String rawId) {
-        int complete = Integer.parseInt(rawId);
-        int patch = complete % 100;
-        int subsidiary = (complete / 100) % 10;
-        int server = (complete / 1000) % 1000;
-        int major = complete / 1000000;
-        return new TransportVersionId(complete, major, server, subsidiary, patch);
-    }
-
     static Directory getDefinitionsDirectory(Directory resourcesDirectory) {
         return resourcesDirectory.dir("defined");
     }
@@ -150,10 +53,4 @@ class TransportVersionUtils {
         Directory projectDir = project.project(projectName.toString()).getLayout().getProjectDirectory();
         return projectDir.dir("src/main/resources/transport");
     }
-
-    static void addTransportVersionReferencesAttribute(AttributeContainer attributes) {
-        attributes.attribute(ARTIFACT_TYPE_ATTRIBUTE, "txt");
-        attributes.attribute(TransportVersionUtils.TRANSPORT_VERSION_REFERENCES_ATTRIBUTE, true);
-    }
-
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/ValidateTransportVersionDefinitionsTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/ValidateTransportVersionDefinitionsTask.java
@@ -11,10 +11,6 @@ package org.elasticsearch.gradle.internal.transport;
 
 import com.google.common.collect.Comparators;
 
-import org.elasticsearch.gradle.internal.transport.TransportVersionUtils.TransportVersionDefinition;
-import org.elasticsearch.gradle.internal.transport.TransportVersionUtils.TransportVersionId;
-import org.elasticsearch.gradle.internal.transport.TransportVersionUtils.TransportVersionLatest;
-import org.elasticsearch.gradle.internal.transport.TransportVersionUtils.TransportVersionReference;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
@@ -47,11 +43,11 @@ import java.util.regex.Pattern;
 
 import javax.inject.Inject;
 
+import static org.elasticsearch.gradle.internal.transport.TransportVersionReference.listFromFile;
 import static org.elasticsearch.gradle.internal.transport.TransportVersionUtils.definitionFilePath;
 import static org.elasticsearch.gradle.internal.transport.TransportVersionUtils.latestFilePath;
 import static org.elasticsearch.gradle.internal.transport.TransportVersionUtils.readDefinitionFile;
 import static org.elasticsearch.gradle.internal.transport.TransportVersionUtils.readLatestFile;
-import static org.elasticsearch.gradle.internal.transport.TransportVersionUtils.readReferencesFile;
 
 /**
  * Validates that each defined transport version constant is referenced by at least one project.
@@ -105,7 +101,7 @@ public abstract class ValidateTransportVersionDefinitionsTask extends DefaultTas
 
         // then collect all names referenced in the codebase
         for (var referencesFile : getReferencesFiles()) {
-            readReferencesFile(referencesFile.toPath()).stream().map(TransportVersionReference::name).forEach(allNames::add);
+            listFromFile(referencesFile.toPath()).stream().map(TransportVersionReference::name).forEach(allNames::add);
         }
 
         // now load all definitions, do some validation and record them by various keys for later quick lookup

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/ValidateTransportVersionReferencesTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/ValidateTransportVersionReferencesTask.java
@@ -51,7 +51,7 @@ public abstract class ValidateTransportVersionReferencesTask extends DefaultTask
         }
         Path namesFile = getReferencesFile().get().getAsFile().toPath();
 
-        for (var tvReference : TransportVersionUtils.readReferencesFile(namesFile)) {
+        for (var tvReference : TransportVersionReference.listFromFile(namesFile)) {
             if (referenceChecker.test(tvReference.name()) == false) {
                 throw new RuntimeException(
                     "TransportVersion.fromName(\""


### PR DESCRIPTION
The utilities class has basically become a package itself. This commit moves inner records from TransportVersionUtils and some related functions out to their own files.