### PR TITLE
Add separate validation for unreferenced transport version definitions

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/TransportVersionValidationFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/TransportVersionValidationFuncTest.groovy
@@ -198,4 +198,35 @@ class TransportVersionValidationFuncTest extends AbstractTransportVersionFuncTes
         then:
         result.task(":myserver:validateTransportVersionDefinitions").outcome == TaskOutcome.SUCCESS
     }
+
+    def "latest can refer to an unreferenced definition"() {
+        given:
+        unreferencedTransportVersion("initial_10.0.0", "10000000")
+        latestTransportVersion("10.0", "initial_10.0.0", "10000000")
+        when:
+        def result = gradleRunner(":myserver:validateTransportVersionDefinitions").build()
+        then:
+        result.task(":myserver:validateTransportVersionDefinitions").outcome == TaskOutcome.SUCCESS
+    }
+
+    def "named and unreferenced definitions cannot have the same name"() {
+        given:
+        unreferencedTransportVersion("existing_92", "10000000")
+        when:
+        def result = validateDefinitionsFails()
+        then:
+        assertDefinitionsFailure(result, "Transport version definition file " +
+                "[myserver/src/main/resources/transport/definitions/named/existing_92.csv] " +
+                "has same name as unreferenced definition " +
+                "[myserver/src/main/resources/transport/definitions/unreferenced/existing_92.csv]")
+    }
+
+    def "unreferenced definitions can have primary ids that are patches"() {
+        given:
+        unreferencedTransportVersion("initial_10.0.1", "10000001")
+        when:
+        def result = gradleRunner(":myserver:validateTransportVersionDefinitions").build()
+        then:
+        result.task(":myserver:validateTransportVersionDefinitions").outcome == TaskOutcome.SUCCESS
+    }
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionResourcesService.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionResourcesService.java
@@ -98,25 +98,10 @@ public abstract class TransportVersionResourcesService implements BuildService<T
 
     /** Return all named definitions, mapped by their name. */
     Map<String, TransportVersionDefinition> getNamedDefinitions() throws IOException {
-        Map<String, TransportVersionDefinition> definitions = new HashMap<>();
-        // temporarily include unreferenced in named until validation understands the distinction
-        for (var dir : List.of(NAMED_DIR, UNREFERENCED_DIR)) {
-            Path path = transportResourcesDir.resolve(dir);
-            if (Files.isDirectory(path) == false) {
-                continue;
-            }
-            try (var definitionsStream = Files.list(path)) {
-                for (var definitionFile : definitionsStream.toList()) {
-                    String contents = Files.readString(definitionFile, StandardCharsets.UTF_8).strip();
-                    var definition = TransportVersionDefinition.fromString(definitionFile.getFileName().toString(), contents);
-                    definitions.put(definition.name(), definition);
-                }
-            }
-        }
-        return definitions;
+        return readDefinitions(transportResourcesDir.resolve(NAMED_DIR));
     }
 
-    /** Test whether the given named definition exists */
+    /** Get a named definition from main if it exists there, or null otherwise */
     TransportVersionDefinition getNamedDefinitionFromMain(String name) {
         String resourcePath = getNamedDefinitionRelativePath(name).toString();
         return getMainFile(resourcePath, TransportVersionDefinition::fromString);
@@ -128,8 +113,29 @@ public abstract class TransportVersionResourcesService implements BuildService<T
     }
 
     /** Return the path within the repository of the given named definition */
