### PR TITLE
Fix release tests for chunk-rescorer tests behind feature flag

### DIFF
--- a/x-pack/plugin/inference/src/yamlRestTest/java/org/elasticsearch/xpack/inference/InferenceRestIT.java
+++ b/x-pack/plugin/inference/src/yamlRestTest/java/org/elasticsearch/xpack/inference/InferenceRestIT.java
@@ -43,7 +43,7 @@ public class InferenceRestIT extends ESClientYamlSuiteTestCase {
         super(testCandidate);
         String testPath = testCandidate.getTestPath();
         if (testPath.startsWith("inference/70_text_similarity_rank_retriever")
-            && (testPath.toLowerCase(Locale.ROOT).contains("snippet") || testPath.toLowerCase(Locale.ROOT).contains("chunk_rescorer"))) {
+            && (testPath.toLowerCase(Locale.ROOT).contains("snippet") || testPath.toLowerCase(Locale.ROOT).contains("rescore"))) {
             assumeTrue("Rerank snippets does not work in release builds", Build.current().isSnapshot());
         }
     }


### PR DESCRIPTION
Followup to https://github.com/elastic/elasticsearch/pull/134729/ - skips tests more permissively under the FF 