### PR TITLE
Fix doc writers block writing logic for diskbbq

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -531,9 +531,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
   method: test {csv-spec:spatial.ConvertFromStringParseError}
   issue: https://github.com/elastic/elasticsearch/issues/134104
-- class: org.elasticsearch.index.codec.vectors.DocIdsWriterTests
-  method: testSorted
-  issue: https://github.com/elastic/elasticsearch/issues/134106
 - class: org.elasticsearch.xpack.writeloadforecaster.WriteLoadForecasterIT
   method: testWriteLoadForecastIsOverriddenBySetting
   issue: https://github.com/elastic/elasticsearch/issues/133455

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/DocIdsWriterTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/DocIdsWriterTests.java
@@ -38,7 +38,6 @@ import java.util.Set;
 
 import static org.elasticsearch.index.codec.vectors.DocIdsWriter.DEFAULT_MAX_POINTS_IN_LEAF_NODE;
 
-@com.carrotsearch.randomizedtesting.annotations.Repeat(iterations = 100)
 public class DocIdsWriterTests extends LuceneTestCase {
 
     public void testNoDocs() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/DocIdsWriterTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/DocIdsWriterTests.java
@@ -38,6 +38,7 @@ import java.util.Set;
 
 import static org.elasticsearch.index.codec.vectors.DocIdsWriter.DEFAULT_MAX_POINTS_IN_LEAF_NODE;
 
+@com.carrotsearch.randomizedtesting.annotations.Repeat(iterations = 100)
 public class DocIdsWriterTests extends LuceneTestCase {
 
     public void testNoDocs() throws Exception {


### PR DESCRIPTION
Instead of relying of "max bpv" logic, which can break in the event of delta encoding, this tracks the relevant statistics utilized to determine the optimal bpv, and picks the biggest ones from there. 

closes: https://github.com/elastic/elasticsearch/issues/134106