### PR TITLE
ESQL: percentile agg accepting doubles but ignoring decimals

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_percentile.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_percentile.csv-spec
@@ -205,3 +205,33 @@ row a=0
 constant_single:double
 5
 ;
+
+percentile precision tests with table read
+required_capability: fix_percentile_precision
+
+FROM employees 
+| SORT emp_no
+| LIMIT 10
+| KEEP emp_no
+| STATS p1 = percentile(emp_no, 50), p2 = percentile(emp_no, 50.55), p3 = percentile(emp_no, 51.0),
+        p4 = percentile(emp_no, 97), p5 = percentile(emp_no, 97.30), p6 = percentile(emp_no, 97.6)
+;
+
+p1:double | p2:double  | p3:double | p4:double | p5:double | p6:double
+10005.5   | 10005.5495 | 10005.59  | 10009.73  | 10009.757 | 10009.784
+;
+
+percentile precision tests with row
+required_capability: fix_percentile_precision
+
+ROW x = [1.1, 2.71, 3.14, 4.0, 5.55, 6, 7, 8, 9, 10, 11.99] 
+| STATS p1=percentile(x, 10.5), p2=percentile(x, 10.55), p3=percentile(x, 11.0),
+        p4=percentile(x, 90.0), p5=percentile(x, 90.28), p6=percentile(x, 90.7)
+;
+
+p1:double | p2:double | p3:double | p4:double | p5:double | p6:double
+2.7315    | 2.73365   | 2.753     | 10.0      | 10.05572  | 10.1393
+;
+
+
+

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1482,7 +1482,9 @@ public class EsqlCapabilities {
         /**
          * Multivalued query parameters
          */
-        QUERY_PARAMS_MULTI_VALUES();
+        QUERY_PARAMS_MULTI_VALUES(),
+
+        FIX_PERCENTILE_PRECISION();
 
         private final boolean enabled;
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/Foldables.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/Foldables.java
@@ -189,4 +189,13 @@ public abstract class Foldables {
             Strings.format(null, "[{}] value must be a constant number in [{}], found [{}]", fieldName, sourceText, field)
         );
     }
+
+    public static double doubleValueOf(Expression field, String sourceText, String fieldName) {
+        if (field instanceof Literal literal && literal.value() instanceof Number n) {
+            return n.doubleValue();
+        }
+        throw new EsqlIllegalArgumentException(
+            Strings.format(null, "[{}] value must be a constant number in [{}], found [{}]", fieldName, sourceText, field)
+        );
+    }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Percentile.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Percentile.java
@@ -37,7 +37,7 @@ import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.Param
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.SECOND;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isFoldable;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isType;
-import static org.elasticsearch.xpack.esql.expression.Foldables.intValueOf;
+import static org.elasticsearch.xpack.esql.expression.Foldables.doubleValueOf;
 
 public class Percentile extends NumericAggregate implements SurrogateExpression {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
@@ -168,8 +168,8 @@ public class Percentile extends NumericAggregate implements SurrogateExpression 
         return new PercentileDoubleAggregatorFunctionSupplier(percentileValue());
     }
 
-    private int percentileValue() {
-        return intValueOf(percentile(), source().text(), "Percentile");
+    private double percentileValue() {
+        return doubleValueOf(percentile(), source().text(), "Percentile");
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/PercentileTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/PercentileTests.java
@@ -69,14 +69,14 @@ public class PercentileTests extends AbstractAggregationTestCase {
             var fieldTypedData = fieldSupplier.get();
             var percentileTypedData = percentileSupplier.get().forceLiteral();
 
-            var percentile = ((Number) percentileTypedData.data()).intValue();
+            var percentile = ((Number) percentileTypedData.data()).doubleValue();
 
             try (var digest = TDigestState.create(newLimitedBreaker(ByteSizeValue.ofMb(100)), 1000)) {
                 for (var value : fieldTypedData.multiRowData()) {
                     digest.add(((Number) value).doubleValue());
                 }
 
-                var expected = digest.size() == 0 ? null : digest.quantile((double) percentile / 100);
+                var expected = digest.size() == 0 ? null : digest.quantile(percentile / 100);
 
                 return new TestCaseSupplier.TestCase(
                     List.of(fieldTypedData, percentileTypedData),


### PR DESCRIPTION
- Ensure the expression in the percentile field (the second parameter) results in a double instead of an int.
- Fix the percentile unit tests by altering expected values.
- The precision field in the count_distinct function (also the second parameter), though using the same code, is left as is since it is already expected to be an int.
