### PR TITLE
Fix TextFieldMapper.Builder constructor compilation error

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java
@@ -339,6 +339,7 @@ final class DynamicFieldsBuilder {
                     new TextFieldMapper.Builder(
                         name,
                         indexSettings.getIndexVersionCreated(),
+                        indexSettings.getMode(),
                         context.indexAnalyzers(),
                         SourceFieldMapper.isSynthetic(indexSettings),
                         false


### PR DESCRIPTION
Looks like https://github.com/elastic/elasticsearch/pull/131317 had been been ready but not merged for several weeks, during which updates were made in main that broke the build, and the CI was not re-run before merging. This PR fixes the build issue.