### PR TITLE
Drop testFetchCoerced

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -474,9 +474,6 @@ tests:
 - class: org.elasticsearch.upgrades.TransformSurvivesUpgradeIT
   method: testTransformRollingUpgrade
   issue: https://github.com/elastic/elasticsearch/issues/132892
-- class: org.elasticsearch.index.mapper.LongFieldMapperTests
-  method: testFetchCoerced
-  issue: https://github.com/elastic/elasticsearch/issues/132893
 - class: org.elasticsearch.xpack.eql.planner.QueryTranslatorTests
   method: testMatchOptimization
   issue: https://github.com/elastic/elasticsearch/issues/132894

--- a/server/src/test/java/org/elasticsearch/index/mapper/LongFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/LongFieldMapperTests.java
@@ -118,10 +118,6 @@ public class LongFieldMapperTests extends WholeNumberFieldMapperTests {
         return randomDoubleBetween(-MAX_SAFE_LONG_FOR_DOUBLE, MAX_SAFE_LONG_FOR_DOUBLE, true);
     }
 
-    public void testFetchCoerced() throws IOException {
-        assertFetch(randomFetchTestMapper(), "field", 3.783147882954537E18, randomFetchTestFormat());
-    }
-
     protected IngestScriptSupport ingestScriptSupport() {
         return new IngestScriptSupport() {
             @Override


### PR DESCRIPTION
It doesn't look like this test has ever worked, and nobody wants to mess with that code.
    
So let's just drop it - if we ever do dare to change the conversion code, we can add proper tests then.

Closes https://github.com/elastic/elasticsearch/issues/132893