### PR TITLE
Avoid randomized test failures for small timestamps

### DIFF
--- a/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/MetricDocumentBuilderTests.java
+++ b/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/docbuilder/MetricDocumentBuilderTests.java
@@ -104,8 +104,8 @@ public class MetricDocumentBuilderTests extends ESTestCase {
         HashMap<String, String> dynamicTemplates = documentBuilder.buildMetricDocument(builder, dataPointGroup);
         ObjectPath doc = ObjectPath.createFromXContent(JsonXContent.jsonXContent, BytesReference.bytes(builder));
 
-        assertThat(doc.evaluate("@timestamp"), equalTo(TimeUnit.NANOSECONDS.toMillis(timestamp)));
-        assertThat(doc.evaluate("start_timestamp"), equalTo(TimeUnit.NANOSECONDS.toMillis(startTimestamp)));
+        assertThat(doc.<Number>evaluate("@timestamp").longValue(), equalTo(TimeUnit.NANOSECONDS.toMillis(timestamp)));
+        assertThat(doc.<Number>evaluate("start_timestamp").longValue(), equalTo(TimeUnit.NANOSECONDS.toMillis(startTimestamp)));
         assertThat(doc.evaluate("data_stream.type"), equalTo("metrics"));
         assertThat(doc.evaluate("data_stream.dataset"), equalTo("generic.otel"));
         assertThat(doc.evaluate("data_stream.namespace"), equalTo("default"));


### PR DESCRIPTION
Spotted on a CI build. Reproducible on main with

```
./gradlew ":x-pack:plugin:otel-data:test" --tests "org.elasticsearch.xpack.oteldata.otlp.docbuilder.MetricDocumentBuilderTests.testBuildMetricDocument" -Dtests.seed=1B4373F9F4BB42B5
```

Failure message:
```
MetricDocumentBuilderTests > testBuildMetricDocument FAILED
    java.lang.ClassCastException: class java.lang.Integer cannot be cast to class java.lang.Long (java.lang.Integer and java.lang.Long are in module java.base of loader 'bootstrap')
        at __randomizedtesting.SeedInfo.seed([1B4373F9F4BB42B5:41A887E2F519F3EB]:0)
        at org.elasticsearch.xpack.oteldata.otlp.docbuilder.MetricDocumentBuilderTests.testBuildMetricDocument(MetricDocumentBuilderTests.java:108)
```