### PR TITLE
ES|QL: Fix telemetry tests after addition of CONTAINS function

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_usage.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_usage.yml
@@ -141,7 +141,7 @@ setup:
         - method: POST
           path: /_query
           parameters: []
-          capabilities: [ non_snapshot_test_for_telemetry, fn_month_name ]
+          capabilities: [ non_snapshot_test_for_telemetry, fn_contains ]
       reason: "Test that should only be executed on release versions"
 
   - do: {xpack.usage: {}}
@@ -229,7 +229,7 @@ setup:
   - gt: {esql.functions.to_long: $functions_to_long}
   - match: {esql.functions.coalesce: $functions_coalesce}
   - gt: {esql.functions.categorize: $functions_categorize}
-  - length: {esql.functions: 139} # check the "sister" test above for a likely update to the same esql.functions length check
+  - length: {esql.functions: 140} # check the "sister" test above for a likely update to the same esql.functions length check
 
 ---
 took:


### PR DESCRIPTION
Fixing release tests (telemetry) after adding CONTAINS function

Fixes: https://github.com/elastic/elasticsearch/issues/133461
Fixes: https://github.com/elastic/elasticsearch/issues/133449