### PR TITLE
Vectorize BQVectorUtils#packAsBinary

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/PackAsBinaryBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/PackAsBinaryBenchmark.java
@@ -82,4 +82,13 @@ public class PackAsBinaryBenchmark {
             bh.consume(packed);
         }
     }
+
+    @Benchmark
+    @Fork(jvmArgsPrepend = { "--add-modules=jdk.incubator.vector" })
+    public void packAsBinaryPanama(Blackhole bh) {
+        for (int i = 0; i < numVectors; i++) {
+            BQVectorUtils.packAsBinary(qVectors[i], packed);
+            bh.consume(packed);
+        }
+    }
 }

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/ESVectorUtil.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/ESVectorUtil.java
@@ -368,4 +368,17 @@ public class ESVectorUtil {
         }
         IMPL.soarDistanceBulk(v1, c0, c1, c2, c3, originalResidual, soarLambda, rnorm, distances);
     }
+
+    /**
+     * Packs the provided int array populated with "0" and "1" values into a byte array.
+     *
+     * @param vector the int array to pack, must contain only "0" and "1" values.
+     * @param packed the byte array to store the packed result, must be large enough to hold the packed data.
+     */
+    public static void packAsBinary(int[] vector, byte[] packed) {
+        if (packed.length * Byte.SIZE < vector.length) {
+            throw new IllegalArgumentException("packed array is too small: " + packed.length * Byte.SIZE + " < " + vector.length);
+        }
+        IMPL.packAsBinary(vector, packed);
+    }
 }

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/DefaultESVectorUtilSupport.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/DefaultESVectorUtilSupport.java
@@ -320,4 +320,37 @@ final class DefaultESVectorUtilSupport implements ESVectorUtilSupport {
         distances[2] = soarDistance(v1, c2, originalResidual, soarLambda, rnorm);
         distances[3] = soarDistance(v1, c3, originalResidual, soarLambda, rnorm);
     }
+
+    @Override
+    public void packAsBinary(int[] vector, byte[] packed) {
+        packAsBinaryImpl(vector, packed);
+    }
+
+    public static void packAsBinaryImpl(int[] vector, byte[] packed) {
+        int limit = vector.length - 7;
+        int i = 0;
+        int index = 0;
+        for (; i < limit; i += 8, index++) {
+            assert vector[i] == 0 || vector[i] == 1;
+            assert vector[i + 1] == 0 || vector[i + 1] == 1;
+            assert vector[i + 2] == 0 || vector[i + 2] == 1;
+            assert vector[i + 3] == 0 || vector[i + 3] == 1;
+            assert vector[i + 4] == 0 || vector[i + 4] == 1;
+            assert vector[i + 5] == 0 || vector[i + 5] == 1;
+            assert vector[i + 6] == 0 || vector[i + 6] == 1;
+            assert vector[i + 7] == 0 || vector[i + 7] == 1;
+            int result = vector[i] << 7 | (vector[i + 1] << 6) | (vector[i + 2] << 5) | (vector[i + 3] << 4) | (vector[i + 4] << 3)
+                | (vector[i + 5] << 2) | (vector[i + 6] << 1) | (vector[i + 7]);
+            packed[index] = (byte) result;
+        }
+        if (i == vector.length) {
+            return;
+        }
+        byte result = 0;
+        for (int j = 7; j >= 0 && i < vector.length; i++, j--) {
+            assert vector[i] == 0 || vector[i] == 1;
+            result |= (byte) ((vector[i] & 1) << j);
+        }
+        packed[index] = result;
+    }
 }

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/ESVectorUtilSupport.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/ESVectorUtilSupport.java
@@ -63,4 +63,6 @@ public interface ESVectorUtilSupport {
         float rnorm,
         float[] distances
     );
+
+    void packAsBinary(int[] vector, byte[] packed);
 }

