### PR TITLE
Expand retriever telemetry to support metadata under each retriever 

### DIFF
--- a/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/AbstractRollingUpgradeWithSecurityTestCase.java
+++ b/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/AbstractRollingUpgradeWithSecurityTestCase.java
@@ -35,6 +35,7 @@ public abstract class AbstractRollingUpgradeWithSecurityTestCase extends Paramet
     private static final ElasticsearchCluster cluster = buildCluster();
 
     private static ElasticsearchCluster buildCluster() {
+
         // Note we need to use OLD_CLUSTER_VERSION directly here, as it may contain special values (e.g. 0.0.0) the ElasticsearchCluster
         // builder uses to lookup a particular distribution
         var cluster = ElasticsearchCluster.local()

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -333,6 +333,7 @@ public class TransportVersions {
     public static final TransportVersion TIME_SERIES_TELEMETRY = def(9_155_0_00);
     public static final TransportVersion INFERENCE_API_EIS_DIAGNOSTICS = def(9_156_0_00);
     public static final TransportVersion ML_INFERENCE_ENDPOINT_CACHE = def(9_157_0_00);
+    public static final TransportVersion RETRIEVERS_TELEMETRY_EXTENDED = def(9_158_0_00);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/SearchUsageStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/SearchUsageStats.java
@@ -36,7 +36,7 @@ public final class SearchUsageStats implements Writeable, ToXContentFragment {
     private final Map<String, Long> queries;
     private final Map<String, Long> rescorers;
     private final Map<String, Long> sections;
-    private final Map<String, Map<String,Long>> retrievers;
+    private final Map<String, Map<String, Long>> retrievers;
 
     /**
      * Creates a new empty stats instance, that will get additional stats added through {@link #add(SearchUsageStats)}
@@ -57,7 +57,7 @@ public final class SearchUsageStats implements Writeable, ToXContentFragment {
         Map<String, Long> queries,
         Map<String, Long> rescorers,
         Map<String, Long> sections,
-        Map<String, Map<String,Long>> retrievers,
+        Map<String, Map<String, Long>> retrievers,
         long totalSearchCount
     ) {
         this.totalSearchCount = totalSearchCount;
@@ -81,9 +81,9 @@ public final class SearchUsageStats implements Writeable, ToXContentFragment {
                     throw new RuntimeException(e);
                 }
             });
-        } else if (in.getTransportVersion().onOrAfter(V_8_16_0) ) {
-            Map<String,Long> retrieverMap = in.readMap(StreamInput::readLong);
-            Map<String, Map<String,Long>> retrieversWithMetadata = new HashMap<>();
+        } else if (in.getTransportVersion().onOrAfter(V_8_16_0)) {
+            Map<String, Long> retrieverMap = in.readMap(StreamInput::readLong);
+            Map<String, Map<String, Long>> retrieversWithMetadata = new HashMap<>();
             for (Map.Entry<String, Long> entry : retrieverMap.entrySet()) {
                 retrieversWithMetadata.put(entry.getKey(), Map.of("count", entry.getValue()));
             }
@@ -103,7 +103,7 @@ public final class SearchUsageStats implements Writeable, ToXContentFragment {
             out.writeMap(rescorers, StreamOutput::writeLong);
         }
         if (out.getTransportVersion().onOrAfter(RETRIEVERS_TELEMETRY_EXTENDED)) {
-            out.writeMap(retrievers, (StreamOutput s, Map<String,Long> m) -> {
+            out.writeMap(retrievers, (StreamOutput s, Map<String, Long> m) -> {
                 try {
                     s.writeMap(m, StreamOutput::writeLong);
                 } catch (IOException e) {
@@ -166,7 +166,7 @@ public final class SearchUsageStats implements Writeable, ToXContentFragment {
         return Collections.unmodifiableMap(sections);
     }
 
-    public Map<String, Map<String,Long>> getRetrieversUsage() {
+    public Map<String, Map<String, Long>> getRetrieversUsage() {
         return Collections.unmodifiableMap(retrievers);
     }
 

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterStatsAction.java
@@ -34,7 +34,8 @@ public class RestClusterStatsAction extends BaseRestHandler {
         "verbose-dense-vector-mapping-stats",
         "ccs-stats",
         "retrievers-usage-stats",
-        "esql-stats"
+        "esql-stats",
+        "metadata_stats"
     );
     private static final Set<String> SUPPORTED_QUERY_PARAMETERS = Set.of("include_remotes", "nodeId", REST_TIMEOUT_PARAM);
 

--- a/server/src/main/java/org/elasticsearch/rest/action/search/SearchCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/SearchCapabilities.java
@@ -59,6 +59,7 @@ public final class SearchCapabilities {
     private static final String KNN_FILTER_ON_NESTED_FIELDS_CAPABILITY = "knn_filter_on_nested_fields";
     private static final String BUCKET_SCRIPT_PARENT_MULTI_BUCKET_ERROR = "bucket_script_parent_multi_bucket_error";
     private static final String EXCLUDE_SOURCE_VECTORS_SETTING = "exclude_source_vectors_setting";
+    private static final String CLUSTER_STATS_METADATA = "metadata_stats";
 
     public static final Set<String> CAPABILITIES;
     static {
@@ -88,6 +89,7 @@ public final class SearchCapabilities {
         capabilities.add(KNN_FILTER_ON_NESTED_FIELDS_CAPABILITY);
         capabilities.add(BUCKET_SCRIPT_PARENT_MULTI_BUCKET_ERROR);
         capabilities.add(EXCLUDE_SOURCE_VECTORS_SETTING);
+        capabilities.add(CLUSTER_STATS_METADATA);
         CAPABILITIES = Set.copyOf(capabilities);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -129,6 +129,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
     public static final ParseField POINT_IN_TIME = new ParseField("pit");
     public static final ParseField RUNTIME_MAPPINGS_FIELD = new ParseField("runtime_mappings");
     public static final ParseField RETRIEVER = new ParseField("retriever");
+    public static final ParseField METADATA = new ParseField("metadata");
 
     private static final boolean RANK_SUPPORTED = Booleans.parseBoolean(System.getProperty("es.search.rank_supported"), true);
 
@@ -1440,6 +1441,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
                         new RetrieverParserContext(searchUsage, clusterSupportsFeature)
                     );
                     searchUsage.trackSectionUsage(RETRIEVER.getPreferredName());
+                    searchUsage.trackSectionUsage(METADATA.getPreferredName());
                 } else if (QUERY_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     if (subSearchSourceBuilders.isEmpty() == false) {
                         throw new IllegalArgumentException(

--- a/server/src/main/java/org/elasticsearch/search/retriever/RetrieverBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/RetrieverBuilder.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * A retriever represents an API element that returns an ordered list of top
@@ -132,7 +133,7 @@ public abstract class RetrieverBuilder implements Rewriteable<RetrieverBuilder>,
             throw new ParsingException(new XContentLocation(nonfe.getLineNumber(), nonfe.getColumnNumber()), message, nonfe);
         }
 
-        context.trackRetrieverUsage(retrieverName);
+        context.trackRetrieverUsage(retrieverName, retrieverBuilder.getMetadataFields());
 
         if (parser.currentToken() != XContentParser.Token.END_OBJECT) {
             throw new ParsingException(
@@ -241,6 +242,10 @@ public abstract class RetrieverBuilder implements Rewriteable<RetrieverBuilder>,
         boolean allowPartialSearchResults
     ) {
         return validationException;
+    }
+
+    public Set<String> getMetadataFields() {
+        return Set.of();
     }
 
     // ---- FOR TESTING XCONTENT PARSING ----

--- a/server/src/main/java/org/elasticsearch/search/retriever/RetrieverParserContext.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/RetrieverParserContext.java
@@ -12,7 +12,9 @@ package org.elasticsearch.search.retriever;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.usage.SearchUsage;
 
+import java.util.Collections;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Predicate;
 
 public class RetrieverParserContext {
@@ -37,8 +39,12 @@ public class RetrieverParserContext {
         searchUsage.trackRescorerUsage(name);
     }
 
+    public void trackRetrieverUsage(String name, Set<String> metadata) {
+        searchUsage.trackRetrieverUsage(name, metadata);
+    }
+
     public void trackRetrieverUsage(String name) {
-        searchUsage.trackRetrieverUsage(name);
+        searchUsage.trackRetrieverUsage(name, Set.of());
     }
 
     public boolean clusterSupportsFeature(NodeFeature nodeFeature) {

--- a/server/src/main/java/org/elasticsearch/search/retriever/RetrieverParserContext.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/RetrieverParserContext.java
@@ -12,7 +12,6 @@ package org.elasticsearch.search.retriever;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.usage.SearchUsage;
 
-import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;

--- a/server/src/main/java/org/elasticsearch/usage/SearchUsage.java
+++ b/server/src/main/java/org/elasticsearch/usage/SearchUsage.java
@@ -10,7 +10,9 @@
 package org.elasticsearch.usage;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -20,7 +22,7 @@ public final class SearchUsage {
     private final Set<String> queries = new HashSet<>();
     private final Set<String> rescorers = new HashSet<>();
     private final Set<String> sections = new HashSet<>();
-    private final Set<String> retrievers = new HashSet<>();
+    private final Map<String, Set<String>> retrievers = new HashMap<>();
     private final Set<String> metadata = new HashSet<>();
 
     /**
@@ -48,12 +50,13 @@ public final class SearchUsage {
      * Track retriever usage
      */
     public void trackRetrieverUsage(String retriever, Set<String> metadata) {
-        trackRetrieverUsage(retriever);
+        retrievers.computeIfAbsent(retriever, k -> new HashSet<>()).addAll(metadata);
+        retrievers.get(retriever).add("count");
         metadata(metadata);
     }
 
     private void trackRetrieverUsage(String retriever) {
-        retrievers.add(retriever);
+        retrievers.computeIfAbsent(retriever, k -> new HashSet<>()).add("count");
     }
 
     private void metadata(Set<String> metadata) {
@@ -82,10 +85,10 @@ public final class SearchUsage {
     }
 
     /**
-     * Returns the retriever names that have been used at least once in the tracked search request
+     * Returns the retriever metadata map
      */
-    public Set<String> getRetrieverUsage() {
-        return Collections.unmodifiableSet(retrievers);
+    public Map<String, Set<String>> getRetrieverUsage() {
+        return Collections.unmodifiableMap(retrievers);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/usage/SearchUsage.java
+++ b/server/src/main/java/org/elasticsearch/usage/SearchUsage.java
@@ -21,6 +21,7 @@ public final class SearchUsage {
     private final Set<String> rescorers = new HashSet<>();
     private final Set<String> sections = new HashSet<>();
     private final Set<String> retrievers = new HashSet<>();
+    private final Set<String> metadata = new HashSet<>();
 
     /**
      * Track the usage of the provided query
@@ -44,10 +45,19 @@ public final class SearchUsage {
     }
 
     /**
-     * Track retrieve usage
+     * Track retriever usage
      */
-    public void trackRetrieverUsage(String retriever) {
+    public void trackRetrieverUsage(String retriever, Set<String> metadata) {
+        trackRetrieverUsage(retriever);
+        metadata(metadata);
+    }
+
+    private void trackRetrieverUsage(String retriever) {
         retrievers.add(retriever);
+    }
+
+    private void metadata(Set<String> metadata) {
+        this.metadata.addAll(metadata);
     }
 
     /**
@@ -76,5 +86,12 @@ public final class SearchUsage {
      */
     public Set<String> getRetrieverUsage() {
         return Collections.unmodifiableSet(retrievers);
+    }
+
+    /**
+     * Returns the retriever names that have been used at least once in the tracked search request
+     */
+    public Set<String> getMetadataUsage() {
+        return Collections.unmodifiableSet(metadata);
     }
 }

--- a/server/src/main/java/org/elasticsearch/usage/SearchUsageHolder.java
+++ b/server/src/main/java/org/elasticsearch/usage/SearchUsageHolder.java
@@ -28,6 +28,7 @@ public final class SearchUsageHolder {
     private final Map<String, LongAdder> rescorersUsage = new ConcurrentHashMap<>();
     private final Map<String, LongAdder> sectionsUsage = new ConcurrentHashMap<>();
     private final Map<String, LongAdder> retrieversUsage = new ConcurrentHashMap<>();
+    private final Map<String, LongAdder> metadataUsage = new ConcurrentHashMap<>();
 
     SearchUsageHolder() {}
 
@@ -48,6 +49,9 @@ public final class SearchUsageHolder {
         for (String retriever : searchUsage.getRetrieverUsage()) {
             retrieversUsage.computeIfAbsent(retriever, q -> new LongAdder()).increment();
         }
+        for (String metadata : searchUsage.getMetadataUsage()) {
+            metadataUsage.computeIfAbsent(metadata, q -> new LongAdder()).increment();
+        }
     }
 
     /**
@@ -62,11 +66,14 @@ public final class SearchUsageHolder {
         rescorersUsage.forEach((query, adder) -> rescorersUsageMap.put(query, adder.longValue()));
         Map<String, Long> retrieversUsageMap = Maps.newMapWithExpectedSize(retrieversUsage.size());
         retrieversUsage.forEach((retriever, adder) -> retrieversUsageMap.put(retriever, adder.longValue()));
+        Map<String, Long> metadataUsageMap = Maps.newMapWithExpectedSize(metadataUsage.size());
+        metadataUsage.forEach((metadata, adder) -> metadataUsageMap.put(metadata, adder.longValue()));
         return new SearchUsageStats(
             Collections.unmodifiableMap(queriesUsageMap),
             Collections.unmodifiableMap(rescorersUsageMap),
             Collections.unmodifiableMap(sectionsUsageMap),
             Collections.unmodifiableMap(retrieversUsageMap),
+            Collections.unmodifiableMap(metadataUsageMap),
             totalSearchCount.longValue()
         );
     }

--- a/server/src/main/java/org/elasticsearch/usage/SearchUsageHolder.java
+++ b/server/src/main/java/org/elasticsearch/usage/SearchUsageHolder.java
@@ -66,7 +66,7 @@ public final class SearchUsageHolder {
         sectionsUsage.forEach((query, adder) -> sectionsUsageMap.put(query, adder.longValue()));
         Map<String, Long> rescorersUsageMap = Maps.newMapWithExpectedSize(rescorersUsage.size());
         rescorersUsage.forEach((query, adder) -> rescorersUsageMap.put(query, adder.longValue()));
-        Map<String, Map<String,Long>> retrieversUsageMap = Maps.newMapWithExpectedSize(retrieversUsage.size());
+        Map<String, Map<String, Long>> retrieversUsageMap = Maps.newMapWithExpectedSize(retrieversUsage.size());
         retrieversUsage.forEach((retriever, metadataMap) -> {
             Map<String, Long> convertedMetadata = Maps.newMapWithExpectedSize(metadataMap.size());
             metadataMap.forEach((key, adder) -> convertedMetadata.put(key, adder.longValue()));

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankRetrieverBuilder.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankRetrieverBuilder.java
@@ -25,8 +25,10 @@ import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 import static org.elasticsearch.search.rank.RankBuilder.DEFAULT_RANK_WINDOW_SIZE;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
@@ -86,7 +88,7 @@ public class TextSimilarityRankRetrieverBuilder extends CompoundRetrieverBuilder
     static {
         PARSER.declareNamedObject(constructorArg(), (p, c, n) -> {
             RetrieverBuilder innerRetriever = p.namedObject(RetrieverBuilder.class, n, c);
-            c.trackRetrieverUsage(innerRetriever.getName());
+            c.trackRetrieverUsage(innerRetriever.getName(), innerRetriever.getMetadataFields());
             return innerRetriever;
         }, RETRIEVER_FIELD);
         PARSER.declareString(optionalConstructorArg(), INFERENCE_ID_FIELD);
@@ -221,6 +223,17 @@ public class TextSimilarityRankRetrieverBuilder extends CompoundRetrieverBuilder
             )
         );
         return sourceBuilder;
+    }
+
+    @Override
+    public Set<String> getMetadataFields() {
+        Set<String> metadataFields = new HashSet<>();
+
+        if (snippets != null) {
+            metadataFields.add(SNIPPETS_FIELD.getPreferredName());
+        }
+
+        return metadataFields;
     }
 
     @Override

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
@@ -592,7 +592,8 @@ public class ClusterStatsMonitoringDocTests extends BaseMonitoringDocTestCase<Cl
                     "queries": {},
                     "rescorers": {},
                     "sections": {},
-                    "retrievers": {}
+                    "retrievers": {},
+                    "metadata": {}
                   },
                   "dense_vector": {
                     "value_count": 0


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/134574

This updates cluster stats to show additional information under retrievers. This example shows us recording the count and when the text similarity retriever includes a call to get snippets. It could be extended to capture things like when multi-field syntax is used in retrievers, for example, or collect advanced metadata about whether people are specifying custom inference endpoints. 

The pros to this approach: 

- Looking at the list is very intuitive - I know exactly what snippets belongs to. 

The cons to this approach: 

- This breaks the existing retriever reporting, there the count is a value rather than a Map. This means that existing Kibana dashboards, etc. relying on this would suffer from continuity issues. 
- While this is a hacky draft POC implementation, it does add some complexity to our search usage calculations. I think some of this could be mitigated by moving to a RetrieverMetadata object instead of a Map, but I wanted this POC to demonstrate functionality first and foremost. 



Example output of command: `GET _cluster/stats?human&filter_path=indices.search*`

```
{
  "indices": {
    "search": {
      "total": 3,
      "queries": {
        "match": 3
      },
      "rescorers": {},
      "sections": {
        "highlight": 3,
        "metadata": 3,
        "retriever": 3,
        "_source": 2
      },
      "retrievers": {
        "standard": {
          "count": 3
        },
        "text_similarity_reranker": {
          "count": 2,
          "snippets": 2
        }
      }
    }
  }
}
```