### PR TITLE
Avoid stale enrich results after policy execution

### DIFF
--- a/docs/changelog/133752.yaml
+++ b/docs/changelog/133752.yaml
@@ -1,0 +1,5 @@
+pr: 133752
+summary: Fix enrich fails to update when source changes
+area: Ingest Node
+type: bug
+issues: []

--- a/docs/changelog/133752.yaml
+++ b/docs/changelog/133752.yaml
@@ -1,5 +1,5 @@
 pr: 133752
-summary: Fix enrich fails to update when source changes
+summary: Avoid stale enrich results after policy execution
 area: Ingest Node
 type: bug
 issues: []

--- a/x-pack/plugin/enrich/src/internalClusterTest/java/org/elasticsearch/xpack/enrich/EnrichSourceDataChangeIT.java
+++ b/x-pack/plugin/enrich/src/internalClusterTest/java/org/elasticsearch/xpack/enrich/EnrichSourceDataChangeIT.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.enrich;
+
+import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.Strings;
+import org.elasticsearch.ingest.common.IngestCommonPlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.reindex.ReindexPlugin;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.XPackSettings;
+import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
+import org.elasticsearch.xpack.core.enrich.action.ExecuteEnrichPolicyAction;
+import org.elasticsearch.xpack.core.enrich.action.PutEnrichPolicyAction;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.enrich.AbstractEnrichTestCase.createSourceIndices;
+import static org.hamcrest.Matchers.equalTo;
+
+public class EnrichSourceDataChangeIT extends ESSingleNodeTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return List.of(LocalStateEnrich.class, ReindexPlugin.class, IngestCommonPlugin.class);
+    }
+
+    @Override
+    protected Settings nodeSettings() {
+        return Settings.builder()
+            // TODO Change this to run with security enabled
+            // https://github.com/elastic/elasticsearch/issues/75940
+            .put(XPackSettings.SECURITY_ENABLED.getKey(), false)
+            .build();
+    }
+
+    private final String policyName = "device-enrich-policy";
+    private final String sourceIndexName = "devices-idx";
+
+    public void testChangesToTheSourceIndexTakeEffectOnPolicyExecution() throws Exception {
+        // create and store the enrich policy
+        final var enrichPolicy = new EnrichPolicy(
+            EnrichPolicy.MATCH_TYPE,
+            null,
+            List.of(sourceIndexName),
+            "host.ip",
+            List.of("device.name", "host.ip")
+        );
+
+        // create the source index
+        createSourceIndices(client(), enrichPolicy);
+
+        final String initialDeviceName = "some.device." + randomAlphaOfLength(10);
+
+        // add a single document to the enrich index
+        setEnrichDeviceName(initialDeviceName);
+
+        // store the enrich policy and execute it
+        var putPolicyRequest = new PutEnrichPolicyAction.Request(TEST_REQUEST_TIMEOUT, policyName, enrichPolicy);
+        client().execute(PutEnrichPolicyAction.INSTANCE, putPolicyRequest).actionGet();
+        executeEnrichPolicy();
+
+        // create an honest to goodness pipeline for repeated executions (we're not running any _simulate requests here)
+        final String pipelineName = "my-pipeline";
+        putJsonPipeline(pipelineName, """
+            {
+              "processors": [
+                  {
+                    "enrich": {
+                      "policy_name": "device-enrich-policy",
+                      "field": "host.ip",
+                      "target_field": "_tmp.device"
+                    }
+                  },
+                  {
+                    "rename" : {
+                      "field" : "_tmp.device.device.name",
+                      "target_field" : "device.name"
+                    }
+                  },
+                  {
+                    "remove" : {
+                      "field" : "_tmp"
+                    }
+                  }
+              ]
+            }""");
+
+        {
+            final var indexRequest = new IndexRequest(sourceIndexName);
+            indexRequest.id("1");
+            indexRequest.setPipeline("my-pipeline");
+            indexRequest.source("""
+                {
+                  "host": {
+                    "ip": "10.151.80.8"
+                  }
+                }
+                """, XContentType.JSON);
+            indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+            client().index(indexRequest).actionGet();
+
+            final var response = client().get(new GetRequest(sourceIndexName).id("1")).actionGet();
+            assertThat(response.getSource().get("device"), equalTo(Map.of("name", initialDeviceName)));
+        }
+
+        // add different document to the enrich index
+        final String changedDeviceName = "some.device." + randomAlphaOfLength(10);
+        setEnrichDeviceName(changedDeviceName);
+
+        // execute the policy to pick up the change
+        executeEnrichPolicy();
+
+        // it can take a moment for the execution to take effect, so assertBusy
+        assertBusy(() -> {
+            final var indexRequest = new IndexRequest(sourceIndexName);
+            indexRequest.id("2");
+            indexRequest.setPipeline("my-pipeline");
+            indexRequest.source("""
+                {
+                  "host": {
+                    "ip": "10.151.80.8"
+                  }
+                }
+                """, XContentType.JSON);
+            indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+            client().index(indexRequest).actionGet();
+
+            final var response = client().get(new GetRequest(sourceIndexName).id("2")).actionGet();
+            assertThat(response.getSource().get("device"), equalTo(Map.of("name", changedDeviceName)));
+        });
+    }
+
+    private void setEnrichDeviceName(final String deviceName) {
+        final var indexRequest = new IndexRequest(sourceIndexName);
+        indexRequest.id("1"); // there's only one document, and we keep overwriting it
+        indexRequest.source(Strings.format("""
+            {
+              "host": {
+                "ip": "10.151.80.8"
+              },
+              "device": {
+                "name": "%s"
+              }
+            }
+            """, deviceName), XContentType.JSON);
+        indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+        client().index(indexRequest).actionGet();
+    }
+
+    private void executeEnrichPolicy() {
+        final var executePolicyRequest = new ExecuteEnrichPolicyAction.Request(TEST_REQUEST_TIMEOUT, policyName);
+        client().execute(ExecuteEnrichPolicyAction.INSTANCE, executePolicyRequest).actionGet();
+    }
+
+}

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichProcessorFactory.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichProcessorFactory.java
@@ -133,7 +133,7 @@ final class EnrichProcessorFactory implements Processor.Factory, Consumer<Cluste
         metadata = state.getMetadata();
     }
 
