### PR TITLE
[8.19] rest-api-spec: fix query_rules.test stability (#133981)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/query_rules.test.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/query_rules.test.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/8.19/test-query-ruleset.html",
       "description": "Test a query ruleset"
     },
-    "stability": "experimental",
+    "stability": "stable",
     "visibility": "public",
     "headers": {
       "accept": [


### PR DESCRIPTION
Backports the following commits to 8.19:
 - rest-api-spec: fix query_rules.test stability (#133981)