### PR TITLE
Temp cuvs load fixes

### DIFF
--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/NativeAccess.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/NativeAccess.java
@@ -9,6 +9,10 @@
 
 package org.elasticsearch.nativeaccess;
 
+import org.elasticsearch.logging.LogManager;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.SymbolLookup;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -17,6 +21,11 @@ import java.util.OptionalLong;
  * Provides access to native functionality needed by Elastisearch.
  */
 public interface NativeAccess {
+
+    static void loadCuvs() {
+        var libCuvs = SymbolLookup.libraryLookup(System.mapLibraryName("cuvs_c"), Arena.ofAuto());
+        LogManager.getLogger(NativeAccess.class).info("Loaded libcuvs_c.so: " + libCuvs);
+    }
 
     /**
      * Get the one and only instance of {@link NativeAccess} which is specific to the running platform and JVM.

--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -183,6 +183,7 @@ class Elasticsearch {
         bootstrap.spawner().spawnNativeControllers(nodeEnv);
 
         nodeEnv.validateNativesConfig(); // temporary directories are important for JNA
+        NativeAccess.loadCuvs();
         initializeNatives(
             nodeEnv.tmpDir(),
             BootstrapSettings.MEMORY_LOCK_SETTING.get(args.nodeSettings()),

--- a/x-pack/plugin/gpu/src/yamlRestTest/java/org/elasticsearch/xpack/gpu/GPUClientYamlTestSuiteIT.java
+++ b/x-pack/plugin/gpu/src/yamlRestTest/java/org/elasticsearch/xpack/gpu/GPUClientYamlTestSuiteIT.java
@@ -21,6 +21,7 @@ public class GPUClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
         .module("gpu")
         .setting("xpack.license.self_generated.type", "trial")
         .setting("xpack.security.enabled", "false")
+        .environment("LD_LIBRARY_PATH", System.getenv("LD_LIBRARY_PATH"))
         .build();
 
     public GPUClientYamlTestSuiteIT(final ClientYamlTestCandidate testCandidate) {


### PR DESCRIPTION
As a temporary fix to our troubles loading cuvs after `NativeAccess` is initialized, this PR contains a workaround to pre-load it during bootstrap.
It also contains a fix for the initialization of the cluster used for YAML rest tests, where we propagate the `LD_LIBRARY_PATH` environment variable.