### PR TITLE
[8.18] Replace -1s with -1 in ML forecast tests (#134016)

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/ForecastJobActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/ForecastJobActionRequestTests.java
@@ -56,7 +56,7 @@ public class ForecastJobActionRequestTests extends AbstractXContentSerializingTe
     }
 
     public void testSetDuration_GivenNegative() {
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> new Request().setDuration("-1s"));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> new Request().setDuration("-1"));
         assertThat(e.getMessage(), equalTo("[duration] must be positive: [-1]"));
     }
 
@@ -67,7 +67,7 @@ public class ForecastJobActionRequestTests extends AbstractXContentSerializingTe
     }
 
     public void testSetExpiresIn_GivenNegative() {
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> new Request().setExpiresIn("-1s"));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> new Request().setExpiresIn("-1"));
         assertThat(e.getMessage(), equalTo("[expires_in] must be non-negative: [-1]"));
     }
 }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/forecast.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/forecast.yml
@@ -45,7 +45,7 @@ setup:
       catch: /\[duration\] must be positive[:] \[-1\]/
       ml.forecast:
         job_id: "forecast-job"
-        duration: "-1s"
+        duration: "-1"
 
 ---
 "Test forecast given duration is too large":
@@ -61,7 +61,7 @@ setup:
       catch: /\[expires_in\] must be non-negative[:] \[-1\]/
       ml.forecast:
         job_id: "forecast-job"
-        expires_in: "-1s"
+        expires_in: "-1"
 ---
 "Test forecast given max_model_memory is too large":
   - do:


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Replace -1s with -1 in ML forecast tests (#134016)