### PR TITLE
Remove docID check from BlockDocValuesReader

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/BlockDocValuesReader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BlockDocValuesReader.java
@@ -38,7 +38,6 @@ import org.elasticsearch.search.fetch.StoredFieldsSpec;
 import java.io.IOException;
 
 import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.COSINE_MAGNITUDE_FIELD_SUFFIX;
-import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.ElementType.BYTE;
 
 /**
  * A reader that supports reading doc-values from a Lucene segment in Block fashion.
@@ -139,18 +138,13 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
                 }
             }
             try (BlockLoader.LongBuilder builder = factory.longsFromDocValues(docs.count() - offset)) {
-                int lastDoc = -1;
                 for (int i = offset; i < docs.count(); i++) {
                     int doc = docs.get(i);
-                    if (doc < lastDoc) {
-                        throw new IllegalStateException("docs within same block must be in order");
-                    }
                     if (numericDocValues.advanceExact(doc)) {
                         builder.appendLong(numericDocValues.longValue());
                     } else {
                         builder.appendNull();
                     }
-                    lastDoc = doc;
                 }
                 return builder.build();
             }
@@ -179,7 +173,6 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
 
     static class Longs extends BlockDocValuesReader {
         private final SortedNumericDocValues numericDocValues;
-        private int docID = -1;
 
         Longs(SortedNumericDocValues numericDocValues) {
             this.numericDocValues = numericDocValues;
@@ -190,9 +183,6 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
             try (BlockLoader.LongBuilder builder = factory.longsFromDocValues(docs.count() - offset)) {
                 for (int i = offset; i < docs.count(); i++) {
                     int doc = docs.get(i);
-                    if (doc < this.docID) {
-                        throw new IllegalStateException("docs within same block must be in order");
-                    }
                     read(doc, builder);
                 }
                 return builder.build();
@@ -205,7 +195,6 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
         }
 
         private void read(int doc, LongBuilder builder) throws IOException {
-            this.docID = doc;
             if (false == numericDocValues.advanceExact(doc)) {
                 builder.appendNull();
                 return;
@@ -224,8 +213,7 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
 
         @Override
         public int docId() {
-            // There is a .docID on the numericDocValues but it is often not implemented.
-            return docID;
+            return numericDocValues.docID();
         }
 
         @Override
@@ -274,18 +262,13 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
         @Override
         public BlockLoader.Block read(BlockFactory factory, Docs docs, int offset) throws IOException {
             try (BlockLoader.IntBuilder builder = factory.intsFromDocValues(docs.count() - offset)) {
-                int lastDoc = -1;
                 for (int i = offset; i < docs.count(); i++) {
                     int doc = docs.get(i);
-                    if (doc < lastDoc) {
-                        throw new IllegalStateException("docs within same block must be in order");
-                    }
                     if (numericDocValues.advanceExact(doc)) {
                         builder.appendInt(Math.toIntExact(numericDocValues.longValue()));
                     } else {
                         builder.appendNull();
                     }
-                    lastDoc = doc;
                 }
                 return builder.build();
             }
@@ -314,7 +297,6 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
 
     private static class Ints extends BlockDocValuesReader {
         private final SortedNumericDocValues numericDocValues;
-        private int docID = -1;
 
         Ints(SortedNumericDocValues numericDocValues) {
             this.numericDocValues = numericDocValues;
@@ -325,9 +307,6 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
             try (BlockLoader.IntBuilder builder = factory.intsFromDocValues(docs.count() - offset)) {
                 for (int i = offset; i < docs.count(); i++) {
                     int doc = docs.get(i);
-                    if (doc < this.docID) {
-                        throw new IllegalStateException("docs within same block must be in order");
-                    }
                     read(doc, builder);
                 }
                 return builder.build();
@@ -340,7 +319,6 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
         }
 
         private void read(int doc, IntBuilder builder) throws IOException {
-            this.docID = doc;
             if (false == numericDocValues.advanceExact(doc)) {
                 builder.appendNull();
                 return;
@@ -359,8 +337,7 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
 
         @Override
         public int docId() {
-            // There is a .docID on the numericDocValues but it is often not implemented.
-            return docID;
+            return numericDocValues.docID();
         }
 
         @Override
@@ -413,7 +390,6 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
     private static class SingletonDoubles extends BlockDocValuesReader {
         private final NumericDocValues docValues;
         private final ToDouble toDouble;
-        private int docID = -1;
 
         SingletonDoubles(NumericDocValues docValues, ToDouble toDouble) {
             this.docValues = docValues;
@@ -423,19 +399,13 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
         @Override
         public BlockLoader.Block read(BlockFactory factory, Docs docs, int offset) throws IOException {
             try (BlockLoader.DoubleBuilder builder = factory.doublesFromDocValues(docs.count() - offset)) {
-                int lastDoc = -1;
                 for (int i = offset; i < docs.count(); i++) {
                     int doc = docs.get(i);
-                    if (doc < lastDoc) {
-                        throw new IllegalStateException("docs within same block must be in order");
-                    }
                     if (docValues.advanceExact(doc)) {
                         builder.appendDouble(toDouble.convert(docValues.longValue()));
                     } else {
                         builder.appendNull();
                     }
-                    lastDoc = doc;
-                    this.docID = doc;
                 }
                 return builder.build();
             }
@@ -443,9 +413,8 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
 
         @Override
         public void read(int docId, BlockLoader.StoredFields storedFields, Builder builder) throws IOException {
-            this.docID = docId;
             DoubleBuilder blockBuilder = (DoubleBuilder) builder;
-            if (docValues.advanceExact(this.docID)) {
+            if (docValues.advanceExact(docId)) {
                 blockBuilder.appendDouble(toDouble.convert(docValues.longValue()));
             } else {
                 blockBuilder.appendNull();
@@ -454,7 +423,7 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
 
         @Override
         public int docId() {
-            return docID;
+            return docValues.docID();
         }
 
         @Override
@@ -466,7 +435,6 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
     private static class Doubles extends BlockDocValuesReader {
         private final SortedNumericDocValues docValues;
         private final ToDouble toDouble;
-        private int docID = -1;
 
         Doubles(SortedNumericDocValues docValues, ToDouble toDouble) {
             this.docValues = docValues;
@@ -478,9 +446,6 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
             try (BlockLoader.DoubleBuilder builder = factory.doublesFromDocValues(docs.count() - offset)) {
                 for (int i = offset; i < docs.count(); i++) {
                     int doc = docs.get(i);
-                    if (doc < this.docID) {
-                        throw new IllegalStateException("docs within same block must be in order");
-                    }
                     read(doc, builder);
                 }
                 return builder.build();
@@ -493,7 +458,6 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
         }
 
         private void read(int doc, DoubleBuilder builder) throws IOException {
-            this.docID = doc;
             if (false == docValues.advanceExact(doc)) {
                 builder.appendNull();
                 return;
@@ -512,7 +476,7 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
 
         @Override
         public int docId() {
-            return docID;
+            return docValues.docID();
         }
 
         @Override
@@ -759,9 +723,6 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
             try (var builder = factory.singletonOrdinalsBuilder(ordinals, docs.count() - offset, false)) {
                 for (int i = offset; i < docs.count(); i++) {
                     int doc = docs.get(i);
-                    if (doc < ordinals.docID()) {
-                        throw new IllegalStateException("docs within same block must be in order");
-                    }
                     if (ordinals.advanceExact(doc)) {
                         builder.appendOrd(ordinals.ordValue());
                     } else {
@@ -909,8 +870,6 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
         private final ByteArrayStreamInput in = new ByteArrayStreamInput();
         private final BytesRef scratch = new BytesRef();
 
-        private int docID = -1;
-
         BytesRefsFromBinary(BinaryDocValues docValues) {
             this.docValues = docValues;
         }
@@ -920,9 +879,6 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
             try (BlockLoader.BytesRefBuilder builder = factory.bytesRefs(docs.count() - offset)) {
                 for (int i = offset; i < docs.count(); i++) {
                     int doc = docs.get(i);
-                    if (doc < docID) {
-                        throw new IllegalStateException("docs within same block must be in order");
-                    }
                     read(doc, builder);
                 }
                 return builder.build();
@@ -935,7 +891,6 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
         }
 
         private void read(int doc, BytesRefBuilder builder) throws IOException {
-            this.docID = doc;
             if (false == docValues.advanceExact(doc)) {
                 builder.appendNull();
                 return;
@@ -964,7 +919,7 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
 
         @Override
         public int docId() {
-            return docID;
+            return docValues.docID();
         }
 
         @Override
@@ -1014,7 +969,6 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
         protected final IndexVersion indexVersion;
         protected final int dimensions;
         protected final T scratch;
-        protected int docID = -1;
 
         AbstractDenseVectorFromBinary(BinaryDocValues docValues, int dims, IndexVersion indexVersion, T scratch) {
             this.docValues = docValues;
@@ -1025,7 +979,7 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
 
         @Override
         public int docId() {
-            return docID;
+            return docValues.docID();
         }
 
         @Override
@@ -1038,9 +992,6 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
             try (BlockLoader.FloatBuilder builder = factory.denseVectors(docs.count() - offset, dimensions)) {
                 for (int i = offset; i < docs.count(); i++) {
                     int doc = docs.get(i);
-                    if (doc < docID) {
-                        throw new IllegalStateException("docs within same block must be in order");
-                    }
                     read(doc, builder);
                 }
                 return builder.build();
@@ -1048,7 +999,6 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
         }
 
         private void read(int doc, BlockLoader.FloatBuilder builder) throws IOException {
-            this.docID = doc;
             if (docValues.advanceExact(doc) == false) {
                 builder.appendNull();
                 return;
@@ -1191,7 +1141,6 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
 
     private static class Booleans extends BlockDocValuesReader {
         private final SortedNumericDocValues numericDocValues;
-        private int docID = -1;
 
         Booleans(SortedNumericDocValues numericDocValues) {
             this.numericDocValues = numericDocValues;
@@ -1202,9 +1151,6 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
             try (BlockLoader.BooleanBuilder builder = factory.booleansFromDocValues(docs.count() - offset)) {
                 for (int i = offset; i < docs.count(); i++) {
                     int doc = docs.get(i);
-                    if (doc < this.docID) {
-                        throw new IllegalStateException("docs within same block must be in order");
-                    }
                     read(doc, builder);
                 }
                 return builder.build();
@@ -1217,7 +1163,6 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
         }
 
         private void read(int doc, BooleanBuilder builder) throws IOException {
-            this.docID = doc;
             if (false == numericDocValues.advanceExact(doc)) {
                 builder.appendNull();
                 return;
@@ -1236,8 +1181,7 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
 
         @Override
         public int docId() {
-            // There is a .docID on the numericDocValues but it is often not implemented.
-            return docID;
+            return numericDocValues.docID();
         }
 
         @Override


### PR DESCRIPTION
I have verified that our DocValues extensions track docId correctly; therefore, I think we can remove the extra docId tracking from BlockDocValuesReader.