### PR TITLE
[9.1] Adding _meta.template_version to kibana reporting mappings (#133846)

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/kibana-reporting@template.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/kibana-reporting@template.json
@@ -10,6 +10,9 @@
   "template": {
     "lifecycle": {},
     "mappings": {
+      "_meta": {
+        "template_version": ${xpack.stack.template.version}
+      },
       "properties": {
         "meta": {
           "properties": {

--- a/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackTemplateRegistry.java
+++ b/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackTemplateRegistry.java
@@ -37,7 +37,7 @@ public class StackTemplateRegistry extends IndexTemplateRegistry {
 
     // The stack template registry version. This number must be incremented when we make changes
     // to built-in templates.
-    public static final int REGISTRY_VERSION = 16;
+    public static final int REGISTRY_VERSION = 18;
 
     public static final String TEMPLATE_VERSION_VARIABLE = "xpack.stack.template.version";
     public static final Setting<Boolean> STACK_TEMPLATES_ENABLED = Setting.boolSetting(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Adding _meta.template_version to kibana reporting mappings (#133846)](https://github.com/elastic/elasticsearch/pull/133846)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)