### PR TITLE
Allow configuring resource root of transport versions

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionResourcesPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionResourcesPlugin.java
@@ -61,8 +61,9 @@ public class TransportVersionResourcesPlugin implements Plugin<Project> {
                 t.getDefinitionsDirectory().set(getDefinitionsDirectory(getResourcesDirectory(project)));
                 t.getManifestFile().set(project.getLayout().getBuildDirectory().file("generated-resources/manifest.txt"));
             });
+        String resourceRoot = TransportVersionUtils.getResourceRoot(project);
         project.getTasks().named(JavaPlugin.PROCESS_RESOURCES_TASK_NAME, Copy.class).configure(t -> {
-            t.into("transport/definitions", c -> c.from(generateManifestTask));
+            t.into(resourceRoot + "/definitions", c -> c.from(generateManifestTask));
         });
     }
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionUtils.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionUtils.java
@@ -50,11 +50,16 @@ class TransportVersionUtils {
         if (projectName == null) {
             projectName = ":server";
         }
+        var resourceRoot = getResourceRoot(project);
+        Directory projectDir = project.project(projectName.toString()).getLayout().getProjectDirectory();
+        return projectDir.dir("src/main/resources/" + resourceRoot);
+    }
+
+    static String getResourceRoot(Project project) {
         var resourceRoot = project.findProperty("org.elasticsearch.transport.resourceRoot");
         if (resourceRoot == null) {
             resourceRoot = "transport";
         }
-        Directory projectDir = project.project(projectName.toString()).getLayout().getProjectDirectory();
-        return projectDir.dir("src/main/resources/" + resourceRoot);
+        return resourceRoot.toString();
     }
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionUtils.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionUtils.java
@@ -50,7 +50,11 @@ class TransportVersionUtils {
         if (projectName == null) {
             projectName = ":server";
         }
+        var resourceRoot = project.findProperty("org.elasticsearch.transport.resourceRoot");
+        if (resourceRoot == null) {
+            resourceRoot = "transport";
+        }
         Directory projectDir = project.project(projectName.toString()).getLayout().getProjectDirectory();
-        return projectDir.dir("src/main/resources/transport");
+        return projectDir.dir("src/main/resources/" + resourceRoot);
     }
 }

--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -165,20 +165,20 @@ public record TransportVersion(String name, int id, TransportVersion nextPatchVe
 
     public static List<TransportVersion> collectFromResources(
         String component,
+        String resourceRoot,
         Function<String, InputStream> resourceLoader,
-        String manifestFileName,
         String latestFileName
     ) {
         TransportVersion latest = parseFromBufferedReader(
             component,
-            "/transport/latest/" + latestFileName,
+            resourceRoot + "/latest/" + latestFileName,
             resourceLoader,
             (c, p, br) -> fromBufferedReader(c, p, true, false, br, Integer.MAX_VALUE)
         );
         if (latest != null) {
             List<String> versionRelativePaths = parseFromBufferedReader(
                 component,
-                "/transport/definitions/" + manifestFileName,
+                resourceRoot + "/definitions/manifest.txt",
                 resourceLoader,
                 (c, p, br) -> br.lines().filter(line -> line.isBlank() == false).toList()
             );
@@ -187,7 +187,7 @@ public record TransportVersion(String name, int id, TransportVersion nextPatchVe
                 for (String versionRelativePath : versionRelativePaths) {
                     TransportVersion transportVersion = parseFromBufferedReader(
                         component,
-                        "/transport/definitions/" + versionRelativePath,
+                        resourceRoot + "/definitions/" + versionRelativePath,
                         resourceLoader,
                         (c, p, br) -> fromBufferedReader(c, p, false, versionRelativePath.startsWith("named/"), br, latest.id())
                     );
@@ -429,8 +429,8 @@ public record TransportVersion(String name, int id, TransportVersion nextPatchVe
             List<TransportVersion> allVersions = new ArrayList<>(TransportVersions.DEFINED_VERSIONS);
             List<TransportVersion> streamVersions = collectFromResources(
                 "<server>",
+                "/transport",
                 TransportVersion.class::getResourceAsStream,
-                "manifest.txt",
                 Version.CURRENT.major + "." + Version.CURRENT.minor + ".csv"
             );
             Map<String, TransportVersion> allVersionsByName = streamVersions.stream()


### PR DESCRIPTION
This commit makes the resource root of transport resources configurable when building and loading transport versions. This allows the multiple sets of transport resources to exist simultaneously when running non-modular in tests, eg in serverless.