### PR TITLE
Make transport version ids have descending ordering

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionId.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionId.java
@@ -22,7 +22,8 @@ record TransportVersionId(int complete, int major, int server, int subsidiary, i
 
     @Override
     public int compareTo(TransportVersionId o) {
-        return Integer.compare(complete, o.complete);
+        // note: this is descending order so the arguments are reversed
+        return Integer.compare(o.complete, complete);
     }
 
     @Override

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/ValidateTransportVersionResourcesTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/ValidateTransportVersionResourcesTask.java
@@ -122,7 +122,7 @@ public abstract class ValidateTransportVersionResourcesTask extends DefaultTask 
         if (definition.ids().isEmpty()) {
             throwDefinitionFailure(definition, "does not contain any ids");
         }
-        if (Comparators.isInOrder(definition.ids(), Comparator.reverseOrder()) == false) {
+        if (Comparators.isInOrder(definition.ids(), Comparator.naturalOrder()) == false) {
             throwDefinitionFailure(definition, "does not have ordered ids");
         }
         for (int ndx = 0; ndx < definition.ids().size(); ++ndx) {


### PR DESCRIPTION
Transport version ids must be in descending order in definition files. However, the compareTo for them was ascending and the validation used reverse ordering. This commit fixes the compareTo so it uses desending ordering and the validation uses natural ordering.