### PR TITLE
[8.18] Add alternate location for upper bounds in serverless (#134418)

### DIFF
--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/VersionPropertiesBuildService.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/VersionPropertiesBuildService.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 import java.util.Properties;
 import javax.inject.Inject;
 
-abstract class VersionPropertiesBuildService implements BuildService<VersionPropertiesBuildService.Params>, AutoCloseable {
+public abstract class VersionPropertiesBuildService implements BuildService<VersionPropertiesBuildService.Params>, AutoCloseable {
 
     private final Properties properties;
 

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/TransportVersionGenerationFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/TransportVersionGenerationFuncTest.groovy
@@ -443,4 +443,46 @@ class TransportVersionGenerationFuncTest extends AbstractTransportVersionFuncTes
         assertUpperBound("9.2", "new_tv,8124000")
         assertReferableDefinition("new_tv", "8124000")
     }
+
+    def "alternate upper bound larger"() {
+        given:
+        referencedTransportVersion("new_tv")
+        file("myserver/alt_upper_bound.csv").text = "some_tv,8126000"
+        file("myserver/build.gradle") << """
+            tasks.named('generateTransportVersionDefinition') {
+                alternateUpperBoundFile = project.file("alt_upper_bound.csv")
+            }
+            tasks.named('validateTransportVersionResources') {
+                shouldValidateDensity = false
+            }
+        """
+
+        when:
+        def result = runGenerateAndValidateTask().build()
+        then:
+        assertGenerateAndValidateSuccess(result)
+        assertUpperBound("9.2", "new_tv,8127000")
+        assertReferableDefinition("new_tv", "8127000")
+    }
+
+    def "alternate upper bound less"() {
+        given:
+        referencedTransportVersion("new_tv")
+        file("myserver/alt_upper_bound.csv").text = "some_tv,8122100"
+        file("myserver/build.gradle") << """
+            tasks.named('generateTransportVersionDefinition') {
+                alternateUpperBoundFile = project.file("alt_upper_bound.csv")
+            }
+            tasks.named('validateTransportVersionResources') {
+                shouldValidateDensity = false
+            }
+        """
+
+        when:
+        def result = runGenerateAndValidateTask().build()
+        then:
+        assertGenerateAndValidateSuccess(result)
+        assertUpperBound("9.2", "new_tv,8124000")
+        assertReferableDefinition("new_tv", "8124000")
+    }
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/GenerateTransportVersionDefinitionTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/GenerateTransportVersionDefinitionTask.java
@@ -11,9 +11,11 @@ package org.elasticsearch.gradle.internal.transport;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.services.ServiceReference;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
@@ -22,6 +24,9 @@ import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -74,6 +79,14 @@ public abstract class GenerateTransportVersionDefinitionTask extends DefaultTask
     @Input
     public abstract Property<String> getCurrentUpperBoundName();
 
+    /**
+     * An additional upper bound file that will be consulted when generating a transport version.
+     * The larger of this and the current upper bound will be used to create the new primary id.
+     */
+    @InputFile
+    @Optional
+    public abstract RegularFileProperty getAlternateUpperBoundFile();
+
     @TaskAction
     public void run() throws IOException {
         TransportVersionResourcesService resources = getResourceService().get();
@@ -119,7 +132,7 @@ public abstract class GenerateTransportVersionDefinitionTask extends DefaultTask
                 if (targetId == null) {
                     // Case: an id doesn't yet exist for this upper bound, so create one
                     int targetIncrement = upperBoundName.equals(currentUpperBoundName) ? increment : 1;
-                    targetId = TransportVersionId.fromInt(existingUpperBound.definitionId().complete() + targetIncrement);
+                    targetId = createTargetId(existingUpperBound, targetIncrement);
                     var newUpperBound = new TransportVersionUpperBound(upperBoundName, definitionName, targetId);
                     resources.writeUpperBound(newUpperBound);
                 }
@@ -235,6 +248,23 @@ public abstract class GenerateTransportVersionDefinitionTask extends DefaultTask
             }
         }
         return null; // no existing id for this upper bound
+    }
+
+    private TransportVersionId createTargetId(TransportVersionUpperBound existingUpperBound, int increment) throws IOException {
+        int currentId = existingUpperBound.definitionId().complete();
+
+        // allow for an alternate upper bound file to be consulted. This supports Serverless basing its
+        // own transport version ids on the greater of server or serverless
+        if (getAlternateUpperBoundFile().isPresent()) {
+            Path altUpperBoundPath = getAlternateUpperBoundFile().get().getAsFile().toPath();
+            String contents = Files.readString(altUpperBoundPath, StandardCharsets.UTF_8);
+            var altUpperBound = TransportVersionUpperBound.fromString(altUpperBoundPath, contents);
+            if (altUpperBound.definitionId().complete() > currentId) {
+                currentId = altUpperBound.definitionId().complete();
+            }
+        }
+
+        return TransportVersionId.fromInt(currentId + increment);
     }
 
 }


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Add alternate location for upper bounds in serverless (#134418)