### PR TITLE
[9.1] [Buildkite] Fix interpolating regex in buildkite pipeline (#133813)

### DIFF
--- a/.buildkite/pipelines/periodic.template.yml
+++ b/.buildkite/pipelines/periodic.template.yml
@@ -246,7 +246,7 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n2-standard-8
       buildDirectory: /dev/shm/bk
-    if: build.branch =~ /^(main|\d+\.\d+|\d+\.x)$/
+    if: build.branch =~ /^(main|\d+\.\d+|\d+\.x)$$/
   - label: check-branch-consistency
     command: .ci/scripts/run-gradle.sh branchConsistency
     timeout_in_minutes: 15

--- a/.buildkite/pipelines/periodic.yml
+++ b/.buildkite/pipelines/periodic.yml
@@ -665,7 +665,7 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: n2-standard-8
       buildDirectory: /dev/shm/bk
-    if: build.branch =~ /^(main|\d+\.\d+|\d+\.x)$/
+    if: build.branch =~ /^(main|\d+\.\d+|\d+\.x)$$/
   - label: check-branch-consistency
     command: .ci/scripts/run-gradle.sh branchConsistency
     timeout_in_minutes: 15


### PR DESCRIPTION
Backports the following commits to 9.1:
 - [Buildkite] Fix interpolating regex in buildkite pipeline (#133813)