### PR TITLE
Unmuting simulate index data stream mapping overrides yaml rest test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -468,9 +468,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.TextEmbeddingQueryIT
   method: testHybridSearch
   issue: https://github.com/elastic/elasticsearch/issues/132703
-- class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
-  method: test {yaml=indices.simulate_index_template/10_basic/Simulate index template with data stream with mapping and setting overrides}
-  issue: https://github.com/elastic/elasticsearch/issues/132702
 - class: org.elasticsearch.xpack.ml.integration.RevertModelSnapshotIT
   method: testRevertModelSnapshot
   issue: https://github.com/elastic/elasticsearch/issues/132733


### PR DESCRIPTION
Closes #132702. Data stream mappings were behind a feature flag so this test failed when running in release mode. The feature is no longer behind a feature flag as of #132043, so the test no longer fails.