### PR TITLE
[9.0] Validate the highest transport id is used (#133689)

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/TransportVersionValidationFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/TransportVersionValidationFuncTest.groovy
@@ -223,10 +223,33 @@ class TransportVersionValidationFuncTest extends AbstractTransportVersionFuncTes
 
     def "unreferable definitions can have primary ids that are patches"() {
         given:
-        unreferableTransportVersion("initial_10.0.1", "10000001")
+        unreferableTransportVersion("initial_7.0.1", "7000001")
         when:
         def result = gradleRunner(":myserver:validateTransportVersionResources").build()
         then:
         result.task(":myserver:validateTransportVersionResources").outcome == TaskOutcome.SUCCESS
+    }
+
+    def "highest id in an referable definition should exist in an upper bounds file"() {
+        given:
+        referableAndReferencedTransportVersion("some_tv", "10000000")
+        when:
+        def result = validateResourcesFails()
+        then:
+        assertValidateResourcesFailure(result, "Transport version definition file " +
+            "[myserver/src/main/resources/transport/definitions/referable/some_tv.csv] " +
+            "has the highest transport version id [10000000] but is not present in any upper bounds files")
+    }
+
+    def "highest id in an unreferable definition should exist in an upper bounds file"() {
+        given:
+        unreferableTransportVersion("initial_10.0.0", "10000000")
+        when:
+        def result = validateResourcesFails()
+        then:
+        // TODO: this should be _unreferable_ in the error message, but will require some rework
+        assertValidateResourcesFailure(result, "Transport version definition file " +
+            "[myserver/src/main/resources/transport/definitions/referable/initial_10.0.0.csv] " +
+            "has the highest transport version id [10000000] but is not present in any upper bounds files")
     }
 }


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Validate the highest transport id is used (#133689)