### PR TITLE
Fix MemorySegmentES92PanamaInt7VectorsScorer for small dimensions

### DIFF
--- a/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/MemorySegmentES92PanamaInt7VectorsScorer.java
+++ b/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/MemorySegmentES92PanamaInt7VectorsScorer.java
@@ -168,7 +168,7 @@ abstract class MemorySegmentES92PanamaInt7VectorsScorer extends ES92Int7VectorsS
                 dotProductBody128Bulk(q, count, scores);
             }
         } else {
-            int7DotProductBulk(q, count, scores);
+            super.int7DotProductBulk(q, count, scores);
         }
     }
 

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -558,9 +558,6 @@ tests:
 - class: org.elasticsearch.xpack.kql.parser.KqlParserBooleanQueryTests
   method: testParseAndQuery
   issue: https://github.com/elastic/elasticsearch/issues/133871
-- class: org.elasticsearch.simdvec.internal.vectorization.ES92Int7VectorScorerTests
-  method: testInt7ScoreBulk
-  issue: https://github.com/elastic/elasticsearch/issues/133893
 
 # Examples:
 #


### PR DESCRIPTION
In case of dimension lower than 16, we should call the parent implementation. We are currently calling ourseleves again and therefore the StackOverflowException.

I set it to non-issue as the code is not used in production.

fixes https://github.com/elastic/elasticsearch/issues/133893