### PR TITLE
PoolingCuVSResourceManager with memory availability

### DIFF
--- a/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/codec/CuVSResourceManager.java
+++ b/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/codec/CuVSResourceManager.java
@@ -164,7 +164,7 @@ public interface CuVSResourceManager {
         @Override
         public void finishedComputation(ManagedCuVSResources resources) {
             // currently does nothing, but could allow acquire to return possibly blocked resources
-            // something like enoughComputationCondition.signal()?
+            // something like enoughComputationCondition.signalAll()?
         }
 
         @Override
@@ -173,7 +173,7 @@ public interface CuVSResourceManager {
                 lock.lock();
                 assert resources.locked;
                 resources.locked = false;
-                enoughMemoryCondition.signal();
+                enoughMemoryCondition.signalAll();
             } finally {
                 lock.unlock();
             }

--- a/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/codec/GPUToHNSWVectorsWriter.java
+++ b/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/codec/GPUToHNSWVectorsWriter.java
@@ -244,7 +244,7 @@ final class GPUToHNSWVectorsWriter extends KnnVectorsWriter {
                 mockGraph = writeGraph(vectors, graphLevelNodeOffsets);
             } else {
                 var dataset = datasetOrVectors.dataset;
-                var cuVSResources = cuVSResourceManager.acquire((int) dataset.size(), (int) dataset.columns());
+                var cuVSResources = cuVSResourceManager.acquire((int) dataset.size(), (int) dataset.columns(), dataset.dataType());
                 try {
                     try (var index = buildGPUIndex(cuVSResources, fieldInfo.getVectorSimilarityFunction(), dataset)) {
                         assert index != null : "GPU index should be built for field: " + fieldInfo.name;

--- a/x-pack/plugin/gpu/src/test/java/org/elasticsearch/xpack/gpu/codec/CuVSResourceManagerTests.java
+++ b/x-pack/plugin/gpu/src/test/java/org/elasticsearch/xpack/gpu/codec/CuVSResourceManagerTests.java
@@ -218,12 +218,12 @@ public class CuVSResourceManagerTests extends ESTestCase {
         }
 
         @Override
-        public List<GPUInfo> availableGPUs() throws Throwable {
+        public List<GPUInfo> availableGPUs() {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public List<GPUInfo> compatibleGPUs() throws Throwable {
+        public List<GPUInfo> compatibleGPUs() {
             throw new UnsupportedOperationException();
         }
 

--- a/x-pack/plugin/gpu/src/test/java/org/elasticsearch/xpack/gpu/codec/CuVSResourceManagerTests.java
+++ b/x-pack/plugin/gpu/src/test/java/org/elasticsearch/xpack/gpu/codec/CuVSResourceManagerTests.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.gpu.codec;
 
 import com.nvidia.cuvs.CuVSResources;
-
 import com.nvidia.cuvs.CuVSResourcesInfo;
 import com.nvidia.cuvs.GPUInfo;
 import com.nvidia.cuvs.GPUInfoProvider;
@@ -161,8 +160,8 @@ public class CuVSResourceManagerTests extends ESTestCase {
         @Override
         public ManagedCuVSResources acquire(int numVectors, int dims) throws InterruptedException {
             var res = super.acquire(numVectors, dims);
-            long memory = (long)(numVectors * dims * Float.BYTES *
-                CuVSResourceManager.PoolingCuVSResourceManager.GPU_COMPUTATION_MEMORY_FACTOR);
+            long memory = (long) (numVectors * dims * Float.BYTES
+                * CuVSResourceManager.PoolingCuVSResourceManager.GPU_COMPUTATION_MEMORY_FACTOR);
             allocations.add(memory);
             log.info("Added [{}]", memory);
             return res;

--- a/x-pack/plugin/gpu/src/test/java/org/elasticsearch/xpack/gpu/codec/CuVSResourceManagerTests.java
+++ b/x-pack/plugin/gpu/src/test/java/org/elasticsearch/xpack/gpu/codec/CuVSResourceManagerTests.java
@@ -9,9 +9,14 @@ package org.elasticsearch.xpack.gpu.codec;
 
 import com.nvidia.cuvs.CuVSResources;
 
+import com.nvidia.cuvs.CuVSResourcesInfo;
+import com.nvidia.cuvs.GPUInfo;
+import com.nvidia.cuvs.GPUInfoProvider;
+
 import org.elasticsearch.test.ESTestCase;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -83,7 +88,7 @@ public class CuVSResourceManagerTests extends ESTestCase {
         final AtomicInteger idGenerator = new AtomicInteger();
 
         MockPoolingCuVSResourceManager(int capacity) {
-            super(capacity);
+            super(capacity, new MockGPUInfoProvider());
         }
 
         @Override
@@ -116,6 +121,23 @@ public class CuVSResourceManagerTests extends ESTestCase {
         @Override
         public String toString() {
             return "MockCuVSResources[id=" + id + "]";
+        }
+    }
+
+    private static class MockGPUInfoProvider implements GPUInfoProvider {
+        @Override
+        public List<GPUInfo> availableGPUs() throws Throwable {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<GPUInfo> compatibleGPUs() throws Throwable {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CuVSResourcesInfo getCurrentInfo(CuVSResources cuVSResources) {
+            return new CuVSResourcesInfo(256L * 1024 * 1024, 2048L * 1024 * 1024);
         }
     }
 }


### PR DESCRIPTION
This PR expands https://github.com/elastic/elasticsearch/pull/132670 to account for GPU memory availability: a requesting thread can obtain a resource only if there are enough GPU physical resources available (in this first iteration, memory). Otherwise the requesting thread will be blocked and signalled again to re-check conditions are satisfied when memory is freed (when another thread release a resource).

Depends on https://github.com/rapidsai/cuvs/pull/1267 (which is now merged into `branch-25.10`)