### PR TITLE
[8.18] [Buildkite] Use ubuntu2204 when testing openjdk17 (#133977)

### DIFF
--- a/.buildkite/pipelines/periodic.template.yml
+++ b/.buildkite/pipelines/periodic.template.yml
@@ -54,7 +54,7 @@ steps:
               - checkRestCompat
         agents:
           provider: gcp
-          image: family/elasticsearch-ubuntu-2404
+          image: family/elasticsearch-ubuntu-2204
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
         env:
@@ -70,7 +70,7 @@ steps:
             BWC_VERSION: $BWC_LIST
         agents:
           provider: gcp
-          image: family/elasticsearch-ubuntu-2404
+          image: family/elasticsearch-ubuntu-2204
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
         env:
@@ -98,7 +98,7 @@ steps:
               - checkRestCompat
         agents:
           provider: gcp
-          image: family/elasticsearch-ubuntu-2404
+          image: family/elasticsearch-ubuntu-2204
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
         env:
@@ -118,7 +118,7 @@ steps:
             BWC_VERSION: $BWC_LIST
         agents:
           provider: gcp
-          image: family/elasticsearch-ubuntu-2404
+          image: family/elasticsearch-ubuntu-2204
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
         env:

--- a/.buildkite/pipelines/periodic.yml
+++ b/.buildkite/pipelines/periodic.yml
@@ -758,7 +758,7 @@ steps:
               - checkRestCompat
         agents:
           provider: gcp
-          image: family/elasticsearch-ubuntu-2404
+          image: family/elasticsearch-ubuntu-2204
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
         env:
@@ -774,7 +774,7 @@ steps:
             BWC_VERSION: ["7.17.30", "8.18.7"]
         agents:
           provider: gcp
-          image: family/elasticsearch-ubuntu-2404
+          image: family/elasticsearch-ubuntu-2204
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
         env:
@@ -802,7 +802,7 @@ steps:
               - checkRestCompat
         agents:
           provider: gcp
-          image: family/elasticsearch-ubuntu-2404
+          image: family/elasticsearch-ubuntu-2204
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
         env:
@@ -822,7 +822,7 @@ steps:
             BWC_VERSION: ["7.17.30", "8.18.7"]
         agents:
           provider: gcp
-          image: family/elasticsearch-ubuntu-2404
+          image: family/elasticsearch-ubuntu-2204
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
         env:


### PR DESCRIPTION
Backports the following commits to 8.18:
 - [Buildkite] Use ubuntu2204 when testing openjdk17 (#133977)