### PR TITLE
[9.1][DOCS] add availability to oversample value of 0 (#131707)

### DIFF
--- a/docs/reference/elasticsearch/mapping-reference/dense-vector.md
+++ b/docs/reference/elasticsearch/mapping-reference/dense-vector.md
@@ -277,7 +277,10 @@ $$$dense-vector-index-options$$$
 :   (Optional, object) An optional section that configures automatic vector rescoring on knn queries for the given field. Only applicable to quantized index types.
 :::::{dropdown} Properties of rescore_vector
 `oversample`
-:   (required, float) The amount to oversample the search results by. This value should be greater than `1.0` and less than `10.0` or exactly `0` to indicate no oversampling & rescoring should occur. The higher the value, the more vectors will be gathered and rescored with the raw values per shard.
+:   (required, float) The amount to oversample the search results by. This value should be one of the following: 
+    * Greater than `1.0` and less than `10.0` 
+    * Exactly `0` to indicate no oversampling and rescoring should occur {applies_to}`stack: ga 9.1`
+    :   The higher the value, the more vectors will be gathered and rescored with the raw values per shard.
     :   In case a knn query specifies a `rescore_vector` parameter, the query `rescore_vector` parameter will be used instead.
     :   See [oversampling and rescoring quantized vectors](docs-content://solutions/search/vector/knn.md#dense-vector-knn-search-rescoring) for details.
 :::::

--- a/docs/reference/query-languages/query-dsl/query-dsl-knn-query.md
+++ b/docs/reference/query-languages/query-dsl/query-dsl-knn-query.md
@@ -113,7 +113,9 @@ Rescoring only makes sense for quantized vectors; when [quantization](/reference
     * Retrieve `num_candidates` candidates per shard.
     * From these candidates, the top `k * oversample` candidates per shard will be rescored using the original vectors.
     * The top `k` rescored candidates will be returned.
-    Must be >= 1f to indicate oversample factor, or exactly `0` to indicate that no oversampling and rescoring should occur.
+    Must be one of the following values: 
+      * \>= 1f to indicate the oversample factor
+      * Exactly `0` to indicate that no oversampling and rescoring should occur. {applies_to}`stack: ga 9.1`
 
 
 See [oversampling and rescoring quantized vectors](docs-content://solutions/search/vector/knn.md#dense-vector-knn-search-rescoring) for details.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [add availability to oversample value of 0 (#131707)](https://github.com/elastic/elasticsearch/pull/131707)

This PR was listed as a missing backport when I attempted to backport https://github.com/elastic/elasticsearch/pull/133609

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)