### PR TITLE
Patterned text conditionally disable templating

### DIFF
--- a/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/patternedtext/PatternedTextBasicRestIT.java
+++ b/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/patternedtext/PatternedTextBasicRestIT.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.logsdb.patternedtext;
 
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.settings.Settings;
@@ -45,6 +47,17 @@ public class PatternedTextBasicRestIT extends ESRestTestCase {
         return cluster.getHttpAddresses();
     }
 
+    @ParametersFactory(argumentFormatting = "disableTemplating=%b")
+    public static List<Object[]> args() {
+        return List.of(new Object[] { true }, new Object[] { false });
+    }
+
+    private final boolean disableTemplating;
+
+    public PatternedTextBasicRestIT(boolean disableTemplating) {
+        this.disableTemplating = disableTemplating;
+    }
+
     @SuppressWarnings("unchecked")
     public void testBulkInsertThenMatchAllSource() throws IOException {
 
@@ -63,11 +76,12 @@ public class PatternedTextBasicRestIT extends ESRestTestCase {
                             "type": "date"
                         },
                         "message": {
-                            "type": "patterned_text"
+                            "type": "patterned_text",
+                            "disable_templating": %disable_templating%
                         }
                     }
                 }
-            """;
+            """.replace("%disable_templating%", Boolean.toString(disableTemplating));
 
         String indexName = "test-index";
         createIndex(indexName, settings.build(), mapping);

--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/patternedtext/PatternedTextFieldType.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/patternedtext/PatternedTextFieldType.java
@@ -30,6 +30,7 @@ import org.elasticsearch.index.fielddata.FieldDataContext;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.SourceValueFetcherSortedBinaryIndexFieldData;
 import org.elasticsearch.index.mapper.BlockLoader;
+import org.elasticsearch.index.mapper.BlockStoredFieldsReader;
 import org.elasticsearch.index.mapper.SourceValueFetcher;
 import org.elasticsearch.index.mapper.StringFieldType;
 import org.elasticsearch.index.mapper.TextFieldMapper;
