### PR TITLE
Handle concurrency exception with FutureUtils in QueryWrapperBitSetProducer#getBitSet

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/cache/bitset/BitsetFilterCache.java
+++ b/server/src/main/java/org/elasticsearch/index/cache/bitset/BitsetFilterCache.java
@@ -24,7 +24,6 @@ import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.BitDocIdSet;
 import org.apache.lucene.util.BitSet;
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.cache.Cache;
@@ -35,6 +34,7 @@ import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
+import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
@@ -236,7 +236,7 @@ public final class BitsetFilterCache
             try {
                 return getAndLoadIfNotPresent(query, context);
             } catch (ExecutionException e) {
-                throw ExceptionsHelper.convertToElastic(e);
+                throw FutureUtils.rethrowExecutionException(e);
             }
         }
 


### PR DESCRIPTION
We are currently blindly converting a ExecutionException to an Elasticsearch exception which can result on harmless exceptions to be reported as 500 exceptions. In order to avoid that this commit changes how to handle those exceptions using FutureUtils#rethrowExecutionException which unwraps the underlaying exception if it is a runtime exception.

fixes https://github.com/elastic/elasticsearch/issues/131548