### PR TITLE
Fix projects state registry filtering in GetClusterState API

### DIFF
--- a/docs/changelog/133401.yaml
+++ b/docs/changelog/133401.yaml
@@ -1,5 +1,0 @@
-pr: 133401
-summary: Fix projects state registry filtering in `GetClusterState` API
-area: Infra/Core
-type: bug
-issues: []

--- a/docs/changelog/133401.yaml
+++ b/docs/changelog/133401.yaml
@@ -1,0 +1,5 @@
+pr: 133401
+summary: Fix projects state registry filtering in `GetClusterState` API
+area: Infra/Core
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
@@ -29,6 +29,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.cluster.project.ProjectResolver;
+import org.elasticsearch.cluster.project.ProjectStateRegistry;
 import org.elasticsearch.cluster.routing.GlobalRoutingTable;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -162,13 +163,19 @@ public class TransportClusterStateAction extends TransportLocalClusterStateActio
         }
         final Metadata.Builder mdBuilder = Metadata.builder(inputState.metadata());
         final GlobalRoutingTable.Builder rtBuilder = GlobalRoutingTable.builder(inputState.globalRoutingTable());
+        final ProjectStateRegistry.Builder psBuilder = ProjectStateRegistry.builder(inputState);
         for (var projectId : metadata.projects().keySet()) {
             if (projectIds.contains(projectId) == false) {
                 mdBuilder.removeProject(projectId);
                 rtBuilder.removeProject(projectId);
+                psBuilder.removeProject(projectId);
             }
         }
-        return ClusterState.builder(inputState).metadata(mdBuilder.build()).routingTable(rtBuilder.build()).build();
+        return ClusterState.builder(inputState)
+            .metadata(mdBuilder.build())
+            .routingTable(rtBuilder.build())
+            .putCustom(ProjectStateRegistry.TYPE, psBuilder.build())
+            .build();
     }
 
     @SuppressForbidden(reason = "exposing ClusterState#compatibilityVersions requires reading them")

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateActionTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.cluster.project.DefaultProjectResolver;
 import org.elasticsearch.cluster.project.ProjectResolver;
+import org.elasticsearch.cluster.project.ProjectStateRegistry;
 import org.elasticsearch.cluster.project.TestProjectResolvers;
 import org.elasticsearch.cluster.routing.GlobalRoutingTableTestHelper;
 import org.elasticsearch.cluster.routing.RoutingTable;
@@ -169,6 +170,13 @@ public class TransportClusterStateActionTests extends ESTestCase {
                 assertThat(routingTable, notNullValue());
                 assertThat(routingTable.indicesRouting().keySet(), containsInAnyOrder(expectedIndices));
             }
+            if (request.customs()) {
+                ProjectStateRegistry projectStateRegistry = ProjectStateRegistry.get(response.getState());
+                assertThat(projectStateRegistry.size(), equalTo(numberOfProjects));
+                Settings projectSettings = projectStateRegistry.getProjectSettings(projectId);
+                assertThat(projectSettings, notNullValue());
+                assertThat(projectSettings.keySet(), contains("setting_1"));
+            }
         }
     }
 
@@ -193,6 +201,13 @@ public class TransportClusterStateActionTests extends ESTestCase {
             assertThat(routingTables.get(projectId).indicesRouting().keySet(), containsInAnyOrder(expectedIndices));
         } else {
             assertThat(routingTables.get(projectId).indicesRouting(), anEmptyMap());
+        }
+        if (request.customs()) {
+            ProjectStateRegistry projectStateRegistry = ProjectStateRegistry.get(response.getState());
+            assertThat(projectStateRegistry.size(), equalTo(1));
+            Settings projectSettings = projectStateRegistry.getProjectSettings(projectId);
+            assertThat(projectSettings, notNullValue());
+            assertThat(projectSettings.keySet(), contains("setting_1"));
         }
     }
 
@@ -232,7 +247,7 @@ public class TransportClusterStateActionTests extends ESTestCase {
         request.nodes(randomBoolean());
         request.routingTable(randomBoolean());
         request.blocks(randomBoolean());
-        request.customs(randomBoolean());
+        request.customs(true);
         return request;
     }
 
@@ -241,9 +256,15 @@ public class TransportClusterStateActionTests extends ESTestCase {
         Arrays.stream(projects).forEach(metadataBuilder::put);
         final var metadata = metadataBuilder.build();
 
-        return ClusterState.builder(new ClusterName(randomAlphaOfLengthBetween(4, 12)))
+        ClusterState.Builder csBuilder = ClusterState.builder(new ClusterName(randomAlphaOfLengthBetween(4, 12)));
+        ProjectStateRegistry.Builder psBuilder = ProjectStateRegistry.builder();
+        for (ProjectMetadata.Builder project : projects) {
+            psBuilder.putProjectSettings(project.getId(), Settings.builder().put("setting_1", randomIdentifier()).build());
+        }
+        return csBuilder
             .metadata(metadata)
             .routingTable(GlobalRoutingTableTestHelper.buildRoutingTable(metadata, RoutingTable.Builder::addAsNew))
+            .putCustom(ProjectStateRegistry.TYPE, psBuilder.build())
             .build();
     }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateActionTests.java
@@ -261,8 +261,7 @@ public class TransportClusterStateActionTests extends ESTestCase {
         for (ProjectMetadata.Builder project : projects) {
             psBuilder.putProjectSettings(project.getId(), Settings.builder().put("setting_1", randomIdentifier()).build());
         }
-        return csBuilder
-            .metadata(metadata)
+        return csBuilder.metadata(metadata)
             .routingTable(GlobalRoutingTableTestHelper.buildRoutingTable(metadata, RoutingTable.Builder::addAsNew))
             .putCustom(ProjectStateRegistry.TYPE, psBuilder.build())
             .build();


### PR DESCRIPTION
Projects in the project state registry were not filtered out in GetClusterState API
