### PR TITLE
Fix FwC test task registration

### DIFF
--- a/.buildkite/pipelines/periodic-fwc.template.yml
+++ b/.buildkite/pipelines/periodic-fwc.template.yml
@@ -1,6 +1,6 @@
 steps:
-  - label: $FWC_VERSION / fwc
-    command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v$FWC_VERSION#fwcTest -Dtests.bwc.snapshot=false
+  - label: "{{matrix.FWC_VERSION}}" / fwc
+    command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v$$FWC_VERSION#fwcTest -Dtests.bwc.snapshot=false
     timeout_in_minutes: 300
     agents:
       provider: gcp
@@ -11,4 +11,4 @@ steps:
       setup:
         FWC_VERSION: $FWC_LIST
     env:
-      FWC_VERSION: $FWC_VERSION
+      FWC_VERSION: "{{matrix.FWC_VERSION}}"

--- a/.buildkite/pipelines/periodic-fwc.yml
+++ b/.buildkite/pipelines/periodic-fwc.yml
@@ -1,7 +1,7 @@
 # This file is auto-generated. See .buildkite/pipelines/periodic-fwc.template.yml
 steps:
-  - label: $FWC_VERSION / fwc
-    command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v$FWC_VERSION#fwcTest -Dtests.bwc.snapshot=false
+  - label: "{{matrix.FWC_VERSION}}" / fwc
+    command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v$$FWC_VERSION#fwcTest -Dtests.bwc.snapshot=false
     timeout_in_minutes: 300
     agents:
       provider: gcp
@@ -12,4 +12,4 @@ steps:
       setup:
         FWC_VERSION: []
     env:
-      FWC_VERSION: $FWC_VERSION
+      FWC_VERSION: "{{matrix.FWC_VERSION}}"

--- a/.buildkite/scripts/fwc-branches.sh
+++ b/.buildkite/scripts/fwc-branches.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Configure FwC test branches
+# We do not want 7.x branch and only to run for branches that:
+# - have released at least one minor version (not main)
+# - have previous minor unreleased (not the oldest development branch)
+FWC_BRANCHES=()
+for branch in "${BRANCHES[@]}"; do
+  if [[ ! "$branch" =~ ^7\..* ]]; then
+    FWC_BRANCHES+=("$branch")
+  fi
+done
+# Remove first and last element
+FWC_BRANCHES=("${FWC_BRANCHES[@]:1:${#FWC_BRANCHES[@]}-2}")
+
+shouldRunFwcFor() {
+  local branch=$1
+  for fwc_branch in "${FWC_BRANCHES[@]}"; do
+    if [[ "$fwc_branch" == "$branch" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}

--- a/.buildkite/scripts/periodic.trigger.sh
+++ b/.buildkite/scripts/periodic.trigger.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 echo "steps:"
 
 source .buildkite/scripts/branches.sh
+source .buildkite/scripts/fwc-branches.sh
 
 IS_FIRST=true
 SKIP_DELAY="${SKIP_DELAY:-false}"
@@ -46,8 +47,7 @@ EOF
       branch: "$BRANCH"
       commit: "$LAST_GOOD_COMMIT"
 EOF
-# Include forward compatibility tests only for the bugfix branch
-if [[ "${BRANCH}" == "${BRANCHES[2]}" ]]; then
+if shouldRunFwcFor "$BRANCH"; then
   cat <<EOF
   - trigger: elasticsearch-periodic-fwc
     label: Trigger periodic-fwc pipeline for $BRANCH

--- a/build-tools-internal/src/main/groovy/elasticsearch.fwc-test.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.fwc-test.gradle
@@ -7,19 +7,23 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import org.elasticsearch.gradle.VersionProperties
+import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
-def fwcVersions = buildParams.bwcVersions.released.findAll { it.major == VersionProperties.elasticsearchVersion.major &&  it.minor == VersionProperties.elasticsearchVersion.minor }
-def previousMinorSnapshot = buildParams.bwcVersions.unreleased.find { it.major == VersionProperties.elasticsearchVersion.major && it.minor == VersionProperties.elasticsearchVersion.minor - 1 }
-
-fwcVersions.each { fwcVersion ->
-  tasks.register("v${fwcVersion}#fwcTest", StandaloneRestIntegTestTask) {
-    usesBwcDistribution(previousMinorSnapshot)
-    usesBwcDistribution(fwcVersion)
-    systemProperty("tests.old_cluster_version", previousMinorSnapshot)
-    systemProperty("tests.new_cluster_version", fwcVersion)
-    nonInputProperties.systemProperty 'tests.fwc', 'true'
+Version elasticsearchVersion = Version.fromString(versions.get("elasticsearch"))
+def fwcVersions = buildParams.bwcVersions.released.findAll { it.major == elasticsearchVersion.major &&  it.minor == elasticsearchVersion.minor }
+def targetMajor = elasticsearchVersion.minor > 0 ? elasticsearchVersion.major : elasticsearchVersion.major - 1
+def targetMinor = elasticsearchVersion.minor > 0 ? elasticsearchVersion.minor - 1 : buildParams.bwcVersions.unreleased.findAll { it.major == targetMajor }*.minor.max()
+def previousMinorSnapshot = buildParams.bwcVersions.unreleased.find { it.major == targetMajor && it.minor == targetMinor }
+if (previousMinorSnapshot != null) {
+  fwcVersions.each { fwcVersion ->
+    tasks.register("v${fwcVersion}#fwcTest", StandaloneRestIntegTestTask) {
+      usesBwcDistribution(previousMinorSnapshot)
+      usesBwcDistribution(fwcVersion)
+      systemProperty("tests.old_cluster_version", previousMinorSnapshot)
+      systemProperty("tests.new_cluster_version", fwcVersion)
+      nonInputProperties.systemProperty 'tests.fwc', 'true'
+    }
   }
 }
 


### PR DESCRIPTION
With this change it takes into account:
- that not all versions have previous minor unreleased version (because we are on the oldest active development branch),
- that current version has minor == 0 (e.g. 9.0) so previous minor have to be calculated differently.