### PR TITLE
Move ES|QL score function out of snapshot

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/lists/search-functions.md
+++ b/docs/reference/query-languages/esql/_snippets/lists/search-functions.md
@@ -2,4 +2,5 @@
 * [`MATCH`](../../functions-operators/search-functions.md#esql-match)
 * [`MATCH_PHRASE`](../../functions-operators/search-functions.md#esql-match_phrase)
 * [`QSTR`](../../functions-operators/search-functions.md#esql-qstr)
+* [`SCORE`](../../functions-operators/search-functions.md#esql-score)
 % * [preview] [`TERM`](../../functions-operators/search-functions.md#esql-term)

--- a/docs/reference/query-languages/esql/_snippets/lists/search-functions.md
+++ b/docs/reference/query-languages/esql/_snippets/lists/search-functions.md
@@ -2,5 +2,5 @@
 * [`MATCH`](../../functions-operators/search-functions.md#esql-match)
 * [`MATCH_PHRASE`](../../functions-operators/search-functions.md#esql-match_phrase)
 * [`QSTR`](../../functions-operators/search-functions.md#esql-qstr)
-* [`SCORE`](../../functions-operators/search-functions.md#esql-score)
+* [preview] [`SCORE`](../../functions-operators/search-functions.md#esql-score)
 % * [preview] [`TERM`](../../functions-operators/search-functions.md#esql-term)

--- a/docs/reference/query-languages/esql/functions-operators/search-functions.md
+++ b/docs/reference/query-languages/esql/functions-operators/search-functions.md
@@ -13,7 +13,7 @@ our [hands-on tutorial](docs-content://solutions/search/esql-search-tutorial.md)
 For a high-level overview of search functionalities in {{esql}}, and to learn about relevance scoring, refer to [{{esql}} for search](docs-content://solutions/search/esql-for-search.md#esql-for-search-scoring).
 :::
 
-{{esql}} provides a set of functions for performing searching on text fields. 
+{{esql}} provides a set of functions for performing searching on text fields.
 
 Use these functions
 for [full-text search](docs-content://solutions/search/full-text.md)
@@ -47,6 +47,10 @@ for information on the limitations of full text search.
 
 :::{include} ../_snippets/functions/layout/qstr.md
 :::
+
+:::{include} ../_snippets/functions/layout/score.md
+:::
+
 
 % TERM is currently a hidden feature
 % To make it visible again, uncomment this and the line in

--- a/docs/reference/query-languages/esql/kibana/definition/functions/score.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/score.json
@@ -21,5 +21,5 @@
     "FROM books METADATA _score\n| WHERE match(title, \"Return\") AND match(author, \"Tolkien\")\n| EVAL first_score = score(match(title, \"Return\"))"
   ],
   "preview" : true,
-  "snapshot_only" : true
+  "snapshot_only" : false
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1126,7 +1126,7 @@ public class EsqlCapabilities {
         /**
          * score function
          */
-        SCORE_FUNCTION(Build.current().isSnapshot()),
+        SCORE_FUNCTION,
 
         /**
          * Support for the SAMPLE command

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
@@ -472,8 +472,7 @@ public class EsqlFunctionRegistry {
                 def(MultiMatch.class, MultiMatch::new, "multi_match"),
                 def(QueryString.class, bi(QueryString::new), "qstr"),
                 def(MatchPhrase.class, tri(MatchPhrase::new), "match_phrase"),
-                def(Score.class, uni(Score::new), "score"),
-            } };
+                def(Score.class, uni(Score::new), "score"), } };
 
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
@@ -471,7 +471,9 @@ public class EsqlFunctionRegistry {
                 def(Match.class, tri(Match::new), "match"),
                 def(MultiMatch.class, MultiMatch::new, "multi_match"),
                 def(QueryString.class, bi(QueryString::new), "qstr"),
-                def(MatchPhrase.class, tri(MatchPhrase::new), "match_phrase") } };
+                def(MatchPhrase.class, tri(MatchPhrase::new), "match_phrase"),
+                def(Score.class, uni(Score::new), "score"),
+            } };
 
     }
 
@@ -492,7 +494,6 @@ public class EsqlFunctionRegistry {
                 def(AvgOverTime.class, uni(AvgOverTime::new), "avg_over_time"),
                 def(LastOverTime.class, uni(LastOverTime::new), "last_over_time"),
                 def(FirstOverTime.class, uni(FirstOverTime::new), "first_over_time"),
-                def(Score.class, uni(Score::new), Score.NAME),
                 def(Term.class, bi(Term::new), "term"),
                 def(Knn.class, quad(Knn::new), "knn"),
                 def(StGeohash.class, StGeohash::new, "st_geohash"),


### PR DESCRIPTION
This exposes the `SCORE` function in ES|QL out of snapshot (tech preview).
`SCORE` function can only be used on the right hand side of an `EVAL` to explicitly put scores of a (combination of) full text functions into a specific column (different than `_score`).
