### PR TITLE
Speed up loading dense singleton keyword fields

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesProducer.java
@@ -398,7 +398,7 @@ final class ES819TSDBDocValuesProducer extends DocValuesProducer {
                         }
                         // TODO: Since ordinals are sorted, start at 0 (offset by startValue), scan until lastValue,
                         // then fill remaining positions with lastValue.
-                        return null;
+                        // Falling back to tryRead(...) is safe here, given that current block index wasn't altered by looking ahead.
                     }
                     try (var builder = factory.singletonOrdinalsBuilder(this, docs.count() - offset, true)) {
                         BlockLoader.SingletonLongBuilder delegate = new SingletonLongToSingletonOrdinalDelegate(builder);

--- a/server/src/main/java/org/elasticsearch/index/mapper/BlockDocValuesReader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BlockDocValuesReader.java
@@ -756,7 +756,7 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
                     return block;
                 }
             }
-            try (var builder = factory.singletonOrdinalsBuilder(ordinals, docs.count() - offset)) {
+            try (var builder = factory.singletonOrdinalsBuilder(ordinals, docs.count() - offset, false)) {
                 for (int i = offset; i < docs.count(); i++) {
                     int doc = docs.get(i);
                     if (doc < ordinals.docID()) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/BlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BlockLoader.java
@@ -447,7 +447,7 @@ public interface BlockLoader {
         /**
          * Build a reader for reading {@link SortedDocValues}
          */
-        SingletonOrdinalsBuilder singletonOrdinalsBuilder(SortedDocValues ordinals, int count);
+        SingletonOrdinalsBuilder singletonOrdinalsBuilder(SortedDocValues ordinals, int count, boolean isDense);
 
         /**
          * Build a reader for reading {@link SortedSetDocValues}
@@ -548,6 +548,8 @@ public interface BlockLoader {
          * Appends an ordinal to the builder.
          */
         SingletonOrdinalsBuilder appendOrd(int value);
+
+        SingletonOrdinalsBuilder appendOrds(int[] values, int from, int length, int minOrd, int maxOrd);
     }
 
     interface SortedSetOrdinalsBuilder extends Builder {

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesFormatTests.java
@@ -1139,20 +1139,11 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                                         return docId;
                                     }
                                 }, start);
-                                Set<String> seenValues = new HashSet<>();
-                                for (int p = start; p <= end; p++) {
-                                    String hostName = hostnames.get(((Number) idBlock.get(p)).intValue());
-                                    seenValues.add(hostName);
-                                }
-                                if (seenValues.size() == 1) {
-                                    assertNotNull(hostBlock);
-                                    assertThat(hostBlock.size(), equalTo(end - start + 1));
-                                    for (int i = 0; i < hostBlock.size(); i++) {
-                                        String actualHostName = BytesRefs.toString(hostBlock.get(i));
-                                        assertThat(actualHostName, equalTo(hostnames.get(((Number) idBlock.get(i + start)).intValue())));
-                                    }
-                                } else {
-                                    assertNull(hostBlock);
+                                assertNotNull(hostBlock);
+                                assertThat(hostBlock.size(), equalTo(end - start + 1));
+                                for (int i = 0; i < hostBlock.size(); i++) {
+                                    String actualHostName = BytesRefs.toString(hostBlock.get(i));
+                                    assertThat(actualHostName, equalTo(hostnames.get(((Number) idBlock.get(i + start)).intValue())));
                                 }
                                 if (start == idBlock.size() - 1) {
                                     break;

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesFormatTests.java
@@ -40,7 +40,10 @@ import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.index.codec.Elasticsearch900Lucene101Codec;
 import org.elasticsearch.index.codec.tsdb.ES87TSDBDocValuesFormatTests;
+import org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesProducer.BaseDenseNumericValues;
+import org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesProducer.BaseSortedDocValues;
 import org.elasticsearch.index.mapper.BlockLoader;
+import org.elasticsearch.index.mapper.BlockLoader.OptionalColumnAtATimeReader;
 import org.elasticsearch.index.mapper.TestBlock;
 import org.elasticsearch.test.ESTestCase;
 
@@ -717,8 +720,9 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
         }
     }
 
-    public void testBulkLoading() throws Exception {
+    public void testOptionalColumnAtATimeReader() throws Exception {
         final String counterField = "counter";
+        final String counterFieldAsString = "counter_as_string";
         final String timestampField = "@timestamp";
         final String gaugeField = "gauge";
         long currentTimestamp = 1704067200000L;
@@ -735,6 +739,7 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                 // Index sorting doesn't work with NumericDocValuesField:
                 d.add(SortedNumericDocValuesField.indexedField(timestampField, timestamp));
                 d.add(new SortedNumericDocValuesField(counterField, currentCounter));
+                d.add(new SortedSetDocValuesField(counterFieldAsString, new BytesRef(Long.toString(currentCounter))));
                 d.add(new SortedNumericDocValuesField(gaugeField, gauge1Values[i % gauge1Values.length]));
 
                 iw.addDocument(d);
@@ -753,9 +758,10 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
             try (var reader = DirectoryReader.open(iw)) {
                 int gaugeIndex = numDocs;
                 for (var leaf : reader.leaves()) {
-                    var timestampDV = getColumnAtTimeReader(leaf.reader(), timestampField);
-                    var counterDV = getColumnAtTimeReader(leaf.reader(), counterField);
-                    var gaugeDV = getColumnAtTimeReader(leaf.reader(), gaugeField);
+                    var timestampDV = getBaseDenseNumericValues(leaf.reader(), timestampField);
+                    var counterDV = getBaseDenseNumericValues(leaf.reader(), counterField);
+                    var gaugeDV = getBaseDenseNumericValues(leaf.reader(), gaugeField);
+                    var stringCounterDV = getBaseSortedDocValues(leaf.reader(), counterFieldAsString);
                     int maxDoc = leaf.reader().maxDoc();
                     for (int i = 0; i < maxDoc;) {
                         int size = Math.max(1, random().nextInt(0, maxDoc - i));
@@ -778,10 +784,18 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                             var block = (TestBlock) counterDV.tryRead(factory, docs, 0);
                             assertNotNull(block);
                             assertEquals(size, block.size());
+                            var stringBlock = (TestBlock) stringCounterDV.tryRead(factory, docs, 0);
+                            assertNotNull(stringBlock);
+                            assertEquals(size, stringBlock.size());
                             for (int j = 0; j < block.size(); j++) {
-                                long actualCounter = (long) block.get(j);
                                 long expectedCounter = currentCounter;
+                                long actualCounter = (long) block.get(j);
                                 assertEquals(expectedCounter, actualCounter);
+
+                                var expectedStringCounter = Long.toString(actualCounter);
+                                var actualStringCounter = ((BytesRef) stringBlock.get(j)).utf8ToString();
+                                assertEquals(expectedStringCounter, actualStringCounter);
+
                                 currentCounter--;
                             }
                         }
@@ -816,9 +830,10 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                 int size = maxDoc - randomOffset;
                 int gaugeIndex = size;
 
-                var timestampDV = getColumnAtTimeReader(leafReader, timestampField);
-                var counterDV = getColumnAtTimeReader(leafReader, counterField);
-                var gaugeDV = getColumnAtTimeReader(leafReader, gaugeField);
+                var timestampDV = getBaseDenseNumericValues(leafReader, timestampField);
+                var counterDV = getBaseDenseNumericValues(leafReader, counterField);
+                var gaugeDV = getBaseDenseNumericValues(leafReader, gaugeField);
+                var stringCounterDV = getBaseSortedDocValues(leafReader, counterFieldAsString);
 
                 var docs = TestBlock.docs(IntStream.range(0, maxDoc).toArray());
 
@@ -839,10 +854,20 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                     var block = (TestBlock) counterDV.tryRead(factory, docs, randomOffset);
                     assertNotNull(block);
                     assertEquals(size, block.size());
+
+                    var stringBlock = (TestBlock) stringCounterDV.tryRead(factory, docs, randomOffset);
+                    assertNotNull(stringBlock);
+                    assertEquals(size, stringBlock.size());
+
                     for (int j = 0; j < block.size(); j++) {
                         long actualCounter = (long) block.get(j);
                         long expectedCounter = currentCounter;
                         assertEquals(expectedCounter, actualCounter);
+
+                        var expectedStringCounter = Long.toString(actualCounter);
+                        var actualStringCounter = ((BytesRef) stringBlock.get(j)).utf8ToString();
+                        assertEquals(expectedStringCounter, actualStringCounter);
+
                         currentCounter--;
                     }
                 }
@@ -863,30 +888,41 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                 size = docs.count();
                 // Test against values loaded using normal doc value apis:
                 long[] expectedCounters = new long[size];
-                counterDV = getColumnAtTimeReader(leafReader, counterField);
+                counterDV = getBaseDenseNumericValues(leafReader, counterField);
                 for (int i = 0; i < docs.count(); i++) {
                     int docId = docs.get(i);
                     counterDV.advanceExact(docId);
                     expectedCounters[i] = counterDV.longValue();
                 }
-                counterDV = getColumnAtTimeReader(leafReader, counterField);
+                counterDV = getBaseDenseNumericValues(leafReader, counterField);
+                stringCounterDV = getBaseSortedDocValues(leafReader, counterFieldAsString);
                 {
                     // bulk loading counter field:
                     var block = (TestBlock) counterDV.tryRead(factory, docs, 0);
                     assertNotNull(block);
                     assertEquals(size, block.size());
+
+                    var stringBlock = (TestBlock) stringCounterDV.tryRead(factory, docs, 0);
+                    assertNotNull(stringBlock);
+                    assertEquals(size, stringBlock.size());
+
                     for (int j = 0; j < block.size(); j++) {
                         long actualCounter = (long) block.get(j);
                         long expectedCounter = expectedCounters[j];
                         assertEquals(expectedCounter, actualCounter);
+
+                        var expectedStringCounter = Long.toString(actualCounter);
+                        var actualStringCounter = ((BytesRef) stringBlock.get(j)).utf8ToString();
+                        assertEquals(expectedStringCounter, actualStringCounter);
                     }
                 }
             }
         }
     }
 
-    public void testBulkLoadingWithSparseDocs() throws Exception {
+    public void testOptionalColumnAtATimeReaderWithSparseDocs() throws Exception {
         final String counterField = "counter";
+        final String counterAsStringField = "counter_as_string";
         final String timestampField = "@timestamp";
         String queryField = "query_field";
         long currentTimestamp = 1704067200000L;
@@ -904,6 +940,7 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                 // Index sorting doesn't work with NumericDocValuesField:
                 d.add(SortedNumericDocValuesField.indexedField(timestampField, timestamp));
                 d.add(new SortedNumericDocValuesField(counterField, currentCounter));
+                d.add(new SortedDocValuesField(counterAsStringField, new BytesRef(Long.toString(currentCounter))));
                 d.add(new SortedNumericDocValuesField(queryField, q));
                 if (i % 120 == 0) {
                     q++;
@@ -937,10 +974,12 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                         false
                     );
                     assertEquals(numDocsPerQValue, topDocs.totalHits.value());
-                    var timestampDV = getColumnAtTimeReader(leafReader, timestampField);
+                    var timestampDV = getBaseDenseNumericValues(leafReader, timestampField);
                     long[] expectedTimestamps = new long[numDocsPerQValue];
-                    var counterDV = getColumnAtTimeReader(leafReader, counterField);
+                    var counterDV = getBaseDenseNumericValues(leafReader, counterField);
                     long[] expectedCounters = new long[numDocsPerQValue];
+                    var counterAsStringDV = getBaseSortedDocValues(leafReader, counterAsStringField);
+                    String[] expectedCounterAsStrings = new String[numDocsPerQValue];
                     int[] docIds = new int[numDocsPerQValue];
                     for (int i = 0; i < topDocs.scoreDocs.length; i++) {
                         var scoreDoc = topDocs.scoreDocs[i];
@@ -951,11 +990,13 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
 
                         assertTrue(counterDV.advanceExact(scoreDoc.doc));
                         expectedCounters[i] = counterDV.longValue();
+                        assertTrue(counterAsStringDV.advanceExact(scoreDoc.doc));
+                        expectedCounterAsStrings[i] = counterAsStringDV.lookupOrd(counterAsStringDV.ordValue()).utf8ToString();
                     }
 
                     var docs = TestBlock.docs(docIds);
                     {
-                        timestampDV = getColumnAtTimeReader(leafReader, timestampField);
+                        timestampDV = getBaseDenseNumericValues(leafReader, timestampField);
                         var block = (TestBlock) timestampDV.tryRead(factory, docs, 0);
                         assertNotNull(block);
                         assertEquals(numDocsPerQValue, block.size());
@@ -966,13 +1007,24 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                         }
                     }
                     {
-                        counterDV = getColumnAtTimeReader(leafReader, counterField);
+                        counterDV = getBaseDenseNumericValues(leafReader, counterField);
                         var block = (TestBlock) counterDV.tryRead(factory, docs, 0);
                         assertNotNull(block);
                         assertEquals(numDocsPerQValue, block.size());
                         for (int j = 0; j < block.size(); j++) {
                             long actualCounter = (long) block.get(j);
                             long expectedCounter = expectedCounters[j];
+                            assertEquals(expectedCounter, actualCounter);
+                        }
+                    }
+                    {
+                        counterAsStringDV = getBaseSortedDocValues(leafReader, counterAsStringField);
+                        var block = (TestBlock) counterAsStringDV.tryRead(factory, docs, 0);
+                        assertNotNull(block);
+                        assertEquals(numDocsPerQValue, block.size());
+                        for (int j = 0; j < block.size(); j++) {
+                            var actualCounter = ((BytesRef) block.get(j)).utf8ToString();
+                            var expectedCounter = expectedCounterAsStrings[j];
                             assertEquals(expectedCounter, actualCounter);
                         }
                     }
@@ -1029,26 +1081,49 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
                                 return i;
                             }
                         };
