### PR TITLE
Gate disable norms on text fields for logsdb/tsdb indices

### DIFF
--- a/docs/changelog/133493.yaml
+++ b/docs/changelog/133493.yaml
@@ -1,0 +1,5 @@
+pr: 133493
+summary: Gate disable norms on text fields for logsdb/tsdb indices
+area: Mapping
+type: bug
+issues: []

--- a/docs/changelog/133493.yaml
+++ b/docs/changelog/133493.yaml
@@ -1,5 +1,0 @@
-pr: 133493
-summary: Gate disable norms on text fields for logsdb/tsdb indices
-area: Mapping
-type: bug
-issues: []

--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -182,6 +182,7 @@ public class IndexVersions {
     public static final IndexVersion MATCH_ONLY_TEXT_STORED_AS_BYTES = def(9_033_0_00, Version.LUCENE_10_2_2);
     public static final IndexVersion IGNORED_SOURCE_FIELDS_PER_ENTRY_WITH_FF = def(9_034_0_00, Version.LUCENE_10_2_2);
     public static final IndexVersion EXCLUDE_SOURCE_VECTORS_DEFAULT = def(9_035_0_00, Version.LUCENE_10_2_2);
+    public static final IndexVersion DISABLE_NORMS_BY_DEFAULT_FOR_LOGSDB_AND_TSDB = def(9_036_0_00, Version.LUCENE_10_2_2);
 
     /*
      * STOP! READ THIS FIRST! No, really,


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/131317 is blocking serverless deployments because [Lucene doesn't allow norms to be changed](https://github.com/apache/lucene/blob/dbaf97f5dcc75078b3ac1fdc512b9ab5cf60b726/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java#L1498), and since we're changing them, we end up hitting the [following Lucene bug](https://github.com/apache/lucene/pull/15125).

Our [docs](https://www.elastic.co/docs/reference/elasticsearch/mapping-reference/norms) and [code](https://github.com/elastic/elasticsearch/blob/79b86c8a8ea04ac1bcbe86360a004d98376ba375/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java#L1331) need to be updated since we document that norms can be disabled (true -> false). This doesn't align with that Lucene has. I will follow up with another PR to update them.