### PR TITLE
[8.19] Change GeoIpCache and EnrichCache to LongAdder (#132922)

### DIFF
--- a/docs/changelog/132922.yaml
+++ b/docs/changelog/132922.yaml
@@ -1,0 +1,5 @@
+pr: 132922
+summary: Change GeoIpCache and EnrichCache to LongAdder
+area: Ingest Node
+type: bug
+issues: []


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Change GeoIpCache and EnrichCache to LongAdder (#132922)