### PR TITLE
[ML] Allow project_routing in API

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
@@ -125,6 +125,7 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
     public static final ParseField DELAYED_DATA_CHECK_CONFIG = new ParseField("delayed_data_check_config");
     public static final ParseField MAX_EMPTY_SEARCHES = new ParseField("max_empty_searches");
     public static final ParseField INDICES_OPTIONS = new ParseField("indices_options");
+    public static final ParseField PROJECT_ROUTING = new ParseField("project_routing");
 
     // These parsers follow the pattern that metadata is parsed leniently (to allow for enhancements), whilst config is parsed strictly
     public static final ObjectParser<Builder, Void> LENIENT_PARSER = createParser(true);
@@ -208,6 +209,7 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
             INDICES_OPTIONS
         );
         parser.declareObject(Builder::setRuntimeMappings, (p, c) -> p.map(), SearchSourceBuilder.RUNTIME_MAPPINGS_FIELD);
+        parser.declareString(Builder::setProjectRouting, PROJECT_ROUTING);
         return parser;
     }
 
@@ -235,6 +237,7 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
     private final Integer maxEmptySearches;
     private final IndicesOptions indicesOptions;
     private final Map<String, Object> runtimeMappings;
+    private final String projectRouting;
 
     private DatafeedConfig(
         String id,
@@ -251,7 +254,8 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
         DelayedDataCheckConfig delayedDataCheckConfig,
         Integer maxEmptySearches,
         IndicesOptions indicesOptions,
-        Map<String, Object> runtimeMappings
+        Map<String, Object> runtimeMappings,
+        String projectRouting
     ) {
         this.id = id;
         this.jobId = jobId;
@@ -268,6 +272,7 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
         this.maxEmptySearches = maxEmptySearches;
         this.indicesOptions = ExceptionsHelper.requireNonNull(indicesOptions, INDICES_OPTIONS);
         this.runtimeMappings = Collections.unmodifiableMap(runtimeMappings);
+        this.projectRouting = projectRouting;
     }
 
     public DatafeedConfig(StreamInput in) throws IOException {
@@ -297,6 +302,7 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
         maxEmptySearches = in.readOptionalVInt();
         indicesOptions = IndicesOptions.readIndicesOptions(in);
         runtimeMappings = in.readGenericMap();
+        projectRouting = null;
     }
 
     /**
@@ -504,6 +510,10 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
         return runtimeMappings;
     }
 
+    public String getProjectRouting() {
+        return projectRouting;
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(id);
@@ -602,6 +612,9 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
         if (runtimeMappings.isEmpty() == false) {
             builder.field(SearchSourceBuilder.RUNTIME_MAPPINGS_FIELD.getPreferredName(), runtimeMappings);
         }
+        if (projectRouting != null) {
+            builder.field(PROJECT_ROUTING.getPreferredName(), projectRouting);
+        }
         builder.endObject();
         return builder;
     }
@@ -662,7 +675,8 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
             && Objects.equals(this.delayedDataCheckConfig, that.delayedDataCheckConfig)
             && Objects.equals(this.maxEmptySearches, that.maxEmptySearches)
             && Objects.equals(this.indicesOptions, that.indicesOptions)
-            && Objects.equals(this.runtimeMappings, that.runtimeMappings);
+            && Objects.equals(this.runtimeMappings, that.runtimeMappings)
+            && Objects.equals(this.projectRouting, that.projectRouting);
     }
 
     @Override
@@ -682,7 +696,8 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
             delayedDataCheckConfig,
             maxEmptySearches,
             indicesOptions,
-            runtimeMappings
+            runtimeMappings,
+            projectRouting
         );
     }
 
@@ -756,6 +771,7 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
         private Integer maxEmptySearches;
         private IndicesOptions indicesOptions;
         private Map<String, Object> runtimeMappings = Collections.emptyMap();
+        private String projectRouting = null;
 
         public Builder() {}
 
@@ -781,6 +797,7 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
             this.maxEmptySearches = config.getMaxEmptySearches();
             this.indicesOptions = config.indicesOptions;
             this.runtimeMappings = new HashMap<>(config.runtimeMappings);
+            this.projectRouting = config.projectRouting;
         }
 
         public Builder(StreamInput in) throws IOException {
@@ -812,6 +829,7 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
                 indicesOptions = IndicesOptions.readIndicesOptions(in);
             }
             runtimeMappings = in.readGenericMap();
+            projectRouting = null;
         }
 
         @Override
@@ -869,7 +887,8 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
                 && Objects.equals(delayedDataCheckConfig, builder.delayedDataCheckConfig)
                 && Objects.equals(maxEmptySearches, builder.maxEmptySearches)
                 && Objects.equals(indicesOptions, builder.indicesOptions)
-                && Objects.equals(runtimeMappings, builder.runtimeMappings);
+                && Objects.equals(runtimeMappings, builder.runtimeMappings)
+                && Objects.equals(projectRouting, builder.projectRouting);
         }
 
         @Override
@@ -889,7 +908,8 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
                 delayedDataCheckConfig,
                 maxEmptySearches,
                 indicesOptions,
-                runtimeMappings
+                runtimeMappings,
+                projectRouting
             );
         }
 
@@ -1032,6 +1052,11 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
             return this;
         }
 
+        public Builder setProjectRouting(String projectRouting) {
+            this.projectRouting = projectRouting;
+            return this;
+        }
+
         public DatafeedConfig build() {
             ExceptionsHelper.requireNonNull(id, ID.getPreferredName());
             ExceptionsHelper.requireNonNull(jobId, JOB_ID.getPreferredName());
@@ -1065,7 +1090,8 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
                 delayedDataCheckConfig,
                 maxEmptySearches,
                 indicesOptions,
-                runtimeMappings
+                runtimeMappings,
+                projectRouting
             );
         }
 


### PR DESCRIPTION
Add `project_routing` as a field in the DatafeedConfig. Kibana (and others) can now create and update Anomaly Detection Jobs and Datafeeds with `project_routing`, unblocking work in Kibana to set the value while we work on implementing this in Elasticsearch.

----------------------------------

Verified by creating and opening an AD job, creating a new datafeed, and updating the datafeed.