### PR TITLE
[8.18] Update deprecation comments to avoid javadoc issues (#134047)

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/VersionProperties.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/VersionProperties.java
@@ -17,8 +17,8 @@ import java.util.Properties;
 /**
  * Accessor for shared dependency versions used by elasticsearch, namely the elasticsearch and lucene versions.
  *
- * @deprecated use ext values set by {@link org.elasticsearch.gradle.internal.conventions.VersionPropertiesPlugin} or
- * {@link org.elasticsearch.gradle.internal.conventions.VersionPropertiesBuildService}
+ * @deprecated use ext values set by org.elasticsearch.gradle.internal.conventions.VersionPropertiesPlugin or
+ * org.elasticsearch.gradle.internal.conventions.VersionPropertiesBuildService
  *
  */
 @Deprecated


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Update deprecation comments to avoid javadoc issues (#134047)