### PR TITLE
[9.1] rest-api-spec: require watcher.put_watch body (#134425)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/watcher.put_watch.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/watcher.put_watch.json
@@ -51,7 +51,7 @@
     },
     "body": {
       "description": "The watch",
-      "required": false
+      "required": true
     }
   }
 }

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/watcher/put_watch/10_basic.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/watcher/put_watch/10_basic.yml
@@ -37,26 +37,3 @@ setup:
             }
           }
   - match: { _id: "my_watch" }
-
----
-"Test empty body is rejected by put watch":
-  - do:
-      watcher.put_watch:
-        id: "my_watch"
-      catch: bad_request
-  - match: { error.root_cause.0.type: "action_request_validation_exception" }
-  - match: { error.root_cause.0.reason: "Validation Failed: 1: request body is missing;" }
-
----
-"Test empty body (with Content-Type) is rejected by put watch":
-  - skip:
-       features:
-         - headers
-  - do:
-      headers:
-        Content-Type: "application/json"
-      watcher.put_watch:
-        id: "my_watch"
-      catch: bad_request
-  - match: { error.root_cause.0.type: "action_request_validation_exception" }
-  - match: { error.root_cause.0.reason: "Validation Failed: 1: request body is missing;" }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [rest-api-spec: require watcher.put_watch body (#134425)](https://github.com/elastic/elasticsearch/pull/134425)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)