### PR TITLE
Add appropriate capability check to a yaml test

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/46_downsample.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/46_downsample.yml
@@ -377,7 +377,7 @@ setup:
         - method: POST
           path: /_query
           parameters: []
-          capabilities: [aggregate_metric_double_implicit_casting_in_aggs]
+          capabilities: [metrics_command, aggregate_metric_double_implicit_casting_in_aggs]
       reason: "Support for casting aggregate metric double implicitly when present in aggregations"
 
   - do:
@@ -499,7 +499,7 @@ setup:
         - method: POST
           path: /_query
           parameters: []
-          capabilities: [aggregate_metric_double_implicit_casting_in_aggs]
+          capabilities: [metrics_command, aggregate_metric_double_implicit_casting_in_aggs]
       reason: "Support for casting aggregate metric double implicitly when present in aggregations"
 
   - do:


### PR DESCRIPTION
These two tests use the TS command, but they don't require the `metrics_command` capability.  I think this is the source of some odd test behavior I'm seeing on another PR, and hopefully adding the required capability will fix it.  It shouldn't hurt, at least.