### PR TITLE
[9.1] Block remote query search too in testCancellationViaTimeoutWithAllowPartialResultsSetToFalse (#134236)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -440,9 +440,6 @@ tests:
 - class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
   method: testCancelViaExpirationOnRemoteResultsWithMinimizeRoundtrips
   issue: https://github.com/elastic/elasticsearch/issues/127302
-- class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
-  method: testCancellationViaTimeoutWithAllowPartialResultsSetToFalse
-  issue: https://github.com/elastic/elasticsearch/issues/131248
 - class: org.elasticsearch.xpack.kql.parser.KqlParserBooleanQueryTests
   method: testParseAndQuery
   issue: https://github.com/elastic/elasticsearch/issues/133871

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
@@ -1752,6 +1752,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
         String remoteIndex = (String) testClusterInfo.get("remote.index");
 
         SearchListenerPlugin.blockLocalQueryPhase();
+        SearchListenerPlugin.blockRemoteQueryPhase();
 
         TimeValue searchTimeout = new TimeValue(100, TimeUnit.MILLISECONDS);
         // query builder that will sleep for the specified amount of time in the query phase
@@ -1810,6 +1811,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
 
         } finally {
             SearchListenerPlugin.allowLocalQueryPhase();
+            SearchListenerPlugin.allowRemoteQueryPhase();
         }
 
         // query phase has begun, so wait for query failure (due to timeout)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Block remote query search too in testCancellationViaTimeoutWithAllowPartialResultsSetToFalse (#134236)](https://github.com/elastic/elasticsearch/pull/134236)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)