### PR TITLE
rest-api-spec: specify master_timeout default value

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/_internal.delete_desired_balance.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/_internal.delete_desired_balance.json
@@ -24,6 +24,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for connection to master node"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/_internal.delete_desired_nodes.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/_internal.delete_desired_nodes.json
@@ -24,6 +24,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for connection to master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/_internal.get_desired_balance.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/_internal.get_desired_balance.json
@@ -24,6 +24,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for connection to master node"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/_internal.prevalidate_node_removal.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/_internal.prevalidate_node_removal.json
@@ -36,6 +36,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/autoscaling.delete_autoscaling_policy.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/autoscaling.delete_autoscaling_policy.json
@@ -30,6 +30,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for processing on master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/autoscaling.get_autoscaling_capacity.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/autoscaling.get_autoscaling_capacity.json
@@ -24,6 +24,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for processing on master node"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/autoscaling.get_autoscaling_policy.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/autoscaling.get_autoscaling_policy.json
@@ -30,6 +30,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for processing on master node"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/autoscaling.put_autoscaling_policy.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/autoscaling.put_autoscaling_policy.json
@@ -33,6 +33,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for processing on master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.aliases.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.aliases.json
@@ -71,8 +71,8 @@
       },
       "master_timeout": {
         "type": "time",
-        "description": "Timeout for waiting for new cluster state in case it is blocked",
-        "default": "30s"
+        "default": "30s",
+        "description": "Timeout for waiting for new cluster state in case it is blocked"
       }
     }
   }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.allocation.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.allocation.json
@@ -62,6 +62,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "h": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.component_templates.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.component_templates.json
@@ -45,6 +45,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "h": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.indices.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.indices.json
@@ -58,6 +58,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "h": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.master.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.master.json
@@ -33,6 +33,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "h": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodeattrs.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodeattrs.json
@@ -33,6 +33,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "h": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodes.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodes.json
@@ -50,6 +50,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "h": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.pending_tasks.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.pending_tasks.json
@@ -33,6 +33,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "h": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.plugins.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.plugins.json
@@ -33,6 +33,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "h": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.repositories.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.repositories.json
@@ -34,6 +34,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "h": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segments.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segments.json
@@ -45,6 +45,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "bytes": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.shards.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.shards.json
@@ -58,6 +58,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "h": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.snapshots.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.snapshots.json
@@ -46,6 +46,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "h": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.templates.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.templates.json
@@ -45,6 +45,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "h": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.thread_pool.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.thread_pool.json
@@ -58,6 +58,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "h": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ccr.delete_auto_follow_pattern.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ccr.delete_auto_follow_pattern.json
@@ -30,6 +30,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ccr.follow.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ccr.follow.json
@@ -38,6 +38,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ccr.follow_info.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ccr.follow_info.json
@@ -30,6 +30,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ccr.get_auto_follow_pattern.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ccr.get_auto_follow_pattern.json
@@ -36,6 +36,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ccr.pause_auto_follow_pattern.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ccr.pause_auto_follow_pattern.json
@@ -30,6 +30,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ccr.pause_follow.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ccr.pause_follow.json
@@ -30,6 +30,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ccr.put_auto_follow_pattern.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ccr.put_auto_follow_pattern.json
@@ -33,6 +33,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ccr.resume_auto_follow_pattern.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ccr.resume_auto_follow_pattern.json
@@ -30,6 +30,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ccr.resume_follow.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ccr.resume_follow.json
@@ -33,6 +33,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ccr.stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ccr.stats.json
@@ -28,6 +28,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ccr.unfollow.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ccr.unfollow.json
@@ -30,6 +30,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.allocation_explain.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.allocation_explain.json
@@ -44,6 +44,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for connection to master node"
       },
       "include_yes_decisions": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.delete_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.delete_component_template.json
