### PR TITLE
ESQL: mark LOOKUP JOIN as ExecutesOn.Any by default

### DIFF
--- a/docs/changelog/133064.yaml
+++ b/docs/changelog/133064.yaml
@@ -1,0 +1,5 @@
+pr: 133064
+summary: Mark LOOKUP JOIN as `ExecutesOn.Any` by default
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/join/Join.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/join/Join.java
@@ -318,7 +318,7 @@ public class Join extends BinaryPlan implements PostAnalysisVerificationAware, S
 
     @Override
     public ExecuteLocation executesOn() {
-        return isRemote ? ExecuteLocation.REMOTE : ExecuteLocation.COORDINATOR;
+        return isRemote ? ExecuteLocation.REMOTE : ExecuteLocation.ANY;
     }
 
     private void checkRemoteJoin(Failures failures) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/OptimizerVerificationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/OptimizerVerificationTests.java
@@ -94,6 +94,39 @@ public class OptimizerVerificationTests extends AbstractLogicalPlanOptimizerTest
 
         String err;
 
+
+        // Remote enrich is ok after limit
+        plan("""
+            FROM test
+            | LIMIT 10
+            | EVAL language_code = languages
+            | ENRICH _remote:languages ON language_code
+            | STATS count(*) BY language_name
+            """, analyzer);
+
+        // Remote enrich is ok after topn
+        plan("""
+            FROM test
+            | EVAL language_code = languages
+            | SORT languages
+            | ENRICH _remote:languages ON language_code
+            """, analyzer);
+        plan("""
+            FROM test
+            | EVAL language_code = languages
+            | SORT languages
+            | LIMIT 2
+            | ENRICH _remote:languages ON language_code
+            """, analyzer);
+
+        // Remote enrich is ok before pipeline breakers
+        plan("""
+            FROM test
+            | EVAL language_code = languages
+            | ENRICH _remote:languages ON language_code
+            | LIMIT 10
+            """, analyzer);
+
         plan("""
             FROM test
             | EVAL language_code = languages
@@ -103,18 +136,17 @@ public class OptimizerVerificationTests extends AbstractLogicalPlanOptimizerTest
 
         plan("""
             FROM test
-            | LIMIT 10
             | EVAL language_code = languages
             | ENRICH _remote:languages ON language_code
             | STATS count(*) BY language_name
+            | LIMIT 10
             """, analyzer);
 
         plan("""
             FROM test
             | EVAL language_code = languages
             | ENRICH _remote:languages ON language_code
-            | STATS count(*) BY language_name
-            | LIMIT 10
+            | SORT language_name
             """, analyzer);
 
         err = error("""
@@ -227,6 +259,9 @@ public class OptimizerVerificationTests extends AbstractLogicalPlanOptimizerTest
         assertThat(err, containsString("4:3: ENRICH with remote policy can't be executed after [CHANGE_POINT salary ON languages]@2:3"));
     }
 
+    /**
+     * The validation should not trigger for remote enrich after a lookup join. Lookup joins can be executed anywhere.
+     */
     public void testRemoteEnrichAfterLookupJoin() {
         EnrichResolution enrichResolution = new EnrichResolution();
         loadEnrichPolicyResolution(
@@ -254,24 +289,22 @@ public class OptimizerVerificationTests extends AbstractLogicalPlanOptimizerTest
             | %s
             """, lookupCommand), analyzer);
 
-        String err = error(Strings.format("""
+        plan(Strings.format("""
             FROM test
             | EVAL language_code = languages
             | %s
             | ENRICH _remote:languages ON language_code
             """, lookupCommand), analyzer);
-        assertThat(err, containsString("4:3: ENRICH with remote policy can't be executed after [" + lookupCommand + "]@3:3"));
 
-        err = error(Strings.format("""
+        plan(Strings.format("""
             FROM test
             | EVAL language_code = languages
             | %s
             | ENRICH _remote:languages ON language_code
             | %s
             """, lookupCommand, lookupCommand), analyzer);
-        assertThat(err, containsString("4:3: ENRICH with remote policy can't be executed after [" + lookupCommand + "]@3:3"));
 
-        err = error(Strings.format("""
+        plan(Strings.format("""
             FROM test
             | EVAL language_code = languages
             | %s
@@ -279,7 +312,6 @@ public class OptimizerVerificationTests extends AbstractLogicalPlanOptimizerTest
             | MV_EXPAND language_code
             | ENRICH _remote:languages ON language_code
             """, lookupCommand), analyzer);
-        assertThat(err, containsString("6:3: ENRICH with remote policy can't be executed after [" + lookupCommand + "]@3:3"));
     }
 
     public void testRemoteLookupJoinWithPipelineBreaker() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/OptimizerVerificationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/OptimizerVerificationTests.java
@@ -94,7 +94,6 @@ public class OptimizerVerificationTests extends AbstractLogicalPlanOptimizerTest
 
         String err;
 
-
         // Remote enrich is ok after limit
         plan("""
             FROM test


### PR DESCRIPTION
This fixes the wrong error message that claims an invalid query whenever there's a remote ENRICH after LOOKUP JOIN.

I'm not sure there's currently any real query that can be made to actually _run_ with this fix, because this is only used when validating remote ENRICH AFAIK. But constructing a query with LOOKUP JOIN and remote ENRICH that would show that our validation is currently overzealous runs into the buggy remote ENRICH planning as described [here](https://github.com/elastic/elasticsearch/issues/115897#issuecomment-3196004014).