### PR TITLE
[DOCS] Update links to start-local

### DIFF
--- a/docs/reference/query-languages/esql/esql-search-tutorial.md
+++ b/docs/reference/query-languages/esql/esql-search-tutorial.md
@@ -15,7 +15,7 @@ In this scenario, we're implementing search for a cooking blog. The blog contain
 
 You need a running {{es}} cluster, together with {{kib}} to use the Dev Tools API Console. Refer to [choose your deployment type](docs-content://deploy-manage/deploy.md#choosing-your-deployment-type) for deployment options.
 
-Want to get started quickly? Run the following command in your terminal to set up a [single-node local cluster in Docker](docs-content://solutions/search/run-elasticsearch-locally.md):
+Want to get started quickly? Run the following command in your terminal to set up a [single-node local cluster in Docker](docs-content://deploy-manage/deploy/self-managed/local-development-installation-quickstart.md):
 
 ```sh
 curl -fsSL https://elastic.co/start-local | sh

--- a/docs/reference/query-languages/query-dsl/full-text-filter-tutorial.md
+++ b/docs/reference/query-languages/query-dsl/full-text-filter-tutorial.md
@@ -33,7 +33,7 @@ You can [convert into other programming languages](docs-content://explore-analyz
 
 You can follow these steps in any type of {{es}} deployment.
 To see all deployment options, refer to [Choosing your deployment type](docs-content://deploy-manage/deploy.md#choosing-your-deployment-type).
-To get started quickly, set up a [single-node local cluster in Docker](docs-content://solutions/search/run-elasticsearch-locally.md).
+To get started quickly, set up a [single-node local cluster in Docker](docs-content://deploy-manage/deploy/self-managed/local-development-installation-quickstart.md).
 
 ## Create an index [full-text-filter-tutorial-create-index]
 


### PR DESCRIPTION
There are two copies of the `start-local` installation instructions: https://www.elastic.co/docs/solutions/search/run-elasticsearch-locally and https://www.elastic.co/docs/deploy-manage/deploy/self-managed/local-development-installation-quickstart.  This PR updates links to target the latter so we can remove the former.