### PR TITLE
Move IndexService out of ReaderContext

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
@@ -164,6 +164,7 @@ final class DefaultSearchContext extends SearchContext {
 
     DefaultSearchContext(
         ReaderContext readerContext,
+        IndexService indexService,
         ShardSearchRequest request,
         SearchShardTarget shardTarget,
         LongSupplier relativeTimeSupplier,
@@ -183,7 +184,7 @@ final class DefaultSearchContext extends SearchContext {
         try {
             this.searchType = request.searchType();
             this.shardTarget = shardTarget;
-            this.indexService = readerContext.indexService();
+            this.indexService = indexService;
             this.indexShard = readerContext.indexShard();
             this.memoryAccountingBufferSize = memoryAccountingBufferSize;
 
@@ -193,7 +194,7 @@ final class DefaultSearchContext extends SearchContext {
                 request,
                 resultsType,
                 enableQueryPhaseParallelCollection,
-                field -> getFieldCardinality(field, readerContext.indexService(), engineSearcher.getDirectoryReader())
+                field -> getFieldCardinality(field, indexService, engineSearcher.getDirectoryReader())
             );
             if (executor == null || maximumNumberOfSlices <= 1) {
                 this.searcher = new ContextIndexSearcher(

--- a/server/src/main/java/org/elasticsearch/search/internal/LegacyReaderContext.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/LegacyReaderContext.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.search.internal;
 
-import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.search.RescoreDocIds;
@@ -27,13 +26,12 @@ public final class LegacyReaderContext extends ReaderContext {
 
     public LegacyReaderContext(
         ShardSearchContextId id,
-        IndexService indexService,
         IndexShard indexShard,
         Engine.SearcherSupplier reader,
         ShardSearchRequest shardSearchRequest,
         long keepAliveInMillis
     ) {
-        super(id, indexService, indexShard, reader, keepAliveInMillis, false);
+        super(id, indexShard, reader, keepAliveInMillis, false);
         assert shardSearchRequest.readerId() == null;
         assert shardSearchRequest.keepAlive() == null;
         assert id.getSearcherId() == null : "Legacy reader context must not have searcher id";

--- a/server/src/main/java/org/elasticsearch/search/internal/ReaderContext.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ReaderContext.java
@@ -13,7 +13,6 @@ import org.elasticsearch.core.AbstractRefCounted;
 import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
-import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.search.RescoreDocIds;
@@ -37,7 +36,6 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class ReaderContext implements Releasable {
     private final ShardSearchContextId id;
-    private final IndexService indexService;
     private final IndexShard indexShard;
     protected final Engine.SearcherSupplier searcherSupplier;
     private final AtomicBoolean closed = new AtomicBoolean(false);
@@ -57,14 +55,12 @@ public class ReaderContext implements Releasable {
     @SuppressWarnings("this-escape")
     public ReaderContext(
         ShardSearchContextId id,
-        IndexService indexService,
         IndexShard indexShard,
         Engine.SearcherSupplier searcherSupplier,
         long keepAliveInMillis,
         boolean singleSession
     ) {
         this.id = id;
-        this.indexService = indexService;
         this.indexShard = indexShard;
         this.searcherSupplier = searcherSupplier;
         this.singleSession = singleSession;
@@ -98,10 +94,6 @@ public class ReaderContext implements Releasable {
 
     public ShardSearchContextId id() {
         return id;
-    }
-
-    public IndexService indexService() {
-        return indexService;
     }
 
     public IndexShard indexShard() {

--- a/server/src/test/java/org/elasticsearch/search/DefaultSearchContextTests.java
+++ b/server/src/test/java/org/elasticsearch/search/DefaultSearchContextTests.java
@@ -172,7 +172,6 @@ public class DefaultSearchContextTests extends MapperServiceTestCase {
 
             ReaderContext readerWithoutScroll = new ReaderContext(
                 newContextId(),
-                indexService,
                 indexShard,
                 searcherSupplier.get(),
                 randomNonNegativeLong(),
@@ -180,6 +179,7 @@ public class DefaultSearchContextTests extends MapperServiceTestCase {
             );
             DefaultSearchContext contextWithoutScroll = new DefaultSearchContext(
                 readerWithoutScroll,
+                indexService,
                 shardSearchRequest,
                 target,
                 null,
@@ -214,7 +214,6 @@ public class DefaultSearchContextTests extends MapperServiceTestCase {
             when(shardSearchRequest.scroll()).thenReturn(TimeValue.timeValueMillis(randomInt(1000)));
             ReaderContext readerContext = new LegacyReaderContext(
                 newContextId(),
-                indexService,
                 indexShard,
                 searcherSupplier.get(),
                 shardSearchRequest,
@@ -223,6 +222,7 @@ public class DefaultSearchContextTests extends MapperServiceTestCase {
             try (
                 DefaultSearchContext context1 = new DefaultSearchContext(
                     readerContext,
+                    indexService,
                     shardSearchRequest,
                     target,
                     null,
@@ -288,14 +288,7 @@ public class DefaultSearchContextTests extends MapperServiceTestCase {
             }
 
             readerContext.close();
-            readerContext = new ReaderContext(
-                newContextId(),
-                indexService,
-                indexShard,
-                searcherSupplier.get(),
-                randomNonNegativeLong(),
-                false
-            ) {
+            readerContext = new ReaderContext(newContextId(), indexShard, searcherSupplier.get(), randomNonNegativeLong(), false) {
                 @Override
                 public ScrollContext scrollContext() {
                     ScrollContext scrollContext = new ScrollContext();
@@ -307,6 +300,7 @@ public class DefaultSearchContextTests extends MapperServiceTestCase {
             try (
                 DefaultSearchContext context2 = new DefaultSearchContext(
                     readerContext,
+                    indexService,
                     shardSearchRequest,
                     target,
                     null,
@@ -350,6 +344,7 @@ public class DefaultSearchContextTests extends MapperServiceTestCase {
             try (
                 DefaultSearchContext context3 = new DefaultSearchContext(
                     readerContext,
+                    indexService,
                     shardSearchRequest,
                     target,
                     null,
@@ -369,19 +364,13 @@ public class DefaultSearchContextTests extends MapperServiceTestCase {
                 when(searchExecutionContext.getFieldType(anyString())).thenReturn(mock(MappedFieldType.class));
 
                 readerContext.close();
-                readerContext = new ReaderContext(
-                    newContextId(),
-                    indexService,
-                    indexShard,
-                    searcherSupplier.get(),
-                    randomNonNegativeLong(),
-                    false
-                );
+                readerContext = new ReaderContext(newContextId(), indexShard, searcherSupplier.get(), randomNonNegativeLong(), false);
             }
 
             try (
                 DefaultSearchContext context4 = new DefaultSearchContext(
                     readerContext,
+                    indexService,
                     shardSearchRequest,
                     target,
                     null,
@@ -444,16 +433,10 @@ public class DefaultSearchContextTests extends MapperServiceTestCase {
                 }
             };
             SearchShardTarget target = new SearchShardTarget("node", shardId, null);
-            ReaderContext readerContext = new ReaderContext(
-                newContextId(),
-                indexService,
-                indexShard,
-                searcherSupplier,
-                randomNonNegativeLong(),
-                false
-            );
+            ReaderContext readerContext = new ReaderContext(newContextId(), indexShard, searcherSupplier, randomNonNegativeLong(), false);
             DefaultSearchContext context = new DefaultSearchContext(
                 readerContext,
+                indexService,
                 shardSearchRequest,
                 target,
                 null,
@@ -1066,7 +1049,6 @@ public class DefaultSearchContextTests extends MapperServiceTestCase {
 
             ReaderContext readerContext = new ReaderContext(
                 newContextId(),
-                indexService,
                 indexShard,
                 searcherSupplier.get(),
                 randomNonNegativeLong(),
@@ -1074,6 +1056,7 @@ public class DefaultSearchContextTests extends MapperServiceTestCase {
             );
             return new DefaultSearchContext(
                 readerContext,
+                indexService,
                 shardSearchRequest,
                 target,
                 null,

--- a/server/src/test/java/org/elasticsearch/search/SearchServiceSingleNodeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchServiceSingleNodeTests.java
@@ -2896,7 +2896,6 @@ public class SearchServiceSingleNodeTests extends ESSingleNodeTestCase {
     private static ReaderContext createReaderContext(IndexService indexService, IndexShard indexShard) {
         return new ReaderContext(
             new ShardSearchContextId(UUIDs.randomBase64UUID(), randomNonNegativeLong()),
-            indexService,
             indexShard,
             indexShard.acquireSearcherSupplier(),
             randomNonNegativeLong(),

--- a/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
@@ -1055,7 +1055,7 @@ public class QueryPhaseTests extends IndexShardTestCase {
 
             @Override
             public ReaderContext readerContext() {
-                return new ReaderContext(new ShardSearchContextId("test", 1L), null, indexShard, null, 0L, false);
+                return new ReaderContext(new ShardSearchContextId("test", 1L), indexShard, null, 0L, false);
             }
         }) {
 

--- a/server/src/test/java/org/elasticsearch/search/stats/ShardSearchStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/stats/ShardSearchStatsTests.java
@@ -271,7 +271,7 @@ public class ShardSearchStatsTests extends IndexShardTestCase {
     }
 
     private static ReaderContext createReaderContext(IndexShard indexShard) {
-        return new ReaderContext(new ShardSearchContextId("test", 1L), null, indexShard, null, 0L, false);
+        return new ReaderContext(new ShardSearchContextId("test", 1L), indexShard, null, 0L, false);
     }
 
     private static SearchContext createSearchContext(boolean suggested) {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/SecuritySearchOperationListenerTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/SecuritySearchOperationListenerTests.java
@@ -67,7 +67,6 @@ public class SecuritySearchOperationListenerTests extends ESSingleNodeTestCase {
         try (
             LegacyReaderContext readerContext = new LegacyReaderContext(
                 new ShardSearchContextId(UUIDs.randomBase64UUID(), 0L),
-                indexService,
                 shard,
                 shard.acquireSearcherSupplier(),
                 shardSearchRequest,
@@ -103,7 +102,6 @@ public class SecuritySearchOperationListenerTests extends ESSingleNodeTestCase {
         try (
             LegacyReaderContext readerContext = new LegacyReaderContext(
                 new ShardSearchContextId(UUIDs.randomBase64UUID(), 0L),
-                indexService,
                 shard,
                 shard.acquireSearcherSupplier(),
                 shardSearchRequest,
@@ -247,7 +245,6 @@ public class SecuritySearchOperationListenerTests extends ESSingleNodeTestCase {
         try (
             LegacyReaderContext readerContext = new LegacyReaderContext(
                 shardSearchContextId,
-                indexService,
                 shard,
                 shard.acquireSearcherSupplier(),
                 shardSearchRequest,


### PR DESCRIPTION
Currently ReaderContext holds an IndexService instance that is only used to later create a search context from it. In order to simplify re-creation of ReaderContext instances in the context of PIT resiliency, this change moves holding the instance directly to the search context.
