### PR TITLE
[8.18] Make transport version comments parsable (#134733)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionDefinition.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionDefinition.java
@@ -20,8 +20,19 @@ record TransportVersionDefinition(String name, List<TransportVersionId> ids) {
         String name = filename.substring(0, filename.length() - 4);
         List<TransportVersionId> ids = new ArrayList<>();
 
+        String idsLine = null;
         if (contents.isEmpty() == false) {
-            for (String rawId : contents.split(",")) {
+            String[] lines = contents.split(System.lineSeparator());
+            for (String line : lines) {
+                line = line.replaceAll("\\s+", "");
+                if (line.startsWith("#") == false) {
+                    idsLine = line;
+                    break;
+                }
+            }
+        }
+        if (idsLine != null) {
+            for (String rawId : idsLine.split(",")) {
                 try {
                     ids.add(TransportVersionId.fromString(rawId));
                 } catch (NumberFormatException e) {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionUpperBound.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionUpperBound.java
@@ -23,7 +23,16 @@ record TransportVersionUpperBound(String name, String definitionName, TransportV
         int slashIndex = filename.lastIndexOf('/');
         String branch = filename.substring(slashIndex == -1 ? 0 : (slashIndex + 1), filename.length() - 4);
 
-        String[] parts = contents.split(",");
+        String idsLine = null;
+        String[] lines = contents.split(System.lineSeparator());
+        for (String line : lines) {
+            line = line.replaceAll("\\s+", "");
+            if (line.startsWith("#") == false) {
+                idsLine = line;
+                break;
+            }
+        }
+        String[] parts = idsLine.split(",");
         if (parts.length != 2) {
             throw new IllegalStateException("Invalid transport version upper bound file [" + file + "]: " + contents);
         }


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Make transport version comments parsable (#134733)