### PR TITLE
Add ability to comment in transport version files

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -108,7 +108,6 @@ public record TransportVersion(String name, int id, TransportVersion nextPatchVe
      * This method takes in the parameter {@code upperBound} which is the highest transport version id
      * that will be loaded by this node.
      */
-    @SuppressWarnings("checkstyle:EmptyBlock")
     public static TransportVersion fromBufferedReader(
         String component,
         String path,

--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -108,6 +108,7 @@ public record TransportVersion(String name, int id, TransportVersion nextPatchVe
      * This method takes in the parameter {@code upperBound} which is the highest transport version id
      * that will be loaded by this node.
      */
+    @SuppressWarnings("checkstyle:EmptyBlock")
     public static TransportVersion fromBufferedReader(
         String component,
         String path,
@@ -117,7 +118,10 @@ public record TransportVersion(String name, int id, TransportVersion nextPatchVe
         Integer upperBound
     ) {
         try {
-            String line = bufferedReader.readLine();
+            String line;
+            do {
+                line = bufferedReader.readLine();
+            } while (line.replaceAll("\\s+", "").startsWith("#"));
             String[] parts = line.replaceAll("\\s+", "").split(",");
             String check;
             while ((check = bufferedReader.readLine()) != null) {

--- a/server/src/test/java/org/elasticsearch/TransportVersionTests.java
+++ b/server/src/test/java/org/elasticsearch/TransportVersionTests.java
@@ -356,7 +356,7 @@ public class TransportVersionTests extends ESTestCase {
     }
 
     public void testComment() {
-        byte[] data1 = "#comment\n1000000".getBytes(StandardCharsets.UTF_8);
+        byte[] data1 = ("#comment" + System.lineSeparator() + "1000000").getBytes(StandardCharsets.UTF_8);
         TransportVersion test1 = TransportVersion.fromBufferedReader(
             "<test>",
             "testSupports3",
@@ -367,7 +367,7 @@ public class TransportVersionTests extends ESTestCase {
         );
         assertThat(new TransportVersion(null, 1000000, null).supports(test1), is(true));
 
-        byte[] data2 = " # comment\n1000000".getBytes(StandardCharsets.UTF_8);
+        byte[] data2 = (" # comment" + System.lineSeparator() + "1000000").getBytes(StandardCharsets.UTF_8);
         TransportVersion test2 = TransportVersion.fromBufferedReader(
             "<test>",
             "testSupports3",
@@ -378,7 +378,9 @@ public class TransportVersionTests extends ESTestCase {
         );
         assertThat(new TransportVersion(null, 1000000, null).supports(test2), is(true));
 
-        byte[] data3 = "#comment\n# comment3\n1000000".getBytes(StandardCharsets.UTF_8);
+        byte[] data3 = ("#comment" + System.lineSeparator() + "# comment3" + System.lineSeparator() + "1000000").getBytes(
+            StandardCharsets.UTF_8
+        );
         TransportVersion test3 = TransportVersion.fromBufferedReader(
             "<test>",
             "testSupports3",

--- a/server/src/test/java/org/elasticsearch/TransportVersionTests.java
+++ b/server/src/test/java/org/elasticsearch/TransportVersionTests.java
@@ -354,4 +354,39 @@ public class TransportVersionTests extends ESTestCase {
         assertThat(new TransportVersion(null, 100001000, null).supports(test4), is(true));
         assertThat(new TransportVersion(null, 100001001, null).supports(test4), is(true));
     }
+
+    public void testComment() {
+        byte[] data1 = "#comment\n1000000".getBytes(StandardCharsets.UTF_8);
+        TransportVersion test1 = TransportVersion.fromBufferedReader(
+            "<test>",
+            "testSupports3",
+            false,
+            true,
+            new BufferedReader(new InputStreamReader(new ByteArrayInputStream(data1), StandardCharsets.UTF_8)),
+            5000000
+        );
+        assertThat(new TransportVersion(null, 1000000, null).supports(test1), is(true));
+
+        byte[] data2 = " # comment\n1000000".getBytes(StandardCharsets.UTF_8);
+        TransportVersion test2 = TransportVersion.fromBufferedReader(
+            "<test>",
+            "testSupports3",
+            false,
+            true,
+            new BufferedReader(new InputStreamReader(new ByteArrayInputStream(data2), StandardCharsets.UTF_8)),
+            5000000
+        );
+        assertThat(new TransportVersion(null, 1000000, null).supports(test2), is(true));
+
+        byte[] data3 = "#comment\n# comment3\n1000000".getBytes(StandardCharsets.UTF_8);
+        TransportVersion test3 = TransportVersion.fromBufferedReader(
+            "<test>",
+            "testSupports3",
+            false,
+            true,
+            new BufferedReader(new InputStreamReader(new ByteArrayInputStream(data3), StandardCharsets.UTF_8)),
+            5000000
+        );
+        assertThat(new TransportVersion(null, 1000000, null).supports(test3), is(true));
+    }
 }


### PR DESCRIPTION
Comments may be added to the beginning of transport version 
files by starting each comment line with the hash `#` character.