### PR TITLE
[9.1] [DOCS] Fix escape character for quotes in esql-syntax.md (#134266)

### DIFF
--- a/docs/reference/query-languages/esql/esql-syntax.md
+++ b/docs/reference/query-languages/esql/esql-syntax.md
@@ -69,7 +69,7 @@ FROM index
 | WHERE first_name == "Georgi"
 ```
 
-If the literal string itself contains quotes, these need to be escaped (`\\"`). {{esql}} also supports the triple-quotes (`"""`) delimiter, for convenience:
+If the literal string itself contains quotes, these need to be escaped (`\"`). {{esql}} also supports the triple-quotes (`"""`) delimiter, for convenience:
 
 ```esql
 ROW name = """Indiana "Indy" Jones"""


### PR DESCRIPTION
Backports the following commits to 9.1:
 - [DOCS] Fix escape character for quotes in esql-syntax.md (#134266)