### PR TITLE
[9.1] rest-api-spec: mark search_mvt as stable (#133915)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_mvt.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_mvt.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search-mvt",
       "description": "Search a vector tile"
     },
-    "stability": "experimental",
+    "stability": "stable",
     "visibility": "public",
     "headers": {
       "accept": [


### PR DESCRIPTION
Backports the following commits to 9.1:
 - rest-api-spec: mark search_mvt as stable (#133915)