### PR TITLE
Fix missing position offset in lossy sum of doubles

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -543,15 +543,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/133077
-- class: org.elasticsearch.compute.aggregation.LossySumDoubleGroupingAggregatorFunctionTests
-  method: testManyInitialManyPartialFinalRunner
-  issue: https://github.com/elastic/elasticsearch/issues/133809
-- class: org.elasticsearch.compute.aggregation.LossySumDoubleGroupingAggregatorFunctionTests
-  method: testInitialIntermediateFinal
-  issue: https://github.com/elastic/elasticsearch/issues/133822
-- class: org.elasticsearch.compute.aggregation.LossySumDoubleGroupingAggregatorFunctionTests
-  method: testInitialFinal
-  issue: https://github.com/elastic/elasticsearch/issues/133829
 - class: org.elasticsearch.xpack.esql.action.RandomizedTimeSeriesIT
   method: testGroupBySubset
   issue: https://github.com/elastic/elasticsearch/issues/133220

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/LossySumDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/LossySumDoubleAggregator.java
@@ -144,8 +144,8 @@ class LossySumDoubleAggregator {
             public void add(int positionOffset, IntVector groupIds) {
                 if (groupIds.isConstant()) {
                     double sum = 0.0;
-                    int positionCount = groupIds.getPositionCount();
-                    for (int i = 0; i < positionCount; i++) {
+                    final int to = positionOffset + groupIds.getPositionCount();
+                    for (int i = positionOffset; i < to; i++) {
                         sum += values.getDouble(i);
                     }
                     state.add(sum, groupIds.getInt(0));


### PR DESCRIPTION
We are missing the positionOffset when calculating the sum in the tight loop.

Relates #133779
Closes #133809
Closes #133822
Closes #133829