-                        var idReader = ESTestCase.asInstanceOf(
-                            BlockLoader.OptionalColumnAtATimeReader.class,
-                            leaf.reader().getNumericDocValues("id")
-                        );
+                        var idReader = ESTestCase.asInstanceOf(OptionalColumnAtATimeReader.class, leaf.reader().getNumericDocValues("id"));
                         TestBlock idBlock = (TestBlock) idReader.tryRead(factory, docs, 0);
                         assertNotNull(idBlock);
-                        var reader2 = ESTestCase.asInstanceOf(
-                            BlockLoader.OptionalColumnAtATimeReader.class,
-                            leaf.reader().getSortedDocValues(secondField)
-                        );
-                        assertNull(reader2.tryRead(factory, docs, 0));
-                        var reader3 = ESTestCase.asInstanceOf(
-                            BlockLoader.OptionalColumnAtATimeReader.class,
-                            leaf.reader().getSortedDocValues(unsortedField)
-                        );
-                        assertNull(reader3.tryRead(factory, docs, 0));
+
+                        {
+                            var reader2 = ESTestCase.asInstanceOf(
+                                OptionalColumnAtATimeReader.class,
+                                leaf.reader().getSortedDocValues(secondField)
+                            );
+                            int randomOffset = 0;
+                            ESTestCase.between(0, docs.count() - 1);
+                            var block = (TestBlock) reader2.tryRead(factory, docs, randomOffset);
+                            assertNotNull(block);
+                            assertThat(block.size(), equalTo(docs.count() - randomOffset));
+                            for (int i = randomOffset; i < block.size(); i++) {
+                                String actualHostName = BytesRefs.toString(block.get(i));
+                                int id = ((Number) idBlock.get(i)).intValue();
+                                String expectedHostName = hostnames.get(id);
+                                assertEquals(expectedHostName, actualHostName);
+                            }
+                        }
+                        {
+                            var reader3 = ESTestCase.asInstanceOf(
+                                OptionalColumnAtATimeReader.class,
+                                leaf.reader().getSortedDocValues(unsortedField)
+                            );
+                            assertNotNull(reader3);
+                            int randomOffset = 0;
+                            ESTestCase.between(0, docs.count() - 1);
+                            var block = (TestBlock) reader3.tryRead(factory, docs, randomOffset);
+                            assertNotNull(block);
+                            assertThat(block.size(), equalTo(docs.count() - randomOffset));
+                            for (int i = randomOffset; i < block.size(); i++) {
+                                String actualHostName = BytesRefs.toString(block.get(i));
+                                int id = ((Number) idBlock.get(i)).intValue();
+                                String expectedHostName = hostnames.get(id);
+                                assertEquals(expectedHostName, actualHostName);
+                            }
+                        }
                         for (int offset = 0; offset < idBlock.size(); offset += ESTestCase.between(1, numDocs)) {
                             int start = offset;
                             var reader1 = ESTestCase.asInstanceOf(
-                                BlockLoader.OptionalColumnAtATimeReader.class,
+                                OptionalColumnAtATimeReader.class,
                                 leaf.reader().getSortedDocValues(primaryField)
                             );
                             while (start < idBlock.size()) {
@@ -1092,11 +1167,16 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
         }
     }
 
