### PR TITLE
Map start_timestamp as date rather than date_nanos

### DIFF
--- a/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/30_logsdb_default_mapping.yml
+++ b/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/30_logsdb_default_mapping.yml
@@ -1143,3 +1143,101 @@ create logsdb data stream with custom sorting on timestamp:
         index: $backing_index
 
   - match: { .$backing_index.mappings.properties.@timestamp.type: date }
+
+---
+create logsdb data stream with timestamp mixed date_nanos and date fields:
+  - requires:
+      test_runner_features: [ "allowed_warnings" ]
+
+  - do:
+      cluster.put_component_template:
+        name: "logsdb-mappings"
+        body:
+          template:
+            settings:
+              mode: "logsdb"
+            mappings:
+              properties:
+                host.name:
+                  type: "keyword"
+                "@timestamp":
+                  type: "date"
+
+  - do:
+      indices.put_index_template:
+        name: "logsdb-index-template"
+        body:
+          index_patterns: ["logsdb"]
+          data_stream: {}
+          composed_of: ["logsdb-mappings"]
+      allowed_warnings:
+        - "index template [logsdb-index-template] has index patterns [logsdb] matching patterns from existing older templates [global] with patterns (global => [*]); this template [logsdb-index-template] will take precedence during new index creation"
+
+  - do:
+      indices.create_data_stream:
+        name: "logsdb"
+
+  - is_true: acknowledged
+  - do:
+      bulk:
+        index: logsdb
+        refresh: true
+        body:
+          - create: {}
+          - "@timestamp": 2025-09-09T14:00:00Z
+            host.name: localhost
+  - is_false: errors
+
+  - do:
+      cluster.put_component_template:
+        name: "logsdb-mappings"
+        body:
+          template:
+            settings:
+              mode: "logsdb"
+            mappings:
+              properties:
+                host.name:
+                  type: "keyword"
+                "@timestamp":
+                  type: "date_nanos"
+  - do:
+      indices.rollover:
+        alias: logsdb
+        wait_for_active_shards: 1
+  - match: { rolled_over: true }
+  - do:
+      bulk:
+        index: logsdb
+        refresh: true
+        body:
+          - create: {}
+          - "@timestamp": 2025-09-09T14:00:01Z
+            host.name: localhost
+  - is_false: errors
+  - do:
+      search:
+        index: logsdb
+        body:
+          query:
+            range:
+              "@timestamp":
+                gte: "2025-09-09"
+          aggs:
+            timestamp_histo:
+              date_histogram:
+                field: "@timestamp"
+                calendar_interval: "day"
+  - length: { hits.hits: 2 }
+  - length: { aggregations.timestamp_histo.buckets: 1 }
+  - match: { aggregations.timestamp_histo.buckets.0.key_as_string: "2025-09-09T00:00:00.000Z" }
+  - do:
+      esql.query:
+        body:
+          query: 'FROM logsdb | WHERE @timestamp >= "2025-09-09" | STATS min = min(@timestamp) BY day = BUCKET(@timestamp, 1 day) | LIMIT 10'
+  - match: { columns.0.name: "min" }
+  - match: { columns.0.type: "date_nanos" }
+  - match: { columns.1.name: "day" }
+  - match: { columns.1.type: "date_nanos" }
+  - length: { values: 1 }
+  - match: { values.0: [ "2025-09-09T14:00:00.000Z", "2025-09-09T00:00:00.000Z" ] }

--- a/x-pack/plugin/otel-data/src/main/resources/component-templates/metrics-otel@mappings.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/component-templates/metrics-otel@mappings.yaml
@@ -9,7 +9,7 @@ template:
   mappings:
     properties:
       start_timestamp:
-        type: date_nanos
+        type: date
       metrics:
         type: passthrough
         dynamic: true

--- a/x-pack/plugin/otel-data/src/main/resources/resources.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/resources.yaml
@@ -1,7 +1,7 @@
 # "version" holds the version of the templates and ingest pipelines installed
 # by xpack-plugin otel-data. This must be increased whenever an existing template is
 # changed, in order for it to be updated on Elasticsearch upgrade.
-version: 11
+version: 12
 
 component-templates:
   - otel@mappings


### PR DESCRIPTION
A nano precision for the start_timestamp is not necessary. For the `@timestamp` field we're also using date, so this is more consistent with that.

As ES|QL supports auto-casting now, this change should be safe. We also don't expect real-world queries to use this field, yet. In the future, we might use it internally to detect resets.
