### PR TITLE
[9.1] rest-api-spec: restore warning about internal use (#133782)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/_internal.delete_desired_nodes.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/_internal.delete_desired_nodes.json
@@ -2,7 +2,7 @@
   "_internal.delete_desired_nodes":{
     "documentation":{
       "url": null,
-      "description": "Deletes the desired nodes"
+      "description": "Designed for indirect use by ECE/ESS and ECK, direct use is not supported."
     },
     "stability":"experimental",
     "visibility":"private",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/_internal.update_desired_nodes.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/_internal.update_desired_nodes.json
@@ -2,7 +2,7 @@
   "_internal.update_desired_nodes":{
     "documentation":{
       "url": null,
-      "description": "Updates the desired nodes"
+      "description": "Designed for indirect use by ECE/ESS and ECK, direct use is not supported."
     },
     "stability":"experimental",
     "visibility":"private",


### PR DESCRIPTION
Backports the following commits to 9.1:
 - rest-api-spec: restore warning about internal use (#133782)