### PR TITLE
PoC: Pluggable node stats

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -368,6 +368,7 @@ public class TransportVersions {
     public static final TransportVersion DATA_STREAM_WRITE_INDEX_ONLY_SETTINGS = def(9_142_0_00);
     public static final TransportVersion SCRIPT_RESCORER = def(9_143_0_00);
     public static final TransportVersion ESQL_LOOKUP_OPERATOR_EMITTED_ROWS = def(9_144_0_00);
+    public static final TransportVersion PLUGGABLE_NODE_STATS = def(9_145_0_00);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequestParameters.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequestParameters.java
@@ -95,7 +95,8 @@ public class NodesStatsRequestParameters implements Writeable {
         SCRIPT_CACHE("script_cache"),
         INDEXING_PRESSURE("indexing_pressure"),
         REPOSITORIES("repositories"),
-        ALLOCATIONS("allocations");
+        ALLOCATIONS("allocations"),
+        PLUGINS("plugins");
 
         public static final Set<Metric> ALL = Collections.unmodifiableSet(EnumSet.allOf(Metric.class));
         public static final Set<String> ALL_NAMES = ALL.stream().map(Metric::metricName).collect(toUnmodifiableSet());

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/PluginNodeStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/PluginNodeStats.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.action.admin.cluster.node.stats;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.plugins.NodeStatsPlugin;
+import org.elasticsearch.xcontent.ToXContent;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.elasticsearch.common.xcontent.ChunkedToXContentHelper.chunk;
+
+/**
+ * Extra plugin-contributed node statistics.
+ */
+public class PluginNodeStats implements Writeable, ChunkedToXContent {
+
+    private final Map<String, NodeStatsPlugin.Stats> pluginNameToStats;
+
+    public PluginNodeStats(Map<String, NodeStatsPlugin.Stats> pluginNameToStats) {
+        this.pluginNameToStats = Objects.requireNonNull(pluginNameToStats);
+    }
+
+    public PluginNodeStats(StreamInput in) throws IOException {
+        this(in.readImmutableMap(StreamInput::readString, in2 -> in2.readNamedWriteable(NodeStatsPlugin.Stats.class)));
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeMap(pluginNameToStats, StreamOutput::writeString, StreamOutput::writeNamedWriteable);
+    }
+
+    @Override
+    public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
+        return chunk((builder, p) -> {
+            builder.startObject("plugins");
+            for (Map.Entry<String, NodeStatsPlugin.Stats> entry : pluginNameToStats.entrySet()) {
+                builder.field(entry.getKey(), entry.getValue(), p);
+            }
+            return builder.endObject();
+        });
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return this == o || (o instanceof PluginNodeStats other && Objects.equals(pluginNameToStats, other.pluginNameToStats));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(pluginNameToStats);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
@@ -175,7 +175,8 @@ public class TransportNodesStatsAction extends TransportNodesAction<
             metrics.contains(Metric.ADAPTIVE_SELECTION),
             metrics.contains(Metric.SCRIPT_CACHE),
             metrics.contains(Metric.INDEXING_PRESSURE),
-            metrics.contains(Metric.REPOSITORIES)
+            metrics.contains(Metric.REPOSITORIES),
+            metrics.contains(Metric.PLUGINS)
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -256,6 +256,7 @@ public class TransportClusterStatsAction extends TransportNodesAction<
             false,
             false,
             false,
+            false,
             false
         );
         List<ShardStats> shardsStats = new ArrayList<>();

--- a/server/src/main/java/org/elasticsearch/health/node/tracker/DiskHealthTracker.java
+++ b/server/src/main/java/org/elasticsearch/health/node/tracker/DiskHealthTracker.java
@@ -121,6 +121,7 @@ public class DiskHealthTracker extends HealthTracker<DiskHealthInfo> {
             false,
             false,
             false,
+            false,
             false
         );
         return DiskUsage.findLeastAvailablePath(nodeStats);

--- a/server/src/main/java/org/elasticsearch/monitor/metrics/NodeMetrics.java
+++ b/server/src/main/java/org/elasticsearch/monitor/metrics/NodeMetrics.java
@@ -761,6 +761,7 @@ public class NodeMetrics extends AbstractLifecycleComponent {
             false,
             false,
             false,
+            false,
             true,
             false
         );
@@ -804,6 +805,7 @@ public class NodeMetrics extends AbstractLifecycleComponent {
                 VersionInformation.CURRENT
             ),
             0,
+            null,
             null,
             null,
             null,

--- a/server/src/main/java/org/elasticsearch/plugins/NodeStatsPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/NodeStatsPlugin.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.plugins;
+
+import org.elasticsearch.common.io.stream.NamedWriteable;
+import org.elasticsearch.xcontent.ToXContent;
+
+/**
+ * An extension point for {@link Plugin} implementations that wish to contribute to node stats.
+ */
+public interface NodeStatsPlugin {
+
+    /** Plugin name. Used for field key for stats. Must be unique across all plugins. */
+    String getNodeStatsPluginName();
+
+    Stats getPluginNodeStats();
+
+    interface Stats extends ToXContent, NamedWriteable {}
+}

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -1114,7 +1114,8 @@ public class NodeStatsTests extends ESTestCase {
             scriptCacheStats,
             indexingPressureStats,
             repositoriesStats,
-            nodeAllocationStats
+            nodeAllocationStats,
+            null
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/DiskUsageTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/DiskUsageTests.java
@@ -232,6 +232,7 @@ public class DiskUsageTests extends ESTestCase {
                 null,
                 null,
                 null,
+                null,
                 null
             );
             DiskUsage leastNode = DiskUsage.findLeastAvailablePath(nodeStats);
@@ -251,6 +252,7 @@ public class DiskUsageTests extends ESTestCase {
                 null,
                 null,
                 new FsInfo(0, null, nodeFSInfo),
+                null,
                 null,
                 null,
                 null,
@@ -282,6 +284,7 @@ public class DiskUsageTests extends ESTestCase {
                 null,
                 null,
                 new FsInfo(0, null, nodeFSInfo),
+                null,
                 null,
                 null,
                 null,
@@ -327,6 +330,7 @@ public class DiskUsageTests extends ESTestCase {
                 null,
                 null,
                 null,
+                null,
                 null
             );
             DiskUsage leastNode = DiskUsage.findLeastAvailablePath(nodeStats);
@@ -347,6 +351,7 @@ public class DiskUsageTests extends ESTestCase {
                 null,
                 null,
                 new FsInfo(0, null, nodeFSInfo),
+                null,
                 null,
                 null,
                 null,
@@ -378,6 +383,7 @@ public class DiskUsageTests extends ESTestCase {
                 null,
                 null,
                 new FsInfo(0, null, node3FSInfo),
+                null,
                 null,
                 null,
                 null,

--- a/server/src/test/java/org/elasticsearch/health/node/tracker/DiskHealthTrackerTests.java
+++ b/server/src/test/java/org/elasticsearch/health/node/tracker/DiskHealthTrackerTests.java
@@ -114,6 +114,7 @@ public class DiskHealthTrackerTests extends ESTestCase {
                 eq(false),
                 eq(false),
                 eq(false),
+                eq(false),
                 eq(false)
             )
         ).thenReturn(nodeStats());
@@ -245,6 +246,7 @@ public class DiskHealthTrackerTests extends ESTestCase {
                 eq(false),
                 eq(false),
                 eq(false),
+                eq(false),
                 eq(false)
             )
         ).thenReturn(nodeStats(1000, 10));
@@ -260,6 +262,7 @@ public class DiskHealthTrackerTests extends ESTestCase {
                 eq(false),
                 eq(false),
                 eq(true),
+                eq(false),
                 eq(false),
                 eq(false),
                 eq(false),
@@ -293,6 +296,7 @@ public class DiskHealthTrackerTests extends ESTestCase {
                 eq(false),
                 eq(false),
                 eq(false),
+                eq(false),
                 eq(false)
             )
         ).thenReturn(nodeStats(1000, 110));
@@ -317,6 +321,7 @@ public class DiskHealthTrackerTests extends ESTestCase {
             null,
             null,
             fs,
+            null,
             null,
             null,
             null,

--- a/server/src/test/java/org/elasticsearch/rest/action/cat/RestNodesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/cat/RestNodesActionTests.java
@@ -119,6 +119,7 @@ public class RestNodesActionTests extends ESTestCase {
             null,
             null,
             null,
+            null,
             null
         );
     }

--- a/server/src/test/java/org/elasticsearch/rest/action/info/RestClusterInfoActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/info/RestClusterInfoActionTests.java
@@ -125,6 +125,7 @@ public class RestClusterInfoActionTests extends ESTestCase {
             null,
             null,
             null,
+            null,
             null
         );
     }

--- a/test/framework/src/main/java/org/elasticsearch/cluster/MockInternalClusterInfoService.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/MockInternalClusterInfoService.java
@@ -91,7 +91,8 @@ public class MockInternalClusterInfoService extends InternalClusterInfoService {
                 nodeStats.getScriptCacheStats(),
                 nodeStats.getIndexingPressureStats(),
                 nodeStats.getRepositoriesStats(),
-                nodeStats.getNodeAllocationStats()
+                nodeStats.getNodeAllocationStats(),
+                nodeStats.getPluginStats()
             );
         }).collect(Collectors.toList());
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -2558,6 +2558,7 @@ public final class InternalTestCluster extends TestCluster {
                     false,
                     false,
                     false,
+                    false,
                     false
                 );
                 assertThat(

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/nodeinfo/AutoscalingNodesInfoServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/nodeinfo/AutoscalingNodesInfoServiceTests.java
@@ -445,6 +445,7 @@ public class AutoscalingNodesInfoServiceTests extends AutoscalingTestCase {
             null,
             null,
             null,
+            null,
             null
         );
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsActionTests.java
@@ -352,6 +352,7 @@ public class TransportGetTrainedModelsStatsActionTests extends ESTestCase {
             null,
             null,
             null,
+            null,
             null
         );
 

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/Monitoring.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/Monitoring.java
@@ -266,13 +266,7 @@ public class Monitoring extends Plugin implements ActionPlugin, ReloadablePlugin
 
     @Override
     public List<NamedWriteableRegistry.Entry> getNamedWriteables() {
-        return List.of(
-            new NamedWriteableRegistry.Entry(
-                NodeStatsPlugin.Stats.class,
-                MonitoringStats.WRITEABLE_NAME,
-                MonitoringStats::new
-            )
-        );
+        return List.of(new NamedWriteableRegistry.Entry(NodeStatsPlugin.Stats.class, MonitoringStats.WRITEABLE_NAME, MonitoringStats::new));
 
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/node/NodeStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/node/NodeStatsMonitoringDocTests.java
@@ -486,6 +486,7 @@ public class NodeStatsMonitoringDocTests extends BaseFilteredMonitoringDocTestCa
             null,
             null,
             null,
+            null,
             null
         );
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityNodeStatsPluginStats.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityNodeStatsPluginStats.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.plugins.NodeStatsPlugin;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Security plugin node stats.
+ */
+public class SecurityNodeStatsPluginStats implements NodeStatsPlugin.Stats {
+
+    public static final String WRITEABLE_NAME = "security_node_stats";
+
+    private final Map<String, Object> dlsCacheStats;
+
+    public SecurityNodeStatsPluginStats(Map<String, Object> dlsCacheStats) {
+        this.dlsCacheStats = Objects.requireNonNull(dlsCacheStats);
+    }
+
+    public SecurityNodeStatsPluginStats(StreamInput in) throws IOException {
+        this(in.readGenericMap());
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeGenericMap(dlsCacheStats);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return WRITEABLE_NAME;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field("dls_cache");
+        builder.map(dlsCacheStats);
+        return builder.endObject();
+    }
+}


### PR DESCRIPTION
- If you're reviewing, I suggest reviewing commit-by-commit to best illuminate approach
- PoC of pluggable `/_nodes/stats` where plugins/x-pack can add statistics from each node to the response
  * Currently only server can contribute statistics to `/_nodes/stats`
  * there's also `/_xpack/usage`, but that only returns stats from the node that the request hits ([used to be only master action, now a local action](https://github.com/elastic/elasticsearch/pull/122933/), so potentially you could aggregate stats by round-robining, but not a clean solution)
- Comes out of customer request to gather stats for entire cluster for security module DLS cache statistics

- Approach:
  * New NodeStatsPlugin interface that each module can implement, similar to existing functionality where a module/x-pack can inject things into server (like ingest pipelines e.g.)
    - Needs a plugin name to be used in response, and the stats that need to be able to output to XContent and be serialized/deserialized in transport
  * from my understanding interface should be generic so that any underlying stats can be included
  * Included example of security DLS cache (what we're after), and monitoring as a dummy

Simple response example, after repeatedly searching an index with DLS with one primary, one replica:

```bash
curl -u elastic:password localhost:9200/_nodes/stats/plugins?filter_path=nodes.*.plugins
```


```json

{
  "nodes": {
    "uhHmghiLTX2YSX-MtHBSnQ": {
      "plugins": {
        "monitoring": {
          "extra plugin": "example"
        },
        "security": {
          "dls_cache": {
            "count": 1,
            "memory": "16b",
            "memory_in_bytes": 16,
            "hits": 40,
            "misses": 1,
            "evictions": 0,
            "hits_time_in_millis": 2,
            "misses_time_in_millis": 0
          }
        }
      }
    },
    "9YK-_NYJS-mll9mCfQ-INA": {
      "plugins": {
        "security": {
          "dls_cache": {
            "hits": 0,
            "memory": "0b",
            "misses": 0,
            "misses_time_in_millis": 0,
            "count": 0,
            "evictions": 0,
            "memory_in_bytes": 0,
            "hits_time_in_millis": 0
          }
        },
        "monitoring": {
          "extra plugin": "example"
        }
      }
    },
    "mUBAgn0UTVO-St7vAJNUIA": {
      "plugins": {
        "security": {
          "dls_cache": {
            "hits": 32,
            "memory": "16b",
            "misses": 1,
            "misses_time_in_millis": 0,
            "count": 1,
            "evictions": 0,
            "memory_in_bytes": 16,
            "hits_time_in_millis": 4
          }
        },
        "monitoring": {
          "extra plugin": "example"
        }
      }
    }
  }
}
```
