### PR TITLE
Add toString implementation to exponential histograms

### DIFF
--- a/libs/exponential-histogram/src/main/java/org/elasticsearch/exponentialhistogram/AbstractExponentialHistogram.java
+++ b/libs/exponential-histogram/src/main/java/org/elasticsearch/exponentialhistogram/AbstractExponentialHistogram.java
@@ -46,4 +46,53 @@ public abstract class AbstractExponentialHistogram implements ExponentialHistogr
         }
         return false;
     }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder(getClassNameWithoutPackage()).append("{");
+        sb.append("scale=").append(scale());
+        sb.append(", sum=").append(sum());
+        sb.append(", valueCount=").append(valueCount());
+        sb.append(", min=").append(min());
+        ZeroBucket zb = zeroBucket();
+        if (zb.zeroThreshold() != 0) {
+            sb.append(", zeroThreshold=").append(zb.zeroThreshold());
+        }
+        if (zb.count() != 0) {
+            sb.append(", zeroCount=").append(zb.count());
+        }
+        BucketIterator neg = negativeBuckets().iterator();
+        if (neg.hasNext()) {
+            sb.append(", negative=[");
+            appendsBucketsAsString(sb, neg);
+            sb.append("]");
+        }
+        BucketIterator pos = positiveBuckets().iterator();
+        if (pos.hasNext()) {
+            sb.append(", positive=[");
+            appendsBucketsAsString(sb, pos);
+            sb.append("]");
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    private String getClassNameWithoutPackage() {
+        String fqn = getClass().getName();
+        int lastDot = fqn.lastIndexOf('.');
+        return fqn.substring(lastDot + 1);
+    }
+
+    private static void appendsBucketsAsString(StringBuilder out, BucketIterator it) {
+        boolean first = true;
+        while (it.hasNext()) {
+            if (first) {
+                first = false;
+            } else {
+                out.append(", ");
+            }
+            out.append(it.peekIndex()).append(": ").append(it.peekCount());
+            it.advance();
+        }
+    }
 }

--- a/libs/exponential-histogram/src/main/java/org/elasticsearch/exponentialhistogram/AbstractExponentialHistogram.java
+++ b/libs/exponential-histogram/src/main/java/org/elasticsearch/exponentialhistogram/AbstractExponentialHistogram.java
@@ -54,6 +54,7 @@ public abstract class AbstractExponentialHistogram implements ExponentialHistogr
         sb.append(", sum=").append(sum());
         sb.append(", valueCount=").append(valueCount());
         sb.append(", min=").append(min());
+        sb.append(", max=").append(max());
         ZeroBucket zb = zeroBucket();
         if (zb.zeroThreshold() != 0) {
             sb.append(", zeroThreshold=").append(zb.zeroThreshold());

--- a/libs/exponential-histogram/src/test/java/org/elasticsearch/exponentialhistogram/ExponentialHistogramToStringTests.java
+++ b/libs/exponential-histogram/src/test/java/org/elasticsearch/exponentialhistogram/ExponentialHistogramToStringTests.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V., and/or licensed to Elasticsearch B.V.
+ * under one or more license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * This file is based on a modification of https://github.com/open-telemetry/opentelemetry-java which is licensed under the Apache 2.0 License.
+ */
+
+package org.elasticsearch.exponentialhistogram;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class ExponentialHistogramToStringTests extends ExponentialHistogramTestCase {
+
+    public void testFullHistogram() {
+        try (FixedCapacityExponentialHistogram histogram = FixedCapacityExponentialHistogram.create(10, breaker())) {
+            histogram.setZeroBucket(ZeroBucket.create(42.0, 7));
+            histogram.resetBuckets(10);
+            histogram.setMin(-100);
+            histogram.setMax(200);
+            histogram.setSum(1234.5);
+            histogram.tryAddBucket(2, 3, false); // negative bucket
+            histogram.tryAddBucket(3, 4, false); // negative bucket
+            histogram.tryAddBucket(4, 2, false); // negative bucket
+            histogram.tryAddBucket(1, 5, true); // positive bucket
+            histogram.tryAddBucket(5, 7, true); // positive bucket
+            histogram.tryAddBucket(6, 1, true); // positive bucket
+            String expected = "FixedCapacityExponentialHistogram{"
+                + "scale=10, sum=1234.5, valueCount=29, min=-100.0, max=200.0, zeroThreshold=42.0, zeroCount=7,"
+                + " negative=[2: 3, 3: 4, 4: 2], positive=[1: 5, 5: 7, 6: 1]}";
+            assertThat(histogram.toString(), equalTo(expected));
+        }
+    }
+
+    public void testEmptyHistogram() {
+        ExponentialHistogram emptyHistogram = ExponentialHistogram.empty();
+        String expected = "EmptyExponentialHistogram{scale=" + emptyHistogram.scale() + ", sum=0.0, valueCount=0, min=NaN, max=NaN}";
+        assertThat(emptyHistogram.toString(), equalTo(expected));
+    }
+}


### PR DESCRIPTION
Currently exponential histograms still use the standard `Object.toString` implementation.
This representation is not very helpful when debugging or when e.g. `equalTo()` assertions fail.

Therefore this PR adds a `toString` implementation printing the simple class name (also for anonymous classes) plus the actual histogram contents, giving a more pleasant experience:

<img width="1052" height="58" alt="image" src="https://github.com/user-attachments/assets/80852992-faa2-40db-8c9b-ac5dd001ed9e" />
