### PR TITLE
Execute single shard each pipeline for rate

### DIFF
--- a/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DownsampleIT.java
+++ b/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DownsampleIT.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.downsample;
 
-import org.elasticsearch.Build;
 import org.elasticsearch.action.admin.cluster.node.capabilities.NodesCapabilitiesRequest;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.admin.indices.delete.TransportDeleteIndexAction;
@@ -28,7 +27,6 @@ import org.elasticsearch.xpack.esql.action.ColumnInfoImpl;
 import org.elasticsearch.xpack.esql.action.EsqlQueryAction;
 import org.elasticsearch.xpack.esql.action.EsqlQueryRequest;
 import org.elasticsearch.xpack.esql.action.EsqlQueryResponse;
-import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -296,15 +294,11 @@ public class DownsampleIT extends DownsamplingIntegTestCase {
             }
 
             // tests on counter types
-            // TODO: remove hard-coded pragmas
-            assumeTrue("query pragmas require snapshot build", Build.current().isSnapshot());
-            var ratePragmas = new QueryPragmas(Settings.builder().put(QueryPragmas.MAX_CONCURRENT_SHARDS_PER_NODE.getKey(), 1).build());
-
             for (String innerCommand : List.of("rate")) {
                 String command = outerCommand + " (" + innerCommand + "(request))";
                 String esqlQuery = "TS " + dataStreamName + " | STATS " + command + " by cluster, bucket(@timestamp, 1 hour)";
                 try (
-                    var resp = client().execute(EsqlQueryAction.INSTANCE, new EsqlQueryRequest().query(esqlQuery).pragmas(ratePragmas))
+                    var resp = client().execute(EsqlQueryAction.INSTANCE, new EsqlQueryRequest().query(esqlQuery))
                         .actionGet(30, TimeUnit.SECONDS)
                 ) {
                     var columns = resp.columns();

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/TimeSeriesIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/TimeSeriesIT.java
@@ -7,15 +7,20 @@
 
 package org.elasticsearch.xpack.esql.action;
 
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.iterable.Iterables;
+import org.elasticsearch.compute.lucene.LuceneSourceOperator;
 import org.elasticsearch.compute.lucene.TimeSeriesSourceOperator;
 import org.elasticsearch.compute.operator.DriverProfile;
 import org.elasticsearch.compute.operator.OperatorStatus;
 import org.elasticsearch.compute.operator.TimeSeriesAggregationOperator;
 import org.elasticsearch.xpack.esql.EsqlTestUtils;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 
 import java.util.ArrayList;
@@ -481,33 +486,113 @@ public class TimeSeriesIT extends AbstractEsqlIntegTestCase {
         }
     }
 
-    public void testRateProfile() {
-        EsqlQueryRequest request = new EsqlQueryRequest();
-        request.profile(true);
-        request.query("TS hosts | STATS sum(rate(request_count)) BY cluster, bucket(@timestamp, 1minute) | SORT cluster");
-        try (var resp = run(request)) {
-            EsqlQueryResponse.Profile profile = resp.profile();
-            List<DriverProfile> dataProfiles = profile.drivers().stream().filter(d -> d.description().equals("data")).toList();
-            int totalTimeSeries = 0;
-            for (DriverProfile p : dataProfiles) {
-                if (p.operators().stream().anyMatch(s -> s.status() instanceof TimeSeriesSourceOperator.Status)) {
-                    totalTimeSeries++;
-                    assertThat(p.operators(), hasSize(2));
-                    assertThat(p.operators().get(1).operator(), equalTo("ExchangeSinkOperator"));
-                } else if (p.operators().stream().anyMatch(s -> s.status() instanceof TimeSeriesAggregationOperator.Status)) {
-                    assertThat(p.operators(), hasSize(3));
-                    assertThat(p.operators().get(0).operator(), equalTo("ExchangeSourceOperator"));
-                    assertThat(p.operators().get(1).operator(), containsString("TimeSeriesAggregationOperator"));
-                    assertThat(p.operators().get(2).operator(), equalTo("ExchangeSinkOperator"));
-                } else {
-                    assertThat(p.operators(), hasSize(4));
-                    assertThat(p.operators().get(0).operator(), equalTo("ExchangeSourceOperator"));
-                    assertThat(p.operators().get(1).operator(), containsString("TimeSeriesExtractFieldOperator"));
-                    assertThat(p.operators().get(2).operator(), containsString("EvalOperator"));
-                    assertThat(p.operators().get(3).operator(), equalTo("ExchangeSinkOperator"));
+    public void testProfile() {
+        String dataNode = Iterables.get(clusterService().state().getNodes().getDataNodes().keySet(), 0);
+        Settings indexSettings = Settings.builder()
+            .put("mode", "time_series")
+            .putList("routing_path", List.of("host", "cluster"))
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 3)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put("index.routing.allocation.require._id", dataNode)
+            .build();
+        String index = "my-hosts";
+        client().admin()
+            .indices()
+            .prepareCreate(index)
+            .setSettings(indexSettings)
+            .setMapping(
+                "@timestamp",
+                "type=date",
+                "host",
+                "type=keyword,time_series_dimension=true",
+                "cluster",
+                "type=keyword,time_series_dimension=true",
+                "memory",
+                "type=long,time_series_metric=gauge",
+                "request_count",
+                "type=integer,time_series_metric=counter"
+            )
+            .get();
+        Randomness.shuffle(docs);
+        for (Doc doc : docs) {
+            client().prepareIndex(index)
+                .setSource(
+                    "@timestamp",
+                    doc.timestamp,
+                    "host",
+                    doc.host,
+                    "cluster",
+                    doc.cluster,
+                    "memory",
+                    doc.memory.getBytes(),
+                    "cpu",
+                    doc.cpu,
+                    "request_count",
+                    doc.requestCount
+                )
+                .get();
+        }
+        client().admin().indices().prepareRefresh(index).get();
+        QueryPragmas pragmas = new QueryPragmas(
+            Settings.builder()
+                .put(QueryPragmas.MAX_CONCURRENT_SHARDS_PER_NODE.getKey(), between(3, 10))
+                .put(QueryPragmas.TASK_CONCURRENCY.getKey(), 1)
+                .build()
+        );
+        // The rate aggregation is executed with one shard at a time
+        {
+            EsqlQueryRequest request = new EsqlQueryRequest();
+            request.profile(true);
+            request.pragmas(pragmas);
+            request.acceptedPragmaRisks(true);
+            request.query("TS my-hosts | STATS sum(rate(request_count)) BY cluster, bucket(@timestamp, 1minute) | SORT cluster");
+            try (var resp = run(request)) {
+                EsqlQueryResponse.Profile profile = resp.profile();
+                List<DriverProfile> dataProfiles = profile.drivers().stream().filter(d -> d.description().equals("data")).toList();
+                for (DriverProfile p : dataProfiles) {
+                    if (p.operators().stream().anyMatch(s -> s.status() instanceof TimeSeriesSourceOperator.Status)) {
+                        assertThat(p.operators(), hasSize(2));
+                        TimeSeriesSourceOperator.Status status = (TimeSeriesSourceOperator.Status) p.operators().get(0).status();
+                        assertThat(status.processedShards(), hasSize(1));
+                        assertThat(p.operators().get(1).operator(), equalTo("ExchangeSinkOperator"));
+                    } else if (p.operators().stream().anyMatch(s -> s.status() instanceof TimeSeriesAggregationOperator.Status)) {
+                        assertThat(p.operators(), hasSize(3));
+                        assertThat(p.operators().get(0).operator(), equalTo("ExchangeSourceOperator"));
+                        assertThat(p.operators().get(1).operator(), containsString("TimeSeriesAggregationOperator"));
+                        assertThat(p.operators().get(2).operator(), equalTo("ExchangeSinkOperator"));
+                    } else {
+                        assertThat(p.operators(), hasSize(4));
+                        assertThat(p.operators().get(0).operator(), equalTo("ExchangeSourceOperator"));
+                        assertThat(p.operators().get(1).operator(), containsString("TimeSeriesExtractFieldOperator"));
+                        assertThat(p.operators().get(2).operator(), containsString("EvalOperator"));
+                        assertThat(p.operators().get(3).operator(), equalTo("ExchangeSinkOperator"));
+                    }
                 }
+                assertThat(dataProfiles, hasSize(9));
             }
-            assertThat(totalTimeSeries, equalTo(dataProfiles.size() / 3));
+        }
+        // non-rate aggregation is executed with multiple shards at a time
+        {
+            EsqlQueryRequest request = new EsqlQueryRequest();
+            request.profile(true);
+            request.pragmas(pragmas);
+            request.acceptedPragmaRisks(true);
+            request.query("TS my-hosts | STATS avg(avg_over_time(cpu)) BY cluster, bucket(@timestamp, 1minute) | SORT cluster");
+            try (var resp = run(request)) {
+                EsqlQueryResponse.Profile profile = resp.profile();
+                List<DriverProfile> dataProfiles = profile.drivers().stream().filter(d -> d.description().equals("data")).toList();
+                assertThat(dataProfiles, hasSize(1));
+                List<OperatorStatus> ops = dataProfiles.get(0).operators();
+                assertThat(ops, hasSize(5));
+                assertThat(ops.get(0).operator(), containsString("LuceneSourceOperator"));
+                assertThat(ops.get(0).status(), Matchers.instanceOf(LuceneSourceOperator.Status.class));
+                LuceneSourceOperator.Status status = (LuceneSourceOperator.Status) ops.get(0).status();
+                assertThat(status.processedShards(), hasSize(3));
+                assertThat(ops.get(1).operator(), containsString("EvalOperator"));
+                assertThat(ops.get(2).operator(), containsString("ValuesSourceReaderOperator"));
+                assertThat(ops.get(3).operator(), containsString("TimeSeriesAggregationOperator"));
+                assertThat(ops.get(4).operator(), containsString("ExchangeSinkOperator"));
+            }
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
@@ -159,6 +159,15 @@ public class PlannerUtils {
         return indices.toArray(String[]::new);
     }
 
+    public static boolean requiresSortedTimeSeriesSource(PhysicalPlan plan) {
+        return plan.anyMatch(e -> {
+            if (e instanceof FragmentExec f) {
+                return f.fragment().anyMatch(l -> l instanceof EsRelation r && r.indexMode() == IndexMode.TIME_SERIES);
+            }
+            return false;
+        });
+    }
+
     private static void forEachRelation(PhysicalPlan plan, Consumer<EsRelation> action) {
         plan.forEachDown(FragmentExec.class, f -> f.fragment().forEachDown(EsRelation.class, r -> {
             if (r.indexMode() != IndexMode.LOOKUP) {


### PR DESCRIPTION
For each pipeline in rate aggregation, we use 3 drivers and execute one shard at a time; therefore, the maximum parallelism per query on data nodes is 3. Unlike non-rate aggregations, we cannot partition shards into multiple slices for concurrent execution, which is one of several limitations of rate aggregation. These changes adjust the data node executor to run multiple pipelines simultaneously, with each pipeline handling a single shard to increase parallelism when there are multiple target shards on data nodes.

This change is expected to improve benchmark by 3 times.