### PR TITLE
rest-api-spec: specify default value for format in cat APIs

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.aliases.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.aliases.json
@@ -37,7 +37,7 @@
     "params": {
       "format": {
         "type": "string",
-        "default": "local",
+        "default": "text",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "h": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.aliases.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.aliases.json
@@ -37,6 +37,7 @@
     "params": {
       "format": {
         "type": "string",
+        "default": "local",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "h": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.allocation.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.allocation.json
@@ -37,7 +37,7 @@
     "params": {
       "format": {
         "type": "string",
-        "default": "local",
+        "default": "text",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "bytes": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.allocation.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.allocation.json
@@ -37,6 +37,7 @@
     "params": {
       "format": {
         "type": "string",
+        "default": "local",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "bytes": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.component_templates.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.component_templates.json
@@ -37,7 +37,7 @@
     "params": {
       "format": {
         "type": "string",
-        "default": "local",
+        "default": "text",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "local": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.component_templates.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.component_templates.json
@@ -37,6 +37,7 @@
     "params": {
       "format": {
         "type": "string",
+        "default": "local",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "local": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.count.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.count.json
@@ -37,7 +37,7 @@
     "params": {
       "format": {
         "type": "string",
-        "default": "local",
+        "default": "text",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "h": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.count.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.count.json
@@ -37,6 +37,7 @@
     "params": {
       "format": {
         "type": "string",
+        "default": "local",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "h": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.fielddata.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.fielddata.json
@@ -37,7 +37,7 @@
     "params": {
       "format": {
         "type": "string",
-        "default": "local",
+        "default": "text",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "bytes": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.fielddata.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.fielddata.json
@@ -37,6 +37,7 @@
     "params": {
       "format": {
         "type": "string",
+        "default": "local",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "bytes": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.health.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.health.json
@@ -25,6 +25,7 @@
     "params": {
       "format": {
         "type": "string",
+        "default": "local",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "h": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.health.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.health.json
@@ -25,7 +25,7 @@
     "params": {
       "format": {
         "type": "string",
-        "default": "local",
+        "default": "text",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "h": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.indices.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.indices.json
@@ -37,7 +37,7 @@
     "params": {
       "format": {
         "type": "string",
-        "default": "local",
+        "default": "text",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "bytes": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.indices.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.indices.json
@@ -37,6 +37,7 @@
     "params": {
       "format": {
         "type": "string",
+        "default": "local",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "bytes": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.master.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.master.json
@@ -25,7 +25,7 @@
     "params": {
       "format": {
         "type": "string",
-        "default": "local",
+        "default": "text",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "local": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.master.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.master.json
@@ -25,6 +25,7 @@
     "params": {
       "format": {
         "type": "string",
+        "default": "local",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "local": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_data_frame_analytics.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_data_frame_analytics.json
@@ -59,7 +59,7 @@
       },
       "format": {
         "type": "string",
-        "default": "local",
+        "default": "text",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "h": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_data_frame_analytics.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_data_frame_analytics.json
@@ -59,6 +59,7 @@
       },
       "format": {
         "type": "string",
+        "default": "local",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "h": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_datafeeds.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_datafeeds.json
@@ -42,7 +42,7 @@
       },
       "format": {
         "type": "string",
-        "default": "local",
+        "default": "text",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "h": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_datafeeds.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_datafeeds.json
@@ -42,6 +42,7 @@
       },
       "format": {
         "type": "string",
+        "default": "local",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "h": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_jobs.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_jobs.json
@@ -59,7 +59,7 @@
       },
       "format": {
         "type": "string",
-        "default": "local",
+        "default": "text",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "h": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_jobs.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_jobs.json
@@ -59,6 +59,7 @@
       },
       "format": {
         "type": "string",
+        "default": "local",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "h": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_trained_models.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_trained_models.json
@@ -70,6 +70,7 @@
       },
       "format": {
         "type": "string",
+        "default": "local",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "h": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_trained_models.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_trained_models.json
@@ -70,7 +70,7 @@
       },
       "format": {
         "type": "string",
-        "default": "local",
+        "default": "text",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "h": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodeattrs.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodeattrs.json
@@ -25,7 +25,7 @@
     "params": {
       "format": {
         "type": "string",
-        "default": "local",
+        "default": "text",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "local": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodeattrs.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodeattrs.json
@@ -25,6 +25,7 @@
     "params": {
       "format": {
         "type": "string",
+        "default": "local",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "local": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodes.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodes.json
@@ -42,6 +42,7 @@
       },
       "format": {
         "type": "string",
+        "default": "local",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "full_id": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodes.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodes.json
@@ -42,7 +42,7 @@
       },
       "format": {
         "type": "string",
-        "default": "local",
+        "default": "text",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "full_id": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.pending_tasks.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.pending_tasks.json
@@ -25,7 +25,7 @@
     "params": {
       "format": {
         "type": "string",
-        "default": "local",
+        "default": "text",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "local": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.pending_tasks.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.pending_tasks.json
@@ -25,6 +25,7 @@
     "params": {
       "format": {
         "type": "string",
+        "default": "local",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "local": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.plugins.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.plugins.json
@@ -25,7 +25,7 @@
     "params": {
       "format": {
         "type": "string",
-        "default": "local",
+        "default": "text",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "local": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.plugins.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.plugins.json
@@ -25,6 +25,7 @@
     "params": {
       "format": {
         "type": "string",
+        "default": "local",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "local": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.recovery.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.recovery.json
@@ -37,6 +37,7 @@
     "params": {
       "format": {
         "type": "string",
+        "default": "local",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "active_only": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.recovery.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.recovery.json
@@ -37,7 +37,7 @@
     "params": {
       "format": {
         "type": "string",
-        "default": "local",
+        "default": "text",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "active_only": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.repositories.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.repositories.json
@@ -25,7 +25,7 @@
     "params": {
       "format": {
         "type": "string",
-        "default": "local",
+        "default": "text",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "local": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.repositories.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.repositories.json
@@ -25,6 +25,7 @@
     "params": {
       "format": {
         "type": "string",
+        "default": "local",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "local": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segments.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segments.json
@@ -37,7 +37,7 @@
     "params": {
       "format": {
         "type": "string",
-        "default": "local",
+        "default": "text",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "local": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segments.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segments.json
@@ -37,6 +37,7 @@
     "params": {
       "format": {
         "type": "string",
+        "default": "local",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "local": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.shards.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.shards.json
@@ -37,7 +37,7 @@
     "params": {
       "format": {
         "type": "string",
-        "default": "local",
+        "default": "text",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "bytes": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.shards.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.shards.json
@@ -37,6 +37,7 @@
     "params": {
       "format": {
         "type": "string",
+        "default": "local",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "bytes": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.snapshots.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.snapshots.json
@@ -37,7 +37,7 @@
     "params": {
       "format": {
         "type": "string",
-        "default": "local",
+        "default": "text",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "ignore_unavailable": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.snapshots.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.snapshots.json
@@ -37,6 +37,7 @@
     "params": {
       "format": {
         "type": "string",
+        "default": "local",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "ignore_unavailable": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.tasks.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.tasks.json
@@ -25,7 +25,7 @@
     "params": {
       "format": {
         "type": "string",
-        "default": "local",
+        "default": "text",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "nodes": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.tasks.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.tasks.json
@@ -25,6 +25,7 @@
     "params": {
       "format": {
         "type": "string",
+        "default": "local",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "nodes": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.templates.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.templates.json
@@ -37,7 +37,7 @@
     "params": {
       "format": {
         "type": "string",
-        "default": "local",
+        "default": "text",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "local": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.templates.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.templates.json
@@ -37,6 +37,7 @@
     "params": {
       "format": {
         "type": "string",
+        "default": "local",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "local": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.thread_pool.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.thread_pool.json
@@ -37,7 +37,7 @@
     "params": {
       "format": {
         "type": "string",
-        "default": "local",
+        "default": "text",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "time": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.thread_pool.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.thread_pool.json
@@ -37,6 +37,7 @@
     "params": {
       "format": {
         "type": "string",
+        "default": "local",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "time": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.transforms.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.transforms.json
@@ -52,7 +52,7 @@
       },
       "format": {
         "type": "string",
-        "default": "local",
+        "default": "text",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "h": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.transforms.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.transforms.json
@@ -52,6 +52,7 @@
       },
       "format": {
         "type": "string",
+        "default": "local",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
       "h": {


### PR DESCRIPTION
When generating rest-api-spec from the Elasticsearch specification, I noticed many missing default values for the `local` parameter in cat APIs. This was automated using this Python script:

```python
import json
import os

for path in os.listdir("api"):
    if path == "_common.json":
        continue
    api_name = path.removesuffix(".json")
    print(api_name)
    with open(f"api/{path}") as f:
        d = json.load(f)

    for name, data in d[api_name].get("params", {}).items():
        if api_name.startswith("cat.") and name == "format":
            desc = data.pop("description")
            data["default"] = "local"
            if desc:
                # make sure description comes after default
                data["description"] = desc

    with open(f"api/{path}", "w") as f:
        d = json.dump(d, f, indent=2)
        print("", file=f)  # end with an empty line

```