@@ -262,6 +263,10 @@ public class PatternedTextFieldType extends StringFieldType {
 
     @Override
     public BlockLoader blockLoader(BlockLoaderContext blContext) {
+        if (disableTemplating) {
+            return new BlockStoredFieldsReader.BytesFromBytesRefsBlockLoader(storedNamed());
+        }
+
         return new PatternedTextBlockLoader((leafReader -> PatternedTextCompositeValues.from(leafReader, this)));
     }
 

--- a/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/patternedtext/PatternedTextFieldMapperTests.java
+++ b/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/patternedtext/PatternedTextFieldMapperTests.java
@@ -97,6 +97,16 @@ public class PatternedTextFieldMapperTests extends MapperTestCase {
         assertPhraseQuery(createSytheticSourceMapperService(fieldMapping(b -> b.field("type", "patterned_text"))));
     }
 
+    public void testPhraseQueryStandardSourceDisableTemplating() throws IOException {
+        assertPhraseQuery(createMapperService(fieldMapping(b -> b.field("type", "patterned_text").field("disable_templating", true))));
+    }
+
+    public void testPhraseQuerySyntheticSourceDisableTemplating() throws IOException {
+        assertPhraseQuery(
+            createSytheticSourceMapperService(fieldMapping(b -> b.field("type", "patterned_text").field("disable_templating", true)))
+        );
+    }
+
     private void assertPhraseQuery(MapperService mapperService) throws IOException {
         try (Directory directory = newDirectory()) {
             RandomIndexWriter iw = new RandomIndexWriter(random(), directory);
@@ -322,6 +332,9 @@ public class PatternedTextFieldMapperTests extends MapperTestCase {
 
         private void mapping(XContentBuilder b) throws IOException {
             b.field("type", "patterned_text");
+            if (randomBoolean()) {
+                b.field("disable_templating", true);
+            }
         }
 
         @Override

--- a/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/patternedtext/PatternedTextIntegrationTests.java
+++ b/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/patternedtext/PatternedTextIntegrationTests.java
@@ -172,7 +172,7 @@ public class PatternedTextIntegrationTests extends ESSingleNodeTestCase {
         assertMappings();
         assertMessagesInSource(messages);
 
-        // assert does not contain stored field
+        // assert only contains stored field if templating is disabled
         try (var searcher = indexService.getShard(0).acquireSearcher(INDEX)) {
             try (var indexReader = searcher.getIndexReader()) {
                 var document = indexReader.storedFields().document(0);

--- a/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/patternedtext/PatternedTextIntegrationTests.java
+++ b/x-pack/plugin/logsdb/src/test/java/org/elasticsearch/xpack/logsdb/patternedtext/PatternedTextIntegrationTests.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.logsdb.patternedtext;
 
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.DocWriteRequest;
@@ -41,6 +43,7 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -55,6 +58,27 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFa
 
 public class PatternedTextIntegrationTests extends ESSingleNodeTestCase {
     private static final Logger logger = LogManager.getLogger(PatternedTextIntegrationTests.class);
+
+    @ParametersFactory(argumentFormatting = "indexOptions=%s, disableTemplating=%b")
+    public static List<Object[]> args() {
+        List<Object[]> args = new ArrayList<>();
+        for (var indexOption : new String[] { "docs", "positions" }) {
+            for (var templating : new boolean[] { true, false }) {
+                args.add(new Object[] { indexOption, templating });
+            }
+        }
+        return Collections.unmodifiableList(args);
+    }
+
+    private final String indexOptions;
+    private final boolean disableTemplating;
+    private final String mapping;
+
+    public PatternedTextIntegrationTests(String indexOptions, boolean disableTemplating) {
+        this.indexOptions = indexOptions;
+        this.disableTemplating = disableTemplating;
+        this.mapping = getMapping(indexOptions, disableTemplating);
+    }
 
     @Override
     protected Settings nodeSettings() {
@@ -75,16 +99,14 @@ public class PatternedTextIntegrationTests extends ESSingleNodeTestCase {
                 "@timestamp": { "type": "date" },
                 "field_match_only_text": { "type": "match_only_text" },
                 "field_patterned_text": {
-                    "type": "patterned_text",
-                    "index_options": "%",
-                    "analyzer": "standard"
+                  "type": "patterned_text",
+                  "index_options": "%index_options%",
+                  "disable_templating": "%disable_templating%",
+                  "analyzer": "standard"
                 }
               }
             }
         """;
-
-    private static final String MAPPING_DOCS_ONLY = MAPPING_TEMPLATE.replace("%", "docs");
-    private static final String MAPPING_POSITIONS = MAPPING_TEMPLATE.replace("%", "positions");
 
     private static final Settings LOGSDB_SETTING = Settings.builder().put(IndexSettings.MODE.getKey(), "logsdb").build();
 
@@ -100,8 +122,12 @@ public class PatternedTextIntegrationTests extends ESSingleNodeTestCase {
         }
     }
 
+    private String getMapping(String indexOptions, boolean disableTemplating) {
+        return MAPPING_TEMPLATE.replace("%index_options%", indexOptions)
+            .replace("%disable_templating%", Boolean.toString(disableTemplating));
+    }
+
     public void testSourceMatchAllManyValues() throws IOException {
-        var mapping = randomBoolean() ? MAPPING_DOCS_ONLY : MAPPING_POSITIONS;
         var createRequest = indicesAdmin().prepareCreate(INDEX).setSettings(LOGSDB_SETTING).setMapping(mapping);
         createIndex(INDEX, createRequest);
 
@@ -114,7 +140,6 @@ public class PatternedTextIntegrationTests extends ESSingleNodeTestCase {
     }
 
     public void testLargeValueIsStored() throws IOException {
-        var mapping = randomBoolean() ? MAPPING_DOCS_ONLY : MAPPING_POSITIONS;
         var createRequest = indicesAdmin().prepareCreate(INDEX).setSettings(LOGSDB_SETTING).setMapping(mapping);
         IndexService indexService = createIndex(INDEX, createRequest);
 
@@ -136,7 +161,6 @@ public class PatternedTextIntegrationTests extends ESSingleNodeTestCase {
     }
 
     public void testSmallValueNotStored() throws IOException {
-        var mapping = randomBoolean() ? MAPPING_DOCS_ONLY : MAPPING_POSITIONS;
         var createRequest = indicesAdmin().prepareCreate(INDEX).setSettings(LOGSDB_SETTING).setMapping(mapping);
         IndexService indexService = createIndex(INDEX, createRequest);
 
@@ -152,13 +176,16 @@ public class PatternedTextIntegrationTests extends ESSingleNodeTestCase {
         try (var searcher = indexService.getShard(0).acquireSearcher(INDEX)) {
             try (var indexReader = searcher.getIndexReader()) {
                 var document = indexReader.storedFields().document(0);
-                assertNull(document.getField("field_patterned_text.stored"));
+                if (disableTemplating) {
+                    assertEquals(document.getField("field_patterned_text.stored").binaryValue().utf8ToString(), message);
+                } else {
+                    assertNull(document.getField("field_patterned_text.stored"));
+                }
             }
         }
     }
 
     public void testQueryResultsSameAsMatchOnlyText() throws IOException {
-        var mapping = randomBoolean() ? MAPPING_DOCS_ONLY : MAPPING_POSITIONS;
         var createRequest = new CreateIndexRequest(INDEX).mapping(mapping);
 
         if (randomBoolean()) {


### PR DESCRIPTION
Follow-up to #134466 to actually check the `disable_templating` parameter in the patterned_text mapper. When the parameter is set, values will be stored as-is in a stored field.