### PR TITLE
Removing the logs stream feature flag

### DIFF
--- a/modules/ingest-otel/src/main/java/org/elasticsearch/ingest/otel/NormalizeForStreamPlugin.java
+++ b/modules/ingest-otel/src/main/java/org/elasticsearch/ingest/otel/NormalizeForStreamPlugin.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.ingest.otel;
 
-import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.ingest.Processor;
 import org.elasticsearch.plugins.IngestPlugin;
 import org.elasticsearch.plugins.Plugin;
@@ -20,10 +19,6 @@ public class NormalizeForStreamPlugin extends Plugin implements IngestPlugin {
 
     @Override
     public Map<String, Processor.Factory> getProcessors(Processor.Parameters parameters) {
-        if (DataStream.LOGS_STREAM_FEATURE_FLAG) {
-            return Map.of(NormalizeForStreamProcessor.TYPE, new NormalizeForStreamProcessor.Factory());
-        } else {
-            return Map.of();
-        }
+        return Map.of(NormalizeForStreamProcessor.TYPE, new NormalizeForStreamProcessor.Factory());
     }
 }

--- a/modules/streams/src/main/java/org/elasticsearch/rest/streams/StreamsPlugin.java
+++ b/modules/streams/src/main/java/org/elasticsearch/rest/streams/StreamsPlugin.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.rest.streams;
 
