### PR TITLE
[Backport][DOCS]: Backport search connector release notes to 9.1

### DIFF
--- a/docs/reference/search-connectors/release-notes.md
+++ b/docs/reference/search-connectors/release-notes.md
@@ -29,6 +29,14 @@ Permissions granted to the `Everyone Except External Users` group were previousl
 ## 9.1.0 [connectors-9.1.0-release-notes]
 There are no new features, enhancements, fixes, known issues, or deprecations associated with this release.
 
+## 9.0.5 [connectors-9.0.5-release-notes]
+
+### Fixes [connectors-9.0.5-fixes]
+
+:::{dropdown} Resolves missing access control for `Everyone Except External Users` in SharePoint connector
+Permissions granted to the `Everyone Except External Users` group were previously ignored, causing incomplete access control metadata in documents. This occurred because the connector did not recognize the group’s login name format. [#3577](https://github.com/elastic/connectors/pull/3577) resolves this issue by recognizing the group’s login format and correctly applying its permissions to document access control metadata.
+:::
+
 ## 9.0.4 [connectors-9.0.4-release-notes]
 No changes since 9.0.3
 

--- a/docs/reference/search-connectors/release-notes.md
+++ b/docs/reference/search-connectors/release-notes.md
@@ -29,6 +29,9 @@ Permissions granted to the `Everyone Except External Users` group were previousl
 ## 9.1.0 [connectors-9.1.0-release-notes]
 There are no new features, enhancements, fixes, known issues, or deprecations associated with this release.
 
+## 9.0.4 [connectors-9.0.4-release-notes]
+No changes since 9.0.3
+
 ## 9.0.3 [connectors-9.0.3-release-notes]
 
 ### Features and enhancements [connectors-9.0.3-features-enhancements]


### PR DESCRIPTION
This PR adds the 9.0.4 and the 9.0.5 search connector release notes to the documentation.
