### PR TITLE
[8.19] Add Reason field to elastic-agent upgrade details metadata (#134711)

### DIFF
--- a/docs/changelog/134711.yaml
+++ b/docs/changelog/134711.yaml
@@ -1,0 +1,5 @@
+pr: 134711
+summary: Add Reason field to elastic-agent upgrade details metadata
+area: Infra/Plugins
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/template-resources/src/main/resources/fleet-agents.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/fleet-agents.json
@@ -305,6 +305,15 @@
                 },
                 "retry_until": {
                   "type": "date"
+                },
+                "reason": {
+                  "type":"text",
+                  "fields": {
+                    "keyword": {
+                      "type": "keyword",
+                      "ignore_above": 1024
+                    }
+                  }
                 }
               }
             }

--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/Fleet.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/Fleet.java
@@ -81,8 +81,8 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
     private static final String MAPPING_VERSION_VARIABLE = "fleet.version";
     private static final List<String> ALLOWED_PRODUCTS = List.of("kibana", "fleet");
     private static final int FLEET_ACTIONS_MAPPINGS_VERSION = 2;
-    private static final int FLEET_AGENTS_MAPPINGS_VERSION = 2;
-    private static final int FLEET_ENROLLMENT_API_KEYS_MAPPINGS_VERSION = 2;
+    private static final int FLEET_AGENTS_MAPPINGS_VERSION = 4;
+    private static final int FLEET_ENROLLMENT_API_KEYS_MAPPINGS_VERSION = 3;
     private static final int FLEET_SECRETS_MAPPINGS_VERSION = 1;
     private static final int FLEET_POLICIES_MAPPINGS_VERSION = 2;
     private static final int FLEET_POLICIES_LEADER_MAPPINGS_VERSION = 1;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Add Reason field to elastic-agent upgrade details metadata (#134711)](https://github.com/elastic/elasticsearch/pull/134711)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)