### PR TITLE
Update distro packaging when testing java ea versions

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/BuildParameterExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/BuildParameterExtension.java
@@ -32,6 +32,8 @@ public interface BuildParameterExtension {
 
     Boolean getIsRuntimeJavaHomeSet();
 
+    Boolean getIsEarlyAccessRuntimeJavaVersion();
+
     List<JavaHome> getJavaVersions();
 
     JavaVersion getMinimumCompilerVersion();

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/DefaultBuildParameterExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/DefaultBuildParameterExtension.java
@@ -29,6 +29,7 @@ public abstract class DefaultBuildParameterExtension implements BuildParameterEx
     private final Provider<Boolean> inFipsJvm;
     private final Provider<File> runtimeJavaHome;
     private final Boolean isRuntimeJavaHomeSet;
+    private final Boolean earlyAccessJavaRuntime;
     private final List<JavaHome> javaVersions;
     private final JavaVersion minimumCompilerVersion;
     private final JavaVersion minimumRuntimeVersion;
@@ -54,6 +55,7 @@ public abstract class DefaultBuildParameterExtension implements BuildParameterEx
         Provider<? extends Action<JavaToolchainSpec>> javaToolChainSpec,
         Provider<JavaVersion> runtimeJavaVersion,
         boolean isRuntimeJavaHomeSet,
+        boolean earlyAccessJavaRuntime,
         Provider<String> runtimeJavaDetails,
         List<JavaHome> javaVersions,
         JavaVersion minimumCompilerVersion,
@@ -72,6 +74,7 @@ public abstract class DefaultBuildParameterExtension implements BuildParameterEx
         this.javaToolChainSpec = cache(providers, javaToolChainSpec);
         this.runtimeJavaVersion = cache(providers, runtimeJavaVersion);
         this.isRuntimeJavaHomeSet = isRuntimeJavaHomeSet;
+        this.earlyAccessJavaRuntime = earlyAccessJavaRuntime;
         this.runtimeJavaDetails = cache(providers, runtimeJavaDetails);
         this.javaVersions = javaVersions;
         this.minimumCompilerVersion = minimumCompilerVersion;
@@ -118,6 +121,12 @@ public abstract class DefaultBuildParameterExtension implements BuildParameterEx
     public Boolean getIsRuntimeJavaHomeSet() {
         return isRuntimeJavaHomeSet;
     }
+
+    @Override
+    public Boolean getIsEarlyAccessRuntimeJavaVersion() {
+        return earlyAccessJavaRuntime;
+    }
+
 
     @Override
     public List<JavaHome> getJavaVersions() {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/DefaultBuildParameterExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/DefaultBuildParameterExtension.java
@@ -127,7 +127,6 @@ public abstract class DefaultBuildParameterExtension implements BuildParameterEx
         return earlyAccessJavaRuntime;
     }
 
-
     @Override
     public List<JavaHome> getJavaVersions() {
         return javaVersions;

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPlugin.java
@@ -118,14 +118,12 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
 
         RuntimeJavaHome runtimeJavaHome = findRuntimeJavaHome();
 
-        Provider<JvmInstallationMetadata> runtimeJdkMetaData = runtimeJavaHome.getJavahome().map(
-            j -> metadataDetector.getMetadata(getJavaInstallation(j))
-        );
+        Provider<JvmInstallationMetadata> runtimeJdkMetaData = runtimeJavaHome.getJavahome()
+            .map(j -> metadataDetector.getMetadata(getJavaInstallation(j)));
         AtomicReference<BwcVersions> cache = new AtomicReference<>();
         Provider<BwcVersions> bwcVersionsProvider = providers.provider(
             () -> cache.updateAndGet(val -> val == null ? resolveBwcVersions() : val)
         );
-
 
         BuildParameterExtension buildParams = project.getExtensions()
             .create(
@@ -362,14 +360,10 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
         // fall back to tool chain if set.
         String env = System.getenv("JAVA_TOOLCHAIN_HOME");
         boolean explicitlySet = env != null;
-        Provider<File> javaHome = explicitlySet ?
-            providers.provider(() -> new File(env)) :
-            resolveJavaHomeFromToolChainService(VersionProperties.getBundledJdkMajorVersion());
-        return
-            new RuntimeJavaHome(
-                javaHome,
-                explicitlySet,
-                false);
+        Provider<File> javaHome = explicitlySet
+            ? providers.provider(() -> new File(env))
+            : resolveJavaHomeFromToolChainService(VersionProperties.getBundledJdkMajorVersion());
+        return new RuntimeJavaHome(javaHome, explicitlySet, false);
     }
 
     private Provider<File> resolveEarlyAccessJavaHome(Integer runtimeJavaProperty) {

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -20,6 +20,8 @@ import org.elasticsearch.gradle.transform.FilteringJarTransform
 import java.nio.file.Files
 import java.nio.file.Path
 
+import static org.elasticsearch.gradle.internal.toolchain.EarlyAccessCatalogJdkToolchainResolver.findLatestEABuildNumber
+
 plugins {
   id 'base'
   id 'elasticsearch.distro'
@@ -48,9 +50,9 @@ dependencies {
 
 def thisProj = project
 rootProject.allprojects { proj ->
-    proj.plugins.withType(DependenciesInfoPlugin) {
-      thisProj.dependencies.add("dependencyInfos", project.dependencies.project(path: proj.path))
-    }
+  proj.plugins.withType(DependenciesInfoPlugin) {
+    thisProj.dependencies.add("dependencyInfos", project.dependencies.project(path: proj.path))
+  }
 }
 
 /*****************************************************************************
@@ -61,9 +63,10 @@ rootProject.allprojects { proj ->
 tasks.register("generateDependenciesReport", ConcatFilesTask) {
   files = configurations.dependencyInfos
   headerLine = "name,version,url,license,sourceURL"
-  target = new File(providers.systemProperty('csv')
-                      .orElse("${project.buildDir}/reports/dependencies/es-dependencies.csv")
-                      .get()
+  target = new File(
+    providers.systemProperty('csv')
+      .orElse("${project.buildDir}/reports/dependencies/es-dependencies.csv")
+      .get()
   )
   // explicitly add our dependency on the JDK
   String jdkVersion = VersionProperties.versions.get('bundled_jdk').split('@')[0]
@@ -246,19 +249,44 @@ configure(subprojects.findAll { ['archives', 'packages'].contains(it.name) }) {
   apply plugin: 'elasticsearch.jdk-download'
   apply plugin: 'elasticsearch.repositories'
 
-  // Setup all required JDKs
-  project.jdks {
-    ['darwin', 'windows', 'linux'].each { platform ->
-      (platform == 'linux' || platform == 'darwin' ? ['x64', 'aarch64'] : ['x64']).each { architecture ->
-        "bundled_${platform}_${architecture}" {
-          it.platform = platform
-          it.version = VersionProperties.bundledJdkVersion
-          it.vendor = VersionProperties.bundledJdkVendor
-          it.architecture = architecture
+  if (buildParams.getIsEarlyAccessRuntimeJavaVersion()) {
+    Integer buildNumber = Integer.getInteger("runtime.java.build");
+    def runtimeJavaMajorVersion = Integer.parseInt(buildParams.runtimeJavaVersion.get().getMajorVersion())
+    if (buildNumber == null) {
+      buildNumber = findLatestEABuildNumber(runtimeJavaMajorVersion);
+    }
+    String eaVersionString = String.format("%d-ea+%d", runtimeJavaMajorVersion, buildNumber);
+
+    project.jdks {
+      ['darwin', 'windows', 'linux'].each { platform ->
+        (platform == 'linux' || platform == 'darwin' ? ['x64', 'aarch64'] : ['x64']).each { architecture ->
+          "bundled_${platform}_${architecture}" {
+            it.version = eaVersionString;
+            it.vendor = "openjdk"
+            it.platform = platform
+            it.architecture = architecture
+            it.distributionVersion = "ea"
+          }
         }
       }
     }
+  } else {
+    // Setup all required JDKs
+    project.jdks {
+      ['darwin', 'windows', 'linux'].each { platform ->
+        (platform == 'linux' || platform == 'darwin' ? ['x64', 'aarch64'] : ['x64']).each { architecture ->
+          "bundled_${platform}_${architecture}" {
+            it.platform = platform
+            it.version = VersionProperties.bundledJdkVersion
+            it.vendor = VersionProperties.bundledJdkVendor
+            it.architecture = architecture
+          }
+        }
+      }
+    }
+
   }
+
 
   // TODO: the map needs to be an input of the tasks, so that when it changes, the task will re-run...
   /*****************************************************************************
@@ -288,7 +316,8 @@ configure(subprojects.findAll { ['archives', 'packages'].contains(it.name) }) {
     }
     all {
       resolutionStrategy.dependencySubstitution {
-        substitute module("org.apache.logging.log4j:log4j-core") using project(":libs:log4j") because "patched to remove JndiLookup class"}
+        substitute module("org.apache.logging.log4j:log4j-core") using project(":libs:log4j") because "patched to remove JndiLookup class"
+      }
     }
   }
 
@@ -354,7 +383,7 @@ configure(subprojects.findAll { ['archives', 'packages'].contains(it.name) }) {
         into('platform') {
           from(configurations.libsNative)
           if (os != null) {
-            include (os + '-' + architecture + '/*')
+            include(os + '-' + architecture + '/*')
           }
         }
         into('entitlement-agent') {
@@ -416,7 +445,7 @@ configure(subprojects.findAll { ['archives', 'packages'].contains(it.name) }) {
           // main config files, processed with distribution specific substitutions
           from '../src/config'
           exclude 'log4j2.properties' // this is handled separately below
-          filter("tokens" : expansionsForDistribution(distributionType, isTestDistro), ReplaceTokens.class)
+          filter("tokens": expansionsForDistribution(distributionType, isTestDistro), ReplaceTokens.class)
         }
         from buildDefaultLog4jConfigTaskProvider
         from isTestDistro ? integTestConfigFiles : defaultConfigFiles
@@ -431,11 +460,11 @@ configure(subprojects.findAll { ['archives', 'packages'].contains(it.name) }) {
           exclude '*.exe'
           exclude '*.bat'
           eachFile {
-            it.permissions{
+            it.permissions {
               unix(0755)
             }
           }
-          filter("tokens" : expansionsForDistribution(distributionType, testDistro), ReplaceTokens.class)
+          filter("tokens": expansionsForDistribution(distributionType, testDistro), ReplaceTokens.class)
         }
         // windows files, only for zip
         if (distributionType == 'zip') {
@@ -443,7 +472,7 @@ configure(subprojects.findAll { ['archives', 'packages'].contains(it.name) }) {
             from '../src/bin'
             include '*.bat'
             filter(FixCrLfFilter, eol: FixCrLfFilter.CrLf.newInstance('crlf'))
-            filter("tokens" : expansionsForDistribution(distributionType, testDistro), ReplaceTokens.class)
+            filter("tokens": expansionsForDistribution(distributionType, testDistro), ReplaceTokens.class)
           }
           with copySpec {
             from '../src/bin'
@@ -466,7 +495,7 @@ configure(subprojects.findAll { ['archives', 'packages'].contains(it.name) }) {
         if (testDistro) {
           from buildServerNoticeTaskProvider
         } else {
-          from (buildDefaultNoticeTaskProvider) {
+          from(buildDefaultNoticeTaskProvider) {
             filePermissions {
               unix(0644)
             }
@@ -547,57 +576,57 @@ subprojects {
     String footer = "# Built for ${project.name}-${project.version} " +
       "(${distributionType})"
     Map<String, Object> expansions = [
-      'project.name': project.name,
-      'project.version': version,
+      'project.name'         : project.name,
+      'project.version'      : version,
       'project.minor.version': "${VersionProperties.elasticsearchVersion.major}.${VersionProperties.elasticsearchVersion.minor}",
 
-      'path.conf': [
+      'path.conf'            : [
         'deb': '/etc/elasticsearch',
         'rpm': '/etc/elasticsearch',
         'def': '"$ES_HOME"/config'
       ],
-      'path.data': [
+      'path.data'            : [
         'deb': packagingPathData,
         'rpm': packagingPathData,
         'def': '#path.data: /path/to/data'
       ],
-      'path.env': [
+      'path.env'             : [
         'deb': '/etc/default/elasticsearch',
         'rpm': '/etc/sysconfig/elasticsearch',
         /* There isn't one of these files for tar or zip but its important to
           make an empty string here so the script can properly skip it. */
         'def': 'if [ -z "$ES_PATH_CONF" ]; then ES_PATH_CONF="$ES_HOME"/config; done',
       ],
-      'source.path.env': [
+      'source.path.env'      : [
         'deb': 'source /etc/default/elasticsearch',
         'rpm': 'source /etc/sysconfig/elasticsearch',
         'def': 'if [ -z "$ES_PATH_CONF" ]; then ES_PATH_CONF="$ES_HOME"/config; fi',
       ],
-      'path.logs': [
+      'path.logs'            : [
         'deb': packagingPathLogs,
         'rpm': packagingPathLogs,
         'def': '#path.logs: /path/to/logs'
       ],
 
-      'scripts.footer': [
+      'scripts.footer'       : [
         /* Debian needs exit 0 on these scripts so we add it here and preserve
           the pretty footer. */
         'deb': "exit 0\n${footer}",
         'def': footer
       ],
 
-      'es.distribution.type': [
+      'es.distribution.type' : [
         'deb': 'deb',
         'rpm': 'rpm',
         'tar': 'tar',
         'zip': 'zip'
       ],
 
-      'license.name': [
+      'license.name'         : [
         'deb': 'Elastic-License'
       ],
 
-      'license.text': [
+      'license.text'         : [
         'deb': licenseText,
       ],
     ]


### PR DESCRIPTION
We rely on archives for packaging serverless distros. 
This adds support for packaging archives containing java ea version when running with runtime java ea versions.