### PR TITLE
Update ES|QL function list for release versions

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -582,9 +582,6 @@ tests:
 - class: org.elasticsearch.upgrades.SyntheticSourceRollingUpgradeIT
   method: testIndexing {upgradedNodes=0}
   issue: https://github.com/elastic/elasticsearch/issues/133061
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=esql/60_usage/Basic ESQL usage output (telemetry) non-snapshot version}
-  issue: https://github.com/elastic/elasticsearch/issues/133014
 - class: org.elasticsearch.test.rest.yaml.CcsCommonYamlTestSuiteIT
   method: test {p0=search/160_exists_query/Test exists query on _id field}
   issue: https://github.com/elastic/elasticsearch/issues/133097

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_usage.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_usage.yml
@@ -141,7 +141,7 @@ setup:
         - method: POST
           path: /_query
           parameters: []
-          capabilities: [ non_snapshot_test_for_telemetry, fn_byte_length ]
+          capabilities: [ non_snapshot_test_for_telemetry, fn_month_name ]
       reason: "Test that should only be executed on release versions"
 
   - do: {xpack.usage: {}}
@@ -229,7 +229,7 @@ setup:
   - gt: {esql.functions.to_long: $functions_to_long}
   - match: {esql.functions.coalesce: $functions_coalesce}
   - gt: {esql.functions.categorize: $functions_categorize}
-  - length: {esql.functions: 138} # check the "sister" test above for a likely update to the same esql.functions length check
+  - length: {esql.functions: 139} # check the "sister" test above for a likely update to the same esql.functions length check
 
 ---
 took:


### PR DESCRIPTION
Update the function list to include the newly introduced `MONTH_NAME` function. 

Relates #132968
Closes #133014