### PR TITLE
[9.0] Add wget to docker fips image (#133346)

### DIFF
--- a/distribution/docker/src/docker/dockerfiles/cloud_ess_fips/Dockerfile
+++ b/distribution/docker/src/docker/dockerfiles/cloud_ess_fips/Dockerfile
@@ -110,7 +110,7 @@ RUN <%= retry.loop(package_manager,
           "      ${package_manager} update && \n" +
           "      ${package_manager} upgrade && \n" +
           "      ${package_manager} add --no-cache \n" +
-          "        bash java-cacerts curl libstdc++ libsystemd netcat-openbsd p11-kit p11-kit-trust posix-libc-utils shadow tini unzip zip zstd && \n" +
+          "        bash java-cacerts curl libstdc++ libsystemd netcat-openbsd p11-kit p11-kit-trust posix-libc-utils shadow tini unzip zip zstd wget && \n" +
           "      rm -rf /var/cache/apk/* "
      ) %>
 


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Add wget to docker fips image (#133346)