### PR TITLE
[9.0] rest-api-spec: update connector visibility/stability (#133814)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.delete.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-delete",
       "description": "Delete a connector"
     },
-    "stability": "experimental",
+    "stability": "beta",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.get.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-get",
       "description": "Get a connector"
     },
-    "stability": "experimental",
+    "stability": "beta",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.last_sync.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.last_sync.json
@@ -5,7 +5,7 @@
       "description": "Update the connector last sync stats"
     },
     "stability": "experimental",
-    "visibility": "public",
+    "visibility": "private",
     "headers": {
       "accept": [
         "application/json"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.list.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-list",
       "description": "Get all connectors"
     },
-    "stability": "experimental",
+    "stability": "beta",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.post.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.post.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-put",
       "description": "Create a connector"
     },
-    "stability": "experimental",
+    "stability": "beta",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.put.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.put.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-put",
       "description": "Create or update a connector"
     },
-    "stability": "experimental",
+    "stability": "beta",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.sync_job_cancel.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.sync_job_cancel.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-sync-job-cancel",
       "description": "Cancel a connector sync job"
     },
-    "stability": "experimental",
+    "stability": "beta",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.sync_job_delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.sync_job_delete.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-sync-job-delete",
       "description": "Delete a connector sync job"
     },
-    "stability": "experimental",
+    "stability": "beta",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.sync_job_get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.sync_job_get.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-sync-job-get",
       "description": "Get a connector sync job"
     },
-    "stability": "experimental",
+    "stability": "beta",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.sync_job_list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.sync_job_list.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-sync-job-list",
       "description": "Get all connector sync jobs"
     },
-    "stability": "experimental",
+    "stability": "beta",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.sync_job_post.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.sync_job_post.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-sync-job-post",
       "description": "Create a connector sync job"
     },
-    "stability": "experimental",
+    "stability": "beta",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_api_key_id.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_api_key_id.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-update-api-key-id",
       "description": "Update the connector API key ID"
     },
-    "stability": "experimental",
+    "stability": "beta",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_configuration.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_configuration.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-update-configuration",
       "description": "Update the connector configuration"
     },
-    "stability": "experimental",
+    "stability": "beta",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_filtering.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_filtering.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-update-filtering",
       "description": "Update the connector filtering"
     },
-    "stability": "experimental",
+    "stability": "beta",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_index_name.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_index_name.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-update-index-name",
       "description": "Update the connector index name"
     },
-    "stability": "experimental",
+    "stability": "beta",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_name.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_name.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-update-name",
       "description": "Update the connector name and description"
     },
-    "stability": "experimental",
+    "stability": "beta",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_native.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_native.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-update-native",
       "description": "Update the connector is_native flag"
     },
-    "stability": "experimental",
+    "stability": "beta",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_pipeline.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_pipeline.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-update-pipeline",
       "description": "Update the connector pipeline"
     },
-    "stability": "experimental",
+    "stability": "beta",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_scheduling.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_scheduling.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-update-scheduling",
       "description": "Update the connector scheduling"
     },
-    "stability": "experimental",
+    "stability": "beta",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_service_type.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_service_type.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-update-service-type",
       "description": "Update the connector service type"
     },
-    "stability": "experimental",
+    "stability": "beta",
     "visibility": "public",
     "headers": {
       "accept": [


### PR DESCRIPTION
Backports the following commits to 9.0:
 - rest-api-spec: update connector visibility/stability (#133814)