### PR TITLE
[DOCS][Backport]: Content connectors release notes

### DIFF
--- a/docs/reference/search-connectors/release-notes.md
+++ b/docs/reference/search-connectors/release-notes.md
@@ -13,6 +13,11 @@ If you are an Enterprise Search user and want to upgrade to Elastic 9.0, refer t
 It includes detailed steps, tooling, and resources to help you transition to supported alternatives in 9.x, such as Elasticsearch, the Open Web Crawler, and self-managed connectors.
 :::
 
+## 9.1.4 [connectors-9.1.4-release-notes]
+
+### Features and enhancements [connectors-9.1.4-features-enhancements]
+* Reduced API calls during field validation with caching, improving sync performance in Salesforce connector. [#3668](https://github.com/elastic/connectors/pull/3668).
+
 ## 9.1.3 [connectors-9.1.3-release-notes]
 There are no new features, enhancements, fixes, known issues, or deprecations associated with this release.
 

--- a/docs/reference/search-connectors/release-notes.md
+++ b/docs/reference/search-connectors/release-notes.md
@@ -32,6 +32,11 @@ Permissions granted to the `Everyone Except External Users` group were previousl
 ## 9.1.0 [connectors-9.1.0-release-notes]
 There are no new features, enhancements, fixes, known issues, or deprecations associated with this release.
 
+## 9.0.7 [connectors-9.0.7-release-notes]
+
+### Features and enhancements [connectors-9.0.7-features-enhancements]
+* Reduced API calls during field validation with caching, improving sync performance in Salesforce connector. [#3668](https://github.com/elastic/connectors/pull/3668).
+
 ## 9.0.6 [connectors-9.0.6-release-notes]
 No changes since 9.0.5
 


### PR DESCRIPTION
This PR backports the content connector release notes for 9.0.7 and 9.1.4 releases.