### PR TITLE
Support querying multiple indices with the simplified RRF retriever

### DIFF
--- a/docs/changelog/134822.yaml
+++ b/docs/changelog/134822.yaml
@@ -1,0 +1,5 @@
+pr: 134822
+summary: Query multiple indices with simplified RRF
+area: Relevance
+type: enhancement
+issues: []

--- a/docs/changelog/134822.yaml
+++ b/docs/changelog/134822.yaml
@@ -1,5 +1,5 @@
 pr: 134822
-summary: Query multiple indices with simplified RRF
+summary: Support querying multiple indices with the simplified RRF retriever
 area: Relevance
 type: enhancement
 issues: []

--- a/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/RankRRFFeatures.java
+++ b/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/RankRRFFeatures.java
@@ -40,7 +40,8 @@ public class RankRRFFeatures implements FeatureSpecification {
             RRFRetrieverBuilder.MULTI_FIELDS_QUERY_FORMAT_SUPPORT,
             RRFRetrieverBuilder.WEIGHTED_SUPPORT,
             LINEAR_RETRIEVER_TOP_LEVEL_NORMALIZER,
-            LinearRetrieverBuilder.MULTI_INDEX_SIMPLIFIED_FORMAT_SUPPORT
+            LinearRetrieverBuilder.MULTI_INDEX_SIMPLIFIED_FORMAT_SUPPORT,
+            RRFRetrieverBuilder.MULTI_INDEX_SIMPLIFIED_FORMAT_SUPPORT
         );
     }
 }

