### PR TITLE
OTLP: add mapping hints

### DIFF
--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/MappingHints.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/MappingHints.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.oteldata.otlp.docbuilder;
+
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.KeyValue;
+
+import java.util.List;
+
+/**
+ * Represents mapping hints that can be used to influence how data is indexed in Elasticsearch.
+ * These hints can be provided by users via data point attributes.
+ *
+ * @param aggregateMetricDouble Indicates that the metric should be mapped as an aggregate_metric_double.
+ *                              This hint is available for histogram and exponential histogram metrics.
+ * @param docCount              Indicates that the metric should be mapped with a _doc_count field.
+ *                              This hint is available for all metric types.
+ *                              When used for a histogram, exponential histogram, or summary metric,
+ *                              the _doc_count field will be populated with the number of total counts.
+ *                              It is not recommended to use this hint for multiple metrics that are grouped together
+ *                              into the same document.
+ *                              In these cases, the behavior is undefined but does not lead to data loss.
+ */
+public record MappingHints(boolean aggregateMetricDouble, boolean docCount) {
+    public static final String MAPPING_HINTS = "elasticsearch.mapping.hints";
+
+    private static final MappingHints EMPTY = new MappingHints(false, false);
+    private static final String AGGREGATE_METRIC_DOUBLE = "aggregate_metric_double";
+    private static final String DOC_COUNT = "_doc_count";
+
+    public static MappingHints fromAttributes(List<KeyValue> attributes) {
+        boolean aggregateMetricDouble = false;
+        boolean docCount = false;
+        for (int i = 0, attributesSize = attributes.size(); i < attributesSize; i++) {
+            KeyValue attribute = attributes.get(i);
+            if (attribute.getKey().equals(MAPPING_HINTS)) {
+                if (attribute.getValue().hasArrayValue()) {
+                    List<AnyValue> valuesList = attribute.getValue().getArrayValue().getValuesList();
+                    for (int j = 0, valuesListSize = valuesList.size(); j < valuesListSize; j++) {
+                        AnyValue hint = valuesList.get(j);
+                        if (hint.hasStringValue()) {
+                            String value = hint.getStringValue();
+                            if (value.equals(AGGREGATE_METRIC_DOUBLE)) {
+                                aggregateMetricDouble = true;
+                            } else if (value.equals(DOC_COUNT)) {
+                                docCount = true;
+                            }
+                        }
+                    }
+                }
+                return new MappingHints(aggregateMetricDouble, docCount);
+            }
+        }
+        return EMPTY;
+    }
+
+    public static MappingHints empty() {
+        return EMPTY;
+    }
+}

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/MetricDocumentBuilder.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/MetricDocumentBuilder.java
@@ -7,11 +7,13 @@
 
 package org.elasticsearch.xpack.oteldata.otlp.docbuilder;
 
-import com.google.protobuf.ByteString;
 import io.opentelemetry.proto.common.v1.AnyValue;
 import io.opentelemetry.proto.common.v1.InstrumentationScope;
 import io.opentelemetry.proto.common.v1.KeyValue;
 import io.opentelemetry.proto.resource.v1.Resource;
+
+import com.google.protobuf.ByteString;
+
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.oteldata.otlp.datapoint.DataPoint;

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/tsid/AttributeListTsidFunnel.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/tsid/AttributeListTsidFunnel.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.oteldata.otlp.tsid;
 
 import io.opentelemetry.proto.common.v1.AnyValue;
 import io.opentelemetry.proto.common.v1.KeyValue;
+
 import org.elasticsearch.cluster.routing.TsidBuilder;
 import org.elasticsearch.cluster.routing.TsidBuilder.TsidFunnel;
 import org.elasticsearch.xpack.oteldata.otlp.docbuilder.MetricDocumentBuilder;

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/tsid/AttributeListTsidFunnel.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/tsid/AttributeListTsidFunnel.java
@@ -9,10 +9,9 @@ package org.elasticsearch.xpack.oteldata.otlp.tsid;
 
 import io.opentelemetry.proto.common.v1.AnyValue;
 import io.opentelemetry.proto.common.v1.KeyValue;
