### PR TITLE
Add 'elasticsearch' crosslink to docset.yml

### DIFF
--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -13,6 +13,7 @@ cross_links:
   - docs-content
   - ecs
   - eland
+  - elasticsearch
   - elasticsearch-hadoop
   - elasticsearch-java
   - elasticsearch-js


### PR DESCRIPTION
As per https://github.com/elastic/docs-content/pull/2658  Certain links to `docs-content` redirect/rewrite themselves back into documentation now living in `elasticsearch`.

To ensure these resolve this now ensures we fetch elasticsearch's own crosslinks. 

cc @leemthompo
