### PR TITLE
[Gradle] Fix distribution package building after Gradle update

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(./gradlew precommit:*)",
+      "Bash(./gradlew:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionDownloadPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionDownloadPluginFuncTest.groovy
@@ -167,8 +167,12 @@ class InternalDistributionDownloadPluginFuncTest extends AbstractGradleFuncTest 
                     }
                 }
             }
+
+            tasks.named('assemble').configure {
+                dependsOn buildTar
+            }
+
             artifacts {
-                it.add("default", buildTar)
                 it.add("extracted", buildExpanded)
             }
         """

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionDownloadPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/InternalDistributionDownloadPluginFuncTest.groovy
@@ -173,6 +173,7 @@ class InternalDistributionDownloadPluginFuncTest extends AbstractGradleFuncTest 
             }
 
             artifacts {
+                it.add("default", buildTar)
                 it.add("extracted", buildExpanded)
             }
         """

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionArchiveSetupPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionArchiveSetupPlugin.java
@@ -9,11 +9,9 @@
 
 package org.elasticsearch.gradle.internal;
 
-import org.gradle.api.Action;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.Task;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.plugins.BasePlugin;
@@ -44,6 +42,7 @@ import static org.elasticsearch.gradle.internal.conventions.GUtils.capitalize;
  */
 public class InternalDistributionArchiveSetupPlugin implements Plugin<Project> {
 
+    public static final String DEFAULT_CONFIGURATION_NAME = "default";
     public static final String EXTRACTED_CONFIGURATION_NAME = "extracted";
     public static final String COMPOSITE_CONFIGURATION_NAME = "composite";
     private NamedDomainObjectContainer<DistributionArchive> container;
@@ -74,7 +73,7 @@ public class InternalDistributionArchiveSetupPlugin implements Plugin<Project> {
             var subProjectName = archiveToSubprojectName(distributionArchive.getName());
             project.project(subProjectName, sub -> {
                 sub.getPlugins().apply(BasePlugin.class);
-
+                sub.getArtifacts().add(DEFAULT_CONFIGURATION_NAME, distributionArchive.getArchiveTask());
                 sub.getTasks().named("assemble").configure(task -> task.dependsOn(distributionArchive.getArchiveTask()));
                 var extractedConfiguration = sub.getConfigurations().create(EXTRACTED_CONFIGURATION_NAME);
                 extractedConfiguration.setCanBeResolved(false);

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionArchiveSetupPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionArchiveSetupPlugin.java
@@ -9,9 +9,11 @@
 
 package org.elasticsearch.gradle.internal;
 
+import org.gradle.api.Action;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.plugins.BasePlugin;
@@ -42,7 +44,6 @@ import static org.elasticsearch.gradle.internal.conventions.GUtils.capitalize;
  */
 public class InternalDistributionArchiveSetupPlugin implements Plugin<Project> {
 
-    public static final String DEFAULT_CONFIGURATION_NAME = "default";
     public static final String EXTRACTED_CONFIGURATION_NAME = "extracted";
     public static final String COMPOSITE_CONFIGURATION_NAME = "composite";
     private NamedDomainObjectContainer<DistributionArchive> container;
@@ -73,7 +74,8 @@ public class InternalDistributionArchiveSetupPlugin implements Plugin<Project> {
             var subProjectName = archiveToSubprojectName(distributionArchive.getName());
             project.project(subProjectName, sub -> {
                 sub.getPlugins().apply(BasePlugin.class);
-                sub.getArtifacts().add(DEFAULT_CONFIGURATION_NAME, distributionArchive.getArchiveTask());
+
+                sub.getTasks().named("assemble").configure(task -> task.dependsOn(distributionArchive.getArchiveTask()));
                 var extractedConfiguration = sub.getConfigurations().create(EXTRACTED_CONFIGURATION_NAME);
                 extractedConfiguration.setCanBeResolved(false);
                 extractedConfiguration.setCanBeConsumed(true);

--- a/distribution/packages/build.gradle
+++ b/distribution/packages/build.gradle
@@ -354,6 +354,10 @@ tasks.register('buildDeb', Deb) {
   configure(commonDebConfig('x64'))
 }
 
+tasks.named('assemble'){
+  dependsOn 'buildDeb', 'buildAarch64Deb'
+}
+
 Closure commonRpmConfig(String architecture) {
   return {
     configure(commonPackageConfig('rpm', architecture))
@@ -386,6 +390,11 @@ tasks.register('buildAarch64Rpm', Rpm) {
 tasks.register('buildRpm', Rpm) {
   configure(commonRpmConfig('x64'))
 }
+
+tasks.named('assemble'){
+  dependsOn 'buildRpm', 'buildAarch64Rpm'
+}
+
 
 Closure dpkgExists = { it -> new File('/bin/dpkg-deb').exists() || new File('/usr/bin/dpkg-deb').exists() || new File('/usr/local/bin/dpkg-deb').exists() }
 Closure rpmExists = { it -> new File('/bin/rpm').exists() || new File('/usr/bin/rpm').exists() || new File('/usr/local/bin/rpm').exists() }


### PR DESCRIPTION
The gradle update silently removed the dependency of assemble on artifacts added to the default configuration. this fixes this by manually declaring the task dependency which is also whats recommended on the gradle update guide