-
 import org.elasticsearch.cluster.routing.TsidBuilder;
 import org.elasticsearch.cluster.routing.TsidBuilder.TsidFunnel;
-import org.elasticsearch.xpack.oteldata.otlp.docbuilder.MappingHints;
+import org.elasticsearch.xpack.oteldata.otlp.docbuilder.MetricDocumentBuilder;
 import org.elasticsearch.xpack.oteldata.otlp.proto.BufferedByteStringAccessor;
 
 import java.util.List;
@@ -36,11 +35,9 @@ class AttributeListTsidFunnel implements TsidFunnel<List<KeyValue>> {
         for (int i = 0; i < attributesList.size(); i++) {
             KeyValue keyValue = attributesList.get(i);
             String attributeKey = keyValue.getKey();
-            if (attributeKey.equals(MappingHints.MAPPING_HINTS)) {
-                // ignore
-                continue;
+            if (MetricDocumentBuilder.isIgnoredAttribute(attributeKey) == false) {
+                hashValue(tsidBuilder, prefix + attributeKey, keyValue.getValue());
             }
-            hashValue(tsidBuilder, prefix + attributeKey, keyValue.getValue());
         }
     }
 

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/tsid/AttributeListTsidFunnel.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/tsid/AttributeListTsidFunnel.java
@@ -12,6 +12,7 @@ import io.opentelemetry.proto.common.v1.KeyValue;
 
 import org.elasticsearch.cluster.routing.TsidBuilder;
 import org.elasticsearch.cluster.routing.TsidBuilder.TsidFunnel;
+import org.elasticsearch.xpack.oteldata.otlp.docbuilder.MappingHints;
 import org.elasticsearch.xpack.oteldata.otlp.proto.BufferedByteStringAccessor;
 
 import java.util.List;
@@ -35,6 +36,10 @@ class AttributeListTsidFunnel implements TsidFunnel<List<KeyValue>> {
         for (int i = 0; i < attributesList.size(); i++) {
             KeyValue keyValue = attributesList.get(i);
             String attributeKey = keyValue.getKey();
+            if (attributeKey.equals(MappingHints.MAPPING_HINTS)) {
+                // ignore
+                continue;
+            }
             hashValue(tsidBuilder, prefix + attributeKey, keyValue.getValue());
         }
     }

--- a/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/DataPointNumberTests.java
+++ b/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/DataPointNumberTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.oteldata.otlp.datapoint;
 
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.oteldata.otlp.docbuilder.MappingHints;
 
 import java.util.List;
 
@@ -28,12 +29,12 @@ public class DataPointNumberTests extends ESTestCase {
             createDoubleDataPoint(nowUnixNanos, List.of()),
             createGaugeMetric("system.cpu.usage", "", List.of())
         );
-        assertThat(doubleGauge.getDynamicTemplate(), equalTo("gauge_double"));
+        assertThat(doubleGauge.getDynamicTemplate(MappingHints.empty()), equalTo("gauge_double"));
         DataPoint.Number longGauge = new DataPoint.Number(
             createLongDataPoint(nowUnixNanos, List.of()),
             createGaugeMetric("system.cpu.usage", "", List.of())
         );
-        assertThat(longGauge.getDynamicTemplate(), equalTo("gauge_long"));
+        assertThat(longGauge.getDynamicTemplate(MappingHints.empty()), equalTo("gauge_long"));
     }
 
     public void testCounterTemporality() {
@@ -41,22 +42,22 @@ public class DataPointNumberTests extends ESTestCase {
             createDoubleDataPoint(nowUnixNanos, List.of()),
             createSumMetric("http.requests.count", "", List.of(), true, AGGREGATION_TEMPORALITY_CUMULATIVE)
         );
-        assertThat(doubleCumulative.getDynamicTemplate(), equalTo("counter_double"));
+        assertThat(doubleCumulative.getDynamicTemplate(MappingHints.empty()), equalTo("counter_double"));
         DataPoint.Number longCumulative = new DataPoint.Number(
             createLongDataPoint(nowUnixNanos, List.of()),
             createSumMetric("http.requests.count", "", List.of(), true, AGGREGATION_TEMPORALITY_CUMULATIVE)
         );
-        assertThat(longCumulative.getDynamicTemplate(), equalTo("counter_long"));
+        assertThat(longCumulative.getDynamicTemplate(MappingHints.empty()), equalTo("counter_long"));
         DataPoint.Number doubleDelta = new DataPoint.Number(
             createDoubleDataPoint(nowUnixNanos, List.of()),
             createSumMetric("http.requests.count", "", List.of(), true, AGGREGATION_TEMPORALITY_DELTA)
         );
-        assertThat(doubleDelta.getDynamicTemplate(), equalTo("gauge_double"));
+        assertThat(doubleDelta.getDynamicTemplate(MappingHints.empty()), equalTo("gauge_double"));
         DataPoint.Number longDelta = new DataPoint.Number(
             createLongDataPoint(nowUnixNanos, List.of()),
             createSumMetric("http.requests.count", "", List.of(), true, AGGREGATION_TEMPORALITY_DELTA)
         );
-        assertThat(longDelta.getDynamicTemplate(), equalTo("gauge_long"));
+        assertThat(longDelta.getDynamicTemplate(MappingHints.empty()), equalTo("gauge_long"));
     }
 
     public void testCounterNonMonotonic() {
@@ -64,12 +65,12 @@ public class DataPointNumberTests extends ESTestCase {
             createDoubleDataPoint(nowUnixNanos, List.of()),
             createSumMetric("http.requests.count", "", List.of(), false, AGGREGATION_TEMPORALITY_CUMULATIVE)
         );
-        assertThat(doubleNonMonotonic.getDynamicTemplate(), equalTo("gauge_double"));
+        assertThat(doubleNonMonotonic.getDynamicTemplate(MappingHints.empty()), equalTo("gauge_double"));
         DataPoint.Number longNonMonotonic = new DataPoint.Number(
             createLongDataPoint(nowUnixNanos, List.of()),
             createSumMetric("http.requests.count", "", List.of(), false, AGGREGATION_TEMPORALITY_DELTA)
         );
-        assertThat(longNonMonotonic.getDynamicTemplate(), equalTo("gauge_long"));
+        assertThat(longNonMonotonic.getDynamicTemplate(MappingHints.empty()), equalTo("gauge_long"));
     }
 
 }