--- a/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/PanamaESVectorUtilSupport.java
+++ b/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/PanamaESVectorUtilSupport.java
@@ -22,8 +22,10 @@ import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.Constants;
 
 import static jdk.incubator.vector.VectorOperators.ADD;
+import static jdk.incubator.vector.VectorOperators.LSHL;
 import static jdk.incubator.vector.VectorOperators.MAX;
 import static jdk.incubator.vector.VectorOperators.MIN;
+import static jdk.incubator.vector.VectorOperators.OR;
 
 public final class PanamaESVectorUtilSupport implements ESVectorUtilSupport {
 
@@ -941,5 +943,70 @@ public final class PanamaESVectorUtilSupport implements ESVectorUtilSupport {
         distances[1] = dsq1 + soarLambda * proj1 * proj1 / rnorm;
         distances[2] = dsq2 + soarLambda * proj2 * proj2 / rnorm;
         distances[3] = dsq3 + soarLambda * proj3 * proj3 / rnorm;
+    }
+
+    private static final VectorSpecies<Integer> INT_SPECIES_128 = IntVector.SPECIES_128;
+    private static final int[] SHIFTS = new int[] { 7, 6, 5, 4, 3, 2, 1, 0 };
+
+    @Override
+    public void packAsBinary(int[] vector, byte[] packed) {
+        // 128 / 32 == 4
+        if (vector.length >= 8 && HAS_FAST_INTEGER_VECTORS) {
+            // TODO: can we optimize for >= 512?
+            if (VECTOR_BITSIZE >= 256) {
+                packAsBinary256(vector, packed);
+                return;
+            } else if (VECTOR_BITSIZE == 128) {
+                packAsBinary128(vector, packed);
+                return;
+            }
+        }
+        DefaultESVectorUtilSupport.packAsBinaryImpl(vector, packed);
+    }
+
+    private void packAsBinary256(int[] vector, byte[] packed) {
+        final int limit = INT_SPECIES_256.loopBound(vector.length);
+        int i = 0;
+        int index = 0;
+        IntVector shifts = IntVector.fromArray(INT_SPECIES_256, SHIFTS, 0);
+        for (; i < limit; i += INT_SPECIES_256.length(), index++) {
+            IntVector v = IntVector.fromArray(INT_SPECIES_256, vector, i);
+            int result = v.lanewise(LSHL, shifts).reduceLanes(OR);
+            packed[index] = (byte) result;
+        }
+        if (i == vector.length) {
+            return; // all done
+        }
+        byte result = 0;
+        for (int j = 7; j >= 0 && i < vector.length; i++, j--) {
+            assert vector[i] == 0 || vector[i] == 1;
+            result |= (byte) ((vector[i] & 1) << j);
+        }
+        packed[index] = result;
+    }
+
+    private void packAsBinary128(int[] vector, byte[] packed) {
+        final int limit = INT_SPECIES_128.loopBound(vector.length) - INT_SPECIES_128.length();
+        int i = 0;
+        int index = 0;
+        IntVector highShifts = IntVector.fromArray(INT_SPECIES_128, SHIFTS, 0);
+        IntVector lowShifts = IntVector.fromArray(INT_SPECIES_128, SHIFTS, INT_SPECIES_128.length());
+        for (; i < limit; i += 2 * INT_SPECIES_128.length(), index++) {
+            IntVector v = IntVector.fromArray(INT_SPECIES_128, vector, i);
+            var v1 = v.lanewise(LSHL, highShifts);
+            v = IntVector.fromArray(INT_SPECIES_128, vector, i + INT_SPECIES_128.length());
+            var v2 = v.lanewise(LSHL, lowShifts);
+            int result = v1.lanewise(OR, v2).reduceLanes(OR);
+            packed[index] = (byte) result;
+        }
+        if (i == vector.length) {
+            return; // all done
+        }
+        byte result = 0;
+        for (int j = 7; j >= 0 && i < vector.length; i++, j--) {
+            assert vector[i] == 0 || vector[i] == 1;
+            result |= (byte) ((vector[i] & 1) << j);
+        }
+        packed[index] = result;
     }
 }

