### PR TITLE
wip - Bulk vector processing

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/vectors/AccessibleVectorSimilarityFloatValueSource.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/AccessibleVectorSimilarityFloatValueSource.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.search.vectors;
+
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.elasticsearch.index.mapper.vectors.VectorSimilarityFloatValueSource;
+
+/**
+ * Subclass of VectorSimilarityFloatValueSource offering access to its members for other classes
+ * in the same package.
+ */
+class AccessibleVectorSimilarityFloatValueSource extends VectorSimilarityFloatValueSource {
+
+    String field;
+    float[] target;
+    VectorSimilarityFunction vectorSimilarityFunction;
+
+    AccessibleVectorSimilarityFloatValueSource(String field,
+                                                      float[] target,
+                                                      VectorSimilarityFunction vectorSimilarityFunction) {
+        super(field, target, vectorSimilarityFunction);
+        this.field = field;
+        this.target = target;
+        this.vectorSimilarityFunction = vectorSimilarityFunction;
+    }
+
+    public String field() {
+        return field;
+    }
+
+    public float[] target() {
+        return target;
+    }
+
+    public VectorSimilarityFunction similarityFunction() {
+        return vectorSimilarityFunction;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/vectors/AccessibleVectorSimilarityFloatValueSource.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/AccessibleVectorSimilarityFloatValueSource.java
@@ -22,9 +22,7 @@ class AccessibleVectorSimilarityFloatValueSource extends VectorSimilarityFloatVa
     float[] target;
     VectorSimilarityFunction vectorSimilarityFunction;
 
-    AccessibleVectorSimilarityFloatValueSource(String field,
-                                                      float[] target,
-                                                      VectorSimilarityFunction vectorSimilarityFunction) {
+    AccessibleVectorSimilarityFloatValueSource(String field, float[] target, VectorSimilarityFunction vectorSimilarityFunction) {
         super(field, target, vectorSimilarityFunction);
         this.field = field;
         this.target = target;

--- a/server/src/main/java/org/elasticsearch/search/vectors/BatchVectorSimilarity.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/BatchVectorSimilarity.java
@@ -15,11 +15,14 @@ import java.util.Map;
 
 public final class BatchVectorSimilarity {
 
-    private BatchVectorSimilarity() {
-    }
+    private BatchVectorSimilarity() {}
 
-    public static float[] computeBatchSimilarity(float[] queryVector, Map<Integer, float[]> docVectors,
-                                               int[] docIds, VectorSimilarityFunction function) {
+    public static float[] computeBatchSimilarity(
+        float[] queryVector,
+        Map<Integer, float[]> docVectors,
+        int[] docIds,
+        VectorSimilarityFunction function
+    ) {
         float[] results = new float[docIds.length];
         float[][] data = organizeSIMDVectors(docVectors, docIds);
 

--- a/server/src/main/java/org/elasticsearch/search/vectors/BatchVectorSimilarity.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/BatchVectorSimilarity.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.search.vectors;
+
+import org.apache.lucene.index.VectorSimilarityFunction;
+
+import java.util.Map;
+
+public final class BatchVectorSimilarity {
+
+    private BatchVectorSimilarity() {
+    }
+
+    public static float[] computeBatchSimilarity(float[] queryVector, Map<Integer, float[]> docVectors,
+                                               int[] docIds, VectorSimilarityFunction function) {
+        float[] results = new float[docIds.length];
+        float[][] data = organizeSIMDVectors(docVectors, docIds);
+
+        for (int i = 0, l = data.length; i < l; i++) {
+            float[] docVector = data[i];
+            results[i] = function.compare(queryVector, docVector);
+        }
+
+        return results;
+    }
+
+    public static float[][] organizeSIMDVectors(Map<Integer, float[]> vectorMap, int[] docIds) {
+        float[][] vectors = new float[docIds.length][];
+        for (int i = 0; i < docIds.length; i++) {
+            vectors[i] = vectorMap.get(docIds[i]);
+        }
+        return vectors;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/vectors/BulkVectorFunctionScoreQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/BulkVectorFunctionScoreQuery.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.search.vectors;
+
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Weight;
+import org.elasticsearch.index.mapper.vectors.VectorSimilarityFloatValueSource;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Enhanced FunctionScoreQuery that enables bulk vector processing for KNN rescoring.
+ * When provided with a ScoreDoc array, performs bulk vector loading and similarity
+ * computation instead of individual per-document processing.
+ */
+public class BulkVectorFunctionScoreQuery extends Query {
+
+    private final Query subQuery;
+    private final AccessibleVectorSimilarityFloatValueSource valueSource;
+    private final ScoreDoc[] scoreDocs;
+
+    public BulkVectorFunctionScoreQuery(Query subQuery, AccessibleVectorSimilarityFloatValueSource valueSource, ScoreDoc[] scoreDocs) {
+        this.subQuery = subQuery;
+        this.valueSource = valueSource;
+        this.scoreDocs = scoreDocs;
+    }
+
+    @Override
+    public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+        // TODO: take a closer look at ScoreMode
+        Weight subQueryWeight = subQuery.createWeight(searcher, scoreMode, boost);
+        return new BulkVectorFunctionScoreWeight(this, subQueryWeight, valueSource, scoreDocs);
+    }
+
+    @Override
+    public Query rewrite(IndexSearcher searcher) throws IOException {
+        Query rewrittenSubQuery = subQuery.rewrite(searcher);
+        if (rewrittenSubQuery != subQuery) {
+            return new BulkVectorFunctionScoreQuery(rewrittenSubQuery, valueSource, scoreDocs);
+        }
+        return this;
+    }
+
+    @Override
+    public String toString(String field) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("bulk_vector_function_score(");
+        sb.append(subQuery.toString(field));
+        sb.append(", vector_similarity=").append(valueSource.toString());
+        if (scoreDocs != null) {
+            sb.append(", bulk_docs=").append(scoreDocs.length);
+        }
+        sb.append(")");
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+
+        BulkVectorFunctionScoreQuery that = (BulkVectorFunctionScoreQuery) obj;
+        return Objects.equals(subQuery, that.subQuery)
+            && Objects.equals(valueSource, that.valueSource)
+            && Arrays.equals(scoreDocs, that.scoreDocs);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(subQuery, valueSource, scoreDocs);
+    }
+
+    @Override
+    public void visit(org.apache.lucene.search.QueryVisitor visitor) {
+        subQuery.visit(visitor.getSubVisitor(org.apache.lucene.search.BooleanClause.Occur.MUST, this));
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/vectors/BulkVectorFunctionScoreQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/BulkVectorFunctionScoreQuery.java
@@ -14,7 +14,6 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Weight;
-import org.elasticsearch.index.mapper.vectors.VectorSimilarityFloatValueSource;
 
 import java.io.IOException;
 import java.util.Arrays;

--- a/server/src/main/java/org/elasticsearch/search/vectors/BulkVectorFunctionScoreWeight.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/BulkVectorFunctionScoreWeight.java
@@ -60,9 +60,8 @@ public class BulkVectorFunctionScoreWeight extends Weight {
         return new ScorerSupplier() {
             @Override
             public Scorer get(long leadCost) throws IOException {
-                throw new UnsupportedOperationException(
-                    "Individual Scorer not supported when bulk vector processing is enabled. Use bulkScorer() instead."
-                );
+                // if asked for basic Scorer, delegate to the underlying subquery scorer
+                return subQueryScorerSupplier.get(leadCost);
             }
 
             @Override

--- a/server/src/main/java/org/elasticsearch/search/vectors/BulkVectorFunctionScoreWeight.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/BulkVectorFunctionScoreWeight.java
@@ -36,7 +36,8 @@ public class BulkVectorFunctionScoreWeight extends Weight {
         Query parent,
         Weight subQueryWeight,
         AccessibleVectorSimilarityFloatValueSource valueSource,
-                                       ScoreDoc[] scoreDocs) {
+        ScoreDoc[] scoreDocs
+    ) {
         super(parent);
         this.subQueryWeight = subQueryWeight;
         this.valueSource = valueSource;
@@ -60,7 +61,8 @@ public class BulkVectorFunctionScoreWeight extends Weight {
             @Override
             public Scorer get(long leadCost) throws IOException {
                 throw new UnsupportedOperationException(
-                    "Individual Scorer not supported when bulk vector processing is enabled. Use bulkScorer() instead.");
+                    "Individual Scorer not supported when bulk vector processing is enabled. Use bulkScorer() instead."
+                );
             }
 
             @Override

--- a/server/src/main/java/org/elasticsearch/search/vectors/BulkVectorFunctionScoreWeight.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/BulkVectorFunctionScoreWeight.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.search.vectors;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.BulkScorer;
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.ScorerSupplier;
+import org.apache.lucene.search.Weight;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Weight implementation that enables bulk vector processing for KNN rescoring queries.
+ * Extracts segment-specific documents from ScoreDoc array and creates bulk scorers.
+ */
+public class BulkVectorFunctionScoreWeight extends Weight {
+
+    private final Weight subQueryWeight;
+    private final AccessibleVectorSimilarityFloatValueSource valueSource;
+    private final ScoreDoc[] scoreDocs;
+
+    public BulkVectorFunctionScoreWeight(
+        Query parent,
+        Weight subQueryWeight,
+        AccessibleVectorSimilarityFloatValueSource valueSource,
+                                       ScoreDoc[] scoreDocs) {
+        super(parent);
+        this.subQueryWeight = subQueryWeight;
+        this.valueSource = valueSource;
+        this.scoreDocs = scoreDocs;
+    }
+
+    @Override
+    public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
+        ScorerSupplier subQueryScorerSupplier = subQueryWeight.scorerSupplier(context);
+        if (subQueryScorerSupplier == null) {
+            return null;
+        }
+
+        // Extract documents belonging to this segment
+        int[] segmentDocIds = extractSegmentDocuments(scoreDocs, context);
+        if (segmentDocIds.length == 0) {
+            return null; // No documents in this segment
+        }
+
+        return new ScorerSupplier() {
+            @Override
+            public Scorer get(long leadCost) throws IOException {
+                throw new UnsupportedOperationException(
+                    "Individual Scorer not supported when bulk vector processing is enabled. Use bulkScorer() instead.");
+            }
+
+            @Override
+            public BulkScorer bulkScorer() throws IOException {
+                // Always use BulkScorer when bulk processing is enabled
+                BulkScorer subQueryBulkScorer = subQueryScorerSupplier.bulkScorer();
+                return new BulkVectorScorer(subQueryBulkScorer, segmentDocIds, valueSource, context);
+            }
+
+            @Override
+            public long cost() {
+                return segmentDocIds.length;
+            }
+        };
+    }
+
+    @Override
+    public Explanation explain(LeafReaderContext context, int doc) throws IOException {
+        // Find the document in our ScoreDoc array
+        int globalDocId = doc + context.docBase;
+        for (ScoreDoc scoreDoc : scoreDocs) {
+            if (scoreDoc.doc == globalDocId) {
+                // Compute explanation for this specific document
+                try {
+                    DirectIOVectorBatchLoader batchLoader = new DirectIOVectorBatchLoader();
+                    float[] docVector = batchLoader.loadSingleVector(doc, context, valueSource.field());
+                    float similarity = valueSource.similarityFunction().compare(valueSource.target(), docVector);
+
+                    return Explanation.match(
+                        similarity,
+                        "bulk vector similarity score, computed with vector similarity function: " + valueSource.similarityFunction()
+                    );
+                } catch (Exception e) {
+                    return Explanation.noMatch("Failed to compute vector similarity: " + e.getMessage());
+                }
+            }
+        }
+        return Explanation.noMatch("Document not in bulk processing set");
+    }
+
+    @Override
+    public boolean isCacheable(LeafReaderContext ctx) {
+        return false;
+    }
+
+    private int[] extractSegmentDocuments(ScoreDoc[] scoreDocs, LeafReaderContext context) {
+        List<Integer> segmentDocs = new ArrayList<>();
+        int docBase = context.docBase;
+        int maxDoc = docBase + context.reader().maxDoc();
+
+        for (ScoreDoc scoreDoc : scoreDocs) {
+            if (scoreDoc.doc >= docBase && scoreDoc.doc < maxDoc) {
+                // Convert to segment-relative document ID
+                segmentDocs.add(scoreDoc.doc - docBase);
+            }
+        }
+
+        return segmentDocs.stream().mapToInt(Integer::intValue).toArray();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/vectors/BulkVectorProcessingSettings.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/BulkVectorProcessingSettings.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.search.vectors;
+
+import org.elasticsearch.common.util.FeatureFlag;
+
+/**
+ * Feature flags and settings for bulk vector processing optimizations.
+ */
+public final class BulkVectorProcessingSettings {
+
+    public static final boolean BULK_VECTOR_SCORING = new FeatureFlag("bulk_vector_scoring").isEnabled();
+
+    public static final int MIN_BULK_PROCESSING_THRESHOLD = 3;
+
+    private BulkVectorProcessingSettings() {
+        // Utility class
+    }
+
+    public static boolean shouldUseBulkProcessing(int documentCount) {
+        return BULK_VECTOR_SCORING && documentCount >= MIN_BULK_PROCESSING_THRESHOLD;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/vectors/BulkVectorScorer.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/BulkVectorScorer.java
@@ -31,9 +31,10 @@ public class BulkVectorScorer extends BulkScorer {
 
     public BulkVectorScorer(
         BulkScorer subQueryBulkScorer,
-                           int[] segmentDocIds,
+        int[] segmentDocIds,
         AccessibleVectorSimilarityFloatValueSource valueSource,
-                           LeafReaderContext context) {
+        LeafReaderContext context
+    ) {
         this.subQueryBulkScorer = subQueryBulkScorer;
         this.segmentDocIds = segmentDocIds;
         this.valueSource = valueSource;
@@ -63,8 +64,7 @@ public class BulkVectorScorer extends BulkScorer {
     private void performBulkVectorProcessing() throws IOException {
         // batch loading
         DirectIOVectorBatchLoader batchLoader = new DirectIOVectorBatchLoader();
-        Map<Integer, float[]> vectorCache = batchLoader.loadSegmentVectors(
-            segmentDocIds, context, valueSource.field());
+        Map<Integer, float[]> vectorCache = batchLoader.loadSegmentVectors(segmentDocIds, context, valueSource.field());
 
         // batch similarity
         float[] similarities = BatchVectorSimilarity.computeBatchSimilarity(

--- a/server/src/main/java/org/elasticsearch/search/vectors/BulkVectorScorer.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/BulkVectorScorer.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.search.vectors;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.BulkScorer;
+import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.Scorable;
+import org.apache.lucene.util.Bits;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class BulkVectorScorer extends BulkScorer {
+
+    private final BulkScorer subQueryBulkScorer;
+    private final int[] segmentDocIds;
+    private final AccessibleVectorSimilarityFloatValueSource valueSource;
+    private final LeafReaderContext context;
+
+    // Bulk processing cache
+    private Map<Integer, Float> precomputedScores;
+    private boolean bulkProcessingCompleted = false;
+
+    public BulkVectorScorer(
+        BulkScorer subQueryBulkScorer,
+                           int[] segmentDocIds,
+        AccessibleVectorSimilarityFloatValueSource valueSource,
+                           LeafReaderContext context) {
+        this.subQueryBulkScorer = subQueryBulkScorer;
+        this.segmentDocIds = segmentDocIds;
+        this.valueSource = valueSource;
+        this.context = context;
+    }
+
+    @Override
+    public int score(LeafCollector collector, Bits acceptDocs, int min, int max) throws IOException {
+        // Perform bulk processing once if not already completed
+        if (bulkProcessingCompleted == false) {
+            performBulkVectorProcessing();
+            bulkProcessingCompleted = true;
+        }
+
+        // Create bulk-aware collector wrapper
+        BulkAwareCollector bulkCollector = new BulkAwareCollector(collector, precomputedScores);
+
+        // Delegate to subquery bulk scorer with our bulk-aware collector
+        return subQueryBulkScorer.score(bulkCollector, acceptDocs, min, max);
+    }
+
+    @Override
+    public long cost() {
+        return segmentDocIds.length;
+    }
+
+    private void performBulkVectorProcessing() throws IOException {
+        // batch loading
+        DirectIOVectorBatchLoader batchLoader = new DirectIOVectorBatchLoader();
+        Map<Integer, float[]> vectorCache = batchLoader.loadSegmentVectors(
+            segmentDocIds, context, valueSource.field());
+
+        // batch similarity
+        float[] similarities = BatchVectorSimilarity.computeBatchSimilarity(
+            valueSource.target(),
+            vectorCache,
+            segmentDocIds,
+            valueSource.similarityFunction()
+        );
+
+        // batch scoring
+        precomputedScores = new java.util.HashMap<>();
+        for (int i = 0; i < segmentDocIds.length; i++) {
+            precomputedScores.put(segmentDocIds[i], similarities[i]);
+        }
+    }
+
+    private static class BulkAwareCollector implements LeafCollector {
+
+        private final LeafCollector delegate;
+        private final Map<Integer, Float> precomputedScores;
+        private final BulkProcessedScorable bulkScorable;
+
+        BulkAwareCollector(LeafCollector delegate, Map<Integer, Float> precomputedScores) {
+            this.delegate = delegate;
+            this.precomputedScores = precomputedScores;
+            this.bulkScorable = new BulkProcessedScorable();
+        }
+
+        @Override
+        public void setScorer(Scorable scorer) throws IOException {
+            // Set our bulk-aware scorer instead of the original
+            bulkScorable.setDelegate(scorer);
+            delegate.setScorer(bulkScorable);
+        }
+
+        @Override
+        public void collect(int doc) throws IOException {
+            // Set the current document for score retrieval
+            bulkScorable.setCurrentDoc(doc);
+            delegate.collect(doc);
+        }
+
+        /**
+         * Scorable that provides pre-computed bulk scores
+         */
+        private class BulkProcessedScorable extends Scorable {
+            private Scorable delegate;
+            private int currentDoc = -1;
+
+            public void setDelegate(Scorable delegate) {
+                this.delegate = delegate;
+            }
+
+            public void setCurrentDoc(int doc) {
+                this.currentDoc = doc;
+            }
+
+            @Override
+            public float score() throws IOException {
+                // Return pre-computed score if available
+                Float precomputedScore = precomputedScores.get(currentDoc);
+                if (precomputedScore != null) {
+                    return precomputedScore;
+                }
+
+                // Fallback to delegate scorer
+                return delegate != null ? delegate.score() : 0.0f;
+            }
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/vectors/DirectIOVectorBatchLoader.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/DirectIOVectorBatchLoader.java
@@ -73,9 +73,10 @@ public class DirectIOVectorBatchLoader {
     }
 
     private Map<Integer, float[]> loadVectorBatch(
-            FloatVectorValues vectorValues,
-            List<Integer> docIdBatch,
-            Map<Integer, Integer> docToOrdinal) throws IOException {
+        FloatVectorValues vectorValues,
+        List<Integer> docIdBatch,
+        Map<Integer, Integer> docToOrdinal
+    ) throws IOException {
 
         Map<Integer, float[]> batchResult = new HashMap<>();
 
@@ -91,9 +92,7 @@ public class DirectIOVectorBatchLoader {
         return batchResult;
     }
 
-    private Map<Integer, Integer> buildDocToOrdinalMapping(
-        FloatVectorValues vectorValues,
-            int[] targetDocIds) throws IOException {
+    private Map<Integer, Integer> buildDocToOrdinalMapping(FloatVectorValues vectorValues, int[] targetDocIds) throws IOException {
 
         Map<Integer, Integer> docToOrdinal = new HashMap<>();
 

--- a/server/src/main/java/org/elasticsearch/search/vectors/DirectIOVectorBatchLoader.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/DirectIOVectorBatchLoader.java
@@ -74,7 +74,7 @@ public class DirectIOVectorBatchLoader {
             .nextDoc()) {
             if (currentDoc == docId) {
                 float[] vector = vectorValues.vectorValue(iterator.index());
-                return vector != null ? vector: null;
+                return vector != null ? vector : null;
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/search/vectors/DirectIOVectorBatchLoader.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/DirectIOVectorBatchLoader.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.search.vectors;
+
+import org.apache.lucene.index.FloatVectorValues;
+import org.apache.lucene.index.KnnVectorValues;
+import org.apache.lucene.index.LeafReaderContext;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Bulk vector loader that performs optimized I/O operations to load multiple vectors
+ * simultaneously using direct I/O and sector alignment when possible.
+ */
+public class DirectIOVectorBatchLoader {
+
+    private static final int SECTOR_SIZE = 4096; // Default sector size for alignment
+
+    /**
+     * Loads vectors for multiple document IDs in a single bulk operation.
+     */
+    public Map<Integer, float[]> loadSegmentVectors(int[] docIds, LeafReaderContext context, String field) throws IOException {
+        Map<Integer, float[]> vectorCache = new HashMap<>();
+
+        // Get vector values for the field
+        FloatVectorValues vectorValues = context.reader().getFloatVectorValues(field);
+        if (vectorValues == null) {
+            throw new IllegalArgumentException("No float vector values found for field: " + field);
+        }
+
+        // TODO: For now, use sequential access - future optimization can implement true bulk I/O
+        KnnVectorValues.DocIndexIterator iterator = vectorValues.iterator();
+
+        // Build a lookup of available documents
+        Map<Integer, Integer> docToIndex = new HashMap<>();
+        for (int docId = iterator.nextDoc(); docId != KnnVectorValues.DocIndexIterator.NO_MORE_DOCS; docId = iterator.nextDoc()) {
+            docToIndex.put(docId, iterator.index());
+        }
+
+        // Load vectors for requested documents
+        for (int docId : docIds) {
+            Integer vectorIndex = docToIndex.get(docId);
+            if (vectorIndex != null) {
+                float[] vector = vectorValues.vectorValue(vectorIndex);
+                if (vector != null) {
+                    vectorCache.put(docId, vector);
+                }
+            }
+        }
+
+        return vectorCache;
+    }
+
+    /**
+     * TODO: look into removing this method
+     */
+    public float[] loadSingleVector(int docId, LeafReaderContext context, String field) throws IOException {
+        FloatVectorValues vectorValues = context.reader().getFloatVectorValues(field);
+        if (vectorValues == null) {
+            throw new IllegalArgumentException("No float vector values found for field: " + field);
+        }
+
+        KnnVectorValues.DocIndexIterator iterator = vectorValues.iterator();
+        for (int currentDoc = iterator.nextDoc(); currentDoc != KnnVectorValues.DocIndexIterator.NO_MORE_DOCS; currentDoc = iterator
+            .nextDoc()) {
+            if (currentDoc == docId) {
+                float[] vector = vectorValues.vectorValue(iterator.index());
+                return vector != null ? vector: null;
+            }
+        }
+
+        throw new IllegalArgumentException("Document " + docId + " not found in vector values");
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/vectors/RescoreKnnVectorQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/RescoreKnnVectorQuery.java
@@ -18,7 +18,6 @@ import org.apache.lucene.search.KnnFloatVectorQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.TopDocs;
-import org.elasticsearch.index.mapper.vectors.VectorSimilarityFloatValueSource;
 import org.elasticsearch.search.profile.query.QueryProfiler;
 
 import java.io.IOException;

--- a/server/src/test/java/org/elasticsearch/search/vectors/BulkVectorFunctionScoreQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/BulkVectorFunctionScoreQueryTests.java
@@ -225,12 +225,7 @@ public class BulkVectorFunctionScoreQueryTests extends ESTestCase {
             var parallelResult = (Map<Integer, float[]>) results[0];
 
             // Verify results are identical
-            assertThat(
-                "Parallel and sequential results should have same size",
-                    parallelResult.size(),
-                    equalTo(sequentialResult.size())
-                );
-
+            assertThat("Parallel and sequential results should have same size", parallelResult.size(), equalTo(sequentialResult.size()));
 
             for (int docId : sequentialResult.keySet()) {
                 float[] sequentialVector = sequentialResult.get(docId);
@@ -238,7 +233,7 @@ public class BulkVectorFunctionScoreQueryTests extends ESTestCase {
 
                 assertNotNull("Parallel result should contain vector for doc " + docId, parallelVector);
                 assertNotNull("Sequential result should contain vector for doc " + docId, sequentialVector);
-                    assertArrayEquals("Vectors should be identical for doc " + docId, sequentialVector, parallelVector, 0.0001f);
+                assertArrayEquals("Vectors should be identical for doc " + docId, sequentialVector, parallelVector, 0.0001f);
             }
         }
     }
@@ -249,9 +244,7 @@ public class BulkVectorFunctionScoreQueryTests extends ESTestCase {
 
             // Get initial documents
             TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), 20);
-            int[] docIds = Arrays.stream(topDocs.scoreDocs)
-                .mapToInt(scoreDoc -> scoreDoc.doc)
-                .toArray();
+            int[] docIds = Arrays.stream(topDocs.scoreDocs).mapToInt(scoreDoc -> scoreDoc.doc).toArray();
 
             var leafReaderContext = reader.leaves().get(0);
             consumer.accept(leafReaderContext, docIds);

--- a/server/src/test/java/org/elasticsearch/search/vectors/BulkVectorFunctionScoreQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/BulkVectorFunctionScoreQueryTests.java
@@ -207,18 +207,12 @@ public class BulkVectorFunctionScoreQueryTests extends ESTestCase {
 
                 // Get initial documents
                 TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), 20);
-                int[] docIds = Arrays.stream(topDocs.scoreDocs)
-                    .mapToInt(scoreDoc -> scoreDoc.doc)
-                    .toArray();
+                int[] docIds = Arrays.stream(topDocs.scoreDocs).mapToInt(scoreDoc -> scoreDoc.doc).toArray();
 
                 // Test parallel loading
                 DirectIOVectorBatchLoader batchLoader = new DirectIOVectorBatchLoader();
 
-                Map<Integer, float[]> parallelResult = batchLoader.loadSegmentVectors(
-                    docIds,
-                    reader.leaves().get(0),
-                    VECTOR_FIELD
-                );
+                Map<Integer, float[]> parallelResult = batchLoader.loadSegmentVectors(docIds, reader.leaves().get(0), VECTOR_FIELD);
 
                 // use regular vector loader
                 Map<Integer, float[]> sequentialResult = new HashMap<>();
@@ -229,7 +223,9 @@ public class BulkVectorFunctionScoreQueryTests extends ESTestCase {
                 // Verify results are identical
                 assertThat(
                     "Parallel and sequential results should have same size",
-                    parallelResult.size(), equalTo(sequentialResult.size()));
+                    parallelResult.size(),
+                    equalTo(sequentialResult.size())
+                );
 
                 for (int docId : docIds) {
                     float[] parallelVector = parallelResult.get(docId);
@@ -237,8 +233,7 @@ public class BulkVectorFunctionScoreQueryTests extends ESTestCase {
 
                     assertNotNull("Parallel result should contain vector for doc " + docId, parallelVector);
                     assertNotNull("Sequential result should contain vector for doc " + docId, sequentialVector);
-                    assertArrayEquals("Vectors should be identical for doc " + docId,
-                        sequentialVector, parallelVector, 0.0001f);
+                    assertArrayEquals("Vectors should be identical for doc " + docId, sequentialVector, parallelVector, 0.0001f);
                 }
             }
         }

--- a/server/src/test/java/org/elasticsearch/search/vectors/BulkVectorFunctionScoreQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/BulkVectorFunctionScoreQueryTests.java
@@ -22,7 +22,6 @@ import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.MMapDirectory;
-import org.elasticsearch.index.mapper.vectors.VectorSimilarityFloatValueSource;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -56,14 +55,20 @@ public class BulkVectorFunctionScoreQueryTests extends ESTestCase {
                 // Create query vector and value source
                 float[] queryVector = randomVector(VECTOR_DIMS);
                 var valueSource = new AccessibleVectorSimilarityFloatValueSource(
-                    VECTOR_FIELD, queryVector, VectorSimilarityFunction.COSINE);
+                    VECTOR_FIELD,
+                    queryVector,
+                    VectorSimilarityFunction.COSINE
+                );
 
                 // Get top documents
                 TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), 50);
 
                 // Test bulk vector function score query
                 BulkVectorFunctionScoreQuery bulkQuery = new BulkVectorFunctionScoreQuery(
-                    new KnnScoreDocQuery(topDocs.scoreDocs, reader), valueSource, topDocs.scoreDocs);
+                    new KnnScoreDocQuery(topDocs.scoreDocs, reader),
+                    valueSource,
+                    topDocs.scoreDocs
+                );
 
                 TopDocs bulkResults = searcher.search(bulkQuery, 10);
 
@@ -97,7 +102,13 @@ public class BulkVectorFunctionScoreQueryTests extends ESTestCase {
                 // Create inline rescoring by using KnnFloatVectorQuery with matching k and rescoreK
                 KnnFloatVectorQuery innerQuery = new KnnFloatVectorQuery(VECTOR_FIELD, queryVector, 10);
                 RescoreKnnVectorQuery rescoreQuery = RescoreKnnVectorQuery.fromInnerQuery(
-                    VECTOR_FIELD, queryVector, VectorSimilarityFunction.COSINE, 5, 10, innerQuery);
+                    VECTOR_FIELD,
+                    queryVector,
+                    VectorSimilarityFunction.COSINE,
+                    5,
+                    10,
+                    innerQuery
+                );
 
                 TopDocs results = searcher.search(rescoreQuery, 5);
 
@@ -129,7 +140,13 @@ public class BulkVectorFunctionScoreQueryTests extends ESTestCase {
 
                 // Create late rescoring by using different k and rescoreK values
                 RescoreKnnVectorQuery rescoreQuery = RescoreKnnVectorQuery.fromInnerQuery(
-                    VECTOR_FIELD, queryVector, VectorSimilarityFunction.COSINE, 8, 30, new MatchAllDocsQuery());
+                    VECTOR_FIELD,
+                    queryVector,
+                    VectorSimilarityFunction.COSINE,
+                    8,
+                    30,
+                    new MatchAllDocsQuery()
+                );
 
                 TopDocs results = searcher.search(rescoreQuery, 8);
 
@@ -156,9 +173,15 @@ public class BulkVectorFunctionScoreQueryTests extends ESTestCase {
                 // Create bulk query
                 float[] queryVector = randomVector(VECTOR_DIMS);
                 var valueSource = new AccessibleVectorSimilarityFloatValueSource(
-                    VECTOR_FIELD, queryVector, VectorSimilarityFunction.COSINE);
+                    VECTOR_FIELD,
+                    queryVector,
+                    VectorSimilarityFunction.COSINE
+                );
                 BulkVectorFunctionScoreQuery query = new BulkVectorFunctionScoreQuery(
-                    new KnnScoreDocQuery(originalScoreDocs, reader), valueSource, originalScoreDocs);
+                    new KnnScoreDocQuery(originalScoreDocs, reader),
+                    valueSource,
+                    originalScoreDocs
+                );
 
                 // Test query rewrite preserves context
                 BulkVectorFunctionScoreQuery rewritten = (BulkVectorFunctionScoreQuery) query.rewrite(searcher);

--- a/server/src/test/java/org/elasticsearch/search/vectors/BulkVectorFunctionScoreQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/BulkVectorFunctionScoreQueryTests.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.search.vectors;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.KnnFloatVectorQuery;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.MMapDirectory;
+import org.elasticsearch.index.mapper.vectors.VectorSimilarityFloatValueSource;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+
+public class BulkVectorFunctionScoreQueryTests extends ESTestCase {
+
+    private static final String VECTOR_FIELD = "vector";
+    private static final int VECTOR_DIMS = 128;
+
+    public void testBulkProcessingWithScoreDocArray() throws IOException {
+        // Create test index with vector documents
+        try (Directory dir = new MMapDirectory(createTempDir())) {
+            IndexWriterConfig config = new IndexWriterConfig();
+            try (IndexWriter writer = new IndexWriter(dir, config)) {
+                // Add documents with random vectors
+                for (int i = 0; i < 100; i++) {
+                    Document doc = new Document();
+                    float[] vector = randomVector(VECTOR_DIMS);
+                    doc.add(new KnnFloatVectorField(VECTOR_FIELD, vector, VectorSimilarityFunction.COSINE));
+                    writer.addDocument(doc);
+                }
+                writer.commit();
+            }
+
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                IndexSearcher searcher = new IndexSearcher(reader);
+
+                // Create query vector and value source
+                float[] queryVector = randomVector(VECTOR_DIMS);
+                var valueSource = new AccessibleVectorSimilarityFloatValueSource(
+                    VECTOR_FIELD, queryVector, VectorSimilarityFunction.COSINE);
+
+                // Get top documents
+                TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), 50);
+
+                // Test bulk vector function score query
+                BulkVectorFunctionScoreQuery bulkQuery = new BulkVectorFunctionScoreQuery(
+                    new KnnScoreDocQuery(topDocs.scoreDocs, reader), valueSource, topDocs.scoreDocs);
+
+                TopDocs bulkResults = searcher.search(bulkQuery, 10);
+
+                // Verify results
+                assertThat("Should return results", bulkResults.totalHits.value(), greaterThan(0L));
+                assertThat("Should not exceed requested count", bulkResults.scoreDocs.length, equalTo(10));
+
+                // Verify scores are computed
+                for (ScoreDoc scoreDoc : bulkResults.scoreDocs) {
+                    assertTrue("Score should be computed", Float.isFinite(scoreDoc.score));
+                    assertTrue("Score should be positive for cosine similarity", scoreDoc.score >= 0.0f);
+                }
+            }
+        }
+    }
+
+    public void testInlineRescoreBulkOptimization() throws IOException {
+        // Test that InlineRescoreQuery uses bulk processing when feature flag is enabled
+        float[] queryVector = randomVector(VECTOR_DIMS);
+
+        // Temporarily enable feature flag for testing
+        boolean originalFlag = BulkVectorProcessingSettings.BULK_VECTOR_SCORING;
+        System.setProperty("es.bulk_vector_scoring", "true");
+
+        try (Directory dir = new MMapDirectory(createTempDir())) {
+            createTestIndex(dir, 20);
+
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                IndexSearcher searcher = new IndexSearcher(reader);
+
+                // Create inline rescoring by using KnnFloatVectorQuery with matching k and rescoreK
+                KnnFloatVectorQuery innerQuery = new KnnFloatVectorQuery(VECTOR_FIELD, queryVector, 10);
+                RescoreKnnVectorQuery rescoreQuery = RescoreKnnVectorQuery.fromInnerQuery(
+                    VECTOR_FIELD, queryVector, VectorSimilarityFunction.COSINE, 5, 10, innerQuery);
+
+                TopDocs results = searcher.search(rescoreQuery, 5);
+
+                assertThat("Should return results from inline rescoring", results.totalHits.value(), greaterThan(0L));
+                assertThat("Should return requested count", results.scoreDocs.length, equalTo(5));
+            }
+        } finally {
+            // Restore original flag state
+            if (originalFlag) {
+                System.setProperty("es.bulk_vector_scoring", "true");
+            } else {
+                System.clearProperty("es.bulk_vector_scoring");
+            }
+        }
+    }
+
+    public void testLateRescoreBulkOptimization() throws IOException {
+        // Test that LateRescoreQuery uses bulk processing when feature flag is enabled
+        float[] queryVector = randomVector(VECTOR_DIMS);
+
+        // Temporarily enable feature flag for testing
+        System.setProperty("es.bulk_vector_scoring", "true");
+
+        try (Directory dir = new MMapDirectory(createTempDir())) {
+            createTestIndex(dir, 50);
+
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                IndexSearcher searcher = new IndexSearcher(reader);
+
+                // Create late rescoring by using different k and rescoreK values
+                RescoreKnnVectorQuery rescoreQuery = RescoreKnnVectorQuery.fromInnerQuery(
+                    VECTOR_FIELD, queryVector, VectorSimilarityFunction.COSINE, 8, 30, new MatchAllDocsQuery());
+
+                TopDocs results = searcher.search(rescoreQuery, 8);
+
+                assertThat("Should return results from late rescoring", results.totalHits.value(), greaterThan(0L));
+                assertThat("Should return requested count", results.scoreDocs.length, equalTo(8));
+            }
+        } finally {
+            System.clearProperty("es.bulk_vector_scoring");
+        }
+    }
+
+    public void testScoreDocContextPreservation() throws IOException {
+        // Test that ScoreDoc context is properly maintained through rewrite cycles
+        try (Directory dir = new MMapDirectory(createTempDir())) {
+            createTestIndex(dir, 30);
+
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                IndexSearcher searcher = new IndexSearcher(reader);
+
+                // Create initial ScoreDoc array
+                TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), 15);
+                ScoreDoc[] originalScoreDocs = topDocs.scoreDocs.clone();
+
+                // Create bulk query
+                float[] queryVector = randomVector(VECTOR_DIMS);
+                var valueSource = new AccessibleVectorSimilarityFloatValueSource(
+                    VECTOR_FIELD, queryVector, VectorSimilarityFunction.COSINE);
+                BulkVectorFunctionScoreQuery query = new BulkVectorFunctionScoreQuery(
+                    new KnnScoreDocQuery(originalScoreDocs, reader), valueSource, originalScoreDocs);
+
+                // Test query rewrite preserves context
+                BulkVectorFunctionScoreQuery rewritten = (BulkVectorFunctionScoreQuery) query.rewrite(searcher);
+                assertNotNull("Rewritten query should not be null", rewritten);
+
+                // Execute rewritten query
+                TopDocs results = searcher.search(rewritten, 10);
+                assertThat("Should return results after rewrite", results.totalHits.value(), greaterThan(0L));
+            }
+        }
+    }
+
+    private void createTestIndex(Directory dir, int docCount) throws IOException {
+        IndexWriterConfig config = new IndexWriterConfig();
+        try (IndexWriter writer = new IndexWriter(dir, config)) {
+            for (int i = 0; i < docCount; i++) {
+                Document doc = new Document();
+                float[] vector = randomVector(VECTOR_DIMS);
+                doc.add(new KnnFloatVectorField(VECTOR_FIELD, vector, VectorSimilarityFunction.COSINE));
+                writer.addDocument(doc);
+            }
+            writer.commit();
+        }
+    }
+
+    private float[] randomVector(int dimensions) {
+        float[] vector = new float[dimensions];
+        for (int i = 0; i < dimensions; i++) {
+            vector[i] = randomFloat() * 2.0f - 1.0f; // Range [-1, 1]
+        }
+        return vector;
+    }
+}

--- a/server/src/test/java/org/elasticsearch/search/vectors/BulkVectorScorerTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/BulkVectorScorerTests.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.search.vectors;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.search.BulkScorer;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Scorable;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.MMapDirectory;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.greaterThan;
+
+public class BulkVectorScorerTests extends ESTestCase {
+
+    private static final String VECTOR_FIELD = "vector";
+    private static final int VECTOR_DIMS = 64;
+
+    public void testBulkScorerImplementation() throws IOException {
+        // Enable bulk processing for this test
+        System.setProperty("es.bulk_vector_scoring", "true");
+
+        try (Directory dir = new MMapDirectory(createTempDir())) {
+            createTestIndex(dir, 30);
+
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                IndexSearcher searcher = new IndexSearcher(reader);
+
+                // Get top documents for bulk processing
+                TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), 20);
+
+                // Create bulk vector query
+                float[] queryVector = randomVector(VECTOR_DIMS);
+                var valueSource = new AccessibleVectorSimilarityFloatValueSource(
+                    VECTOR_FIELD, queryVector, VectorSimilarityFunction.COSINE);
+
+                BulkVectorFunctionScoreQuery bulkQuery = new BulkVectorFunctionScoreQuery(
+                    new KnnScoreDocQuery(topDocs.scoreDocs, reader), valueSource, topDocs.scoreDocs);
+
+                Weight weight = bulkQuery.createWeight(searcher, org.apache.lucene.search.ScoreMode.COMPLETE, 1.0f);
+
+                LeafReaderContext leafContext = reader.leaves().get(0);
+                BulkScorer bulkScorer = weight.scorerSupplier(leafContext).bulkScorer();
+
+                assertNotNull("BulkScorer should be created", bulkScorer);
+                assertTrue("Should be BulkVectorScorer instance",
+                    bulkScorer instanceof BulkVectorScorer);
+
+                // Test bulk scoring execution
+                TestCollector collector = new TestCollector();
+                int result = bulkScorer.score(collector, null, 0, Integer.MAX_VALUE);
+
+                // Verify bulk processing occurred
+                assertThat("Should collect documents", collector.collectedDocs.size(), greaterThan(0));
+                assertTrue("Should have precomputed scores", collector.hasValidScores());
+
+            }
+        } finally {
+            System.clearProperty("es.bulk_vector_scoring");
+        }
+    }
+
+    public void testBulkProcessorCollectorInterception() throws IOException {
+        // Test that BulkVectorScorer properly intercepts collector calls
+        System.setProperty("es.bulk_vector_scoring", "true");
+
+        try (Directory dir = new MMapDirectory(createTempDir())) {
+            createTestIndex(dir, 25);
+
+            try (DirectoryReader reader = DirectoryReader.open(dir)) {
+                IndexSearcher searcher = new IndexSearcher(reader);
+
+                // Create bulk query with known documents
+                TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), 15);
+                float[] queryVector = randomVector(VECTOR_DIMS);
+                var valueSource = new AccessibleVectorSimilarityFloatValueSource(
+                    VECTOR_FIELD, queryVector, VectorSimilarityFunction.DOT_PRODUCT);
+
+                BulkVectorFunctionScoreQuery bulkQuery = new BulkVectorFunctionScoreQuery(
+                    new KnnScoreDocQuery(topDocs.scoreDocs, reader), valueSource, topDocs.scoreDocs);
+
+                // Execute with custom collector to verify interception
+                TestCollector collector = new TestCollector();
+
+                Weight weight = bulkQuery.createWeight(searcher, org.apache.lucene.search.ScoreMode.COMPLETE, 1.0f);
+                LeafReaderContext leafContext = reader.leaves().get(0);
+                BulkScorer bulkScorer = weight.scorerSupplier(leafContext).bulkScorer();
+
+                bulkScorer.score(collector, null, 0, 50);
+
+                // Verify collector received bulk-processed scores
+                assertTrue("Collector should have received documents", collector.collectedDocs.size() > 0);
+
+                for (CollectedDoc doc : collector.collectedDocs) {
+                    assertTrue("All scores should be finite", Float.isFinite(doc.score));
+                    // For DOT_PRODUCT, scores can be negative, so just check they're computed
+                    assertNotEquals("Score should not be exactly zero (indicating computation)", 0.0f, doc.score, 0.001f);
+                }
+            }
+        } finally {
+            System.clearProperty("es.bulk_vector_scoring");
+        }
+    }
+
+    private void createTestIndex(Directory dir, int docCount) throws IOException {
+        IndexWriterConfig config = new IndexWriterConfig();
+        try (IndexWriter writer = new IndexWriter(dir, config)) {
+            for (int i = 0; i < docCount; i++) {
+                Document doc = new Document();
+                float[] vector = randomVector(VECTOR_DIMS);
+                doc.add(new KnnFloatVectorField(VECTOR_FIELD, vector, VectorSimilarityFunction.COSINE));
+                writer.addDocument(doc);
+            }
+            writer.commit();
+        }
+    }
+
+    private float[] randomVector(int dimensions) {
+        float[] vector = new float[dimensions];
+        for (int i = 0; i < dimensions; i++) {
+            vector[i] = randomFloat() * 2.0f - 1.0f;
+        }
+        return vector;
+    }
+
+    /**
+     * Test collector that captures documents and scores for verification
+     */
+    private static class TestCollector implements LeafCollector {
+        final List<CollectedDoc> collectedDocs = new ArrayList<>();
+        private Scorable scorer;
+
+        @Override
+        public void setScorer(Scorable scorer) throws IOException {
+            this.scorer = scorer;
+        }
+
+        @Override
+        public void collect(int doc) throws IOException {
+            float score = scorer.score();
+            collectedDocs.add(new CollectedDoc(doc, score));
+        }
+
+        boolean hasValidScores() {
+            return collectedDocs.stream().allMatch(doc -> Float.isFinite(doc.score));
+        }
+    }
+
+    private static class CollectedDoc {
+        final int docId;
+        final float score;
+
+        CollectedDoc(int docId, float score) {
+            this.docId = docId;
+            this.score = score;
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/search/vectors/BulkVectorScorerTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/BulkVectorScorerTests.java
@@ -54,10 +54,16 @@ public class BulkVectorScorerTests extends ESTestCase {
                 // Create bulk vector query
                 float[] queryVector = randomVector(VECTOR_DIMS);
                 var valueSource = new AccessibleVectorSimilarityFloatValueSource(
-                    VECTOR_FIELD, queryVector, VectorSimilarityFunction.COSINE);
+                    VECTOR_FIELD,
+                    queryVector,
+                    VectorSimilarityFunction.COSINE
+                );
 
                 BulkVectorFunctionScoreQuery bulkQuery = new BulkVectorFunctionScoreQuery(
-                    new KnnScoreDocQuery(topDocs.scoreDocs, reader), valueSource, topDocs.scoreDocs);
+                    new KnnScoreDocQuery(topDocs.scoreDocs, reader),
+                    valueSource,
+                    topDocs.scoreDocs
+                );
 
                 Weight weight = bulkQuery.createWeight(searcher, org.apache.lucene.search.ScoreMode.COMPLETE, 1.0f);
 
@@ -65,8 +71,7 @@ public class BulkVectorScorerTests extends ESTestCase {
                 BulkScorer bulkScorer = weight.scorerSupplier(leafContext).bulkScorer();
 
                 assertNotNull("BulkScorer should be created", bulkScorer);
-                assertTrue("Should be BulkVectorScorer instance",
-                    bulkScorer instanceof BulkVectorScorer);
+                assertTrue("Should be BulkVectorScorer instance", bulkScorer instanceof BulkVectorScorer);
 
                 // Test bulk scoring execution
                 TestCollector collector = new TestCollector();
@@ -96,10 +101,16 @@ public class BulkVectorScorerTests extends ESTestCase {
                 TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), 15);
                 float[] queryVector = randomVector(VECTOR_DIMS);
                 var valueSource = new AccessibleVectorSimilarityFloatValueSource(
-                    VECTOR_FIELD, queryVector, VectorSimilarityFunction.DOT_PRODUCT);
+                    VECTOR_FIELD,
+                    queryVector,
+                    VectorSimilarityFunction.DOT_PRODUCT
+                );
 
                 BulkVectorFunctionScoreQuery bulkQuery = new BulkVectorFunctionScoreQuery(
-                    new KnnScoreDocQuery(topDocs.scoreDocs, reader), valueSource, topDocs.scoreDocs);
+                    new KnnScoreDocQuery(topDocs.scoreDocs, reader),
+                    valueSource,
+                    topDocs.scoreDocs
+                );
 
                 // Execute with custom collector to verify interception
                 TestCollector collector = new TestCollector();


### PR DESCRIPTION
Add processing bulk at various stages of the KNN query: a. BulkVectorFunctionQuery
 To capture the array of ScoreDocs for bulk processing
b. BulkVectorScorer (through dedicated Weight)
 1. To load the vectors in bulk through DirectIOVectorBatchLoader
 2. Compute the similarity across multiple vectors
 3. Store the scores across a batch of docs

wip