@@ -34,6 +34,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.delete_voting_config_exclusions.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.delete_voting_config_exclusions.json
@@ -29,8 +29,8 @@
       },
       "master_timeout": {
         "type": "time",
-        "description": "Timeout for submitting request to master",
-        "default": "30s"
+        "default": "30s",
+        "description": "Timeout for submitting request to master"
       }
     }
   }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.exists_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.exists_component_template.json
@@ -30,6 +30,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for waiting for new cluster state in case it is blocked"
       },
       "local": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_component_template.json
@@ -36,6 +36,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for waiting for new cluster state in case it is blocked"
       },
       "local": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_settings.json
@@ -28,6 +28,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for waiting for new cluster state in case it is blocked"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.health.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.health.json
@@ -62,6 +62,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.pending_tasks.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.pending_tasks.json
@@ -28,6 +28,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.post_voting_config_exclusions.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.post_voting_config_exclusions.json
@@ -37,8 +37,8 @@
       },
       "master_timeout": {
         "type": "time",
-        "description": "Timeout for submitting request to master",
-        "default": "30s"
+        "default": "30s",
+        "description": "Timeout for submitting request to master"
       }
     }
   }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_component_template.json
@@ -44,6 +44,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_settings.json
@@ -31,6 +31,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.reroute.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.reroute.json
@@ -53,6 +53,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.state.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.state.json
@@ -77,6 +77,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for waiting for new cluster state in case it is blocked"
       },
       "flat_settings": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/dangling_indices.delete_dangling_index.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/dangling_indices.delete_dangling_index.json
@@ -38,6 +38,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/dangling_indices.import_dangling_index.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/dangling_indices.import_dangling_index.json
@@ -38,6 +38,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_script.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_script.json
@@ -34,6 +34,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/enrich.delete_policy.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/enrich.delete_policy.json
@@ -30,6 +30,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for processing on master node"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/enrich.execute_policy.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/enrich.execute_policy.json
@@ -35,6 +35,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for processing on master node"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/enrich.get_policy.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/enrich.get_policy.json
@@ -36,6 +36,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for waiting for new cluster state in case it is blocked"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/enrich.put_policy.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/enrich.put_policy.json
@@ -37,6 +37,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for processing on master node"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/enrich.stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/enrich.stats.json
@@ -24,6 +24,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for waiting for new cluster state in case it is blocked"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/features.get_features.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/features.get_features.json
@@ -24,6 +24,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/features.reset_features.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/features.reset_features.json
@@ -24,6 +24,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/get_script.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/get_script.json
@@ -30,6 +30,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.delete_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.delete_lifecycle.json
@@ -30,6 +30,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.explain_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.explain_lifecycle.json
@@ -38,6 +38,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.get_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.get_lifecycle.json
@@ -36,6 +36,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.migrate_to_data_tiers.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.migrate_to_data_tiers.json
@@ -27,6 +27,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "dry_run": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.put_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.put_lifecycle.json
@@ -33,6 +33,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.start.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.start.json
@@ -24,6 +24,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.stop.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.stop.json
@@ -24,6 +24,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.add_block.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.add_block.json
@@ -38,6 +38,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       },
       "ignore_unavailable": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.clone.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.clone.json
@@ -42,6 +42,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       },
       "wait_for_active_shards": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.close.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.close.json
@@ -34,6 +34,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       },
       "ignore_unavailable": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.create.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.create.json
@@ -41,6 +41,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.create_data_stream.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.create_data_stream.json
@@ -34,6 +34,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete.json
@@ -34,6 +34,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       },
       "ignore_unavailable": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_alias.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_alias.json
@@ -54,6 +54,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_data_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_data_lifecycle.json
@@ -46,6 +46,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_data_stream.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_data_stream.json
@@ -42,6 +42,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_data_stream_options.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_data_stream_options.json
@@ -46,6 +46,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_index_template.json
@@ -34,6 +34,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_template.json
@@ -34,6 +34,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_alias.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_alias.json
@@ -66,8 +66,8 @@
       },
       "master_timeout": {
         "type": "time",
-        "description": "Timeout for waiting for new cluster state in case it is blocked",
-        "default": "30s"
+        "default": "30s",
+        "description": "Timeout for waiting for new cluster state in case it is blocked"
       }
     }
   }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_index_template.json
