### PR TITLE
[Renovate] Auto update common ci-agent-images

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>elastic/renovate-config:only-chainguard",
+    "github>elastic/renovate-config:ci-agent-images",
     ":disableDependencyDashboard"
   ],
   "schedule": [
@@ -10,6 +11,7 @@
   "labels": [
     ">non-issue",
     ":Delivery/Packaging",
+    ":Delivery/Build",
     "Team:Delivery",
     "auto-merge-without-approval"
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -1,18 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
+    "github>elastic/renovate-config:base",
     "github>elastic/renovate-config:ci-agent-images",
     ":disableDependencyDashboard"
   ],
   "schedule": [
     "after 1pm on tuesday"
   ],
-
-  "includePaths": [
-    ".buildkite/pipelines/pull-request/pr-upgrade.yml",
-    "distribution/docker/src/docker/dockerfiles/wolfi/Dockerfile"
-  ],
-
   "labels": [
     ">non-issue",
     ":Delivery/Packaging",

--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,18 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>elastic/renovate-config:only-chainguard",
     "github>elastic/renovate-config:ci-agent-images",
     ":disableDependencyDashboard"
   ],
   "schedule": [
     "after 1pm on tuesday"
   ],
+
+  "includePaths": [
+    ".buildkite/pipelines/pull-request/pr-upgrade.yml",
+    "distribution/docker/src/docker/dockerfiles/wolfi/Dockerfile"
+  ],
+
   "labels": [
     ">non-issue",
     ":Delivery/Packaging",
@@ -22,5 +27,21 @@
     "8.19",
     "8.18",
     "7.17"
+  ],
+  "packageRules": [
+    {
+      "description": "Don't manage dependencies by default",
+      "matchPackageNames": [
+        "*"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Explicitly enable Elastic Docker updates",
+      "matchPackageNames": [
+        "/docker.elastic.co/.*/"
+      ],
+      "enabled": true
+    }
   ]
 }


### PR DESCRIPTION
This should help us keeping buildkite agent images up-to-date in our pipelines. 

This is a follow up on https://github.com/elastic/elasticsearch/pull/134118/files#r2321516783 