--- a/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/MappingHintsTests.java
+++ b/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/MappingHintsTests.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.oteldata.otlp.datapoint;
+
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.ArrayValue;
+import io.opentelemetry.proto.common.v1.KeyValue;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.oteldata.otlp.docbuilder.MappingHints;
+
+import java.util.List;
+
+public class MappingHintsTests extends ESTestCase {
+
+    public void testEmptyAttributes() {
+        MappingHints hints = MappingHints.fromAttributes(List.of());
+        assertFalse(hints.aggregateMetricDouble());
+        assertFalse(hints.docCount());
+    }
+
+    public void testNoMappingHints() {
+        KeyValue kv = KeyValue.newBuilder()
+            .setKey("some.other.key")
+            .setValue(AnyValue.newBuilder().setStringValue("some_value").build())
+            .build();
+        MappingHints hints = MappingHints.fromAttributes(List.of(kv));
+        assertFalse(hints.aggregateMetricDouble());
+        assertFalse(hints.docCount());
+    }
+
+    public void testSingleMappingHint() {
+        // Test with just aggregate_metric_double hint
+        KeyValue aggregateMetricHint = createMappingHint("aggregate_metric_double");
+        MappingHints hints = MappingHints.fromAttributes(List.of(aggregateMetricHint));
+        assertTrue(hints.aggregateMetricDouble());
+        assertFalse(hints.docCount());
+
+        // Test with just _doc_count hint
+        KeyValue docCountHint = createMappingHint("_doc_count");
+        hints = MappingHints.fromAttributes(List.of(docCountHint));
+        assertFalse(hints.aggregateMetricDouble());
+        assertTrue(hints.docCount());
+    }
+
+    public void testMultipleMappingHints() {
+        // Test with both hints
+        KeyValue bothHints = createMappingHint("aggregate_metric_double", "_doc_count");
+        MappingHints hints = MappingHints.fromAttributes(List.of(bothHints));
+        assertTrue(hints.aggregateMetricDouble());
+        assertTrue(hints.docCount());
+    }
+
+    public void testInvalidHints() {
+        // Test with invalid hint
+        KeyValue invalidHint = createMappingHint("invalid_hint");
+        MappingHints hints = MappingHints.fromAttributes(List.of(invalidHint));
+        assertFalse(hints.aggregateMetricDouble());
+        assertFalse(hints.docCount());
+
+        // Test with mix of valid and invalid hints
+        KeyValue mixedHints = createMappingHint("aggregate_metric_double", "invalid_hint", "_doc_count");
+        hints = MappingHints.fromAttributes(List.of(mixedHints));
+        assertTrue(hints.aggregateMetricDouble());
+        assertTrue(hints.docCount());
+    }
+
+    public void testNonArrayValue() {
+        // Test with non-array value
+        KeyValue nonArrayHint = KeyValue.newBuilder()
+            .setKey("elasticsearch.mapping.hints")
+            .setValue(AnyValue.newBuilder().setStringValue("aggregate_metric_double").build())
+            .build();
+        MappingHints hints = MappingHints.fromAttributes(List.of(nonArrayHint));
+        assertFalse(hints.aggregateMetricDouble());
+        assertFalse(hints.docCount());
+    }
+
+    public void testNonStringArrayValues() {
+        // Test with non-string array values
+        AnyValue numberValue = AnyValue.newBuilder().setIntValue(42).build();
+        AnyValue boolValue = AnyValue.newBuilder().setBoolValue(true).build();
+
+        ArrayValue.Builder arrayBuilder = ArrayValue.newBuilder();
+        arrayBuilder.addValues(numberValue);
+        arrayBuilder.addValues(boolValue);
+
+        KeyValue invalidTypeHints = KeyValue.newBuilder()
+            .setKey("elasticsearch.mapping.hints")
+            .setValue(AnyValue.newBuilder().setArrayValue(arrayBuilder).build())
+            .build();
+
+        MappingHints hints = MappingHints.fromAttributes(List.of(invalidTypeHints));
+        assertFalse(hints.aggregateMetricDouble());
+        assertFalse(hints.docCount());
+    }
+
+    private KeyValue createMappingHint(String... hintValues) {
+        ArrayValue.Builder arrayBuilder = ArrayValue.newBuilder();
+        for (String hint : hintValues) {
+            arrayBuilder.addValues(AnyValue.newBuilder().setStringValue(hint));
+        }
+
+        return KeyValue.newBuilder()
+            .setKey("elasticsearch.mapping.hints")
+            .setValue(AnyValue.newBuilder().setArrayValue(arrayBuilder))
+            .build();
+    }
+}


### PR DESCRIPTION
Adds support for the following mapping hints that can be provided as an `elasticsearch.mapping.hints` data point attribute:

* `aggregate_metric_double`: map histograms as `aggregate_metric_double`
* `_doc_count`: add a [`_doc_count`](https://www.elastic.co/docs/reference/elasticsearch/mapping-reference/mapping-doc-count-field) field to the metric document

This mimics functionality of the [OTel collector's elasticsearchexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.134.0/exporter/elasticsearchexporter/internal/elasticsearch/mapping_hint.go), which is used to power the metrics-based APM UI.

Part of https://github.com/elastic/elasticsearch/pull/133057

After https://github.com/elastic/elasticsearch/pull/133898 is merged, mapping hints will need to be wired in to to the `MetricDocumentBuilder`. There's no strong dependency between these PRs, though. They can be independently reviewed and merged.