### PR TITLE
[DOCS]: Backport release notes for search connectors

### DIFF
--- a/docs/reference/search-connectors/release-notes.md
+++ b/docs/reference/search-connectors/release-notes.md
@@ -29,6 +29,9 @@ Permissions granted to the `Everyone Except External Users` group were previousl
 ## 9.1.0 [connectors-9.1.0-release-notes]
 There are no new features, enhancements, fixes, known issues, or deprecations associated with this release.
 
+## 9.0.6 [connectors-9.0.6-release-notes]
+No changes since 9.0.5
+
 ## 9.0.5 [connectors-9.0.5-release-notes]
 
 ### Fixes [connectors-9.0.5-fixes]

--- a/docs/reference/search-connectors/release-notes.md
+++ b/docs/reference/search-connectors/release-notes.md
@@ -13,6 +13,9 @@ If you are an Enterprise Search user and want to upgrade to Elastic 9.0, refer t
 It includes detailed steps, tooling, and resources to help you transition to supported alternatives in 9.x, such as Elasticsearch, the Open Web Crawler, and self-managed connectors.
 :::
 
+## 9.1.3 [connectors-9.1.3-release-notes]
+There are no new features, enhancements, fixes, known issues, or deprecations associated with this release.
+
 ## 9.1.2 [connectors-9.1.2-release-notes]
 There are no new features, enhancements, fixes, known issues, or deprecations associated with this release.
 


### PR DESCRIPTION
This PR backports the 9.0.6 and 9.1.3 search connectors release notes to main.