### PR TITLE
Increment ESQL expected function count

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_usage.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_usage.yml
@@ -226,7 +226,7 @@ setup:
   - gt: {esql.functions.to_long: $functions_to_long}
   - match: {esql.functions.coalesce: $functions_coalesce}
   - gt: {esql.functions.categorize: $functions_categorize}
-  - length: {esql.functions: 150} # check the "sister" test above for a likely update to the same esql.functions length check
+  - length: {esql.functions: 151} # check the "sister" test above for a likely update to the same esql.functions length check
 
 ---
 took:


### PR DESCRIPTION
In #134475 we added another ES|QL function, but forgot to increment the expected function count in the "60_usage/Basic ESQL usage output (telemetry) non-snapshot version" test, causing release tests to fail. This PR fixes that.