### PR TITLE
[8.19] Block remote query search too in testCancellationViaTimeoutWithAllowPartialResultsSetToFalse (#134236)

### DIFF
--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
@@ -1752,6 +1752,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
         String remoteIndex = (String) testClusterInfo.get("remote.index");
 
         SearchListenerPlugin.blockLocalQueryPhase();
+        SearchListenerPlugin.blockRemoteQueryPhase();
 
         TimeValue searchTimeout = new TimeValue(100, TimeUnit.MILLISECONDS);
         // query builder that will sleep for the specified amount of time in the query phase
@@ -1809,6 +1810,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
 
         } finally {
             SearchListenerPlugin.allowLocalQueryPhase();
+            SearchListenerPlugin.allowRemoteQueryPhase();
         }
 
         // query phase has begun, so wait for query failure (due to timeout)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Block remote query search too in testCancellationViaTimeoutWithAllowPartialResultsSetToFalse (#134236)](https://github.com/elastic/elasticsearch/pull/134236)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)