### PR TITLE
[8.18] [Gradle] Cleanup test mutes for gradle func tests (#133768)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -534,15 +534,6 @@ tests:
 - class: org.elasticsearch.packaging.test.DebPreservationTests
   method: test40RestartOnUpgrade
   issue: https://github.com/elastic/elasticsearch/issues/125821
-- class: org.elasticsearch.gradle.internal.transport.TransportVersionManagementPluginFuncTest
-  method: cannot change committed ids to a branch
-  issue: https://github.com/elastic/elasticsearch/issues/132790
-- class: org.elasticsearch.gradle.internal.transport.TransportVersionManagementPluginFuncTest
-  method: latest files cannot change base id
-  issue: https://github.com/elastic/elasticsearch/issues/132789
-- class: org.elasticsearch.gradle.internal.transport.TransportVersionManagementPluginFuncTest
-  method: definitions have primary ids which cannot change
-  issue: https://github.com/elastic/elasticsearch/issues/132788
 - class: org.elasticsearch.core.GlobTests
   method: testSuffixMatch
   issue: https://github.com/elastic/elasticsearch/issues/133117


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Gradle] Cleanup test mutes for gradle func tests (#133768)](https://github.com/elastic/elasticsearch/pull/133768)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)