### PR TITLE
[8.17] [Gradle] Avoid usage of archives configuration (#133526)

### DIFF
--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -630,22 +630,6 @@ subprojects {
   }
 }
 
-['archives:windows-zip',
- 'archives:darwin-tar',
- 'archives:darwin-aarch64-tar',
- 'archives:linux-aarch64-tar',
- 'archives:linux-tar',
- 'archives:integ-test-zip',
- 'packages:rpm', 'packages:deb',
- 'packages:aarch64-rpm', 'packages:aarch64-deb',
-].forEach { subName ->
-  Project subproject = project("${project.path}:${subName}")
-  Configuration configuration = configurations.create(subproject.name)
-  dependencies {
-    "${configuration.name}" project(path: subproject.path, configuration:'default')
-  }
-}
-
 // This artifact makes it possible for other projects to pull
 // in the final log4j2.properties configuration, as it appears in the
 // archive distribution.

--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -106,9 +106,9 @@ def mlCppVersion(){
       (project.version + "-SNAPSHOT") : project.version;
 }
 
-artifacts {
-  // normal es plugins do not publish the jar but we need to since users need it for extensions
-  archives tasks.named("jar")
+
+tasks.named('assemble').configure {
+  dependsOn tasks.named('jar')
 }
 
 tasks.register("extractNativeLicenses", Copy) {

--- a/x-pack/plugin/security/build.gradle
+++ b/x-pack/plugin/security/build.gradle
@@ -173,9 +173,10 @@ tasks.named("processTestResources").configure {
   from(project(xpackModule('core')).file('src/test/resources'))
 }
 
-artifacts {
+
+tasks.named('assemble').configure {
   // normal es plugins do not publish the jar but we need to since users need it for extensions
-  archives tasks.named("jar")
+  dependsOn tasks.named('jar')
 }
 
 tasks.named("dependencyLicenses").configure {

--- a/x-pack/rest-resources-zip/build.gradle
+++ b/x-pack/rest-resources-zip/build.gradle
@@ -56,6 +56,6 @@ def restResourcesZip = tasks.register('restResourcesZip', Zip) {
   }
 }
 
-artifacts {
-  archives restResourcesZip
+tasks.named('assemble').configure {
+  dependsOn restResourcesZip
 }


### PR DESCRIPTION
Backports the following commits to 8.17:
 - [Gradle] Avoid usage of archives configuration (#133526)