### PR TITLE
[9.0] Fix MergeWithLowDiskSpaceIT testRelocationWhileForceMerging

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/index/engine/MergeWithLowDiskSpaceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/engine/MergeWithLowDiskSpaceIT.java
@@ -182,6 +182,7 @@ public class MergeWithLowDiskSpaceIT extends DiskUsageIntegTestCase {
             indexName,
             Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0).put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).build()
         );
+        ensureGreen(indexName);
         // get current disk space usage (for all indices on the node)
         IndicesStatsResponse stats = indicesAdmin().prepareStats().clear().setStore(true).get();
         long usedDiskSpaceAfterIndexing = stats.getTotal().getStore().sizeInBytes();
@@ -257,6 +258,7 @@ public class MergeWithLowDiskSpaceIT extends DiskUsageIntegTestCase {
             indexName,
             Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0).put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).build()
         );
+        ensureGreen(indexName);
         // get current disk space usage (for all indices on the node)
         IndicesStatsResponse stats = indicesAdmin().prepareStats().clear().setStore(true).get();
         long usedDiskSpaceAfterIndexing = stats.getTotal().getStore().sizeInBytes();
@@ -290,8 +292,8 @@ public class MergeWithLowDiskSpaceIT extends DiskUsageIntegTestCase {
         ThreadPoolMergeExecutorService threadPoolMergeExecutorService = internalCluster().getInstance(IndicesService.class, node1)
             .getThreadPoolMergeExecutorService();
         assertBusy(() -> {
-            // merge executor says merging is blocked due to insufficient disk space while there is a single merge task enqueued
-            assertThat(threadPoolMergeExecutorService.getMergeTasksQueueLength(), equalTo(1));
+            // merge executor says merging is blocked due to insufficient disk space
+            assertThat(threadPoolMergeExecutorService.getMergeTasksQueueLength(), greaterThan(0));
             assertTrue(threadPoolMergeExecutorService.isMergingBlockedDueToInsufficientDiskSpace());
             // indices stats also says that no merge is currently running (blocked merges are NOT considered as "running")
             IndicesStatsResponse indicesStatsResponse = client().admin().indices().prepareStats(indexName).setMerge(true).get();


### PR DESCRIPTION
After triggering a force merge, there might still be other merge tasks running concurrently, so it is incorrect to assert a single merge is blocked in the test.

Fix https://github.com/elastic/elasticsearch/issues/131789
Backport of https://github.com/elastic/elasticsearch/pull/132496

Co-authored-by: Patrick Doyle [patrick.doyle@elastic.co](mailto:patrick.doyle@elastic.co)