### PR TITLE
Unify rest api bulk handling code

### DIFF
--- a/qa/smoke-test-http/src/internalClusterTest/java/org/elasticsearch/http/BulkRestIT.java
+++ b/qa/smoke-test-http/src/internalClusterTest/java/org/elasticsearch/http/BulkRestIT.java
@@ -152,12 +152,9 @@ public class BulkRestIT extends HttpSmokeTestCase {
 
         updateClusterSettings(Settings.builder().put(IncrementalBulkService.INCREMENTAL_BULK.getKey(), false));
 
-        internalCluster().getInstances(IncrementalBulkService.class).forEach(i -> i.setForTests(false));
-
         try {
             sendLargeBulk();
         } finally {
-            internalCluster().getInstances(IncrementalBulkService.class).forEach(i -> i.setForTests(true));
             updateClusterSettings(Settings.builder().put(IncrementalBulkService.INCREMENTAL_BULK.getKey(), (String) null));
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
@@ -173,10 +173,6 @@ public class BulkRequest extends LegacyActionRequest
      * (for example, if no id is provided, one will be generated, or usage of the create flag).
      */
     public BulkRequest add(IndexRequest request) {
-        return internalAdd(request);
-    }
-
-    BulkRequest internalAdd(IndexRequest request) {
         Objects.requireNonNull(request, "'request' must not be null");
         applyGlobalMandatoryParameters(request);
 
@@ -191,10 +187,6 @@ public class BulkRequest extends LegacyActionRequest
      * Adds an {@link UpdateRequest} to the list of actions to execute.
      */
     public BulkRequest add(UpdateRequest request) {
-        return internalAdd(request);
-    }
-
-    BulkRequest internalAdd(UpdateRequest request) {
         Objects.requireNonNull(request, "'request' must not be null");
         applyGlobalMandatoryParameters(request);
 
@@ -304,8 +296,8 @@ public class BulkRequest extends LegacyActionRequest
             defaultListExecutedPipelines,
             allowExplicitIndex,
             xContentType,
-            (indexRequest, type) -> internalAdd(indexRequest),
-            this::internalAdd,
+            (indexRequest, type) -> add(indexRequest),
+            this::add,
             this::add
         );
         return this;

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestBulkActionTests.java
@@ -58,6 +58,7 @@ public class RestBulkActionTests extends ESTestCase {
 
     public void testBulkPipelineUpsert() throws Exception {
         SetOnce<Boolean> bulkCalled = new SetOnce<>();
+        IndexingPressure indexingPressure = new IndexingPressure(Settings.EMPTY);
         try (var threadPool = createThreadPool()) {
             final var verifyingClient = new NoOpNodeClient(threadPool) {
                 @Override
@@ -73,7 +74,7 @@ public class RestBulkActionTests extends ESTestCase {
             new RestBulkAction(
                 settings(IndexVersion.current()).build(),
                 ClusterSettings.createBuiltInClusterSettings(),
-                new IncrementalBulkService(mock(Client.class), mock(IndexingPressure.class), MeterRegistry.NOOP)
+                new IncrementalBulkService(verifyingClient, indexingPressure, MeterRegistry.NOOP)
             ).handleRequest(
                 new FakeRestRequest.Builder(xContentRegistry()).withPath("my_index/_bulk").withParams(params).withContent(new BytesArray("""
                     {"index":{"_id":"1"}}
@@ -92,6 +93,7 @@ public class RestBulkActionTests extends ESTestCase {
         AtomicBoolean bulkCalled = new AtomicBoolean(false);
         AtomicBoolean listExecutedPipelinesRequest1 = new AtomicBoolean(false);
         AtomicBoolean listExecutedPipelinesRequest2 = new AtomicBoolean(false);
+        IndexingPressure indexingPressure = new IndexingPressure(Settings.EMPTY);
         try (var threadPool = createThreadPool()) {
             final var verifyingClient = new NoOpNodeClient(threadPool) {
                 @Override
@@ -109,7 +111,7 @@ public class RestBulkActionTests extends ESTestCase {
                 new RestBulkAction(
                     settings(IndexVersion.current()).build(),
                     ClusterSettings.createBuiltInClusterSettings(),
-                    new IncrementalBulkService(mock(Client.class), mock(IndexingPressure.class), MeterRegistry.NOOP)
+                    new IncrementalBulkService(verifyingClient, indexingPressure, MeterRegistry.NOOP)
                 ).handleRequest(
                     new FakeRestRequest.Builder(xContentRegistry()).withPath("my_index/_bulk")
                         .withParams(params)
@@ -134,7 +136,7 @@ public class RestBulkActionTests extends ESTestCase {
                 new RestBulkAction(
                     settings(IndexVersion.current()).build(),
                     ClusterSettings.createBuiltInClusterSettings(),
-                    new IncrementalBulkService(mock(Client.class), mock(IndexingPressure.class), MeterRegistry.NOOP)
+                    new IncrementalBulkService(verifyingClient, indexingPressure, MeterRegistry.NOOP)
                 ).handleRequest(
                     new FakeRestRequest.Builder(xContentRegistry()).withPath("my_index/_bulk")
                         .withParams(params)
@@ -158,7 +160,7 @@ public class RestBulkActionTests extends ESTestCase {
                 new RestBulkAction(
                     settings(IndexVersion.current()).build(),
                     ClusterSettings.createBuiltInClusterSettings(),
-                    new IncrementalBulkService(mock(Client.class), mock(IndexingPressure.class), MeterRegistry.NOOP)
+                    new IncrementalBulkService(verifyingClient, indexingPressure, MeterRegistry.NOOP)
                 ).handleRequest(
                     new FakeRestRequest.Builder(xContentRegistry()).withPath("my_index/_bulk")
                         .withParams(params)
@@ -183,7 +185,7 @@ public class RestBulkActionTests extends ESTestCase {
                 new RestBulkAction(
                     settings(IndexVersion.current()).build(),
                     ClusterSettings.createBuiltInClusterSettings(),
-                    new IncrementalBulkService(mock(Client.class), mock(IndexingPressure.class), MeterRegistry.NOOP)
+                    new IncrementalBulkService(verifyingClient, indexingPressure, MeterRegistry.NOOP)
                 ).handleRequest(
                     new FakeRestRequest.Builder(xContentRegistry()).withPath("my_index/_bulk")
                         .withParams(params)


### PR DESCRIPTION
Currently the various bulk apis go down different code paths related to
handling, parsing, and creating requests. This commit attempts to unify
the code paths to make the code easier to maintain.