### PR TITLE
Upgrade MinIO to `RELEASE.2025-09-07T16-13-09Z`

### DIFF
--- a/test/fixtures/minio-fixture/src/main/java/org/elasticsearch/test/fixtures/minio/MinioTestContainer.java
+++ b/test/fixtures/minio-fixture/src/main/java/org/elasticsearch/test/fixtures/minio/MinioTestContainer.java
@@ -15,10 +15,14 @@ import org.testcontainers.images.builder.ImageFromDockerfile;
 
 public final class MinioTestContainer extends DockerEnvironmentAwareTestContainer {
 
-    // NB releases earlier than 2025-05-24 are buggy, see https://github.com/minio/minio/issues/21189, and #127166 for a workaround.
-    // However the 2025-05-24 release is also buggy, see https://github.com/minio/minio/issues/21377, and this has no workaround.
-    // Also https://github.com/minio/minio/issues/21456 seems to affect releases newer than 2025-05-24, see #131815 for workaround.
-    public static final String DOCKER_BASE_IMAGE = "minio/minio:RELEASE.2025-07-23T15-54-02Z";
+    /*
+     * Known issues broken down by MinIO release date:
+     * [< 2025-05-24                ] known issue https://github.com/minio/minio/issues/21189; workaround in #127166
+     * [= 2025-05-24                ] known issue https://github.com/minio/minio/issues/21377; no workaround
+     * [> 2025-05-24 && < 2025-09-07] known issue https://github.com/minio/minio/issues/21456; workaround in #131815
+     * [>= 2025-09-07               ] no known issues (yet)
+     */
+    public static final String DOCKER_BASE_IMAGE = "minio/minio:RELEASE.2025-09-07T16-13-09Z";
 
     private static final int servicePort = 9000;
     private final boolean enabled;

--- a/x-pack/plugin/snapshot-repo-test-kit/qa/minio/src/javaRestTest/java/org/elasticsearch/repositories/blobstore/testkit/analyze/MinioRepositoryAnalysisRestIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/qa/minio/src/javaRestTest/java/org/elasticsearch/repositories/blobstore/testkit/analyze/MinioRepositoryAnalysisRestIT.java
@@ -33,11 +33,6 @@ public class MinioRepositoryAnalysisRestIT extends AbstractRepositoryAnalysisRes
         .keystore("s3.client.repository_test_kit.secret_key", "s3_test_secret_key")
         .setting("s3.client.repository_test_kit.endpoint", minioFixture::getAddress)
         .setting("xpack.security.enabled", "false")
-        // Skip listing of pre-existing uploads during a CAS because MinIO sometimes leaks them; also reduce the delay before proceeding
-        // TODO do not set these if running a MinIO version in which https://github.com/minio/minio/issues/21189
-        // and https://github.com/minio/minio/issues/21456 are both fixed
-        .setting("repository_s3.compare_and_exchange.time_to_live", "-1")
-        .setting("repository_s3.compare_and_exchange.anti_contention_delay", "100ms")
         .setting("xpack.ml.enabled", "false")
         .build();
 


### PR DESCRIPTION
Reverts workaround for minio/minio#21456 introduced in #131815.