@@ -34,6 +34,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "local": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_template.json
@@ -34,6 +34,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for waiting for new cluster state in case it is blocked"
       },
       "local": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.explain_data_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.explain_data_lifecycle.json
@@ -34,6 +34,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get.json
@@ -73,6 +73,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_alias.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_alias.json
@@ -84,8 +84,8 @@
       },
       "master_timeout": {
         "type": "time",
-        "description": "Timeout for waiting for new cluster state in case it is blocked",
-        "default": "30s"
+        "default": "30s",
+        "description": "Timeout for waiting for new cluster state in case it is blocked"
       }
     }
   }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_lifecycle.json
@@ -46,6 +46,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_stream.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_stream.json
@@ -52,6 +52,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       },
       "verbose": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_stream_mappings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_stream_mappings.json
@@ -30,6 +30,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Period to wait for a connection to the master node"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_stream_options.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_stream_options.json
@@ -42,6 +42,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_stream_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_stream_settings.json
@@ -30,6 +30,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Period to wait for a connection to the master node"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_index_template.json
@@ -40,6 +40,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for waiting for new cluster state in case it is blocked"
       },
       "local": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_mapping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_mapping.json
@@ -56,6 +56,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for waiting for new cluster state in case it is blocked"
       },
       "local": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_settings.json
@@ -64,6 +64,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       },
       "ignore_unavailable": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_template.json
@@ -40,6 +40,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for waiting for new cluster state in case it is blocked"
       },
       "local": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.migrate_to_data_stream.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.migrate_to_data_stream.json
@@ -34,6 +34,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.open.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.open.json
@@ -34,6 +34,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       },
       "ignore_unavailable": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.promote_data_stream.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.promote_data_stream.json
@@ -30,6 +30,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_alias.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_alias.json
@@ -59,6 +59,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_data_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_data_lifecycle.json
@@ -49,6 +49,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_data_stream_mappings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_data_stream_mappings.json
@@ -39,6 +39,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Period to wait for a connection to the master node"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_data_stream_options.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_data_stream_options.json
@@ -49,6 +49,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_data_stream_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_data_stream_settings.json
@@ -39,6 +39,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Period to wait for a connection to the master node"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_index_template.json
@@ -44,6 +44,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_mapping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_mapping.json
@@ -38,6 +38,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       },
       "ignore_unavailable": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_settings.json
@@ -39,6 +39,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_template.json
@@ -48,6 +48,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.remove_block.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.remove_block.json
@@ -38,6 +38,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       },
       "ignore_unavailable": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.rollover.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.rollover.json
@@ -57,6 +57,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       },
       "wait_for_active_shards": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.shrink.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.shrink.json
@@ -42,6 +42,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       },
       "wait_for_active_shards": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.simulate_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.simulate_index_template.json
@@ -43,6 +43,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       },
       "include_defaults": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.simulate_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.simulate_template.json
@@ -49,6 +49,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       },
       "include_defaults": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.split.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.split.json
@@ -42,6 +42,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       },
       "wait_for_active_shards": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.update_aliases.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.update_aliases.json
@@ -31,6 +31,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.delete_geoip_database.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.delete_geoip_database.json
@@ -30,6 +30,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.delete_ip_location_database.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.delete_ip_location_database.json
@@ -30,6 +30,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.delete_pipeline.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.delete_pipeline.json
@@ -30,6 +30,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.get_pipeline.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.get_pipeline.json
@@ -40,6 +40,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_geoip_database.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_geoip_database.json
@@ -33,6 +33,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_ip_location_database.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_ip_location_database.json
@@ -33,6 +33,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_pipeline.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_pipeline.json
@@ -37,6 +37,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/license.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/license.delete.json
@@ -24,6 +24,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for processing on master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/license.post.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/license.post.json
@@ -32,6 +32,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for processing on master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/license.post_start_basic.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/license.post_start_basic.json
@@ -28,6 +28,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for processing on master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/license.post_start_trial.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/license.post_start_trial.json
@@ -32,6 +32,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for processing on master node"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_memory_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_memory_stats.json
@@ -36,6 +36,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/profiling.status.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/profiling.status.json
@@ -24,6 +24,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/put_script.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/put_script.json
@@ -55,6 +55,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       },
       "context": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_shards.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_shards.json
