### PR TITLE
Fix an AWS SDK v2 release note

### DIFF
--- a/docs/reference/migration/migrate_8_19.asciidoc
+++ b/docs/reference/migration/migrate_8_19.asciidoc
@@ -100,7 +100,7 @@ Unfortunately there are several differences between the two AWS SDK versions whi
 
 * AWS SDK v2 counts 4xx responses differently in its metrics reporting.
 
-* AWS SDK v2 always uses the regional STS endpoint, whereas AWS SDK v2
+* AWS SDK v2 always uses the regional STS endpoint, whereas AWS SDK v1
   could use either a regional endpoint or the global
   `https://sts.amazonaws.com` one.
 

--- a/docs/reference/release-notes/8.19.0.asciidoc
+++ b/docs/reference/release-notes/8.19.0.asciidoc
@@ -117,7 +117,7 @@ Existing `repository-s3` configurations may no longer be compatible. Notable dif
 * AWS SDK v2 requires the use of the V4 signature algorithm, therefore, the `s3.client.${CLIENT_NAME}.signer_override` setting is deprecated and no longer has any effect.
 * AWS SDK v2 does not support the `log-delivery-write` canned ACL.
 * AWS SDK v2 counts 4xx responses differently in its metrics reporting.
-* AWS SDK v2 always uses the regional STS endpoint, whereas AWS SDK v2 could use either a regional endpoint or the global `https://sts.amazonaws.com` one.
+* AWS SDK v2 always uses the regional STS endpoint, whereas AWS SDK v1 could use either a regional endpoint or the global `https://sts.amazonaws.com` one.
 
 **Action:**
 Test the upgrade in a non-production environment. Adapt your configuration to the new SDK functionality. This includes, but may not be limited to, the following items:


### PR DESCRIPTION
Fixes a release note where AWS SDK v2 was used instead of AWS SDK v1.

#133155 is the PR for `main`.