### PR TITLE
[9.1][DOCS] Clarify dense vector field update graph availability (#131724)

### DIFF
--- a/docs/reference/elasticsearch/mapping-reference/dense-vector.md
+++ b/docs/reference/elasticsearch/mapping-reference/dense-vector.md
@@ -396,9 +396,18 @@ POST /my-bit-vectors/_search?filter_path=hits.hits
 
 To better accommodate scaling and performance needs, updating the `type` setting in `index_options` is possible with the [Update Mapping API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-put-mapping), according to the following graph (jumps allowed):
 
+::::{tab-set}
+:::{tab-item} {{stack}} 9.1+
 ```txt
 flat --> int8_flat --> int4_flat --> bbq_flat --> hnsw --> int8_hnsw --> int4_hnsw --> bbq_hnsw
 ```
+:::
+:::{tab-item} {{stack}} 9.0
+```txt
+flat --> int8_flat --> int4_flat --> hnsw --> int8_hnsw --> int4_hnsw
+```
+:::
+::::
 
 For updating all HNSW types (`hnsw`, `int8_hnsw`, `int4_hnsw`, `bbq_hnsw`) the number of connections `m` must either stay the same or increase. For the scalar quantized formats  `int8_flat`, `int4_flat`, `int8_hnsw` and `int4_hnsw` the `confidence_interval` must always be consistent (once defined, it cannot change).
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Clarify dense vector field update graph availability (#131724)](https://github.com/elastic/elasticsearch/pull/131724)

This was listed as a missing dependency when I tried to backport https://github.com/elastic/elasticsearch/pull/133609

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)