### PR TITLE
[9.1] [DOCS] Highlight the subscription requirement for synthetic `_source` (#133443)

### DIFF
--- a/docs/reference/elasticsearch/mapping-reference/mapping-source-field.md
+++ b/docs/reference/elasticsearch/mapping-reference/mapping-source-field.md
@@ -14,7 +14,11 @@ If disk usage is important to you, then consider the following options:
 
 ## Synthetic `_source` [synthetic-source]
 
-Though very handy to have around, the source field takes up a significant amount of space on disk. Instead of storing source documents on disk exactly as you send them, Elasticsearch can reconstruct source content on the fly upon retrieval. To enable this [subscription](https://www.elastic.co/subscriptions) feature, use the value `synthetic` for the index setting `index.mapping.source.mode`:
+:::{note}
+This feature requires a [subscription](https://www.elastic.co/subscriptions).
+:::
+
+Though very handy to have around, the source field takes up a significant amount of space on disk. Instead of storing source documents on disk exactly as you send them, Elasticsearch can reconstruct source content on the fly upon retrieval. To enable this feature, use the value `synthetic` for the index setting `index.mapping.source.mode`:
 
 $$$enable-synthetic-source-example$$$
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[DOCS] Highlight the subscription requirement for synthetic `_source` (#133443)](https://github.com/elastic/elasticsearch/pull/133443)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)