### PR TITLE
Add 'elasticsearch' to the docset configuration on 9.1 branch

### DIFF
--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -13,6 +13,7 @@ cross_links:
   - docs-content
   - ecs
   - eland
+  - elasticsearch
   - elasticsearch-hadoop
   - elasticsearch-java
   - elasticsearch-js


### PR DESCRIPTION
backport of: https://github.com/elastic/elasticsearch/pull/133491

To fix the backport of https://github.com/elastic/elasticsearch/pull/133459