-import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
@@ -29,7 +28,6 @@ import org.elasticsearch.rest.streams.logs.StreamsStatusAction;
 import org.elasticsearch.rest.streams.logs.TransportLogsStreamsToggleActivation;
 import org.elasticsearch.rest.streams.logs.TransportStreamsStatusAction;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -53,10 +51,7 @@ public class StreamsPlugin extends Plugin implements ActionPlugin {
         Supplier<DiscoveryNodes> nodesInCluster,
         Predicate<NodeFeature> clusterSupportsFeature
     ) {
-        if (DataStream.LOGS_STREAM_FEATURE_FLAG) {
-            return List.of(new RestSetLogStreamsEnabledAction(), new RestStreamsStatusAction());
-        }
-        return Collections.emptyList();
+        return List.of(new RestSetLogStreamsEnabledAction(), new RestStreamsStatusAction());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
@@ -90,7 +90,6 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
     private static final TransportVersion MAPPINGS_IN_DATA_STREAMS = TransportVersion.fromName("mappings_in_data_streams");
 
     public static final NodeFeature DATA_STREAM_FAILURE_STORE_FEATURE = new NodeFeature("data_stream.failure_store");
-    public static final boolean LOGS_STREAM_FEATURE_FLAG = new FeatureFlag("logs_stream").isEnabled();
     public static final TransportVersion ADDED_FAILURE_STORE_TRANSPORT_VERSION = TransportVersions.V_8_12_0;
     public static final TransportVersion ADDED_AUTO_SHARDING_EVENT_VERSION = TransportVersions.V_8_14_0;
     public static final TransportVersion ADD_DATA_STREAM_OPTIONS_VERSION = TransportVersions.V_8_16_0;

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
@@ -35,7 +35,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.DateFormatters;
-import org.elasticsearch.common.util.FeatureFlag;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.FixForMultiProject;
 import org.elasticsearch.core.Nullable;

--- a/server/src/main/java/org/elasticsearch/ingest/IngestFeatures.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestFeatures.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.ingest;
 
-import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.features.FeatureSpecification;
 import org.elasticsearch.features.NodeFeature;
 
@@ -21,11 +20,7 @@ public class IngestFeatures implements FeatureSpecification {
 
     @Override
     public Set<NodeFeature> getFeatures() {
-        if (DataStream.LOGS_STREAM_FEATURE_FLAG) {
-            return Set.of(IngestService.FIELD_ACCESS_PATTERN);
-        } else {
-            return Set.of();
-        }
+        return Set.of(IngestService.FIELD_ACCESS_PATTERN);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -132,12 +132,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
      * @return true if the node feature can be supported in the local library code, false if it is not supported
      */
     public static boolean locallySupportedIngestFeature(NodeFeature nodeFeature) {
-        if (DataStream.LOGS_STREAM_FEATURE_FLAG) {
-            // logs_stream feature flag guard
-            return IngestService.FIELD_ACCESS_PATTERN.equals(nodeFeature);
-        }
-        // Default to unsupported if not contained here
-        return false;
+        return IngestService.FIELD_ACCESS_PATTERN.equals(nodeFeature);
     }
 
     private final MasterServiceTaskQueue<PipelineClusterStateUpdateTask> taskQueue;

--- a/server/src/main/java/org/elasticsearch/rest/action/ingest/RestPutPipelineAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/ingest/RestPutPipelineAction.java
@@ -13,7 +13,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ingest.PutPipelineRequest;
 import org.elasticsearch.action.ingest.PutPipelineTransportAction;
 import org.elasticsearch.client.internal.node.NodeClient;
-import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.rest.BaseRestHandler;
@@ -79,10 +78,6 @@ public class RestPutPipelineAction extends BaseRestHandler {
     @Override
     public Set<String> supportedCapabilities() {
         // pipeline_tracking info: `{created,modified}_date` system properties defined within pipeline definition.
-        if (DataStream.LOGS_STREAM_FEATURE_FLAG) {
-            return Set.of("pipeline_tracking_info", "field_access_pattern.flexible");
-        } else {
-            return Set.of("pipeline_tracking_info");
-        }
+        return Set.of("pipeline_tracking_info", "field_access_pattern.flexible");
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/ingest/SimulatePipelineRequestParsingTests.java
+++ b/server/src/test/java/org/elasticsearch/action/ingest/SimulatePipelineRequestParsingTests.java
@@ -10,7 +10,6 @@
 package org.elasticsearch.action.ingest;
 
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.ingest.CompoundProcessor;
@@ -197,7 +196,7 @@ public class SimulatePipelineRequestParsingTests extends ESTestCase {
             false,
             ingestService,
             RestApiVersion.current(),
-            (nodeFeature) -> DataStream.LOGS_STREAM_FEATURE_FLAG
+            (nodeFeature) -> true
         );
         assertThat(actualRequest.verbose(), equalTo(false));
         assertThat(actualRequest.documents().size(), equalTo(numDocs));
@@ -276,7 +275,7 @@ public class SimulatePipelineRequestParsingTests extends ESTestCase {
                 false,
                 ingestService,
                 RestApiVersion.current(),
-                (nodeFeature) -> DataStream.LOGS_STREAM_FEATURE_FLAG
+                (nodeFeature) -> true
             )
         );
         assertThat(e1.getMessage(), equalTo("must specify at least one document in [docs]"));
@@ -294,7 +293,7 @@ public class SimulatePipelineRequestParsingTests extends ESTestCase {
                 false,
                 ingestService,
                 RestApiVersion.current(),
-                (nodeFeature) -> DataStream.LOGS_STREAM_FEATURE_FLAG
+                (nodeFeature) -> true
             )
         );
         assertThat(e2.getMessage(), equalTo("malformed [docs] section, should include an inner object"));
@@ -310,7 +309,7 @@ public class SimulatePipelineRequestParsingTests extends ESTestCase {
                 false,
                 ingestService,
                 RestApiVersion.current(),
-                (nodeFeature) -> DataStream.LOGS_STREAM_FEATURE_FLAG
+                (nodeFeature) -> true
             )
         );
         assertThat(e3.getMessage(), containsString("required property is missing"));
@@ -391,7 +390,7 @@ public class SimulatePipelineRequestParsingTests extends ESTestCase {
             false,
             ingestService,
             RestApiVersion.V_8,
-            (nodeFeature) -> DataStream.LOGS_STREAM_FEATURE_FLAG
+            (nodeFeature) -> true
         );
         assertThat(actualRequest.verbose(), equalTo(false));
         assertThat(actualRequest.documents().size(), equalTo(numDocs));

--- a/server/src/test/java/org/elasticsearch/ingest/IngestDocumentTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestDocumentTests.java
@@ -9,13 +9,11 @@
 
 package org.elasticsearch.ingest;
 
-import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentType;
 import org.hamcrest.Matchers;
-import org.junit.Assume;
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 
@@ -2108,8 +2106,6 @@ public class IngestDocumentTests extends ESTestCase {
      * restore the previous pipeline's access pattern.
      */
     public void testNestedAccessPatternPropagation() {
-        Assume.assumeTrue(DataStream.LOGS_STREAM_FEATURE_FLAG);
-
         Map<String, Object> source = new HashMap<>(Map.of("foo", 1));
         IngestDocument document = new IngestDocument("index", "id", 1, null, null, source);
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidatorTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidatorTests.java
@@ -19,7 +19,6 @@ import org.elasticsearch.client.internal.RemoteClusterClient;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
-import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -601,14 +600,7 @@ public class SourceDestValidatorTests extends ESTestCase {
         );
         Map<String, Processor.Factory> processorRegistry = Collections.singletonMap("test", new TestProcessor.Factory());
         var projectId = randomProjectIdOrDefault();
-        Pipeline pipeline = Pipeline.create(
-            "missing-pipeline",
-            pipelineConfig,
-            processorRegistry,
-            null,
-            projectId,
-            nodeFeature -> DataStream.LOGS_STREAM_FEATURE_FLAG
-        );
+        Pipeline pipeline = Pipeline.create("missing-pipeline", pipelineConfig, processorRegistry, null, projectId, nodeFeature -> true);
         when(ingestService.getPipeline("missing-pipeline")).thenReturn(pipeline);
 
         assertValidation(


### PR DESCRIPTION
This removes the feature flag from the logs streams feature. The rest endpoints[ `/_streams/logs/_enable`, `/_streams/logs/_disable`, and `/_streams/status`](https://github.com/elastic/elasticsearch/pull/129474) are no longer behind a feature flag, and neither are the new [flexible field access pattern](https://github.com/elastic/elasticsearch/pull/133270) or [`normalize_for_stream` processor](http://github.com/elastic/elasticsearch/pull/125699).