### PR TITLE
[8.19] rest-api-spec: remove required: false for query parameters (#134658)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_data_frame_analytics.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_data_frame_analytics.json
@@ -37,7 +37,6 @@
     "params": {
       "allow_no_match": {
         "type": "boolean",
-        "required": false,
         "description": "Whether to ignore if a wildcard expression matches no configs. (This includes `_all` string or when no configs have been specified)"
       },
       "bytes": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_datafeeds.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_datafeeds.json
@@ -37,7 +37,6 @@
     "params": {
       "allow_no_match": {
         "type": "boolean",
-        "required": false,
         "description": "Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)"
       },
       "format": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_jobs.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_jobs.json
@@ -37,7 +37,6 @@
     "params": {
       "allow_no_match": {
         "type": "boolean",
-        "required": false,
         "description": "Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
       },
       "bytes": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_trained_models.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_trained_models.json
@@ -37,7 +37,6 @@
     "params": {
       "allow_no_match": {
         "type": "boolean",
-        "required": false,
         "description": "Whether to ignore if a wildcard expression matches no trained models. (This includes `_all` string or when no trained models have been specified)",
         "default": true
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.transforms.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.transforms.json
@@ -37,17 +37,14 @@
     "params": {
       "from": {
         "type": "int",
-        "required": false,
         "description": "skips a number of transform configs, defaults to 0"
       },
       "size": {
         "type": "int",
-        "required": false,
         "description": "specifies a max number of transforms to get, defaults to 100"
       },
       "allow_no_match": {
         "type": "boolean",
-        "required": false,
         "description": "Whether to ignore if a wildcard expression matches no transforms. (This includes `_all` string or when no transforms have been specified)"
       },
       "format": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.delete.json
@@ -46,13 +46,11 @@
     "params": {
       "dry_run": {
         "type": "boolean",
-        "description": "If true the endpoint will not be deleted and a list of ingest processors which reference this endpoint will be returned.",
-        "required": false
+        "description": "If true the endpoint will not be deleted and a list of ingest processors which reference this endpoint will be returned."
       },
       "force": {
         "type": "boolean",
-        "description": "If true the endpoint will be forcefully stopped (regardless of whether or not it is referenced by any ingest processors or semantic text fields).",
-        "required": false
+        "description": "If true the endpoint will be forcefully stopped (regardless of whether or not it is referenced by any ingest processors or semantic text fields)."
       }
     }
   }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.close_job.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.close_job.json
@@ -33,12 +33,10 @@
     "params": {
       "allow_no_match": {
         "type": "boolean",
-        "required": false,
         "description": "Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
       },
       "force": {
         "type": "boolean",
-        "required": false,
         "description": "True if the job should be forcefully closed"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.delete_datafeed.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.delete_datafeed.json
@@ -30,7 +30,6 @@
     "params": {
       "force": {
         "type": "boolean",
-        "required": false,
         "description": "True if the datafeed should be forcefully deleted"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.delete_expired_data.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.delete_expired_data.json
@@ -39,12 +39,10 @@
     "params": {
       "requests_per_second": {
         "type": "number",
-        "required": false,
         "description": "The desired requests per second for the deletion processes."
       },
       "timeout": {
         "type": "time",
-        "required": false,
         "description": "How long can the underlying delete processes run until they are canceled"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.delete_forecast.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.delete_forecast.json
@@ -46,12 +46,10 @@
     "params": {
       "allow_no_forecasts": {
         "type": "boolean",
-        "required": false,
         "description": "Whether to ignore if `_all` matches no forecasts"
       },
       "timeout": {
         "type": "time",
-        "required": false,
         "description": "Controls the time to wait until the forecast(s) are deleted. Default to 30 seconds"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.delete_trained_model.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.delete_trained_model.json
@@ -30,13 +30,11 @@
     "params": {
       "timeout": {
         "type": "time",
-        "required": false,
         "description": "Controls the amount of time to wait for the model to be deleted.",
         "default": "30s"
       },
       "force": {
         "type": "boolean",
-        "required": false,
         "description": "True if the model should be forcefully deleted"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.forecast.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.forecast.json
@@ -33,17 +33,14 @@
     "params": {
       "duration": {
         "type": "time",
-        "required": false,
         "description": "The duration of the forecast"
       },
       "expires_in": {
         "type": "time",
-        "required": false,
         "description": "The time interval after which the forecast expires. Expired forecasts will be deleted at the first opportunity."
       },
       "max_model_memory": {
         "type": "string",
-        "required": false,
         "description": "The max memory able to be used by the forecast. Default is 20mb."
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_data_frame_analytics.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_data_frame_analytics.json
@@ -36,7 +36,6 @@
     "params": {
       "allow_no_match": {
         "type": "boolean",
-        "required": false,
         "description": "Whether to ignore if a wildcard expression matches no data frame analytics. (This includes `_all` string or when no data frame analytics have been specified)",
         "default": true
       },
@@ -51,7 +50,6 @@
         "default": 100
       },
       "exclude_generated": {
-        "required": false,
         "type": "boolean",
         "default": false,
         "description": "Omits fields that are illegal to set on data frame analytics PUT"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_data_frame_analytics_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_data_frame_analytics_stats.json
@@ -36,7 +36,6 @@
     "params": {
       "allow_no_match": {
         "type": "boolean",
-        "required": false,
         "description": "Whether to ignore if a wildcard expression matches no data frame analytics. (This includes `_all` string or when no data frame analytics have been specified)",
         "default": true
       },
@@ -52,7 +51,6 @@
       },
       "verbose": {
         "type": "boolean",
-        "required": false,
         "description": "whether the stats response should be verbose",
         "default": false
       }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_datafeed_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_datafeed_stats.json
@@ -36,7 +36,6 @@
     "params": {
       "allow_no_match": {
         "type": "boolean",
-        "required": false,
         "description": "Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_datafeeds.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_datafeeds.json
@@ -36,11 +36,9 @@
     "params": {
       "allow_no_match": {
         "type": "boolean",
-        "required": false,
         "description": "Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)"
       },
       "exclude_generated": {
-        "required": false,
         "type": "boolean",
         "default": false,
         "description": "Omits fields that are illegal to set on datafeed PUT"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_job_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_job_stats.json
@@ -36,7 +36,6 @@
     "params": {
       "allow_no_match": {
         "type": "boolean",
-        "required": false,
         "description": "Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_jobs.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_jobs.json
@@ -36,11 +36,9 @@
     "params": {
       "allow_no_match": {
         "type": "boolean",
-        "required": false,
         "description": "Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
       },
       "exclude_generated": {
-        "required": false,
         "type": "boolean",
         "default": false,
         "description": "Omits fields that are illegal to set on job PUT"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_model_snapshot_upgrade_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_model_snapshot_upgrade_stats.json
@@ -34,7 +34,6 @@
     "params": {
       "allow_no_match": {
         "type": "boolean",
-        "required": false,
         "description": "Whether to ignore if a wildcard expression matches no jobs or no snapshots. (This includes the `_all` string.)"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_trained_models.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_trained_models.json
@@ -36,47 +36,39 @@
     "params": {
       "allow_no_match": {
         "type": "boolean",
-        "required": false,
         "description": "Whether to ignore if a wildcard expression matches no trained models. (This includes `_all` string or when no trained models have been specified)",
         "default": true
       },
       "include": {
         "type": "string",
-        "required": false,
         "description": "A comma-separate list of fields to optionally include. Valid options are 'definition' and 'total_feature_importance'. Default is none."
       },
       "include_model_definition": {
         "type": "boolean",
-        "required": false,
         "description": "Should the full model definition be included in the results. These definitions can be large. So be cautious when including them. Defaults to false.",
         "default": false,
         "deprecated": true
       },
       "decompress_definition": {
         "type": "boolean",
-        "required": false,
         "default": true,
         "description": "Should the model definition be decompressed into valid JSON or returned in a custom compressed format. Defaults to true."
       },
       "from": {
-        "required": false,
         "type": "int",
         "description": "skips a number of trained models",
         "default": 0
       },
       "size": {
-        "required": false,
         "type": "int",
         "description": "specifies a max number of trained models to get",
         "default": 100
       },
       "tags": {
-        "required": false,
         "type": "list",
         "description": "A comma-separated list of tags that the model must have."
       },
       "exclude_generated": {
-        "required": false,
         "type": "boolean",
         "default": false,
         "description": "Omits fields that are illegal to set on model PUT"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_trained_models_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_trained_models_stats.json
@@ -36,7 +36,6 @@
     "params": {
       "allow_no_match": {
         "type": "boolean",
-        "required": false,
         "description": "Whether to ignore if a wildcard expression matches no trained models. (This includes `_all` string or when no trained models have been specified)",
         "default": true
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.infer_trained_model.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.infer_trained_model.json
@@ -51,7 +51,6 @@
     "params": {
       "timeout": {
         "type": "time",
-        "required": false,
         "description": "Controls the amount of time to wait for inference results.",
         "default": "10s"
       }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.preview_datafeed.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.preview_datafeed.json
@@ -41,12 +41,10 @@
     "params": {
       "start": {
         "type": "string",
-        "required": false,
         "description": "The start time from where the datafeed preview should begin"
       },
       "end": {
         "type": "string",
-        "required": false,
         "description": "The end time when the datafeed preview should stop"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_trained_model.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_trained_model.json
@@ -32,13 +32,11 @@
     },
     "params": {
       "defer_definition_decompression": {
-        "required": false,
         "type": "boolean",
         "description": "If set to `true` and a `compressed_definition` is provided, the request defers definition decompression and skips relevant validations.",
         "default": false
       },
       "wait_for_completion": {
-        "required": false,
         "type": "boolean",
         "description": "Whether to wait for all child operations(e.g. model download) to complete, before returning or not. Default to false",
         "default": false

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.start_data_frame_analytics.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.start_data_frame_analytics.json
@@ -33,7 +33,6 @@
     "params": {
       "timeout": {
         "type": "time",
-        "required": false,
         "description": "Controls the time to wait until the task has started. Defaults to 20 seconds"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.start_datafeed.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.start_datafeed.json
@@ -33,17 +33,14 @@
     "params": {
       "start": {
         "type": "string",
-        "required": false,
         "description": "The start time from where the datafeed should begin"
       },
       "end": {
         "type": "string",
-        "required": false,
         "description": "The end time when the datafeed should stop. When not set, the datafeed continues in real time"
       },
       "timeout": {
         "type": "time",
-        "required": false,
         "description": "Controls the time to wait until a datafeed has started. Default to 20 seconds"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.start_trained_model_deployment.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.start_trained_model_deployment.json
@@ -34,47 +34,39 @@
     "params": {
       "cache_size": {
         "type": "string",
-        "description": "A byte-size value for configuring the inference cache size. For example, 20mb.",
-        "required": false
+        "description": "A byte-size value for configuring the inference cache size. For example, 20mb."
       },
       "deployment_id": {
         "type": "string",
-        "description": "The Id of the new deployment. Defaults to the model_id if not set.",
-        "required": false
+        "description": "The Id of the new deployment. Defaults to the model_id if not set."
       },
       "number_of_allocations": {
         "type": "int",
         "description": "The total number of allocations this model is assigned across machine learning nodes.",
-        "required": false,
         "default": 1
       },
       "threads_per_allocation": {
         "type": "int",
         "description": "The number of threads used by each model allocation during inference.",
-        "required": false,
         "default": 1
       },
       "priority": {
         "type": "string",
         "description": "The deployment priority.",
-        "required": false,
         "default": "normal"
       },
       "queue_capacity": {
         "type": "int",
         "description": "Controls how many inference requests are allowed in the queue at a time.",
-        "required": false,
         "default": 1024
       },
       "timeout": {
         "type": "time",
-        "required": false,
         "description": "Controls the amount of time to wait for the model to deploy.",
         "default": "20s"
       },
       "wait_for": {
         "type": "string",
-        "required": false,
         "description": "The allocation status for which to wait",
         "options": [
           "starting",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.stop_data_frame_analytics.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.stop_data_frame_analytics.json
@@ -33,17 +33,14 @@
     "params": {
       "allow_no_match": {
         "type": "boolean",
-        "required": false,
         "description": "Whether to ignore if a wildcard expression matches no data frame analytics. (This includes `_all` string or when no data frame analytics have been specified)"
       },
       "force": {
         "type": "boolean",
-        "required": false,
         "description": "True if the data frame analytics should be forcefully stopped"
       },
       "timeout": {
         "type": "time",
-        "required": false,
         "description": "Controls the time to wait until the task has stopped. Defaults to 20 seconds"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.stop_datafeed.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.stop_datafeed.json
@@ -33,17 +33,14 @@
     "params": {
       "allow_no_match": {
         "type": "boolean",
-        "required": false,
         "description": "Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)"
       },
       "force": {
         "type": "boolean",
-        "required": false,
         "description": "True if the datafeed should be forcefully stopped."
       },
       "timeout": {
         "type": "time",
-        "required": false,
         "description": "Controls the time to wait until a datafeed has stopped. Default to 20 seconds"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.stop_trained_model_deployment.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.stop_trained_model_deployment.json
@@ -34,12 +34,10 @@
     "params": {
       "allow_no_match": {
         "type": "boolean",
-        "required": false,
         "description": "Whether to ignore if a wildcard expression matches no deployments. (This includes `_all` string or when no deployments have been specified)"
       },
       "force": {
         "type": "boolean",
-        "required": false,
         "description": "True if the deployment should be forcefully stopped"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.update_trained_model_deployment.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.update_trained_model_deployment.json
@@ -33,7 +33,6 @@
     "params": {
       "number_of_allocations": {
         "type": "int",
-        "required": false,
         "description": "Update the model deployment to this number of allocations."
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.upgrade_job_snapshot.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.upgrade_job_snapshot.json
@@ -34,12 +34,10 @@
     "params": {
       "timeout": {
         "type": "time",
-        "required": false,
         "description": "How long should the API wait for the job to be opened and the old snapshot to be loaded."
       },
       "wait_for_completion": {
         "type": "boolean",
-        "required": false,
         "description": "Should the request wait until the task is complete before responding to the caller. Default is false."
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.stop_job.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.stop_job.json
@@ -30,12 +30,10 @@
     "params": {
       "wait_for_completion": {
         "type": "boolean",
-        "required": false,
         "description": "True if the API should block until the job has fully stopped, false if should be executed async. Defaults to false."
       },
       "timeout": {
         "type": "time",
-        "required": false,
         "description": "Block for (at maximum) the specified duration while waiting for the job to stop.  Defaults to 30s."
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.clear_cached_realms.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.clear_cached_realms.json
@@ -30,8 +30,7 @@
     "params": {
       "usernames": {
         "type": "list",
-        "description": "Comma-separated list of usernames to clear from the cache",
-        "required": false
+        "description": "Comma-separated list of usernames to clear from the cache"
       }
     }
   }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.delete_transform.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.delete_transform.json
@@ -30,17 +30,14 @@
     "params": {
       "force": {
         "type": "boolean",
-        "required": false,
         "description": "When `true`, the transform is deleted regardless of its current state. The default value is `false`, meaning that the transform must be `stopped` before it can be deleted."
       },
       "delete_dest_index": {
         "type": "boolean",
-        "required": false,
         "description": "When `true`, the destination index is deleted together with the transform. The default value is `false`, meaning that the destination index will not be deleted."
       },
       "timeout": {
         "type": "time",
-        "required": false,
         "description": "Controls the time to wait for the transform deletion"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.get_transform.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.get_transform.json
@@ -36,21 +36,17 @@
     "params": {
       "from": {
         "type": "int",
-        "required": false,
         "description": "skips a number of transform configs, defaults to 0"
       },
       "size": {
         "type": "int",
-        "required": false,
         "description": "specifies a max number of transforms to get, defaults to 100"
       },
       "allow_no_match": {
         "type": "boolean",
-        "required": false,
         "description": "Whether to ignore if a wildcard expression matches no transforms. (This includes `_all` string or when no transforms have been specified)"
       },
       "exclude_generated": {
-        "required": false,
         "type": "boolean",
         "default": false,
         "description": "Omits fields that are illegal to set on transform PUT"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.get_transform_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.get_transform_stats.json
@@ -30,22 +30,18 @@
     "params": {
       "from": {
         "type": "number",
-        "required": false,
         "description": "skips a number of transform stats, defaults to 0"
       },
       "size": {
         "type": "number",
-        "required": false,
         "description": "specifies a max number of transform stats to get, defaults to 100"
       },
       "timeout": {
         "type": "time",
-        "required": false,
         "description": "Controls the time to wait for the stats"
       },
       "allow_no_match": {
         "type": "boolean",
-        "required": false,
         "description": "Whether to ignore if a wildcard expression matches no transforms. (This includes `_all` string or when no transforms have been specified)"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.preview_transform.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.preview_transform.json
@@ -41,7 +41,6 @@
     "params": {
       "timeout": {
         "type": "time",
-        "required": false,
         "description": "Controls the time to wait for the preview"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.put_transform.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.put_transform.json
@@ -33,12 +33,10 @@
     "params": {
       "defer_validation": {
         "type": "boolean",
-        "required": false,
         "description": "If validations should be deferred until transform starts, defaults to false."
       },
       "timeout": {
         "type": "time",
-        "required": false,
         "description": "Controls the time to wait for the transform to start"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.reset_transform.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.reset_transform.json
@@ -30,12 +30,10 @@
     "params": {
       "force": {
         "type": "boolean",
-        "required": false,
         "description": "When `true`, the transform is reset regardless of its current state. The default value is `false`, meaning that the transform must be `stopped` before it can be reset."
       },
       "timeout": {
         "type": "time",
-        "required": false,
         "description": "Controls the time to wait for the transform to reset"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.schedule_now_transform.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.schedule_now_transform.json
@@ -34,7 +34,6 @@
     "params": {
       "timeout": {
         "type": "time",
-        "required": false,
         "description": "Controls the time to wait for the scheduling to take place"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.start_transform.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.start_transform.json
@@ -30,12 +30,10 @@
     "params": {
       "from": {
         "type": "string",
-        "required": false,
         "description": "Restricts the set of transformed entities to those changed after this time"
       },
       "timeout": {
         "type": "time",
-        "required": false,
         "description": "Controls the time to wait for the transform to start"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.stop_transform.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.stop_transform.json
@@ -30,27 +30,22 @@
     "params": {
       "force": {
         "type": "boolean",
-        "required": false,
         "description": "Whether to force stop a failed transform or not. Default to false"
       },
       "wait_for_completion": {
         "type": "boolean",
-        "required": false,
         "description": "Whether to wait for the transform to fully stop before returning or not. Default to false"
       },
       "timeout": {
         "type": "time",
-        "required": false,
         "description": "Controls the time to wait until the transform has stopped. Default to 30 seconds"
       },
       "allow_no_match": {
         "type": "boolean",
-        "required": false,
         "description": "Whether to ignore if a wildcard expression matches no transforms. (This includes `_all` string or when no transforms have been specified)"
       },
       "wait_for_checkpoint": {
         "type": "boolean",
-        "required": false,
         "description": "Whether to wait for the transform to reach a checkpoint before stopping. Default to false"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.update_transform.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.update_transform.json
@@ -34,12 +34,10 @@
     "params": {
       "defer_validation": {
         "type": "boolean",
-        "required": false,
         "description": "If validations should be deferred until transform starts, defaults to false."
       },
       "timeout": {
         "type": "time",
-        "required": false,
         "description": "Controls the time to wait for the update"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.upgrade_transforms.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.upgrade_transforms.json
@@ -27,12 +27,10 @@
     "params": {
       "dry_run": {
         "type": "boolean",
-        "required": false,
         "description": "Whether to only check for updates but don't execute"
       },
       "timeout": {
         "type": "time",
-        "required": false,
         "description": "Controls the time to wait for the upgrade"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/watcher.execute_watch.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/watcher.execute_watch.json
@@ -41,8 +41,7 @@
     "params": {
       "debug": {
         "type": "boolean",
-        "description": "indicates whether the watch should execute in debug mode",
-        "required": false
+        "description": "indicates whether the watch should execute in debug mode"
       }
     },
     "body": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/watcher.stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/watcher.stats.json
@@ -52,8 +52,7 @@
       },
       "emit_stacktraces": {
         "type": "boolean",
-        "description": "Emits stack traces of currently running watches",
-        "required": false
+        "description": "Emits stack traces of currently running watches"
       }
     }
   }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/xpack.info.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/xpack.info.json
@@ -24,7 +24,6 @@
     "params": {
       "human": {
         "type": "boolean",
-        "required": false,
         "description": "Defines whether additional human-readable information is included in the response. In particular, it adds descriptions and a tag line. The default value is true.",
         "default": true
       },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [rest-api-spec: remove required: false for query parameters (#134658)](https://github.com/elastic/elasticsearch/pull/134658)