### PR TITLE
[8.18] Fix generating docker exports by triggering assemble (#133475)

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -588,6 +588,11 @@ subprojects { Project subProject ->
       dependsOn compressExportTask
     }
 
+    tasks.named('assemble').configure {
+      dependsOn exportTask
+    }
+
+    // deprecated here for backwards compatibility of DistroTestPlugin and DistributionDownloadPlugin
     artifacts.add('default', file(tarFile)) {
       type = 'tar'
       name = artifactName


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Fix generating docker exports by triggering assemble (#133475)