### PR TITLE
Consolidate CCS metadata tests to reduce copypaste

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractCrossClusterTestCase.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractCrossClusterTestCase.java
@@ -141,6 +141,15 @@ public abstract class AbstractCrossClusterTestCase extends AbstractMultiClusters
         assertThat(cluster.getFailures().size(), equalTo(0));
     }
 
+    protected void assertClusterInfoSkipped(EsqlExecutionInfo.Cluster cluster) {
+        assertThat(cluster.getTook().millis(), greaterThanOrEqualTo(0L));
+        assertThat(cluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
+        assertThat(cluster.getTotalShards(), equalTo(0));
+        assertThat(cluster.getSuccessfulShards(), equalTo(0));
+        assertThat(cluster.getSkippedShards(), equalTo(0));
+        assertThat(cluster.getFailedShards(), equalTo(0));
+    }
+
     protected static void assertClusterMetadataInResponse(EsqlQueryResponse resp, boolean responseExpectMeta, int numClusters) {
         try {
             final Map<String, Object> esqlResponseAsMap = XContentTestUtils.convertToMap(resp);

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractEnrichBasedCrossClusterTestCase.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractEnrichBasedCrossClusterTestCase.java
@@ -50,6 +50,8 @@ import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 public abstract class AbstractEnrichBasedCrossClusterTestCase extends AbstractMultiClustersTestCase {
 
@@ -286,5 +288,24 @@ public abstract class AbstractEnrichBasedCrossClusterTestCase extends AbstractMu
         protected Class<? extends TransportAction<XPackInfoRequest, XPackInfoResponse>> getInfoAction() {
             return CrossClusterQueriesWithInvalidLicenseIT.LocalStateEnrich.EnrichTransportXPackInfoAction.class;
         }
+    }
+
+    protected void assertClusterInfoSuccess(EsqlExecutionInfo.Cluster cluster, int numShards) {
+        assertThat(cluster.getTook().millis(), greaterThanOrEqualTo(0L));
+        assertThat(cluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
+        assertThat(cluster.getTotalShards(), equalTo(numShards));
+        assertThat(cluster.getSuccessfulShards(), equalTo(numShards));
+        assertThat(cluster.getSkippedShards(), equalTo(0));
+        assertThat(cluster.getFailedShards(), equalTo(0));
+        assertThat(cluster.getFailures().size(), equalTo(0));
+    }
+
+    protected void assertClusterInfoSkipped(EsqlExecutionInfo.Cluster cluster) {
+        assertThat(cluster.getTook().millis(), greaterThanOrEqualTo(0L));
+        assertThat(cluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
+        assertThat(cluster.getTotalShards(), equalTo(0));
+        assertThat(cluster.getSuccessfulShards(), equalTo(0));
+        assertThat(cluster.getSkippedShards(), equalTo(0));
+        assertThat(cluster.getFailedShards(), equalTo(0));
     }
 }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterEnrichUnavailableClustersIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterEnrichUnavailableClustersIT.java
@@ -78,18 +78,10 @@ public class CrossClusterEnrichUnavailableClustersIT extends AbstractEnrichBased
                     assertThat(executionInfo.clusterAliases(), equalTo(Set.of(REMOTE_CLUSTER_1, REMOTE_CLUSTER_2)));
 
                     EsqlExecutionInfo.Cluster cluster1 = executionInfo.getCluster(REMOTE_CLUSTER_1);
-                    assertThat(cluster1.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
-                    assertThat(cluster1.getTotalShards(), equalTo(0));
-                    assertThat(cluster1.getSuccessfulShards(), equalTo(0));
-                    assertThat(cluster1.getSkippedShards(), equalTo(0));
-                    assertThat(cluster1.getFailedShards(), equalTo(0));
+                    assertClusterInfoSkipped(cluster1);
 
                     EsqlExecutionInfo.Cluster cluster2 = executionInfo.getCluster(REMOTE_CLUSTER_2);
-                    assertThat(cluster2.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-                    assertThat(cluster2.getTotalShards(), greaterThanOrEqualTo(0));
-                    assertThat(cluster2.getSuccessfulShards(), equalTo(cluster2.getSuccessfulShards()));
-                    assertThat(cluster2.getSkippedShards(), equalTo(0));
-                    assertThat(cluster2.getFailedShards(), equalTo(0));
+                    assertClusterInfoSuccess(cluster2, cluster2.getSuccessfulShards());
                 }
             }
 
@@ -116,18 +108,10 @@ public class CrossClusterEnrichUnavailableClustersIT extends AbstractEnrichBased
                     assertThat(executionInfo.clusterAliases(), equalTo(Set.of(REMOTE_CLUSTER_1, REMOTE_CLUSTER_2)));
 
                     EsqlExecutionInfo.Cluster cluster1 = executionInfo.getCluster(REMOTE_CLUSTER_1);
-                    assertThat(cluster1.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
-                    assertThat(cluster1.getTotalShards(), equalTo(0));
-                    assertThat(cluster1.getSuccessfulShards(), equalTo(0));
-                    assertThat(cluster1.getSkippedShards(), equalTo(0));
-                    assertThat(cluster1.getFailedShards(), equalTo(0));
+                    assertClusterInfoSkipped(cluster1);
 
                     EsqlExecutionInfo.Cluster cluster2 = executionInfo.getCluster(REMOTE_CLUSTER_2);
-                    assertThat(cluster2.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
-                    assertThat(cluster2.getTotalShards(), equalTo(0));
-                    assertThat(cluster2.getSuccessfulShards(), equalTo(0));
-                    assertThat(cluster2.getSkippedShards(), equalTo(0));
-                    assertThat(cluster2.getFailedShards(), equalTo(0));
+                    assertClusterInfoSkipped(cluster2);
                 }
             }
         } finally {
@@ -160,18 +144,10 @@ public class CrossClusterEnrichUnavailableClustersIT extends AbstractEnrichBased
                     assertThat(executionInfo.clusterAliases(), equalTo(Set.of(REMOTE_CLUSTER_1, REMOTE_CLUSTER_2)));
 
                     EsqlExecutionInfo.Cluster cluster1 = executionInfo.getCluster(REMOTE_CLUSTER_1);
-                    assertThat(cluster1.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
-                    assertThat(cluster1.getTotalShards(), equalTo(0));
-                    assertThat(cluster1.getSuccessfulShards(), equalTo(0));
-                    assertThat(cluster1.getSkippedShards(), equalTo(0));
-                    assertThat(cluster1.getFailedShards(), equalTo(0));
+                    assertClusterInfoSkipped(cluster1);
 
                     EsqlExecutionInfo.Cluster cluster2 = executionInfo.getCluster(REMOTE_CLUSTER_2);
-                    assertThat(cluster2.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-                    assertThat(cluster2.getTotalShards(), greaterThanOrEqualTo(0));
-                    assertThat(cluster2.getSuccessfulShards(), equalTo(cluster2.getSuccessfulShards()));
-                    assertThat(cluster2.getSkippedShards(), equalTo(0));
-                    assertThat(cluster2.getFailedShards(), equalTo(0));
+                    assertClusterInfoSuccess(cluster2, cluster2.getSuccessfulShards());
                 }
             }
 
@@ -218,25 +194,13 @@ public class CrossClusterEnrichUnavailableClustersIT extends AbstractEnrichBased
                     assertCCSExecutionInfoDetails(executionInfo);
 
                     EsqlExecutionInfo.Cluster cluster1 = executionInfo.getCluster(REMOTE_CLUSTER_1);
-                    assertThat(cluster1.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-                    assertThat(cluster1.getTotalShards(), greaterThanOrEqualTo(0));
-                    assertThat(cluster1.getSuccessfulShards(), equalTo(cluster1.getSuccessfulShards()));
-                    assertThat(cluster1.getSkippedShards(), equalTo(0));
-                    assertThat(cluster1.getFailedShards(), equalTo(0));
+                    assertClusterInfoSuccess(cluster1, cluster1.getSuccessfulShards());
 
                     EsqlExecutionInfo.Cluster cluster2 = executionInfo.getCluster(REMOTE_CLUSTER_2);
-                    assertThat(cluster2.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
-                    assertThat(cluster2.getTotalShards(), equalTo(0));
-                    assertThat(cluster2.getSuccessfulShards(), equalTo(0));
-                    assertThat(cluster2.getSkippedShards(), equalTo(0));
-                    assertThat(cluster2.getFailedShards(), equalTo(0));
+                    assertClusterInfoSkipped(cluster2);
 
                     EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
-                    assertThat(localCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-                    assertThat(localCluster.getTotalShards(), greaterThan(0));
-                    assertThat(localCluster.getSuccessfulShards(), equalTo(localCluster.getTotalShards()));
-                    assertThat(localCluster.getSkippedShards(), equalTo(0));
-                    assertThat(localCluster.getFailedShards(), equalTo(0));
+                    assertClusterInfoSuccess(localCluster, localCluster.getSuccessfulShards());
                 }
             }
 
@@ -264,26 +228,13 @@ public class CrossClusterEnrichUnavailableClustersIT extends AbstractEnrichBased
                         assertCCSExecutionInfoDetails(executionInfo);
 
                         EsqlExecutionInfo.Cluster cluster1 = executionInfo.getCluster(REMOTE_CLUSTER_1);
-                        assertThat(cluster1.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
-                        assertThat(cluster1.getTotalShards(), equalTo(0));
-                        assertThat(cluster1.getSuccessfulShards(), equalTo(0));
-                        assertThat(cluster1.getSkippedShards(), equalTo(0));
-                        assertThat(cluster1.getFailedShards(), equalTo(0));
-                        assertThat(cluster1.getTook().millis(), greaterThanOrEqualTo(0L));
+                        assertClusterInfoSkipped(cluster1);
 
                         EsqlExecutionInfo.Cluster cluster2 = executionInfo.getCluster(REMOTE_CLUSTER_2);
-                        assertThat(cluster2.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
-                        assertThat(cluster2.getTotalShards(), equalTo(0));
-                        assertThat(cluster2.getSuccessfulShards(), equalTo(0));
-                        assertThat(cluster2.getSkippedShards(), equalTo(0));
-                        assertThat(cluster2.getFailedShards(), equalTo(0));
+                        assertClusterInfoSkipped(cluster2);
 
                         EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
-                        assertThat(localCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-                        assertThat(localCluster.getTotalShards(), greaterThan(0));
-                        assertThat(localCluster.getSuccessfulShards(), equalTo(localCluster.getTotalShards()));
-                        assertThat(localCluster.getSkippedShards(), equalTo(0));
-                        assertThat(localCluster.getFailedShards(), equalTo(0));
+                        assertClusterInfoSuccess(localCluster, localCluster.getSuccessfulShards());
                     }
                 }
             }
@@ -326,18 +277,10 @@ public class CrossClusterEnrichUnavailableClustersIT extends AbstractEnrichBased
                     assertCCSExecutionInfoDetails(executionInfo);
 
                     EsqlExecutionInfo.Cluster cluster1 = executionInfo.getCluster(REMOTE_CLUSTER_1);
-                    assertThat(cluster1.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
-                    assertThat(cluster1.getTotalShards(), equalTo(0));
-                    assertThat(cluster1.getSuccessfulShards(), equalTo(0));
-                    assertThat(cluster1.getSkippedShards(), equalTo(0));
-                    assertThat(cluster1.getFailedShards(), equalTo(0));
+                    assertClusterInfoSkipped(cluster1);
 
                     EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
-                    assertThat(localCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-                    assertThat(localCluster.getTotalShards(), greaterThan(0));
-                    assertThat(localCluster.getSuccessfulShards(), equalTo(localCluster.getTotalShards()));
-                    assertThat(localCluster.getSkippedShards(), equalTo(0));
-                    assertThat(localCluster.getFailedShards(), equalTo(0));
+                    assertClusterInfoSuccess(localCluster, localCluster.getSuccessfulShards());
                 }
             }
         } finally {
@@ -382,11 +325,7 @@ public class CrossClusterEnrichUnavailableClustersIT extends AbstractEnrichBased
                     assertCCSExecutionInfoDetails(executionInfo);
 
                     EsqlExecutionInfo.Cluster cluster1 = executionInfo.getCluster(REMOTE_CLUSTER_1);
-                    assertThat(cluster1.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
-                    assertThat(cluster1.getTotalShards(), equalTo(0));
-                    assertThat(cluster1.getSuccessfulShards(), equalTo(0));
-                    assertThat(cluster1.getSkippedShards(), equalTo(0));
-                    assertThat(cluster1.getFailedShards(), equalTo(0));
+                    assertClusterInfoSkipped(cluster1);
                 }
             }
         } finally {
@@ -427,26 +366,13 @@ public class CrossClusterEnrichUnavailableClustersIT extends AbstractEnrichBased
                     assertCCSExecutionInfoDetails(executionInfo);
 
                     EsqlExecutionInfo.Cluster cluster1 = executionInfo.getCluster(REMOTE_CLUSTER_1);
-                    assertThat(cluster1.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
-                    assertThat(cluster1.getTotalShards(), equalTo(0));
-                    assertThat(cluster1.getSuccessfulShards(), equalTo(0));
-                    assertThat(cluster1.getSkippedShards(), equalTo(0));
-                    assertThat(cluster1.getFailedShards(), equalTo(0));
-                    assertThat(cluster1.getTook().millis(), greaterThanOrEqualTo(0L));
+                    assertClusterInfoSkipped(cluster1);
 
                     EsqlExecutionInfo.Cluster cluster2 = executionInfo.getCluster(REMOTE_CLUSTER_2);
-                    assertThat(cluster2.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-                    assertThat(cluster2.getTotalShards(), greaterThan(0));
-                    assertThat(cluster2.getSuccessfulShards(), equalTo(cluster2.getSuccessfulShards()));
-                    assertThat(cluster2.getSkippedShards(), equalTo(0));
-                    assertThat(cluster2.getFailedShards(), equalTo(0));
+                    assertClusterInfoSuccess(cluster2, cluster2.getSuccessfulShards());
 
                     EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
-                    assertThat(localCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-                    assertThat(localCluster.getTotalShards(), greaterThan(0));
-                    assertThat(localCluster.getSuccessfulShards(), equalTo(localCluster.getTotalShards()));
-                    assertThat(localCluster.getSkippedShards(), equalTo(0));
-                    assertThat(localCluster.getFailedShards(), equalTo(0));
+                    assertClusterInfoSuccess(localCluster, localCluster.getSuccessfulShards());
                 }
             }
 
@@ -478,26 +404,13 @@ public class CrossClusterEnrichUnavailableClustersIT extends AbstractEnrichBased
                         assertCCSExecutionInfoDetails(executionInfo);
 
                         EsqlExecutionInfo.Cluster cluster1 = executionInfo.getCluster(REMOTE_CLUSTER_1);
-                        assertThat(cluster1.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
-                        assertThat(cluster1.getTotalShards(), equalTo(0));
-                        assertThat(cluster1.getSuccessfulShards(), equalTo(0));
-                        assertThat(cluster1.getSkippedShards(), equalTo(0));
-                        assertThat(cluster1.getFailedShards(), equalTo(0));
-                        assertThat(cluster1.getTook().millis(), greaterThanOrEqualTo(0L));
+                        assertClusterInfoSkipped(cluster1);
 
                         EsqlExecutionInfo.Cluster cluster2 = executionInfo.getCluster(REMOTE_CLUSTER_2);
-                        assertThat(cluster2.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
-                        assertThat(cluster2.getTotalShards(), equalTo(0));
-                        assertThat(cluster2.getSuccessfulShards(), equalTo(0));
-                        assertThat(cluster2.getSkippedShards(), equalTo(0));
-                        assertThat(cluster2.getFailedShards(), equalTo(0));
+                        assertClusterInfoSkipped(cluster2);
 
                         EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
-                        assertThat(localCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-                        assertThat(localCluster.getTotalShards(), greaterThan(0));
-                        assertThat(localCluster.getSuccessfulShards(), equalTo(localCluster.getTotalShards()));
-                        assertThat(localCluster.getSkippedShards(), equalTo(0));
-                        assertThat(localCluster.getFailedShards(), equalTo(0));
+                        assertClusterInfoSuccess(localCluster, localCluster.getSuccessfulShards());
                     }
                 }
             }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterQueryIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterQueryIT.java
@@ -63,6 +63,12 @@ public class CrossClusterQueryIT extends AbstractCrossClusterTestCase {
         return Map.of(REMOTE_CLUSTER_1, randomBoolean(), REMOTE_CLUSTER_2, randomBoolean());
     }
 
+    protected void assertClusterInfoSuccess(EsqlExecutionInfo.Cluster clusterInfo, int numShards, long overallTookMillis) {
+        assertThat(clusterInfo.getIndexExpression(), equalTo("logs-*"));
+        assertThat(clusterInfo.getTook().millis(), lessThanOrEqualTo(overallTookMillis));
+        super.assertClusterInfoSuccess(clusterInfo, numShards);
+    }
+
     public void testSuccessfulPathways() throws Exception {
         Map<String, Object> testClusterInfo = setupTwoClusters();
         int localNumShards = (Integer) testClusterInfo.get("local.num_shards");
@@ -86,24 +92,10 @@ public class CrossClusterQueryIT extends AbstractCrossClusterTestCase {
             assertThat(executionInfo.clusterAliases(), equalTo(Set.of(REMOTE_CLUSTER_1, LOCAL_CLUSTER)));
 
             EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER_1);
-            assertThat(remoteCluster.getIndexExpression(), equalTo("logs-*"));
-            assertThat(remoteCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-            assertThat(remoteCluster.getTook().millis(), greaterThanOrEqualTo(0L));
-            assertThat(remoteCluster.getTook().millis(), lessThanOrEqualTo(overallTookMillis));
-            assertThat(remoteCluster.getTotalShards(), equalTo(remoteNumShards));
-            assertThat(remoteCluster.getSuccessfulShards(), equalTo(remoteNumShards));
-            assertThat(remoteCluster.getSkippedShards(), equalTo(0));
-            assertThat(remoteCluster.getFailedShards(), equalTo(0));
+            assertClusterInfoSuccess(remoteCluster, remoteNumShards, overallTookMillis);
 
             EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(LOCAL_CLUSTER);
-            assertThat(localCluster.getIndexExpression(), equalTo("logs-*"));
-            assertThat(localCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-            assertThat(localCluster.getTook().millis(), greaterThanOrEqualTo(0L));
-            assertThat(localCluster.getTook().millis(), lessThanOrEqualTo(overallTookMillis));
-            assertThat(localCluster.getTotalShards(), equalTo(localNumShards));
-            assertThat(localCluster.getSuccessfulShards(), equalTo(localNumShards));
-            assertThat(localCluster.getSkippedShards(), equalTo(0));
-            assertThat(localCluster.getFailedShards(), equalTo(0));
+            assertClusterInfoSuccess(localCluster, localNumShards, overallTookMillis);
 
             // ensure that the _clusters metadata is present only if requested
             assertClusterMetadataInResponse(resp, responseExpectMeta);
@@ -125,24 +117,10 @@ public class CrossClusterQueryIT extends AbstractCrossClusterTestCase {
             assertThat(executionInfo.clusterAliases(), equalTo(Set.of(REMOTE_CLUSTER_1, LOCAL_CLUSTER)));
 
             EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER_1);
-            assertThat(remoteCluster.getIndexExpression(), equalTo("logs-*"));
-            assertThat(remoteCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-            assertThat(remoteCluster.getTook().millis(), greaterThanOrEqualTo(0L));
-            assertThat(remoteCluster.getTook().millis(), lessThanOrEqualTo(overallTookMillis));
-            assertThat(remoteCluster.getTotalShards(), equalTo(remoteNumShards));
-            assertThat(remoteCluster.getSuccessfulShards(), equalTo(remoteNumShards));
-            assertThat(remoteCluster.getSkippedShards(), equalTo(0));
-            assertThat(remoteCluster.getFailedShards(), equalTo(0));
+            assertClusterInfoSuccess(remoteCluster, remoteNumShards, overallTookMillis);
 
             EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(LOCAL_CLUSTER);
-            assertThat(localCluster.getIndexExpression(), equalTo("logs-*"));
-            assertThat(localCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-            assertThat(localCluster.getTook().millis(), greaterThanOrEqualTo(0L));
-            assertThat(localCluster.getTook().millis(), lessThanOrEqualTo(overallTookMillis));
-            assertThat(localCluster.getTotalShards(), equalTo(localNumShards));
-            assertThat(localCluster.getSuccessfulShards(), equalTo(localNumShards));
-            assertThat(localCluster.getSkippedShards(), equalTo(0));
-            assertThat(localCluster.getFailedShards(), equalTo(0));
+            assertClusterInfoSuccess(localCluster, localNumShards, overallTookMillis);
 
             // ensure that the _clusters metadata is present only if requested
             assertClusterMetadataInResponse(resp, responseExpectMeta);
@@ -159,7 +137,8 @@ public class CrossClusterQueryIT extends AbstractCrossClusterTestCase {
             assertThat(e.getDetailedMessage(), containsString("no such index [nomatch]"));
 
             // MP TODO: am I able to fix this from the field-caps call? Yes, if we detect concrete vs. wildcard expressions in user query
-            // TODO bug - this does not throw; uncomment this test once https://github.com/elastic/elasticsearch/issues/114495 is fixed
+            // TODO bug - this does not throw; uncomment this test once this is fixed:
+            // AwaitsFix https://github.com/elastic/elasticsearch/issues/114495
             // String limit0 = q + " | LIMIT 0";
             // VerificationException ve = expectThrows(VerificationException.class, () -> runQuery(limit0, false));
             // assertThat(ve.getDetailedMessage(), containsString("No matching indices for [nomatch]"));
@@ -556,21 +535,11 @@ public class CrossClusterQueryIT extends AbstractCrossClusterTestCase {
 
             EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER_1);
             assertThat(remoteCluster.getIndexExpression(), equalTo("no_such_index*"));
-            assertThat(remoteCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-            assertThat(remoteCluster.getTook().millis(), greaterThanOrEqualTo(0L));
-            assertThat(remoteCluster.getTotalShards(), equalTo(0));
-            assertThat(remoteCluster.getSuccessfulShards(), equalTo(0));
-            assertThat(remoteCluster.getSkippedShards(), equalTo(0));
-            assertThat(remoteCluster.getFailedShards(), equalTo(0));
+            assertClusterInfoSuccess(remoteCluster, 0);
 
             EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(LOCAL_CLUSTER);
             assertThat(localCluster.getIndexExpression(), equalTo("logs-*,no_such_index*"));
-            assertThat(localCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-            assertThat(localCluster.getTook().millis(), greaterThanOrEqualTo(0L));
-            assertThat(localCluster.getTotalShards(), equalTo(localNumShards));
-            assertThat(localCluster.getSuccessfulShards(), equalTo(localNumShards));
-            assertThat(localCluster.getSkippedShards(), equalTo(0));
-            assertThat(localCluster.getFailedShards(), equalTo(0));
+            assertClusterInfoSuccess(localCluster, localNumShards);
         } finally {
             clearSkipUnavailable();
         }
@@ -600,7 +569,7 @@ public class CrossClusterQueryIT extends AbstractCrossClusterTestCase {
         }
 
         // ensure cross-cluster searches have overall took time and correct per-cluster details in EsqlExecutionInfo
-        try (EsqlQueryResponse resp = runQuery("FROM logs*,cluster-a:* | LIMIT 0", requestIncludeMeta)) {
+        try (EsqlQueryResponse resp = runQuery("FROM logs-*,cluster-a:* | LIMIT 0", requestIncludeMeta)) {
             EsqlExecutionInfo executionInfo = resp.getExecutionInfo();
             assertNotNull(executionInfo);
             assertThat(executionInfo.isCrossClusterSearch(), is(true));
@@ -612,23 +581,11 @@ public class CrossClusterQueryIT extends AbstractCrossClusterTestCase {
 
             EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER_1);
             assertThat(remoteCluster.getIndexExpression(), equalTo("*"));
-            assertThat(remoteCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-            assertThat(remoteCluster.getTook().millis(), greaterThanOrEqualTo(0L));
             assertThat(remoteCluster.getTook().millis(), lessThanOrEqualTo(overallTookMillis));
-            assertThat(remoteCluster.getTotalShards(), equalTo(0));
-            assertThat(remoteCluster.getSuccessfulShards(), equalTo(0));
-            assertThat(remoteCluster.getSkippedShards(), equalTo(0));
-            assertThat(remoteCluster.getFailedShards(), equalTo(0));
+            assertClusterInfoSuccess(remoteCluster, 0);
 
             EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(LOCAL_CLUSTER);
-            assertThat(localCluster.getIndexExpression(), equalTo("logs*"));
-            assertThat(localCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-            assertThat(localCluster.getTook().millis(), greaterThanOrEqualTo(0L));
-            assertThat(localCluster.getTook().millis(), lessThanOrEqualTo(overallTookMillis));
-            assertThat(remoteCluster.getTotalShards(), equalTo(0));
-            assertThat(remoteCluster.getSuccessfulShards(), equalTo(0));
-            assertThat(remoteCluster.getSkippedShards(), equalTo(0));
-            assertThat(remoteCluster.getFailedShards(), equalTo(0));
+            assertClusterInfoSuccess(localCluster, 0, overallTookMillis);
         }
     }
 
@@ -643,7 +600,7 @@ public class CrossClusterQueryIT extends AbstractCrossClusterTestCase {
 
         try (
             EsqlQueryResponse resp = runQuery(
-                Strings.format("FROM logs*,%s:logs* METADATA _index | stats sum(v) by _index | sort _index", REMOTE_CLUSTER_1),
+                Strings.format("FROM logs-*,%s:logs-* METADATA _index | stats sum(v) by _index | sort _index", REMOTE_CLUSTER_1),
                 requestIncludeMeta
             )
         ) {
@@ -655,26 +612,15 @@ public class CrossClusterQueryIT extends AbstractCrossClusterTestCase {
             assertNotNull(executionInfo);
             assertThat(executionInfo.isCrossClusterSearch(), is(true));
             assertThat(executionInfo.includeCCSMetadata(), equalTo(responseExpectMeta));
-            assertThat(executionInfo.overallTook().millis(), greaterThanOrEqualTo(0L));
+            long overallTookMillis = executionInfo.overallTook().millis();
+            assertThat(overallTookMillis, greaterThanOrEqualTo(0L));
             assertThat(executionInfo.isPartial(), equalTo(false));
 
             EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER_1);
-            assertThat(remoteCluster.getIndexExpression(), equalTo("logs*"));
-            assertThat(remoteCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-            assertThat(remoteCluster.getTook().millis(), greaterThanOrEqualTo(0L));
-            assertThat(remoteCluster.getTotalShards(), equalTo(remoteNumShards));
-            assertThat(remoteCluster.getSuccessfulShards(), equalTo(remoteNumShards));
-            assertThat(remoteCluster.getSkippedShards(), equalTo(0));
-            assertThat(remoteCluster.getFailedShards(), equalTo(0));
+            assertClusterInfoSuccess(remoteCluster, remoteNumShards, overallTookMillis);
 
             EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(LOCAL_CLUSTER);
-            assertThat(localCluster.getIndexExpression(), equalTo("logs*"));
-            assertThat(localCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-            assertThat(localCluster.getTook().millis(), greaterThanOrEqualTo(0L));
-            assertThat(localCluster.getTotalShards(), equalTo(localNumShards));
-            assertThat(localCluster.getSuccessfulShards(), equalTo(localNumShards));
-            assertThat(localCluster.getSkippedShards(), equalTo(0));
-            assertThat(localCluster.getFailedShards(), equalTo(0));
+            assertClusterInfoSuccess(localCluster, localNumShards, overallTookMillis);
         }
     }
 
@@ -726,7 +672,7 @@ public class CrossClusterQueryIT extends AbstractCrossClusterTestCase {
         final int remoteOnlyProfiles;
         {
             EsqlQueryRequest request = EsqlQueryRequest.syncEsqlQueryRequest();
-            request.query("FROM c*:logs* | stats sum(v)");
+            request.query("FROM c*:logs-* | stats sum(v)");
             request.pragmas(pragmas);
             request.profile(true);
             try (EsqlQueryResponse resp = runQuery(request)) {
@@ -744,13 +690,7 @@ public class CrossClusterQueryIT extends AbstractCrossClusterTestCase {
                 assertThat(executionInfo.overallTook().millis(), greaterThanOrEqualTo(0L));
 
                 EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER_1);
-                assertThat(remoteCluster.getIndexExpression(), equalTo("logs*"));
-                assertThat(remoteCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-                assertThat(remoteCluster.getTook().millis(), greaterThanOrEqualTo(0L));
-                assertThat(remoteCluster.getTotalShards(), equalTo(remoteNumShards));
-                assertThat(remoteCluster.getSuccessfulShards(), equalTo(remoteNumShards));
-                assertThat(remoteCluster.getSkippedShards(), equalTo(0));
-                assertThat(remoteCluster.getFailedShards(), equalTo(0));
+                assertClusterInfoSuccess(remoteCluster, remoteNumShards, executionInfo.overallTook().millis());
 
                 EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(LOCAL_CLUSTER);
                 assertNull(localCluster);
@@ -759,7 +699,7 @@ public class CrossClusterQueryIT extends AbstractCrossClusterTestCase {
         final int allProfiles;
         {
             EsqlQueryRequest request = EsqlQueryRequest.syncEsqlQueryRequest();
-            request.query("FROM logs*,c*:logs* | stats total = sum(v)");
+            request.query("FROM logs-*,c*:logs-* | stats total = sum(v)");
             request.pragmas(pragmas);
             request.profile(true);
             try (EsqlQueryResponse resp = runQuery(request)) {
@@ -774,25 +714,14 @@ public class CrossClusterQueryIT extends AbstractCrossClusterTestCase {
                 assertNotNull(executionInfo);
                 assertThat(executionInfo.isCrossClusterSearch(), is(true));
                 assertThat(executionInfo.includeCCSMetadata(), is(false));
-                assertThat(executionInfo.overallTook().millis(), greaterThanOrEqualTo(0L));
+                long overallTookMillis = executionInfo.overallTook().millis();
+                assertThat(overallTookMillis, greaterThanOrEqualTo(0L));
 
                 EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER_1);
-                assertThat(remoteCluster.getIndexExpression(), equalTo("logs*"));
-                assertThat(remoteCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-                assertThat(remoteCluster.getTook().millis(), greaterThanOrEqualTo(0L));
-                assertThat(remoteCluster.getTotalShards(), equalTo(remoteNumShards));
-                assertThat(remoteCluster.getSuccessfulShards(), equalTo(remoteNumShards));
-                assertThat(remoteCluster.getSkippedShards(), equalTo(0));
-                assertThat(remoteCluster.getFailedShards(), equalTo(0));
+                assertClusterInfoSuccess(remoteCluster, remoteNumShards, overallTookMillis);
 
                 EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(LOCAL_CLUSTER);
-                assertThat(localCluster.getIndexExpression(), equalTo("logs*"));
-                assertThat(localCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-                assertThat(localCluster.getTook().millis(), greaterThanOrEqualTo(0L));
-                assertThat(localCluster.getTotalShards(), equalTo(localNumShards));
-                assertThat(localCluster.getSuccessfulShards(), equalTo(localNumShards));
-                assertThat(localCluster.getSkippedShards(), equalTo(0));
-                assertThat(localCluster.getFailedShards(), equalTo(0));
+                assertClusterInfoSuccess(localCluster, localNumShards, overallTookMillis);
             }
         }
         assertThat(allProfiles, equalTo(localOnlyProfiles + remoteOnlyProfiles - 1));
@@ -804,7 +733,7 @@ public class CrossClusterQueryIT extends AbstractCrossClusterTestCase {
         int remoteNumShards = (Integer) testClusterInfo.get("remote1.num_shards");
 
         EsqlQueryRequest request = EsqlQueryRequest.syncEsqlQueryRequest();
-        request.query("FROM logs*,c*:logs* | EVAL ip = to_ip(id) | STATS total = sum(v) by ip | LIMIT 10");
+        request.query("FROM logs-*,c*:logs-* | EVAL ip = to_ip(id) | STATS total = sum(v) by ip | LIMIT 10");
         InternalTestCluster cluster = cluster(LOCAL_CLUSTER);
         String node = randomFrom(cluster.getNodeNames());
         CountDownLatch latch = new CountDownLatch(1);
@@ -824,25 +753,14 @@ public class CrossClusterQueryIT extends AbstractCrossClusterTestCase {
             assertNotNull(executionInfo);
             assertThat(executionInfo.isCrossClusterSearch(), is(true));
             assertThat(executionInfo.includeCCSMetadata(), is(false));
-            assertThat(executionInfo.overallTook().millis(), greaterThanOrEqualTo(0L));
+            long overallTookMillis = executionInfo.overallTook().millis();
+            assertThat(overallTookMillis, greaterThanOrEqualTo(0L));
 
             EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER_1);
-            assertThat(remoteCluster.getIndexExpression(), equalTo("logs*"));
-            assertThat(remoteCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-            assertThat(remoteCluster.getTook().millis(), greaterThanOrEqualTo(0L));
-            assertThat(remoteCluster.getTotalShards(), equalTo(remoteNumShards));
-            assertThat(remoteCluster.getSuccessfulShards(), equalTo(remoteNumShards));
-            assertThat(remoteCluster.getSkippedShards(), equalTo(0));
-            assertThat(remoteCluster.getFailedShards(), equalTo(0));
+            assertClusterInfoSuccess(remoteCluster, remoteNumShards, overallTookMillis);
 
             EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(LOCAL_CLUSTER);
-            assertThat(localCluster.getIndexExpression(), equalTo("logs*"));
-            assertThat(localCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SUCCESSFUL));
-            assertThat(localCluster.getTook().millis(), greaterThanOrEqualTo(0L));
-            assertThat(localCluster.getTotalShards(), equalTo(localNumShards));
-            assertThat(localCluster.getSuccessfulShards(), equalTo(localNumShards));
-            assertThat(localCluster.getSkippedShards(), equalTo(0));
-            assertThat(localCluster.getFailedShards(), equalTo(0));
+            assertClusterInfoSuccess(localCluster, localNumShards, overallTookMillis);
 
             latch.countDown();
         }, e -> {
@@ -867,13 +785,7 @@ public class CrossClusterQueryIT extends AbstractCrossClusterTestCase {
 
             EsqlExecutionInfo.Cluster remoteCluster = executionInfo.getCluster(REMOTE_CLUSTER_1);
             assertThat(remoteCluster.getIndexExpression(), equalTo("logs-2*"));
-            assertThat(remoteCluster.getStatus(), equalTo(EsqlExecutionInfo.Cluster.Status.SKIPPED));
-            assertThat(remoteCluster.getTook().millis(), greaterThanOrEqualTo(0L));
-            assertThat(remoteCluster.getTotalShards(), equalTo(0));
-            assertThat(remoteCluster.getSuccessfulShards(), equalTo(0));
-            assertThat(remoteCluster.getSkippedShards(), equalTo(0));
-            assertThat(remoteCluster.getFailedShards(), equalTo(0));
-            assertThat(remoteCluster.getFailures(), hasSize(1));
+            assertClusterInfoSkipped(remoteCluster);
             assertThat(remoteCluster.getFailures().getFirst().reason(), containsString("Accessing failing field"));
         }
     }


### PR DESCRIPTION
A lot of tests just do the same thing over and over - consolidate it into semantically meaningful methods. 