### PR TITLE
ESQL: Runtime typed composite Block

### DIFF
--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/plugin/EsqlCorePlugin.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/plugin/EsqlCorePlugin.java
@@ -15,4 +15,5 @@ public class EsqlCorePlugin extends Plugin implements ExtensiblePlugin {
 
     public static final FeatureFlag AGGREGATE_METRIC_DOUBLE_FEATURE_FLAG = new FeatureFlag("esql_aggregate_metric_double");
     public static final FeatureFlag DENSE_VECTOR_FEATURE_FLAG = new FeatureFlag("esql_dense_vector");
+    public static final FeatureFlag COLUMNS_FEATURE_FLAG = new FeatureFlag("esql_columns_type");
 }

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
@@ -308,6 +308,13 @@ public enum DataType {
     AGGREGATE_METRIC_DOUBLE(builder().esType("aggregate_metric_double").estimatedSize(Double.BYTES * 3 + Integer.BYTES)),
 
     /**
+     * NOCOMMIT.
+     */
+    COLUMNS(builder().esType("columns")
+        // NOCOMMIT on estimate
+        .estimatedSize(Double.BYTES * 3 + Integer.BYTES)),
+
+    /**
      * Fields with this type are dense vectors, represented as an array of double values.
      */
     DENSE_VECTOR(builder().esType("dense_vector").unknownSize());
@@ -331,7 +338,8 @@ public enum DataType {
      */
     public static final Map<DataType, FeatureFlag> UNDER_CONSTRUCTION = Map.ofEntries(
         Map.entry(AGGREGATE_METRIC_DOUBLE, EsqlCorePlugin.AGGREGATE_METRIC_DOUBLE_FEATURE_FLAG),
-        Map.entry(DENSE_VECTOR, EsqlCorePlugin.DENSE_VECTOR_FEATURE_FLAG)
+        Map.entry(DENSE_VECTOR, EsqlCorePlugin.DENSE_VECTOR_FEATURE_FLAG),
+        Map.entry(COLUMNS, EsqlCorePlugin.COLUMNS_FEATURE_FLAG)
     );
 
     private final String typeName;

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
@@ -310,9 +310,11 @@ public enum DataType {
     /**
      * NOCOMMIT.
      */
-    COLUMNS(builder().esType("columns")
-        // NOCOMMIT on estimate
-        .estimatedSize(Double.BYTES * 3 + Integer.BYTES)),
+    COLUMNS(
+        builder().esType("columns")
+            // NOCOMMIT on estimate
+            .estimatedSize(Double.BYTES * 3 + Integer.BYTES)
+    ),
 
     /**
      * Fields with this type are dense vectors, represented as an array of double values.

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockUtils.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockUtils.java
@@ -299,6 +299,7 @@ public final class BlockUtils {
                     aggBlock.countBlock().getInt(offset)
                 );
             }
+            case COLUMNS -> throw new IllegalArgumentException("NOCOMMIT");
             case UNKNOWN -> throw new IllegalArgumentException("can't read values from [" + block + "]");
         };
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ColumnsBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ColumnsBlock.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.apache.lucene.util.Accountable;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.ReleasableIterator;
+import org.elasticsearch.core.Releasables;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A {@link Block} containing a {@code Map} from column name to a {@code Block} of data.
+ */
+public class ColumnsBlock extends AbstractNonThreadSafeRefCounted implements Block {
+    private final BlockFactory blockFactory;
+    private final int positionCount;
+
+    // NOCOMMIT rendering assumes all sub-types are KEYWORD.
+    private final Map<String, RuntimeTypedBlock> columns;
+
+    public ColumnsBlock(BlockFactory blockFactory, int positionCount, Map<String, RuntimeTypedBlock> columns) {
+        this.blockFactory = blockFactory;
+        this.positionCount = positionCount;
+        this.columns = columns;
+        for (Map.Entry<String, RuntimeTypedBlock> c : columns.entrySet()) {
+            if (c.getValue().block.isReleased()) {
+                throw new IllegalStateException(
+                    c.getKey() + ": can't build ColumnsBlock out of released blocks but [" + c.getValue() + "] was released"
+                );
+            }
+            if (c.getValue().block.getPositionCount() != positionCount) {
+                throw new IllegalStateException(c.getKey() + ": " + c.getValue() + " doesn't have " + positionCount + " positions");
+            }
+        }
+    }
+
+    public Map<String, RuntimeTypedBlock> columns() {
+        return columns;
+    }
+
+    @Override
+    public Vector asVector() {
+        return null;
+    }
+
+    @Override
+    public int getTotalValueCount() {
+        return columns.values().stream().mapToInt(b -> b.block.getTotalValueCount()).sum();
+    }
+
+    @Override
+    public int getPositionCount() {
+        return positionCount;
+    }
+
+    @Override
+    public int getFirstValueIndex(int position) {
+        throw new UnsupportedOperationException("ColumnsBlock");
+    }
+
+    @Override
+    public int getValueCount(int position) {
+        throw new UnsupportedOperationException("ColumnsBlock");
+    }
+
+    @Override
+    public ElementType elementType() {
+        return ElementType.COLUMNS;
+    }
+
+    @Override
+    public BlockFactory blockFactory() {
+        return blockFactory;
+    }
+
+    @Override
+    public void allowPassingToDifferentDriver() {
+        for (RuntimeTypedBlock c : columns.values()) {
+            c.block.allowPassingToDifferentDriver();
+        }
+    }
+
+    @Override
+    public boolean isNull(int position) {
+        return false;
+    }
+
+    @Override
+    public boolean mayHaveNulls() {
+        return false;
+    }
+
+    @Override
+    public boolean areAllValuesNull() {
+        return false;
+    }
+
+    @Override
+    public boolean mayHaveMultivaluedFields() {
+        throw new UnsupportedOperationException("ColumnsBlock");
+    }
+
+    @Override
+    public boolean doesHaveMultivaluedFields() {
+        throw new UnsupportedOperationException("ColumnsBlock");
+    }
+
+    @Override
+    public Block filter(int... positions) {
+        ColumnsBlock result = null;
+        Map<String, RuntimeTypedBlock> newColumns = new HashMap<>();
+        try {
+            for (Map.Entry<String, RuntimeTypedBlock> c : columns.entrySet()) {
+                newColumns.put(c.getKey(), new RuntimeTypedBlock(c.getValue().type, c.getValue().block.filter(positions)));
+            }
+            result = new ColumnsBlock(blockFactory, positions.length, newColumns);
+            return result;
+        } finally {
+            if (result == null) {
+                Releasables.close(newColumns.values());
+            }
+        }
+    }
+
+    @Override
+    public Block keepMask(BooleanVector mask) {
+        ColumnsBlock result = null;
+        Map<String, RuntimeTypedBlock> newColumns = new HashMap<>();
+        try {
+            for (Map.Entry<String, RuntimeTypedBlock> c : columns.entrySet()) {
+                newColumns.put(c.getKey(), new RuntimeTypedBlock(c.getValue().type, c.getValue().block.keepMask(mask)));
+            }
+            result = new ColumnsBlock(blockFactory, mask.getPositionCount(), newColumns);
+            return result;
+        } finally {
+            if (result == null) {
+                Releasables.close(newColumns.values());
+            }
+        }
+    }
+
+    @Override
+    public ReleasableIterator<? extends Block> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
+        throw new UnsupportedOperationException("ColumnsBlock");
+    }
+
+    @Override
+    public MvOrdering mvOrdering() {
+        return MvOrdering.UNORDERED;
+    }
+
+    @Override
+    public Block expand() {
+        throw new UnsupportedOperationException("ColumnsBlock");
+    }
+
+    @Override
+    public Block deepCopy(BlockFactory blockFactory) {
+        ColumnsBlock result = null;
+        Map<String, RuntimeTypedBlock> newColumns = new HashMap<>();
+        try {
+            for (Map.Entry<String, RuntimeTypedBlock> c : columns.entrySet()) {
+                newColumns.put(c.getKey(), new RuntimeTypedBlock(c.getValue().type, c.getValue().block.deepCopy(blockFactory)));
+            }
+            result = new ColumnsBlock(blockFactory, positionCount, newColumns);
+            return result;
+        } finally {
+            if (result == null) {
+                Releasables.close(newColumns.values());
+            }
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        throw new UnsupportedOperationException("NOCOMMIT ColumnsBlock");
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        // NOCOMMIT some bytes of my own
+        return columns.values().stream().mapToLong(Accountable::ramBytesUsed).sum();
+    }
+
+    @Override
+    protected void closeInternal() {
+        Releasables.close(columns.values());
+    }
+
+    public record RuntimeTypedBlock(Object type, Block block) implements Accountable, Releasable {
+        @Override
+        public long ramBytesUsed() {
+            // NOCOMMIT some bytes of my own.
+            return block.ramBytesUsed();
+        }
+
+        @Override
+        public void close() {
+            block.close();
+        }
+    }
+
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ElementType.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ElementType.java
@@ -64,7 +64,9 @@ public enum ElementType {
         "AggregateMetricDouble",
         BlockFactory::newAggregateMetricDoubleBlockBuilder,
         AggregateMetricDoubleArrayBlock::readFrom
-    );
+    ),
+
+    COLUMNS(11, "Columns", null, null);
 
     private interface BuilderSupplier {
         Block.Builder newBlockBuilder(BlockFactory blockFactory, int estimatedSize);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/QueryList.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/QueryList.java
@@ -194,6 +194,7 @@ public abstract class QueryList implements LookupEnrichQueryGenerator {
             case DOC -> throw new IllegalArgumentException("can't read values from [doc] block");
             case COMPOSITE -> throw new IllegalArgumentException("can't read values from [composite] block");
             case AGGREGATE_METRIC_DOUBLE -> throw new IllegalArgumentException("can't read values from [aggregate metric double] block");
+            case COLUMNS -> throw new IllegalArgumentException("can't read values from [columns] block");
             case UNKNOWN -> throw new IllegalArgumentException("can't read values from [" + block + "]");
         };
         return new TermQueryList(field, searchExecutionContext, aliasFilter, block, null, blockToJavaObject);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/ColumnsPositionToXContent.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/ColumnsPositionToXContent.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.ColumnsBlock;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class ColumnsPositionToXContent extends PositionToXContent {
+    private final Map<String, PositionToXContent> columns = new TreeMap<>();
+
+    ColumnsPositionToXContent(ColumnInfoImpl columnInfo, Block block, BytesRef scratch) {
+        super(block);
+        for (Map.Entry<String, ColumnsBlock.RuntimeTypedBlock> c : ((ColumnsBlock) block).columns().entrySet()) {
+            ColumnInfoImpl subInfo = new ColumnInfoImpl(columnInfo.name() + "." + c.getKey(), (DataType) c.getValue().type(), null);
+            columns.put(c.getKey(), PositionToXContent.positionToXContent(subInfo, c.getValue().block(), scratch));
+        }
+    }
+
+    @Override
+    public XContentBuilder positionToXContent(XContentBuilder builder, ToXContent.Params params, int position) throws IOException {
+        builder.startObject();
+        for (Map.Entry<String, PositionToXContent> c : columns.entrySet()) {
+            if (c.getValue().block.isNull(position) == false) {
+                builder.field(c.getKey());
+                c.getValue().positionToXContent(builder, params, position);
+            }
+        }
+        return builder.endObject();
+    }
+
+    @Override
+    protected XContentBuilder valueToXContent(XContentBuilder builder, ToXContent.Params params, int valueIndex) throws IOException {
+        throw new IllegalStateException("NOCOMMIT");
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/PositionToXContent.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/PositionToXContent.java
@@ -25,6 +25,7 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
+import java.util.Map;
 
 import static org.elasticsearch.xpack.esql.core.util.NumericUtils.unsignedLongAsNumber;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.aggregateMetricDoubleBlockToString;
@@ -199,6 +200,7 @@ public abstract class PositionToXContent {
                     return builder.value(((FloatBlock) block).getFloat(valueIndex));
                 }
             };
+            case COLUMNS -> new ColumnsPositionToXContent(columnInfo, block, scratch);
             case DATE_PERIOD, TIME_DURATION, DOC_DATA_TYPE, TSID_DATA_TYPE, SHORT, BYTE, OBJECT, FLOAT, HALF_FLOAT, SCALED_FLOAT,
                 PARTIAL_AGG -> throw new IllegalArgumentException("can't convert values of type [" + columnInfo.type() + "]");
         };

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/PositionToXContent.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/PositionToXContent.java
@@ -25,7 +25,6 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
-import java.util.Map;
 
 import static org.elasticsearch.xpack.esql.core.util.NumericUtils.unsignedLongAsNumber;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypeConverter.aggregateMetricDoubleBlockToString;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/ResponseValueUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/ResponseValueUtils.java
@@ -151,6 +151,7 @@ public final class ResponseValueUtils {
                 }
             }
             case DENSE_VECTOR -> ((FloatBlock) block).getFloat(offset);
+            case COLUMNS -> throw new IllegalArgumentException("NOCOMMIT");
             case SHORT, BYTE, FLOAT, HALF_FLOAT, SCALED_FLOAT, OBJECT, DATE_PERIOD, TIME_DURATION, DOC_DATA_TYPE, TSID_DATA_TYPE, NULL,
                 PARTIAL_AGG -> throw EsqlIllegalArgumentException.illegalDataType(dataType);
         };

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
@@ -190,6 +190,8 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.string.Substring;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.ToLower;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.ToUpper;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.Trim;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.UriParts;
+import org.elasticsearch.xpack.esql.expression.function.scalar.util.Column;
 import org.elasticsearch.xpack.esql.expression.function.scalar.util.Delay;
 import org.elasticsearch.xpack.esql.expression.function.vector.CosineSimilarity;
 import org.elasticsearch.xpack.esql.expression.function.vector.DotProduct;
@@ -514,6 +516,7 @@ public class EsqlFunctionRegistry {
                 def(MaxOverTime.class, uni(MaxOverTime::new), "max_over_time"),
                 def(MinOverTime.class, uni(MinOverTime::new), "min_over_time"),
                 def(SumOverTime.class, uni(SumOverTime::new), "sum_over_time"),
+                def(Column.class, Column::new, "column"),
                 def(CountOverTime.class, uni(CountOverTime::new), "count_over_time"),
                 def(CountDistinctOverTime.class, bi(CountDistinctOverTime::new), "count_distinct_over_time"),
                 def(AvgOverTime.class, uni(AvgOverTime::new), "avg_over_time"),
@@ -529,6 +532,7 @@ public class EsqlFunctionRegistry {
                 def(L2Norm.class, L2Norm::new, "v_l2_norm"),
                 def(Magnitude.class, Magnitude::new, "v_magnitude"),
                 def(Hamming.class, Hamming::new, "v_hamming"),
+                def(UriParts.class, UriParts::new, "uri_parts", "url_parts"),
                 def(UrlEncode.class, UrlEncode::new, "url_encode"),
                 def(UrlDecode.class, UrlDecode::new, "url_decode"),
                 def(PresentOverTime.class, uni(PresentOverTime::new), "present_over_time") } };

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/Coalesce.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/Coalesce.java
@@ -208,6 +208,7 @@ public class Coalesce extends EsqlScalarFunction implements OptionalArgument {
             case KEYWORD, TEXT, CARTESIAN_POINT, CARTESIAN_SHAPE, GEO_POINT, GEO_SHAPE, IP, VERSION -> CoalesceBytesRefEvaluator
                 .toEvaluator(toEvaluator, children());
             case NULL -> EvalOperator.CONSTANT_NULL_FACTORY;
+            case COLUMNS -> throw new UnsupportedOperationException("NOCOMMIT " + dataType() + " can’t be coalesced");
             case UNSUPPORTED, SHORT, BYTE, DATE_PERIOD, OBJECT, DOC_DATA_TYPE, SOURCE, TIME_DURATION, FLOAT, HALF_FLOAT, TSID_DATA_TYPE,
                 SCALED_FLOAT, PARTIAL_AGG, AGGREGATE_METRIC_DOUBLE, DENSE_VECTOR -> throw new UnsupportedOperationException(
                     dataType() + " can’t be coalesced"

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/UriParts.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/UriParts.java
@@ -38,7 +38,6 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/UriParts.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/UriParts.java
@@ -1,0 +1,373 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.string;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.BytesRefVector;
+import org.elasticsearch.compute.data.ColumnsBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.TypeResolutions;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
+import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.expression.function.scalar.UnaryScalarFunction;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isString;
+
+public class UriParts extends UnaryScalarFunction {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "Trim", UriParts::new);
+
+    @FunctionInfo(
+        returnType = { "columns" },
+        description = "NOCOMMIT",
+        examples = {} // NOCOMMIT
+    )
+    public UriParts(
+        Source source,
+        @Param(
+            name = "string",
+            type = { "keyword", "text" },
+            description = "URI/URL to parse. If `null`, the function returns `null`."
+        ) Expression str
+    ) {
+        super(source, str);
+    }
+
+    private UriParts(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    @Override
+    protected TypeResolution resolveType() {
+        if (childrenResolved() == false) {
+            return new Expression.TypeResolution("Unresolved children");
+        }
+
+        return isString(field, sourceText(), TypeResolutions.ParamOrdinal.DEFAULT);
+    }
+
+    @Override
+    public DataType dataType() {
+        return DataType.COLUMNS;
+    }
+
+    @Override
+    public EvalOperator.ExpressionEvaluator.Factory toEvaluator(ToEvaluator toEvaluator) {
+        var field = toEvaluator.apply(field());
+        return new EvaluatorFactory(source(), field);
+    }
+
+    @Override
+    public Expression replaceChildren(List<Expression> newChildren) {
+        return new UriParts(source(), newChildren.getFirst());
+    }
+
+    @Override
+    protected NodeInfo<? extends Expression> info() {
+        return NodeInfo.create(this, UriParts::new, field());
+    }
+
+    static class EvaluatorFactory implements EvalOperator.ExpressionEvaluator.Factory {
+        private final Source source;
+        private final EvalOperator.ExpressionEvaluator.Factory val;
+
+        EvaluatorFactory(Source source, EvalOperator.ExpressionEvaluator.Factory val) {
+            this.source = source;
+            this.val = val;
+        }
+
+        @Override
+        public Evaluator get(DriverContext context) {
+            return new Evaluator(source, val.get(context), context);
+        }
+
+        @Override
+        public String toString() {
+            return "UriPartsEvaluator[val=" + val + "]";
+        }
+    }
+
+    static class Evaluator implements EvalOperator.ExpressionEvaluator {
+        private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(Evaluator.class);
+
+        private final Source source;
+
+        private final EvalOperator.ExpressionEvaluator val;
+
+        private final DriverContext driverContext;
+
+        private Warnings warnings;
+
+        Evaluator(Source source, EvalOperator.ExpressionEvaluator val, DriverContext driverContext) {
+            this.source = source;
+            this.val = val;
+            this.driverContext = driverContext;
+        }
+
+        @Override
+        public Block eval(Page page) {
+            try (BytesRefBlock valBlock = (BytesRefBlock) val.eval(page)) {
+                BytesRefVector valVector = valBlock.asVector();
+                if (valVector == null) {
+                    throw new UnsupportedOperationException("NOCOMMIT TODO UriParts");
+                }
+                return new Process(valVector.getPositionCount(), driverContext.blockFactory()).eval(valVector);
+            }
+        }
+
+        @Override
+        public long baseRamBytesUsed() {
+            long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+            baseRamBytesUsed += val.baseRamBytesUsed();
+            return baseRamBytesUsed;
+        }
+
+        Warnings warnings() {
+            if (warnings == null) {
+                this.warnings = Warnings.createWarnings(
+                    driverContext.warningsMode(),
+                    source.source().getLineNumber(),
+                    source.source().getColumnNumber(),
+                    source.text()
+                );
+            }
+            return warnings;
+        }
+
+        @Override
+        public void close() {
+            Releasables.close(val);
+        }
+
+        @Override
+        public String toString() {
+            return "NOCOMMIT";
+        }
+
+        class Process {
+            private final BytesRefBlock.Builder scheme;
+            private final BytesRefBlock.Builder userInfo;
+            private final BytesRefBlock.Builder domain;
+            private final IntBlock.Builder port;
+            private final BytesRefBlock.Builder path;
+            private final BytesRefBlock.Builder extension;
+            private final BytesRefBlock.Builder query;
+            private final BytesRefBlock.Builder fragment;
+
+            private final BytesRefBuilder scratch;
+
+            Process(int estimatedSize, BlockFactory factory) {
+                BytesRefBlock.Builder scheme = null;
+                BytesRefBlock.Builder userInfo = null;
+                BytesRefBlock.Builder domain = null;
+                IntBlock.Builder port = null;
+                BytesRefBlock.Builder path = null;
+                BytesRefBlock.Builder extension = null;
+                BytesRefBlock.Builder query = null;
+                BytesRefBlock.Builder fragment = null;
+
+                try {
+                    scheme = factory.newBytesRefBlockBuilder(estimatedSize);
+                    userInfo = factory.newBytesRefBlockBuilder(estimatedSize);
+                    domain = factory.newBytesRefBlockBuilder(estimatedSize);
+                    port = factory.newIntBlockBuilder(estimatedSize);
+                    path = factory.newBytesRefBlockBuilder(estimatedSize);
+                    extension = factory.newBytesRefBlockBuilder(estimatedSize);
+                    query = factory.newBytesRefBlockBuilder(estimatedSize);
+                    fragment = factory.newBytesRefBlockBuilder(estimatedSize);
+
+                    this.scheme = scheme;
+                    this.userInfo = userInfo;
+                    this.domain = domain;
+                    this.port = port;
+                    this.path = path;
+                    this.extension = extension;
+                    this.query = query;
+                    this.fragment = fragment;
+                } finally {
+                    // NOCOMMIT this needs to be the last one
+                    if (extension == null) {
+                        // NOCOMMIT this needs to be all of them
+                        Releasables.close(scheme, userInfo, domain, port, path, extension, query, fragment);
+                    }
+                }
+                scratch = new BytesRefBuilder();
+            }
+
+            public Block eval(BytesRefVector valVector) {
+                for (int i = 0; i < valVector.getPositionCount(); i++) {
+                    BytesRef v = valVector.getBytesRef(i, scratch.get());
+                    apply(v.utf8ToString());
+                }
+                return finish();
+            }
+
+            private Block finish() {
+                BytesRefBlock scheme = null;
+                BytesRefBlock userInfo = null;
+                BytesRefBlock domain = null;
+                IntBlock port = null;
+                BytesRefBlock path = null;
+                BytesRefBlock extension = null;
+                BytesRefBlock query = null;
+                BytesRefBlock fragment = null;
+                ColumnsBlock result = null;
+                try {
+                    scheme = this.scheme.build();
+                    userInfo = this.userInfo.build();
+                    domain = this.domain.build();
+                    port = this.port.build();
+                    path = this.path.build();
+                    extension = this.extension.build();
+                    query = this.query.build();
+                    fragment = this.fragment.build();
+
+                    result = new ColumnsBlock(
+                        domain.blockFactory(),
+                        domain.getPositionCount(),
+                        Map.ofEntries(
+                            Map.entry("scheme", new ColumnsBlock.RuntimeTypedBlock(DataType.KEYWORD, scheme)),
+                            Map.entry("user_info", new ColumnsBlock.RuntimeTypedBlock(DataType.KEYWORD, userInfo)),
+                            Map.entry("domain", new ColumnsBlock.RuntimeTypedBlock(DataType.KEYWORD, domain)),
+                            Map.entry("port", new ColumnsBlock.RuntimeTypedBlock(DataType.INTEGER, port)),
+                            Map.entry("path", new ColumnsBlock.RuntimeTypedBlock(DataType.KEYWORD, path)),
+                            Map.entry("extension", new ColumnsBlock.RuntimeTypedBlock(DataType.KEYWORD, extension)),
+                            Map.entry("query", new ColumnsBlock.RuntimeTypedBlock(DataType.KEYWORD, query)),
+                            Map.entry("fragment", new ColumnsBlock.RuntimeTypedBlock(DataType.KEYWORD, fragment))
+                        )
+                    );
+                    return result;
+                } finally {
+                    if (result == null) {
+                        Releasables.close(scheme, userInfo, domain, port, path, extension, query, fragment);
+                    }
+                }
+            }
+
+            public void apply(String urlString) {
+                try {
+                    apply(new URI(urlString));
+                } catch (URISyntaxException e) {
+                    try {
+                        apply(new URL(urlString));
+                    } catch (MalformedURLException e2) {
+                        unableToParse(urlString);
+                    }
+                }
+            }
+
+            private void apply(URI uri) {
+                apply(uri.getScheme(), uri.getUserInfo(), uri.getHost(), uri.getPort(), uri.getPath(), uri.getQuery(), uri.getFragment());
+            }
+
+            @SuppressForbidden(reason = "URL.getPath is used only if URI.getPath is unavailable")
+            private void apply(URL url) {
+                apply(url.getProtocol(), url.getUserInfo(), url.getHost(), url.getPort(), url.getPath(), url.getQuery(), url.getRef());
+            }
+
+            private void unableToParse(String urlString) {
+                scheme.appendNull();
+                userInfo.appendNull();
+                domain.appendNull();
+                port.appendNull();
+                path.appendNull();
+                extension.appendNull();
+                query.appendNull();
+                fragment.appendNull();
+                warnings().registerException(IllegalArgumentException.class, "unable to parse URI [" + urlString + "]");
+            }
+
+            private void apply(String scheme, String userInfo, String domain, int port, String path, String query, String fragment) {
+                append(this.scheme, scheme);
+                if (userInfo == null) {
+                    this.userInfo.appendNull();
+                } else {
+                    append(this.userInfo, userInfo);
+                }
+                if (domain == null) {
+                    this.domain.appendNull();
+                } else {
+                    append(this.domain, domain);
+                }
+                if (port < 0) {
+                    this.port.appendNull();
+                } else {
+                    this.port.appendInt(port);
+                }
+                if (path == null) {
+                    this.path.appendNull();
+                    this.extension.appendNull();
+                } else {
+                    appendPath(path);
+                }
+                if (query == null) {
+                    this.query.appendNull();
+                } else {
+                    append(this.query, query);
+                }
+                if (fragment == null) {
+                    this.fragment.appendNull();
+                } else {
+                    append(this.fragment, query);
+                }
+            }
+
+            private void append(BytesRefBlock.Builder builder, String value) {
+                scratch.clear();
+                scratch.copyChars(value);
+                builder.appendBytesRef(scratch.get());
+            }
+
+            private void appendPath(String path) {
+                append(this.path, path);
+                int lastSegmentIndex = path.lastIndexOf('/');
+                if (lastSegmentIndex < 0) {
+                    this.extension.appendNull();
+                    return;
+                }
+                String lastSegment = path.substring(lastSegmentIndex);
+                int periodIndex = path.lastIndexOf('.');
+                if (periodIndex < 0) {
+                    this.extension.appendNull();
+                    return;
+                }
+                append(this.extension, lastSegment.substring(periodIndex + 1));
+            }
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/util/Column.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/util/Column.java
@@ -27,7 +27,6 @@ import org.elasticsearch.xpack.esql.core.util.PlanStreamInput;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
 import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
-import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToIntegerFromStringEvaluator;
 
 import java.io.IOException;
 import java.util.List;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/util/Column.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/util/Column.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.util;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.ColumnsBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.util.PlanStreamInput;
+import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
+import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToIntegerFromStringEvaluator;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+
+public class Column extends EsqlScalarFunction {
+    // NOCOMMIT I think we'd be better off having casting take RUNTIME typed blocks and Column just index and return a runtime type block.
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "Column", Column::new);
+
+    private final Expression columns;
+    private final Expression nameExpression;
+    private final Expression targetTypeExpression;
+
+    private String name;
+    private DataType targetType;
+
+    @FunctionInfo(
+        returnType = { "keyword | int" },
+        description = "NOCOMMIT",
+        examples = {} // NOCOMMIT
+    )
+    public Column(
+        Source source,
+        @Param(name = "columns", type = { "columns" }, description = "NOCOMMIT") Expression columns,
+        @Param(name = "name", type = { "keyword" }, description = "Name to lookup") Expression name,
+        @Param(name = "target_type", type = { "keyword" }, description = "Type to convert to") Expression targetType
+    ) {
+        super(source, List.of(columns, name, targetType));
+        this.columns = columns;
+        this.nameExpression = name;
+        this.targetTypeExpression = targetType;
+    }
+
+    private Column(StreamInput in) throws IOException {
+        super(Source.readFrom((StreamInput & PlanStreamInput) in));
+        this.columns = in.readNamedWriteable(Expression.class);
+        this.nameExpression = in.readNamedWriteable(Expression.class);
+        this.targetTypeExpression = in.readNamedWriteable(Expression.class);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        throw new IOException("NOCOMMIT Column");
+    }
+
+    @Override
+    protected TypeResolution resolveType() {
+        if (childrenResolved() == false) {
+            return new TypeResolution("Unresolved children");
+        }
+
+        if (columns.dataType() != DataType.COLUMNS) {
+            // NOCOMMIT what a terrible name to show to users.
+            return new TypeResolution("[column] first argument must be a columns function");
+        }
+        {
+            if (nameExpression instanceof Literal l && l.value() instanceof BytesRef b) {
+                name = b.utf8ToString();
+            } else {
+                return new TypeResolution("[column] second argument must be a constant string");
+            }
+        }
+        {
+            if (targetTypeExpression instanceof Literal l && l.value() instanceof BytesRef b) {
+                String t = b.utf8ToString().toUpperCase(Locale.ROOT);
+                switch (t) {
+                    case "KEYWORD":
+                        targetType = DataType.KEYWORD;
+                        break;
+                    case "INT":
+                        targetType = DataType.INTEGER;
+                        break;
+                    default:
+                        return new TypeResolution("[column] third argument must be one of [KEYWORD, INT] but was " + t);
+                }
+            } else {
+                return new TypeResolution("[column] third argument must be a constant string");
+            }
+        }
+        return TypeResolution.TYPE_RESOLVED;
+    }
+
+    @Override
+    public DataType dataType() {
+        resolveType();
+        return targetType;
+    }
+
+    @Override
+    public Expression replaceChildren(List<Expression> newChildren) {
+        return new Column(source(), newChildren.get(0), newChildren.get(1), newChildren.get(2));
+    }
+
+    @Override
+    protected NodeInfo<? extends Expression> info() {
+        return NodeInfo.create(this, Column::new, columns, nameExpression, targetTypeExpression);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
+    }
+
+    @Override
+    public EvalOperator.ExpressionEvaluator.Factory toEvaluator(ToEvaluator toEvaluator) {
+        resolveType();
+        EvalOperator.ExpressionEvaluator.Factory columns = toEvaluator.apply(this.columns);
+        return new EvaluatorFactory(source(), columns, name, targetType);
+    }
+
+    static class EvaluatorFactory implements EvalOperator.ExpressionEvaluator.Factory {
+        private final Source source;
+        private final EvalOperator.ExpressionEvaluator.Factory columns;
+        private final String name;
+        private final DataType targetType;
+
+        EvaluatorFactory(Source source, EvalOperator.ExpressionEvaluator.Factory columns, String name, DataType targetType) {
+            this.source = source;
+            this.columns = columns;
+            this.name = name;
+            this.targetType = targetType;
+        }
+
+        @Override
+        public Evaluator get(DriverContext context) {
+            return new Evaluator(source, columns.get(context), name, targetType, context);
+        }
+
+        @Override
+        public String toString() {
+            return "Columns[columns=" + columns + ", name=" + name + ", targetType=" + targetType + "]";
+        }
+    }
+
+    static class Evaluator implements EvalOperator.ExpressionEvaluator {
+        private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(Evaluator.class);
+
+        private final Source source;
+
+        private final EvalOperator.ExpressionEvaluator columns;
+        private final String name;
+        private final DataType targetType;
+
+        private final DriverContext driverContext;
+
+        private Warnings warnings;
+
+        Evaluator(Source source, EvalOperator.ExpressionEvaluator columns, String name, DataType targetType, DriverContext driverContext) {
+            this.source = source;
+            this.columns = columns;
+            this.name = name;
+            this.targetType = targetType;
+            this.driverContext = driverContext;
+        }
+
+        @Override
+        public Block eval(Page page) {
+            try (ColumnsBlock valBlock = (ColumnsBlock) columns.eval(page)) {
+                ColumnsBlock.RuntimeTypedBlock uncast = valBlock.columns().get(name);
+                if (uncast == null) {
+                    return nulls(page);
+                }
+                DataType runtimeType = (DataType) uncast.type();
+                if (targetType == runtimeType) {
+                    uncast.block().incRef();
+                    return uncast.block();
+                }
+                warnings().registerException(
+                    IllegalArgumentException.class,
+                    "runtime type [" + runtimeType + "] incompatible with target type [" + targetType + "]"
+                );
+                return nulls(page);
+            }
+        }
+
+        private Block nulls(Page page) {
+            return driverContext.blockFactory().newConstantNullBlock(page.getPositionCount());
+        }
+
+        @Override
+        public long baseRamBytesUsed() {
+            long baseRamBytesUsed = BASE_RAM_BYTES_USED;
+            baseRamBytesUsed += columns.baseRamBytesUsed();
+            // NOCOMMIT bytes for name and type
+            return baseRamBytesUsed;
+        }
+
+        @Override
+        public void close() {
+            columns.close();
+        }
+
+        @Override
+        public String toString() {
+            return "NOCOMMIT";
+        }
+
+        Warnings warnings() {
+            if (warnings == null) {
+                this.warnings = Warnings.createWarnings(
+                    driverContext.warningsMode(),
+                    source.source().getLineNumber(),
+                    source.source().getColumnNumber(),
+                    source.text()
+                );
+            }
+            return warnings;
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AggregateMapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AggregateMapper.java
@@ -109,7 +109,7 @@ final class AggregateMapper {
             case INT -> DataType.INTEGER;
             case LONG -> DataType.LONG;
             case DOUBLE -> DataType.DOUBLE;
-            case FLOAT, NULL, DOC, COMPOSITE, AGGREGATE_METRIC_DOUBLE, UNKNOWN -> throw new EsqlIllegalArgumentException(
+            case FLOAT, NULL, DOC, COMPOSITE, AGGREGATE_METRIC_DOUBLE, COLUMNS, UNKNOWN -> throw new EsqlIllegalArgumentException(
                 "unsupported agg type: " + elementType
             );
         };

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -471,7 +471,7 @@ public class LocalExecutionPlanner {
                 case BOOLEAN, NULL, BYTE, SHORT, INTEGER, LONG, DOUBLE, FLOAT, HALF_FLOAT, DATETIME, DATE_NANOS, DATE_PERIOD, TIME_DURATION,
                     OBJECT, SCALED_FLOAT, UNSIGNED_LONG, DOC_DATA_TYPE, TSID_DATA_TYPE -> TopNEncoder.DEFAULT_SORTABLE;
                 case GEO_POINT, CARTESIAN_POINT, GEO_SHAPE, CARTESIAN_SHAPE, COUNTER_LONG, COUNTER_INTEGER, COUNTER_DOUBLE, SOURCE,
-                    AGGREGATE_METRIC_DOUBLE, DENSE_VECTOR, GEOHASH, GEOTILE, GEOHEX -> TopNEncoder.DEFAULT_UNSORTABLE;
+                    AGGREGATE_METRIC_DOUBLE, DENSE_VECTOR, COLUMNS, GEOHASH, GEOTILE, GEOHEX -> TopNEncoder.DEFAULT_UNSORTABLE;
                 // unsupported fields are encoded as BytesRef, we'll use the same encoder; all values should be null at this point
                 case PARTIAL_AGG, UNSUPPORTED -> TopNEncoder.UNSUPPORTED;
             };

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
@@ -31,7 +31,6 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.util.Holder;
 import org.elasticsearch.xpack.esql.core.util.Queries;
-import org.elasticsearch.xpack.esql.expression.function.scalar.math.E;
 import org.elasticsearch.xpack.esql.expression.predicate.Predicates;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamWrapperQueryBuilder;
 import org.elasticsearch.xpack.esql.optimizer.LocalLogicalOptimizerContext;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
@@ -31,6 +31,7 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.util.Holder;
 import org.elasticsearch.xpack.esql.core.util.Queries;
+import org.elasticsearch.xpack.esql.expression.function.scalar.math.E;
 import org.elasticsearch.xpack.esql.expression.predicate.Predicates;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamWrapperQueryBuilder;
 import org.elasticsearch.xpack.esql.optimizer.LocalLogicalOptimizerContext;
@@ -352,6 +353,7 @@ public class PlannerUtils {
             case PARTIAL_AGG -> ElementType.COMPOSITE;
             case AGGREGATE_METRIC_DOUBLE -> ElementType.AGGREGATE_METRIC_DOUBLE;
             case DENSE_VECTOR -> ElementType.FLOAT;
+            case COLUMNS -> ElementType.COLUMNS;
             case SHORT, BYTE, DATE_PERIOD, TIME_DURATION, OBJECT, FLOAT, HALF_FLOAT, SCALED_FLOAT -> throw EsqlIllegalArgumentException
                 .illegalDataType(dataType);
         };


### PR DESCRIPTION
This adds a URI_PARTS function which you can evaluate like any function:
```
FROM test | EVAL URI_PARTS(uri)
```

Which renders as the fairly normal:
```
    [
      "https://localhost:9200/test/_doc?refresh",
      {
        "domain" : "localhost",
        "path" : "/test/_doc",
        "port" : 9200,
        "query" : "refresh",
        "scheme" : "https"
      }
    ]
```

The magic here is that this adds a new `ColumnBlock` which contains more `Block`s that are keyed by *name*. It's pretty much a `Map<String, Block>`.

Except everything is a string but `port`. So we ship type information with the block too. There's a prototype for runtime typing hiding in there too.

For runtime typing this prototypes this:
```
FROM test | EVAL COLUMN(URI_PARTS(uri), "scheme", "KEYWORD")
```

Which is kind of a lame way to extract the runtime type. It'd be much nicer to have:
```
FROM test | EVAL COLUMN(URI_PARTS(uri), "scheme")::KEYWORD
```

Or something like:
```
FROM test | EVAL URI_PARTS(uri).scheme::KEYWORD
```

This prototype expects all of the values for a "column" in a page to be the same type. Which is *fine* for URI_PARTS because the types are known. We do already know the types for URI_PARTS - but not for `kv` or `xpath`. It'd work for flattened fields.