-    Path getRepositoryPath(TransportVersionDefinition definition) {
+    Path getNamedDefinitionRepositoryPath(TransportVersionDefinition definition) {
         return rootDir.relativize(transportResourcesDir.resolve(getNamedDefinitionRelativePath(definition.name())));
+    }
+
+    // return the path, relative to the resources dir, of an unreferenced definition
+    private Path getUnreferencedDefinitionRelativePath(String name) {
+        return UNREFERENCED_DIR.resolve(name + ".csv");
+    }
+
+    /** Return all unreferenced definitions, mapped by their name. */
+    Map<String, TransportVersionDefinition> getUnreferencedDefinitions() throws IOException {
+        return readDefinitions(transportResourcesDir.resolve(UNREFERENCED_DIR));
+    }
+
+    /** Get a named definition from main if it exists there, or null otherwise */
+    TransportVersionDefinition getUnreferencedDefinitionFromMain(String name) {
+        String resourcePath = getUnreferencedDefinitionRelativePath(name).toString();
+        return getMainFile(resourcePath, TransportVersionDefinition::fromString);
+    }
+
+    /** Return the path within the repository of the given named definition */
+    Path getUnreferencedDefinitionRepositoryPath(TransportVersionDefinition definition) {
+        return rootDir.relativize(transportResourcesDir.resolve(getUnreferencedDefinitionRelativePath(definition.name())));
     }
 
     /** Read all latest files and return them mapped by their release branch */
@@ -152,7 +158,7 @@ public abstract class TransportVersionResourcesService implements BuildService<T
     }
 
     /** Return the path within the repository of the given latest */
-    Path getRepositoryPath(TransportVersionLatest latest) {
+    Path getLatestRepositoryPath(TransportVersionLatest latest) {
         return rootDir.relativize(transportResourcesDir.resolve(getLatestRelativePath(latest.branch())));
     }
 
@@ -195,6 +201,21 @@ public abstract class TransportVersionResourcesService implements BuildService<T
         }
         String content = gitCommand("show", "main:./" + resourcePath).strip();
         return parser.apply(resourcePath, content);
+    }
+
+    private static Map<String, TransportVersionDefinition> readDefinitions(Path dir) throws IOException {
+        if (Files.isDirectory(dir) == false) {
+            return Map.of();
+        }
+        Map<String, TransportVersionDefinition> definitions = new HashMap<>();
+        try (var definitionsStream = Files.list(dir)) {
+            for (var definitionFile : definitionsStream.toList()) {
+                String contents = Files.readString(definitionFile, StandardCharsets.UTF_8).strip();
+                var definition = TransportVersionDefinition.fromString(definitionFile.getFileName().toString(), contents);
+                definitions.put(definition.name(), definition);
+            }
+        }
+        return definitions;
     }
 
     // run a git command, relative to the transport version resources directory

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/ValidateTransportVersionResourcesTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/ValidateTransportVersionResourcesTask.java
@@ -85,7 +85,10 @@ public abstract class ValidateTransportVersionResourcesTask extends DefaultTask 
         }
     }
 
