### PR TITLE
Set storage engine as codeowner for the OTLP endpoint

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,6 +34,11 @@ x-pack/plugin/apm-data/src/yamlRestTest/resources @elastic/obs-ds-intake-service
 x-pack/plugin/otel-data/src/main/resources @elastic/obs-ds-intake-services
 x-pack/plugin/otel-data/src/yamlRestTest/resources @elastic/obs-ds-intake-services
 
+# Storage Engine
+x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp @elastic/es-storage-engine
+x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp @elastic/es-storage-engine
+x-pack/plugin/otel-data/src/javaRestTest/java/org/elasticsearch/xpack/oteldata/otlp @elastic/es-storage-engine
+
 # Delivery
 gradle @elastic/es-delivery
 build-conventions @elastic/es-delivery

--- a/x-pack/plugin/otel-data/src/javaRestTest/java/org/elasticsearch/xpack/oteldata/otlp/OTLPMetricsIndexingRestIT.java
+++ b/x-pack/plugin/otel-data/src/javaRestTest/java/org/elasticsearch/xpack/oteldata/otlp/OTLPMetricsIndexingRestIT.java
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-package org.elasticsearch.action.otlp;
+package org.elasticsearch.xpack.oteldata.otlp;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.exporter.internal.FailedExportException;


### PR DESCRIPTION
Sets the storage engine team as the code owners of the OTLP endpoint

Part of https://github.com/elastic/elasticsearch/pull/133057