### PR TITLE
[8.18] [Gradle] Fix test seed handling when running with cc (#133811)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/BuildParameterExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/BuildParameterExtension.java
@@ -56,6 +56,8 @@ public interface BuildParameterExtension {
 
     String getTestSeed();
 
+    Provider<String> getTestSeedProvider();
+
     Boolean getCi();
 
     Integer getDefaultParallel();
@@ -66,7 +68,7 @@ public interface BuildParameterExtension {
 
     Provider<BwcVersions> getBwcVersionsProvider();
 
-    Random getRandom();
+    Provider<Random> getRandom();
 
     Boolean getGraalVmRuntime();
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/DefaultBuildParameterExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/DefaultBuildParameterExtension.java
@@ -39,7 +39,7 @@ public abstract class DefaultBuildParameterExtension implements BuildParameterEx
     private final Provider<String> gitRevision;
 
     private transient AtomicReference<ZonedDateTime> buildDate = new AtomicReference<>();
-    private final String testSeed;
+    private final Provider<String> testSeed;
     private final Boolean isCi;
     private final Integer defaultParallel;
     private final Boolean snapshotBuild;
@@ -58,7 +58,7 @@ public abstract class DefaultBuildParameterExtension implements BuildParameterEx
         JavaVersion gradleJavaVersion,
         Provider<String> gitRevision,
         Provider<String> gitOrigin,
-        String testSeed,
+        Provider<String> testSeed,
         boolean isCi,
         int defaultParallel,
         final boolean isSnapshotBuild,
@@ -181,6 +181,11 @@ public abstract class DefaultBuildParameterExtension implements BuildParameterEx
 
     @Override
     public String getTestSeed() {
+        return testSeed.get();
+    }
+
+    @Override
+    public Provider<String> getTestSeedProvider() {
         return testSeed;
     }
 
@@ -205,8 +210,8 @@ public abstract class DefaultBuildParameterExtension implements BuildParameterEx
     }
 
     @Override
-    public Random getRandom() {
-        return new Random(Long.parseUnsignedLong(testSeed.split(":")[0], 16));
+    public Provider<Random> getRandom() {
+        return getTestSeedProvider().map(seed -> new Random(Long.parseUnsignedLong(seed.split(":")[0], 16)));
     }
 
     @Override

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPlugin.java
@@ -29,6 +29,7 @@ import org.gradle.api.JavaVersion;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.configuration.BuildFeatures;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.model.ObjectFactory;
@@ -60,7 +61,6 @@ import java.nio.file.Files;
 import java.util.List;
 import java.util.Locale;
 import java.util.Properties;
-import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -87,7 +87,7 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
     private final JavaInstallationRegistry javaInstallationRegistry;
     private final JvmMetadataDetector metadataDetector;
     private final ProviderFactory providers;
-    private final BranchesFileParser branchesFileParser;
+    private final BuildFeatures buildFeatures;
     private JavaToolchainService toolChainService;
     private Project project;
 
@@ -96,13 +96,14 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
         ObjectFactory objectFactory,
         JavaInstallationRegistry javaInstallationRegistry,
         JvmMetadataDetector metadataDetector,
-        ProviderFactory providers
+        ProviderFactory providers,
+        BuildFeatures buildFeatures
     ) {
         this.objectFactory = objectFactory;
         this.javaInstallationRegistry = javaInstallationRegistry;
         this.metadataDetector = new ErrorTraceMetadataDetector(metadataDetector);
         this.providers = providers;
-        this.branchesFileParser = new BranchesFileParser(new ObjectMapper());
+        this.buildFeatures = buildFeatures;
     }
 
     @Override
@@ -113,6 +114,7 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
         this.project = project;
         project.getPlugins().apply(JvmToolchainsPlugin.class);
         project.getPlugins().apply(JdkDownloadPlugin.class);
+        project.getPlugins().apply(VersionPropertiesPlugin.class);
         Provider<GitInfo> gitInfo = project.getPlugins().apply(GitInfoPlugin.class).getGitInfo();
 
         toolChainService = project.getExtensions().getByType(JavaToolchainService.class);
@@ -121,11 +123,9 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
             throw new GradleException("Gradle " + minimumGradleVersion.getVersion() + "+ is required");
         }
 
-        project.getPlugins().apply(VersionPropertiesPlugin.class);
         Properties versionProperties = (Properties) project.getExtensions().getByName(VERSIONS_EXT);
         JavaVersion minimumCompilerVersion = JavaVersion.toVersion(versionProperties.get("minimumCompilerJava"));
         JavaVersion minimumRuntimeVersion = JavaVersion.toVersion(versionProperties.get("minimumRuntimeJava"));
-
         Version elasticsearchVersionProperty = Version.fromString(versionProperties.getProperty("elasticsearch"));
 
         RuntimeJava runtimeJavaHome = findRuntimeJavaHome();
@@ -233,6 +233,7 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
             }
         }
 