--- a/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilder.java
+++ b/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilder.java
@@ -50,7 +50,9 @@ import static org.elasticsearch.xpack.rank.rrf.RRFRetrieverComponent.DEFAULT_WEI
 public final class RRFRetrieverBuilder extends CompoundRetrieverBuilder<RRFRetrieverBuilder> {
     public static final NodeFeature MULTI_FIELDS_QUERY_FORMAT_SUPPORT = new NodeFeature("rrf_retriever.multi_fields_query_format_support");
     public static final NodeFeature WEIGHTED_SUPPORT = new NodeFeature("rrf_retriever.weighted_support");
-
+    public static final NodeFeature MULTI_INDEX_SIMPLIFIED_FORMAT_SUPPORT = new NodeFeature(
+        "rrf_retriever.multi_index_simplified_format_support"
+    );
     public static final String NAME = "rrf";
 
     public static final ParseField RETRIEVERS_FIELD = new ParseField("retrievers");
@@ -253,11 +255,7 @@ public final class RRFRetrieverBuilder extends CompoundRetrieverBuilder<RRFRetri
             // TODO: Refactor duplicate code
             // Using the multi-fields query format
             var localIndicesMetadata = resolvedIndices.getConcreteLocalIndicesMetadata();
-            if (localIndicesMetadata.size() > 1) {
-                throw new IllegalArgumentException(
-                    "[" + NAME + "] cannot specify [" + QUERY_FIELD.getPreferredName() + "] when querying multiple indices"
-                );
-            } else if (resolvedIndices.getRemoteClusterIndices().isEmpty() == false) {
+            if (resolvedIndices.getRemoteClusterIndices().isEmpty() == false) {
                 throw new IllegalArgumentException(
                     "[" + NAME + "] cannot specify [" + QUERY_FIELD.getPreferredName() + "] when querying remote indices"
                 );

--- a/x-pack/plugin/rank-rrf/src/test/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilderTests.java
+++ b/x-pack/plugin/rank-rrf/src/test/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilderTests.java
@@ -236,7 +236,7 @@ public class RRFRetrieverBuilderTests extends AbstractRetrieverBuilderTests<RRFR
         );
     }
 
-        public void testMultiIndexMultiFieldsParamsRewrite() {
+    public void testMultiIndexMultiFieldsParamsRewrite() {
         String indexName = "test-index";
         String anotherIndexName = "test-another-index";
         final ResolvedIndices resolvedIndices = createMockResolvedIndices(

--- a/x-pack/plugin/rank-rrf/src/test/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilderTests.java
+++ b/x-pack/plugin/rank-rrf/src/test/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilderTests.java
@@ -449,6 +449,31 @@ public class RRFRetrieverBuilderTests extends AbstractRetrieverBuilderTests<RRFR
             null
         );
 
+        // Glob matching on inference and non-inference fields
+        retriever = new RRFRetrieverBuilder(
+            null,
+            List.of("field_*", "field_1", "*_field_1", "semantic_*"),
+            "baz2",
+            DEFAULT_RANK_WINDOW_SIZE,
+            RRFRetrieverBuilder.DEFAULT_RANK_CONSTANT,
+            new float[0]
+        );
+        assertMultiIndexMultiFieldsParamsRewrite(
+            retriever,
+            queryRewriteContext,
+            Map.of(Map.of("field_*", 1.0f, "field_1", 1.0f, "*_field_1", 1.0f, "semantic_*", 1.0f), List.of()),
+            Map.of(
+                new Tuple<>("semantic_field_1", List.of(indexName)),
+                1.0f,
+                new Tuple<>("semantic_field_2", List.of()),
+                1.0f,
+                new Tuple<>("semantic_field_3", List.of(anotherIndexName)),
+                1.0f
+            ),
+            "baz2",
+            null
+        );
+
         // All-fields wildcard
         retriever = new RRFRetrieverBuilder(
             null,

--- a/x-pack/plugin/rank-rrf/src/test/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilderTests.java
+++ b/x-pack/plugin/rank-rrf/src/test/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilderTests.java
@@ -292,6 +292,33 @@ public class RRFRetrieverBuilderTests extends AbstractRetrieverBuilderTests<RRFR
             null
         );
 
+        // Glob matching on inference and non-inference fields
+        retriever = new RRFRetrieverBuilder(
+            null,
+            List.of("field_*", "field_1", "*_field_1", "semantic_*"),
+            "baz2",
+            DEFAULT_RANK_WINDOW_SIZE,
+            RRFRetrieverBuilder.DEFAULT_RANK_CONSTANT,
+            new float[0]
+        );
+        assertMultiIndexMultiFieldsParamsRewrite(
+            retriever,
+            queryRewriteContext,
+            Map.of(Map.of("field_*", 1.0f, "field_1", 1.0f, "*_field_1", 1.0f, "semantic_*", 1.0f), List.of()),
+            Map.of(
+                new Tuple<>("semantic_field_1", List.of(indexName)),
+                1.0f,
+                new Tuple<>("semantic_field_2", List.of(indexName)),
+                1.0f,
+                new Tuple<>("semantic_field_2", List.of(anotherIndexName)),
+                1.0f,
+                new Tuple<>("semantic_field_3", List.of(anotherIndexName)),
+                1.0f
+            ),
+            "baz2",
+            null
+        );
+
         // Non-default rank window size
         retriever = new RRFRetrieverBuilder(
             null,

--- a/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/rrf/310_rrf_retriever_simplified.yml
+++ b/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/rrf/310_rrf_retriever_simplified.yml
@@ -35,6 +35,36 @@ setup:
             "task_settings": {
             }
           }
+  - do:
+      inference.put:
+        task_type: sparse_embedding
+        inference_id: sparse-inference-another-id
+        body: >
+          {
+            "service": "test_service",
+            "service_settings": {
+              "model": "my_model",
+              "api_key": "abc64"
+            },
+            "task_settings": {
+            }
+          }
+  - do:
+      inference.put:
+        task_type: text_embedding
+        inference_id: dense-inference-another-id
+        body: >
+          {
+            "service": "text_embedding_test_service",
+            "service_settings": {
+              "model": "my_model",
+              "dimensions": 128,
+              "similarity": "cosine",
+              "api_key": "xyz"
+            },
+            "task_settings": {
+            }
+          }
 
   - do:
       indices.create:
@@ -106,6 +136,66 @@ setup:
             "text_2": "z match 6",
             "timestamp": "2024-08-08",
             "dense_vector": [3],
+            "sparse_vector": {
+              "baz": 1.0
+            }
+          }
+  - do:
+      indices.create:
+        index: test-another-index
+        body:
+          mappings:
+            properties:
+              keyword:
+                type: keyword
+              dense_inference:
+                type: semantic_text
+                inference_id: dense-inference-id
+              sparse_inference:
+                type: semantic_text
+                inference_id: sparse-inference-another-id
+              text_1:
+                type: semantic_text
+                inference_id: dense-inference-another-id
+              text_2:
+                type: text
+              sparse_vector:
+                type: sparse_vector
+
+  - do:
+      bulk:
+        index: test-another-index
+        refresh: true
+        body: |
+          {"index": {"_id": "4"}}
+          {
+            "keyword": "keyword match 1",
+            "dense_inference": "You know",
+            "sparse_inference": "For Search",
+            "text_1": "Be excellent to each other",
+            "text_2": "xyz match match 2",
+            "sparse_vector": {
+              "foo": 1.0
+            }
+          }
+          {"index": {"_id": "5"}}
+          {
+            "keyword": "keyword match 2",
+            "dense_inference": "Elasticsearch is simply the best",
+            "sparse_inference": "Better than all the rest",
+            "text_1": "Better than another vector database",
+            "text_2": "yy match match 4",
+            "sparse_vector": {
+              "bar": 1.0
+            }
+          }
+          {"index": {"_id": "6"}}
+          {
+            "keyword": "keyword match 3",
+            "dense_inference": "Elasticsearch is the best vector database",
+            "sparse_inference": "Live long and prosper",
+            "text_1": "Most excellent",
+            "text_2": "z match match 6",
             "sparse_vector": {
               "baz": 1.0
             }
@@ -266,43 +356,6 @@ setup:
   - length: { hits.hits: 0 }
 
 ---
-"Multi-index searches are not allowed":
-  - do:
-      indices.create:
-        index: test-index-2
-
-  - do:
-      catch: bad_request
-      search:
-        index: [ test-index, test-index-2 ]
-        body:
-          retriever:
-            rrf:
-              query: "match"
-
-  - match: { error.root_cause.0.reason: "[rrf] cannot specify [query] when querying multiple indices" }
-
-  - do:
-      indices.put_alias:
-        index: test-index
-        name: test-alias
-  - do:
-      indices.put_alias:
-        index: test-index-2
-        name: test-alias
-
-  - do:
-      catch: bad_request
-      search:
-        index: test-alias
-        body:
-          retriever:
-            rrf:
-              query: "match"
-
-  - match: { error.root_cause.0.reason: "[rrf] cannot specify [query] when querying multiple indices" }
-
----
 "Wildcard field patterns that do not resolve to any field are handled gracefully":
   - do:
       search:
@@ -429,3 +482,49 @@ setup:
   - match: { hits.hits.0._id: "2" }
   - match: { hits.hits.1._id: "1" }
   - match: { hits.hits.2._id: "3" }
+
+
+---
+"Queries multiple indices using default_field":
+  - requires:
+      cluster_features: [ "rrf_retriever.multi_index_simplified_format_support" ]
+      reason: "Support for querying multiple indices in simplified RRF retriever"
+  - do:
+      search:
+        index: test-index,test-another-index
+        body:
+          retriever:
+            rrf:
+              query: "match"
+
+  - match: { hits.total.value: 6 }
+  - length: { hits.hits: 6 }
+  - match: { hits.hits.0._id: "4" }
+  - match: { hits.hits.1._id: "6" }
+  - match: { hits.hits.2._id: "1" }
+  - match: { hits.hits.3._id: "2" }
+  - match: { hits.hits.4._id: "3" }
+  - match: { hits.hits.5._id: "5" }
+
+---
+"Queries multiple indices with a list of fields":
+  - requires:
+      cluster_features: [ "rrf_retriever.multi_index_simplified_format_support" ]
+      reason: "Support for querying multiple indices in simplified RRF retriever"
+  - do:
+      search:
+        index: test-index,test-another-index
+        body:
+          retriever:
+            rrf:
+              fields: ["dense_inference", "text_1", "sparse_vector"]
+              query: "match"
+
+  - match: { hits.total.value: 6 }
+  - length: { hits.hits: 6 }
+  - match: { hits.hits.0._id: "1" }
+  - match: { hits.hits.1._id: "2" }
+  - match: { hits.hits.2._id: "3" }
+  - match: { hits.hits.3._id: "6" }
+  - match: { hits.hits.4._id: "4" }
+  - match: { hits.hits.5._id: "5" }


### PR DESCRIPTION
follows the same approach from https://github.com/elastic/elasticsearch/pull/133720 where we add support for querying multiple indices for the simplified linear retriever.
https://github.com/elastic/elasticsearch/pull/133720 already does most of it, here we just need to remove the validation check that disallowed querying multiple indices and add tests.
the tests are very similar to  https://github.com/elastic/elasticsearch/pull/133720, I just needed to adjust them slightly since specifying boosts for fields is disallowed for the simplified RRF retriever.
