### PR TITLE
[Gradle] Simple fix the dependencies in test-framework

### DIFF
--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -10,6 +10,16 @@
 apply plugin: 'elasticsearch.build'
 apply plugin: 'elasticsearch.publish'
 
+configurations {
+  // we do not wanto expose the inheritedly conflict in transitive dependencies by
+  // bringing in different versions of junit, hamcrest and randomizedtesting
+  // so we exclude them here and re-declare the versions we want below
+  // to keep the example build happy that does not align transitive dependencies.
+  //
+  runtimeElements {
+    transitive = false
+  }
+}
 dependencies {
   api project(":client:rest")
   api project(':modules:transport-netty4')

--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -11,10 +11,10 @@ apply plugin: 'elasticsearch.build'
 apply plugin: 'elasticsearch.publish'
 
 configurations {
-  // we do not wanto expose the inheritedly conflict in transitive dependencies by
-  // bringing in different versions of junit, hamcrest and randomizedtesting
-  // so we exclude them here and re-declare the versions we want below
-  // to keep the example build happy that does not align transitive dependencies.
+  // we do not want to expose a version conflict in transitive dependencies by
+  // bringing in different versions of hamcrest.
+  // Therefore we exclude transitive deps on hamcrest here as we have a direct
+  // dependency on a newer version.
   runtimeElements {
     exclude group: 'org.hamcrest'
   }
@@ -27,7 +27,7 @@ dependencies {
   api project(":libs:cli")
   api project(":libs:entitlement:bridge")
   api "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
-  api("junit:junit:${versions.junit}") 
+  api("junit:junit:${versions.junit}")
   api "org.hamcrest:hamcrest:${versions.hamcrest}"
   api "org.apache.lucene:lucene-test-framework:${versions.lucene}"
   api "org.apache.lucene:lucene-codecs:${versions.lucene}"

--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -15,9 +15,8 @@ configurations {
   // bringing in different versions of junit, hamcrest and randomizedtesting
   // so we exclude them here and re-declare the versions we want below
   // to keep the example build happy that does not align transitive dependencies.
-  //
   runtimeElements {
-    transitive = false
+    exclude group: 'org.hamcrest'
   }
 }
 dependencies {
@@ -28,7 +27,7 @@ dependencies {
   api project(":libs:cli")
   api project(":libs:entitlement:bridge")
   api "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
-  api "junit:junit:${versions.junit}"
+  api("junit:junit:${versions.junit}") 
   api "org.hamcrest:hamcrest:${versions.hamcrest}"
   api "org.apache.lucene:lucene-test-framework:${versions.lucene}"
   api "org.apache.lucene:lucene-codecs:${versions.lucene}"

--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -12,11 +12,11 @@ apply plugin: 'elasticsearch.publish'
 
 configurations {
   // we do not want to expose a version conflict in transitive dependencies by
-  // bringing in different versions of hamcrest.
-  // Therefore we exclude transitive deps on hamcrest here as we have a direct
+  // bringing in different versions of hamcrest and hamcrest-core.
+  // Therefore we exclude transitive deps on hamcrest-core here as we have a direct
   // dependency on a newer version.
   runtimeElements {
-    exclude group: 'org.hamcrest'
+    exclude group: 'org.hamcrest', module: 'hamcrest-core'
   }
 }
 dependencies {
@@ -27,9 +27,13 @@ dependencies {
   api project(":libs:cli")
   api project(":libs:entitlement:bridge")
   api "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
-  api("junit:junit:${versions.junit}")
+  api("junit:junit:${versions.junit}") {
+//    exclude group: 'org.hamcrest'
+  }
   api "org.hamcrest:hamcrest:${versions.hamcrest}"
-  api "org.apache.lucene:lucene-test-framework:${versions.lucene}"
+  api("org.apache.lucene:lucene-test-framework:${versions.lucene}") {
+//    exclude group: 'org.hamcrest'
+  }
   api "org.apache.lucene:lucene-codecs:${versions.lucene}"
   api "commons-logging:commons-logging:${versions.commonslogging}"
   api "commons-codec:commons-codec:${versions.commonscodec}"


### PR DESCRIPTION
The transitive dependencies in test-framework inheritely have a version conflict that
results in a jarHell in our example builds.
We fix that for now by keeping the dependencies non transitive for now as it has been
in the past before we changed transitive dependency handling.

Fixes example build