-    private Map<String, TransportVersionDefinition> collectAllDefinitions(Map<String, TransportVersionDefinition> namedDefinitions, Map<String, TransportVersionDefinition> unreferencedDefinitions) {
+    private Map<String, TransportVersionDefinition> collectAllDefinitions(
+        Map<String, TransportVersionDefinition> namedDefinitions,
+        Map<String, TransportVersionDefinition> unreferencedDefinitions
+    ) {
         Map<String, TransportVersionDefinition> allDefinitions = new HashMap<>(namedDefinitions);
         for (var entry : unreferencedDefinitions.entrySet()) {
             TransportVersionDefinition existing = allDefinitions.put(entry.getKey(), entry.getValue());

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/ValidateTransportVersionResourcesTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/ValidateTransportVersionResourcesTask.java
@@ -60,13 +60,20 @@ public abstract class ValidateTransportVersionResourcesTask extends DefaultTask 
 
     @TaskAction
     public void validateTransportVersions() throws IOException {
+        TransportVersionResourcesService resources = getResources().get();
         Set<String> referencedNames = TransportVersionReference.collectNames(getReferencesFiles());
-        Map<String, TransportVersionDefinition> definitions = getResources().get().getNamedDefinitions();
-        Map<Integer, List<IdAndDefinition>> idsByBase = collectIdsByBase(definitions.values());
-        Map<String, TransportVersionLatest> latestByReleaseBranch = getResources().get().getLatestByReleaseBranch();
+        Map<String, TransportVersionDefinition> namedDefinitions = resources.getNamedDefinitions();
+        Map<String, TransportVersionDefinition> unreferencedDefinitions = resources.getUnreferencedDefinitions();
+        Map<String, TransportVersionDefinition> allDefinitions = collectAllDefinitions(namedDefinitions, unreferencedDefinitions);
+        Map<Integer, List<IdAndDefinition>> idsByBase = collectIdsByBase(allDefinitions.values());
+        Map<String, TransportVersionLatest> latestByReleaseBranch = resources.getLatestByReleaseBranch();
 
-        for (var definition : definitions.values()) {
-            validateDefinition(definition, referencedNames);
+        for (var definition : namedDefinitions.values()) {
+            validateNamedDefinition(definition, referencedNames);
+        }
+
+        for (var definition : unreferencedDefinitions.values()) {
+            validateUnreferencedDefinition(definition);
         }
 
         for (var entry : idsByBase.entrySet()) {
@@ -74,8 +81,20 @@ public abstract class ValidateTransportVersionResourcesTask extends DefaultTask 
         }
 
         for (var latest : latestByReleaseBranch.values()) {
-            validateLatest(latest, definitions, idsByBase);
+            validateLatest(latest, allDefinitions, idsByBase);
         }
+    }
+
+    private Map<String, TransportVersionDefinition> collectAllDefinitions(Map<String, TransportVersionDefinition> namedDefinitions, Map<String, TransportVersionDefinition> unreferencedDefinitions) {
+        Map<String, TransportVersionDefinition> allDefinitions = new HashMap<>(namedDefinitions);
+        for (var entry : unreferencedDefinitions.entrySet()) {
+            TransportVersionDefinition existing = allDefinitions.put(entry.getKey(), entry.getValue());
+            if (existing != null) {
+                Path unreferencedPath = getResources().get().getUnreferencedDefinitionRepositoryPath(entry.getValue());
+                throwDefinitionFailure(existing, "has same name as unreferenced definition [" + unreferencedPath + "]");
+            }
+        }
+        return allDefinitions;
     }
 
     private Map<Integer, List<IdAndDefinition>> collectIdsByBase(Collection<TransportVersionDefinition> definitions) {
@@ -97,23 +116,17 @@ public abstract class ValidateTransportVersionResourcesTask extends DefaultTask 
         return idsByBase;
     }
 
-    private void validateDefinition(TransportVersionDefinition definition, Set<String> referencedNames) {
+    private void validateNamedDefinition(TransportVersionDefinition definition, Set<String> referencedNames) {
 
         // validate any modifications
         Map<Integer, TransportVersionId> existingIdsByBase = new HashMap<>();
         TransportVersionDefinition originalDefinition = getResources().get().getNamedDefinitionFromMain(definition.name());
         if (originalDefinition != null) {
-
-            int primaryId = definition.ids().get(0).complete();
-            int originalPrimaryId = originalDefinition.ids().get(0).complete();
-            if (primaryId != originalPrimaryId) {
-                throwDefinitionFailure(definition, "has modified primary id from " + originalPrimaryId + " to " + primaryId);
-            }
-
+            validateIdenticalPrimaryId(definition, originalDefinition);
             originalDefinition.ids().forEach(id -> existingIdsByBase.put(id.base(), id));
         }
 
-        if (referencedNames.contains(definition.name()) == false && definition.name().startsWith("initial_") == false) {
+        if (referencedNames.contains(definition.name()) == false) {
             throwDefinitionFailure(definition, "is not referenced");
         }
         if (NAME_FORMAT.matcher(definition.name()).matches() == false) {
@@ -129,9 +142,7 @@ public abstract class ValidateTransportVersionResourcesTask extends DefaultTask 
             TransportVersionId id = definition.ids().get(ndx);
 
             if (ndx == 0) {
-                // TODO: initial versions will only be applicable to a release branch, so they won't have an associated
-                // main version. They will also be loaded differently in the future, but until they are separate, we ignore them here.
-                if (id.patch() != 0 && definition.name().startsWith("initial_") == false) {
+                if (id.patch() != 0) {
                     throwDefinitionFailure(definition, "has patch version " + id.complete() + " as primary id");
                 }
             } else {
@@ -148,6 +159,30 @@ public abstract class ValidateTransportVersionResourcesTask extends DefaultTask 
         }
     }
 
+    private void validateUnreferencedDefinition(TransportVersionDefinition definition) {
+        TransportVersionDefinition originalDefinition = getResources().get().getUnreferencedDefinitionFromMain(definition.name());
+        if (originalDefinition != null) {
+            validateIdenticalPrimaryId(definition, originalDefinition);
+        }
+        if (definition.ids().isEmpty()) {
+            throwDefinitionFailure(definition, "does not contain any ids");
+        }
+        if (definition.ids().size() > 1) {
+            throwDefinitionFailure(definition, " contains more than one id");
+        }
+        // note: no name validation, anything that is a valid filename is ok, this allows eg initial_8.9.1
+    }
+
+    private void validateIdenticalPrimaryId(TransportVersionDefinition definition, TransportVersionDefinition originalDefinition) {
+        assert definition.name().equals(originalDefinition.name());
+
+        int primaryId = definition.ids().get(0).complete();
+        int originalPrimaryId = originalDefinition.ids().get(0).complete();
+        if (primaryId != originalPrimaryId) {
+            throwDefinitionFailure(definition, "has modified primary id from " + originalPrimaryId + " to " + primaryId);
+        }
+    }
+
     private void validateLatest(
         TransportVersionLatest latest,
         Map<String, TransportVersionDefinition> definitions,
@@ -158,7 +193,7 @@ public abstract class ValidateTransportVersionResourcesTask extends DefaultTask 
             throwLatestFailure(latest, "contains transport version name [" + latest.name() + "] which is not defined");
         }
         if (latestDefinition.ids().contains(latest.id()) == false) {
-            Path relativePath = getResources().get().getRepositoryPath(latestDefinition);
+            Path relativePath = getResources().get().getNamedDefinitionRepositoryPath(latestDefinition);
             throwLatestFailure(latest, "has id " + latest.id() + " which is not in definition [" + relativePath + "]");
         }
 
@@ -196,7 +231,7 @@ public abstract class ValidateTransportVersionResourcesTask extends DefaultTask 
             IdAndDefinition current = ids.get(ndx);
 
             if (previous.id().equals(current.id())) {
-                Path existingDefinitionPath = getResources().get().getRepositoryPath(previous.definition);
+                Path existingDefinitionPath = getResources().get().getNamedDefinitionRepositoryPath(previous.definition);
                 throwDefinitionFailure(
                     current.definition(),
                     "contains id " + current.id + " already defined in [" + existingDefinitionPath + "]"
@@ -213,12 +248,12 @@ public abstract class ValidateTransportVersionResourcesTask extends DefaultTask 
     }
 
     private void throwDefinitionFailure(TransportVersionDefinition definition, String message) {
-        Path relativePath = getResources().get().getRepositoryPath(definition);
+        Path relativePath = getResources().get().getNamedDefinitionRepositoryPath(definition);
         throw new IllegalStateException("Transport version definition file [" + relativePath + "] " + message);
     }
 
     private void throwLatestFailure(TransportVersionLatest latest, String message) {
-        Path relativePath = getResources().get().getRepositoryPath(latest);
+        Path relativePath = getResources().get().getLatestRepositoryPath(latest);
         throw new IllegalStateException("Latest transport version file [" + relativePath + "] " + message);
     }
 }


### PR DESCRIPTION
This commit splits out the validation that is pertinent to unreferenced definitions. It also adds validation that names of named and unreferenced definitions cannot collide.