### PR TITLE
Correct Typo In Latest Transport Version ID

### DIFF
--- a/docs/changelog/133962.yaml
+++ b/docs/changelog/133962.yaml
@@ -1,5 +1,0 @@
-pr: 133962
-summary: Update `TransportVersions.java`
-area: Infra/Core
-type: bug
-issues: []

--- a/docs/changelog/133962.yaml
+++ b/docs/changelog/133962.yaml
@@ -1,0 +1,5 @@
+pr: 133962
+summary: Update `TransportVersions.java`
+area: Infra/Core
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -354,7 +354,7 @@ public class TransportVersions {
     public static final TransportVersion SHARD_WRITE_LOAD_IN_CLUSTER_INFO = def(9_126_0_00);
     public static final TransportVersion ESQL_SAMPLE_OPERATOR_STATUS = def(9_127_0_00);
     public static final TransportVersion PROJECT_RESERVED_STATE_MOVE_TO_REGISTRY = def(9_147_0_00);
-    public static final TransportVersion STREAMS_ENDPOINT_PARAM_RESTRICTIONS = def(9_148_00_00);
+    public static final TransportVersion STREAMS_ENDPOINT_PARAM_RESTRICTIONS = def(9_148_0_00);
 
     /*
      * STOP! READ THIS FIRST! No, really,


### PR DESCRIPTION
Correct typo in latest version number which has an erroneous 0 in the minor version part.
