### PR TITLE
Introduce Type-Driven Source Exclusion via `auto_exclude_types`

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -204,6 +204,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 IndexSettings.INDEX_MAPPER_SOURCE_MODE_SETTING,
                 IndexSettings.RECOVERY_USE_SYNTHETIC_SOURCE_SETTING,
                 InferenceMetadataFieldsMapper.USE_LEGACY_SEMANTIC_TEXT_FORMAT,
+                IndexSettings.INDEX_MAPPER_SOURCE_AUTO_EXCLUDE_TYPES_SETTING,
 
                 // validate that built-in similarities don't get redefined
                 Setting.groupSetting("index.similarity.", (s) -> {

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -856,6 +856,14 @@ public final class IndexSettings {
         Property.ServerlessPublic
     );
 
+    public static final Setting<List<String>> INDEX_MAPPER_SOURCE_AUTO_EXCLUDE_TYPES_SETTING = Setting.listSetting(
+        "index.mapping.source.auto_exclude_types",
+        Collections.emptyList(),
+        String::toString,
+        Setting.Property.Final,
+        Setting.Property.IndexScope
+    );
+
     private final Index index;
     private final IndexVersion version;
     private final Logger logger;

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingParser.java
@@ -123,6 +123,9 @@ public final class MappingParser {
         final MappingParserContext mappingParserContext = mappingParserContextSupplier.get();
 
         RootObjectMapper.Builder rootObjectMapper = RootObjectMapper.parse(type, mappingSource, mappingParserContext);
+        if (mappingParserContext.getAutoExcludes().isEmpty() == false && mappingSource.containsKey(SourceFieldMapper.NAME) == false) {
+            mappingSource.put(SourceFieldMapper.NAME, new HashMap<>());
+        }
 
         Map<Class<? extends MetadataFieldMapper>, MetadataFieldMapper> metadataMappers = metadataMappersSupplier.get();
         Map<String, Object> meta = null;

--- a/server/src/test/java/org/elasticsearch/index/mapper/DynamicFieldsBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DynamicFieldsBuilderTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -69,7 +70,9 @@ public class DynamicFieldsBuilderTests extends ESTestCase {
         XContentParser parser = createParser(JsonXContent.jsonXContent, source);
         SourceToParse sourceToParse = new SourceToParse("test", new BytesArray(source), XContentType.JSON);
 
-        SourceFieldMapper sourceMapper = new SourceFieldMapper.Builder(null, Settings.EMPTY, false, false, false).setSynthetic().build();
+        SourceFieldMapper sourceMapper = new SourceFieldMapper.Builder(null, Settings.EMPTY, Collections.emptyList(), false, false, false)
+            .setSynthetic()
+            .build();
         RootObjectMapper root = new RootObjectMapper.Builder("_doc", Optional.empty()).add(
             new PassThroughObjectMapper.Builder("labels").setPriority(0).setContainsDimensions().dynamic(ObjectMapper.Dynamic.TRUE)
         ).build(MapperBuilderContext.root(false, false));

--- a/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SearchExecutionContextTests.java
@@ -384,7 +384,9 @@ public class SearchExecutionContextTests extends ESTestCase {
 
     public void testSyntheticSourceSearchLookup() throws IOException {
         // Build a mapping using synthetic source
-        SourceFieldMapper sourceMapper = new SourceFieldMapper.Builder(null, Settings.EMPTY, false, false, false).setSynthetic().build();
+        SourceFieldMapper sourceMapper = new SourceFieldMapper.Builder(null, Settings.EMPTY, Collections.emptyList(), false, false, false)
+            .setSynthetic()
+            .build();
         RootObjectMapper root = new RootObjectMapper.Builder("_doc", Optional.empty()).add(
             new KeywordFieldMapper.Builder("cat", IndexVersion.current()).ignoreAbove(100)
         ).build(MapperBuilderContext.root(true, false));


### PR DESCRIPTION
### Summary
This PR introduces a new index-level setting:
```
PUT /my_index
{
  "settings": {
    "index.mapping.source.auto_exclude_types": ["dense_vector", "binary" ... ] 
  }
}
```
---
### Key innovations
1. ✨ **Type-Driven Automation**  
   Automatically excludes all fields of specified types from `_source` at index time  
2. ⚡️ Zero-Overhead Integration  
   - Dynamically injects exclusions during mapping parsing  
   - Requires no manual field declarations   
---
### Synergy with Related Work
Provides foundational infrastructure for #133337's hybrid source reconstruction:  
```
auto_exclude_types → Pruned _source → Adaptive Hybrid Reconstruction
```
---
### Why This Approach?

As discussed by @benwtrent:
> @mayya-sharipova the idea is that you have one parameter to exclude all vector fields, by their type, instead of providing each unique vector field name. 
> 
> I also suppose this unlocks future consideration of having an index level default for `_source inclusion at query time` type of setting that is applied by default for all queries. 
> 
> But, your comment @mayya-sharipova makes me wonder if we should do something like:
> 
> ```
> {
>   "_source": {
>     "mapping_type_excludes": [ "dense_vector", "sparse_vector" ]
>   }...
> }
> ```
> 
> Instead of having something called `include_vectors`.
> 
> 
> 
> @jimczi would we add some index level setting that applies this default source filtering at query time? Is that the ultimate goal here?

_Originally posted in https://github.com/elastic/elasticsearch/issues/128735#issuecomment-2930597063_

By implementing this through `index.mapping.source.auto_exclude_types`, we maintain backward compatibility with existing `_source.includes/excludes`. I believe this approach delivers immediate value while paving the way for more advanced source optimization techniques.