### PR TITLE
Streamline and optimize check to use decode or decode ordinals.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesProducer.java
@@ -1276,10 +1276,10 @@ final class ES819TSDBDocValuesProducer extends DocValuesProducer {
                         valuesData.seek(indexReader.get(blockIndex));
                     }
                     currentBlockIndex = blockIndex;
-                    if (maxOrd >= 0) {
-                        decoder.decodeOrdinals(valuesData, currentBlock, bitsPerOrd);
-                    } else {
+                    if (bitsPerOrd == -1) {
                         decoder.decode(valuesData, currentBlock);
+                    } else {
+                        decoder.decodeOrdinals(valuesData, currentBlock, bitsPerOrd);
                     }
                     return currentBlock[blockInIndex];
                 }
@@ -1347,7 +1347,7 @@ final class ES819TSDBDocValuesProducer extends DocValuesProducer {
                         if (lookaheadBlockIndex + 1 != blockIndex) {
                             lookaheadData.seek(indexReader.get(blockIndex));
                         }
-                        if (maxOrd == -1L) {
+                        if (bitsPerOrd == -1) {
                             decoder.decode(lookaheadData, lookaheadBlock);
                         } else {
                             decoder.decodeOrdinals(lookaheadData, lookaheadBlock, bitsPerOrd);
@@ -1417,10 +1417,10 @@ final class ES819TSDBDocValuesProducer extends DocValuesProducer {
                             valuesData.seek(indexReader.get(blockIndex));
                         }
                         currentBlockIndex = blockIndex;
-                        if (maxOrd >= 0) {
-                            decoder.decodeOrdinals(valuesData, currentBlock, bitsPerOrd);
-                        } else {
+                        if (bitsPerOrd == -1) {
                             decoder.decode(valuesData, currentBlock);
+                        } else {
+                            decoder.decodeOrdinals(valuesData, currentBlock, bitsPerOrd);
                         }
                     }
                     return currentBlock[blockInIndex];
@@ -1452,10 +1452,10 @@ final class ES819TSDBDocValuesProducer extends DocValuesProducer {
                         valuesData.seek(indexReader.get(blockIndex));
                     }
                     currentBlockIndex = blockIndex;
-                    if (bitsPerOrd >= 0) {
-                        decoder.decodeOrdinals(valuesData, currentBlock, bitsPerOrd);
-                    } else {
+                    if (bitsPerOrd == -1) {
                         decoder.decode(valuesData, currentBlock);
+                    } else {
+                        decoder.decodeOrdinals(valuesData, currentBlock, bitsPerOrd);
                     }
                 }
                 return currentBlock[blockInIndex];


### PR DESCRIPTION
Comparing `bitsPerOrd == -1` should be a little bit more optimal compared to `maxOrd >= 0` (int vs long comparison).