### PR TITLE
introduce AbstractLocalStateSecurity

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecuritySettingsSource.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecuritySettingsSource.java
@@ -136,24 +136,14 @@ public class SecuritySettingsSource extends NodeConfigurationSource {
         }
     }
 
-    Path homePath(final int nodeOrdinal) {
+    protected Path homePath(final int nodeOrdinal) {
         return parentFolder.resolve(subfolderPrefix + "-" + nodeOrdinal);
     }
 
     @Override
     public Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
         final Path home = homePath(nodeOrdinal);
-        final Path xpackConf = home.resolve("config");
-        try {
-            Files.createDirectories(xpackConf);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-        writeFile(xpackConf, "roles.yml", configRoles());
-        writeFile(xpackConf, "users", configUsers());
-        writeFile(xpackConf, "users_roles", configUsersRoles());
-        writeFile(xpackConf, "operator_users.yml", configOperatorUsers());
-        writeFile(xpackConf, "service_tokens", configServiceTokens());
+        writeConfigFiles(home);
 
         Settings.Builder builder = Settings.builder()
             .put(Environment.PATH_HOME_SETTING.getKey(), home)
@@ -174,6 +164,20 @@ public class SecuritySettingsSource extends NodeConfigurationSource {
             .put("xpack.license.self_generated.type", "trial");
         addNodeSSLSettings(builder);
         return builder.build();
+    }
+
+    protected void writeConfigFiles(Path home) {
+        final Path xpackConf = home.resolve("config");
+        try {
+            Files.createDirectories(xpackConf);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        writeFile(xpackConf, "roles.yml", configRoles());
+        writeFile(xpackConf, "users", configUsers());
+        writeFile(xpackConf, "users_roles", configUsersRoles());
+        writeFile(xpackConf, "operator_users.yml", configOperatorUsers());
+        writeFile(xpackConf, "service_tokens", configServiceTokens());
     }
 
     @Override
@@ -244,7 +248,7 @@ public class SecuritySettingsSource extends NodeConfigurationSource {
         );
     }
 
-    private void addNodeSSLSettings(Settings.Builder builder) {
+    protected void addNodeSSLSettings(Settings.Builder builder) {
         if (sslEnabled) {
             builder.put("xpack.security.transport.ssl.enabled", true);
             if (usePEM) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/AbstractLocalStateSecurity.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/AbstractLocalStateSecurity.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.plugins.ReloadablePlugin;
+import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
+import org.elasticsearch.xpack.core.security.SecurityExtension;
+import org.elasticsearch.xpack.core.ssl.SSLService;
+
+import java.nio.file.Path;
+import java.util.List;
+
+public abstract class AbstractLocalStateSecurity extends LocalStateCompositeXPackPlugin implements ReloadablePlugin {
+    @SuppressWarnings("this-escape")
+    public AbstractLocalStateSecurity(Settings settings, Path configPath) {
+        super(settings, configPath);
+
+        plugins.add(new Security(settings, AbstractLocalStateSecurity.this.securityExtensions()) {
+            @Override
+            protected SSLService getSslService() {
+                return AbstractLocalStateSecurity.this.getSslService();
+            }
+
+            @Override
+            protected XPackLicenseState getLicenseState() {
+                return AbstractLocalStateSecurity.this.getLicenseState();
+            }
+        });
+    }
+
+    @Override
+    public void reload(Settings settings) throws Exception {
+        plugins.stream().filter(p -> p instanceof ReloadablePlugin).forEach(p -> {
+            try {
+                ((ReloadablePlugin) p).reload(settings);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    protected List<SecurityExtension> securityExtensions() {
+        return List.of();
+    }
+}

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/LocalStateSecurity.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/LocalStateSecurity.java
@@ -16,13 +16,11 @@ import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.license.LicenseService;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.plugins.ReloadablePlugin;
 import org.elasticsearch.protocol.xpack.XPackInfoRequest;
 import org.elasticsearch.protocol.xpack.XPackInfoResponse;
 import org.elasticsearch.protocol.xpack.XPackUsageRequest;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
 import org.elasticsearch.xpack.core.action.TransportXPackInfoAction;
 import org.elasticsearch.xpack.core.action.TransportXPackUsageAction;
 import org.elasticsearch.xpack.core.action.XPackInfoFeatureAction;
@@ -30,7 +28,6 @@ import org.elasticsearch.xpack.core.action.XPackInfoFeatureResponse;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureAction;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureResponse;
 import org.elasticsearch.xpack.core.action.XPackUsageResponse;
-import org.elasticsearch.xpack.core.security.SecurityExtension;
 import org.elasticsearch.xpack.core.ssl.SSLService;
 import org.elasticsearch.xpack.ilm.IndexLifecycle;
 import org.elasticsearch.xpack.monitoring.Monitoring;
@@ -39,7 +36,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 
-public class LocalStateSecurity extends LocalStateCompositeXPackPlugin implements ReloadablePlugin {
+public class LocalStateSecurity extends AbstractLocalStateSecurity {
 
     public static class SecurityTransportXPackUsageAction extends TransportXPackUsageAction {
         @Inject
@@ -102,21 +99,6 @@ public class LocalStateSecurity extends LocalStateCompositeXPackPlugin implement
                 return thisVar.getLicenseState();
             }
         });
-        plugins.add(new Security(settings, thisVar.securityExtensions()) {
-            @Override
-            protected SSLService getSslService() {
-                return thisVar.getSslService();
-            }
-
-            @Override
-            protected XPackLicenseState getLicenseState() {
-                return thisVar.getLicenseState();
-            }
-        });
-    }
-
-    protected List<SecurityExtension> securityExtensions() {
-        return List.of();
     }
 
     @Override
@@ -131,16 +113,5 @@ public class LocalStateSecurity extends LocalStateCompositeXPackPlugin implement
 
     public List<Plugin> plugins() {
         return plugins;
-    }
-
-    @Override
-    public void reload(Settings settings) throws Exception {
-        plugins.stream().filter(p -> p instanceof ReloadablePlugin).forEach(p -> {
-            try {
-                ((ReloadablePlugin) p).reload(settings);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        });
     }
 }


### PR DESCRIPTION
Enables registering a Security plugin using local state, without also registering IndexLifecycle and Monitoring