### PR TITLE
Replaces links to the deduplicated/reconciled privileges page

### DIFF
--- a/docs/reference/elasticsearch/elasticsearch-audit-events.md
+++ b/docs/reference/elasticsearch/elasticsearch-audit-events.md
@@ -31,7 +31,7 @@ Certain audit events require the `security_config_change` event type to log the 
 $$$event-access-denied$$$
 
 `access_denied`
-:   Logged when an authenticated user attempts to execute an action they do not have the necessary [privilege](docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/elasticsearch-privileges.md) to perform.
+:   Logged when an authenticated user attempts to execute an action they do not have the necessary [privilege](/reference/elasticsearch/security-privileges.md) to perform.
 
     ::::{dropdown} Example
     ```js
@@ -510,7 +510,7 @@ $$$event-realm-auth-failed$$$
 $$$event-runas-denied$$$
 
 `run_as_denied`
-:   Logged when an authenticated user attempts to [run as](docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/submitting-requests-on-behalf-of-other-users.md) another user that they do not have the necessary [privileges](docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/elasticsearch-privileges.md) to do so.
+:   Logged when an authenticated user attempts to [run as](docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/submitting-requests-on-behalf-of-other-users.md) another user that they do not have the necessary [privileges](/reference/elasticsearch/security-privileges.md) to do so.
 
     ::::{dropdown} Example
     ```js

--- a/docs/reference/elasticsearch/rest-apis/create-index-from-source.md
+++ b/docs/reference/elasticsearch/rest-apis/create-index-from-source.md
@@ -26,7 +26,7 @@ For the most up-to-date API details, refer to [Index APIs](https://www.elastic.c
 
 ## {{api-prereq-title}} [indices-create-index-from-source-api-prereqs]
 
-* If the {{es}} {{security-features}} are enabled, you must have the `manage` [index privilege](docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/elasticsearch-privileges.md#privileges-list-indices) for the index.
+* If the {{es}} {{security-features}} are enabled, you must have the `manage` [index privilege](/reference/elasticsearch/security-privileges.md#privileges-list-indices) for the index.
 
 
 ## {{api-description-title}} [indices-create-index-from-source-api-desc]

--- a/docs/reference/elasticsearch/rest-apis/reindex-data-stream.md
+++ b/docs/reference/elasticsearch/rest-apis/reindex-data-stream.md
@@ -33,7 +33,7 @@ This api runs in the background because reindexing all indices in a large data s
 
 ## {{api-prereq-title}} [data-stream-reindex-api-prereqs]
 
-* If the {{es}} {{security-features}} are enabled, you must have the `manage` [index privilege](docs-content://deploy-manage/users-roles/cluster-or-deployment-auth/elasticsearch-privileges.md#privileges-list-indices) for the data stream.
+* If the {{es}} {{security-features}} are enabled, you must have the `manage` [index privilege](/reference/elasticsearch/security-privileges.md#privileges-list-indices) for the data stream.
 
 
 ## {{api-request-body-title}} [data-stream-reindex-body]


### PR DESCRIPTION
The [Elasticsearch privileges page in the Deploy and manage section](https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/elasticsearch-privileges) is being replaced with its [counterpart in the Reference section](https://www.elastic.co/docs/reference/elasticsearch/security-privileges). This PR replaces all links with the correct (deduplicated and reconciled) page.

Relates to #2218(https://github.com/elastic/docs-content/issues/2218)

