### PR TITLE
Make `AsyncWaitStep#evaluateCondition` take an `IndexMetadata` instead of `Index`

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AsyncWaitStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AsyncWaitStep.java
@@ -8,10 +8,10 @@ package org.elasticsearch.xpack.core.ilm;
 
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ProjectState;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.xcontent.ToXContentObject;
 
 /**
@@ -40,7 +40,7 @@ public abstract class AsyncWaitStep extends Step {
         return client.projectClient(projectId);
     }
 
-    public abstract void evaluateCondition(ProjectState state, Index index, Listener listener, TimeValue masterTimeout);
+    public abstract void evaluateCondition(ProjectState state, IndexMetadata indexMetadata, Listener listener, TimeValue masterTimeout);
 
     public interface Listener {
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SegmentCountStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SegmentCountStep.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.admin.indices.segments.ShardSegments;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ProjectState;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.TimeValue;
@@ -56,7 +57,8 @@ public class SegmentCountStep extends AsyncWaitStep {
     }
 
     @Override
-    public void evaluateCondition(ProjectState state, Index index, Listener listener, TimeValue masterTimeout) {
+    public void evaluateCondition(ProjectState state, IndexMetadata indexMetadata, Listener listener, TimeValue masterTimeout) {
+        Index index = indexMetadata.getIndex();
         getClient(state.projectId()).admin()
             .indices()
             .segments(new IndicesSegmentsRequest(index.getName()), ActionListener.wrap(response -> {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForFollowShardTasksStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForFollowShardTasksStep.java
@@ -12,7 +12,6 @@ import org.elasticsearch.cluster.ProjectState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -39,8 +38,7 @@ final class WaitForFollowShardTasksStep extends AsyncWaitStep {
     }
 
     @Override
-    public void evaluateCondition(ProjectState state, Index index, Listener listener, TimeValue masterTimeout) {
-        IndexMetadata indexMetadata = state.metadata().index(index);
+    public void evaluateCondition(ProjectState state, IndexMetadata indexMetadata, Listener listener, TimeValue masterTimeout) {
         Map<String, String> customIndexMetadata = indexMetadata.getCustomData(CCR_METADATA_KEY);
         if (customIndexMetadata == null) {
             listener.onResponse(true, null);
@@ -48,7 +46,7 @@ final class WaitForFollowShardTasksStep extends AsyncWaitStep {
         }
 
         FollowStatsAction.StatsRequest request = new FollowStatsAction.StatsRequest();
-        request.setIndices(new String[] { index.getName() });
+        request.setIndices(new String[] { indexMetadata.getIndex().getName() });
         getClient(state.projectId()).execute(
             FollowStatsAction.INSTANCE,
             request,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForRolloverReadyStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForRolloverReadyStep.java
@@ -80,7 +80,8 @@ public class WaitForRolloverReadyStep extends AsyncWaitStep {
     }
 
     @Override
-    public void evaluateCondition(ProjectState state, Index index, Listener listener, TimeValue masterTimeout) {
+    public void evaluateCondition(ProjectState state, IndexMetadata indexMetadata, Listener listener, TimeValue masterTimeout) {
+        Index index = indexMetadata.getIndex();
         IndexAbstraction indexAbstraction = state.metadata().getIndicesLookup().get(index.getName());
         assert indexAbstraction != null : "invalid cluster metadata. index [" + index.getName() + "] was not found";
         final String rolloverTarget;
@@ -95,14 +96,13 @@ public class WaitForRolloverReadyStep extends AsyncWaitStep {
                     index.getName(),
                     targetFailureStore ? "failure store " : "",
                     dataStream.getName(),
-                    state.metadata().index(index).getLifecyclePolicyName()
+                    indexMetadata.getLifecyclePolicyName()
                 );
                 listener.onResponse(true, EmptyInfo.INSTANCE);
                 return;
             }
             rolloverTarget = dataStream.getName();
         } else {
-            IndexMetadata indexMetadata = state.metadata().index(index);
             String rolloverAlias = RolloverAction.LIFECYCLE_ROLLOVER_ALIAS_SETTING.get(indexMetadata.getSettings());
 
             if (Strings.isNullOrEmpty(rolloverAlias)) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForSnapshotStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitForSnapshotStep.java
@@ -15,7 +15,6 @@ import org.elasticsearch.cluster.ProjectState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xpack.core.ilm.step.info.EmptyInfo;
 import org.elasticsearch.xpack.core.slm.SnapshotLifecycleMetadata;
@@ -43,7 +42,6 @@ public class WaitForSnapshotStep extends AsyncWaitStep {
 
     private static final String UNEXPECTED_SNAPSHOT_STATE_MESSAGE =
         "unexpected number of snapshots retrieved for repository '%s' and snapshot '%s' (expected 1, found %d)";
-    private static final String NO_INDEX_METADATA_MESSAGE = "no index metadata found for index '%s'";
     private static final String NO_ACTION_TIME_MESSAGE = "no information about ILM action start in index metadata for index '%s'";
 
     private final String policy;
@@ -54,17 +52,12 @@ public class WaitForSnapshotStep extends AsyncWaitStep {
     }
 
     @Override
-    public void evaluateCondition(ProjectState state, Index index, Listener listener, TimeValue masterTimeout) {
-        IndexMetadata indexMetadata = state.metadata().index(index);
-        if (indexMetadata == null) {
-            listener.onFailure(error(NO_INDEX_METADATA_MESSAGE, index.getName()));
-            return;
-        }
-
+    public void evaluateCondition(ProjectState state, IndexMetadata indexMetadata, Listener listener, TimeValue masterTimeout) {
+        String indexName = indexMetadata.getIndex().getName();
         Long actionTime = indexMetadata.getLifecycleExecutionState().actionTime();
 
         if (actionTime == null) {
-            listener.onFailure(error(NO_ACTION_TIME_MESSAGE, index.getName()));
+            listener.onFailure(error(NO_ACTION_TIME_MESSAGE, indexName));
             return;
         }
 
@@ -112,10 +105,10 @@ public class WaitForSnapshotStep extends AsyncWaitStep {
             if (response.getSnapshots().size() != 1) {
                 listener.onFailure(error(UNEXPECTED_SNAPSHOT_STATE_MESSAGE, repositoryName, snapshotName, response.getSnapshots().size()));
             } else {
-                if (response.getSnapshots().get(0).indices().contains(index.getName())) {
+                if (response.getSnapshots().get(0).indices().contains(indexName)) {
                     listener.onResponse(true, EmptyInfo.INSTANCE);
                 } else {
-                    listener.onFailure(error(INDEX_NOT_INCLUDED_IN_SNAPSHOT_MESSAGE, policy, index.getName()));
+                    listener.onFailure(error(INDEX_NOT_INCLUDED_IN_SNAPSHOT_MESSAGE, policy, indexName));
                 }
             }
         }, listener::onFailure));

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitUntilReplicateForTimePassesStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitUntilReplicateForTimePassesStep.java
@@ -12,7 +12,6 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.LifecycleExecutionState;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.xpack.core.ilm.step.info.EmptyInfo;
 import org.elasticsearch.xpack.core.ilm.step.info.SingleMessageFieldInfo;
 
@@ -66,18 +65,15 @@ public class WaitUntilReplicateForTimePassesStep extends AsyncWaitStep {
     }
 
     @Override
-    public void evaluateCondition(ProjectState state, Index index, Listener listener, TimeValue masterTimeout) {
-        IndexMetadata indexMetadata = state.metadata().index(index);
-        assert indexMetadata != null
-            : "the index metadata for index [" + index.getName() + "] must exist in the cluster state for step [" + NAME + "]";
-
-        final LifecycleExecutionState executionState = state.metadata().index(index.getName()).getLifecycleExecutionState();
+    public void evaluateCondition(ProjectState state, IndexMetadata indexMetadata, Listener listener, TimeValue masterTimeout) {
+        String indexName = indexMetadata.getIndex().getName();
+        final LifecycleExecutionState executionState = indexMetadata.getLifecycleExecutionState();
         assert executionState != null
-            : "the lifecycle execution state for index [" + index.getName() + "] must exist in the cluster state for step [" + NAME + "]";
+            : "the lifecycle execution state for index [" + indexName + "] must exist in the cluster state for step [" + NAME + "]";
 
         if (replicateFor == null) {
             // assert at dev-time, but treat this as a no-op at runtime if somehow this should happen (which it shouldn't)
-            assert false : "the replicate_for time value for index [" + index.getName() + "] must not be null for step [" + NAME + "]";
+            assert false : "the replicate_for time value for index [" + indexName + "] must not be null for step [" + NAME + "]";
             listener.onResponse(true, EmptyInfo.INSTANCE);
             return;
         }
@@ -97,7 +93,7 @@ public class WaitUntilReplicateForTimePassesStep extends AsyncWaitStep {
                         // balance between precision and efficiency.
                         approximateTimeRemaining(remaining),
                         this.replicateFor,
-                        index.getName()
+                        indexName
                     )
                 )
             );

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitUntilTimeSeriesEndTimePassesStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/WaitUntilTimeSeriesEndTimePassesStep.java
@@ -10,7 +10,6 @@ import org.elasticsearch.cluster.ProjectState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.xpack.core.ilm.step.info.EmptyInfo;
@@ -43,18 +42,15 @@ public class WaitUntilTimeSeriesEndTimePassesStep extends AsyncWaitStep {
     }
 
     @Override
-    public void evaluateCondition(ProjectState state, Index index, Listener listener, TimeValue masterTimeout) {
-        IndexMetadata indexMetadata = state.metadata().index(index);
-        assert indexMetadata != null
-            : "the index metadata for index [" + index.getName() + "] must exist in the cluster state for step [" + NAME + "]";
-
+    public void evaluateCondition(ProjectState state, IndexMetadata indexMetadata, Listener listener, TimeValue masterTimeout) {
+        String indexName = indexMetadata.getIndex().getName();
         if (IndexSettings.MODE.get(indexMetadata.getSettings()) != IndexMode.TIME_SERIES) {
             // this index is not a time series index so no need to wait
             listener.onResponse(true, EmptyInfo.INSTANCE);
             return;
         }
         Instant configuredEndTime = IndexSettings.TIME_SERIES_END_TIME.get(indexMetadata.getSettings());
-        assert configuredEndTime != null : "a time series index must have an end time configured but [" + index.getName() + "] does not";
+        assert configuredEndTime != null : "a time series index must have an end time configured but [" + indexName + "] does not";
         if (nowSupplier.get().isBefore(configuredEndTime)) {
             listener.onResponse(
                 false,
@@ -63,7 +59,7 @@ public class WaitUntilTimeSeriesEndTimePassesStep extends AsyncWaitStep {
                         "The [%s] setting for index [%s] is [%s]. Waiting until the index's time series end time lapses before"
                             + " proceeding with action [%s] as the index can still accept writes.",
                         IndexSettings.TIME_SERIES_END_TIME.getKey(),
-                        index.getName(),
+                        indexName,
                         configuredEndTime.toEpochMilli(),
                         getKey().action()
                     )

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SegmentCountStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SegmentCountStepTests.java
@@ -104,7 +104,7 @@ public class SegmentCountStepTests extends AbstractStepTestCase<SegmentCountStep
         SegmentCountStep step = new SegmentCountStep(stepKey, nextStepKey, client, maxNumSegments);
         IndexMetadata indexMetadata = makeMeta(index);
         final var state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, true));
-        step.evaluateCondition(state, indexMetadata.getIndex(), new AsyncWaitStep.Listener() {
+        step.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
             @Override
             public void onResponse(boolean conditionMet, ToXContentObject info) {
                 conditionMetResult.set(conditionMet);
@@ -157,7 +157,7 @@ public class SegmentCountStepTests extends AbstractStepTestCase<SegmentCountStep
         SegmentCountStep step = new SegmentCountStep(stepKey, nextStepKey, client, maxNumSegments);
         IndexMetadata indexMetadata = makeMeta(index);
         final var state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, true));
-        step.evaluateCondition(state, indexMetadata.getIndex(), new AsyncWaitStep.Listener() {
+        step.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
             @Override
             public void onResponse(boolean conditionMet, ToXContentObject info) {
                 conditionMetResult.set(conditionMet);
@@ -215,7 +215,7 @@ public class SegmentCountStepTests extends AbstractStepTestCase<SegmentCountStep
         SegmentCountStep step = new SegmentCountStep(stepKey, nextStepKey, client, maxNumSegments);
         IndexMetadata indexMetadata = makeMeta(index);
         final var state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, true));
-        step.evaluateCondition(state, indexMetadata.getIndex(), new AsyncWaitStep.Listener() {
+        step.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
             @Override
             public void onResponse(boolean conditionMet, ToXContentObject info) {
                 conditionMetResult.set(conditionMet);
@@ -253,7 +253,7 @@ public class SegmentCountStepTests extends AbstractStepTestCase<SegmentCountStep
         SegmentCountStep step = new SegmentCountStep(stepKey, nextStepKey, client, maxNumSegments);
         IndexMetadata indexMetadata = makeMeta(index);
         final var state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, true));
-        step.evaluateCondition(state, indexMetadata.getIndex(), new AsyncWaitStep.Listener() {
+        step.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
             @Override
             public void onResponse(boolean conditionMet, ToXContentObject info) {
                 throw new AssertionError("unexpected method call");

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForFollowShardTasksStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForFollowShardTasksStepTests.java
@@ -71,7 +71,7 @@ public class WaitForFollowShardTasksStepTests extends AbstractStepTestCase<WaitF
         final ToXContentObject[] informationContextHolder = new ToXContentObject[1];
         final Exception[] exceptionHolder = new Exception[1];
         final var state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, true));
-        createRandomInstance().evaluateCondition(state, indexMetadata.getIndex(), new AsyncWaitStep.Listener() {
+        createRandomInstance().evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
             @Override
             public void onResponse(boolean conditionMet, ToXContentObject informationContext) {
                 conditionMetHolder[0] = conditionMet;
@@ -106,7 +106,7 @@ public class WaitForFollowShardTasksStepTests extends AbstractStepTestCase<WaitF
         final ToXContentObject[] informationContextHolder = new ToXContentObject[1];
         final Exception[] exceptionHolder = new Exception[1];
         final var state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, true));
-        createRandomInstance().evaluateCondition(state, indexMetadata.getIndex(), new AsyncWaitStep.Listener() {
+        createRandomInstance().evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
             @Override
             public void onResponse(boolean conditionMet, ToXContentObject informationContext) {
                 conditionMetHolder[0] = conditionMet;
@@ -140,7 +140,7 @@ public class WaitForFollowShardTasksStepTests extends AbstractStepTestCase<WaitF
         final ToXContentObject[] informationContextHolder = new ToXContentObject[1];
         final Exception[] exceptionHolder = new Exception[1];
         final var state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, true));
-        createRandomInstance().evaluateCondition(state, indexMetadata.getIndex(), new AsyncWaitStep.Listener() {
+        createRandomInstance().evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
             @Override
             public void onResponse(boolean conditionMet, ToXContentObject informationContext) {
                 conditionMetHolder[0] = conditionMet;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForNoFollowersStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForNoFollowersStepTests.java
@@ -85,7 +85,7 @@ public class WaitForNoFollowersStepTests extends AbstractStepTestCase<WaitForNoF
         final SetOnce<Boolean> conditionMetHolder = new SetOnce<>();
         final SetOnce<ToXContentObject> stepInfoHolder = new SetOnce<>();
         final var state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, true));
-        step.evaluateCondition(state, indexMetadata.getIndex(), new AsyncWaitStep.Listener() {
+        step.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
             @Override
             public void onResponse(boolean conditionMet, ToXContentObject informationContext) {
                 conditionMetHolder.set(conditionMet);
@@ -120,7 +120,7 @@ public class WaitForNoFollowersStepTests extends AbstractStepTestCase<WaitForNoF
         final SetOnce<Boolean> conditionMetHolder = new SetOnce<>();
         final SetOnce<ToXContentObject> stepInfoHolder = new SetOnce<>();
         final var state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, true));
-        step.evaluateCondition(state, indexMetadata.getIndex(), new AsyncWaitStep.Listener() {
+        step.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
             @Override
             public void onResponse(boolean conditionMet, ToXContentObject informationContext) {
                 conditionMetHolder.set(conditionMet);
@@ -155,7 +155,7 @@ public class WaitForNoFollowersStepTests extends AbstractStepTestCase<WaitForNoF
         final SetOnce<Boolean> conditionMetHolder = new SetOnce<>();
         final SetOnce<ToXContentObject> stepInfoHolder = new SetOnce<>();
         final var state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, true));
-        step.evaluateCondition(state, indexMetadata.getIndex(), new AsyncWaitStep.Listener() {
+        step.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
             @Override
             public void onResponse(boolean conditionMet, ToXContentObject informationContext) {
                 conditionMetHolder.set(conditionMet);
@@ -197,7 +197,7 @@ public class WaitForNoFollowersStepTests extends AbstractStepTestCase<WaitForNoF
         final SetOnce<Boolean> conditionMetHolder = new SetOnce<>();
         final SetOnce<ToXContentObject> stepInfoHolder = new SetOnce<>();
         final var state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, true));
-        step.evaluateCondition(state, indexMetadata.getIndex(), new AsyncWaitStep.Listener() {
+        step.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
             @Override
             public void onResponse(boolean conditionMet, ToXContentObject informationContext) {
                 conditionMetHolder.set(conditionMet);
@@ -238,7 +238,7 @@ public class WaitForNoFollowersStepTests extends AbstractStepTestCase<WaitForNoF
 
         final SetOnce<Exception> exceptionHolder = new SetOnce<>();
         final var state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, true));
-        step.evaluateCondition(state, indexMetadata.getIndex(), new AsyncWaitStep.Listener() {
+        step.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
             @Override
             public void onResponse(boolean conditionMet, ToXContentObject informationContext) {
                 fail(

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForRolloverReadyStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForRolloverReadyStepTests.java
@@ -235,7 +235,7 @@ public class WaitForRolloverReadyStepTests extends AbstractStepTestCase<WaitForR
 
         SetOnce<Boolean> conditionsMet = new SetOnce<>();
         final var state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, true));
-        step.evaluateCondition(state, indexMetadata.getIndex(), new AsyncWaitStep.Listener() {
+        step.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
 
             @Override
             public void onResponse(boolean complete, ToXContentObject informationContext) {
@@ -294,7 +294,7 @@ public class WaitForRolloverReadyStepTests extends AbstractStepTestCase<WaitForR
                 )
         );
         IndexMetadata indexToOperateOn = failureStoreIndex ? failureStoreMetadata : indexMetadata;
-        step.evaluateCondition(state, indexToOperateOn.getIndex(), new AsyncWaitStep.Listener() {
+        step.evaluateCondition(state, indexToOperateOn, new AsyncWaitStep.Listener() {
 
             @Override
             public void onResponse(boolean complete, ToXContentObject informationContext) {
@@ -373,7 +373,7 @@ public class WaitForRolloverReadyStepTests extends AbstractStepTestCase<WaitForR
                 )
         );
         IndexMetadata indexToOperateOn = failureStoreIndex ? firstGenerationFailureIndex : firstGenerationIndex;
-        step.evaluateCondition(state, indexToOperateOn.getIndex(), new AsyncWaitStep.Listener() {
+        step.evaluateCondition(state, indexToOperateOn, new AsyncWaitStep.Listener() {
 
             @Override
             public void onResponse(boolean complete, ToXContentObject informationContext) {
@@ -422,7 +422,7 @@ public class WaitForRolloverReadyStepTests extends AbstractStepTestCase<WaitForR
         WaitForRolloverReadyStep step = createRandomInstance();
 
         final var state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, true));
-        step.evaluateCondition(state, indexMetadata.getIndex(), new AsyncWaitStep.Listener() {
+        step.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
 
             @Override
             public void onResponse(boolean complete, ToXContentObject informationContext) {
@@ -457,7 +457,7 @@ public class WaitForRolloverReadyStepTests extends AbstractStepTestCase<WaitForR
         WaitForRolloverReadyStep step = createRandomInstance();
 
         final var state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, true));
-        step.evaluateCondition(state, indexMetadata.getIndex(), new AsyncWaitStep.Listener() {
+        step.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
 
             @Override
             public void onResponse(boolean complete, ToXContentObject informationContext) {
@@ -484,7 +484,7 @@ public class WaitForRolloverReadyStepTests extends AbstractStepTestCase<WaitForR
 
         WaitForRolloverReadyStep step = createRandomInstance();
         final var state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, true));
-        step.evaluateCondition(state, indexMetadata.getIndex(), new AsyncWaitStep.Listener() {
+        step.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
 
             @Override
             public void onResponse(boolean complete, ToXContentObject informationContext) {
@@ -526,7 +526,7 @@ public class WaitForRolloverReadyStepTests extends AbstractStepTestCase<WaitForR
 
         SetOnce<Boolean> conditionsMet = new SetOnce<>();
         final var state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, true));
-        step.evaluateCondition(state, indexMetadata.getIndex(), new AsyncWaitStep.Listener() {
+        step.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
 
             @Override
             public void onResponse(boolean complete, ToXContentObject informationContext) {
@@ -558,7 +558,7 @@ public class WaitForRolloverReadyStepTests extends AbstractStepTestCase<WaitForR
 
         SetOnce<Boolean> correctFailureCalled = new SetOnce<>();
         final var state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, true));
-        step.evaluateCondition(state, indexMetadata.getIndex(), new AsyncWaitStep.Listener() {
+        step.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
 
             @Override
             public void onResponse(boolean complete, ToXContentObject informationContext) {
@@ -589,7 +589,7 @@ public class WaitForRolloverReadyStepTests extends AbstractStepTestCase<WaitForR
 
         SetOnce<Boolean> actionCompleted = new SetOnce<>();
         final var state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, true));
-        step.evaluateCondition(state, indexMetadata.getIndex(), new AsyncWaitStep.Listener() {
+        step.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
 
             @Override
             public void onResponse(boolean complete, ToXContentObject informationContext) {
@@ -634,7 +634,7 @@ public class WaitForRolloverReadyStepTests extends AbstractStepTestCase<WaitForR
 
         SetOnce<Boolean> exceptionThrown = new SetOnce<>();
         final var state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, true));
-        step.evaluateCondition(state, indexMetadata.getIndex(), new AsyncWaitStep.Listener() {
+        step.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
 
             @Override
             public void onResponse(boolean complete, ToXContentObject informationContext) {
@@ -668,7 +668,7 @@ public class WaitForRolloverReadyStepTests extends AbstractStepTestCase<WaitForR
 
         SetOnce<Exception> exceptionThrown = new SetOnce<>();
         final var state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, true));
-        step.evaluateCondition(state, indexMetadata.getIndex(), new AsyncWaitStep.Listener() {
+        step.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
             @Override
             public void onResponse(boolean complete, ToXContentObject informationContext) {
                 throw new AssertionError("Unexpected method call");
@@ -704,7 +704,7 @@ public class WaitForRolloverReadyStepTests extends AbstractStepTestCase<WaitForR
 
         SetOnce<Exception> exceptionThrown = new SetOnce<>();
         final var state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, true));
-        step.evaluateCondition(state, indexMetadata.getIndex(), new AsyncWaitStep.Listener() {
+        step.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
             @Override
             public void onResponse(boolean complete, ToXContentObject informationContext) {
                 throw new AssertionError("Unexpected method call");

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForSnapshotStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForSnapshotStepTests.java
@@ -85,7 +85,7 @@ public class WaitForSnapshotStepTests extends AbstractStepTestCase<WaitForSnapsh
         WaitForSnapshotStep instance = createRandomInstance();
         SetOnce<Exception> error = new SetOnce<>();
         final var state = projectStateFromProject(ProjectMetadata.builder(randomProjectIdOrDefault()).put(indexMetadata, true));
-        instance.evaluateCondition(state, indexMetadata.getIndex(), new AsyncWaitStep.Listener() {
+        instance.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
             @Override
             public void onResponse(boolean conditionMet, ToXContentObject info) {
                 logger.warn("expected an error got unexpected response {}", conditionMet);
@@ -126,7 +126,7 @@ public class WaitForSnapshotStepTests extends AbstractStepTestCase<WaitForSnapsh
                 .put(indexMetadata, true)
                 .putCustom(SnapshotLifecycleMetadata.TYPE, smlMetadata)
         );
-        instance.evaluateCondition(state, indexMetadata.getIndex(), new AsyncWaitStep.Listener() {
+        instance.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
             @Override
             public void onResponse(boolean conditionMet, ToXContentObject info) {
                 isConditionMet.set(conditionMet);
@@ -239,7 +239,7 @@ public class WaitForSnapshotStepTests extends AbstractStepTestCase<WaitForSnapsh
         final var state = projectStateFromProject(
             ProjectMetadata.builder(projectId).put(indexMetadata, true).putCustom(SnapshotLifecycleMetadata.TYPE, smlMetadata)
         );
-        instance.evaluateCondition(state, indexMetadata.getIndex(), new AsyncWaitStep.Listener() {
+        instance.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
             @Override
             public void onResponse(boolean conditionMet, ToXContentObject info) {
                 logger.warn("expected an error got unexpected response {}", conditionMet);
@@ -306,7 +306,7 @@ public class WaitForSnapshotStepTests extends AbstractStepTestCase<WaitForSnapsh
         final var state = projectStateFromProject(
             ProjectMetadata.builder(projectId).put(indexMetadata, true).putCustom(SnapshotLifecycleMetadata.TYPE, smlMetadata)
         );
-        instance.evaluateCondition(state, indexMetadata.getIndex(), new AsyncWaitStep.Listener() {
+        instance.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
             @Override
             public void onResponse(boolean conditionMet, ToXContentObject info) {
                 isConditionMet.set(conditionMet);
@@ -364,7 +364,7 @@ public class WaitForSnapshotStepTests extends AbstractStepTestCase<WaitForSnapsh
                 .put(indexMetadata, true)
                 .putCustom(SnapshotLifecycleMetadata.TYPE, smlMetadata)
         );
-        instance.evaluateCondition(state, indexMetadata.getIndex(), new AsyncWaitStep.Listener() {
+        instance.evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
             @Override
             public void onResponse(boolean conditionMet, ToXContentObject info) {
                 logger.warn("expected an error got unexpected response {}", conditionMet);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitUntilReplicateForTimePassesStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitUntilReplicateForTimePassesStepTests.java
@@ -79,7 +79,7 @@ public class WaitUntilReplicateForTimePassesStepTests extends AbstractStepTestCa
 
         // if we evaluate the condition now, it hasn't been met, because it hasn't been an hour
         returnVal.set(now);
-        step.evaluateCondition(state, indexMeta.getIndex(), new AsyncWaitStep.Listener() {
+        step.evaluateCondition(state, indexMeta, new AsyncWaitStep.Listener() {
             @Override
             public void onResponse(boolean complete, ToXContentObject informationContext) {
                 assertThat(complete, is(false));
@@ -92,7 +92,7 @@ public class WaitUntilReplicateForTimePassesStepTests extends AbstractStepTestCa
         }, MASTER_TIMEOUT);
 
         returnVal.set(t1); // similarly, if we were in the past, enough time also wouldn't have passed
-        step.evaluateCondition(state, indexMeta.getIndex(), new AsyncWaitStep.Listener() {
+        step.evaluateCondition(state, indexMeta, new AsyncWaitStep.Listener() {
             @Override
             public void onResponse(boolean complete, ToXContentObject informationContext) {
                 assertThat(complete, is(false));
@@ -105,7 +105,7 @@ public class WaitUntilReplicateForTimePassesStepTests extends AbstractStepTestCa
         }, MASTER_TIMEOUT);
 
         returnVal.set(t2); // but two hours from now in the future, an hour will have passed
-        step.evaluateCondition(state, indexMeta.getIndex(), new AsyncWaitStep.Listener() {
+        step.evaluateCondition(state, indexMeta, new AsyncWaitStep.Listener() {
             @Override
             public void onResponse(boolean complete, ToXContentObject informationContext) {
                 assertThat(complete, is(true));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitUntilTimeSeriesEndTimePassesStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitUntilTimeSeriesEndTimePassesStepTests.java
@@ -79,7 +79,7 @@ public class WaitUntilTimeSeriesEndTimePassesStepTests extends AbstractStepTestC
             // end_time has lapsed already so condition must be met
             Index previousGeneration = dataStream.getIndices().get(0);
 
-            step.evaluateCondition(state, previousGeneration, new AsyncWaitStep.Listener() {
+            step.evaluateCondition(state, project.index(previousGeneration), new AsyncWaitStep.Listener() {
 
                 @Override
                 public void onResponse(boolean complete, ToXContentObject informationContext) {
@@ -97,7 +97,7 @@ public class WaitUntilTimeSeriesEndTimePassesStepTests extends AbstractStepTestC
             // end_time is in the future
             Index writeIndex = dataStream.getIndices().get(1);
 
-            step.evaluateCondition(state, writeIndex, new AsyncWaitStep.Listener() {
+            step.evaluateCondition(state, project.index(writeIndex), new AsyncWaitStep.Listener() {
 
                 @Override
                 public void onResponse(boolean complete, ToXContentObject informationContext) {
@@ -131,7 +131,7 @@ public class WaitUntilTimeSeriesEndTimePassesStepTests extends AbstractStepTestC
                 .build();
 
             ProjectState newState = state.updateProject(ProjectMetadata.builder(project).put(indexMeta, true).build());
-            step.evaluateCondition(newState, indexMeta.getIndex(), new AsyncWaitStep.Listener() {
+            step.evaluateCondition(newState, indexMeta, new AsyncWaitStep.Listener() {
 
                 @Override
                 public void onResponse(boolean complete, ToXContentObject informationContext) {

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunner.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunner.java
@@ -236,7 +236,7 @@ class IndexLifecycleRunner {
             }
         } else if (currentStep instanceof AsyncWaitStep) {
             logger.debug("[{}] running periodic policy with current-step [{}]", index, currentStep.getKey());
-            ((AsyncWaitStep) currentStep).evaluateCondition(state, indexMetadata.getIndex(), new AsyncWaitStep.Listener() {
+            ((AsyncWaitStep) currentStep).evaluateCondition(state, indexMetadata, new AsyncWaitStep.Listener() {
 
                 @Override
                 public void onResponse(boolean conditionMet, ToXContentObject stepInfo) {

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunnerTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunnerTests.java
@@ -1042,7 +1042,7 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
         }
 
         @Override
-        public void evaluateCondition(ProjectState state, Index index, Listener listener, TimeValue masterTimeout) {
+        public void evaluateCondition(ProjectState state, IndexMetadata indexMetadata, Listener listener, TimeValue masterTimeout) {
             executeCount++;
             if (latch != null) {
                 latch.countDown();


### PR DESCRIPTION
This avoids subclasses from having to look up the index metadata themselves, which in turn saves some null-checks.