### PR TITLE
Avoid expensive status update in LuceneOperator

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneOperator.java
@@ -33,7 +33,6 @@ import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -284,18 +283,12 @@ public abstract class LuceneOperator extends SourceOperator {
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append(this.getClass().getSimpleName()).append("[");
-        sb.append("shards = ").append(sortedUnion(processedShards, sliceQueue.remainingShardsIdentifiers()));
+        sb.append("shards = ")
+            .append(sliceQueue.partitioningStrategies().keySet().stream().sorted().collect(Collectors.joining(",", "[", "]")));
         sb.append(", maxPageSize = ").append(maxPageSize);
         describe(sb);
         sb.append("]");
         return sb.toString();
-    }
-
-    private static Set<String> sortedUnion(Collection<String> a, Collection<String> b) {
-        var result = new TreeSet<String>();
-        result.addAll(a);
-        result.addAll(b);
-        return result;
     }
 
     protected abstract void describe(StringBuilder sb);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneSliceQueue.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneSliceQueue.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -176,17 +175,6 @@ public final class LuceneSliceQueue {
      */
     public Map<String, PartitioningStrategy> partitioningStrategies() {
         return partitioningStrategies;
-    }
-
-    public Collection<String> remainingShardsIdentifiers() {
-        List<String> remaining = new ArrayList<>(slices.length());
-        for (int i = 0; i < slices.length(); i++) {
-            LuceneSlice slice = slices.get(i);
-            if (slice != null) {
-                remaining.add(slice.shardContext().shardIdentifier());
-            }
-        }
-        return remaining;
     }
 
     public static LuceneSliceQueue create(


### PR DESCRIPTION
With doc_partitioning targeting large shards, updating the status of LuceneOperator can be expensive with many slices. This change uses the keys of the partitioning map instead of iterating over all slices in the queue.