### PR TITLE
Fix: `ESGpuHnswVectorsWriter#mergeOneField` now supports non memory-mapped inputs

### DIFF
--- a/x-pack/plugin/gpu/src/test/java/org/elasticsearch/xpack/gpu/codec/ESGpuHnswSQVectorsFormatTests.java
+++ b/x-pack/plugin/gpu/src/test/java/org/elasticsearch/xpack/gpu/codec/ESGpuHnswSQVectorsFormatTests.java
@@ -10,11 +10,13 @@ import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.tests.index.BaseKnnVectorsFormatTestCase;
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.tests.util.TestUtil;
 import org.elasticsearch.common.logging.LogConfigurator;
 import org.elasticsearch.xpack.gpu.GPUSupport;
 import org.junit.BeforeClass;
 
+@LuceneTestCase.SuppressSysoutChecks(bugUrl = "https://github.com/rapidsai/cuvs/issues/1310")
 public class ESGpuHnswSQVectorsFormatTests extends BaseKnnVectorsFormatTestCase {
 
     static {


### PR DESCRIPTION
Extracted from https://github.com/elastic/elasticsearch/pull/134048

Separate two different paths/conditions: a) the vector size is too small, so we generate a mock graph (on the CPU) and b) the vector data file is not mmappable (e.g. filter or network FS), and so we fall back to alternative read methods.
