### PR TITLE
[9.0] rest-api-spec: fix query_rules.test stability (#133981)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/query_rules.test.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/query_rules.test.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-query-rules-test",
       "description": "Test a query ruleset"
     },
-    "stability": "experimental",
+    "stability": "stable",
     "visibility": "public",
     "headers": {
       "accept": [


### PR DESCRIPTION
Backports the following commits to 9.0:
 - rest-api-spec: fix query_rules.test stability (#133981)