### PR TITLE
Fix generating docker exports by triggering assemble

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -668,6 +668,11 @@ subprojects { Project subProject ->
       dependsOn compressExportTask
     }
 
+    tasks.named('assemble').configure {
+      dependsOn exportTask
+    }
+
+    // deprecated here for backwards compatibility of DistroTestPlugin and DistributionDownloadPlugin
     artifacts.add('default', file(tarFile)) {
       type = 'tar'
       name = artifactName


### PR DESCRIPTION
The kibana team relies on using `:distribution:docker:docker-export:assemble` which
has been broken after the gradle 9.0 update due to
the (by now known) change in behaviour of not tying default artifacts to
the assemble task anymore.

The recommended fix is, setting this up explicitly.