### PR TITLE
[9.1] [DOCS] Update doc links (#133534)

### DIFF
--- a/docs/reference/elasticsearch/configuration-reference/thread-pool-settings.md
+++ b/docs/reference/elasticsearch/configuration-reference/thread-pool-settings.md
@@ -84,7 +84,7 @@ $$$search-throttled$$$`search_throttled`
 :   For [watch executions](docs-content://explore-analyze/alerts-cases/watcher.md). Thread pool type is `fixed` with a default maximum size of `min(5 * (`[`# of allocated processors`](#node.processors)`), 50)` and queue_size of `1000`.
 
 $$$modules-threadpool-esql$$$`esql_worker`
-:   Executes [{{esql}}](docs-content://explore-analyze/query-filter/languages/esql.md) operations. Thread pool type is `fixed` with a size of `int((`[`# of allocated processors`](#node.processors) ` * 3) / 2) + 1`, and queue_size of `1000`.
+:   Executes [{{esql}}](/reference/query-languages/esql.md) operations. Thread pool type is `fixed` with a size of `int((`[`# of allocated processors`](#node.processors) ` * 3) / 2) + 1`, and queue_size of `1000`.
 
 Thread pool settings are [Static](docs-content://deploy-manage/stack-settings.md#static-cluster-setting) and can be changed by editing `elasticsearch.yml`. Changing a specific thread pool can be done by setting its type-specific parameters; for example, changing the number of threads in the `write` thread pool:
 

--- a/docs/reference/elasticsearch/index.md
+++ b/docs/reference/elasticsearch/index.md
@@ -46,7 +46,7 @@
 - [Learn how to search your data](docs-content://solutions/search/querying-for-search.md)
 - Query data programmatically: use query languages to run advanced search, filtering, or analytics
   - [Query DSL](docs-content://explore-analyze/query-filter/languages/querydsl.md): full JSON-based query language
-  - [ES|QL](docs-content://explore-analyze/query-filter/languages/esql.md): fast, SQL-like language with piped syntax
+  - [ES|QL](/reference/query-languages/esql.md): fast, SQL-like language with piped syntax
   - [EQL](docs-content://explore-analyze/query-filter/languages/eql.md): for event-based time series data, such as logs, metrics, and traces
   - [SQL](docs-content://explore-analyze/query-filter/languages/sql.md): SQL-style queries on Elasticsearch data
 - [Search applications](docs-content://solutions/search/search-applications.md)

--- a/docs/reference/query-languages/esql/_snippets/commands/layout/enrich.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/enrich.md
@@ -22,7 +22,7 @@ ENRICH policy [ON match_field] [WITH [new_name1 = ]field1, [new_name2 = ]field2,
 
 `mode`
 :   The mode of the enrich command in cross cluster {{esql}}.
-    See [enrich across clusters](docs-content://explore-analyze/query-filter/languages/esql-cross-clusters.md#ccq-enrich).
+    See [enrich across clusters](/reference/query-languages/esql/esql-cross-clusters.md#ccq-enrich).
 
 `match_field`
 :   The match field. `ENRICH` uses its value to look for records in the enrich

--- a/docs/reference/query-languages/esql/_snippets/commands/layout/from.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/from.md
@@ -59,14 +59,14 @@ FROM <logs-{now/d}>
 ```
 
 Use comma-separated lists or wildcards to
-[query multiple data streams, indices, or aliases](docs-content://explore-analyze/query-filter/languages/esql-multi-index.md):
+[query multiple data streams, indices, or aliases](/reference/query-languages/esql/esql-multi-index.md):
 
 ```esql
 FROM employees-00001,other-employees-*
 ```
 
 Use the format `<remote_cluster_name>:<target>` to
-[query data streams and indices on remote clusters](docs-content://explore-analyze/query-filter/languages/esql-cross-clusters.md):
+[query data streams and indices on remote clusters](/reference/query-languages/esql/esql-cross-clusters.md):
 
 ```esql
 FROM cluster_one:employees-00001,cluster_two:other-employees-*

--- a/docs/reference/query-languages/esql/esql-getting-started.md
+++ b/docs/reference/query-languages/esql/esql-getting-started.md
@@ -420,5 +420,5 @@ For more about data processing with {{esql}}, refer to [Data processing with DIS
 - Explore the zero-setup, live [{{esql}} demo environment](http://esql.demo.elastic.co/).
 - 
 - Follow along with our hands-on tutorials:
-  - [Search and filter with {{esql}}](docs-content://solutions/search/esql-search-tutorial.md): A hands-on tutorial that shows you how to use {{esql}} to search and filter data.
+  - [Search and filter with {{esql}}](/reference/query-languages/esql/esql-search-tutorial.md): A hands-on tutorial that shows you how to use {{esql}} to search and filter data.
   - [Threat hunting with {{esql}}](docs-content://solutions/security/esql-for-security/esql-threat-hunting-tutorial.md): A hands-on tutorial that shows you how to use {{esql}} for advanced threat hunting techniques and security analysis.

--- a/docs/reference/query-languages/esql/esql-rest.md
+++ b/docs/reference/query-languages/esql/esql-rest.md
@@ -12,7 +12,7 @@ products:
 # Use the {{esql}} REST API [esql-rest]
 
 ::::{tip}
-The [Search and filter with {{esql}}](docs-content://solutions/search/esql-search-tutorial.md) tutorial provides a hands-on introduction to the {{esql}} `_query` API.
+The [Search and filter with {{esql}}](/reference/query-languages/esql/esql-search-tutorial.md) tutorial provides a hands-on introduction to the {{esql}} `_query` API.
 ::::
 
 ## Overview [esql-rest-overview]

--- a/docs/reference/query-languages/esql/esql-search-tutorial.md
+++ b/docs/reference/query-languages/esql/esql-search-tutorial.md
@@ -31,7 +31,7 @@ FROM cooking_blog
 | LIMIT 1000
 ```
 
-If you want to run these queries in the [Dev Tools Console](docs-content://explore-analyze/query-filter/languages/esql-rest.md#esql-kibana-console), you need to use the following syntax:
+If you want to run these queries in the [Dev Tools Console](/reference/query-languages/esql/esql-rest.md#esql-kibana-console), you need to use the following syntax:
 
 ```console
 POST /_query?format=txt

--- a/docs/reference/query-languages/esql/esql-syntax.md
+++ b/docs/reference/query-languages/esql/esql-syntax.md
@@ -159,7 +159,7 @@ FROM library
 }
 ```
 
-You can also use [query parameters](docs-content://explore-analyze/query-filter/languages/esql-rest.md#esql-rest-params) in function named parameters:
+You can also use [query parameters](/reference/query-languages/esql/esql-rest.md#esql-rest-params) in function named parameters:
 
 ```console
 POST /_query

--- a/docs/reference/query-languages/esql/functions-operators/search-functions.md
+++ b/docs/reference/query-languages/esql/functions-operators/search-functions.md
@@ -8,7 +8,7 @@ mapped_pages:
 
 :::{tip}
 Get started with {{esql}} for search use cases with
-our [hands-on tutorial](docs-content://solutions/search/esql-search-tutorial.md).
+our [hands-on tutorial](/reference/query-languages/esql/esql-search-tutorial.md).
 
 For a high-level overview of search functionalities in {{esql}}, and to learn about relevance scoring, refer to [{{esql}} for search](docs-content://solutions/search/esql-for-search.md#esql-for-search-scoring).
 :::

--- a/docs/reference/query-languages/esql/limitations.md
+++ b/docs/reference/query-languages/esql/limitations.md
@@ -93,7 +93,7 @@ Some [field types](/reference/elasticsearch/mapping-reference/field-data-types.m
     * `cartesian_shape`
 
 
-In addition, when [querying multiple indexes](docs-content://explore-analyze/query-filter/languages/esql-multi-index.md), it’s possible for the same field to be mapped to multiple types. These fields cannot be directly used in queries or returned in results, unless they’re [explicitly converted to a single type](docs-content://explore-analyze/query-filter/languages/esql-multi-index.md#esql-multi-index-union-types).
+In addition, when [querying multiple indexes](/reference/query-languages/esql/esql-multi-index.md), it’s possible for the same field to be mapped to multiple types. These fields cannot be directly used in queries or returned in results, unless they’re [explicitly converted to a single type](/reference/query-languages/esql/esql-multi-index.md#esql-multi-index-union-types).
 
 
 ## _source availability [esql-_source-availability]
@@ -177,10 +177,10 @@ Or consider using one of the [full-text search](/reference/query-languages/esql/
 
 ## Using {{esql}} to query multiple indices [esql-multi-index-limitations]
 
-As discussed in more detail in [Using {{esql}} to query multiple indices](docs-content://explore-analyze/query-filter/languages/esql-multi-index.md), {{esql}} can execute a single query across multiple indices, data streams, or aliases. However, there are some limitations to be aware of:
+As discussed in more detail in [Using {{esql}} to query multiple indices](/reference/query-languages/esql/esql-multi-index.md), {{esql}} can execute a single query across multiple indices, data streams, or aliases. However, there are some limitations to be aware of:
 
 * All underlying indexes and shards must be active. Using admin commands or UI, it is possible to pause an index or shard, for example by disabling a frozen tier instance, but then any {{esql}} query that includes that index or shard will fail, even if the query uses [`WHERE`](/reference/query-languages/esql/commands/where.md) to filter out the results from the paused index. If you see an error of type `search_phase_execution_exception`, with the message `Search rejected due to missing shards`, you likely have an index or shard in `UNASSIGNED` state.
-* The same field must have the same type across all indexes. If the same field is mapped to different types it is still possible to query the indexes, but the field must be [explicitly converted to a single type](docs-content://explore-analyze/query-filter/languages/esql-multi-index.md#esql-multi-index-union-types).
+* The same field must have the same type across all indexes. If the same field is mapped to different types it is still possible to query the indexes, but the field must be [explicitly converted to a single type](/reference/query-languages/esql/esql-multi-index.md#esql-multi-index-union-types).
 
 
 ## Time series data streams are not supported [esql-tsdb]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[DOCS] Update doc links (#133534)](https://github.com/elastic/elasticsearch/pull/133534)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)