### PR TITLE
Throw away test dates with year greater than 9999

### DIFF
--- a/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/patternedtext/PatternedTextVsMatchOnlyTextTests.java
+++ b/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/patternedtext/PatternedTextVsMatchOnlyTextTests.java
@@ -260,8 +260,9 @@ public class PatternedTextVsMatchOnlyTextTests extends ESIntegTestCase {
     private static String randomTimestamp() {
         // The random millis are below year 10000 in UTC, but if the date is within 1 day of year 10000, the year can be 10000 in the
         // selected timezone. Since the date formatter cannot handle years greater than 9999, select another date.
-        var zonedDateTime = randomValueOtherThanMany(t -> t.getYear() == 10000, () ->
-            ZonedDateTime.ofInstant(Instant.ofEpochMilli(randomMillisUpToYear9999()), randomZone())
+        var zonedDateTime = randomValueOtherThanMany(
+            t -> t.getYear() == 10000,
+            () -> ZonedDateTime.ofInstant(Instant.ofEpochMilli(randomMillisUpToYear9999()), randomZone())
         );
         DateFormatter formatter = DateFormatter.forPattern(randomDateFormatterPattern()).withLocale(randomLocale(random()));
         return formatter.format(zonedDateTime);

--- a/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/patternedtext/PatternedTextVsMatchOnlyTextTests.java
+++ b/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/patternedtext/PatternedTextVsMatchOnlyTextTests.java
@@ -263,8 +263,8 @@ public class PatternedTextVsMatchOnlyTextTests extends ESIntegTestCase {
             long millis = randomMillisUpToYear9999();
             zonedDateTime = ZonedDateTime.ofInstant(Instant.ofEpochMilli(millis), randomZone());
 
-        // The random millis are below year 10000 in UTC, but if the date is within 1 day of year 10000, the year can be 10000 in the
-        // selected timezone. Since the date formatter cannot handle years greater than 9999, select another date.
+            // The random millis are below year 10000 in UTC, but if the date is within 1 day of year 10000, the year can be 10000 in the
+            // selected timezone. Since the date formatter cannot handle years greater than 9999, select another date.
         } while (zonedDateTime.getYear() == 10000);
 
         DateFormatter formatter = DateFormatter.forPattern(randomDateFormatterPattern()).withLocale(randomLocale(random()));

--- a/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/patternedtext/PatternedTextVsMatchOnlyTextTests.java
+++ b/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/patternedtext/PatternedTextVsMatchOnlyTextTests.java
@@ -258,8 +258,15 @@ public class PatternedTextVsMatchOnlyTextTests extends ESIntegTestCase {
     }
 
     private static String randomTimestamp() {
-        long millis = randomMillisUpToYear9999();
-        ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(Instant.ofEpochMilli(millis), randomZone());
+        ZonedDateTime zonedDateTime;
+        do {
+            long millis = randomMillisUpToYear9999();
+            zonedDateTime = ZonedDateTime.ofInstant(Instant.ofEpochMilli(millis), randomZone());
+
+        // The random millis are below year 10000 in UTC, but if the date is within 1 day of year 10000, the year can be 10000 in the
+        // selected timezone. Since the date formatter cannot handle years greater than 9999, select another date.
+        } while (zonedDateTime.getYear() == 10000);
+
         DateFormatter formatter = DateFormatter.forPattern(randomDateFormatterPattern()).withLocale(randomLocale(random()));
         return formatter.format(zonedDateTime);
     }

--- a/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/patternedtext/PatternedTextVsMatchOnlyTextTests.java
+++ b/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/patternedtext/PatternedTextVsMatchOnlyTextTests.java
@@ -258,15 +258,11 @@ public class PatternedTextVsMatchOnlyTextTests extends ESIntegTestCase {
     }
 
     private static String randomTimestamp() {
-        ZonedDateTime zonedDateTime;
-        do {
-            long millis = randomMillisUpToYear9999();
-            zonedDateTime = ZonedDateTime.ofInstant(Instant.ofEpochMilli(millis), randomZone());
-
-            // The random millis are below year 10000 in UTC, but if the date is within 1 day of year 10000, the year can be 10000 in the
-            // selected timezone. Since the date formatter cannot handle years greater than 9999, select another date.
-        } while (zonedDateTime.getYear() == 10000);
-
+        // The random millis are below year 10000 in UTC, but if the date is within 1 day of year 10000, the year can be 10000 in the
+        // selected timezone. Since the date formatter cannot handle years greater than 9999, select another date.
+        var zonedDateTime = randomValueOtherThanMany(t -> t.getYear() == 10000, () ->
+            ZonedDateTime.ofInstant(Instant.ofEpochMilli(randomMillisUpToYear9999()), randomZone())
+        );
         DateFormatter formatter = DateFormatter.forPattern(randomDateFormatterPattern()).withLocale(randomLocale(random()));
         return formatter.format(zonedDateTime);
     }


### PR DESCRIPTION
The patterned_text random testing code picks dates with year less 10000, as the date formatter cannot handle years with 5 digits. Since  a random time zone is used, if a date is within 1 day of year 10k, the formatted date in the selected timezone may be year 10k. If this occurs, just pick a different date.

Fixes https://github.com/elastic/elasticsearch/issues/133598