### PR TITLE
ES|QL: Make kibana docs for Query settings more consistent

### DIFF
--- a/docs/reference/query-languages/esql/kibana/definition/settings/project_routing.json
+++ b/docs/reference/query-languages/esql/kibana/definition/settings/project_routing.json
@@ -4,6 +4,6 @@
   "type" : "keyword",
   "serverlessOnly" : true,
   "preview" : false,
-  "snapshot_only" : true,
+  "snapshotOnly" : true,
   "description" : "A project routing expression, used to define which projects to route the query to. Only supported if Cross-Project Search is enabled."
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/DocsV3Support.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/DocsV3Support.java
@@ -1109,7 +1109,7 @@ public abstract class DocsV3Support {
                 builder.field("type", setting.type().typeName());
                 builder.field("serverlessOnly", setting.serverlessOnly());
                 builder.field("preview", setting.preview());
-                builder.field("snapshot_only", setting.snapshotOnly());
+                builder.field("snapshotOnly", setting.snapshotOnly());
                 builder.field("description", setting.description());
                 String rendered = Strings.toString(builder.endObject());
                 logger.info("Writing kibana setting definition for [{}]:\n{}", name, rendered);


### PR DESCRIPTION
Just make the json for SET docs more consistent (camelCase vs snake_case)

cc @stratoula 