### PR TITLE
[Buildkite] Use ubuntu2204 when testing openjdk17

### DIFF
--- a/.buildkite/pipelines/periodic.template.yml
+++ b/.buildkite/pipelines/periodic.template.yml
@@ -55,7 +55,7 @@ steps:
               - checkRestCompat
         agents:
           provider: gcp
-          image: family/elasticsearch-ubuntu-2404
+          image: family/elasticsearch-ubuntu-2204
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
         env:
@@ -71,7 +71,7 @@ steps:
             BWC_VERSION: $BWC_LIST
         agents:
           provider: gcp
-          image: family/elasticsearch-ubuntu-2404
+          image: family/elasticsearch-ubuntu-2204
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
         env:
@@ -100,7 +100,7 @@ steps:
               - checkRestCompat
         agents:
           provider: gcp
-          image: family/elasticsearch-ubuntu-2404
+          image: family/elasticsearch-ubuntu-2204
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
         env:
@@ -120,7 +120,7 @@ steps:
             BWC_VERSION: $BWC_LIST
         agents:
           provider: gcp
-          image: family/elasticsearch-ubuntu-2404
+          image: family/elasticsearch-ubuntu-2204
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
         env:

--- a/.buildkite/pipelines/periodic.yml
+++ b/.buildkite/pipelines/periodic.yml
@@ -778,7 +778,7 @@ steps:
               - checkRestCompat
         agents:
           provider: gcp
-          image: family/elasticsearch-ubuntu-2404
+          image: family/elasticsearch-ubuntu-2204
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
         env:
@@ -794,7 +794,7 @@ steps:
             BWC_VERSION: ["7.17.30", "8.18.7", "8.19.4"]
         agents:
           provider: gcp
-          image: family/elasticsearch-ubuntu-2404
+          image: family/elasticsearch-ubuntu-2204
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
         env:
@@ -823,7 +823,7 @@ steps:
               - checkRestCompat
         agents:
           provider: gcp
-          image: family/elasticsearch-ubuntu-2404
+          image: family/elasticsearch-ubuntu-2204
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
         env:
@@ -843,7 +843,7 @@ steps:
             BWC_VERSION: ["7.17.30", "8.18.7", "8.19.4"]
         agents:
           provider: gcp
-          image: family/elasticsearch-ubuntu-2404
+          image: family/elasticsearch-ubuntu-2204
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
         env:


### PR DESCRIPTION
OpenJDK is incompatible to our standard ubuntu2404 ci images. Therefore we fall back to 2204 for now to
- still benefit from freshly baked images (up-to-date cache)
- have decent openjdk 17 coverage