### PR TITLE
Update esql-syntax.md - escapechar and quotes.

### DIFF
--- a/docs/reference/query-languages/esql/esql-syntax.md
+++ b/docs/reference/query-languages/esql/esql-syntax.md
@@ -69,7 +69,7 @@ FROM index
 | WHERE first_name == "Georgi"
 ```
 
-If the literal string itself contains quotes, these need to be escaped (`\\"`). {{esql}} also supports the triple-quotes (`"""`) delimiter, for convenience:
+If the literal string itself contains quotes, these need to be escaped (`\"`). {{esql}} also supports the triple-quotes (`"""`) delimiter, for convenience:
 
 ```esql
 ROW name = """Indiana "Indy" Jones"""


### PR DESCRIPTION
I think we need to reword this bit as we don't actually say things like `\` is the escape character - which I'm not too well equipped for.

but the `\\"` is wrong and should be `\"` so <escape char><quote> vs escaping escape char and then quote as this fails:

```
POST _query?format=txt
{
  "query":"""
    ROW a = 1
    | EVAL b = "\\""
"""
}
```
vs:
```
POST _query?format=txt
{
  "query":"""
    ROW a = 1
    | EVAL b = "\""
"""
}
```