### PR TITLE
Updates the Roles page title

### DIFF
--- a/docs/reference/elasticsearch/roles.md
+++ b/docs/reference/elasticsearch/roles.md
@@ -5,7 +5,7 @@ applies_to:
   stack: all
 ---
 
-# Roles [built-in-roles]
+# Built-in roles [built-in-roles]
 
 This section provides detailed **reference information** for {{es}} roles.
 


### PR DESCRIPTION
To better differentiate between built-in roles and roles that you can create yourself, this page is renamed to **Built-in roles**.

Related to [#2738](https://github.com/elastic/docs-content/issues/2738)
