### PR TITLE
[9.0] test(version_utils): fix uneven distribution when selecting a random version (#133214)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/TransportVersionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TransportVersionUtils.java
@@ -40,7 +40,7 @@ public class TransportVersionUtils {
 
     /** Returns a random {@link TransportVersion} from all available versions. */
     public static TransportVersion randomVersion() {
-        return VersionUtils.randomFrom(random(), allReleasedVersions(), TransportVersion::fromId);
+        return VersionUtils.randomFrom(random(), allReleasedVersions());
     }
 
     /** Returns a random {@link TransportVersion} from all available versions without the ignore set */
@@ -50,7 +50,7 @@ public class TransportVersionUtils {
 
     /** Returns a random {@link TransportVersion} from all available versions. */
     public static TransportVersion randomVersion(Random random) {
-        return VersionUtils.randomFrom(random, allReleasedVersions(), TransportVersion::fromId);
+        return VersionUtils.randomFrom(random, allReleasedVersions());
     }
 
     /** Returns a random {@link TransportVersion} between <code>minVersion</code> and <code>maxVersion</code> (inclusive). */
@@ -77,7 +77,7 @@ public class TransportVersionUtils {
             versions = versions.headSet(maxVersion, true);
         }
 
-        return VersionUtils.randomFrom(random, versions, TransportVersion::fromId);
+        return VersionUtils.randomFrom(random, versions);
     }
 
     public static TransportVersion getPreviousVersion() {

--- a/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
@@ -9,7 +9,7 @@
 
 package org.elasticsearch.test;
 
-import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
+import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 
 import org.elasticsearch.Build;
 import org.elasticsearch.Version;
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.NavigableSet;
 import java.util.Random;
 import java.util.TreeSet;
-import java.util.function.IntFunction;
 
 /** Utilities for selecting versions in tests */
 public class VersionUtils {
@@ -77,7 +76,7 @@ public class VersionUtils {
 
     /** Returns a random {@link Version} from all available versions. */
     public static Version randomVersion(Random random) {
-        return randomFrom(random, ALL_VERSIONS, Version::fromId);
+        return randomFrom(random, ALL_VERSIONS);
     }
 
     /** Returns a random {@link Version} from all available versions, that is compatible with the given version. */
@@ -106,7 +105,7 @@ public class VersionUtils {
             versions = versions.headSet(maxVersion, true);
         }
 
-        return randomFrom(random, versions, Version::fromId);
+        return randomFrom(random, versions);
     }
 
     /** Returns the maximum {@link Version} that is compatible with the given version. */
@@ -114,16 +113,7 @@ public class VersionUtils {
         return ALL_VERSIONS.tailSet(version, true).descendingSet().stream().filter(version::isCompatible).findFirst().orElseThrow();
     }
 
-    public static <T extends VersionId<T>> T randomFrom(Random random, NavigableSet<T> set, IntFunction<T> ctor) {
-        // get the first and last id, pick a random id in the middle, then find that id in the set in O(nlogn) time
-        // this assumes the id numbers are reasonably evenly distributed in the set
-        assert set.isEmpty() == false;
-        int lowest = set.getFirst().id();
-        int highest = set.getLast().id();
-
-        T randomId = ctor.apply(RandomNumbers.randomIntBetween(random, lowest, highest));
-        // try to find the id below, then the id above. We're just looking for *some* item in the set that is close to randomId
-        T found = set.floor(randomId);
-        return found != null ? found : set.ceiling(randomId);
+    public static <T extends VersionId<T>> T randomFrom(Random random, NavigableSet<T> set) {
+        return RandomPicks.randomFrom(random, set);
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/index/IndexVersionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/index/IndexVersionUtils.java
@@ -45,12 +45,12 @@ public class IndexVersionUtils {
 
     /** Returns a random {@link IndexVersion} from all available versions. */
     public static IndexVersion randomVersion() {
-        return VersionUtils.randomFrom(random(), ALL_VERSIONS, IndexVersion::fromId);
+        return VersionUtils.randomFrom(random(), ALL_VERSIONS);
     }
 
     /** Returns a random {@link IndexVersion} from all versions that can be written to. */
     public static IndexVersion randomWriteVersion() {
-        return VersionUtils.randomFrom(random(), ALL_WRITE_VERSIONS, IndexVersion::fromId);
+        return VersionUtils.randomFrom(random(), ALL_WRITE_VERSIONS);
     }
 
     /** Returns a random {@link IndexVersion} from all available versions without the ignore set */
@@ -78,7 +78,7 @@ public class IndexVersionUtils {
             versions = versions.headSet(maxVersion, true);
         }
 
-        return VersionUtils.randomFrom(random, versions, IndexVersion::fromId);
+        return VersionUtils.randomFrom(random, versions);
     }
 
     public static IndexVersion getPreviousVersion() {


### PR DESCRIPTION
Backports the following commits to 9.0:
 - test(version_utils): fix uneven distribution when selecting a random version (#133214)