### PR TITLE
Re-linking test mutes to related issue

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -512,10 +512,10 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/132880
 - class: org.elasticsearch.index.mapper.LongFieldMapperTests
   method: testFetchMany
-  issue: https://github.com/elastic/elasticsearch/issues/132948
+  issue: https://github.com/elastic/elasticsearch/issues/132893
 - class: org.elasticsearch.index.mapper.LongFieldMapperTests
   method: testFetch
-  issue: https://github.com/elastic/elasticsearch/issues/132956
+  issue: https://github.com/elastic/elasticsearch/issues/132893
 - class: org.elasticsearch.cluster.ClusterInfoServiceIT
   method: testMaxQueueLatenciesInClusterInfo
   issue: https://github.com/elastic/elasticsearch/issues/132957


### PR DESCRIPTION
Changing to mutes test links because issues were related and closed as duplicates.