### PR TITLE
ESQL: Simply reenable a disabled test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -537,9 +537,6 @@ tests:
 - class: org.elasticsearch.compute.data.BasicBlockTests
   method: testFloatBlock
   issue: https://github.com/elastic/elasticsearch/issues/133621
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  method: test {csv-spec:inlinestats.EvalBeforeDoubleInlinestats1}
-  issue: https://github.com/elastic/elasticsearch/issues/133729
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/133077


### PR DESCRIPTION
`org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT test {csv-spec:inlinestats.EvalBeforeDoubleInlinestats1}` got run on version preceding the one it was introduced in. The failure only occured if the planning of a query happened on an older version (2e8507f427bb6538480ef0aa582fba6e180f5a5a), not containing the fix (2f0010c86a27f1928479be7c9716fea1cb569763) the test was testing against. This is why the tests passed. An inlinestats version capability bump should have been introduced along the fix.

Meanwhile the inlinestats capability version got bumped, so this situation can no longer occur.

Fixes #133729