### PR TITLE
[9.0] Rename the transport version generate task to be shorter (#134420)

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/AbstractTransportVersionFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/AbstractTransportVersionFuncTest.groovy
@@ -122,7 +122,7 @@ class AbstractTransportVersionFuncTest extends AbstractGradleFuncTest {
             apply plugin: 'elasticsearch.transport-version-references'
             apply plugin: 'elasticsearch.transport-version-resources'
 
-            tasks.named('generateTransportVersionDefinition') {
+            tasks.named('generateTransportVersion') {
                 currentUpperBoundName = '9.2'
             }
         """

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/TransportVersionGenerationFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/TransportVersionGenerationFuncTest.groovy
@@ -18,14 +18,14 @@ class TransportVersionGenerationFuncTest extends AbstractTransportVersionFuncTes
     def runGenerateAndValidateTask(String... additionalArgs) {
         List<String> args = new ArrayList<>()
         args.add(":myserver:validateTransportVersionResources")
-        args.add(":myserver:generateTransportVersionDefinition")
+        args.add(":myserver:generateTransportVersion")
         args.addAll(additionalArgs);
         return gradleRunner(args.toArray())
     }
 
     def runGenerateTask(String... additionalArgs) {
         List<String> args = new ArrayList<>()
-        args.add(":myserver:generateTransportVersionDefinition")
+        args.add(":myserver:generateTransportVersion")
         args.addAll(additionalArgs);
         return gradleRunner(args.toArray())
     }
@@ -35,11 +35,11 @@ class TransportVersionGenerationFuncTest extends AbstractTransportVersionFuncTes
     }
 
     void assertGenerateSuccess(BuildResult result) {
-        assert result.task(":myserver:generateTransportVersionDefinition").outcome == TaskOutcome.SUCCESS
+        assert result.task(":myserver:generateTransportVersion").outcome == TaskOutcome.SUCCESS
     }
 
     void assertGenerateFailure(BuildResult result, String expectedOutput) {
-        assert result.task(":myserver:generateTransportVersionDefinition").outcome == TaskOutcome.FAILED
+        assert result.task(":myserver:generateTransportVersion").outcome == TaskOutcome.FAILED
         assertOutputContains(result.output, expectedOutput)
     }
 
@@ -449,7 +449,7 @@ class TransportVersionGenerationFuncTest extends AbstractTransportVersionFuncTes
         referencedTransportVersion("new_tv")
         file("myserver/alt_upper_bound.csv").text = "some_tv,8126000"
         file("myserver/build.gradle") << """
-            tasks.named('generateTransportVersionDefinition') {
+            tasks.named('generateTransportVersion') {
                 alternateUpperBoundFile = project.file("alt_upper_bound.csv")
             }
             tasks.named('validateTransportVersionResources') {
@@ -470,7 +470,7 @@ class TransportVersionGenerationFuncTest extends AbstractTransportVersionFuncTes
         referencedTransportVersion("new_tv")
         file("myserver/alt_upper_bound.csv").text = "some_tv,8122100"
         file("myserver/build.gradle") << """
-            tasks.named('generateTransportVersionDefinition') {
+            tasks.named('generateTransportVersion') {
                 alternateUpperBoundFile = project.file("alt_upper_bound.csv")
             }
             tasks.named('validateTransportVersionResources') {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionResourcesPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionResourcesPlugin.java
@@ -83,7 +83,7 @@ public class TransportVersionResourcesPlugin implements Plugin<Project> {
         });
 
         var generateDefinitionsTask = project.getTasks()
-            .register("generateTransportVersionDefinition", GenerateTransportVersionDefinitionTask.class, t -> {
+            .register("generateTransportVersion", GenerateTransportVersionDefinitionTask.class, t -> {
                 t.setGroup(taskGroup);
                 t.setDescription("(Re)generates a transport version definition file");
                 t.getReferencesFiles().setFrom(tvReferencesConfig);


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Rename the transport version generate task to be shorter (#134420)