### PR TITLE
Fix task name in transport version unreferenced tests

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/TransportVersionValidationFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/TransportVersionValidationFuncTest.groovy
@@ -204,18 +204,18 @@ class TransportVersionValidationFuncTest extends AbstractTransportVersionFuncTes
         unreferencedTransportVersion("initial_10.0.0", "10000000")
         latestTransportVersion("10.0", "initial_10.0.0", "10000000")
         when:
-        def result = gradleRunner(":myserver:validateTransportVersionDefinitions").build()
+        def result = gradleRunner(":myserver:validateTransportVersionResources").build()
         then:
-        result.task(":myserver:validateTransportVersionDefinitions").outcome == TaskOutcome.SUCCESS
+        result.task(":myserver:validateTransportVersionResources").outcome == TaskOutcome.SUCCESS
     }
 
     def "named and unreferenced definitions cannot have the same name"() {
         given:
         unreferencedTransportVersion("existing_92", "10000000")
         when:
-        def result = validateDefinitionsFails()
+        def result = validateResourcesFails()
         then:
-        assertDefinitionsFailure(result, "Transport version definition file " +
+        assertValidateResourcesFailure(result, "Transport version definition file " +
                 "[myserver/src/main/resources/transport/definitions/named/existing_92.csv] " +
                 "has same name as unreferenced definition " +
                 "[myserver/src/main/resources/transport/definitions/unreferenced/existing_92.csv]")
@@ -225,8 +225,8 @@ class TransportVersionValidationFuncTest extends AbstractTransportVersionFuncTes
         given:
         unreferencedTransportVersion("initial_10.0.1", "10000001")
         when:
-        def result = gradleRunner(":myserver:validateTransportVersionDefinitions").build()
+        def result = gradleRunner(":myserver:validateTransportVersionResources").build()
         then:
-        result.task(":myserver:validateTransportVersionDefinitions").outcome == TaskOutcome.SUCCESS
+        result.task(":myserver:validateTransportVersionResources").outcome == TaskOutcome.SUCCESS
     }
 }


### PR DESCRIPTION
This was merged at the same time as a rename of the task.