### PR TITLE
[9.1] Limit frequency of feature last-used time updates (#133004)

### DIFF
--- a/docs/changelog/133004.yaml
+++ b/docs/changelog/133004.yaml
@@ -1,0 +1,5 @@
+pr: 133004
+summary: Limit frequency of feature last-used time updates
+area: License
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
@@ -447,7 +447,13 @@ public class XPackLicenseState {
 
     void featureUsed(LicensedFeature feature) {
         checkExpiry();
-        usage.put(new FeatureUsage(feature, null), epochMillisProvider.getAsLong());
+        final long now = epochMillisProvider.getAsLong();
+        final FeatureUsage feat = new FeatureUsage(feature, null);
+        final Long mostRecent = usage.get(feat);
+        // only update if needed, to prevent ConcurrentHashMap lock-contention on writes
+        if (mostRecent == null || now > mostRecent) {
+            usage.put(feat, now);
+        }
     }
 
     void enableUsageTracking(LicensedFeature feature, String contextName) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/XPackLicenseStateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/XPackLicenseStateTests.java
@@ -244,6 +244,13 @@ public class XPackLicenseStateTests extends ESTestCase {
         lastUsed = licenseState.getLastUsed();
         assertThat("feature.check updates usage", lastUsed.keySet(), containsInAnyOrder(usage));
         assertThat(lastUsed.get(usage), equalTo(200L));
+
+        // updates to the last used timestamp only happen if the time has increased
+        currentTime.set(199);
+        goldFeature.check(licenseState);
+        lastUsed = licenseState.getLastUsed();
+        assertThat("feature.check updates usage", lastUsed.keySet(), containsInAnyOrder(usage));
+        assertThat(lastUsed.get(usage), equalTo(200L));
     }
 
     public void testLastUsedMomentaryFeatureWithSameNameDifferentFamily() {


### PR DESCRIPTION
Backports the following commits to 9.1:
 - Limit frequency of feature last-used time updates (#133004)