### PR TITLE
[DOCS]: Add security advisory to 9.0.6 and 9.1.3 release notes

### DIFF
--- a/docs/release-notes/changelog-bundles/9.0.6.yml
+++ b/docs/release-notes/changelog-bundles/9.0.6.yml
@@ -70,3 +70,10 @@ changelogs:
     area: Ingest Node
     type: upgrade
     issues: []
+    highlight:
+      notable: true
+      title: Security advisory
+      body: |-
+        The 9.0.6 release contains fixes for potential security vulnerabilities. Please see our (security advisory)[https://discuss.elastic.co/c/announcements/security-announcements/31] for more details.
+      pr: 133410
+

--- a/docs/release-notes/changelog-bundles/9.1.3.yml
+++ b/docs/release-notes/changelog-bundles/9.1.3.yml
@@ -92,3 +92,9 @@ changelogs:
     area: Ingest Node
     type: upgrade
     issues: []
+    highlight:
+      notable: true
+      title: Security advisory
+      body: |-
+        The 9.1.3 release contains fixes for potential security vulnerabilities. Please see our (security advisory)[https://discuss.elastic.co/c/announcements/security-announcements/31] for more details.
+      pr: 133410

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -25,6 +25,12 @@ To check for security updates, go to [Security announcements for the Elastic sta
 stack: coming 9.1.3
 ```
 
+### Highlights [elasticsearch-9.1.3-highlights]
+
+::::{dropdown} Security advisory
+The 9.1.3 release contains fixes for potential security vulnerabilities. Please see our (security advisory)[https://discuss.elastic.co/c/announcements/security-announcements/31] for more details.
+::::
+
 ### Features and enhancements [elasticsearch-9.1.3-features-enhancements]
 
 Infra/REST API:
@@ -69,6 +75,12 @@ Search:
 ```{applies_to}
 stack: coming 9.0.6
 ```
+
+### Highlights [elasticsearch-9.0.6-highlights]
+
+::::{dropdown} Security advisory
+The 9.0.6 release contains fixes for potential security vulnerabilities. Please see our (security advisory)[https://discuss.elastic.co/c/announcements/security-announcements/31] for more details.
+::::
 
 ### Features and enhancements [elasticsearch-9.0.6-features-enhancements]
 


### PR DESCRIPTION
This PR adds security advisory to Elasticsearch release notes for 9.0.6 and 9.1.3.
