### PR TITLE
Shorten metadata.name of PR benchmark pipeline

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -306,7 +306,7 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
-  name: buildkite-pipeline-elasticsearch-pull-request-performance-benchmark
+  name: buildkite-pipeline-elasticsearch-pull-request-perf-benchmark
   description: Elasticsearch pull request performance benchmark
   links:
     - title: Pipeline


### PR DESCRIPTION
Looks like https://github.com/elastic/elasticsearch/pull/132941 resulted in silent failure with pipeline not installed.

It fails validation as `metadata.name` cannot exceed 63 characters:
```
1 validation error for RRE
metadata.name
  String should match pattern '^[a-z0-9A-Z][a-z0-9A-Z_.-]{0,62}$' [type=string_pattern_mismatch, input_value='buildkite-pipeline-elast...t-performance-benchmark', input_type=str]
```

After this change validation is successful:
```
Validated (RRE) Resource buildkite-pipeline-elasticsearch-update-serverless-submodule ✓
Validated (RRE) Resource buildkite-pipeline-elasticsearch-check-serverless-submodule ✓
Validated (RRE) Resource buildkite-pipeline-elasticsearch-periodic ✓
Validated (RRE) Resource buildkite-pipeline-elasticsearch-lucene-snapshot-build ✓
Validated (RRE) Resource buildkite-pipeline-elasticsearch-lucene-snapshot-update-branch ✓
Validated (RRE) Resource buildkite-pipeline-elasticsearch-lucene-snapshot-tests ✓
Validated (RRE) Resource buildkite-pipeline-elasticsearch-ecs-dynamic-template-tests ✓
Validated (RRE) Resource buildkite-pipeline-elasticsearch-periodic-micro-benchmarks ✓
Validated (RRE) Resource buildkite-pipeline-elasticsearch-pull-request-perf-benchmark ✓
```