### PR TITLE
Use expectedDocs instead of actualDocs to stop posting lists iteration

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/IVFVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/IVFVectorsReader.java
@@ -251,7 +251,7 @@ public abstract class IVFVectorsReader extends KnnVectorsReader {
         // TODO do we need to handle nested doc counts similarly to how we handle
         // filtering? E.g. keep exploring until we hit an expected number of parent documents vs. child vectors?
         while (centroidIterator.hasNext()
-            && (maxVectorVisited > actualDocs || knnCollector.minCompetitiveSimilarity() == Float.NEGATIVE_INFINITY)) {
+            && (maxVectorVisited > expectedDocs || knnCollector.minCompetitiveSimilarity() == Float.NEGATIVE_INFINITY)) {
             // todo do we actually need to know the score???
             long offset = centroidIterator.nextPostingListOffset();
             // todo do we need direct access to the raw centroid???, this is used for quantizing, maybe hydrating and quantizing


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/132722, we change the condition to stop the iteration of posting lists tot ake into account the number of documents visited instead of the number of posting lists. The condition was changed to take into account the number of scored docs.

This had a side effect because now in the case of a search with a filter we are visiting much more posting lists because we don't stop until we visit a non-filtered number of documents where before this was not taking into account. Ic hecked and I think the current check is wrong as we are visiting too many documents and the condition should be using expectedDocs so we bail out when we reach that number and we collected enough documents.

running a filtered search in main:
```
index_name       index_type  visit_percentage(%)  latency(ms)  net_cpu_time(ms)  avg_cpu_count     QPS  recall    visited  filter_selectivity
---------------  ----------  -------------------  -----------  ----------------  -------------  ------  ------  ---------  ------------------  
wiki1024en.docs         ivf                 0.00        12.99              0.00           0.00   76.98    0.99  180720.32                0.50
```

With this PR:

```
index_name       index_type  visit_percentage(%)  latency(ms)  net_cpu_time(ms)  avg_cpu_count      QPS  recall   visited  filter_selectivity
---------------  ----------  -------------------  -----------  ----------------  -------------  -------  ------  --------  ------------------  
wiki1024en.docs         ivf                 0.00         6.79              0.00           0.00   147.28    0.98  90911.02                0.50
```
