### PR TITLE
Ensure enough nodes in `WriteLoadForecasterIT`

### DIFF
--- a/x-pack/plugin/write-load-forecaster/src/internalClusterTest/java/org/elasticsearch/xpack/writeloadforecaster/WriteLoadForecasterIT.java
+++ b/x-pack/plugin/write-load-forecaster/src/internalClusterTest/java/org/elasticsearch/xpack/writeloadforecaster/WriteLoadForecasterIT.java
@@ -145,6 +145,8 @@ public class WriteLoadForecasterIT extends ESIntegTestCase {
     private void setUpDataStreamWriteDocsAndRollover(String dataStreamName, Settings extraIndexTemplateSettings) throws Exception {
         final int numberOfShards = randomIntBetween(1, 5);
         final int numberOfReplicas = randomIntBetween(0, 1);
+        internalCluster().ensureAtLeastNumDataNodes(numberOfReplicas + 1);
+
         final Settings indexSettings = Settings.builder()
             .put(extraIndexTemplateSettings)
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numberOfShards)
@@ -194,6 +196,7 @@ public class WriteLoadForecasterIT extends ESIntegTestCase {
 
             assertAcked(indicesAdmin().rolloverIndex(new RolloverRequest(dataStreamName, null)).actionGet());
         }
+        ensureGreen();
     }
 
     static void indexDocs(String dataStream, int numDocs) {


### PR DESCRIPTION
These tests would sometimes create 1-replica indices in a 1-node cluster
which will never reach `green` health. This commit ensures there are
enough nodes to allocate all the shards.

Closes #133455
Closes #134124
Closes #134123
Backport of #134132 and #134099 to `8.18`