### PR TITLE
Fix TimeSeriesIT#testProfile

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -648,9 +648,6 @@ tests:
 - class: org.elasticsearch.compute.data.BasicBlockTests
   method: testFloatBlock
   issue: https://github.com/elastic/elasticsearch/issues/133621
-- class: org.elasticsearch.xpack.esql.action.TimeSeriesIT
-  method: testProfile
-  issue: https://github.com/elastic/elasticsearch/issues/133624
 
 # Examples:
 #


### PR DESCRIPTION
If the target shard is empty or does not match the query, processedShards will be empty. 
This change relaxes the assertion to permit these cases.

Closes #133624