### PR TITLE
[ML] Fix double-counting of inference memory in the assignment rebalancer

### DIFF
--- a/docs/changelog/133919.yaml
+++ b/docs/changelog/133919.yaml
@@ -1,0 +1,5 @@
+pr: 133919
+summary: Fix double-counting of inference memory in the assignment rebalancer
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentRebalancer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentRebalancer.java
@@ -298,9 +298,7 @@ class TrainedModelAssignmentRebalancer {
                         nodes.add(
                             new AssignmentPlan.Node(
                                 discoveryNode.getId(),
-                                // We subtract native inference memory as the planner expects available memory for
-                                // native inference including current assignments.
-                                getNodeFreeMemoryExcludingPerNodeOverheadAndNativeInference(load),
+                                load.getFreeMemoryExcludingPerNodeOverhead(),
                                 MlProcessors.get(discoveryNode, allocatedProcessorsScale).roundUp()
                             )
                         );
@@ -315,10 +313,6 @@ class TrainedModelAssignmentRebalancer {
             }
             return nodes;
         }));
-    }
-
-    private static long getNodeFreeMemoryExcludingPerNodeOverheadAndNativeInference(NodeLoad load) {
-        return load.getFreeMemoryExcludingPerNodeOverhead() - load.getAssignedNativeInferenceMemory();
     }
 
     private TrainedModelAssignmentMetadata.Builder buildAssignmentsFromPlan(AssignmentPlan assignmentPlan) {


### PR DESCRIPTION
The static method `TrainedModelAssignmentRebalancer.getNodeFreeMemoryExcludingPerNodeOverheadAndNativeInference` was used to subtract `load.getAssignedNativeInferenceMemory()` from `load.getFreeMemoryExcludingPerNodeOverhead()`. However, in `NodeLoad.getFreeMemoryExcludingPerNodeOverhead()`, native inference memory was already subtracted as part of the `getAssignedJobMemoryExcludingPerNodeOverhead()` calculation. 

This led to double-counting of the native inference memory. Avoiding this double-counting allows us to remove the private method `getNodeFreeMemoryExcludingPerNodeOverheadAndNativeInference()` entirely. 
