### PR TITLE
[8.18] Add --resolve-conflict flag to transport version generate task (#134421)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/GenerateInitialTransportVersionTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/GenerateInitialTransportVersionTask.java
@@ -55,13 +55,13 @@ public abstract class GenerateInitialTransportVersionTask extends DefaultTask {
         var definition = new TransportVersionDefinition(initialDefinitionName, List.of(id));
         resources.writeUnreferableDefinition(definition);
         var newUpperBound = new TransportVersionUpperBound(upperBoundName, initialDefinitionName, id);
-        resources.writeUpperBound(newUpperBound);
+        resources.writeUpperBound(newUpperBound, false);
 
         if (releaseVersion.getRevision() == 0) {
             Version currentVersion = getCurrentVersion().get();
             String currentUpperBoundName = getUpperBoundName(currentVersion);
             var currentUpperBound = new TransportVersionUpperBound(currentUpperBoundName, initialDefinitionName, id);
-            resources.writeUpperBound(currentUpperBound);
+            resources.writeUpperBound(currentUpperBound, false);
         }
     }
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/GenerateTransportVersionDefinitionTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/GenerateTransportVersionDefinitionTask.java
@@ -72,6 +72,14 @@ public abstract class GenerateTransportVersionDefinitionTask extends DefaultTask
     @Option(option = "increment", description = "The amount to increment the id from the current upper bounds file by")
     public abstract Property<Integer> getIncrement();
 
+    @Input
+    @Optional
+    @Option(
+        option = "resolve-conflict",
+        description = "Regenerate the transport version currently being added to upstream to resolve a merge conflict"
+    )
+    public abstract Property<Boolean> getResolveConflict();
+
     /**
      * The name of the upper bounds file which will be used at runtime on the current branch. Normally
      * this equates to VersionProperties.getElasticsearchVersion().
@@ -95,7 +103,7 @@ public abstract class GenerateTransportVersionDefinitionTask extends DefaultTask
         String targetDefinitionName = getTargetDefinitionName(resources, referencedNames, changedDefinitionNames);
 
         List<TransportVersionUpperBound> upstreamUpperBounds = resources.getUpperBoundsFromUpstream();
-        Set<String> targetUpperBoundNames = getTargetUpperBoundNames(upstreamUpperBounds);
+        Set<String> targetUpperBoundNames = getTargetUpperBoundNames(resources, upstreamUpperBounds, targetDefinitionName);
 
         getLogger().lifecycle("Generating transport version name: " + targetDefinitionName);
         if (targetDefinitionName.isEmpty()) {
@@ -121,6 +129,7 @@ public abstract class GenerateTransportVersionDefinitionTask extends DefaultTask
             throw new IllegalArgumentException("Invalid increment " + increment + ", must be a positive integer");
         }
         List<TransportVersionId> ids = new ArrayList<>();
+        boolean stageInGit = getResolveConflict().getOrElse(false);
 
         TransportVersionDefinition existingDefinition = resources.getReferableDefinitionFromUpstream(definitionName);
         for (TransportVersionUpperBound existingUpperBound : existingUpperBounds) {
@@ -134,12 +143,12 @@ public abstract class GenerateTransportVersionDefinitionTask extends DefaultTask
                     int targetIncrement = upperBoundName.equals(currentUpperBoundName) ? increment : 1;
                     targetId = createTargetId(existingUpperBound, targetIncrement);
                     var newUpperBound = new TransportVersionUpperBound(upperBoundName, definitionName, targetId);
-                    resources.writeUpperBound(newUpperBound);
+                    resources.writeUpperBound(newUpperBound, stageInGit);
                 }
                 ids.add(targetId);
             } else {
                 // Default case: we're not targeting this branch so reset it
-                resources.writeUpperBound(existingUpperBound);
+                resources.writeUpperBound(existingUpperBound, false);
             }
         }
 
@@ -180,7 +189,19 @@ public abstract class GenerateTransportVersionDefinitionTask extends DefaultTask
         }
     }
 
-    private Set<String> getTargetUpperBoundNames(List<TransportVersionUpperBound> upstreamUpperBounds) {
+    private Set<String> getTargetUpperBoundNames(
+        TransportVersionResourcesService resources,
+        List<TransportVersionUpperBound> upstreamUpperBounds,
+        String targetDefinitionName
+    ) throws IOException {
+        if (getResolveConflict().getOrElse(false)) {
+            if (getBackportBranches().isPresent()) {
+                throw new IllegalArgumentException("Cannot use --resolve-conflict with --backport-branches");
+            }
+
+            return getUpperBoundNamesFromDefinition(resources, upstreamUpperBounds, targetDefinitionName);
+        }
+
         Set<String> targetUpperBoundNames = new HashSet<>();
         targetUpperBoundNames.add(getCurrentUpperBoundName().get());
         if (getBackportBranches().isPresent()) {
@@ -204,9 +225,32 @@ public abstract class GenerateTransportVersionDefinitionTask extends DefaultTask
         return targetUpperBoundNames;
     }
 
+    private Set<String> getUpperBoundNamesFromDefinition(
+        TransportVersionResourcesService resources,
+        List<TransportVersionUpperBound> upstreamUpperBounds,
+        String targetDefinitionName
+    ) throws IOException {
+        TransportVersionDefinition definition = resources.getReferableDefinition(targetDefinitionName);
+        Set<String> upperBoundNames = new HashSet<>();
+        upperBoundNames.add(getCurrentUpperBoundName().get());
+
+        // skip the primary id as that is current, which we always add
+        for (int i = 1; i < definition.ids().size(); ++i) {
+            TransportVersionId id = definition.ids().get(i);
+            // we have a small number of upper bound files, so just scan for the ones we want
+            for (TransportVersionUpperBound upperBound : upstreamUpperBounds) {
+                if (upperBound.definitionId().base() == id.base()) {
+                    upperBoundNames.add(upperBound.name());
+                }
+            }
+        }
+
+        return upperBoundNames;
+    }
+
     private void resetAllUpperBounds(TransportVersionResourcesService resources) throws IOException {
         for (TransportVersionUpperBound upperBound : resources.getUpperBoundsFromUpstream()) {
-            resources.writeUpperBound(upperBound);
+            resources.writeUpperBound(upperBound, false);
         }
     }
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionResourcesService.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionResourcesService.java
@@ -107,6 +107,12 @@ public abstract class TransportVersionResourcesService implements BuildService<T
         return readDefinitions(transportResourcesDir.resolve(REFERABLE_DIR));
     }
 
+    /** Return a single referable definition by name */
+    TransportVersionDefinition getReferableDefinition(String name) throws IOException {
+        Path resourcePath = transportResourcesDir.resolve(getReferableDefinitionRelativePath(name));
+        return TransportVersionDefinition.fromString(resourcePath, Files.readString(resourcePath, StandardCharsets.UTF_8));
+    }
+
     /** Get a referable definition from upstream if it exists there, or null otherwise */
     TransportVersionDefinition getReferableDefinitionFromUpstream(String name) {
         Path resourcePath = getReferableDefinitionRelativePath(name);
@@ -218,10 +224,14 @@ public abstract class TransportVersionResourcesService implements BuildService<T
     }
 
     /** Write the given upper bound to a file in the transport resources */
-    void writeUpperBound(TransportVersionUpperBound upperBound) throws IOException {
+    void writeUpperBound(TransportVersionUpperBound upperBound, boolean stageInGit) throws IOException {
         Path path = transportResourcesDir.resolve(getUpperBoundRelativePath(upperBound.name()));
         logger.debug("Writing upper bound [" + upperBound + "] to [" + path + "]");
         Files.writeString(path, upperBound.definitionName() + "," + upperBound.definitionId().complete() + "\n", StandardCharsets.UTF_8);
+
+        if (stageInGit) {
+            gitCommand("add", path.toString());
+        }
     }
 
     /** Return the path within the repository of the given latest */


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Add --resolve-conflict flag to transport version generate task (#134421)