### PR TITLE
rest-api-spec: improve mode documentation in indices.resolve_index

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.resolve_index.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.resolve_index.json
@@ -51,8 +51,10 @@
         "default": true
       },
       "mode": {
-        "type": "string",
-        "description": "Filter indices by index mode"
+        "type": "enum",
+        "options": ["standard", "time_series", "logsdb", "lookup"],
+        "default": "",
+        "description": "Filter indices by index mode. Comma-separated list of IndexMode. Empty means no filter."
       }
     }
   }


### PR DESCRIPTION
This is a follow-up of https://github.com/elastic/elasticsearch/pull/133616.