### PR TITLE
Set default_metric for time series on the index level

### DIFF
--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamFeatures.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamFeatures.java
@@ -30,6 +30,10 @@ public class DataStreamFeatures implements FeatureSpecification {
 
     public static final NodeFeature FAILURE_STORE_IN_LOG_DATA_STREAMS = new NodeFeature("logs_data_streams.failure_store.enabled");
 
+    public static final NodeFeature DOWNSAMPLE_INDEX_LEVEL_DEFAULT_METRIC = new NodeFeature(
+        "data_stream.downsample.index_level_default_metric"
+    );
+
     @Override
     public Set<NodeFeature> getFeatures() {
         return Set.of(DataStream.DATA_STREAM_FAILURE_STORE_FEATURE);
@@ -41,7 +45,8 @@ public class DataStreamFeatures implements FeatureSpecification {
             DATA_STREAM_FAILURE_STORE_TSDB_FIX,
             DOWNSAMPLE_AGGREGATE_DEFAULT_METRIC_FIX,
             LOGS_STREAM_FEATURE,
-            FAILURE_STORE_IN_LOG_DATA_STREAMS
+            FAILURE_STORE_IN_LOG_DATA_STREAMS,
+            DOWNSAMPLE_INDEX_LEVEL_DEFAULT_METRIC
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -223,6 +223,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 // TSDB index settings
                 IndexSettings.MODE,
                 IndexMetadata.INDEX_ROUTING_PATH,
+                IndexSettings.TIME_SERIES_DEFAULT_METRIC,
                 IndexSettings.TIME_SERIES_START_TIME,
                 IndexSettings.TIME_SERIES_END_TIME,
                 IndexSettings.SEQ_NO_INDEX_OPTIONS_SETTING,

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -647,6 +647,26 @@ public final class IndexSettings {
         Property.Final
     );
 
+    public enum AggregateMetricDoubleDefaultMetric {
+        MIN,
+        MAX,
+        SUM,
+        VALUE_COUNT;
+    }
+
+    public static final Setting<AggregateMetricDoubleDefaultMetric> TIME_SERIES_DEFAULT_METRIC = Setting.enumSetting(
+        AggregateMetricDoubleDefaultMetric.class,
+        "index.time_series.default_metric",
+        AggregateMetricDoubleDefaultMetric.MAX,
+        Property.IndexScope,
+        Property.Final,
+        Property.ServerlessPublic
+    );
+
+    public AggregateMetricDoubleDefaultMetric getDefaultMetric() {
+        return defaultMetric;
+    }
+
     /**
      * Returns <code>true</code> if TSDB encoding is enabled. The default is <code>true</code>
      */
@@ -896,6 +916,7 @@ public final class IndexSettings {
     private final boolean softDeleteEnabled;
     private volatile long softDeleteRetentionOperations;
     private final boolean es87TSDBCodecEnabled;
+    private final AggregateMetricDoubleDefaultMetric defaultMetric;
     private final boolean logsdbRouteOnSortFields;
     private final boolean logsdbSortOnHostName;
     private final boolean logsdbAddHostNameField;
@@ -1116,6 +1137,7 @@ public final class IndexSettings {
         indexRouting = IndexRouting.fromIndexMetadata(indexMetadata);
         sourceKeepMode = scopedSettings.get(Mapper.SYNTHETIC_SOURCE_KEEP_INDEX_SETTING);
         es87TSDBCodecEnabled = scopedSettings.get(TIME_SERIES_ES87TSDB_CODEC_ENABLED_SETTING);
+        defaultMetric = scopedSettings.get(TIME_SERIES_DEFAULT_METRIC);
         logsdbRouteOnSortFields = scopedSettings.get(LOGSDB_ROUTE_ON_SORT_FIELDS);
         logsdbSortOnHostName = scopedSettings.get(LOGSDB_SORT_ON_HOST_NAME);
         logsdbAddHostNameField = scopedSettings.get(LOGSDB_ADD_HOST_NAME_FIELD);

--- a/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesParams.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesParams.java
@@ -21,6 +21,7 @@ public final class TimeSeriesParams {
 
     public static final String TIME_SERIES_METRIC_PARAM = "time_series_metric";
     public static final String TIME_SERIES_DIMENSION_PARAM = "time_series_dimension";
+    public static final String TIME_SERIES_DEFAULT_METRIC_PARAM = "default_metric";
 
     private TimeSeriesParams() {}
 

--- a/x-pack/plugin/downsample/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/downsample/80_downsample_aggregate.yml
+++ b/x-pack/plugin/downsample/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/downsample/80_downsample_aggregate.yml
@@ -77,3 +77,91 @@
         metrics: [min, sum, value_count]
         default_metric: sum
         time_series_metric: gauge
+
+---
+"downsample numeric field":
+  - requires:
+      cluster_features: ["data_stream.downsample.index_level_default_metric"]
+      reason: "Specify default metric to be used in an index when downsampling numerics"
+
+  - do:
+      indices.create:
+        index: test
+        body:
+          settings:
+            number_of_shards: 1
+            index:
+              mode: time_series
+              routing_path: [sensor_id]
+              time_series:
+                start_time: 2021-04-28T00:00:00Z
+                end_time: 2021-04-29T00:00:00Z
+                default_metric: value_count
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+              sensor_id:
+                type: keyword
+                time_series_dimension: true
+              temperature:
+                type: double
+                time_series_metric: gauge
+              agg_metric:
+                type: aggregate_metric_double
+                metrics: [ min, sum, value_count ]
+                default_metric: sum
+                time_series_metric: gauge
+
+  - do:
+      bulk:
+        refresh: true
+        index: test
+        body:
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T17:34:00Z", "sensor_id": "1", "temperature": 24.1, "agg_metric": {"min": -1, "sum": 20, "value_count": 5}}'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T17:39:00Z", "sensor_id": "1", "temperature": 25.3, "agg_metric": {"min": 3, "sum": 50, "value_count": 7}}'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T17:45:00Z", "sensor_id": "1", "temperature": 24.8, "agg_metric": {"min": -5, "sum": 33, "value_count": 9}}'
+
+  - do:
+      indices.put_settings:
+        index: test
+        body:
+          index.blocks.write: true
+
+  - do:
+      indices.downsample:
+        index: test
+        target_index: test-downsample
+        body:  >
+          {
+            "fixed_interval": "30m"
+          }
+  - is_true: acknowledged
+
+  - do:
+      search:
+        index: test-downsample
+        body:
+          size: 0
+
+  - match:
+      hits.total.value: 1
+
+  - do:
+      indices.get_mapping:
+        index: test-downsample
+  - match:
+      test-downsample.mappings.properties.temperature:
+        type: aggregate_metric_double
+        metrics: [min, max, sum, value_count]
+        default_metric: value_count
+        time_series_metric: gauge
+  - match:
+      test-downsample.mappings.properties.agg_metric:
+        type: aggregate_metric_double
+        metrics: [min, sum, value_count]
+        default_metric: sum
+        time_series_metric: gauge

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/TimeseriesFieldTypeHelper.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/TimeseriesFieldTypeHelper.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.downsample;
 
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MappingLookup;
@@ -54,6 +55,10 @@ class TimeseriesFieldTypeHelper {
 
     public static boolean isPassthroughField(final Map<String, ?> fieldMapping) {
         return PassThroughObjectMapper.CONTENT_TYPE.equals(fieldMapping.get(ContextMapping.FIELD_TYPE));
+    }
+
+    public IndexSettings.AggregateMetricDoubleDefaultMetric getDefaultMetric() {
+        return mapperService.getIndexSettings().getDefaultMetric();
     }
 
     public List<String> extractFlattenedDimensions(final String field, final Map<String, ?> fieldMapping) {

--- a/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/TransportDownsampleActionTests.java
+++ b/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/TransportDownsampleActionTests.java
@@ -123,12 +123,20 @@ public class TransportDownsampleActionTests extends ESTestCase {
             "sum"
         );
 
-        var supported = TransportDownsampleAction.getSupportedMetrics(metricType, fieldProperties);
+        var supported = TransportDownsampleAction.getSupportedMetrics(
+            metricType,
+            fieldProperties,
+            IndexSettings.AggregateMetricDoubleDefaultMetric.MAX
+        );
         assertThat(supported.defaultMetric(), is("sum"));
         assertThat(supported.supportedMetrics(), is(List.of("max", "sum")));
 
         fieldProperties = Map.of("type", "integer");
-        supported = TransportDownsampleAction.getSupportedMetrics(metricType, fieldProperties);
+        supported = TransportDownsampleAction.getSupportedMetrics(
+            metricType,
+            fieldProperties,
+            IndexSettings.AggregateMetricDoubleDefaultMetric.MAX
+        );
         assertThat(supported.defaultMetric(), is("max"));
         assertThat(supported.supportedMetrics(), is(List.of(metricType.supportedAggs())));
     }


### PR DESCRIPTION
This PR adds in an index-level setting that allows you to specify which metric (min, max, sum, value_count) will be used as the default metric when downsampling indices containing gauges in time series indices.
When the setting is not present, it defaults to max.
If an aggregate_metric_double has a setting different from the index-level setting, the aggregate_metric_double's setting takes precedence for that field.

Example settings/mappings:
```
"settings": {
  "index.mode": "time_series",
  "index.time_series.default_metric": "min",
  ...
},
"mappings": {
  "properties": {
    "my-metric": {
      "type": "double",
      "time_series_metric": "gauge"
    },
  ...
  }
}
```
becomes this after downsampling:
```
"my-metric": {
    "type": "aggregate_metric_double",
    "metrics": [
        "min",
        "max",
        "sum",
        "value_count"
    ],
    "default_metric": "min",
    "time_series_metric": "gauge"
}
```