### PR TITLE
[9.1] [ML] Improve log message for model snapshot update (#134541)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/ReferenceDocs.java
+++ b/server/src/main/java/org/elasticsearch/common/ReferenceDocs.java
@@ -84,6 +84,7 @@ public enum ReferenceDocs {
     ALLOCATION_EXPLAIN_MAX_RETRY,
     SECURE_SETTINGS,
     CLUSTER_SHARD_LIMIT,
+    DELETE_INDEX_BLOCK,
     // this comment keeps the ';' on the next line so every entry above has a trailing ',' which makes the diff for adding new links cleaner
     ;
 

--- a/server/src/main/resources/org/elasticsearch/common/reference-docs-links.txt
+++ b/server/src/main/resources/org/elasticsearch/common/reference-docs-links.txt
@@ -46,3 +46,4 @@ ALLOCATION_EXPLAIN_NO_COPIES                                    troubleshoot/ela
 ALLOCATION_EXPLAIN_MAX_RETRY                                    troubleshoot/elasticsearch/diagnose-unassigned-shards#maximum-retries-exceeded
 SECURE_SETTINGS                                                 deploy-manage/security/secure-settings
 CLUSTER_SHARD_LIMIT                                             reference/elasticsearch/configuration-reference/miscellaneous-cluster-settings#cluster-shard-limit
+DELETE_INDEX_BLOCK                                              api/doc/elasticsearch/operation/operation-indices-remove-block


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[ML] Improve log message for model snapshot update (#134541)](https://github.com/elastic/elasticsearch/pull/134541)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)