### PR TITLE
security advisory link fix

### DIFF
--- a/docs/release-notes/changelog-bundles/9.0.6.yml
+++ b/docs/release-notes/changelog-bundles/9.0.6.yml
@@ -74,6 +74,6 @@ changelogs:
       notable: true
       title: Security advisory
       body: |-
-        The 9.0.6 release contains fixes for potential security vulnerabilities. Please see our (security advisory)[https://discuss.elastic.co/c/announcements/security-announcements/31] for more details.
+        The 9.0.6 release contains fixes for potential security vulnerabilities. Please see our [security advisory](https://discuss.elastic.co/c/announcements/security-announcements/31) for more details.
       pr: 133410
 

--- a/docs/release-notes/changelog-bundles/9.1.3.yml
+++ b/docs/release-notes/changelog-bundles/9.1.3.yml
@@ -96,5 +96,5 @@ changelogs:
       notable: true
       title: Security advisory
       body: |-
-        The 9.1.3 release contains fixes for potential security vulnerabilities. Please see our (security advisory)[https://discuss.elastic.co/c/announcements/security-announcements/31] for more details.
+        The 9.1.3 release contains fixes for potential security vulnerabilities. Please see our [security advisory](https://discuss.elastic.co/c/announcements/security-announcements/31) for more details.
       pr: 133410

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -28,7 +28,7 @@ stack: coming 9.1.3
 ### Highlights [elasticsearch-9.1.3-highlights]
 
 ::::{dropdown} Security advisory
-The 9.1.3 release contains fixes for potential security vulnerabilities. Please see our (security advisory)[https://discuss.elastic.co/c/announcements/security-announcements/31] for more details.
+The 9.1.3 release contains fixes for potential security vulnerabilities. Please see our [security advisory](https://discuss.elastic.co/c/announcements/security-announcements/31) for more details.
 ::::
 
 ### Features and enhancements [elasticsearch-9.1.3-features-enhancements]
@@ -79,7 +79,7 @@ stack: coming 9.0.6
 ### Highlights [elasticsearch-9.0.6-highlights]
 
 ::::{dropdown} Security advisory
-The 9.0.6 release contains fixes for potential security vulnerabilities. Please see our (security advisory)[https://discuss.elastic.co/c/announcements/security-announcements/31] for more details.
+The 9.0.6 release contains fixes for potential security vulnerabilities. Please see our [security advisory](https://discuss.elastic.co/c/announcements/security-announcements/31) for more details.
 ::::
 
 ### Features and enhancements [elasticsearch-9.0.6-features-enhancements]


### PR DESCRIPTION
fixed malformed links in release notes and source yml (didn't regenerate, just fixed manually - skill issue)

links that were broken: security advisory on 9.1.3 and 9.0.6