### PR TITLE
[8.18] Limit the depth of a filter (#133194)

### DIFF
--- a/docs/changelog/133113.yaml
+++ b/docs/changelog/133113.yaml
@@ -1,0 +1,5 @@
+pr: 133113
+summary: Limit the depth of a filter
+area: Infra/REST API
+type: enhancement
+issues: []

--- a/libs/x-content/src/test/java/org/elasticsearch/xcontent/support/filtering/FilterPathTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/xcontent/support/filtering/FilterPathTests.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.singleton;
 import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 public class FilterPathTests extends ESTestCase {
@@ -402,5 +403,17 @@ public class FilterPathTests extends ESTestCase {
         assertEquals(nextFilters.size(), 0);
         assertTrue(filterPaths[0].matches("a.b.c.d", nextFilters, true));
         assertEquals(nextFilters.size(), 0);
+    }
+
+    public void testDepthChecking() {
+        final String atLimit = "x" + (".x").repeat(FilterPath.MAX_TREE_DEPTH);
+        final String aboveLimit = atLimit + ".y";
+
+        var paths = FilterPath.compile(Set.of(atLimit));
+        assertThat(paths, arrayWithSize(1));
+
+        var ex = expectThrows(IllegalArgumentException.class, () -> FilterPath.compile(Set.of(aboveLimit)));
+        assertThat(ex.getMessage(), containsString("maximum depth"));
+        assertThat(ex.getMessage(), containsString("[y]"));
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Limit the depth of a filter (#133194)