### PR TITLE
[9.1] Remove logging of trusted system classes to not risk causing ClassCircularityError. (#134431)

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
@@ -369,15 +369,15 @@ public class PolicyManager {
     boolean isTriviallyAllowed(Class<?> requestingClass) {
         // note: do not log exceptions in here, this could interfere with loading of additionally necessary classes such as ThrowableProxy
         if (requestingClass == null) {
-            generalLogger.debug("Entitlement trivially allowed: no caller frames outside the entitlement library");
+            generalLogger.trace("Entitlement trivially allowed: no caller frames outside the entitlement library");
             return true;
         }
         if (requestingClass == NO_CLASS) {
-            generalLogger.debug("Entitlement trivially allowed from outermost frame");
+            generalLogger.trace("Entitlement trivially allowed from outermost frame");
             return true;
         }
         if (isTrustedSystemClass(requestingClass)) {
-            generalLogger.debug("Entitlement trivially allowed from system module [{}]", requestingClass.getModule().getName());
+            // note: no logging here, this has caused ClassCircularityErrors in certain cases
             return true;
         }
         generalLogger.trace("Entitlement not trivially allowed");

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/settings/ClusterSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/settings/ClusterSettingsIT.java
@@ -574,7 +574,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         assertEquals("Unknown level constant [BOOM].", e.getMessage());
 
         try {
-            final Settings.Builder testSettings = Settings.builder().put("logger.test", "TRACE").put("logger._root", "trace");
+            final Settings.Builder testSettings = Settings.builder().put("logger.test", "DEBUG").put("logger._root", "debug");
             ClusterUpdateSettingsRequestBuilder updateBuilder = clusterAdmin().prepareUpdateSettings(
                 TEST_REQUEST_TIMEOUT,
                 TEST_REQUEST_TIMEOUT
@@ -582,8 +582,8 @@ public class ClusterSettingsIT extends ESIntegTestCase {
             consumer.accept(testSettings, updateBuilder);
 
             updateBuilder.get();
-            assertEquals(Level.TRACE, LogManager.getLogger("test").getLevel());
-            assertEquals(Level.TRACE, LogManager.getRootLogger().getLevel());
+            assertEquals(Level.DEBUG, LogManager.getLogger("test").getLevel());
+            assertEquals(Level.DEBUG, LogManager.getRootLogger().getLevel());
         } finally {
             ClusterUpdateSettingsRequestBuilder undoBuilder = clusterAdmin().prepareUpdateSettings(
                 TEST_REQUEST_TIMEOUT,


### PR DESCRIPTION
Backports the following commits to 9.1:
 - Remove logging of trusted system classes to not risk causing ClassCircularityError. (#134431)