### PR TITLE
Omit project ID from snapshot metrics

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/repositories/SnapshotMetricsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/repositories/SnapshotMetricsIT.java
@@ -276,12 +276,12 @@ public class SnapshotMetricsIT extends AbstractSnapshotIntegTestCase {
         assertMetricsHaveAttributes(
             InstrumentType.LONG_GAUGE,
             SnapshotMetrics.SNAPSHOT_SHARDS_BY_STATE,
-            Map.of("project_id", ProjectId.DEFAULT.id(), "repo_name", repositoryName, "repo_type", "mock")
+            Map.of("repo_name", repositoryName, "repo_type", "mock")
         );
         assertMetricsHaveAttributes(
             InstrumentType.LONG_GAUGE,
             SnapshotMetrics.SNAPSHOTS_BY_STATE,
-            Map.of("project_id", ProjectId.DEFAULT.id(), "repo_name", repositoryName, "repo_type", "mock")
+            Map.of("repo_name", repositoryName, "repo_type", "mock")
         );
     }
 
@@ -345,12 +345,12 @@ public class SnapshotMetricsIT extends AbstractSnapshotIntegTestCase {
         assertMetricsHaveAttributes(
             InstrumentType.LONG_GAUGE,
             SnapshotMetrics.SNAPSHOT_SHARDS_BY_STATE,
-            Map.of("project_id", ProjectId.DEFAULT.id(), "repo_name", repositoryName, "repo_type", "mock")
+            Map.of("repo_name", repositoryName, "repo_type", "mock")
         );
         assertMetricsHaveAttributes(
             InstrumentType.LONG_GAUGE,
             SnapshotMetrics.SNAPSHOTS_BY_STATE,
-            Map.of("project_id", ProjectId.DEFAULT.id(), "repo_name", repositoryName, "repo_type", "mock")
+            Map.of("repo_name", repositoryName, "repo_type", "mock")
         );
     }
 
@@ -421,12 +421,12 @@ public class SnapshotMetricsIT extends AbstractSnapshotIntegTestCase {
         assertMetricsHaveAttributes(
             InstrumentType.LONG_GAUGE,
             SnapshotMetrics.SNAPSHOT_SHARDS_BY_STATE,
-            Map.of("project_id", ProjectId.DEFAULT.id(), "repo_name", repositoryName, "repo_type", "mock")
+            Map.of("repo_name", repositoryName, "repo_type", "mock")
         );
         assertMetricsHaveAttributes(
             InstrumentType.LONG_GAUGE,
             SnapshotMetrics.SNAPSHOTS_BY_STATE,
-            Map.of("project_id", ProjectId.DEFAULT.id(), "repo_name", repositoryName, "repo_type", "mock")
+            Map.of("repo_name", repositoryName, "repo_type", "mock")
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/repositories/SnapshotMetrics.java
+++ b/server/src/main/java/org/elasticsearch/repositories/SnapshotMetrics.java
@@ -94,7 +94,7 @@ public record SnapshotMetrics(
     }
 
     public static Map<String, Object> createAttributesMap(ProjectId projectId, RepositoryMetadata meta) {
-        assert projectId != null : "Project ID should always be set";
-        return Map.of("project_id", projectId.id(), "repo_type", meta.type(), "repo_name", meta.name());
+        // Omit project ID until we go multi-project
+        return Map.of("repo_type", meta.type(), "repo_name", meta.name());
     }
 }

--- a/server/src/main/java/org/elasticsearch/repositories/SnapshotMetrics.java
+++ b/server/src/main/java/org/elasticsearch/repositories/SnapshotMetrics.java
@@ -11,6 +11,7 @@ package org.elasticsearch.repositories;
 
 import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
+import org.elasticsearch.core.FixForMultiProject;
 import org.elasticsearch.telemetry.metric.DoubleHistogram;
 import org.elasticsearch.telemetry.metric.LongCounter;
 import org.elasticsearch.telemetry.metric.LongWithAttributes;
@@ -93,8 +94,8 @@ public record SnapshotMetrics(
         meterRegistry.registerLongsGauge(SNAPSHOTS_BY_STATE, "snapshots by state", "unit", snapshotsByStatusObserver);
     }
 
+    @FixForMultiProject(description = "When multi-project arrives we should add project ID to the labels")
     public static Map<String, Object> createAttributesMap(ProjectId projectId, RepositoryMetadata meta) {
-        // Omit project ID until we go multi-project
         return Map.of("repo_type", meta.type(), "repo_name", meta.name());
     }
 }


### PR DESCRIPTION
This metric label won't be required until we go multi-project and is interfering with the existing automatically populated `project_id` label.