### PR TITLE
[9.0] [D0CS] Fix semantic_text example in mapping-reference/semantic-text.md (#134119)

### DIFF
--- a/docs/reference/elasticsearch/mapping-reference/semantic-text.md
+++ b/docs/reference/elasticsearch/mapping-reference/semantic-text.md
@@ -264,14 +264,14 @@ inference data that `semantic_text` typically hides using `fields`.
 ```console
 POST test-index/_search
 {
-    "query": {
-        "match": {
-            "my_semantic_field": "Which country is Paris in?"
-        },
-        "fields": [
-            "_inference_fields"
-          ]
+  "query": {
+    "match": {
+      "my_semantic_field": "Which country is Paris in?"
     }
+  },
+  "fields": [
+    "_inference_fields"
+  ]
 }
 ```
 


### PR DESCRIPTION
Backports the following commits to 9.0:
 - [D0CS] Fix semantic_text example in mapping-reference/semantic-text.md (#134119)