### PR TITLE
[9.0] Check entitlements for URLClassLoader.newInstance (#132725)

### DIFF
--- a/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementChecker.java
+++ b/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementChecker.java
@@ -134,6 +134,10 @@ public interface EntitlementChecker {
 
     void check$java_net_URLClassLoader$(Class<?> callerClass, String name, URL[] urls, ClassLoader parent, URLStreamHandlerFactory factory);
 
+    void check$java_net_URLClassLoader$$newInstance(Class<?> callerClass, URL[] urls, ClassLoader parent);
+
+    void check$java_net_URLClassLoader$$newInstance(Class<?> callerClass, URL[] urls);
+
     void check$java_security_SecureClassLoader$(Class<?> callerClass);
 
     void check$java_security_SecureClassLoader$(Class<?> callerClass, ClassLoader parent);

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/JvmActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/JvmActions.java
@@ -72,6 +72,20 @@ class JvmActions {
         }
     }
 
+    @EntitlementTest(expectedAccess = PLUGINS)
+    static void createClassLoaderNewInstance1() throws IOException {
+        try (var classLoader = URLClassLoader.newInstance(new URL[0])) {
+            // intentionally empty, just let the loader close
+        }
+    }
+
+    @EntitlementTest(expectedAccess = PLUGINS)
+    static void createClassLoaderNewInstance2() throws IOException {
+        try (var classLoader = URLClassLoader.newInstance(new URL[0], RestEntitlementsCheckAction.class.getClassLoader())) {
+            // intentionally empty, just let the loader close
+        }
+    }
+
     @EntitlementTest(expectedAccess = ALWAYS_DENIED)
     static void createLogManager() {
         new java.util.logging.LogManager() {

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/api/ElasticsearchEntitlementChecker.java
@@ -192,6 +192,16 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
     }
 
     @Override
+    public void check$java_net_URLClassLoader$$newInstance(Class<?> callerClass, URL[] urls) {
+        policyChecker.checkCreateClassLoader(callerClass);
+    }
+
+    @Override
+    public void check$java_net_URLClassLoader$$newInstance(Class<?> callerClass, URL[] urls, ClassLoader parent) {
+        policyChecker.checkCreateClassLoader(callerClass);
+    }
+
+    @Override
     public void check$java_security_SecureClassLoader$(Class<?> callerClass) {
         policyChecker.checkCreateClassLoader(callerClass);
     }


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Check entitlements for URLClassLoader.newInstance (#132725)