### PR TITLE
Validate the highest transport id is used

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/TransportVersionValidationFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/TransportVersionValidationFuncTest.groovy
@@ -229,4 +229,27 @@ class TransportVersionValidationFuncTest extends AbstractTransportVersionFuncTes
         then:
         result.task(":myserver:validateTransportVersionResources").outcome == TaskOutcome.SUCCESS
     }
+
+    def "highest id in an referable definition should exist in an upper bounds file"() {
+        given:
+        referableAndReferencedTransportVersion("some_tv", "10000000")
+        when:
+        def result = validateResourcesFails()
+        then:
+        assertValidateResourcesFailure(result, "Transport version definition file " +
+            "[myserver/src/main/resources/transport/definitions/referable/some_tv.csv] " +
+            "has the highest transport version id [10000000] but is not present in any upper bounds files")
+    }
+
+    def "highest id in an unreferable definition should exist in an upper bounds file"() {
+        given:
+        unreferableTransportVersion("initial_10.0.0", "10000000")
+        when:
+        def result = validateResourcesFails()
+        then:
+        // TODO: this should be _unreferable_ in the error message, but will require some rework
+        assertValidateResourcesFailure(result, "Transport version definition file " +
+            "[myserver/src/main/resources/transport/definitions/referable/initial_10.0.0.csv] " +
+            "has the highest transport version id [10000000] but is not present in any upper bounds files")
+    }
 }

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/TransportVersionValidationFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/TransportVersionValidationFuncTest.groovy
@@ -223,7 +223,7 @@ class TransportVersionValidationFuncTest extends AbstractTransportVersionFuncTes
 
     def "unreferable definitions can have primary ids that are patches"() {
         given:
-        unreferableTransportVersion("initial_10.0.1", "10000001")
+        unreferableTransportVersion("initial_7.0.1", "7000001")
         when:
         def result = gradleRunner(":myserver:validateTransportVersionResources").build()
         then:

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/ValidateTransportVersionResourcesTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/ValidateTransportVersionResourcesTask.java
@@ -11,6 +11,7 @@ package org.elasticsearch.gradle.internal.transport;
 
 import com.google.common.collect.Comparators;
 
+import org.elasticsearch.gradle.VersionProperties;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.provider.Property;
@@ -83,6 +84,8 @@ public abstract class ValidateTransportVersionResourcesTask extends DefaultTask 
         for (var upperBound : upperBounds.values()) {
             validateUpperBound(upperBound, allDefinitions, idsByBase);
         }
+
+        validateLargestIdIsUsed(upperBounds, allDefinitions);
     }
 
     private Map<String, TransportVersionDefinition> collectAllDefinitions(
@@ -251,6 +254,23 @@ public abstract class ValidateTransportVersionResourcesTask extends DefaultTask 
             }
             previous = current;
         }
+    }
+
+
+    private void validateLargestIdIsUsed(Map<String, TransportVersionUpperBound> upperBounds, Map<String, TransportVersionDefinition> allDefinitions) {
+        // first id is always the highest within a definition, and validated earlier
+        // note we use min instead of max because the id comparator is in descending order
+        var highestDefinition = allDefinitions.values().stream().min(Comparator.comparing(d -> d.ids().get(0))).get();
+        var highestId = highestDefinition.ids().get(0);
+
+        for (var upperBound : upperBounds.values()) {
+            if (upperBound.id().equals(highestId)) {
+                return;
+            }
+        }
+
+        throwDefinitionFailure(highestDefinition, "has the highest transport version id ["
+            + highestId + "] but is not present in any upper bounds files");
     }
 
     private void throwDefinitionFailure(TransportVersionDefinition definition, String message) {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/ValidateTransportVersionResourcesTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/ValidateTransportVersionResourcesTask.java
@@ -11,7 +11,6 @@ package org.elasticsearch.gradle.internal.transport;
 
 import com.google.common.collect.Comparators;
 
-import org.elasticsearch.gradle.VersionProperties;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.provider.Property;
@@ -256,8 +255,10 @@ public abstract class ValidateTransportVersionResourcesTask extends DefaultTask 
         }
     }
 
-
-    private void validateLargestIdIsUsed(Map<String, TransportVersionUpperBound> upperBounds, Map<String, TransportVersionDefinition> allDefinitions) {
+    private void validateLargestIdIsUsed(
+        Map<String, TransportVersionUpperBound> upperBounds,
+        Map<String, TransportVersionDefinition> allDefinitions
+    ) {
         // first id is always the highest within a definition, and validated earlier
         // note we use min instead of max because the id comparator is in descending order
         var highestDefinition = allDefinitions.values().stream().min(Comparator.comparing(d -> d.ids().get(0))).get();
@@ -269,8 +270,10 @@ public abstract class ValidateTransportVersionResourcesTask extends DefaultTask 
             }
         }
 
-        throwDefinitionFailure(highestDefinition, "has the highest transport version id ["
-            + highestId + "] but is not present in any upper bounds files");
+        throwDefinitionFailure(
+            highestDefinition,
+            "has the highest transport version id [" + highestId + "] but is not present in any upper bounds files"
+        );
     }
 
     private void throwDefinitionFailure(TransportVersionDefinition definition, String message) {


### PR DESCRIPTION
Most upper bounds files for transport version are for an already branched version. For those, the upper bound must be within the base id for that branch, and validation exists to ensure the highest id within a branch is in the upper bound file for that branch. But for main the base is always different. This commit adds validation to ensure that the highest transport version id exists in _some_ upper bound file.

Note that while we could try to identify which upper bound file belongs to main, this is tricky when validation runs in non-main branches. This check is just as good, just a little less specific than "it should exist in x.y upper bound file".