### PR TITLE
[Gradle] Remove unused spool support in LoggedExec

### DIFF
--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/LoggedExecFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/LoggedExecFuncTest.groovy
@@ -29,46 +29,23 @@ class LoggedExecFuncTest extends AbstractGradleFuncTest {
         """
     }
 
-    @Unroll
-    def "can configure spooling #spooling"() {
-        setup:
-        buildFile << """
-        import org.elasticsearch.gradle.LoggedExec
-        tasks.register('loggedExec', LoggedExec) {
-          commandLine 'ls', '-lh'
-          getSpoolOutput().set($spooling)
-        }
-        """
-        when:
-        def result = gradleRunner("loggedExec").build()
-        then:
-        result.task(':loggedExec').outcome == TaskOutcome.SUCCESS
-        file("build/buffered-output/loggedExec").exists() == spooling
-        where:
-        spooling << [false, true]
-    }
 
-    @Unroll
-    def "failed tasks output logged to console when spooling #spooling"() {
+    def "failed tasks output logged to console"() {
         setup:
         buildFile << """
         import org.elasticsearch.gradle.LoggedExec
         tasks.register('loggedExec', LoggedExec) {
           commandLine 'ls', 'wtf'
-          getSpoolOutput().set($spooling)
         }
         """
         when:
         def result = gradleRunner("loggedExec").buildAndFail()
         then:
         result.task(':loggedExec').outcome == TaskOutcome.FAILED
-        file("build/buffered-output/loggedExec").exists() == spooling
         assertOutputContains(result.output, """\
             > Task :loggedExec FAILED
             Output for ls:""".stripIndent())
         assertOutputContains(result.output, "No such file or directory")
-        where:
-        spooling << [false, true]
     }
 
     def "can capture output"() {
@@ -91,27 +68,6 @@ class LoggedExecFuncTest extends AbstractGradleFuncTest {
         result.getOutput().contains("OUTPUT HELLO")
     }
 
-    def "capturing output with spooling enabled is not supported"() {
-        setup:
-        buildFile << """
-        import org.elasticsearch.gradle.LoggedExec
-        tasks.register('loggedExec', LoggedExec) {
-          commandLine 'echo', 'HELLO'
-          getCaptureOutput().set(true)
-          getSpoolOutput().set(true)
-        }
-        """
-        when:
-        def result = gradleRunner("loggedExec").buildAndFail()
-        then:
-        result.task(':loggedExec').outcome == TaskOutcome.FAILED
-        assertOutputContains(result.output, '''\
-            FAILURE: Build failed with an exception.
-
-            * What went wrong:
-            Execution failed for task ':loggedExec'.
-            > Capturing output is not supported when spoolOutput is true.'''.stripIndent())
-    }
 
 
     def "can configure output indenting"() {

--- a/build-tools/src/main/java/org/elasticsearch/gradle/LoggedExec.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/LoggedExec.java
@@ -39,7 +39,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -98,9 +97,6 @@ public abstract class LoggedExec extends DefaultTask implements FileSystemOperat
     @Internal
     abstract public Property<File> getWorkingDir();
 
-    @Internal
-    abstract public Property<Boolean> getSpoolOutput();
-
     private String output;
 
     @Inject
@@ -117,7 +113,6 @@ public abstract class LoggedExec extends DefaultTask implements FileSystemOperat
         // For now mimic default behaviour of Gradle Exec task here
         setupDefaultEnvironment(providerFactory);
         getCaptureOutput().convention(false);
-        getSpoolOutput().convention(false);
     }
 
     /**
@@ -146,34 +141,12 @@ public abstract class LoggedExec extends DefaultTask implements FileSystemOperat
 
     @TaskAction
     public void run() {
-        boolean spoolOutput = getSpoolOutput().get();
-        if (spoolOutput && getCaptureOutput().get()) {
-            throw new GradleException("Capturing output is not supported when spoolOutput is true.");
-        }
         if (getCaptureOutput().get() && getIndentingConsoleOutput().isPresent()) {
             throw new GradleException("Capturing output is not supported when indentingConsoleOutput is configured.");
         }
         Consumer<Logger> outputLogger;
-        OutputStream out;
-        if (spoolOutput) {
-            File spoolFile = new File(projectLayout.getBuildDirectory().dir("buffered-output").get().getAsFile(), this.getName());
-            out = new LazyFileOutputStream(spoolFile);
-            outputLogger = logger -> {
-                try {
-                    // the file may not exist if the command never output anything
-                    if (Files.exists(spoolFile.toPath())) {
-                        try (var lines = Files.lines(spoolFile.toPath())) {
-                            lines.forEach(logger::error);
-                        }
-                    }
-                } catch (IOException e) {
-                    throw new RuntimeException("could not log", e);
-                }
-            };
-        } else {
-            out = new ByteArrayOutputStream();
-            outputLogger = getIndentingConsoleOutput().isPresent() ? logger -> {} : logger -> logger.error(byteStreamToString(out));
-        }
+        OutputStream out = new ByteArrayOutputStream();
+        outputLogger = getIndentingConsoleOutput().isPresent() ? logger -> {} : logger -> logger.error(byteStreamToString(out));
 
         OutputStream finalOutputStream = getIndentingConsoleOutput().isPresent()
             ? new IndentingOutputStream(System.out, getIndentingConsoleOutput().get())

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -342,9 +342,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.inference.bulk.BulkInferenceExecutorTests
   method: testSuccessfulExecution
   issue: https://github.com/elastic/elasticsearch/issues/130306
-- class: org.elasticsearch.gradle.LoggedExecFuncTest
-  method: failed tasks output logged to console when spooling true
-  issue: https://github.com/elastic/elasticsearch/issues/119509
 - class: org.elasticsearch.indices.stats.IndexStatsIT
   method: testFilterCacheStats
   issue: https://github.com/elastic/elasticsearch/issues/124447


### PR DESCRIPTION
This is not used anywhere so we should simplify this down to what
we actually use.

Fixes #119509