### PR TITLE
Don't use tsdb codec for recovery_source fields

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -531,12 +531,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.InferenceIT
   method: testInferClassificationModel
   issue: https://github.com/elastic/elasticsearch/issues/133448
-- class: org.elasticsearch.xpack.logsdb.LogsIndexingIT
-  method: testRouteOnSortFields
-  issue: https://github.com/elastic/elasticsearch/issues/133993
-- class: org.elasticsearch.xpack.logsdb.LogsIndexingIT
-  method: testShrink
-  issue: https://github.com/elastic/elasticsearch/issues/133875
 - class: org.elasticsearch.xpack.esql.action.CrossClusterQueryWithPartialResultsIT
   method: testPartialResults
   issue: https://github.com/elastic/elasticsearch/issues/131481

--- a/server/src/main/java/org/elasticsearch/index/codec/PerFieldFormatSupplier.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/PerFieldFormatSupplier.java
@@ -27,6 +27,7 @@ import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.SeqNoFieldMapper;
+import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 
 /**
@@ -127,6 +128,11 @@ public class PerFieldFormatSupplier {
 
     private boolean excludeFields(String fieldName) {
         // TODO: should we just allow all fields to use tsdb doc values codec?
+        // Values of these doc_values fields can be filtered out in RecoverySourcePruneMergePolicy,
+        // which leads to inconsistencies between merge stats and actual values.
+        if (SourceFieldMapper.RECOVERY_SOURCE_SIZE_NAME.equals(fieldName) || SourceFieldMapper.RECOVERY_SOURCE_NAME.equals(fieldName)) {
+            return true;
+        }
         // Avoid using tsdb codec for fields like _seq_no, _primary_term.
         // But _tsid and _ts_routing_hash should always use the tsdb codec.
         return fieldName.startsWith("_")


### PR DESCRIPTION
We should not enable the TSDB codec for _recovery_source and _recovery_source_size fields, as their doc_values can be filtered out in RecoverySourcePruneMergePolicy, leading to inconsistencies between merge stats and actual values.

Closes #133875
Closes #133993