### PR TITLE
[9.1] Remove legacy log4j-1.2 dependencies completely (#132238)

### DIFF
--- a/x-pack/plugin/security/src/main/java/module-info.java
+++ b/x-pack/plugin/security/src/main/java/module-info.java
@@ -25,7 +25,6 @@ module org.elasticsearch.security {
     requires org.apache.httpcomponents.httpclient;
     requires org.apache.httpcomponents.httpasyncclient;
     requires org.apache.httpcomponents.httpcore.nio;
-    requires org.apache.log4j;
     requires org.apache.logging.log4j;
     requires org.apache.logging.log4j.core;
     requires org.apache.lucene.core;


### PR DESCRIPTION
Backports the following commits to 9.1:
 - Remove legacy log4j-1.2 dependencies completely (#132238)