### PR TITLE
[8.19] Return unique deprecation for old indices with incompatible date formats (#124597)

### DIFF
--- a/docs/changelog/124597.yaml
+++ b/docs/changelog/124597.yaml
@@ -1,0 +1,5 @@
+pr: 124597
+summary: Return unique deprecation for old indices with incompatible date formats
+area: Infra/Core
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/common/time/DateUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateUtils.java
@@ -519,8 +519,10 @@ public class DateUtils {
     private static final boolean USES_COMPAT = System.getProperty("java.locale.providers", "").contains("COMPAT");
     // check for all textual fields, and localized zone offset
     // the weird thing with Z is to ONLY match 4 in a row, with no Z before or after (but those groups can also be empty)
+    private static final Predicate<String> LEGACY_DATE_FORMAT_MATCHER = Pattern.compile("[BEGOavz]|LLL|MMM|QQQ|qqq|ccc|eee|(?<!Z)Z{4}(?!Z)")
+        .asPredicate();
     private static final Predicate<String> CONTAINS_CHANGING_TEXT_SPECIFIERS = USES_COMPAT
-        ? Pattern.compile("[BEGOavz]|LLL|MMM|QQQ|qqq|ccc|eee|(?<!Z)Z{4}(?!Z)").asPredicate()
+        ? LEGACY_DATE_FORMAT_MATCHER
         : Predicates.never();
     // week dates are changing on CLDR, as the rules are changing for start-of-week and min-days-in-week
     private static final Predicate<String> CONTAINS_WEEK_DATE_SPECIFIERS = USES_COMPAT
@@ -546,5 +548,9 @@ public class DateUtils {
                 ReferenceDocs.JDK_LOCALE_DIFFERENCES
             );
         }
+    }
+
+    public static boolean containsCompatOnlyDateFormat(String format) {
+        return LEGACY_DATE_FORMAT_MATCHER.test(format);
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.18` to `8.19`:
 - [Return unique deprecation for old indices with incompatible date formats (#124597)](https://github.com/elastic/elasticsearch/pull/124597)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)