### PR TITLE
Vectorize BQSpaceUtils#transposeHalfByte

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/TransposeHalfByteBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/TransposeHalfByteBenchmark.java
@@ -83,4 +83,13 @@ public class TransposeHalfByteBenchmark {
             bh.consume(packed);
         }
     }
+
+    @Benchmark
+    @Fork(jvmArgsPrepend = { "--add-modules=jdk.incubator.vector" })
+    public void transposeHalfBytePanama(Blackhole bh) {
+        for (int i = 0; i < numVectors; i++) {
+            BQSpaceUtils.transposeHalfByte(qVectors[i], packed);
+            bh.consume(packed);
+        }
+    }
 }

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/ESVectorUtil.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/ESVectorUtil.java
@@ -381,4 +381,22 @@ public class ESVectorUtil {
         }
         IMPL.packAsBinary(vector, packed);
     }
+
+    /**
+     * The idea here is to organize the query vector bits such that the first bit
+     * of every dimension is in the first set dimensions bits, or (dimensions/8) bytes. The second,
+     * third, and fourth bits are in the second, third, and fourth set of dimensions bits,
+     * respectively. This allows for direct bitwise comparisons with the stored index vectors through
+     * summing the bitwise results with the relative required bit shifts.
+     *
+     * @param q the query vector, assumed to be half-byte quantized with values between 0 and 15
+     * @param quantQueryByte the byte array to store the transposed query vector.
+     *
+     **/
+    public static void transposeHalfByte(int[] q, byte[] quantQueryByte) {
+        if (quantQueryByte.length * Byte.SIZE < 4 * q.length) {
+            throw new IllegalArgumentException("packed array is too small: " + quantQueryByte.length * Byte.SIZE + " < " + 4 * q.length);
+        }
+        IMPL.transposeHalfByte(q, quantQueryByte);
+    }
 }

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/DefaultESVectorUtilSupport.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/DefaultESVectorUtilSupport.java
@@ -353,4 +353,54 @@ final class DefaultESVectorUtilSupport implements ESVectorUtilSupport {
         }
         packed[index] = result;
     }
