### PR TITLE
Skip using value 1 for `skipIndexIntervalSize`

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -621,15 +621,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.action.RandomizedTimeSeriesIT
   method: testGroupBySubset
   issue: https://github.com/elastic/elasticsearch/issues/133220
-- class: org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesFormatTests
-  method: testSortedDocValuesSingleUniqueValue
-  issue: https://github.com/elastic/elasticsearch/issues/133221
-- class: org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesFormatTests
-  method: testSortedNumberMergeAwayAllValuesWithSkipper
-  issue: https://github.com/elastic/elasticsearch/issues/133223
-- class: org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesFormatTests
-  method: testSortedSetDocValuesWithSkipperSmall
-  issue: https://github.com/elastic/elasticsearch/issues/133224
 - class: org.elasticsearch.xpack.esql.action.RandomizedTimeSeriesIT
   method: testGroupByNothing
   issue: https://github.com/elastic/elasticsearch/issues/133225

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesFormatTests.java
@@ -66,7 +66,7 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
     private final Codec codec = new Elasticsearch900Lucene101Codec() {
 
         final ES819TSDBDocValuesFormat docValuesFormat = new ES819TSDBDocValuesFormat(
-            ESTestCase.randomIntBetween(1, 4096),
+            ESTestCase.randomIntBetween(2, 4096),
             ESTestCase.randomIntBetween(1, 512),
             random().nextBoolean()
         );


### PR DESCRIPTION
Fixes #133221
Fixes #133223
Fixes #133224