### PR TITLE
[8.19] rest-api-spec: stop advertising unitless bytes values in cat APIs (#134540)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.allocation.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.allocation.json
@@ -41,15 +41,10 @@
         "description":"The unit in which to display byte values",
         "options":[
           "b",
-          "k",
           "kb",
-          "m",
           "mb",
-          "g",
           "gb",
-          "t",
           "tb",
-          "p",
           "pb"
         ]
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.fielddata.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.fielddata.json
@@ -41,15 +41,10 @@
         "description":"The unit in which to display byte values",
         "options":[
           "b",
-          "k",
           "kb",
-          "m",
           "mb",
-          "g",
           "gb",
-          "t",
           "tb",
-          "p",
           "pb"
         ]
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.indices.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.indices.json
@@ -41,15 +41,10 @@
         "description":"The unit in which to display byte values",
         "options":[
           "b",
-          "k",
           "kb",
-          "m",
           "mb",
-          "g",
           "gb",
-          "t",
           "tb",
-          "p",
           "pb"
         ]
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_data_frame_analytics.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_data_frame_analytics.json
@@ -42,15 +42,10 @@
         "description":"The unit in which to display byte values",
         "options":[
           "b",
-          "k",
           "kb",
-          "m",
           "mb",
-          "g",
           "gb",
-          "t",
           "tb",
-          "p",
           "pb"
         ]
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_jobs.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_jobs.json
@@ -42,15 +42,10 @@
         "description":"The unit in which to display byte values",
         "options":[
           "b",
-          "k",
           "kb",
-          "m",
           "mb",
-          "g",
           "gb",
-          "t",
           "tb",
-          "p",
           "pb"
         ]
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_trained_models.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_trained_models.json
@@ -53,15 +53,10 @@
         "description":"The unit in which to display byte values",
         "options":[
           "b",
-          "k",
           "kb",
-          "m",
           "mb",
-          "g",
           "gb",
-          "t",
           "tb",
-          "p",
           "pb"
         ]
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodes.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodes.json
@@ -25,15 +25,10 @@
         "description":"The unit in which to display byte values",
         "options":[
           "b",
-          "k",
           "kb",
-          "m",
           "mb",
-          "g",
           "gb",
-          "t",
           "tb",
-          "p",
           "pb"
         ]
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.recovery.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.recovery.json
@@ -46,15 +46,10 @@
         "description":"The unit in which to display byte values",
         "options":[
           "b",
-          "k",
           "kb",
-          "m",
           "mb",
-          "g",
           "gb",
-          "t",
           "tb",
-          "p",
           "pb"
         ]
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segments.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segments.json
@@ -49,15 +49,10 @@
         "description":"The unit in which to display byte values",
         "options":[
           "b",
-          "k",
           "kb",
-          "m",
           "mb",
-          "g",
           "gb",
-          "t",
           "tb",
-          "p",
           "pb"
         ]
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.shards.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.shards.json
@@ -41,15 +41,10 @@
         "description":"The unit in which to display byte values",
         "options":[
           "b",
-          "k",
           "kb",
-          "m",
           "mb",
-          "g",
           "gb",
-          "t",
           "tb",
-          "p",
           "pb"
         ]
       },


### PR DESCRIPTION
Backports the following commits to 8.19:
 - rest-api-spec: stop advertising unitless bytes values in cat APIs (#134540)