### PR TITLE
[9.0] Reenable Index Compatibility BWC Tests

### DIFF
--- a/qa/lucene-index-compatibility/build.gradle
+++ b/qa/lucene-index-compatibility/build.gradle
@@ -14,9 +14,7 @@ buildParams.bwcVersions.withLatestReadOnlyIndexCompatible { bwcVersion ->
   tasks.named("javaRestTest").configure {
     systemProperty("tests.minimum.index.compatible", bwcVersion)
     usesBwcDistribution(bwcVersion)
-
-    // Tests rely on unreleased code in 8.18 branch
-    enabled = buildParams.snapshotBuild
+    enabled = true
   }
 }
 


### PR DESCRIPTION
Always execute N-3 BWC tests, not just for snapshot builds.

Relates #134784

Tests passed: https://gradle-enterprise.elastic.co/s/bs3whqrfhh4ug/tests/task/:qa:lucene-index-compatibility:javaRestTest/overview
