### PR TITLE
ES|QL: Fix VectorSimilarityFunctionsIT

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/VectorSimilarityFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/VectorSimilarityFunction.java
@@ -116,7 +116,7 @@ public abstract class VectorSimilarityFunction extends BinaryScalarFunction impl
                             }
                         }
                         if (dimensions == 0) {
-                            return context.blockFactory().newConstantFloatBlockWith(0F, 0);
+                            return context.blockFactory().newConstantNullBlock(positionCount);
                         }
 
                         float[] leftScratch = new float[dimensions];


### PR DESCRIPTION
fixes https://github.com/elastic/elasticsearch/issues/133059

### Error details:

The tests fail with this type of error:

```
VectorSimilarityFunctionsIT > testSimilarityBetweenVectors {functionName=v_l2_norm similarityFunction=org.elasticsearch.xpack.esql.vector.VectorSimilarityFunctionsIT$$Lambda/0x00000e00003db5d0@48df4071} FAILED
    java.lang.IllegalStateException: Block [FloatVectorBlock[vector=ConstantFloatVector[positions=0, value=0.0]]] does not have same position count: 0 != 1
        at org.elasticsearch.compute.data.Page.<init>(Page.java:88)
        at org.elasticsearch.compute.data.Page.appendBlock(Page.java:162)
        at org.elasticsearch.compute.operator.EvalOperator.process(EvalOperator.java:46)
        at org.elasticsearch.compute.operator.AbstractPageMappingOperator.getOutput(AbstractPageMappingOperator.java:85)
        at org.elasticsearch.compute.operator.Driver.runSingleLoopIteration(Driver.java:272)
        at org.elasticsearch.compute.operator.Driver.run(Driver.java:186)
        at org.elasticsearch.compute.operator.Driver$1.doRun(Driver.java:420)
        at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:27)
        at org.elasticsearch.compute.operator.DriverScheduler$1.doRun(DriverScheduler.java:57)
        at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:27)
        at org.elasticsearch.common.util.concurrent.TimedRunnable.doRun(TimedRunnable.java:35)
        at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:1067)
        at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:27)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1095)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:619)
        at java.base/java.lang.Thread.run(Thread.java:1447)
```

when this happens, we are not releasing the blocks so the next tests fail with :
```
    java.lang.AssertionError: Request breaker not reset to 0 on node: node_s0
    Expected: <0L>
         but: was <64L>
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
```

### Fix

In the `VectorSimilarityFunction` evaluator, we first try and detect the vector dimensions by checking the left vector.
We need the vector dimension to instantiate the `leftScratch` and `rightScratch` float arrays which we reuse for each row.
In the case where the `leftVector` has only null values (0 dimensions) - we can return early, since in this case the similarity function should just return null values (as per https://github.com/elastic/elasticsearch/pull/132919).
This is where the bug resides, we return a constant float block with a single position (and 0 value, not null).
Changing this to return a constant null block with the right `positionCount` should fix the issue.
