### PR TITLE
[9.1] [Test] Fix WriteLoadForecasterIT testWriteLoadForecastIsOverriddenBySetting (#134099)

### DIFF
--- a/x-pack/plugin/write-load-forecaster/src/internalClusterTest/java/org/elasticsearch/xpack/writeloadforecaster/WriteLoadForecasterIT.java
+++ b/x-pack/plugin/write-load-forecaster/src/internalClusterTest/java/org/elasticsearch/xpack/writeloadforecaster/WriteLoadForecasterIT.java
@@ -194,6 +194,7 @@ public class WriteLoadForecasterIT extends ESIntegTestCase {
 
             assertAcked(indicesAdmin().rolloverIndex(new RolloverRequest(dataStreamName, null)).actionGet());
         }
+        ensureGreen();
     }
 
     static void indexDocs(String dataStream, int numDocs) {


### PR DESCRIPTION
Backports the following commits to 9.1:
 - [Test] Fix WriteLoadForecasterIT testWriteLoadForecastIsOverriddenBySetting (#134099)