### PR TITLE
Allow require_data_stream param in stream bulk requests

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportAbstractBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportAbstractBulkAction.java
@@ -64,7 +64,7 @@ import java.util.function.LongSupplier;
 public abstract class TransportAbstractBulkAction extends HandledTransportAction<BulkRequest, BulkResponse> {
     private static final Logger logger = LogManager.getLogger(TransportAbstractBulkAction.class);
 
-    public static final Set<String> STREAMS_ALLOWED_PARAMS = new HashSet<>(8) {
+    public static final Set<String> STREAMS_ALLOWED_PARAMS = new HashSet<>(9) {
         {
             add("error_trace");
             add("filter_path");
@@ -73,6 +73,7 @@ public abstract class TransportAbstractBulkAction extends HandledTransportAction
             add("op_type");
             add("pretty");
             add("refresh");
+            add("require_data_stream");
             add("timeout");
         }
     };


### PR DESCRIPTION
Observability have requested we enable this param for streams requests