### PR TITLE
ES|QL: Capability check for CCS when using FORK

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
@@ -752,7 +752,7 @@ public class LogicalPlanBuilder extends ExpressionBuilder {
         }
 
         return input -> {
-            if (EsqlCapabilities.Cap.ENABLE_LOOKUP_JOIN_ON_REMOTE.isEnabled() == false) {
+            if (EsqlCapabilities.Cap.ENABLE_FORK_FOR_REMOTE_INDICES.isEnabled() == false) {
                 checkForRemoteClusters(input, source(ctx), "FORK");
             }
             List<LogicalPlan> subPlans = subQueries.stream().map(planFactory -> planFactory.apply(input)).toList();


### PR DESCRIPTION
CCS for FORK is only enabled under snapshot.
I used the wrong capability to enable the feature under snapshot - `ENABLE_LOOKUP_JOIN_ON_REMOTE` instead of `ENABLE_FORK_FOR_REMOTE_INDICES`.
Luckily they are both only available under snapshot.