### PR TITLE
Update deprecation comments to avoid javadoc issues

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/VersionProperties.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/VersionProperties.java
@@ -17,8 +17,8 @@ import java.util.Properties;
 /**
  * Accessor for shared dependency versions used by elasticsearch, namely the elasticsearch and lucene versions.
  *
- * @deprecated use ext values set by {@link org.elasticsearch.gradle.internal.conventions.VersionPropertiesPlugin} or
- * {@link org.elasticsearch.gradle.internal.conventions.VersionPropertiesBuildService}
+ * @deprecated use ext values set by org.elasticsearch.gradle.internal.conventions.VersionPropertiesPlugin or
+ * org.elasticsearch.gradle.internal.conventions.VersionPropertiesBuildService
  *
  */
 @Deprecated


### PR DESCRIPTION
This had to be changed because there is no access to the classes described as alternatives in the deprecated field.