+
+    @Override
+    public void transposeHalfByte(int[] q, byte[] quantQueryByte) {
+        transposeHalfByteImpl(q, quantQueryByte);
+    }
+
+    public static void transposeHalfByteImpl(int[] q, byte[] quantQueryByte) {
+        int limit = q.length - 7;
+        int i = 0;
+        int index = 0;
+        for (; i < limit; i += 8, index++) {
+            assert q[i] >= 0 && q[i] <= 15;
+            assert q[i + 1] >= 0 && q[i + 1] <= 15;
+            assert q[i + 2] >= 0 && q[i + 2] <= 15;
+            assert q[i + 3] >= 0 && q[i + 3] <= 15;
+            assert q[i + 4] >= 0 && q[i + 4] <= 15;
+            assert q[i + 5] >= 0 && q[i + 5] <= 15;
+            assert q[i + 6] >= 0 && q[i + 6] <= 15;
+            assert q[i + 7] >= 0 && q[i + 7] <= 15;
+            int lowerByte = (q[i] & 1) << 7 | (q[i + 1] & 1) << 6 | (q[i + 2] & 1) << 5 | (q[i + 3] & 1) << 4 | (q[i + 4] & 1) << 3 | (q[i
+                + 5] & 1) << 2 | (q[i + 6] & 1) << 1 | (q[i + 7] & 1);
+            int lowerMiddleByte = ((q[i] >> 1) & 1) << 7 | ((q[i + 1] >> 1) & 1) << 6 | ((q[i + 2] >> 1) & 1) << 5 | ((q[i + 3] >> 1) & 1)
+                << 4 | ((q[i + 4] >> 1) & 1) << 3 | ((q[i + 5] >> 1) & 1) << 2 | ((q[i + 6] >> 1) & 1) << 1 | ((q[i + 7] >> 1) & 1);
+            int upperMiddleByte = ((q[i] >> 2) & 1) << 7 | ((q[i + 1] >> 2) & 1) << 6 | ((q[i + 2] >> 2) & 1) << 5 | ((q[i + 3] >> 2) & 1)
+                << 4 | ((q[i + 4] >> 2) & 1) << 3 | ((q[i + 5] >> 2) & 1) << 2 | ((q[i + 6] >> 2) & 1) << 1 | ((q[i + 7] >> 2) & 1);
+            int upperByte = ((q[i] >> 3) & 1) << 7 | ((q[i + 1] >> 3) & 1) << 6 | ((q[i + 2] >> 3) & 1) << 5 | ((q[i + 3] >> 3) & 1) << 4
+                | ((q[i + 4] >> 3) & 1) << 3 | ((q[i + 5] >> 3) & 1) << 2 | ((q[i + 6] >> 3) & 1) << 1 | ((q[i + 7] >> 3) & 1);
+            quantQueryByte[index] = (byte) lowerByte;
+            quantQueryByte[index + quantQueryByte.length / 4] = (byte) lowerMiddleByte;
+            quantQueryByte[index + quantQueryByte.length / 2] = (byte) upperMiddleByte;
+            quantQueryByte[index + 3 * quantQueryByte.length / 4] = (byte) upperByte;
+        }
+        if (i == q.length) {
+            return; // all done
+        }
+        int lowerByte = 0;
+        int lowerMiddleByte = 0;
+        int upperMiddleByte = 0;
+        int upperByte = 0;
+        for (int j = 7; i < q.length; j--, i++) {
+            lowerByte |= (q[i] & 1) << j;
+            lowerMiddleByte |= ((q[i] >> 1) & 1) << j;
+            upperMiddleByte |= ((q[i] >> 2) & 1) << j;
+            upperByte |= ((q[i] >> 3) & 1) << j;
+        }
+        quantQueryByte[index] = (byte) lowerByte;
+        quantQueryByte[index + quantQueryByte.length / 4] = (byte) lowerMiddleByte;
+        quantQueryByte[index + quantQueryByte.length / 2] = (byte) upperMiddleByte;
+        quantQueryByte[index + 3 * quantQueryByte.length / 4] = (byte) upperByte;
+    }
 }

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/ESVectorUtilSupport.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/internal/vectorization/ESVectorUtilSupport.java
@@ -65,4 +65,6 @@ public interface ESVectorUtilSupport {
     );
 
     void packAsBinary(int[] vector, byte[] packed);
+
+    void transposeHalfByte(int[] q, byte[] quantQueryByte);
 }

--- a/libs/simdvec/src/test/java/org/elasticsearch/simdvec/ESVectorUtilTests.java
+++ b/libs/simdvec/src/test/java/org/elasticsearch/simdvec/ESVectorUtilTests.java
@@ -370,6 +370,20 @@ public class ESVectorUtilTests extends BaseVectorizationTests {
         assertArrayEquals(packedLegacy, packed);
     }
 
