### PR TITLE
Fallback to working dir for native lib dir in tests

### DIFF
--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/lib/LoaderHelper.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/lib/LoaderHelper.java
@@ -26,7 +26,16 @@ public class LoaderHelper {
             return Paths.get(path);
         }
 
-        Path homeDir = Paths.get(System.getProperty("es.path.home"));
+        String homeDirPath = System.getProperty("es.path.home");
+        if (homeDirPath == null) {
+            // if we don't have the native libs passed in for tests, and we don't have the home dir set
+            // then we must be in a test for an external plugin. there's nothing we can do to get the
+            // native libs, they don't exist, so just return the working dir, it will fail if the test
+            // actually tries to load a library
+            return Paths.get("");
+        }
+
+        Path homeDir = Paths.get(homeDirPath);
         Path platformDir = homeDir.resolve("lib/platform");
 
         String osname = System.getProperty("os.name");


### PR DESCRIPTION
When finding the platform dir to pass to jna we check for system properties which are either set by internal test gradle code or or the cli shell script. If neither of thse are set, we are in test code for an external plugin. This commit fixes the code to use the working dir in this fallback case. Previously we would have created a bogus path. Both are the same: external plugin tests can't load ES native libs since they don't have them available.