### PR TITLE
All failures seem to be fallout from other tests - unmute

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -468,9 +468,6 @@ tests:
 - class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
   method: testCancelViaExpirationOnRemoteResultsWithMinimizeRoundtrips
   issue: https://github.com/elastic/elasticsearch/issues/127302
-- class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
-  method: testCCSClusterDetailsWhereAllShardsSkippedInCanMatch
-  issue: https://github.com/elastic/elasticsearch/issues/133370
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=esql/60_usage/Basic ESQL usage output (telemetry) non-snapshot version}
   issue: https://github.com/elastic/elasticsearch/issues/133449


### PR DESCRIPTION
Those test will need to be fixed but there's no point to mute this one because of it. 

Closes https://github.com/elastic/elasticsearch/issues/133370