### PR TITLE
ES|QL: unmute GenerativeIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -483,9 +483,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.inference.rerank.RerankOperatorTests
   method: testSimpleCircuitBreaking
   issue: https://github.com/elastic/elasticsearch/issues/133619
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/133077
 - class: org.elasticsearch.xpack.kql.parser.KqlParserBooleanQueryTests
   method: testParseOrQuery
   issue: https://github.com/elastic/elasticsearch/issues/133863


### PR DESCRIPTION
Fixes: https://github.com/elastic/elasticsearch/issues/133077

Unmuting single node GenerativeIT tests.

The first error (validation exception) was fixed long time ago. 
The second one ("can't release already released object") is a sneaky one, I couldn't manage to reproduce it locally. It's strange that it happened only on single node runs (the same test with multi-node keeps running smoothly). I'm unmuting also to see we can have a better reproducer.