### PR TITLE
[9.1] Fix MergeWithLowDiskSpaceIT testRelocationWhileForceMerging (#132496)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -425,9 +425,6 @@ tests:
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test151MachineDependentHeapWithSizeOverride
   issue: https://github.com/elastic/elasticsearch/issues/123437
-- class: org.elasticsearch.index.engine.MergeWithLowDiskSpaceIT
-  method: testRelocationWhileForceMerging
-  issue: https://github.com/elastic/elasticsearch/issues/131789
 - class: org.elasticsearch.search.sort.FieldSortIT
   method: testSortMixedFieldTypes
   issue: https://github.com/elastic/elasticsearch/issues/129445

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/engine/MergeWithLowDiskSpaceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/engine/MergeWithLowDiskSpaceIT.java
@@ -196,6 +196,7 @@ public class MergeWithLowDiskSpaceIT extends DiskUsageIntegTestCase {
             indexName,
             Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0).put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).build()
         );
+        ensureGreen(indexName);
         // get current disk space usage (for all indices on the node)
         IndicesStatsResponse stats = indicesAdmin().prepareStats().clear().setStore(true).get();
         long usedDiskSpaceAfterIndexing = stats.getTotal().getStore().sizeInBytes();
@@ -286,6 +287,7 @@ public class MergeWithLowDiskSpaceIT extends DiskUsageIntegTestCase {
             indexName,
             Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0).put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).build()
         );
+        ensureGreen(indexName);
         // get current disk space usage (for all indices on the node)
         IndicesStatsResponse stats = indicesAdmin().prepareStats().clear().setStore(true).get();
         long usedDiskSpaceAfterIndexing = stats.getTotal().getStore().sizeInBytes();
@@ -320,8 +322,8 @@ public class MergeWithLowDiskSpaceIT extends DiskUsageIntegTestCase {
             .getThreadPoolMergeExecutorService();
         TestTelemetryPlugin testTelemetryPlugin = getTelemetryPlugin(node1);
         assertBusy(() -> {
-            // merge executor says merging is blocked due to insufficient disk space while there is a single merge task enqueued
-            assertThat(threadPoolMergeExecutorService.getMergeTasksQueueLength(), equalTo(1));
+            // merge executor says merging is blocked due to insufficient disk space
+            assertThat(threadPoolMergeExecutorService.getMergeTasksQueueLength(), greaterThan(0));
             assertTrue(threadPoolMergeExecutorService.isMergingBlockedDueToInsufficientDiskSpace());
             // telemetry says that there are indeed some segments enqueued to be merged
             testTelemetryPlugin.collect();


### PR DESCRIPTION
After triggering a force merge, there might still be other merge tasks running concurrently, so it is incorrect to assert a single merge is blocked in the test.

Fix https://github.com/elastic/elasticsearch/issues/131789
Backport of https://github.com/elastic/elasticsearch/pull/132496

Co-authored-by: Patrick Doyle [patrick.doyle@elastic.co](mailto:patrick.doyle@elastic.co)