### PR TITLE
[8.19] Do not run ES|QL planning and scheduling on transport thread

### DIFF
--- a/docs/changelog/133313.yaml
+++ b/docs/changelog/133313.yaml
@@ -1,0 +1,5 @@
+pr: 133313
+summary: Do not run on transport thread
+area: ES|QL
+type: enhancement
+issues: []

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/premapper/PreMapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/premapper/PreMapper.java
@@ -41,7 +41,6 @@ public class PreMapper {
     }
 
     private void queryRewrite(LogicalPlan plan, ActionListener<LogicalPlan> listener) {
-        QueryBuilderResolver.resolveQueryBuilders(plan, services, listener);
         // see https://github.com/elastic/elasticsearch/issues/133312
         // ThreadedActionListener might be removed if above issue is resolved
         SubscribableListener.<LogicalPlan>newForked(l -> QueryBuilderResolver.resolveQueryBuilders(plan, services, l))

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/premapper/PreMapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/premapper/PreMapper.java
@@ -8,9 +8,13 @@
 package org.elasticsearch.xpack.esql.planner.premapper;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.SubscribableListener;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.esql.expression.function.fulltext.QueryBuilderResolver;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plugin.TransportActionServices;
+
+import java.util.concurrent.Executor;
 
 /**
  * The class is responsible for invoking any premapping steps that need to be applied to the logical plan,
@@ -19,9 +23,11 @@ import org.elasticsearch.xpack.esql.plugin.TransportActionServices;
 public class PreMapper {
 
     private final TransportActionServices services;
+    private final Executor searchExecutor;
 
     public PreMapper(TransportActionServices services) {
         this.services = services;
+        this.searchExecutor = services.transportService().getThreadPool().executor(ThreadPool.Names.SEARCH);
     }
 
     /**
@@ -36,5 +42,9 @@ public class PreMapper {
 
     private void queryRewrite(LogicalPlan plan, ActionListener<LogicalPlan> listener) {
         QueryBuilderResolver.resolveQueryBuilders(plan, services, listener);
+        // see https://github.com/elastic/elasticsearch/issues/133312
+        // ThreadedActionListener might be removed if above issue is resolved
+        SubscribableListener.<LogicalPlan>newForked(l -> QueryBuilderResolver.resolveQueryBuilders(plan, services, l))
+            .addListener(listener, searchExecutor, null);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -145,7 +145,12 @@ public class ComputeService {
         EsqlExecutionInfo execInfo,
         ActionListener<Result> listener
     ) {
-
+        assert ThreadPool.assertCurrentThreadPool(
+            EsqlPlugin.ESQL_WORKER_THREAD_POOL_NAME,
+            ThreadPool.Names.SYSTEM_READ,
+            ThreadPool.Names.SEARCH,
+            ThreadPool.Names.SEARCH_COORDINATION
+        );
         Tuple<PhysicalPlan, PhysicalPlan> coordinatorAndDataNodePlan = PlannerUtils.breakPlanBetweenCoordinatorAndDataNode(
             physicalPlan,
             configuration

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeRequestSender.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeRequestSender.java
@@ -32,6 +32,7 @@ import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.internal.AliasFilter;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.TaskCancelledException;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportService;
@@ -123,6 +124,12 @@ abstract class DataNodeRequestSender {
     }
 
     final void startComputeOnDataNodes(Set<String> concreteIndices, Runnable runOnTaskFailure, ActionListener<ComputeResponse> listener) {
+        assert ThreadPool.assertCurrentThreadPool(
+            EsqlPlugin.ESQL_WORKER_THREAD_POOL_NAME,
+            ThreadPool.Names.SYSTEM_READ,
+            ThreadPool.Names.SEARCH,
+            ThreadPool.Names.SEARCH_COORDINATION
+        );
         final long startTimeInNanos = System.nanoTime();
         searchShards(concreteIndices, ActionListener.wrap(targetShards -> {
             try (


### PR DESCRIPTION
This change manually (due to conflicts caused by missing thread assertions) backports #133313 to 8.19