### PR TITLE
ESQL: Create unique lookup data to avoid matching multiple lookup docs

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -354,9 +354,6 @@ tests:
 - class: org.elasticsearch.search.SearchWithRejectionsIT
   method: testOpenContextsAfterRejections
   issue: https://github.com/elastic/elasticsearch/issues/130821
-- class: org.elasticsearch.xpack.esql.ccq.MultiClustersIT
-  method: testLookupJoinAliases
-  issue: https://github.com/elastic/elasticsearch/issues/131166
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test090SecurityCliPackaging
   issue: https://github.com/elastic/elasticsearch/issues/131107
@@ -408,9 +405,6 @@ tests:
 - class: org.elasticsearch.compute.lucene.read.SortedSetOrdinalsBuilderTests
   method: testReader
   issue: https://github.com/elastic/elasticsearch/issues/131573
-- class: org.elasticsearch.xpack.esql.ccq.MultiClustersIT
-  method: testLookupJoinAliasesSkipOld
-  issue: https://github.com/elastic/elasticsearch/issues/131697
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test151MachineDependentHeapWithSizeOverride
   issue: https://github.com/elastic/elasticsearch/issues/123437

--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/MultiClustersIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/MultiClustersIT.java
@@ -128,14 +128,12 @@ public class MultiClustersIT extends ESRestTestCase {
              }
             """;
         var randomDocsData = new ArrayList<Integer>();
-        var lookupDocs = IntStream.range(0, between(1, 5))
-            .mapToObj(n -> {
-                String color = randomFrom("red", "yellow", "green");
-                int data = randomValueOtherThanMany(i -> randomDocsData.contains(i), () -> randomIntBetween(1, 1000));
-                randomDocsData.add(data);
-                return new Doc(n, color, data);
-            })
-            .toList();
+        var lookupDocs = IntStream.range(0, between(1, 5)).mapToObj(n -> {
+            String color = randomFrom("red", "yellow", "green");
+            int data = randomValueOtherThanMany(i -> randomDocsData.contains(i), () -> randomIntBetween(1, 1000));
+            randomDocsData.add(data);
+            return new Doc(n, color, data);
+        }).toList();
         createIndex(
             localClient,
             lookupIndexLocal,

--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/MultiClustersIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/MultiClustersIT.java
@@ -127,8 +127,14 @@ public class MultiClustersIT extends ESRestTestCase {
                "morecolor": { "type": "keyword" }
              }
             """;
+        var randomDocsData = new ArrayList<Integer>();
         var lookupDocs = IntStream.range(0, between(1, 5))
-            .mapToObj(n -> new Doc(n, randomFrom("red", "yellow", "green"), randomIntBetween(1, 1000)))
+            .mapToObj(n -> {
+                String color = randomFrom("red", "yellow", "green");
+                int data = randomValueOtherThanMany(i -> randomDocsData.contains(i), () -> randomIntBetween(1, 1000));
+                randomDocsData.add(data);
+                return new Doc(n, color, data);
+            })
             .toList();
         createIndex(
             localClient,


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/131697
Fixes https://github.com/elastic/elasticsearch/issues/131166

The test data for the lookup indices was sometimes creating identical lookup join key values and, thus, messing up the documents returned and, implicitly, the counts.