### PR TITLE
Add a test of an edge case for the set processor

### DIFF
--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/270_set_processor.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/270_set_processor.yml
@@ -6,7 +6,7 @@ teardown:
         ignore: 404
 
 ---
-"Test set processor with template value":
+"Test set processor with a templated value":
   - do:
       ingest.put_pipeline:
         id: "1"

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/270_set_processor.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/270_set_processor.yml
@@ -295,3 +295,38 @@ teardown:
   - match: { _source.result_2: "{{bar}}" }
   - match: { _source.old_bar: 2 }
   - match: { _source.bar: 3 }
+
+---
+"Test set processor with ignore_empty_value and a literal empty value":
+  - do:
+      ingest.put_pipeline:
+        id: "1"
+        body:  >
+          {
+            "processors": [
+              {
+                "set" : {
+                  "description": "we don't forbid this, even though it's a little silly",
+                  "field" : "foo",
+                  "value" : "",
+                  "ignore_empty_value" : true
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      index:
+        index: test
+        id: "1"
+        pipeline: "1"
+        body: {
+          foo: "hello"
+        }
+
+  - do:
+      get:
+        index: test
+        id: "1"
+  - match: { _source.foo: "" }

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/270_set_processor.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/270_set_processor.yml
@@ -53,6 +53,7 @@ teardown:
         index: test
         id: "2"
   - match: { _source.foo: "hello" }
+
 ---
 "Test set processor with index change and require_alias":
   - do:


### PR DESCRIPTION
`ignore_empty_value` generally means what it says, but for the `set` processor we only apply the logic of `ignore_empty_value` to the results from Mustache templating, or the results of a `copy_from`. So there's an edge case in that if you have a literal empty String (`""`) as your value and also `ignore_empty_value` set to `true`, then we don't actually run the `ignore_empty_value` logic and we happily set the empty String.

There's a different PR out there that's touching some of the logic around `ignore_empty_value`, and I want to get this test in first before that PR comes through.

Note: I'm not necessarily making the case that this behavior is especially amazing, I'm just recording what the behavior **is**. Separately, I also think this is an edge case that has been run into by nobody ever, and I'm not worried about it.