### PR TITLE
[9.0] Mark user profile APIs as public (#133819)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.activate_user_profile.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.activate_user_profile.json
@@ -5,7 +5,7 @@
       "description":"Activate a user profile"
     },
     "stability":"stable",
-    "visibility":"private",
+    "visibility":"public",
     "headers":{
       "accept": [ "application/json"],
       "content_type": ["application/json"]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.disable_user_profile.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.disable_user_profile.json
@@ -5,7 +5,7 @@
       "description":"Disable a user profile"
     },
     "stability":"stable",
-    "visibility":"private",
+    "visibility":"public",
     "headers":{
       "accept": [ "application/json"]
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.enable_user_profile.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.enable_user_profile.json
@@ -5,7 +5,7 @@
       "description":"Enable a user profile"
     },
     "stability":"stable",
-    "visibility":"private",
+    "visibility":"public",
     "headers":{
       "accept": [ "application/json"]
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.get_user_profile.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.get_user_profile.json
@@ -5,7 +5,7 @@
       "description":"Get a user profile"
     },
     "stability":"stable",
-    "visibility":"private",
+    "visibility":"public",
     "headers":{
       "accept": [ "application/json"]
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.has_privileges_user_profile.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.has_privileges_user_profile.json
@@ -5,7 +5,7 @@
       "description":"Check user profile privileges"
     },
     "stability":"stable",
-    "visibility":"private",
+    "visibility":"public",
     "headers":{
       "accept": [ "application/json"],
       "content_type": ["application/json"]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.suggest_user_profiles.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.suggest_user_profiles.json
@@ -5,7 +5,7 @@
       "description":"Suggest a user profile"
     },
     "stability":"stable",
-    "visibility":"private",
+    "visibility":"public",
     "headers":{
       "accept": [ "application/json"],
       "content_type": ["application/json"]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.update_user_profile_data.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.update_user_profile_data.json
@@ -5,7 +5,7 @@
       "description":"Update user profile data"
     },
     "stability":"stable",
-    "visibility":"private",
+    "visibility":"public",
     "headers":{
       "accept": [ "application/json"],
       "content_type": ["application/json"]


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Mark user profile APIs as public (#133819)