### PR TITLE
[8.19] Add entitlement annotation to allow renderDocs (#134578)

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
@@ -123,6 +123,7 @@ import static org.hamcrest.Matchers.nullValue;
 /**
  * Base class for function tests.
  */
+@ESTestCase.EntitledTestPackages({ "sun.font", "sun.awt" }) // For renderDocs
 public abstract class AbstractFunctionTestCase extends ESTestCase {
     /**
      * Operators are unregistered functions.


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Add entitlement annotation to allow renderDocs (#134578)