--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/ESVectorUtilTests.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/ESVectorUtilTests.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.simdvec;
 
+import org.elasticsearch.index.codec.vectors.BQVectorUtils;
 import org.elasticsearch.index.codec.vectors.OptimizedScalarQuantizer;
 import org.elasticsearch.simdvec.internal.vectorization.BaseVectorizationTests;
 import org.elasticsearch.simdvec.internal.vectorization.ESVectorizationProvider;
@@ -353,6 +354,20 @@ public class ESVectorUtilTests extends BaseVectorizationTests {
         defaultedProvider.getVectorUtilSupport().soarDistanceBulk(query, v0, v1, v2, v3, diff, soarLambda, rnorm, expectedDistances);
         defOrPanamaProvider.getVectorUtilSupport().soarDistanceBulk(query, v0, v1, v2, v3, diff, soarLambda, rnorm, panamaDistances);
         assertArrayEquals(expectedDistances, panamaDistances, deltaEps);
+    }
+
+    public void testPackAsBinary() {
+        int dims = randomIntBetween(16, 2048);
+        int[] toPack = new int[dims];
+        for (int i = 0; i < dims; i++) {
+            toPack[i] = randomInt(1);
+        }
+        int length = BQVectorUtils.discretize(dims, 64) / 8;
+        byte[] packed = new byte[length];
+        byte[] packedLegacy = new byte[length];
+        defaultedProvider.getVectorUtilSupport().packAsBinary(toPack, packedLegacy);
+        defOrPanamaProvider.getVectorUtilSupport().packAsBinary(toPack, packed);
+        assertArrayEquals(packedLegacy, packed);
     }
 
     private float[] generateRandomVector(int size) {

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/BQVectorUtils.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/BQVectorUtils.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.codec.vectors;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.VectorUtil;
+import org.elasticsearch.simdvec.ESVectorUtil;
 
 /** Utility class for vector quantization calculations */
 public class BQVectorUtils {
@@ -55,31 +56,7 @@ public class BQVectorUtils {
     }
 
     public static void packAsBinary(int[] vector, byte[] packed) {
-        int limit = vector.length - 7;
-        int i = 0;
-        int index = 0;
-        for (; i < limit; i += 8, index++) {
-            assert vector[i] == 0 || vector[i] == 1;
-            assert vector[i + 1] == 0 || vector[i + 1] == 1;
-            assert vector[i + 2] == 0 || vector[i + 2] == 1;
-            assert vector[i + 3] == 0 || vector[i + 3] == 1;
-            assert vector[i + 4] == 0 || vector[i + 4] == 1;
-            assert vector[i + 5] == 0 || vector[i + 5] == 1;
-            assert vector[i + 6] == 0 || vector[i + 6] == 1;
-            assert vector[i + 7] == 0 || vector[i + 7] == 1;
-            int result = vector[i] << 7 | (vector[i + 1] << 6) | (vector[i + 2] << 5) | (vector[i + 3] << 4) | (vector[i + 4] << 3)
-                | (vector[i + 5] << 2) | (vector[i + 6] << 1) | (vector[i + 7]);
-            packed[index] = (byte) result;
-        }
-        if (i == vector.length) {
-            return;
-        }
-        byte result = 0;
-        for (int j = 7; j >= 0 && i < vector.length; i++, j--) {
-            assert vector[i] == 0 || vector[i] == 1;
-            result |= (byte) ((vector[i] & 1) << j);
-        }
-        packed[index] = result;
+        ESVectorUtil.packAsBinary(vector, packed);
     }
 
     public static int discretize(int value, int bucket) {


### PR DESCRIPTION
After #132820, the method BQVectorUtils#packAsBinary can be easily vectorize by using a helper array that defines the shifts we need to apply to the vector elements.

For 128 bits in my mac, the improvements are almost 2x:

```
Benchmark                                 (dims)   Mode  Cnt   Score   Error   Units
PackAsBinaryBenchmark.packAsBinary           384  thrpt    5  16.493 ± 0.253  ops/ms
PackAsBinaryBenchmark.packAsBinary           782  thrpt    5   8.193 ± 0.043  ops/ms
PackAsBinaryBenchmark.packAsBinary          1024  thrpt    5   6.461 ± 0.155  ops/ms
PackAsBinaryBenchmark.packAsBinaryLegacy     384  thrpt    5   6.897 ± 0.018  ops/ms
PackAsBinaryBenchmark.packAsBinaryLegacy     782  thrpt    5   1.321 ± 0.007  ops/ms
PackAsBinaryBenchmark.packAsBinaryLegacy    1024  thrpt    5   2.546 ± 0.043  ops/ms
PackAsBinaryBenchmark.packAsBinaryPanama     384  thrpt    5  30.626 ± 0.179  ops/ms
PackAsBinaryBenchmark.packAsBinaryPanama     782  thrpt    5  14.035 ± 0.096  ops/ms
PackAsBinaryBenchmark.packAsBinaryPanama    1024  thrpt    5  11.421 ± 0.977  ops/ms
```

For 256 bits on a GCP instancem looks similar:

```
Benchmark                                 (dims)   Mode  Cnt   Score   Error   Units
PackAsBinaryBenchmark.packAsBinary           384  thrpt    5   7.620 ± 0.238  ops/ms
PackAsBinaryBenchmark.packAsBinary           782  thrpt    5   3.818 ± 0.306  ops/ms
PackAsBinaryBenchmark.packAsBinary          1024  thrpt    5   3.070 ± 0.025  ops/ms
PackAsBinaryBenchmark.packAsBinaryLegacy     384  thrpt    5   4.321 ± 0.048  ops/ms
PackAsBinaryBenchmark.packAsBinaryLegacy     782  thrpt    5   1.000 ± 0.099  ops/ms
PackAsBinaryBenchmark.packAsBinaryLegacy    1024  thrpt    5   1.686 ± 0.016  ops/ms
PackAsBinaryBenchmark.packAsBinaryPanama     384  thrpt    5  13.296 ± 0.270  ops/ms
PackAsBinaryBenchmark.packAsBinaryPanama     782  thrpt    5   7.064 ± 0.257  ops/ms
PackAsBinaryBenchmark.packAsBinaryPanama    1024  thrpt    5   5.941 ± 0.077  ops/ms
```

For 512 bits on a GCP instance does look so great, still an improvement though. I tried to optimize this case by doing two bytes at a time and shifting the second to build a short but it did not help.

```
Benchmark                                 (dims)   Mode  Cnt  Score   Error   Units
PackAsBinaryBenchmark.packAsBinary           384  thrpt    5  7.254 ± 0.146  ops/ms
PackAsBinaryBenchmark.packAsBinary           782  thrpt    5  4.057 ± 0.026  ops/ms
PackAsBinaryBenchmark.packAsBinary          1024  thrpt    5  3.213 ± 0.036  ops/ms
PackAsBinaryBenchmark.packAsBinaryLegacy     384  thrpt    5  4.216 ± 0.457  ops/ms
PackAsBinaryBenchmark.packAsBinaryLegacy     782  thrpt    5  0.892 ± 0.030  ops/ms
PackAsBinaryBenchmark.packAsBinaryLegacy    1024  thrpt    5  1.665 ± 0.107  ops/ms
PackAsBinaryBenchmark.packAsBinaryPanama     384  thrpt    5  8.862 ± 0.248  ops/ms
PackAsBinaryBenchmark.packAsBinaryPanama     782  thrpt    5  4.861 ± 0.268  ops/ms
PackAsBinaryBenchmark.packAsBinaryPanama    1024  thrpt    5  4.037 ± 0.242  ops/ms
```

relates https://github.com/elastic/elasticsearch/issues/132761