### PR TITLE
Unmute OldRepositoryAccessIT testOldRepoAccess / testOldSourceOnlyRepoAccess

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -120,12 +120,6 @@ tests:
 - class: org.elasticsearch.xpack.security.QueryableReservedRolesIT
   method: testConfiguredReservedRolesAfterClosingAndOpeningIndex
   issue: https://github.com/elastic/elasticsearch/issues/120127
-- class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
-  method: testOldRepoAccess
-  issue: https://github.com/elastic/elasticsearch/issues/120148
-- class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
-  method: testOldSourceOnlyRepoAccess
-  issue: https://github.com/elastic/elasticsearch/issues/120080
 - class: org.elasticsearch.xpack.ccr.FollowIndexSecurityIT
   method: testCleanShardFollowTaskAfterDeleteFollower
   issue: https://github.com/elastic/elasticsearch/issues/120339


### PR DESCRIPTION
This has been muted for a long time now, unmuting to get some pulse on whether this test generally still works and if the infrequent failures persist.
