### PR TITLE
[9.0] rest-api-spec: mark search application as beta (#133914)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.delete.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search-application-delete",
       "description": "Delete a search application"
     },
-    "stability": "experimental",
+    "stability": "beta",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.get.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search-application-get",
       "description": "Get search application details"
     },
-    "stability": "experimental",
+    "stability": "beta",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.list.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search-application-get-behavioral-analytics",
       "description": "Get search applications"
     },
-    "stability": "experimental",
+    "stability": "beta",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.put.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.put.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search-application-put",
       "description": "Create or update a search application"
     },
-    "stability": "experimental",
+    "stability": "beta",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.search.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search-application-search",
       "description": "Run a search application search"
     },
-    "stability": "experimental",
+    "stability": "beta",
     "visibility": "public",
     "headers": {
       "accept": [


### PR DESCRIPTION
Backports the following commits to 9.0:
 - rest-api-spec: mark search application as beta (#133914)