### PR TITLE
Add explicit versions to branches.json

### DIFF
--- a/branches.json
+++ b/branches.json
@@ -1,23 +1,29 @@
 {
-  "notice": "This file is not maintained outside of the main branch and should only be used for tooling.",
-  "branches": [
+  "notice" : "This file is not maintained outside of the main branch and should only be used for tooling.",
+  "branches" : [
     {
-      "branch": "main"
+      "branch" : "main",
+      "version" : "9.2.0"
     },
     {
-      "branch": "9.1"
+      "branch" : "9.1",
+      "version" : "9.1.4"
     },
     {
-      "branch": "9.0"
+      "branch" : "9.0",
+      "version" : "9.0.7"
     },
     {
-      "branch": "8.19"
+      "branch" : "8.19",
+      "version" : "8.19.4"
     },
     {
-      "branch": "8.18"
+      "branch" : "8.18",
+      "version" : "8.18.7"
     },
     {
-      "branch": "7.17"
+      "branch" : "7.17",
+      "version" : "7.17.30"
     }
   ]
 }


### PR DESCRIPTION
Versions added in branches.json will be used as a source of truth for versions currently developed. This will be used primarily for BwC tests.

This PR is a part of https://github.com/elastic/elasticsearch/pull/129637 and needs to be merged first to avoid the necessity to merge failing PRs with failing builds.
After this is merged I will be able to remove [this line](https://github.com/elastic/elasticsearch/pull/129637/files#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19R27-R28).

I expect that adding those versions shouldn't have any influence on the existing processes because it doesn't change the structure, and only add the field.