### PR TITLE
Propagate filter in TOP(field, 1, order) surrogate.

### DIFF
--- a/docs/changelog/134376.yaml
+++ b/docs/changelog/134376.yaml
@@ -1,0 +1,6 @@
+pr: 134376
+summary: "Propagate filter in TOP(field, 1, order) surrogate"
+area: ES|QL
+type: bug
+issues:
+ - 134293

--- a/docs/changelog/134376.yaml
+++ b/docs/changelog/134376.yaml
@@ -1,5 +1,5 @@
 pr: 134376
-summary: "Propagate filter in TOP(field, 1, order) surrogate"
+summary: "Fix ES|QL TOP 1 aggregation with condition"
 area: ES|QL
 type: bug
 issues:

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_top.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_top.csv-spec
@@ -300,3 +300,17 @@ FROM books
                                                     The Lord of the Rings Poster Collection: Six Paintings by Alan Lee (No. 1) | he Lo |                                                                [J. R. R. Tolkien, Alan Lee] | Alan Lee
 A Gentle Creature and Other Stories: White Nights, A Gentle Creature, and The Dream of a Ridiculous Man (The World's Classics) |  Gent |                                        [W. J. Leatherbarrow, Fyodor Dostoevsky, Alan Myers] | Alan Myers
 ;
+
+topWithConditions
+required_capability: stats_top_1_with_condition_fixed
+
+FROM employees
+| STATS min1 = TOP(emp_no, 1, "ASC") WHERE emp_no > 10010,
+        min2 = TOP(emp_no, 2, "ASC") WHERE emp_no > 10010,
+        max1 = TOP(emp_no, 1, "DESC") WHERE emp_no < 10080,
+        max2 = TOP(emp_no, 2, "DESC") WHERE emp_no < 10080
+;
+
+min1:integer | min2:integer   | max1:integer | max2:integer
+10011        | [10011, 10012] | 10079        | [10079, 10078]
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1457,7 +1457,12 @@ public class EsqlCapabilities {
         /**
          * Support for the Present function
          */
-        FN_PRESENT;
+        FN_PRESENT,
+
+        /**
+         * Bugfix for STATS TOP(field, 1, order) WHERE condition.
+         */
+        STATS_TOP_1_WITH_CONDITION_FIXED;
 
         private final boolean enabled;
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Top.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Top.java
@@ -289,9 +289,9 @@ public class Top extends AggregateFunction implements ToAggregator, SurrogateExp
         var s = source();
         if (orderField() instanceof Literal && limitField() instanceof Literal && limitValue() == 1) {
             if (orderValue()) {
-                return new Min(s, field());
+                return new Min(s, field(), filter());
             } else {
-                return new Max(s, field());
+                return new Max(s, field(), filter());
             }
         }
         return null;


### PR DESCRIPTION
fixes https://github.com/elastic/elasticsearch/issues/134293
