### PR TITLE
Fix TimeSeriesFeatureSetUsageTests testEqualsAndHashcode (#134332)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -516,9 +516,6 @@ tests:
 - class: org.elasticsearch.action.support.nodes.TransportNodesActionTests
   method: testConcurrentlyCompletionAndCancellation
   issue: https://github.com/elastic/elasticsearch/issues/134277
-- class: org.elasticsearch.xpack.core.datastreams.TimeSeriesFeatureSetUsageTests
-  method: testEqualsAndHashcode
-  issue: https://github.com/elastic/elasticsearch/issues/134332
 
 # Examples:
 #

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/datastreams/TimeSeriesFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/datastreams/TimeSeriesFeatureSetUsage.java
@@ -34,8 +34,8 @@ import java.util.Objects;
  *   "time_series": {
  *      "enabled": true,
  *      "available": true,
- *      "data_streams_count": 10,
- *      "indices_count": 100,
+ *      "data_stream_count": 10,
+ *      "index_count": 100,
  *      "downsampling": {
  *         "index_count_per_interval": {
  *           "5m": 5,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/datastreams/TimeSeriesFeatureSetUsageTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/datastreams/TimeSeriesFeatureSetUsageTests.java
@@ -57,7 +57,7 @@ public class TimeSeriesFeatureSetUsageTests extends AbstractWireSerializingTestC
         var dataStreamCount = instance.getTimeSeriesDataStreamCount();
         if (dataStreamCount == 0) {
             return new TimeSeriesFeatureSetUsage(
-                randomIntBetween(0, 100),
+                randomIntBetween(1, 100),
                 randomIntBetween(100, 100000),
                 TimeSeriesFeatureSetUsage.DownsamplingFeatureStats.EMPTY,
                 Map.of()


### PR DESCRIPTION
There was a mistake on the mutation method in `TimeSeriesFeatureSetUsageTests`. This was fixed along with some errors in the javadoc of the `TimeSeriesFeatureSetUsage`.

Fixes: #134332