### PR TITLE
[8.19] Improve missing tranport version error message (#134506)

### DIFF
--- a/server/src/test/java/org/elasticsearch/TransportVersionTests.java
+++ b/server/src/test/java/org/elasticsearch/TransportVersionTests.java
@@ -438,4 +438,25 @@ public class TransportVersionTests extends ESTestCase {
         );
         assertThat(new TransportVersion(null, 1000000, null).supports(test3), is(true));
     }
+
+    public void testMoreLikeThis() {
+        IllegalStateException ise = expectThrows(IllegalStateException.class, () -> TransportVersion.fromName("to_child_lock_join_query"));
+        assertThat(
+            ise.getMessage(),
+            is(
+                "Unknown transport version [to_child_lock_join_query]. "
+                    + "Did you mean [to_child_block_join_query]? "
+                    + "If this is a new transport version, run './gradle generateTransportVersion'."
+            )
+        );
+
+        ise = expectThrows(IllegalStateException.class, () -> TransportVersion.fromName("brand_new_version_unrelated_to_others"));
+        assertThat(
+            ise.getMessage(),
+            is(
+                "Unknown transport version [brand_new_version_unrelated_to_others]. "
+                    + "If this is a new transport version, run './gradle generateTransportVersion'."
+            )
+        );
+    }
 }

--- a/server/src/test/java/org/elasticsearch/TransportVersionTests.java
+++ b/server/src/test/java/org/elasticsearch/TransportVersionTests.java
@@ -440,12 +440,12 @@ public class TransportVersionTests extends ESTestCase {
     }
 
     public void testMoreLikeThis() {
-        IllegalStateException ise = expectThrows(IllegalStateException.class, () -> TransportVersion.fromName("to_child_lock_join_query"));
+        IllegalStateException ise = expectThrows(IllegalStateException.class, () -> TransportVersion.fromName("esql_ixed_index_like"));
         assertThat(
             ise.getMessage(),
             is(
-                "Unknown transport version [to_child_lock_join_query]. "
-                    + "Did you mean [to_child_block_join_query]? "
+                "Unknown transport version [esql_ixed_index_like]. "
+                    + "Did you mean [esql_fixed_index_like]? "
                     + "If this is a new transport version, run './gradle generateTransportVersion'."
             )
         );


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Improve missing tranport version error message (#134506)