### PR TITLE
[9.1] Reenable Index Compatibility BWC Tests

### DIFF
--- a/qa/lucene-index-compatibility/build.gradle
+++ b/qa/lucene-index-compatibility/build.gradle
@@ -14,6 +14,7 @@ buildParams.bwcVersions.withLatestReadOnlyIndexCompatible { bwcVersion ->
   tasks.named("javaRestTest").configure {
     systemProperty("tests.minimum.index.compatible", bwcVersion)
     usesBwcDistribution(bwcVersion)
+    enabled = true
   }
 }
 


### PR DESCRIPTION
Similar to #134784 for `9.1`

Tests passed: https://gradle-enterprise.elastic.co/s/pdvaannpmegfa/tests/task/:qa:lucene-index-compatibility:javaRestTest/overview