### PR TITLE
Improve `ShardLockObtainFailedException` message

### DIFF
--- a/docs/changelog/134198.yaml
+++ b/docs/changelog/134198.yaml
@@ -1,0 +1,5 @@
+pr: 134198
+summary: Improve `ShardLockObtainFailedException` message
+area: Store
+type: enhancement
+issues: []


### PR DESCRIPTION
It's unclear whether the age mentioned here is the age of the lock, or
just of the detailed state of the lock. This commit clarifies the
message.