### PR TITLE
Add agent_policy_id attribute to fleet-agents doc.

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/fleet-agents.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/fleet-agents.json
@@ -227,6 +227,9 @@
         "policy_id": {
           "type": "keyword"
         },
+        "agent_policy_id": {
+          "type": "keyword"
+        },
         "policy_output_permissions_hash": {
           "type": "keyword"
         },


### PR DESCRIPTION
Add the agent_policy_id attribute to the fleet-agents doc definition. This attribute differs from the existing policy_id attribute as the new agent_policy_id is used by the agent to communicate what policy its currently running whereas the existing policy_id is used to what policy it should run.