### PR TITLE
Fix: Include script params in BulkRequest size calculation

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
@@ -35,6 +35,7 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.script.Script;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import org.elasticsearch.transport.RawIndexingDataTransportRequest;
 import org.elasticsearch.xcontent.XContentType;
@@ -195,8 +196,10 @@ public class BulkRequest extends LegacyActionRequest
         if (request.upsertRequest() != null) {
             sizeInBytes += request.upsertRequest().source().length();
         }
-        if (request.script() != null) {
-            sizeInBytes += request.script().getIdOrCode().length() * 2;
+        Script script = request.script();
+        if (script != null) {
+            sizeInBytes += (long) script.getIdOrCode().length() * 2L;
+            sizeInBytes += script.getParams().toString().length();
         }
         indices.add(request.index());
         return this;


### PR DESCRIPTION
## Description
The BulkRequest's size calculation currently doesn't account for the size of script parameters in update operations. This can lead to underestimating the actual request size when script parameters are used, potentially causing memory-related issues in bulk operations.

## Changes
- Added script parameters size calculation in `BulkRequest.internalAdd(UpdateRequest)`
- Size is calculated using `script.getParams().toString().length()`

## Example Use Case
When using bulk updates with scripted updates that contain parameters:
```java
BulkRequest bulk = new BulkRequest();
UpdateRequest update = new UpdateRequest("index", "id")
    .script(new Script(ScriptType.INLINE, "painless", 
        "ctx._source.field += params.value", 
        Collections.singletonMap("value", "large_parameter_value")));
bulk.add(update);