-    private static ES819TSDBDocValuesProducer.BaseDenseNumericValues getColumnAtTimeReader(LeafReader leafReader, String counterField)
-        throws IOException {
-        return (ES819TSDBDocValuesProducer.BaseDenseNumericValues) DocValues.unwrapSingleton(
-            leafReader.getSortedNumericDocValues(counterField)
-        );
+    private static BaseDenseNumericValues getBaseDenseNumericValues(LeafReader leafReader, String field) throws IOException {
+        return (BaseDenseNumericValues) DocValues.unwrapSingleton(leafReader.getSortedNumericDocValues(field));
+    }
+
+    private static BaseSortedDocValues getBaseSortedDocValues(LeafReader leafReader, String field) throws IOException {
+        var sortedDocValues = leafReader.getSortedDocValues(field);
+        if (sortedDocValues == null) {
+            sortedDocValues = DocValues.unwrapSingleton(leafReader.getSortedSetDocValues(field));
+        }
+        return (BaseSortedDocValues) sortedDocValues;
     }
 
     private IndexWriterConfig getTimeSeriesIndexWriterConfig(String hostnameField, String timestampField) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/DelegatingBlockLoaderFactory.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/DelegatingBlockLoaderFactory.java
@@ -114,8 +114,8 @@ public abstract class DelegatingBlockLoaderFactory implements BlockLoader.BlockF
     }
 
     @Override
