### PR TITLE
Use consistent terminology for transport version resources/references (#132882)

### DIFF
--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -220,13 +220,13 @@ gradlePlugin {
       id = 'elasticsearch.internal-yaml-rest-test'
       implementationClass = 'org.elasticsearch.gradle.internal.test.rest.InternalYamlRestTestPlugin'
     }
-    transportVersionManagementPlugin {
-      id = 'elasticsearch.transport-version-management'
-      implementationClass = 'org.elasticsearch.gradle.internal.transport.TransportVersionManagementPlugin'
+    transportVersionReferencesPlugin {
+      id = 'elasticsearch.transport-version-references'
+      implementationClass = 'org.elasticsearch.gradle.internal.transport.TransportVersionReferencesPlugin'
     }
-    globalTransportVersionManagementPlugin {
-      id = 'elasticsearch.global-transport-version-management'
-      implementationClass = 'org.elasticsearch.gradle.internal.transport.GlobalTransportVersionManagementPlugin'
+    transportVersionResourcesPlugin {
+      id = 'elasticsearch.transport-version-resources'
+      implementationClass = 'org.elasticsearch.gradle.internal.transport.TransportVersionResourcesPlugin'
     }
   }
 }

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/TransportVersionManagementPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/TransportVersionManagementPluginFuncTest.groovy
@@ -92,8 +92,8 @@ class TransportVersionManagementPluginFuncTest extends AbstractGradleFuncTest {
 
         file("myserver/build.gradle") << """
             apply plugin: 'java-library'
-            apply plugin: 'elasticsearch.transport-version-management'
-            apply plugin: 'elasticsearch.global-transport-version-management'
+            apply plugin: 'elasticsearch.transport-version-references'
+            apply plugin: 'elasticsearch.transport-version-resources'
         """
         definedTransportVersion("existing_91", "8012000")
         definedTransportVersion("existing_92", "8123000,8012001")
@@ -112,7 +112,7 @@ class TransportVersionManagementPluginFuncTest extends AbstractGradleFuncTest {
 
         file("myplugin/build.gradle") << """
             apply plugin: 'java-library'
-            apply plugin: 'elasticsearch.transport-version-management'
+            apply plugin: 'elasticsearch.transport-version-references'
 
             dependencies {
                 implementation project(":myserver")

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BaseInternalPluginBuildPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BaseInternalPluginBuildPlugin.java
@@ -15,7 +15,7 @@ import org.elasticsearch.gradle.internal.conventions.util.Util;
 import org.elasticsearch.gradle.internal.info.BuildParameterExtension;
 import org.elasticsearch.gradle.internal.precommit.JarHellPrecommitPlugin;
 import org.elasticsearch.gradle.internal.test.HistoricalFeaturesMetadataPlugin;
-import org.elasticsearch.gradle.internal.transport.TransportVersionManagementPlugin;
+import org.elasticsearch.gradle.internal.transport.TransportVersionReferencesPlugin;
 import org.elasticsearch.gradle.plugin.PluginBuildPlugin;
 import org.elasticsearch.gradle.plugin.PluginPropertiesExtension;
 import org.elasticsearch.gradle.util.GradleUtils;
@@ -37,7 +37,7 @@ public class BaseInternalPluginBuildPlugin implements Plugin<Project> {
         project.getPluginManager().apply(JarHellPrecommitPlugin.class);
         project.getPluginManager().apply(ElasticsearchJavaPlugin.class);
         project.getPluginManager().apply(HistoricalFeaturesMetadataPlugin.class);
-        project.getPluginManager().apply(TransportVersionManagementPlugin.class);
+        project.getPluginManager().apply(TransportVersionReferencesPlugin.class);
         boolean isCi = project.getRootProject().getExtensions().getByType(BuildParameterExtension.class).getCi();
         // Clear default dependencies added by public PluginBuildPlugin as we add our
         // own project dependencies for internal builds

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionReferencesPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionReferencesPlugin.java
@@ -20,7 +20,7 @@ import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import static org.elasticsearch.gradle.internal.transport.TransportVersionUtils.getDefinitionsDirectory;
 import static org.elasticsearch.gradle.internal.transport.TransportVersionUtils.getResourcesDirectory;
 
-public class TransportVersionManagementPlugin implements Plugin<Project> {
+public class TransportVersionReferencesPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionResourcesPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionResourcesPlugin.java
@@ -22,7 +22,7 @@ import java.util.Map;
 
 import static org.elasticsearch.gradle.internal.transport.TransportVersionUtils.getResourcesDirectory;
 
-public class GlobalTransportVersionManagementPlugin implements Plugin<Project> {
+public class TransportVersionResourcesPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
@@ -36,13 +36,13 @@ public class GlobalTransportVersionManagementPlugin implements Plugin<Project> {
 
         // iterate through all projects, and if the management plugin is applied, add that project back as a dep to check
         for (Project subProject : project.getRootProject().getSubprojects()) {
-            subProject.getPlugins().withType(TransportVersionManagementPlugin.class).configureEach(plugin -> {
+            subProject.getPlugins().withType(TransportVersionReferencesPlugin.class).configureEach(plugin -> {
                 tvReferencesConfig.getDependencies().add(depsHandler.project(Map.of("path", subProject.getPath())));
             });
         }
 
         var validateTask = project.getTasks()
-            .register("validateTransportVersionDefinitions", ValidateTransportVersionDefinitionsTask.class, t -> {
+            .register("validateTransportVersionDefinitions", ValidateTransportVersionResourcesTask.class, t -> {
                 t.setGroup("Transport Versions");
                 t.setDescription("Validates that all defined TransportVersion constants are used in at least one project");
                 Directory resourcesDir = getResourcesDirectory(project);

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/ValidateTransportVersionResourcesTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/ValidateTransportVersionResourcesTask.java
@@ -53,7 +53,7 @@ import static org.elasticsearch.gradle.internal.transport.TransportVersionUtils.
  * Validates that each defined transport version constant is referenced by at least one project.
  */
 @CacheableTask
-public abstract class ValidateTransportVersionDefinitionsTask extends DefaultTask {
+public abstract class ValidateTransportVersionResourcesTask extends DefaultTask {
 
     @InputDirectory
     @Optional
@@ -85,7 +85,7 @@ public abstract class ValidateTransportVersionDefinitionsTask extends DefaultTas
     Map<String, TransportVersionLatest> latestByBranch = new HashMap<>();
 
     @Inject
-    public ValidateTransportVersionDefinitionsTask(ExecOperations execOperations) {
+    public ValidateTransportVersionResourcesTask(ExecOperations execOperations) {
         this.execOperations = execOperations;
         this.rootPath = getProject().getRootProject().getLayout().getProjectDirectory().getAsFile().toPath();
     }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -13,8 +13,8 @@ apply plugin: 'elasticsearch.build'
 apply plugin: 'elasticsearch.publish'
 apply plugin: 'elasticsearch.internal-cluster-test'
 apply plugin: 'elasticsearch.internal-test-artifact'
-apply plugin: 'elasticsearch.transport-version-management'
-apply plugin: 'elasticsearch.global-transport-version-management'
+apply plugin: 'elasticsearch.transport-version-references'
+apply plugin: 'elasticsearch.transport-version-resources'
 
 publishing {
   publications {

--- a/x-pack/plugin/esql/compute/build.gradle
+++ b/x-pack/plugin/esql/compute/build.gradle
@@ -3,7 +3,7 @@ import org.elasticsearch.gradle.internal.util.SourceDirectoryCommandLineArgument
 apply plugin: 'elasticsearch.build'
 apply plugin: 'elasticsearch.string-templates'
 apply plugin: 'elasticsearch.publish'
-apply plugin: 'elasticsearch.transport-version-management'
+apply plugin: 'elasticsearch.transport-version-references'
 
 base {
   archivesName = 'x-pack-esql-compute'


### PR DESCRIPTION
The build system for transport versions operate on two different types of projects. A project can have named references to transport versions, and it could also be the source of truth for transport version resources, where latest and definitions files exist. This commit renames the plugins and tasks to consistently use that terminology.