### PR TITLE
[9.0] [Gradle] Simple fix the dependencies in test-framework (#134746)

### DIFF
--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -10,6 +10,15 @@
 apply plugin: 'elasticsearch.build'
 apply plugin: 'elasticsearch.publish'
 
+configurations {
+  // we do not want to expose a version conflict in transitive dependencies by
+  // bringing in different versions of hamcrest and hamcrest-core.
+  // Therefore we exclude transitive deps on hamcrest-core here as we have a direct
+  // dependency on a newer version.
+  runtimeElements {
+    exclude group: 'org.hamcrest', module: 'hamcrest-core'
+  }
+}
 dependencies {
   api project(":client:rest")
   api project(':modules:transport-netty4')
@@ -17,9 +26,13 @@ dependencies {
   api project(":server")
   api project(":libs:cli")
   api "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
-  api "junit:junit:${versions.junit}"
+  api("junit:junit:${versions.junit}") {
+//    exclude group: 'org.hamcrest'
+  }
   api "org.hamcrest:hamcrest:${versions.hamcrest}"
-  api "org.apache.lucene:lucene-test-framework:${versions.lucene}"
+  api("org.apache.lucene:lucene-test-framework:${versions.lucene}") {
+//    exclude group: 'org.hamcrest'
+  }
   api "org.apache.lucene:lucene-codecs:${versions.lucene}"
   api "commons-logging:commons-logging:${versions.commonslogging}"
   api "commons-codec:commons-codec:${versions.commonscodec}"


### PR DESCRIPTION
Backports the following commits to 9.0:
 - [Gradle] Simple fix the dependencies in test-framework (#134746)