### PR TITLE
Fix rate tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -564,12 +564,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
   method: test {csv-spec:fork.ForkBeforeStatsByWithWhere}
   issue: https://github.com/elastic/elasticsearch/issues/134817
-- class: org.elasticsearch.xpack.esql.expression.function.aggregate.RateTests
-  method: testGroupingAggregate {TestCase=<0 longs>}
-  issue: https://github.com/elastic/elasticsearch/issues/134844
-- class: org.elasticsearch.xpack.esql.expression.function.aggregate.RateTests
-  method: testGroupingAggregate {TestCase=<0 ints>}
-  issue: https://github.com/elastic/elasticsearch/issues/134845
 - class: org.elasticsearch.cluster.metadata.MetadataCreateIndexServiceTests
   method: testIndexSettingProviderPrivateSetting
   issue: https://github.com/elastic/elasticsearch/issues/134846

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateDoubleGroupingAggregatorFunction.java
@@ -193,7 +193,7 @@ public final class RateDoubleGroupingAggregatorFunction implements GroupingAggre
     private void addRawInput(int positionOffset, IntVector groups, DoubleBlock valueBlock, LongVector timestampVector) {
         if (groups.isConstant()) {
             int groupId = groups.getInt(0);
-            Buffer buffer = getBuffer(groupId, groups.getPositionCount(), timestampVector.getLong(0));
+            Buffer buffer = getBuffer(groupId, groups.getPositionCount(), timestampVector.getLong(positionOffset));
             for (int p = 0; p < groups.getPositionCount(); p++) {
                 int valuePosition = positionOffset + p;
                 if (valueBlock.isNull(valuePosition)) {
@@ -229,7 +229,7 @@ public final class RateDoubleGroupingAggregatorFunction implements GroupingAggre
         int positionCount = groups.getPositionCount();
         if (groups.isConstant()) {
             int groupId = groups.getInt(0);
-            Buffer buffer = getBuffer(groupId, positionCount, timestampVector.getLong(0));
+            Buffer buffer = getBuffer(groupId, positionCount, timestampVector.getLong(positionOffset));
             for (int p = 0; p < positionCount; p++) {
                 int valuePosition = positionOffset + p;
                 buffer.appendWithoutResize(timestampVector.getLong(valuePosition), valueVector.getDouble(valuePosition));

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
@@ -193,7 +193,7 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
     private void addRawInput(int positionOffset, IntVector groups, IntBlock valueBlock, LongVector timestampVector) {
         if (groups.isConstant()) {
             int groupId = groups.getInt(0);
-            Buffer buffer = getBuffer(groupId, groups.getPositionCount(), timestampVector.getLong(0));
+            Buffer buffer = getBuffer(groupId, groups.getPositionCount(), timestampVector.getLong(positionOffset));
             for (int p = 0; p < groups.getPositionCount(); p++) {
                 int valuePosition = positionOffset + p;
                 if (valueBlock.isNull(valuePosition)) {
@@ -229,7 +229,7 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
         int positionCount = groups.getPositionCount();
         if (groups.isConstant()) {
             int groupId = groups.getInt(0);
-            Buffer buffer = getBuffer(groupId, positionCount, timestampVector.getLong(0));
+            Buffer buffer = getBuffer(groupId, positionCount, timestampVector.getLong(positionOffset));
             for (int p = 0; p < positionCount; p++) {
                 int valuePosition = positionOffset + p;
                 buffer.appendWithoutResize(timestampVector.getLong(valuePosition), valueVector.getInt(valuePosition));

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateLongGroupingAggregatorFunction.java
@@ -193,7 +193,7 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
     private void addRawInput(int positionOffset, IntVector groups, LongBlock valueBlock, LongVector timestampVector) {
         if (groups.isConstant()) {
             int groupId = groups.getInt(0);
-            Buffer buffer = getBuffer(groupId, groups.getPositionCount(), timestampVector.getLong(0));
+            Buffer buffer = getBuffer(groupId, groups.getPositionCount(), timestampVector.getLong(positionOffset));
             for (int p = 0; p < groups.getPositionCount(); p++) {
                 int valuePosition = positionOffset + p;
                 if (valueBlock.isNull(valuePosition)) {
@@ -229,7 +229,7 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
         int positionCount = groups.getPositionCount();
         if (groups.isConstant()) {
             int groupId = groups.getInt(0);
-            Buffer buffer = getBuffer(groupId, positionCount, timestampVector.getLong(0));
+            Buffer buffer = getBuffer(groupId, positionCount, timestampVector.getLong(positionOffset));
             for (int p = 0; p < positionCount; p++) {
                 int valuePosition = positionOffset + p;
                 buffer.appendWithoutResize(timestampVector.getLong(valuePosition), valueVector.getLong(valuePosition));

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-RateGroupingAggregatorFunction.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-RateGroupingAggregatorFunction.java.st
@@ -193,7 +193,7 @@ public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggre
     private void addRawInput(int positionOffset, IntVector groups, $Type$Block valueBlock, LongVector timestampVector) {
         if (groups.isConstant()) {
             int groupId = groups.getInt(0);
-            Buffer buffer = getBuffer(groupId, groups.getPositionCount(), timestampVector.getLong(0));
+            Buffer buffer = getBuffer(groupId, groups.getPositionCount(), timestampVector.getLong(positionOffset));
             for (int p = 0; p < groups.getPositionCount(); p++) {
                 int valuePosition = positionOffset + p;
                 if (valueBlock.isNull(valuePosition)) {
@@ -229,7 +229,7 @@ public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggre
         int positionCount = groups.getPositionCount();
         if (groups.isConstant()) {
             int groupId = groups.getInt(0);
-            Buffer buffer = getBuffer(groupId, positionCount, timestampVector.getLong(0));
+            Buffer buffer = getBuffer(groupId, positionCount, timestampVector.getLong(positionOffset));
             for (int p = 0; p < positionCount; p++) {
                 int valuePosition = positionOffset + p;
                 buffer.appendWithoutResize(timestampVector.getLong(valuePosition), valueVector.get$Type$(valuePosition));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/RateTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/RateTests.java
@@ -87,7 +87,7 @@ public class RateTests extends AbstractAggregationTestCase {
             TestCaseSupplier.TypedData fieldTypedData = fieldSupplier.get();
             List<Object> dataRows = fieldTypedData.multiRowData();
             if (randomBoolean()) {
-                List<Object> withNulls = new ArrayList<>(dataRows);
+                List<Object> withNulls = new ArrayList<>(dataRows.size());
                 for (Object dataRow : dataRows) {
                     if (randomBoolean()) {
                         withNulls.add(null);


### PR DESCRIPTION
We are supposed to initialize the new list with the size of the testing list, not with the elements from the testing list. I also found that we generate more slices in tests than we should - this is not an issue in production, as the offset should always be zero.

Closes #134844
Closes #134845