### PR TITLE
Changes method from HEAD to OPTIONS for ping in rest-spec-api

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ping.json
@@ -14,7 +14,7 @@
         {
           "path":"/",
           "methods":[
-            "HEAD"
+            "OPTIONS"
           ]
         }
       ]


### PR DESCRIPTION
Fixes #97613

Related:
* https://github.com/elastic/elasticsearch-specification/pull/5138