+        var branchesFileParser = new BranchesFileParser(new ObjectMapper());
         return branchesFileParser.parse(branchesBytes);
     }
 
@@ -266,7 +267,11 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
         if (javaToolchainHome != null) {
             LOGGER.quiet("  JAVA_TOOLCHAIN_HOME   : " + javaToolchainHome);
         }
-        LOGGER.quiet("  Random Testing Seed   : " + buildParams.getTestSeed());
+
+        if (buildFeatures.getConfigurationCache().getActive().get() == false) {
+            // if configuration cache is enabled, resolving the test seed early breaks configuration cache reuse
+            LOGGER.quiet("  Random Testing Seed   : " + buildParams.getTestSeed());
+        }
         LOGGER.quiet("  In FIPS 140 mode      : " + buildParams.getInFipsJvm());
         LOGGER.quiet("=======================================");
     }
@@ -321,16 +326,8 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
         );
     }
 
-    private static String getTestSeed() {
-        String testSeedProperty = System.getProperty("tests.seed");
-        final String testSeed;
-        if (testSeedProperty == null) {
-            long seed = new Random(System.currentTimeMillis()).nextLong();
-            testSeed = Long.toUnsignedString(seed, 16).toUpperCase(Locale.ROOT);
-        } else {
-            testSeed = testSeedProperty;
-        }
-        return testSeed;
+    private Provider<String> getTestSeed() {
+        return project.getProviders().of(TestSeedValueSource.class, spec -> {});
     }
 
     private static void throwInvalidJavaHomeException(String description, File javaHome, int expectedVersion, int actualVersion) {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/TestSeedValueSource.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/TestSeedValueSource.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.gradle.internal.info;
+
+import org.gradle.api.provider.ValueSource;
+import org.gradle.api.provider.ValueSourceParameters;
+
+import java.util.Locale;
+import java.util.Random;
+
+public abstract class TestSeedValueSource implements ValueSource<String, ValueSourceParameters.None> {
+
+    @Override
+    public ValueSourceParameters.None getParameters() {
+        return null;
+    }
+
+    @Override
+    public String obtain() {
+        String testSeedProperty = System.getProperty("tests.seed");
+        final String testSeed;
+        if (testSeedProperty == null) {
+            long seed = new Random(System.currentTimeMillis()).nextLong();
+            testSeed = Long.toUnsignedString(seed, 16).toUpperCase(Locale.ROOT);
+        } else {
+            testSeed = testSeedProperty;
+        }
+        return testSeed;
+    }
+}

--- a/x-pack/plugin/security/qa/profile/build.gradle
+++ b/x-pack/plugin/security/qa/profile/build.gradle
@@ -9,6 +9,5 @@ dependencies {
 
 tasks.named("javaRestTest").configure {
   usesDefaultDistribution()
-  systemProperty 'test.literalUsername', literalUsername
   systemProperty 'test.literalUsername', buildParams.random.map{r -> r.nextBoolean()}.get()
 }

--- a/x-pack/plugin/security/qa/profile/build.gradle
+++ b/x-pack/plugin/security/qa/profile/build.gradle
@@ -7,9 +7,8 @@ dependencies {
   javaRestTestImplementation project(':x-pack:plugin:security')
 }
 
-boolean literalUsername = buildParams.random.nextBoolean()
-
 tasks.named("javaRestTest").configure {
   usesDefaultDistribution()
   systemProperty 'test.literalUsername', literalUsername
+  systemProperty 'test.literalUsername', buildParams.random.map{r -> r.nextBoolean()}.get()
 }

--- a/x-pack/plugin/sql/qa/jdbc/security/build.gradle
+++ b/x-pack/plugin/sql/qa/jdbc/security/build.gradle
@@ -1,8 +1,4 @@
 import org.elasticsearch.gradle.internal.test.RestIntegTestTask
-import org.elasticsearch.gradle.testclusters.TestClusterValueSource
-import org.elasticsearch.gradle.testclusters.TestClustersPlugin
-import org.elasticsearch.gradle.testclusters.TestClustersRegistry
-import org.elasticsearch.gradle.util.GradleUtils
 
 apply plugin: 'elasticsearch.internal-test-artifact'
 

--- a/x-pack/qa/multi-cluster-search-security/legacy-with-basic-license/build.gradle
+++ b/x-pack/qa/multi-cluster-search-security/legacy-with-basic-license/build.gradle
@@ -13,7 +13,7 @@ restResources {
 }
 
 // randomise between sniff and proxy modes
-boolean proxyMode = buildParams.random.nextBoolean()
+var proxyModeProvider = buildParams.random.map{r -> r.nextBoolean()}
 
 def fulfillingCluster = testClusters.register('fulfilling-cluster') {
   setting 'xpack.security.enabled', 'true'
@@ -51,7 +51,7 @@ def queryingCluster = testClusters.register('querying-cluster') {
   user username: "test_user", password: "x-pack-test-password"
   setting 'xpack.ml.enabled', 'false'
   setting 'cluster.remote.my_remote_cluster.skip_unavailable', 'false'
-  if (proxyMode) {
+  if (proxyModeProvider.get()) {
     setting 'cluster.remote.my_remote_cluster.mode', 'proxy'
     setting 'cluster.remote.my_remote_cluster.proxy_address', {
       "\"${fulfillingCluster.get().getAllTransportPortURI().get(0)}\""
@@ -73,7 +73,7 @@ tasks.register('querying-cluster', RestIntegTestTask) {
   useCluster fulfillingCluster
   useCluster queryingCluster
   systemProperty 'tests.rest.suite', 'querying_cluster'
-  if (proxyMode) {
+  if (proxyModeProvider.get()) {
     systemProperty 'tests.rest.blacklist', [
       'querying_cluster/10_basic/Add persistent remote cluster based on the preset cluster',
       'querying_cluster/20_info/Add persistent remote cluster based on the preset cluster and check remote info',

--- a/x-pack/qa/multi-cluster-search-security/legacy-with-full-license/build.gradle
+++ b/x-pack/qa/multi-cluster-search-security/legacy-with-full-license/build.gradle
@@ -13,7 +13,7 @@ restResources {
 }
 
 // randomise between sniff and proxy modes
-boolean proxyMode = buildParams.random.nextBoolean()
+var proxyModeProvider = buildParams.random.map{r -> r.nextBoolean()}
 
 def fulfillingCluster = testClusters.register('fulfilling-cluster') {
   setting 'xpack.security.enabled', 'true'
@@ -37,7 +37,7 @@ def queryingCluster = testClusters.register('querying-cluster') {
   setting 'cluster.remote.connections_per_cluster', "1"
   user username: "test_user", password: "x-pack-test-password"
 
-  if (proxyMode) {
+  if (proxyModeProvider.get()) {
     setting 'cluster.remote.my_remote_cluster.mode', 'proxy'
     setting 'cluster.remote.my_remote_cluster.proxy_address', {
       "\"${fulfillingCluster.get().getAllTransportPortURI().get(0)}\""

--- a/x-pack/qa/multi-cluster-search-security/legacy-with-restricted-trust/build.gradle
+++ b/x-pack/qa/multi-cluster-search-security/legacy-with-restricted-trust/build.gradle
@@ -23,7 +23,7 @@ tasks.register("copyCerts", Sync) {
 }
 
 // randomise between sniff and proxy modes
-boolean proxyMode = buildParams.random.nextBoolean()
+var proxyModeProvider = buildParams.random.map{r -> r.nextBoolean()}
 
 def fulfillingCluster = testClusters.register('fulfilling-cluster') {
   setting 'xpack.security.enabled', 'true'
@@ -60,7 +60,7 @@ def queryingCluster = testClusters.register('querying-cluster') {
   setting 'cluster.remote.connections_per_cluster', "1"
   user username: "test_user", password: "x-pack-test-password"
 
-  if (proxyMode) {
+  if (proxyModeProvider.get()) {
     setting 'cluster.remote.my_remote_cluster.mode', 'proxy'
     setting 'cluster.remote.my_remote_cluster.proxy_address', {
       "\"${fulfillingCluster.get().getAllTransportPortURI().get(0)}\""


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Gradle] Fix test seed handling when running with cc (#133811)](https://github.com/elastic/elasticsearch/pull/133811)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)