### PR TITLE
Fix cross cluster test to use system agnostic path

### DIFF
--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/transport/CrossClusterSigningConfigReloaderIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/transport/CrossClusterSigningConfigReloaderIntegTests.java
@@ -200,15 +200,16 @@ public class CrossClusterSigningConfigReloaderIntegTests extends SecurityIntegTe
     }
 
     public void testValidationFailsWhenUpdateWithInvalidPath() throws Exception {
+        Path unknownFile = createTempDir().resolve("unknown_file");
         var exception = assertThrows(
             IllegalArgumentException.class,
             () -> updateClusterSettings(
                 Settings.builder()
-                    .put(SIGNING_CERT_PATH.getConcreteSettingForNamespace("test").getKey(), "/unknown/path")
-                    .put(SIGNING_KEY_PATH.getConcreteSettingForNamespace("test").getKey(), "/unknown/path")
+                    .put(SIGNING_CERT_PATH.getConcreteSettingForNamespace("test").getKey(), unknownFile)
+                    .put(SIGNING_KEY_PATH.getConcreteSettingForNamespace("test").getKey(), unknownFile)
             )
         );
-        assertThat(exception.getMessage(), equalTo("File [/unknown/path] configured for remote cluster [test] does no exist"));
+        assertThat(exception.getMessage(), equalTo("File [" + unknownFile + "] configured for remote cluster [test] does no exist"));
     }
 
     private void addAndRemoveClusterConfigsRuntime(


### PR DESCRIPTION
This commit fixes a cross cluster signing test that deals with an unknown configuration file to work on both *nix and windows.