### PR TITLE
[9.1] Bump asm to 9.8 for JDK 25 support in remaining places (#133938)

### DIFF
--- a/modules/repository-azure/build.gradle
+++ b/modules/repository-azure/build.gradle
@@ -76,7 +76,7 @@ dependencies {
   api "net.minidev:accessors-smart:2.5.2"
   api "net.minidev:json-smart:2.5.2"
   api "org.codehaus.woodstox:stax2-api:4.2.2"
-  api "org.ow2.asm:asm:9.7.1"
+  api "org.ow2.asm:asm:9.8"
 
   runtimeOnly "com.google.code.gson:gson:2.11.0"
   runtimeOnly "org.cryptomator:siv-mode:1.5.2"

--- a/test/logger-usage/build.gradle
+++ b/test/logger-usage/build.gradle
@@ -10,9 +10,9 @@
 apply plugin: 'elasticsearch.java'
 
 dependencies {
-  api 'org.ow2.asm:asm:9.7.1'
-  api 'org.ow2.asm:asm-tree:9.7.1'
-  api 'org.ow2.asm:asm-analysis:9.7.1'
+  api 'org.ow2.asm:asm:9.8'
+  api 'org.ow2.asm:asm-tree:9.8'
+  api 'org.ow2.asm:asm-analysis:9.8'
   api "org.apache.logging.log4j:log4j-api:${versions.log4j}"
   testImplementation project(":test:framework")
 }

--- a/x-pack/plugin/security/build.gradle
+++ b/x-pack/plugin/security/build.gradle
@@ -87,7 +87,7 @@ dependencies {
   api "net.jcip:jcip-annotations:1.0"
   api "net.minidev:json-smart:2.5.2"
   api "net.minidev:accessors-smart:2.5.2"
-  api "org.ow2.asm:asm:9.7.1"
+  api "org.ow2.asm:asm:9.8"
 
   testImplementation "org.elasticsearch:mocksocket:${versions.mocksocket}"
 


### PR DESCRIPTION
Backports the following commits to 9.1:
 - Bump asm to 9.8 for JDK 25 support in remaining places (#133938)