### PR TITLE
[9.0] Allow trailing empty string field names in paths of flattened field (#133611)

### DIFF
--- a/docs/changelog/133611.yaml
+++ b/docs/changelog/133611.yaml
@@ -1,0 +1,6 @@
+pr: 133611
+summary: Allow trailing empty string field names in paths of flattened field
+area: Mapping
+type: bug
+issues:
+ - 130139

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldSyntheticWriterHelper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldSyntheticWriterHelper.java
@@ -116,7 +116,9 @@ public class FlattenedFieldSyntheticWriterHelper {
 
         KeyValue(final BytesRef keyValue) {
             this(
-                FlattenedFieldParser.extractKey(keyValue).utf8ToString().split(PATH_SEPARATOR_PATTERN),
+                // Splitting with a negative limit includes trailing empty strings.
+                // This is needed in case the provide path has trailing path separators.
+                FlattenedFieldParser.extractKey(keyValue).utf8ToString().split(PATH_SEPARATOR_PATTERN, -1),
                 FlattenedFieldParser.extractValue(keyValue).utf8ToString()
             );
         }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Allow trailing empty string field names in paths of flattened field (#133611)](https://github.com/elastic/elasticsearch/pull/133611)

<!--- Backport version: 9.6.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)