### PR TITLE
[8.19] Mark migrate_reindex APIs as public and stable (#133912)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.cancel_migrate_reindex.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.cancel_migrate_reindex.json
@@ -4,8 +4,8 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/8.19/migrate-data-stream.html",
       "description":"Cancel a migration reindex operation"
     },
-    "stability":"experimental",
-    "visibility":"private",
+    "stability":"stable",
+    "visibility":"public",
     "headers":{
       "accept": [ "application/json"],
       "content_type": ["application/json"]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.create_from.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.create_from.json
@@ -4,8 +4,8 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/8.19/migrate-data-stream.html",
       "description":"Create an index from a source index"
     },
-    "stability":"experimental",
-    "visibility":"private",
+    "stability":"stable",
+    "visibility":"public",
     "headers":{
       "accept": [ "application/json"],
       "content_type": ["application/json"]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_migrate_reindex_status.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_migrate_reindex_status.json
@@ -4,8 +4,8 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/8.19/migrate-data-stream.html",
       "description":"Get the migration reindexing status"
     },
-    "stability":"experimental",
-    "visibility":"private",
+    "stability":"stable",
+    "visibility":"public",
     "headers":{
       "accept": [ "application/json"],
       "content_type": ["application/json"]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.migrate_reindex.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.migrate_reindex.json
@@ -4,8 +4,8 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/8.19/migrate-data-stream.html",
       "description":"Reindex legacy backing indices"
     },
-    "stability":"experimental",
-    "visibility":"private",
+    "stability":"stable",
+    "visibility":"public",
     "headers":{
       "accept": [ "application/json"],
       "content_type": ["application/json"]


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Mark migrate_reindex APIs as public and stable (#133912)