### PR TITLE
Add entitlement annotation to allow renderDocs

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
@@ -93,7 +93,7 @@ import static org.hamcrest.Matchers.nullValue;
 /**
  * Base class for function tests.
  */
-@ESTestCase.EntitledTestPackages({"sun.font", "sun.awt"}) // For renderDocs
+@ESTestCase.EntitledTestPackages({ "sun.font", "sun.awt" }) // For renderDocs
 public abstract class AbstractFunctionTestCase extends ESTestCase {
 
     private static EsqlFunctionRegistry functionRegistry = new EsqlFunctionRegistry().snapshotRegistry();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
@@ -93,6 +93,7 @@ import static org.hamcrest.Matchers.nullValue;
 /**
  * Base class for function tests.
  */
+@ESTestCase.EntitledTestPackages({"sun.font", "sun.awt"}) // For renderDocs
 public abstract class AbstractFunctionTestCase extends ESTestCase {
 
     private static EsqlFunctionRegistry functionRegistry = new EsqlFunctionRegistry().snapshotRegistry();


### PR DESCRIPTION
ESQL finishes its unit tests by doing a `renderDocs` call that is not run in production.

Fallout from #134454.

This is what stdout says when the failure happens:
```
1> [2025-09-11T12:58:35,818][WARN ][o.e.e.r.p.P.(.j.d.j.awt  ][suite] Not entitled: component [(server)], module [java.desktop], class [class java.awt.Toolkit], entitlement [file], operation [read], path [/Users/prdoyle/.accessibility.properties]
  1> org.elasticsearch.entitlement.runtime.api.NotEntitledException: component [(server)], module [java.desktop], class [class java.awt.Toolkit], entitlement [file], operation [read], path [/Users/prdoyle/.accessibility.properties]
  1>    at org.elasticsearch.entitlement.runtime.policy.PolicyCheckerImpl.notEntitled(PolicyCheckerImpl.java:467) ~[elasticsearch-entitlement-9.2.0-SNAPSHOT.jar:9.2.0-SNAPSHOT]
  1>    at org.elasticsearch.entitlement.runtime.policy.PolicyCheckerImpl.checkFileRead(PolicyCheckerImpl.java:245) ~[elasticsearch-entitlement-9.2.0-SNAPSHOT.jar:9.2.0-SNAPSHOT]
  1>    at org.elasticsearch.entitlement.runtime.policy.PolicyCheckerImpl.checkFileRead(PolicyCheckerImpl.java:208) ~[elasticsearch-entitlement-9.2.0-SNAPSHOT.jar:9.2.0-SNAPSHOT]
  1>    at org.elasticsearch.entitlement.runtime.policy.PolicyCheckerImpl.checkFileRead(PolicyCheckerImpl.java:202) ~[elasticsearch-entitlement-9.2.0-SNAPSHOT.jar:9.2.0-SNAPSHOT]
  1>    at org.elasticsearch.entitlement.runtime.policy.ElasticsearchEntitlementChecker.check$java_io_FileInputStream$(ElasticsearchEntitlementChecker.java:1641) ~[elasticsearch-entitlement-9.2.0-SNAPSHOT.jar:9.2.0-SNAPSHOT]
  1>    at java.io.FileInputStream.<init>(FileInputStream.java) ~[?:?]
  1>    at java.awt.Toolkit.initAssistiveTechnologies(Toolkit.java:407) ~[?:?]
  1>    at java.awt.Toolkit.initStatic(Toolkit.java:1319) ~[?:?]
  1>    at java.awt.Toolkit.<clinit>(Toolkit.java:1299) ~[?:?]
  1>    at java.awt.Font.<clinit>(Font.java:285) ~[?:?]
  1>    at net.nextencia.rrdiagram.grammar.rrdiagram.RRDiagramToSVG.<init>(RRDiagramToSVG.java:33) ~[rrdiagram-0.9.4.jar:?]
  1>    at org.elasticsearch.xpack.esql.expression.function.RailRoadDiagram.toSvg(RailRoadDiagram.java:155) ~[test/:?]
  1>    at org.elasticsearch.xpack.esql.expression.function.RailRoadDiagram.functionSignature(RailRoadDiagram.java:49) ~[test/:?]
  1>    at org.elasticsearch.xpack.esql.expression.function.DocsV3Support.buildFunctionSignatureSvg(DocsV3Support.java:1082) ~[test/:?]
  1>    at org.elasticsearch.xpack.esql.expression.function.DocsV3Support$FunctionDocsSupport.renderSignature(DocsV3Support.java:592) ~[test/:?]
  1>    at org.elasticsearch.xpack.esql.expression.function.DocsV3Support.renderDocs(DocsV3Support.java:129) ~[test/:?]
  1>    at org.elasticsearch.xpack.esql.expression.function.AbstractFunctionTestCase.renderDocs(AbstractFunctionTestCase.java:985) ~[test/:?]

```