-    private SearchRunner createSearchRunner(ProjectMetadata project, String indexAlias) {
+    private SearchRunner createSearchRunner(final ProjectMetadata project, final String indexAlias) {
         Client originClient = new OriginSettingClient(client, ENRICH_ORIGIN);
         return (value, maxMatches, reqSupplier, handler) -> {
             // intentionally non-locking for simplicity...it's OK if we re-put the same key/value in the cache during a race condition.
@@ -152,7 +152,7 @@ final class EnrichProcessorFactory implements Processor.Factory, Consumer<Cluste
         };
     }
 
-    private String getEnrichIndexKey(ProjectMetadata project, String indexAlias) {
+    private String getEnrichIndexKey(final ProjectMetadata project, final String indexAlias) {
         IndexAbstraction ia = project.getIndicesLookup().get(indexAlias);
         if (ia == null) {
             throw new IndexNotFoundException("no generated enrich index [" + indexAlias + "]");

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichProcessorFactory.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichProcessorFactory.java
@@ -63,14 +63,18 @@ final class EnrichProcessorFactory implements Processor.Factory, Consumer<Cluste
         if (metadata == null) {
             throw new IllegalStateException("enrich processor factory has not yet been initialized with cluster state");
         }
-        final var project = metadata.getProject(projectId);
-        IndexAbstraction indexAbstraction = project.getIndicesLookup().get(indexAlias);
-        if (indexAbstraction == null) {
-            throw new IllegalArgumentException("no enrich index exists for policy with name [" + policyName + "]");
+
+        final IndexMetadata imd;
+        {
+            final var project = metadata.getProject(projectId);
+            IndexAbstraction indexAbstraction = project.getIndicesLookup().get(indexAlias);
+            if (indexAbstraction == null) {
+                throw new IllegalArgumentException("no enrich index exists for policy with name [" + policyName + "]");
+            }
+            assert indexAbstraction.getType() == IndexAbstraction.Type.ALIAS;
+            assert indexAbstraction.getIndices().size() == 1;
+            imd = project.index(indexAbstraction.getIndices().get(0));
         }
-        assert indexAbstraction.getType() == IndexAbstraction.Type.ALIAS;
-        assert indexAbstraction.getIndices().size() == 1;
-        IndexMetadata imd = project.index(indexAbstraction.getIndices().get(0));
 
         Map<String, Object> mappingAsMap = imd.mapping().sourceAsMap();
         String policyType = (String) XContentMapValues.extractValue(


### PR DESCRIPTION
In the course of reviewing #133680, @jbaiera realized that there's an unrelated bug in the `enrich` processor. 

The updated logic of the `enrich` processor from https://github.com/elastic/elasticsearch/pull/124099 (released in 9.1.0) captures the project metadata, rather than the project id, which means that it doesn't see changes to the cluster state over time, including updates to the enrich index. As a consequence, executing an enrich policy wouldn't result in changes from the source index being reflected in the results of the `enrich` processor.

The fix here is to bind the project id and look up the project metadata.