### PR TITLE
[9.1] It doesn't look like this test has ever worked, and nobody wants to mess with that code. (#133688)

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/LongFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/LongFieldMapperTests.java
@@ -118,11 +118,6 @@ public class LongFieldMapperTests extends WholeNumberFieldMapperTests {
         return randomDoubleBetween(-MAX_SAFE_LONG_FOR_DOUBLE, MAX_SAFE_LONG_FOR_DOUBLE, true);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/70585")
-    public void testFetchCoerced() throws IOException {
-        assertFetch(randomFetchTestMapper(), "field", 3.783147882954537E18, randomFetchTestFormat());
-    }
-
     protected IngestScriptSupport ingestScriptSupport() {
         return new IngestScriptSupport() {
             @Override


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [It doesn&#x27;t look like this test has ever worked, and nobody wants to mess with that code. (#133688)](https://github.com/elastic/elasticsearch/pull/133688)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)