### PR TITLE
[8.18] [CI] Add missing support for skip-target-branches (#134743)

### DIFF
--- a/.buildkite/scripts/pull-request/__snapshots__/pipeline.test.ts.snap
+++ b/.buildkite/scripts/pull-request/__snapshots__/pipeline.test.ts.snap
@@ -309,3 +309,68 @@ exports[`generatePipelines should generate correct pipelines with a non-docs cha
   },
 ]
 `;
+
+exports[`generatePipelines should generate correct pipelines with a different branch that is not skipped 1`] = `
+[
+  {
+    "name": "bwc-snapshots",
+    "pipeline": {
+      "steps": [
+        {
+          "group": "bwc-snapshots",
+          "steps": [
+            {
+              "agents": {
+                "buildDirectory": "/dev/shm/bk",
+                "image": "family/elasticsearch-ubuntu-2404",
+                "machineType": "custom-32-98304",
+                "provider": "gcp",
+              },
+              "command": ".ci/scripts/run-gradle.sh -Dignore.tests.seed v{{matrix.BWC_VERSION}}#bwcTest",
+              "env": {
+                "BWC_VERSION": "{{matrix.BWC_VERSION}}",
+              },
+              "label": "{{matrix.BWC_VERSION}} / bwc-snapshots",
+              "matrix": {
+                "setup": {
+                  "BWC_VERSION": [
+                    "7.17.14",
+                    "8.10.3",
+                    "8.11.0",
+                  ],
+                },
+              },
+              "timeout_in_minutes": 300,
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    "name": "skip-branch",
+    "pipeline": {
+      "steps": [
+        {
+          "command": "echo 1",
+          "label": "skip-me",
+        },
+      ],
+    },
+  },
+  {
+    "name": "using-defaults",
+    "pipeline": {
+      "env": {
+        "CUSTOM_ENV_VAR": "value",
+      },
+      "steps": [
+        {
+          "command": "echo 'hello world'",
+          "label": "test-step",
+        },
+      ],
+    },
+  },
+]
+`;

--- a/.buildkite/scripts/pull-request/mocks/pipelines/skip-branch.yml
+++ b/.buildkite/scripts/pull-request/mocks/pipelines/skip-branch.yml
@@ -1,0 +1,5 @@
+config:
+  skip-target-branches: "test-branch"
+steps:
+  - label: skip-me
+    command: echo 1

--- a/.buildkite/scripts/pull-request/pipeline.test.ts
+++ b/.buildkite/scripts/pull-request/pipeline.test.ts
@@ -8,6 +8,7 @@ describe("generatePipelines", () => {
     setBwcVersionsPath(`${import.meta.dir}/mocks/bwcVersions`);
     setSnapshotBwcVersionsPath(`${import.meta.dir}/mocks/snapshotBwcVersions`);
 
+    process.env["GITHUB_PR_TARGET_BRANCH"] = "test-branch";
     process.env["GITHUB_PR_LABELS"] = "test-label-1,test-label-2";
     process.env["GITHUB_PR_TRIGGER_COMMENT"] = "";
   });
@@ -32,6 +33,12 @@ describe("generatePipelines", () => {
 
   test("should generate correct pipelines with full BWC expansion", () => {
     process.env["GITHUB_PR_LABELS"] = "test-full-bwc";
+
+    testWithTriggerCheck(`${import.meta.dir}/mocks/pipelines`, ["build.gradle"]);
+  });
+
+  test("should generate correct pipelines with a different branch that is not skipped", () => {
+    process.env["GITHUB_PR_TARGET_BRANCH"] = "main";
 
     testWithTriggerCheck(`${import.meta.dir}/mocks/pipelines`, ["build.gradle"]);
   });

--- a/.buildkite/scripts/pull-request/pipeline.ts
+++ b/.buildkite/scripts/pull-request/pipeline.ts
@@ -50,6 +50,14 @@ const changedFilesIncludedCheck = (pipeline: EsPipeline, changedFiles: string[])
   return true;
 };
 
+const checkTargetBranch = (pipeline: EsPipeline, targetBranch: string | undefined) => {
+  if (!targetBranch || !pipeline.config?.["skip-target-branches"]) {
+    return true;
+  }
+
+  return !getArray(pipeline.config["skip-target-branches"]).some((branch) => branch === targetBranch);
+};
+
 const triggerCommentCheck = (pipeline: EsPipeline): boolean => {
   if (process.env["GITHUB_PR_TRIGGER_COMMENT"] && pipeline.config?.["trigger-phrase"]) {
     return !!process.env["GITHUB_PR_TRIGGER_COMMENT"].match(pipeline.config["trigger-phrase"]);
@@ -138,6 +146,7 @@ export const generatePipelines = (
   }
 
   let filters: ((pipeline: EsPipeline) => boolean)[] = [
+    (pipeline) => checkTargetBranch(pipeline, process.env["GITHUB_PR_TARGET_BRANCH"]),
     (pipeline) => labelCheckAllow(pipeline, labels),
     (pipeline) => labelCheckSkip(pipeline, labels),
     (pipeline) => changedFilesExcludedCheck(pipeline, changedFiles),

--- a/.buildkite/scripts/pull-request/types.ts
+++ b/.buildkite/scripts/pull-request/types.ts
@@ -5,6 +5,7 @@ export type EsPipelineConfig = {
     "included-regions"?: string | string[];
     "excluded-regions"?: string | string[];
     "trigger-phrase"?: string;
+    "skip-target-branches"?: string | string[];
   };
 };
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[CI] Add missing support for skip-target-branches (#134743)](https://github.com/elastic/elasticsearch/pull/134743)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)