### PR TITLE
Fix `testFailIfAlreadyExists`

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -540,9 +540,6 @@ tests:
 - class: org.elasticsearch.aggregations.bucket.AggregationReductionCircuitBreakingIT
   method: testCBTrippingOnReduction
   issue: https://github.com/elastic/elasticsearch/issues/134667
-- class: org.elasticsearch.repositories.s3.S3BlobStoreRepositoryTests
-  method: testFailIfAlreadyExists
-  issue: https://github.com/elastic/elasticsearch/issues/134669
 - class: org.elasticsearch.xpack.esql.expression.function.scalar.score.DecayTests
   method: "testEvaluateBlockWithNulls {TestCase=<integer>, <integer>, <integer>, <_source> #2}"
   issue: https://github.com/elastic/elasticsearch/issues/134679


### PR DESCRIPTION
This test was only waiting for a second for the tasks to complete, which
is too short to be reliable in CI. This commit reworks the test to use
`runInParallel` which waits more tenaciously for completion.

Closes #134669