### PR TITLE
[ML] Lower Scale to Zero to 4 hours

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -765,6 +765,7 @@ public class MachineLearning extends Plugin
         "xpack.ml.trained_models.adaptive_allocations.scale_to_zero_time",
         TimeValue.timeValueHours(4),
         TimeValue.timeValueMinutes(1),
+        TimeValue.timeValueHours(72),
         Property.Dynamic,
         Setting.Property.NodeScope
     );

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -763,7 +763,7 @@ public class MachineLearning extends Plugin
      */
     public static final Setting<TimeValue> SCALE_TO_ZERO_AFTER_NO_REQUESTS_TIME = Setting.timeSetting(
         "xpack.ml.trained_models.adaptive_allocations.scale_to_zero_time",
-        TimeValue.timeValueHours(24),
+        TimeValue.timeValueHours(4),
         TimeValue.timeValueMinutes(1),
         Property.Dynamic,
         Setting.Property.NodeScope


### PR DESCRIPTION
Set default value to 4 hours to lower the dollar cost for most users, who only use inference intermittently, at the risk of cold start times.

Set a max value to 72 hours to prevent an effective nonzero min allocation.