### PR TITLE
[8.19] Adding internal input types (#132849)

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceSparseEmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceSparseEmbeddingsRequest.java
@@ -108,10 +108,10 @@ public class ElasticInferenceServiceSparseEmbeddingsRequest extends ElasticInfer
     // visible for testing
     static ElasticInferenceServiceUsageContext inputTypeToUsageContext(InputType inputType) {
         switch (inputType) {
-            case SEARCH -> {
+            case SEARCH, INTERNAL_SEARCH -> {
                 return ElasticInferenceServiceUsageContext.SEARCH;
             }
-            case INGEST -> {
+            case INGEST, INTERNAL_INGEST -> {
                 return ElasticInferenceServiceUsageContext.INGEST;
             }
             default -> {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Adding internal input types (#132849)](https://github.com/elastic/elasticsearch/pull/132849)

<!--- Backport version: 9.2.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)