+    public void testTransposeHalfByte() {
+        int dims = randomIntBetween(16, 2048);
+        int[] toPack = new int[dims];
+        for (int i = 0; i < dims; i++) {
+            toPack[i] = randomInt(15);
+        }
+        int length = 4 * BQVectorUtils.discretize(dims, 64) / 8;
+        byte[] packed = new byte[length];
+        byte[] packedLegacy = new byte[length];
+        defaultedProvider.getVectorUtilSupport().transposeHalfByte(toPack, packedLegacy);
+        defOrPanamaProvider.getVectorUtilSupport().transposeHalfByte(toPack, packed);
+        assertArrayEquals(packedLegacy, packed);
+    }
+
     private float[] generateRandomVector(int size) {
         float[] vector = new float[size];
         for (int i = 0; i < size; ++i) {

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/BQSpaceUtils.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/BQSpaceUtils.java
@@ -19,6 +19,8 @@
  */
 package org.elasticsearch.index.codec.vectors;
 
+import org.elasticsearch.simdvec.ESVectorUtil;
+
 /** Utility class for quantization calculations */
 public class BQSpaceUtils {
 
@@ -117,48 +119,7 @@ public class BQSpaceUtils {
      * @param quantQueryByte the byte array to store the transposed query vector
      * */
     public static void transposeHalfByte(int[] q, byte[] quantQueryByte) {
-        int limit = q.length - 7;
-        int i = 0;
-        int index = 0;
-        for (; i < limit; i += 8, index++) {
-            assert q[i] >= 0 && q[i] <= 15;
-            assert q[i + 1] >= 0 && q[i + 1] <= 15;
-            assert q[i + 2] >= 0 && q[i + 2] <= 15;
-            assert q[i + 3] >= 0 && q[i + 3] <= 15;
-            assert q[i + 4] >= 0 && q[i + 4] <= 15;
-            assert q[i + 5] >= 0 && q[i + 5] <= 15;
-            assert q[i + 6] >= 0 && q[i + 6] <= 15;
-            assert q[i + 7] >= 0 && q[i + 7] <= 15;
-            int lowerByte = (q[i] & 1) << 7 | (q[i + 1] & 1) << 6 | (q[i + 2] & 1) << 5 | (q[i + 3] & 1) << 4 | (q[i + 4] & 1) << 3 | (q[i
-                + 5] & 1) << 2 | (q[i + 6] & 1) << 1 | (q[i + 7] & 1);
-            int lowerMiddleByte = ((q[i] >> 1) & 1) << 7 | ((q[i + 1] >> 1) & 1) << 6 | ((q[i + 2] >> 1) & 1) << 5 | ((q[i + 3] >> 1) & 1)
-                << 4 | ((q[i + 4] >> 1) & 1) << 3 | ((q[i + 5] >> 1) & 1) << 2 | ((q[i + 6] >> 1) & 1) << 1 | ((q[i + 7] >> 1) & 1);
-            int upperMiddleByte = ((q[i] >> 2) & 1) << 7 | ((q[i + 1] >> 2) & 1) << 6 | ((q[i + 2] >> 2) & 1) << 5 | ((q[i + 3] >> 2) & 1)
-                << 4 | ((q[i + 4] >> 2) & 1) << 3 | ((q[i + 5] >> 2) & 1) << 2 | ((q[i + 6] >> 2) & 1) << 1 | ((q[i + 7] >> 2) & 1);
-            int upperByte = ((q[i] >> 3) & 1) << 7 | ((q[i + 1] >> 3) & 1) << 6 | ((q[i + 2] >> 3) & 1) << 5 | ((q[i + 3] >> 3) & 1) << 4
-                | ((q[i + 4] >> 3) & 1) << 3 | ((q[i + 5] >> 3) & 1) << 2 | ((q[i + 6] >> 3) & 1) << 1 | ((q[i + 7] >> 3) & 1);
-            quantQueryByte[index] = (byte) lowerByte;
-            quantQueryByte[index + quantQueryByte.length / 4] = (byte) lowerMiddleByte;
-            quantQueryByte[index + quantQueryByte.length / 2] = (byte) upperMiddleByte;
-            quantQueryByte[index + 3 * quantQueryByte.length / 4] = (byte) upperByte;
-        }
-        if (i == q.length) {
-            return; // all done
-        }
-        int lowerByte = 0;
-        int lowerMiddleByte = 0;
-        int upperMiddleByte = 0;
-        int upperByte = 0;
-        for (int j = 7; i < q.length; j--, i++) {
-            lowerByte |= (q[i] & 1) << j;
-            lowerMiddleByte |= ((q[i] >> 1) & 1) << j;
-            upperMiddleByte |= ((q[i] >> 2) & 1) << j;
-            upperByte |= ((q[i] >> 3) & 1) << j;
-        }
-        quantQueryByte[index] = (byte) lowerByte;
-        quantQueryByte[index + quantQueryByte.length / 4] = (byte) lowerMiddleByte;
-        quantQueryByte[index + quantQueryByte.length / 2] = (byte) upperMiddleByte;
-        quantQueryByte[index + 3 * quantQueryByte.length / 4] = (byte) upperByte;
+        ESVectorUtil.transposeHalfByte(q, quantQueryByte);
     }
 
     /**


### PR DESCRIPTION
After https://github.com/elastic/elasticsearch/pull/132797, the method BQVectorUtils#transposeHalfByte can be easily vectorize by using a helper array that defines the shifts we need to apply to the vector elements.

For 128 bits in my mac, the improvements are around 60%:

```
Benchmark                                           (dims)   Mode  Cnt  Score   Error   Units
TransposeHalfByteBenchmark.transposeHalfByte           384  thrpt    5  3.344 ± 0.100  ops/ms
TransposeHalfByteBenchmark.transposeHalfByte           782  thrpt    5  1.599 ± 0.020  ops/ms
TransposeHalfByteBenchmark.transposeHalfByte          1024  thrpt    5  1.263 ± 0.010  ops/ms
TransposeHalfByteBenchmark.transposeHalfByteLegacy     384  thrpt    5  1.661 ± 0.031  ops/ms
TransposeHalfByteBenchmark.transposeHalfByteLegacy     782  thrpt    5  0.805 ± 0.034  ops/ms
TransposeHalfByteBenchmark.transposeHalfByteLegacy    1024  thrpt    5  0.625 ± 0.022  ops/ms
TransposeHalfByteBenchmark.transposeHalfBytePanama     384  thrpt    5  5.891 ± 0.047  ops/ms
TransposeHalfByteBenchmark.transposeHalfBytePanama     782  thrpt    5  2.829 ± 0.025  ops/ms
TransposeHalfByteBenchmark.transposeHalfBytePanama    1024  thrpt    5  2.205 ± 0.042  ops/ms
```

For 256 bits on a GCP instance shows up to 3x faster:

```
Benchmark                                           (dims)   Mode  Cnt  Score   Error   Units
TransposeHalfByteBenchmark.transposeHalfByte           384  thrpt    5  1.198 ± 0.035  ops/ms
TransposeHalfByteBenchmark.transposeHalfByte           782  thrpt    5  0.931 ± 0.055  ops/ms
TransposeHalfByteBenchmark.transposeHalfByte          1024  thrpt    5  0.454 ± 0.006  ops/ms
TransposeHalfByteBenchmark.transposeHalfByteLegacy     384  thrpt    5  0.751 ± 0.033  ops/ms
TransposeHalfByteBenchmark.transposeHalfByteLegacy     782  thrpt    5  0.347 ± 0.004  ops/ms
TransposeHalfByteBenchmark.transposeHalfByteLegacy    1024  thrpt    5  0.284 ± 0.010  ops/ms
TransposeHalfByteBenchmark.transposeHalfBytePanama     384  thrpt    5  3.368 ± 0.187  ops/ms
TransposeHalfByteBenchmark.transposeHalfBytePanama     782  thrpt    5  1.625 ± 0.004  ops/ms
TransposeHalfByteBenchmark.transposeHalfBytePanama    1024  thrpt    5  1.354 ± 0.059  ops/ms
```
For 512 bits on a GCP instance up to 2x faster:

```
Benchmark                                           (dims)   Mode  Cnt  Score   Error   Units
TransposeHalfByteBenchmark.transposeHalfByte           384  thrpt    5  1.251 ± 0.049  ops/ms
TransposeHalfByteBenchmark.transposeHalfByte           782  thrpt    5  0.737 ± 0.013  ops/ms
TransposeHalfByteBenchmark.transposeHalfByte          1024  thrpt    5  0.469 ± 0.036  ops/ms
TransposeHalfByteBenchmark.transposeHalfByteLegacy     384  thrpt    5  0.683 ± 0.064  ops/ms
TransposeHalfByteBenchmark.transposeHalfByteLegacy     782  thrpt    5  0.341 ± 0.007  ops/ms
TransposeHalfByteBenchmark.transposeHalfByteLegacy    1024  thrpt    5  0.260 ± 0.002  ops/ms
TransposeHalfByteBenchmark.transposeHalfBytePanama     384  thrpt    5  2.634 ± 0.056  ops/ms
TransposeHalfByteBenchmark.transposeHalfBytePanama     782  thrpt    5  1.258 ± 0.016  ops/ms
TransposeHalfByteBenchmark.transposeHalfBytePanama    1024  thrpt    5  1.026 ± 0.054  ops/ms
```