### PR TITLE
ES|QL: Unmute tests for GenerativeForkIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -299,12 +299,6 @@ tests:
 - class: org.elasticsearch.compute.operator.LimitOperatorTests
   method: testEarlyTermination
   issue: https://github.com/elastic/elasticsearch/issues/128721
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeForkIT
-  method: test {csv-spec:lookup-join.EnrichLookupStatsBug}
-  issue: https://github.com/elastic/elasticsearch/issues/129228
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeForkIT
-  method: test {lookup-join.MultipleBatches*
-  issue: https://github.com/elastic/elasticsearch/issues/129210
 - class: org.elasticsearch.entitlement.runtime.policy.FileAccessTreeTests
   method: testWindowsMixedCaseAccess
   issue: https://github.com/elastic/elasticsearch/issues/129167

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -465,9 +465,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.RevertModelSnapshotIT
   method: testRevertModelSnapshot
   issue: https://github.com/elastic/elasticsearch/issues/132733
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeForkIT
-  method: test {csv-spec:lookup-join.MvJoinKeyFromRowExpanded}
-  issue: https://github.com/elastic/elasticsearch/issues/132778
 - class: org.elasticsearch.gradle.internal.transport.TransportVersionManagementPluginFuncTest
   method: definitions have primary ids which cannot change
   issue: https://github.com/elastic/elasticsearch/issues/132788


### PR DESCRIPTION
closes https://github.com/elastic/elasticsearch/issues/129228
closes https://github.com/elastic/elasticsearch/issues/129210

After we improved the field resolution in https://github.com/elastic/elasticsearch/pull/131723, it should be safe to unmute these tests.

The initial failures had to do with the queries returning warning headers that were not accounted for in the test.
Initially a query using FORK would request all fields, so we would generate warnings like this one when date nanos fields were loaded:
```
1: <unexpected> but was "Line 1:1: java.lang.IllegalArgumentException: milliSeconds [-1457696696640] are before the epoch in 1970 and cannot be converted to nanoseconds"
```

The field resolution for FORK was improved, we are trying to request only the fields that are used in the query.
Therefore we will no longer load the date nanos fields that were causing these warnings and we can unmute the tests.
