### PR TITLE
[DOCS] Enable cumulative docs comment bot in docs build workflow

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -13,6 +13,7 @@ jobs:
     with:
       path-pattern: docs/**
       path-pattern-ignore: docs/changelog/**/*.yaml
+      enable-cumulative-comment: true
     permissions:
       deployments: write
       id-token: write


### PR DESCRIPTION
Per https://github.com/elastic/docs-builder/pull/1667
