### PR TITLE
[9.1] Fix accessing main files in transport version resources (#133349)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionDefinition.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionDefinition.java
@@ -9,11 +9,13 @@
 
 package org.elasticsearch.gradle.internal.transport;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
 record TransportVersionDefinition(String name, List<TransportVersionId> ids) {
-    public static TransportVersionDefinition fromString(String filename, String contents) {
+    public static TransportVersionDefinition fromString(Path file, String contents) {
+        String filename = file.getFileName().toString();
         assert filename.endsWith(".csv");
         String name = filename.substring(0, filename.length() - 4);
         List<TransportVersionId> ids = new ArrayList<>();
@@ -23,7 +25,7 @@ record TransportVersionDefinition(String name, List<TransportVersionId> ids) {
                 try {
                     ids.add(TransportVersionId.fromString(rawId));
                 } catch (NumberFormatException e) {
-                    throw new IllegalStateException("Failed to parse id " + rawId + " in " + filename, e);
+                    throw new IllegalStateException("Failed to parse id " + rawId + " in " + file, e);
                 }
             }
         }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionLatest.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionLatest.java
@@ -9,14 +9,17 @@
 
 package org.elasticsearch.gradle.internal.transport;
 
+import java.nio.file.Path;
+
 record TransportVersionLatest(String branch, String name, TransportVersionId id) {
-    public static TransportVersionLatest fromString(String filename, String contents) {
+    public static TransportVersionLatest fromString(Path file, String contents) {
+        String filename = file.getFileName().toString();
         assert filename.endsWith(".csv");
         String branch = filename.substring(0, filename.length() - 4);
 
         String[] parts = contents.split(",");
         if (parts.length != 2) {
-            throw new IllegalStateException("Invalid transport version latest file [" + filename + "]: " + contents);
+            throw new IllegalStateException("Invalid transport version latest file [" + file + "]: " + contents);
         }
 
         return new TransportVersionLatest(branch, parts[0], TransportVersionId.fromString(parts[1]));


### PR DESCRIPTION
Backports the following commits to 9.1:
 - Fix accessing main files in transport version resources (#133349)