@@ -70,6 +70,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/searchable_snapshots.mount.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/searchable_snapshots.mount.json
@@ -37,6 +37,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "wait_for_completion": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.get_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.get_settings.json
@@ -27,6 +27,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for connection to master"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.update_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.update_settings.json
@@ -27,6 +27,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for connection to master"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/shutdown.delete_node.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/shutdown.delete_node.json
@@ -33,6 +33,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/shutdown.get_node.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/shutdown.get_node.json
@@ -40,6 +40,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for processing on master node"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/shutdown.put_node.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/shutdown.put_node.json
@@ -33,6 +33,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/slm.delete_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/slm.delete_lifecycle.json
@@ -30,6 +30,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/slm.execute_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/slm.execute_lifecycle.json
@@ -30,6 +30,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/slm.execute_retention.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/slm.execute_retention.json
@@ -24,6 +24,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/slm.get_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/slm.get_lifecycle.json
@@ -36,6 +36,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/slm.get_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/slm.get_stats.json
@@ -24,6 +24,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/slm.get_status.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/slm.get_status.json
@@ -24,6 +24,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/slm.put_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/slm.put_lifecycle.json
@@ -33,6 +33,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/slm.start.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/slm.start.json
@@ -24,6 +24,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for processing on master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/slm.stop.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/slm.stop.json
@@ -24,6 +24,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for processing on master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.cleanup_repository.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.cleanup_repository.json
@@ -30,6 +30,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.clone.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.clone.json
@@ -41,6 +41,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.create.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.create.json
@@ -38,6 +38,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "wait_for_completion": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.create_repository.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.create_repository.json
@@ -34,6 +34,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.delete.json
@@ -34,6 +34,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "wait_for_completion": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.delete_repository.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.delete_repository.json
@@ -30,6 +30,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.get.json
@@ -34,6 +34,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "ignore_unavailable": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.get_repository.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.get_repository.json
@@ -36,6 +36,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "local": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.restore.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.restore.json
@@ -37,6 +37,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "wait_for_completion": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.status.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.status.json
@@ -52,6 +52,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "ignore_unavailable": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.verify_repository.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.verify_repository.json
@@ -30,6 +30,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout for connection to master node"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/streams.logs_disable.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/streams.logs_disable.json
@@ -30,6 +30,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error."
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/streams.logs_enable.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/streams.logs_enable.json
@@ -30,6 +30,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error."
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/watcher.get_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/watcher.get_settings.json
@@ -27,6 +27,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/watcher.start.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/watcher.start.json
@@ -24,6 +24,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/watcher.stop.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/watcher.stop.json
@@ -24,6 +24,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/watcher.update_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/watcher.update_settings.json
@@ -31,6 +31,7 @@
       },
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for connection to master"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/xpack.usage.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/xpack.usage.json
@@ -24,6 +24,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for watch write operation"
       }
     }


### PR DESCRIPTION
When generating rest-api-spec from the Elasticsearch specification, I noticed many missing default values. This was automated using this Python script:

```python
import json
import os

for path in os.listdir("api"):
    if path == "_common.json":
        continue
    api_name = path.removesuffix(".json")
    print(api_name)
    with open(f"api/{path}") as f:
        d = json.load(f)

    for name, data in d[api_name].get("params", {}).items():
        if name == "master_timeout":
            desc = data.pop("description")
            data["default"] = "30s"
            if desc:
                # make sure description comes after default
                data["description"] = desc

    with open(f"api/{path}", "w") as f:
        d = json.dump(d, f, indent=2)
        print("", file=f)  # end with an empty line
```