### PR TITLE
Set default processor allocation for test clusters

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalTestClustersPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalTestClustersPlugin.java
@@ -34,11 +34,15 @@ public class InternalTestClustersPlugin implements Plugin<Project> {
                 || buildParams.getBwcVersions().unreleasedInfo(version) == null
         );
 
+        NamedDomainObjectContainer<ElasticsearchCluster> testClusters = (NamedDomainObjectContainer<ElasticsearchCluster>) project
+            .getExtensions()
+            .getByName(TestClustersPlugin.EXTENSION_NAME);
         if (shouldConfigureTestClustersWithOneProcessor()) {
-            NamedDomainObjectContainer<ElasticsearchCluster> testClusters = (NamedDomainObjectContainer<ElasticsearchCluster>) project
-                .getExtensions()
-                .getByName(TestClustersPlugin.EXTENSION_NAME);
             testClusters.configureEach(elasticsearchCluster -> elasticsearchCluster.setting("node.processors", "1"));
+        } else {
+            // Limit the number of allocated processors for all nodes in the cluster by default.
+            // This is to ensure that the tests run consistently across different environments.
+            testClusters.configureEach(elasticsearchCluster -> elasticsearchCluster.setting("node.processors", "2"));
         }
     }
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalTestClustersPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalTestClustersPlugin.java
@@ -37,13 +37,10 @@ public class InternalTestClustersPlugin implements Plugin<Project> {
         NamedDomainObjectContainer<ElasticsearchCluster> testClusters = (NamedDomainObjectContainer<ElasticsearchCluster>) project
             .getExtensions()
             .getByName(TestClustersPlugin.EXTENSION_NAME);
-        if (shouldConfigureTestClustersWithOneProcessor()) {
-            testClusters.configureEach(elasticsearchCluster -> elasticsearchCluster.setting("node.processors", "1"));
-        } else {
-            // Limit the number of allocated processors for all nodes in the cluster by default.
-            // This is to ensure that the tests run consistently across different environments.
-            testClusters.configureEach(elasticsearchCluster -> elasticsearchCluster.setting("node.processors", "2"));
-        }
+        // Limit the number of allocated processors for all nodes to 2 in the cluster by default.
+        // This is to ensure that the tests run consistently across different environments.
+        String processorCount = shouldConfigureTestClustersWithOneProcessor() ? "1" : "2";
+        testClusters.configureEach(elasticsearchCluster -> elasticsearchCluster.setting("node.processors", processorCount));
     }
 
     private boolean shouldConfigureTestClustersWithOneProcessor() {

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultSettingsProvider.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultSettingsProvider.java
@@ -42,6 +42,10 @@ public class DefaultSettingsProvider implements SettingsProvider {
             }
         }
 
+        // Limit the number of allocated processors for all nodes in the cluster by default.
+        // This is to ensure that the tests run consistently across different environments.
+        settings.put("node.processors", "2");
+
         // Default the watermarks to absurdly low to prevent the tests from failing on nodes without enough disk space
         settings.put("cluster.routing.allocation.disk.watermark.low", "1b");
         settings.put("cluster.routing.allocation.disk.watermark.high", "1b");


### PR DESCRIPTION
Setting the number of processors available for node to adequately size thread pools.
Related to #130612 