### PR TITLE
ESQL: Add names to aggregator tests

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/First.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/First.java
@@ -91,6 +91,10 @@ public class First extends AggregateFunction implements ToAggregator {
         return new First(source(), field(), filter, sort);
     }
 
+    public Expression sort() {
+        return sort;
+    }
+
     @Override
     public DataType dataType() {
         return field().dataType();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Last.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Last.java
@@ -91,6 +91,10 @@ public class Last extends AggregateFunction implements ToAggregator {
         return new Last(source(), field(), filter, sort);
     }
 
+    public Expression sort() {
+        return sort;
+    }
+
     @Override
     public DataType dataType() {
         return field().dataType();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractAggregationTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractAggregationTestCase.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.esql.expression.function;
 
+import joptsimple.internal.Strings;
+
 import org.elasticsearch.compute.aggregation.Aggregator;
 import org.elasticsearch.compute.aggregation.AggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.AggregatorMode;
@@ -506,41 +508,46 @@ public abstract class AbstractAggregationTestCase extends AbstractFunctionTestCa
     }
 
     private void assertAggregatorToString(Object aggregator) {
-        if (optIntoToAggregatorToStringChecks() == false) {
-            return;
-        }
         String expectedStart = switch (aggregator) {
             case Aggregator a -> "Aggregator[aggregatorFunction=";
             case GroupingAggregator a -> "GroupingAggregator[aggregatorFunction=";
             default -> throw new UnsupportedOperationException("can't check toString for [" + aggregator.getClass() + "]");
         };
+        String channels = initialInputChannels().stream().map(Object::toString).collect(Collectors.joining(", "));
         String expectedEnd = switch (aggregator) {
-            case Aggregator a -> "AggregatorFunction[channels=[0]], mode=SINGLE]";
-            case GroupingAggregator a -> "GroupingAggregatorFunction[channels=[0]], mode=SINGLE]";
+            case Aggregator a -> "AggregatorFunction[channels=[" + channels + "]], mode=SINGLE]";
+            case GroupingAggregator a -> "GroupingAggregatorFunction[channels=[" + channels + "]], mode=SINGLE]";
             default -> throw new UnsupportedOperationException("can't check toString for [" + aggregator.getClass() + "]");
         };
 
         String toString = aggregator.toString();
         assertThat(toString, startsWith(expectedStart));
-        assertThat(toString.substring(expectedStart.length(), toString.length() - expectedEnd.length()), testCase.evaluatorToString());
         assertThat(toString, endsWith(expectedEnd));
-    }
-
-    protected boolean optIntoToAggregatorToStringChecks() {
-        // TODO remove this when everyone has opted in
-        return false;
+        assertThat(toString.substring(expectedStart.length(), toString.length() - expectedEnd.length()), testCase.evaluatorToString());
     }
 
     protected static String standardAggregatorName(String prefix, DataType type) {
         String typeName = switch (type) {
             case BOOLEAN -> "Boolean";
+            case CARTESIAN_POINT -> "CartesianPoint";
+            case CARTESIAN_SHAPE -> "CartesianShape";
+            case GEO_POINT -> "GeoPoint";
+            case GEO_SHAPE -> "GeoShape";
             case KEYWORD, TEXT, VERSION -> "BytesRef";
-            case DOUBLE -> "Double";
-            case INTEGER -> "Int";
+            case DOUBLE, COUNTER_DOUBLE -> "Double";
+            case INTEGER, COUNTER_INTEGER -> "Int";
             case IP -> "Ip";
-            case DATETIME, DATE_NANOS, LONG, UNSIGNED_LONG -> "Long";
+            case DATETIME, DATE_NANOS, LONG, COUNTER_LONG, UNSIGNED_LONG -> "Long";
+            case NULL -> "Null";
             default -> throw new UnsupportedOperationException("name for [" + type + "]");
         };
         return prefix + typeName;
+    }
+
+    protected static String standardAggregatorNameAllBytesTheSame(String prefix, DataType type) {
+        return standardAggregatorName(prefix, switch (type) {
+            case CARTESIAN_POINT, CARTESIAN_SHAPE, GEO_POINT, GEO_SHAPE, IP -> DataType.KEYWORD;
+            default -> type;
+        });
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractAggregationTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractAggregationTestCase.java
@@ -7,8 +7,6 @@
 
 package org.elasticsearch.xpack.esql.expression.function;
 
-import joptsimple.internal.Strings;
-
 import org.elasticsearch.compute.aggregation.Aggregator;
 import org.elasticsearch.compute.aggregation.AggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.AggregatorMode;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinctTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinctTests.java
@@ -127,7 +127,7 @@ public class CountDistinctTests extends AbstractAggregationTestCase {
 
             return new TestCaseSupplier.TestCase(
                 List.of(fieldTypedData, precisionTypedData),
-                "CountDistinct[field=Attribute[channel=0],precision=Attribute[channel=1]]",
+                standardAggregatorNameAllBytesTheSame("CountDistinct", fieldTypedData.type()),
                 DataType.LONG,
                 equalTo(result)
             );
@@ -149,7 +149,7 @@ public class CountDistinctTests extends AbstractAggregationTestCase {
 
             return new TestCaseSupplier.TestCase(
                 List.of(fieldTypedData),
-                "CountDistinct[field=Attribute[channel=0]]",
+                standardAggregatorNameAllBytesTheSame("CountDistinct", fieldTypedData.type()),
                 DataType.LONG,
                 equalTo(result)
             );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountTests.java
@@ -78,7 +78,7 @@ public class CountTests extends AbstractAggregationTestCase {
                     List.of(dataType),
                     () -> new TestCaseSupplier.TestCase(
                         List.of(TestCaseSupplier.TypedData.multiRow(List.of(), dataType, "field")),
-                        "Count[field=Attribute[channel=0]]",
+                        "Count",
                         DataType.LONG,
                         equalTo(0L)
                     )
@@ -102,7 +102,7 @@ public class CountTests extends AbstractAggregationTestCase {
 
             return new TestCaseSupplier.TestCase(
                 List.of(fieldTypedData),
-                "Count[field=Attribute[channel=0]]",
+                "Count",
                 DataType.LONG,
                 equalTo(rowCount)
             );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountTests.java
@@ -100,12 +100,7 @@ public class CountTests extends AbstractAggregationTestCase {
             var fieldTypedData = fieldSupplier.get();
             var rowCount = fieldTypedData.multiRowData().stream().filter(Objects::nonNull).count();
 
-            return new TestCaseSupplier.TestCase(
-                List.of(fieldTypedData),
-                "Count",
-                DataType.LONG,
-                equalTo(rowCount)
-            );
+            return new TestCaseSupplier.TestCase(List.of(fieldTypedData), "Count", DataType.LONG, equalTo(rowCount));
         });
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/FirstOverTimeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/FirstOverTimeTests.java
@@ -85,7 +85,7 @@ public class FirstOverTimeTests extends AbstractAggregationTestCase {
             }
             return new TestCaseSupplier.TestCase(
                 List.of(fieldTypedData, timestampsField),
-                "FirstOverTime[field=Attribute[channel=0],timestamp=Attribute[channel=1]]",
+                standardAggregatorName("First", fieldSupplier.type()) + "ByTimestamp",
                 type,
                 equalTo(expected)
             );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/FirstSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/FirstSerializationTests.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.aggregate;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+
+import java.io.IOException;
+
+public class FirstSerializationTests extends AbstractExpressionSerializationTests<First> {
+    @Override
+    protected First createTestInstance() {
+        return new First(randomSource(), randomChild(), randomChild());
+    }
+
+    @Override
+    protected First mutateInstance(First instance) throws IOException {
+        Expression field = instance.field();
+        Expression sort = instance.sort();
+        if (randomBoolean()) {
+            field = randomValueOtherThan(field, AbstractExpressionSerializationTests::randomChild);
+        } else {
+            sort = randomValueOtherThan(sort, AbstractExpressionSerializationTests::randomChild);
+        }
+        return new First(instance.source(), field, sort);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/FirstTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/FirstTests.java
@@ -81,7 +81,7 @@ public class FirstTests extends AbstractAggregationTestCase {
                 }
                 return new TestCaseSupplier.TestCase(
                     List.of(values, sorts),
-                    "unused",
+                    standardAggregatorName(first ? "First" : "Last", values.type()) + "ByTimestamp",
                     values.type(),
                     anyOf(() -> Iterators.map(expected.iterator(), Matchers::equalTo))
                 );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/LastOverTimeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/LastOverTimeTests.java
@@ -85,7 +85,7 @@ public class LastOverTimeTests extends AbstractAggregationTestCase {
             }
             return new TestCaseSupplier.TestCase(
                 List.of(fieldTypedData, timestampsField),
-                "LastOverTime[field=Attribute[channel=0],timestamp=Attribute[channel=1]]",
+                standardAggregatorName("Last", fieldSupplier.type()) + "ByTimestamp",
                 type,
                 equalTo(expected)
             );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/LastSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/LastSerializationTests.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.aggregate;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+
+import java.io.IOException;
+
+public class LastSerializationTests extends AbstractExpressionSerializationTests<Last> {
+    @Override
+    protected Last createTestInstance() {
+        return new Last(randomSource(), randomChild(), randomChild());
+    }
+
+    @Override
+    protected Last mutateInstance(Last instance) throws IOException {
+        Expression field = instance.field();
+        Expression sort = instance.sort();
+        if (randomBoolean()) {
+            field = randomValueOtherThan(field, AbstractExpressionSerializationTests::randomChild);
+        } else {
+            sort = randomValueOtherThan(sort, AbstractExpressionSerializationTests::randomChild);
+        }
+        return new Last(instance.source(), field, sort);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/MaxTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/MaxTests.java
@@ -209,9 +209,4 @@ public class MaxTests extends AbstractAggregationTestCase {
             );
         });
     }
-
-    @Override
-    protected boolean optIntoToAggregatorToStringChecks() {
-        return true;
-    }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/MedianAbsoluteDeviationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/MedianAbsoluteDeviationTests.java
@@ -60,7 +60,7 @@ public class MedianAbsoluteDeviationTests extends AbstractAggregationTestCase {
 
                 return new TestCaseSupplier.TestCase(
                     List.of(fieldTypedData),
-                    "MedianAbsoluteDeviation[number=Attribute[channel=0]]",
+                    standardAggregatorName("MedianAbsoluteDeviation", fieldSupplier.type()),
                     DataType.DOUBLE,
                     equalTo(expected)
                 );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/MedianTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/MedianTests.java
@@ -101,9 +101,4 @@ public class MedianTests extends AbstractAggregationTestCase {
             }
         });
     }
-
-    @Override
-    protected boolean optIntoToAggregatorToStringChecks() {
-        return true;
-    }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/MinTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/MinTests.java
@@ -209,9 +209,4 @@ public class MinTests extends AbstractAggregationTestCase {
             );
         });
     }
-
-    @Override
-    protected boolean optIntoToAggregatorToStringChecks() {
-        return true;
-    }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/PercentileTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/PercentileTests.java
@@ -80,7 +80,7 @@ public class PercentileTests extends AbstractAggregationTestCase {
 
                 return new TestCaseSupplier.TestCase(
                     List.of(fieldTypedData, percentileTypedData),
-                    "Percentile[number=Attribute[channel=0],percentile=Attribute[channel=1]]",
+                    standardAggregatorName("Percentile", fieldSupplier.type()),
                     DataType.DOUBLE,
                     equalTo(expected)
                 );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/RateTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/RateTests.java
@@ -120,7 +120,7 @@ public class RateTests extends AbstractAggregationTestCase {
             }
             return new TestCaseSupplier.TestCase(
                 List.of(fieldTypedData, timestampsField),
-                "Rate[field=Attribute[channel=0],timestamp=Attribute[channel=1]]",
+                standardAggregatorName("Rate", fieldTypedData.type()),
                 DataType.DOUBLE,
                 matcher
             );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SampleSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SampleSerializationTests.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.aggregate;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+
+import java.io.IOException;
+
+public class SampleSerializationTests extends AbstractExpressionSerializationTests<Sample> {
+    @Override
+    protected Sample createTestInstance() {
+        Source source = randomSource();
+        Expression field = randomChild();
+        Expression limit = randomChild();
+        return new Sample(source, field, limit);
+    }
+
+    @Override
+    protected Sample mutateInstance(Sample instance) throws IOException {
+        Source source = randomSource();
+        Expression field = instance.field();
+        Expression limit = instance.limitField();
+        switch (between(0, 1)) {
+            case 0 -> field = randomValueOtherThan(field, AbstractExpressionSerializationTests::randomChild);
+            case 1 -> limit = randomValueOtherThan(limit, AbstractExpressionSerializationTests::randomChild);
+        }
+        return new Sample(source, field, limit);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SampleTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SampleTests.java
@@ -86,7 +86,7 @@ public class SampleTests extends AbstractAggregationTestCase {
 
             return new TestCaseSupplier.TestCase(
                 List.of(fieldTypedData, limitTypedData),
-                "Sample[field=Attribute[channel=0], limit=Attribute[channel=1]]",
+                standardAggregatorNameAllBytesTheSame("Sample", fieldSupplier.type()),
                 fieldSupplier.type(),
                 subsetOfSize(rows, limit)
             );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SpatialCentroidTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SpatialCentroidTests.java
@@ -86,7 +86,7 @@ public class SpatialCentroidTests extends AbstractAggregationTestCase {
 
             return new TestCaseSupplier.TestCase(
                 List.of(fieldTypedData),
-                "SpatialCentroid[field=Attribute[channel=0]]",
+                standardAggregatorName("SpatialCentroid", fieldSupplier.type()) + "SourceValues",
                 fieldTypedData.type(),
                 centroidMatches(expectedX, expectedY, 1e-14)
             );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SpatialExtentSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SpatialExtentSerializationTests.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.aggregate;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+
+import java.io.IOException;
+
+public class SpatialExtentSerializationTests extends AbstractExpressionSerializationTests<SpatialExtent> {
+    @Override
+    protected SpatialExtent createTestInstance() {
+        return new SpatialExtent(randomSource(), randomChild());
+    }
+
+    @Override
+    protected SpatialExtent mutateInstance(SpatialExtent instance) throws IOException {
+        return new SpatialExtent(
+            instance.source(),
+            randomValueOtherThan(instance.field(), AbstractExpressionSerializationTests::randomChild)
+        );
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SpatialExtentSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SpatialExtentSerializationTests.java
@@ -7,8 +7,6 @@
 
 package org.elasticsearch.xpack.esql.expression.function.aggregate;
 
-import org.elasticsearch.xpack.esql.core.expression.Expression;
-import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
 
 import java.io.IOException;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SpatialExtentTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SpatialExtentTests.java
@@ -83,7 +83,7 @@ public class SpatialExtentTests extends SpatialAggregationTestCase {
             Rectangle result = pointVisitor.getResult();
             return new TestCaseSupplier.TestCase(
                 List.of(fieldTypedData),
-                "SpatialExtent[field=Attribute[channel=0]]",
+                standardAggregatorName("SpatialExtent", fieldSupplier.type()) + "SourceValues",
                 expectedType,
                 new WellKnownBinaryBytesRefMatcher<>(RectangleMatcher.closeToFloat(result, 1e-3, pointType.encoder()))
             );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/StdDevSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/StdDevSerializationTests.java
@@ -19,9 +19,6 @@ public class StdDevSerializationTests extends AbstractExpressionSerializationTes
 
     @Override
     protected StdDev mutateInstance(StdDev instance) throws IOException {
-        return new StdDev(
-            instance.source(),
-            randomValueOtherThan(instance.field(), AbstractExpressionSerializationTests::randomChild)
-        );
+        return new StdDev(instance.source(), randomValueOtherThan(instance.field(), AbstractExpressionSerializationTests::randomChild));
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/StdDevSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/StdDevSerializationTests.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.aggregate;
+
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+
+import java.io.IOException;
+
+public class StdDevSerializationTests extends AbstractExpressionSerializationTests<StdDev> {
+    @Override
+    protected StdDev createTestInstance() {
+        return new StdDev(randomSource(), randomChild());
+    }
+
+    @Override
+    protected StdDev mutateInstance(StdDev instance) throws IOException {
+        return new StdDev(
+            instance.source(),
+            randomValueOtherThan(instance.field(), AbstractExpressionSerializationTests::randomChild)
+        );
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/StdDevTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/StdDevTests.java
@@ -64,7 +64,7 @@ public class StdDevTests extends AbstractAggregationTestCase {
             var expected = Double.isFinite(result) ? result : null;
             return new TestCaseSupplier.TestCase(
                 List.of(fieldTypedData),
-                "StdDev[field=Attribute[channel=0]]",
+                standardAggregatorName("StdDev", fieldSupplier.type()),
                 DataType.DOUBLE,
                 equalTo(expected)
             );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SumTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SumTests.java
@@ -51,7 +51,7 @@ public class SumTests extends AbstractAggregationTestCase {
                     List.of(DataType.INTEGER),
                     () -> new TestCaseSupplier.TestCase(
                         List.of(TestCaseSupplier.TypedData.multiRow(List.of(200), DataType.INTEGER, "field")),
-                        "Sum[field=Attribute[channel=0]]",
+                        "SumInt",
                         DataType.LONG,
                         equalTo(200L)
                     )
@@ -60,7 +60,7 @@ public class SumTests extends AbstractAggregationTestCase {
                     List.of(DataType.LONG),
                     () -> new TestCaseSupplier.TestCase(
                         List.of(TestCaseSupplier.TypedData.multiRow(List.of(200L), DataType.LONG, "field")),
-                        "Sum[field=Attribute[channel=0]]",
+                        "SumLong",
                         DataType.LONG,
                         equalTo(200L)
                     )
@@ -69,7 +69,7 @@ public class SumTests extends AbstractAggregationTestCase {
                     List.of(DataType.DOUBLE),
                     () -> new TestCaseSupplier.TestCase(
                         List.of(TestCaseSupplier.TypedData.multiRow(List.of(200.), DataType.DOUBLE, "field")),
-                        "Sum[field=Attribute[channel=0]]",
+                        "SumDouble",
                         DataType.DOUBLE,
                         equalTo(200.)
                     )
@@ -126,7 +126,12 @@ public class SumTests extends AbstractAggregationTestCase {
                 ? DataType.DOUBLE
                 : DataType.LONG;
 
-            return new TestCaseSupplier.TestCase(List.of(fieldTypedData), "Sum[field=Attribute[channel=0]]", dataType, equalTo(expected));
+            return new TestCaseSupplier.TestCase(
+                List.of(fieldTypedData),
+                standardAggregatorName("Sum", fieldSupplier.type()),
+                dataType,
+                equalTo(expected)
+            );
         });
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/TopTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/TopTests.java
@@ -67,7 +67,7 @@ public class TopTests extends AbstractAggregationTestCase {
                             new TestCaseSupplier.TypedData(1, DataType.INTEGER, "limit").forceLiteral(),
                             new TestCaseSupplier.TypedData(new BytesRef("desc"), DataType.KEYWORD, "order").forceLiteral()
                         ),
-                        "Top[field=Attribute[channel=0], limit=Attribute[channel=1], order=Attribute[channel=2]]",
+                        "MaxBoolean",
                         DataType.BOOLEAN,
                         equalTo(true)
                     )
@@ -80,7 +80,7 @@ public class TopTests extends AbstractAggregationTestCase {
                             new TestCaseSupplier.TypedData(1, DataType.INTEGER, "limit").forceLiteral(),
                             new TestCaseSupplier.TypedData(new BytesRef("desc"), DataType.KEYWORD, "order").forceLiteral()
                         ),
-                        "Top[field=Attribute[channel=0], limit=Attribute[channel=1], order=Attribute[channel=2]]",
+                        "MaxInt",
                         DataType.INTEGER,
                         equalTo(200)
                     )
@@ -93,7 +93,7 @@ public class TopTests extends AbstractAggregationTestCase {
                             new TestCaseSupplier.TypedData(1, DataType.INTEGER, "limit").forceLiteral(),
                             new TestCaseSupplier.TypedData(new BytesRef("desc"), DataType.KEYWORD, "order").forceLiteral()
                         ),
-                        "Top[field=Attribute[channel=0], limit=Attribute[channel=1], order=Attribute[channel=2]]",
+                        "MaxLong",
                         DataType.LONG,
                         equalTo(200L)
                     )
@@ -106,7 +106,7 @@ public class TopTests extends AbstractAggregationTestCase {
                             new TestCaseSupplier.TypedData(1, DataType.INTEGER, "limit").forceLiteral(),
                             new TestCaseSupplier.TypedData(new BytesRef("desc"), DataType.KEYWORD, "order").forceLiteral()
                         ),
-                        "Top[field=Attribute[channel=0], limit=Attribute[channel=1], order=Attribute[channel=2]]",
+                        "MaxDouble",
                         DataType.DOUBLE,
                         equalTo(200.)
                     )
@@ -119,7 +119,7 @@ public class TopTests extends AbstractAggregationTestCase {
                             new TestCaseSupplier.TypedData(1, DataType.INTEGER, "limit").forceLiteral(),
                             new TestCaseSupplier.TypedData(new BytesRef("desc"), DataType.KEYWORD, "order").forceLiteral()
                         ),
-                        "Top[field=Attribute[channel=0], limit=Attribute[channel=1], order=Attribute[channel=2]]",
+                        "MaxLong",
                         DataType.DATETIME,
                         equalTo(200L)
                     )
@@ -141,7 +141,7 @@ public class TopTests extends AbstractAggregationTestCase {
                             new TestCaseSupplier.TypedData(1, DataType.INTEGER, "limit").forceLiteral(),
                             new TestCaseSupplier.TypedData(new BytesRef("desc"), DataType.KEYWORD, "order").forceLiteral()
                         ),
-                        "Top[field=Attribute[channel=0], limit=Attribute[channel=1], order=Attribute[channel=2]]",
+                        "MaxIp",
                         DataType.IP,
                         equalTo(new BytesRef(InetAddressPoint.encode(InetAddresses.forString("ffff::"))))
                     )
@@ -156,7 +156,7 @@ public class TopTests extends AbstractAggregationTestCase {
                             new TestCaseSupplier.TypedData(1, DataType.INTEGER, "limit").forceLiteral(),
                             new TestCaseSupplier.TypedData(new BytesRef("desc"), DataType.KEYWORD, "order").forceLiteral()
                         ),
-                        "Top[field=Attribute[channel=0], limit=Attribute[channel=1], order=Attribute[channel=2]]",
+                        "MaxBoolean",
                         DataType.BOOLEAN,
                         equalTo(true)
                     )
@@ -169,7 +169,7 @@ public class TopTests extends AbstractAggregationTestCase {
                             new TestCaseSupplier.TypedData(1, DataType.INTEGER, "limit").forceLiteral(),
                             new TestCaseSupplier.TypedData(new BytesRef("desc"), DataType.KEYWORD, "order").forceLiteral()
                         ),
-                        "Top[field=Attribute[channel=0], limit=Attribute[channel=1], order=Attribute[channel=2]]",
+                        "MaxInt",
                         DataType.INTEGER,
                         equalTo(200)
                     )
@@ -182,7 +182,7 @@ public class TopTests extends AbstractAggregationTestCase {
                             new TestCaseSupplier.TypedData(1, DataType.INTEGER, "limit").forceLiteral(),
                             new TestCaseSupplier.TypedData(new BytesRef("desc"), DataType.KEYWORD, "order").forceLiteral()
                         ),
-                        "Top[field=Attribute[channel=0], limit=Attribute[channel=1], order=Attribute[channel=2]]",
+                        "MaxLong",
                         DataType.LONG,
                         equalTo(200L)
                     )
@@ -195,7 +195,7 @@ public class TopTests extends AbstractAggregationTestCase {
                             new TestCaseSupplier.TypedData(1, DataType.INTEGER, "limit").forceLiteral(),
                             new TestCaseSupplier.TypedData(new BytesRef("desc"), DataType.KEYWORD, "order").forceLiteral()
                         ),
-                        "Top[field=Attribute[channel=0], limit=Attribute[channel=1], order=Attribute[channel=2]]",
+                        "MaxDouble",
                         DataType.DOUBLE,
                         equalTo(200.)
                     )
@@ -208,7 +208,7 @@ public class TopTests extends AbstractAggregationTestCase {
                             new TestCaseSupplier.TypedData(1, DataType.INTEGER, "limit").forceLiteral(),
                             new TestCaseSupplier.TypedData(new BytesRef("desc"), DataType.KEYWORD, "order").forceLiteral()
                         ),
-                        "Top[field=Attribute[channel=0], limit=Attribute[channel=1], order=Attribute[channel=2]]",
+                        "MaxLong",
                         DataType.DATETIME,
                         equalTo(200L)
                     )
@@ -225,7 +225,7 @@ public class TopTests extends AbstractAggregationTestCase {
                             new TestCaseSupplier.TypedData(1, DataType.INTEGER, "limit").forceLiteral(),
                             new TestCaseSupplier.TypedData(new BytesRef("desc"), DataType.KEYWORD, "order").forceLiteral()
                         ),
-                        "Top[field=Attribute[channel=0], limit=Attribute[channel=1], order=Attribute[channel=2]]",
+                        "MaxIp",
                         DataType.IP,
                         equalTo(new BytesRef(InetAddressPoint.encode(InetAddresses.forString("127.0.0.1"))))
                     )
@@ -310,7 +310,7 @@ public class TopTests extends AbstractAggregationTestCase {
                     limitTypedData,
                     new TestCaseSupplier.TypedData(new BytesRef(order), DataType.KEYWORD, order + " order").forceLiteral()
                 ),
-                "Top[field=Attribute[channel=0], limit=Attribute[channel=1], order=Attribute[channel=2]]",
+                standardAggregatorName("Top", fieldTypedData.type()),
                 fieldSupplier.type(),
                 equalTo(expected.size() == 1 ? expected.get(0) : expected)
             );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/ValuesTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/ValuesTests.java
@@ -76,7 +76,7 @@ public class ValuesTests extends AbstractAggregationTestCase {
             var expected = new HashSet<>(fieldTypedData.multiRowData());
             return new TestCaseSupplier.TestCase(
                 List.of(fieldTypedData),
-                "Values[field=Attribute[channel=0]]",
+                standardAggregatorNameAllBytesTheSame("Values", fieldSupplier.type()),
                 fieldSupplier.type(),
                 valuesInAnyOrder(expected)
             );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/WeightedAvgSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/WeightedAvgSerializationTests.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.aggregate;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+import org.elasticsearch.xpack.esql.expression.function.Example;
+
+import java.io.IOException;
+
+public class WeightedAvgSerializationTests extends AbstractExpressionSerializationTests<WeightedAvg> {
+    @Override
+    protected WeightedAvg createTestInstance() {
+        return new WeightedAvg(randomSource(), randomChild(), randomChild());
+    }
+
+    @Override
+    protected WeightedAvg mutateInstance(WeightedAvg instance) throws IOException {
+        Expression field = instance.field();
+        Expression weight = instance.weight();
+        if (randomBoolean()) {
+            field = randomValueOtherThan(field, AbstractExpressionSerializationTests::randomChild);
+        } else {
+            weight = randomValueOtherThan(weight, AbstractExpressionSerializationTests::randomChild);
+        }
+        return new WeightedAvg(instance.source(), field, weight);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/WeightedAvgSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/WeightedAvgSerializationTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.esql.expression.function.aggregate;
 
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
-import org.elasticsearch.xpack.esql.expression.function.Example;
 
 import java.io.IOException;
 


### PR DESCRIPTION
Opts all remaining aggs into the name tests. Adds a couple more serialization tests while I'm there.
