### PR TITLE
ES|QL: Fix CsvTests to not break randomized tests

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/union_types.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/union_types.csv-spec
@@ -2534,6 +2534,7 @@ required_capability: tbucket
 FROM sample_data_ts_nanos, sample_data
 | stats x = 1 day + tbucket(1 hour) by b1d = tbucket(1 hour)
 ;
+ignoreOrder:true
 
 x:date_nanos             | b1d:date_nanos
 2023-10-24T13:00:00.000Z | 2023-10-23T13:00:00.000Z


### PR DESCRIPTION
One of the tests for the tbucket function fails due to the random order of the results.

It can be reproduced by the following command:

```
./gradlew ":x-pack:plugin:esql:qa:server:mixed-cluster:bcUpgradeTest" -Dtests.class="org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT" -Dtests.method="test {csv-spec:union_types.MultiIndexTBucketGroupingAndAggregation}" -Dtests.seed=6FDF997729FCF32C -Dtests.bwc.main.version=9.2.0-SNAPSHOT -Dtests.bwc.refspec.main=54a24728971697d3f7af2d13fd33412d9f7dc145 -Dtests.locale=jv-ID -Dtests.timezone=MIT -Druntime.java=24
```