### PR TITLE
Set lower bound on DLM retention in tests

### DIFF
--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
@@ -1394,7 +1394,7 @@ public class DataStreamIT extends ESIntegTestCase {
     public void testGetDataStream() throws Exception {
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, maximumNumberOfReplicas() + 2).build();
         DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.dataLifecycleBuilder()
-            .dataRetention(randomTimeValueOfAtLeast(TimeValue.timeValueSeconds(10)))
+            .dataRetention(randomTimeValueGreaterThan(TimeValue.timeValueSeconds(10)))
             .buildTemplate();
         putComposableIndexTemplate("template_for_foo", null, List.of("metrics-foo*"), settings, null, null, lifecycle, false);
         int numDocsFoo = randomIntBetween(2, 16);

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
@@ -87,6 +87,7 @@ import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.mapper.DataStreamTimestampFieldMapper;
@@ -1393,7 +1394,7 @@ public class DataStreamIT extends ESIntegTestCase {
     public void testGetDataStream() throws Exception {
         Settings settings = Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, maximumNumberOfReplicas() + 2).build();
         DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.dataLifecycleBuilder()
-            .dataRetention(randomPositiveTimeValue())
+            .dataRetention(randomTimeValueOfAtLeast(TimeValue.timeValueSeconds(10)))
             .buildTemplate();
         putComposableIndexTemplate("template_for_foo", null, List.of("metrics-foo*"), settings, null, null, lifecycle, false);
         int numDocsFoo = randomIntBetween(2, 16);

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/CrudDataStreamLifecycleIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/CrudDataStreamLifecycleIT.java
@@ -227,7 +227,7 @@ public class CrudDataStreamLifecycleIT extends ESIntegTestCase {
 
     public void testDeleteLifecycle() throws Exception {
         DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.dataLifecycleBuilder()
-            .dataRetention(randomTimeValueOfAtLeast(TimeValue.timeValueSeconds(10)))
+            .dataRetention(randomTimeValueGreaterThan(TimeValue.timeValueSeconds(10)))
             .buildTemplate();
         putComposableIndexTemplate("id1", null, List.of("with-lifecycle*"), null, null, lifecycle);
         putComposableIndexTemplate("id2", null, List.of("without-lifecycle*"), null, null, null);

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/CrudDataStreamLifecycleIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/CrudDataStreamLifecycleIT.java
@@ -227,7 +227,7 @@ public class CrudDataStreamLifecycleIT extends ESIntegTestCase {
 
     public void testDeleteLifecycle() throws Exception {
         DataStreamLifecycle.Template lifecycle = DataStreamLifecycle.dataLifecycleBuilder()
-            .dataRetention(randomPositiveTimeValue())
+            .dataRetention(randomTimeValueOfAtLeast(TimeValue.timeValueSeconds(10)))
             .buildTemplate();
         putComposableIndexTemplate("id1", null, List.of("with-lifecycle*"), null, null, lifecycle);
         putComposableIndexTemplate("id2", null, List.of("without-lifecycle*"), null, null, null);

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/CrudSystemDataStreamLifecycleIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/CrudSystemDataStreamLifecycleIT.java
@@ -210,7 +210,7 @@ public class CrudSystemDataStreamLifecycleIT extends ESIntegTestCase {
                                     .mappings(mappings)
                                     .lifecycle(
                                         DataStreamLifecycle.dataLifecycleBuilder()
-                                            .dataRetention(randomTimeValueOfAtLeast(TimeValue.timeValueSeconds(10)))
+                                            .dataRetention(randomTimeValueGreaterThan(TimeValue.timeValueSeconds(10)))
                                     )
                             )
                             .dataStreamTemplate(new DataStreamTemplate())

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/CrudSystemDataStreamLifecycleIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/CrudSystemDataStreamLifecycleIT.java
@@ -34,6 +34,7 @@ import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.datastreams.DataStreamsPlugin;
 import org.elasticsearch.indices.ExecutorNames;
 import org.elasticsearch.indices.SystemDataStreamDescriptor;
@@ -207,7 +208,10 @@ public class CrudSystemDataStreamLifecycleIT extends ESIntegTestCase {
                                 Template.builder()
                                     .settings(Settings.EMPTY)
                                     .mappings(mappings)
-                                    .lifecycle(DataStreamLifecycle.dataLifecycleBuilder().dataRetention(randomPositiveTimeValue()))
+                                    .lifecycle(
+                                        DataStreamLifecycle.dataLifecycleBuilder()
+                                            .dataRetention(randomTimeValueOfAtLeast(TimeValue.timeValueSeconds(10)))
+                                    )
                             )
                             .dataStreamTemplate(new DataStreamTemplate())
                             .build(),

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -1423,6 +1423,20 @@ public abstract class ESTestCase extends LuceneTestCase {
     }
 
     /**
+     * Generate a random TimeValue that is at least the provided timeValue.
+     * Chooses a random TimeUnit, adds between 0 and 1000 of that unit to {@code timeValue}, and returns a TimeValue in that unit.
+     */
+    public static TimeValue randomTimeValueOfAtLeast(TimeValue timeValue) {
+        final var randomUnit = randomFrom(TimeUnit.values());
+        long lowerBound = timeValue.getMillis();
+        // This could result in an overflow, but since this is only a test utility method, we're ok with that.
+        long upperBound = lowerBound + randomUnit.toMillis(1000);
+        final var durationMillis = randomLongBetween(lowerBound, upperBound);
+        final var duration = randomUnit.convert(durationMillis, TimeUnit.MILLISECONDS);
+        return new TimeValue(duration, randomUnit);
+    }
+
+    /**
      * generate a random epoch millis in a range 1 to 9999-12-31T23:59:59.999
      */
     public static long randomMillisUpToYear9999() {

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -1423,7 +1423,7 @@ public abstract class ESTestCase extends LuceneTestCase {
     }
 
     /**
-     * Generate a random TimeValue that is at least the provided timeValue.
+     * Generate a random TimeValue that is greater than the provided timeValue.
      * Chooses a random TimeUnit, adds between 1 and 1000 of that unit to {@code timeValue}, and returns a TimeValue in that unit.
      */
     public static TimeValue randomTimeValueGreaterThan(TimeValue lowerBound) {

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -1424,15 +1424,13 @@ public abstract class ESTestCase extends LuceneTestCase {
 
     /**
      * Generate a random TimeValue that is at least the provided timeValue.
-     * Chooses a random TimeUnit, adds between 0 and 1000 of that unit to {@code timeValue}, and returns a TimeValue in that unit.
+     * Chooses a random TimeUnit, adds between 1 and 1000 of that unit to {@code timeValue}, and returns a TimeValue in that unit.
      */
-    public static TimeValue randomTimeValueOfAtLeast(TimeValue timeValue) {
-        final var randomUnit = randomFrom(TimeUnit.values());
-        long lowerBound = timeValue.getMillis();
-        // This could result in an overflow, but since this is only a test utility method, we're ok with that.
-        long upperBound = lowerBound + randomUnit.toMillis(1000);
-        final var durationMillis = randomLongBetween(lowerBound, upperBound);
-        final var duration = randomUnit.convert(durationMillis, TimeUnit.MILLISECONDS);
+    public static TimeValue randomTimeValueGreaterThan(TimeValue lowerBound) {
+        final TimeUnit randomUnit = randomFrom(TimeUnit.values());
+        // This conversion might round down, but that's fine since we add at least 1 below, ensuring we still satisfy the "greater than".
+        final long lowerBoundDuration = randomUnit.convert(lowerBound.duration(), lowerBound.timeUnit());
+        final long duration = lowerBoundDuration + randomLongBetween(1, 1000);
         return new TimeValue(duration, randomUnit);
     }
 

--- a/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/DataStreamAndIndexLifecycleMixingTests.java
+++ b/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/DataStreamAndIndexLifecycleMixingTests.java
@@ -154,7 +154,7 @@ public class DataStreamAndIndexLifecycleMixingTests extends ESIntegTestCase {
         // note that this index template change will NOT configure a data stream lifecycle on the data stream, only for **new** data streams
         // All existing data streams will fallback to their default data stream lifecycle
         DataStreamLifecycle.Template customLifecycle = DataStreamLifecycle.dataLifecycleBuilder()
-            .dataRetention(randomTimeValueOfAtLeast(TimeValue.timeValueSeconds(10)))
+            .dataRetention(randomTimeValueGreaterThan(TimeValue.timeValueSeconds(10)))
             .buildTemplate();
         putComposableIndexTemplate(indexTemplateName, null, List.of(dataStreamName + "*"), Settings.EMPTY, null, customLifecycle);
 
@@ -480,7 +480,7 @@ public class DataStreamAndIndexLifecycleMixingTests extends ESIntegTestCase {
         // let's update the index template to configure the management preference to be data stream lifecycle using the prefer_ilm setting
         // note that this index template change will NOT affect existing indices but only the new ones after a rollover.
         DataStreamLifecycle.Template customLifecycle = DataStreamLifecycle.dataLifecycleBuilder()
-            .dataRetention(randomTimeValueOfAtLeast(TimeValue.timeValueSeconds(10)))
+            .dataRetention(randomTimeValueGreaterThan(TimeValue.timeValueSeconds(10)))
             .buildTemplate();
         putComposableIndexTemplate(
             indexTemplateName,

--- a/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/DataStreamAndIndexLifecycleMixingTests.java
+++ b/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/DataStreamAndIndexLifecycleMixingTests.java
@@ -152,18 +152,15 @@ public class DataStreamAndIndexLifecycleMixingTests extends ESIntegTestCase {
 
         // let's update the index template to remove the ILM configuration and configured data stream lifecycle
         // note that this index template change will NOT configure a data stream lifecycle on the data stream, only for **new** data streams
-
         // All existing data streams will fallback to their default data stream lifecycle
-
-        // we'll rollover the data stream by indexing 2 documents (like ILM expects) and assert that the rollover happens once so the
-        // data stream has 3 backing indices, two managed by ILM and one will be managed by the data stream lifecycle
         DataStreamLifecycle.Template customLifecycle = DataStreamLifecycle.dataLifecycleBuilder()
-            .dataRetention(randomPositiveTimeValue())
+            .dataRetention(randomTimeValueOfAtLeast(TimeValue.timeValueSeconds(10)))
             .buildTemplate();
         putComposableIndexTemplate(indexTemplateName, null, List.of(dataStreamName + "*"), Settings.EMPTY, null, customLifecycle);
 
+        // we'll rollover the data stream by indexing 2 documents (like ILM expects) and assert that the rollover happens once so the
+        // data stream has 3 backing indices, two managed by ILM and one will be managed by the data stream lifecycle
         indexDocs(dataStreamName, 2);
-
         // data stream was rolled over and has 3 indices, two managed by ILM and the write index will be unmanaged
         backingIndices = waitForDataStreamBackingIndices(dataStreamName, 3);
         String thirdGenerationIndex = backingIndices.get(2);
@@ -482,11 +479,8 @@ public class DataStreamAndIndexLifecycleMixingTests extends ESIntegTestCase {
 
         // let's update the index template to configure the management preference to be data stream lifecycle using the prefer_ilm setting
         // note that this index template change will NOT affect existing indices but only the new ones after a rollover.
-
-        // we'll rollover the data stream by indexing 2 documents (like ILM expects) and assert that the rollover happens once so the
-        // data stream has 3 backing indices, 2 managed by ILM and 1 by the default data stream lifecycle
         DataStreamLifecycle.Template customLifecycle = DataStreamLifecycle.dataLifecycleBuilder()
-            .dataRetention(randomPositiveTimeValue())
+            .dataRetention(randomTimeValueOfAtLeast(TimeValue.timeValueSeconds(10)))
             .buildTemplate();
         putComposableIndexTemplate(
             indexTemplateName,
@@ -497,8 +491,9 @@ public class DataStreamAndIndexLifecycleMixingTests extends ESIntegTestCase {
             customLifecycle
         );
 
+        // we'll rollover the data stream by indexing 2 documents (like ILM expects) and assert that the rollover happens once so the
+        // data stream has 3 backing indices, 2 managed by ILM and 1 by the default data stream lifecycle
         indexDocs(dataStreamName, 2);
-
         backingIndices = waitForDataStreamBackingIndices(dataStreamName, 3);
         String thirdGenerationIndex = backingIndices.get(2);
 


### PR DESCRIPTION
The previous randomization logic in these tests could result in a retention sufficiently short enough for the index to (unexpectedly) be deleted by DLM during the test, resulting in a failure.

Fixes #134276