### PR TITLE
Fix disk usage estimation for SORTED_SET doc values.

### DIFF
--- a/docs/changelog/133722.yaml
+++ b/docs/changelog/133722.yaml
@@ -1,0 +1,5 @@
+pr: 133722
+summary: Fix disk usage estimation for SORTED_SET doc values
+area: Codec
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzer.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzer.java
@@ -277,6 +277,7 @@ final class IndexDiskUsageAnalyzer {
                     SortedSetDocValues sortedSet = iterateDocValues(maxDocs, () -> docValuesReader.getSortedSet(field), dv -> {
                         for (int i = 0; i < dv.docValueCount(); i++) {
                             cancellationChecker.logEvent();
+                            dv.nextOrd();
                         }
                     });
                     if (sortedSet.getValueCount() > 0) {


### PR DESCRIPTION
The `nextOrd()` was never invoked, which can hugely underestimate bytes used for doc sorted set doc values.