### PR TITLE
ES|QL: Fix release yamlRestTest

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_usage.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_usage.yml
@@ -229,7 +229,7 @@ setup:
   - gt: {esql.functions.to_long: $functions_to_long}
   - match: {esql.functions.coalesce: $functions_coalesce}
   - gt: {esql.functions.categorize: $functions_categorize}
-  - length: {esql.functions: 140} # check the "sister" test above for a likely update to the same esql.functions length check
+  - length: {esql.functions: 141} # check the "sister" test above for a likely update to the same esql.functions length check
 
 ---
 took:


### PR DESCRIPTION
To reproduce: 
```
./gradlew ":x-pack:plugin:esql:qa:server:single-node:yamlRestTest" --tests "org.elasticsearch.xpack.esql.qa.single_node.EsqlClientYamlIT.test {p0=esql/60_usage/Basic ESQL usage output (telemetry) non-snapshot version}" -Dtests.seed=74340BA13985282B -Dbuild.snapshot=false -Dtests.jvm.argline="-Dbuild.snapshot=false" -Dlicense.key=x-pack/license-tools/src/test/resources/public.key -Dtests.locale=ki-Latn-KE -Dtests.timezone=America/El_Salvador -Druntime.java=24
```

Failed build: https://gradle-enterprise.elastic.co/s/ojsn52vw6435c