### PR TITLE
[Enhancement][Mapping] Validate copy_to target exists when dynamic ma…

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -34,6 +34,7 @@ import org.elasticsearch.xcontent.XContentParseException;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.index.mapper.MapperParsingException;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -905,6 +906,18 @@ public final class DocumentParser {
                 // ignore copy_to that targets inference fields, values are already extracted in the coordinating node to perform inference.
                 continue;
             }
+            
+            // Validate that copy_to target field exists when dynamic mappings are disabled
+            ObjectMapper.Dynamic dynamic = context.dynamic();
+            if (dynamic == ObjectMapper.Dynamic.FALSE || dynamic == ObjectMapper.Dynamic.STRICT) {
+                if (context.mappingLookup().getMapper(field) == null) {
+                    throw new MapperParsingException(
+                        "Cannot copy_to non-existent field '" + field + 
+                        "' when dynamic mappings are disabled (dynamic=[" + dynamic + "])"
+                    );
+                }
+            }
+            
             // In case of a hierarchy of nested documents, we need to figure out
             // which document the field should go to
             LuceneDocument targetDoc = null;


### PR DESCRIPTION
…ppings disabled (Fixes #112812)

- Added check in DocumentParser.parseCopyFields for non-existent targets when dynamic=false or strict
- Included unit test to assert error is thrown with descriptive message
- Prevents silent failures when copy_to targets don't exist in strict mapping mode

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
