### PR TITLE
OTLP: reuse hasher for creating _metric_names_hash

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/hash/MurmurHash3.java
+++ b/server/src/main/java/org/elasticsearch/common/hash/MurmurHash3.java
@@ -60,7 +60,7 @@ public enum MurmurHash3 {
 
         @Override
         public int hashCode() {
-            return (int) (h1 ^ h2);
+            return Long.hashCode(h1 ^ h2);
         }
 
         @Override

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/DataPointGroupingContext.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/DataPointGroupingContext.java
@@ -265,9 +265,9 @@ public class DataPointGroupingContext {
             return dataPoints.getFirst().getStartTimestampUnixNano();
         }
 
-        public String getMetricNamesHash() {
+        public String getMetricNamesHash(BufferedMurmur3Hasher hasher) {
             if (metricNamesHash == null) {
-                BufferedMurmur3Hasher hasher = new BufferedMurmur3Hasher(0);
+                hasher.reset();
                 for (int i = 0; i < dataPoints.size(); i++) {
                     hasher.addString(dataPoints.get(i).getMetricName());
                 }

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/MetricDocumentBuilder.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/MetricDocumentBuilder.java
@@ -15,6 +15,7 @@ import io.opentelemetry.proto.resource.v1.Resource;
 import com.google.protobuf.ByteString;
 
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.hash.BufferedMurmur3Hasher;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.oteldata.otlp.datapoint.DataPoint;
 import org.elasticsearch.xpack.oteldata.otlp.datapoint.DataPointGroupingContext;
@@ -32,6 +33,7 @@ import java.util.concurrent.TimeUnit;
 public class MetricDocumentBuilder {
 
     private final BufferedByteStringAccessor byteStringAccessor;
+    private final BufferedMurmur3Hasher hasher = new BufferedMurmur3Hasher(0);
 
     public MetricDocumentBuilder(BufferedByteStringAccessor byteStringAccessor) {
         this.byteStringAccessor = byteStringAccessor;
@@ -49,7 +51,7 @@ public class MetricDocumentBuilder {
         buildResource(dataPointGroup.resource(), dataPointGroup.resourceSchemaUrl(), builder);
         buildScope(builder, dataPointGroup.scopeSchemaUrl(), dataPointGroup.scope());
         buildDataPointAttributes(builder, dataPointGroup.dataPointAttributes(), dataPointGroup.unit());
-        builder.field("_metric_names_hash", dataPointGroup.getMetricNamesHash());
+        builder.field("_metric_names_hash", dataPointGroup.getMetricNamesHash(hasher));
 
         builder.startObject("metrics");
         for (int i = 0, dataPointsSize = dataPoints.size(); i < dataPointsSize; i++) {


### PR DESCRIPTION
Small optimization to re-use `BufferedMurmur3Hasher` instances used to create the `_metric_names_hash`.

Part of https://github.com/elastic/elasticsearch/pull/133057