-    public BlockLoader.SingletonOrdinalsBuilder singletonOrdinalsBuilder(SortedDocValues ordinals, int count) {
-        return new SingletonOrdinalsBuilder(factory, ordinals, count);
+    public BlockLoader.SingletonOrdinalsBuilder singletonOrdinalsBuilder(SortedDocValues ordinals, int count, boolean isDense) {
+        return new SingletonOrdinalsBuilder(factory, ordinals, count, isDense);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/SingletonOrdinalsBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/SingletonOrdinalsBuilder.java
@@ -33,16 +33,23 @@ public class SingletonOrdinalsBuilder implements BlockLoader.SingletonOrdinalsBu
     private int maxOrd = Integer.MIN_VALUE;
     private final int[] ords;
     private int count;
+    private final boolean isDense;
 
     public SingletonOrdinalsBuilder(BlockFactory blockFactory, SortedDocValues docValues, int count) {
+        this(blockFactory, docValues, count, false);
+    }
+
+    public SingletonOrdinalsBuilder(BlockFactory blockFactory, SortedDocValues docValues, int count, boolean isDense) {
         this.blockFactory = blockFactory;
         this.docValues = docValues;
         blockFactory.adjustBreaker(ordsSize(count));
         this.ords = new int[count];
+        this.isDense = isDense;
     }
 
     @Override
     public SingletonOrdinalsBuilder appendNull() {
+        assert isDense == false;
         ords[count++] = -1; // real ords can't be < 0, so we use -1 as null
         return this;
     }
@@ -52,6 +59,15 @@ public class SingletonOrdinalsBuilder implements BlockLoader.SingletonOrdinalsBu
         ords[count++] = ord;
         minOrd = Math.min(minOrd, ord);
         maxOrd = Math.max(maxOrd, ord);
+        return this;
+    }
+
+    @Override
+    public BlockLoader.SingletonOrdinalsBuilder appendOrds(int[] values, int from, int length, int minOrd, int maxOrd) {
+        System.arraycopy(values, from, ords, count, length);
+        this.count += length;
+        this.minOrd = Math.min(this.minOrd, minOrd);
+        this.maxOrd = Math.max(this.maxOrd, maxOrd);
         return this;
     }
 
@@ -69,9 +85,11 @@ public class SingletonOrdinalsBuilder implements BlockLoader.SingletonOrdinalsBu
         if (minOrd != maxOrd) {
             return null;
         }
-        for (int ord : ords) {
-            if (ord == -1) {
-                return null;
+        if (isDense == false) {
+            for (int ord : ords) {
+                if (ord == -1) {
+                    return null;
+                }
             }
         }
         final BytesRef v;
@@ -107,33 +125,61 @@ public class SingletonOrdinalsBuilder implements BlockLoader.SingletonOrdinalsBu
         try {
             int[] newOrds = new int[valueCount];
             Arrays.fill(newOrds, -1);
-            for (int ord : ords) {
-                if (ord != -1) {
+            // Re-mapping ordinals to be more space-efficient:
+            if (isDense) {
+                for (int ord : ords) {
                     newOrds[ord - minOrd] = 0;
+                }
+            } else {
+                for (int ord : ords) {
+                    if (ord != -1) {
+                        newOrds[ord - minOrd] = 0;
+                    }
                 }
             }
             // resolve the ordinals and remaps the ordinals
-            int nextOrd = -1;
-            try (BytesRefVector.Builder bytesBuilder = blockFactory.newBytesRefVectorBuilder(Math.min(valueCount, ords.length))) {
-                for (int i = 0; i < newOrds.length; i++) {
-                    if (newOrds[i] != -1) {
-                        newOrds[i] = ++nextOrd;
-                        bytesBuilder.appendBytesRef(docValues.lookupOrd(i + minOrd));
-                    }
+            try {
+                int nextOrd = -1;
+                BytesRef firstTerm = minOrd != Integer.MAX_VALUE ? docValues.lookupOrd(minOrd) : null;
+                int estimatedSize;
+                if (firstTerm != null) {
+                    estimatedSize = Math.min(valueCount, ords.length) * firstTerm.length;
+                } else {
+                    estimatedSize = Math.min(valueCount, ords.length);
                 }
-                bytesVector = bytesBuilder.build();
+                try (BytesRefVector.Builder bytesBuilder = blockFactory.newBytesRefVectorBuilder(estimatedSize)) {
+                    if (firstTerm != null) {
+                        newOrds[0] = ++nextOrd;
+                        bytesBuilder.appendBytesRef(firstTerm);
+                    }
+                    for (int i = firstTerm != null ? 1 : 0; i < newOrds.length; i++) {
+                        if (newOrds[i] != -1) {
+                            newOrds[i] = ++nextOrd;
+                            bytesBuilder.appendBytesRef(docValues.lookupOrd(i + minOrd));
+                        }
+                    }
+                    bytesVector = bytesBuilder.build();
+                }
             } catch (IOException e) {
                 throw new UncheckedIOException("error resolving ordinals", e);
             }
-            try (IntBlock.Builder ordinalsBuilder = blockFactory.newIntBlockBuilder(ords.length)) {
-                for (int ord : ords) {
-                    if (ord == -1) {
-                        ordinalsBuilder.appendNull();
-                    } else {
-                        ordinalsBuilder.appendInt(newOrds[ord - minOrd]);
-                    }
+            if (isDense) {
+                // Reusing ords array and overwrite all slots with re-mapped ordinals
+                for (int i = 0; i < ords.length; i++) {
+                    ords[i] = newOrds[ords[i] - minOrd];
                 }
-                ordinalBlock = ordinalsBuilder.build();
+                ordinalBlock = blockFactory.newIntArrayVector(ords, ords.length).asBlock();
+            } else {
+                try (IntBlock.Builder ordinalsBuilder = blockFactory.newIntBlockBuilder(ords.length)) {
+                    for (int ord : ords) {
+                        if (ord == -1) {
+                            ordinalsBuilder.appendNull();
+                        } else {
+                            ordinalsBuilder.appendInt(newOrds[ord - minOrd]);
+                        }
+                    }
+                    ordinalBlock = ordinalsBuilder.build();
+                }
             }
             final OrdinalBytesRefBlock result = new OrdinalBytesRefBlock(ordinalBlock, bytesVector);
             bytesVector = null;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/SingletonOrdinalsBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/SingletonOrdinalsBuilder.java
@@ -35,10 +35,6 @@ public class SingletonOrdinalsBuilder implements BlockLoader.SingletonOrdinalsBu
     private int count;
     private final boolean isDense;
 
-    public SingletonOrdinalsBuilder(BlockFactory blockFactory, SortedDocValues docValues, int count) {
-        this(blockFactory, docValues, count, false);
-    }
-
     public SingletonOrdinalsBuilder(BlockFactory blockFactory, SortedDocValues docValues, int count, boolean isDense) {
         this.blockFactory = blockFactory;
         this.docValues = docValues;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/TimeSeriesExtractFieldOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/TimeSeriesExtractFieldOperator.java
@@ -202,7 +202,7 @@ public class TimeSeriesExtractFieldOperator extends AbstractPageMappingOperator 
         }
 
         @Override
-        public BlockLoader.SingletonOrdinalsBuilder singletonOrdinalsBuilder(SortedDocValues ordinals, int count) {
+        public BlockLoader.SingletonOrdinalsBuilder singletonOrdinalsBuilder(SortedDocValues ordinals, int count, boolean isDense) {
             throw new UnsupportedOperationException("must not be used by column readers");
         }
     }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/read/SingletonOrdinalsBuilderTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/read/SingletonOrdinalsBuilderTests.java
@@ -141,12 +141,7 @@ public class SingletonOrdinalsBuilderTests extends ComputeTestCase {
     public void testAllNull() throws IOException {
         BlockFactory factory = blockFactory();
         int count = 1000;
-        var iwc = newIndexWriterConfig();
-        boolean maybeSoftDeletes = randomBoolean();
-        try (
-            Directory directory = newDirectory();
-            RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory, iwc, maybeSoftDeletes)
-        ) {
+        try (Directory directory = newDirectory(); RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory)) {
             for (int i = 0; i < count; i++) {
                 for (BytesRef v : new BytesRef[] { new BytesRef("a"), new BytesRef("b"), new BytesRef("c"), new BytesRef("d") }) {
                     indexWriter.addDocument(List.of(new SortedDocValuesField("f", v)));
@@ -156,12 +151,7 @@ public class SingletonOrdinalsBuilderTests extends ComputeTestCase {
                 for (LeafReaderContext ctx : reader.leaves()) {
                     SortedDocValues docValues = ctx.reader().getSortedDocValues("f");
                     try (
-                        SingletonOrdinalsBuilder builder = new SingletonOrdinalsBuilder(
-                            factory,
-                            docValues,
-                            ctx.reader().numDocs(),
-                            maybeSoftDeletes == false
-                        );
+                        SingletonOrdinalsBuilder builder = new SingletonOrdinalsBuilder(factory, docValues, ctx.reader().numDocs(), false);
                     ) {
                         for (int i = 0; i < ctx.reader().maxDoc(); i++) {
                             if (ctx.reader().getLiveDocs() == null || ctx.reader().getLiveDocs().get(i)) {


### PR DESCRIPTION
With this change both sorted set and number doc values use the same bulk loading for values/ordinals.

This PR supersedes (#132715) that also sped up loading dense singleton keyword fields, but duplicated the bulk encoding logic.