### PR TITLE
[8.18] Fill in missing transport version error message (#134590)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/ValidateTransportVersionReferencesTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/ValidateTransportVersionReferencesTask.java
@@ -58,8 +58,8 @@ public abstract class ValidateTransportVersionReferencesTask extends DefaultTask
                         + tvReference.name()
                         + "\") was used at "
                         + tvReference.location()
-                        + ", but lacks a"
-                        + " transport version definition. This can be generated with the <TODO> task" // todo
+                        + ", but lacks a transport version definition. "
+                        + "If this is a new transport version, run './gradle generateTransportVersion'."
                 );
             }
         }


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Fill in missing transport version error message (#134590)