### PR TITLE
Reduce direct buffer size in test clusters

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/ElasticsearchCluster.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/ElasticsearchCluster.java
@@ -35,7 +35,10 @@ public interface ElasticsearchCluster extends TestRule, LocalClusterHandle {
      * @return a builder for a local cluster
      */
     static LocalClusterSpecBuilder<ElasticsearchCluster> local() {
-        return locateBuilderImpl();
+        LocalClusterSpecBuilder<ElasticsearchCluster> elasticsearchClusterSpecBuilder = locateBuilderImpl();
+        // reduce the size of direct buffers so we don't OOM when reserving direct memory on small machines with many CPUs in tests
+        elasticsearchClusterSpecBuilder.systemProperty("es.searchable.snapshot.shared_cache.write_buffer.size", "256k");
+        return elasticsearchClusterSpecBuilder;
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })


### PR DESCRIPTION
This fixes the esql spec pipeline that sometimes fails due to being unable to reserve 
direct buffer memory in rest tests due to the small agents machines that have
a high cpu count. 

Relates to https://github.com/elastic/elasticsearch/issues/130612