### PR TITLE
ESQL: Fix name test for TOP

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/TopTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/TopTests.java
@@ -304,13 +304,25 @@ public class TopTests extends AbstractAggregationTestCase {
                 .limit(limit)
                 .toList();
 
+            String baseName;
+            if (limit != 1) {
+                baseName = "Top";
+            } else {
+                // If the limit is 1 we rewrite TOP into MIN or MAX and never run our lovely TOP code.
+                if (order.equals("asc")) {
+                    baseName = "Min";
+                } else {
+                    baseName = "Max";
+                }
+            }
+
             return new TestCaseSupplier.TestCase(
                 List.of(
                     fieldTypedData,
                     limitTypedData,
                     new TestCaseSupplier.TypedData(new BytesRef(order), DataType.KEYWORD, order + " order").forceLiteral()
                 ),
-                standardAggregatorName("Top", fieldTypedData.type()),
+                standardAggregatorName(baseName, fieldTypedData.type()),
                 fieldSupplier.type(),
                 equalTo(expected.size() == 1 ? expected.get(0) : expected)
             );


### PR DESCRIPTION
Sometimes we rewrite `TOP` into `MIN` or `MAX`.
