### PR TITLE
Fix offset handling in ipv6 parsing

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -576,24 +576,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.TextEmbeddingQueryIT
   method: testModelWithPrefixStrings
   issue: https://github.com/elastic/elasticsearch/issues/133138
-- class: org.elasticsearch.index.mapper.blockloader.IpFieldBlockLoaderTests
-  method: testBlockLoaderOfMultiField {preference=Params[syntheticSource=true, preference=DOC_VALUES]}
-  issue: https://github.com/elastic/elasticsearch/issues/133149
-- class: org.elasticsearch.index.mapper.blockloader.IpFieldBlockLoaderTests
-  method: testBlockLoaderOfMultiField {preference=Params[syntheticSource=true, preference=STORED]}
-  issue: https://github.com/elastic/elasticsearch/issues/133150
-- class: org.elasticsearch.index.mapper.blockloader.IpFieldBlockLoaderTests
-  method: testBlockLoaderOfMultiField {preference=Params[syntheticSource=true, preference=NONE]}
-  issue: https://github.com/elastic/elasticsearch/issues/133151
-- class: org.elasticsearch.index.mapper.blockloader.IpFieldBlockLoaderTests
-  method: testBlockLoaderForFieldInObject {preference=Params[syntheticSource=true, preference=STORED]}
-  issue: https://github.com/elastic/elasticsearch/issues/133178
-- class: org.elasticsearch.index.mapper.blockloader.IpFieldBlockLoaderTests
-  method: testBlockLoaderForFieldInObject {preference=Params[syntheticSource=true, preference=DOC_VALUES]}
-  issue: https://github.com/elastic/elasticsearch/issues/133179
-- class: org.elasticsearch.index.mapper.blockloader.IpFieldBlockLoaderTests
-  method: testBlockLoaderForFieldInObject {preference=Params[syntheticSource=true, preference=NONE]}
-  issue: https://github.com/elastic/elasticsearch/issues/133180
 - class: org.elasticsearch.test.rest.yaml.CcsCommonYamlTestSuiteIT
   method: test {p0=search.vectors/90_sparse_vector/Indexing and searching multi-value sparse vectors in >=8.15}
   issue: https://github.com/elastic/elasticsearch/issues/133184

--- a/server/src/main/java/org/elasticsearch/common/network/InetAddresses.java
+++ b/server/src/main/java/org/elasticsearch/common/network/InetAddresses.java
@@ -239,8 +239,8 @@ public class InetAddresses {
                 return null; // Invalid character
             }
         }
-        if (currentHextetStart != length) {
-            // Handle the last hextet
+        // Handle the last hextet unless the IP address ends with ::
+        if (currentHextetStart < offset + length) {
             if (putHextet(bytes, currentHextet) == false) {
                 return null;
             }


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/elastic/elasticsearch/pull/132463.

Thanks to @Tim-Brooks for catching this!