### PR TITLE
[9.1] DocValuesConsumerUtil tweak

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/DocValuesConsumerUtil.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/DocValuesConsumerUtil.java
@@ -64,6 +64,9 @@ class DocValuesConsumerUtil {
                             if (entry != null) {
                                 sumNumValues += entry.numValues;
                                 sumNumDocsWithField += entry.numDocsWithField;
+                            } else {
+                                assert false : "unexpectedly got no entry for field [" + fieldInfo.number + "\\" + fieldInfo.name + "]";
+                                return UNSUPPORTED;
                             }
                         }
                         case SORTED_NUMERIC -> {
@@ -71,6 +74,9 @@ class DocValuesConsumerUtil {
                             if (entry != null) {
                                 sumNumValues += entry.numValues;
                                 sumNumDocsWithField += entry.numDocsWithField;
+                            } else {
+                                assert false : "unexpectedly got no entry for field [" + fieldInfo.number + "\\" + fieldInfo.name + "]";
+                                return UNSUPPORTED;
                             }
                         }
                         case SORTED -> {
@@ -78,6 +84,9 @@ class DocValuesConsumerUtil {
                             if (entry != null) {
                                 sumNumValues += entry.ordsEntry.numValues;
                                 sumNumDocsWithField += entry.ordsEntry.numDocsWithField;
+                            } else {
+                                assert false : "unexpectedly got no entry for field [" + fieldInfo.number + "\\" + fieldInfo.name + "]";
+                                return UNSUPPORTED;
                             }
                         }
                         case SORTED_SET -> {
@@ -90,6 +99,9 @@ class DocValuesConsumerUtil {
                                     sumNumValues += entry.ordsEntry.numValues;
                                     sumNumDocsWithField += entry.ordsEntry.numDocsWithField;
                                 }
+                            } else {
+                                assert false : "unexpectedly got no entry for field [" + fieldInfo.number + "\\" + fieldInfo.name + "]";
+                                return UNSUPPORTED;
                             }
                         }
                         case BINARY -> {
@@ -98,6 +110,9 @@ class DocValuesConsumerUtil {
                                 sumNumDocsWithField += entry.numDocsWithField;
                                 minLength = Math.min(minLength, entry.minLength);
                                 maxLength = Math.max(maxLength, entry.maxLength);
+                            } else {
+                                assert false : "unexpectedly got no entry for field [" + fieldInfo.number + "\\" + fieldInfo.name + "]";
+                                return UNSUPPORTED;
                             }
                         }
                         default -> throw new IllegalStateException("unexpected doc values producer type: " + fieldInfo.getDocValuesType());


### PR DESCRIPTION
Backporting #132586 to 9.1 branch.

Be more strict about not finding a metadata entry based on field info number. If this were to happen, then this can cause issues in doc value consumer later. An example of such a failure is what is fixed via #132597, here with shrinking the local segment and merged field numbers were not aligned causing serious merge errors in the tsdb doc value consumer. Currently such an issue shouldn't occur anymore.