### PR TITLE
Use path separator for git path in transport resources

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionResourcesService.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionResourcesService.java
@@ -16,6 +16,7 @@ import org.gradle.process.ExecOperations;
 import org.gradle.process.ExecResult;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -193,7 +194,8 @@ public abstract class TransportVersionResourcesService implements BuildService<T
         if (getMainResources().contains(resourcePath) == false) {
             return null;
         }
-        String content = gitCommand("show", "main:./" + resourcePath).strip();
+
+        String content = gitCommand("show", "main:." + File.separator + resourcePath).strip();
         return parser.apply(resourcePath, content);
     }
 


### PR DESCRIPTION
When looking up files from main in transport resources, the system dependent path is used. However, the beginning slash also needs to be system dependent.