### PR TITLE
Fix service destination template file name

### DIFF
--- a/docs/changelog/133403.yaml
+++ b/docs/changelog/133403.yaml
@@ -1,0 +1,5 @@
+pr: 133403
+summary: Fix service destination template file name
+area: Data streams
+type: bug
+issues: []

--- a/x-pack/plugin/otel-data/src/main/resources/index-templates/metrics-service_destination.10m.otel@template.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/index-templates/metrics-service_destination.10m.otel@template.yaml
@@ -1,7 +1,7 @@
 ---
 version: ${xpack.oteldata.template.version}
 index_patterns: ["metrics-service_destination.10m.otel-*"]
-priority: 130
+priority: 131
 data_stream:
   hidden: true
 allow_auto_create: true

--- a/x-pack/plugin/otel-data/src/main/resources/index-templates/metrics-service_destination.1m.otel@template.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/index-templates/metrics-service_destination.1m.otel@template.yaml
@@ -1,7 +1,7 @@
 ---
 version: ${xpack.oteldata.template.version}
 index_patterns: ["metrics-service_destination.1m.otel-*"]
-priority: 130
+priority: 131
 data_stream: {}
 allow_auto_create: true
 _meta:

--- a/x-pack/plugin/otel-data/src/main/resources/index-templates/metrics-service_destination.60m.otel@template.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/index-templates/metrics-service_destination.60m.otel@template.yaml
@@ -1,7 +1,7 @@
 ---
 version: ${xpack.oteldata.template.version}
 index_patterns: ["metrics-service_destination.60m.otel-*"]
-priority: 130
+priority: 131
 data_stream:
   hidden: true
 allow_auto_create: true

--- a/x-pack/plugin/otel-data/src/main/resources/resources.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/resources.yaml
@@ -24,6 +24,6 @@ index-templates:
   - metrics-service_summary.60m.otel@template
   - metrics-service_summary.10m.otel@template
   - metrics-service_summary.1m.otel@template
-  - metrics-service_destination.60m@template
-  - metrics-service_destination.10m@template
-  - metrics-service_destination.1m@template
+  - metrics-service_destination.60m.otel@template
+  - metrics-service_destination.10m.otel@template
+  - metrics-service_destination.1m.otel@template

--- a/x-pack/plugin/otel-data/src/main/resources/resources.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/resources.yaml
@@ -1,7 +1,7 @@
 # "version" holds the version of the templates and ingest pipelines installed
 # by xpack-plugin otel-data. This must be increased whenever an existing template is
 # changed, in order for it to be updated on Elasticsearch upgrade.
-version: 10
+version: 11
 
 component-templates:
   - otel@mappings


### PR DESCRIPTION
@carsonip found this issue - the file name of the `metrics-service_destination.[xyz]@template` templates did not have the `.otel` postfix.

This PR fixes the file names - the index pattern itself was correct, so that's untouched and I expect those continue to work.

I bumped the priority of the renamed files by 1 to avoid issues in clusters where the old templates are used.

