### PR TITLE
[8.19][DOCS] Highlight the subscription requirement for synthetic `_source`

### DIFF
--- a/docs/reference/mapping/fields/synthetic-source.asciidoc
+++ b/docs/reference/mapping/fields/synthetic-source.asciidoc
@@ -1,7 +1,7 @@
 [[synthetic-source]]
 ==== Synthetic `_source`
 
-NOTE: This feature is only available with a certain subscription license. For more information, refer to https://www.elastic.co/subscriptions[Subscriptions].
+NOTE: This feature requires a https://www.elastic.co/subscriptions[subscription].
 
 Though very handy to have around, the source field takes up a significant amount
 of space on disk. Instead of storing source documents on disk exactly as you

--- a/docs/reference/mapping/fields/synthetic-source.asciidoc
+++ b/docs/reference/mapping/fields/synthetic-source.asciidoc
@@ -1,10 +1,12 @@
 [[synthetic-source]]
 ==== Synthetic `_source`
 
+NOTE: This feature is only available with a certain subscription license. For more information, refer to https://www.elastic.co/subscriptions[Subscriptions].
+
 Though very handy to have around, the source field takes up a significant amount
 of space on disk. Instead of storing source documents on disk exactly as you
 send them, Elasticsearch can reconstruct source content on the fly upon retrieval.
-To enable this https://www.elastic.co/subscriptions[subscription] feature, use the value `synthetic` for the index setting `index.mapping.source.mode`:
+To enable this feature, use the value `synthetic` for the index setting `index.mapping.source.mode`:
 
 [source,console,id=enable-synthetic-source-example]
 ----


### PR DESCRIPTION
This PR adds a note in the [Synthetic `_source`](https://www.elastic.co/docs/reference/elasticsearch/mapping-reference/mapping-source-field#synthetic-source) doc (8.18 & 8.19) to highlight the subscription requirement for this feature.