### PR TITLE
Use inner query for equals/hashCode() in SourceConfirmedTextQuery

### DIFF
--- a/docs/changelog/134451.yaml
+++ b/docs/changelog/134451.yaml
@@ -1,0 +1,6 @@
+pr: 134451
+summary: Use inner query for equals/hashCode() in `SourceConfirmedTextQuery`
+area: "Mapping, Search"
+type: bug
+issues:
+ - 134432

--- a/docs/changelog/134451.yaml
+++ b/docs/changelog/134451.yaml
@@ -1,6 +1,6 @@
 pr: 134451
 summary: Use inner query for equals/hashCode() in `SourceConfirmedTextQuery`
-area: "Mapping, Search"
+area: "Search"
 type: bug
 issues:
  - 134432

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/SourceConfirmedTextQuery.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/SourceConfirmedTextQuery.java
@@ -176,14 +176,18 @@ public final class SourceConfirmedTextQuery extends Query {
             return false;
         }
         SourceConfirmedTextQuery that = (SourceConfirmedTextQuery) obj;
-        return Objects.equals(in, that.in)
-            && Objects.equals(valueFetcherProvider, that.valueFetcherProvider)
-            && Objects.equals(indexAnalyzer, that.indexAnalyzer);
+        // We intentionally do not compare the value fetcher or analyzer, as they
+        // do not typically implement equals() themselves, and the inner
+        // Query is sufficient to establish identity.
+        return Objects.equals(in, that.in);
     }
 
     @Override
     public int hashCode() {
-        return 31 * Objects.hash(in, valueFetcherProvider, indexAnalyzer) + classHash();
+        // We intentionally do not hash the value fetcher or analyzer, as they
+        // do not typically implement hashCode() themselves, and the inner
+        // Query is sufficient to establish identity.
+        return 31 * Objects.hash(in) + classHash();
     }
 
     @Override


### PR DESCRIPTION
We were using a valueFetcher lambda and an Analyzer as part of the equals 
and hashCode implementations which could easily compare as unequal for 
logically equal queries.  We can safely just use the inner query for comparisons 
and hashcodes as the results of the outer query are identical to running the 
inner query against a shard with indexed positions.

Fixes #134432 