### PR TITLE
[8.19] Avoid holding references to SearchExecutionContext in SourceConfirmedTextQuery (#134887)

### DIFF
--- a/docs/changelog/134887.yaml
+++ b/docs/changelog/134887.yaml
@@ -1,0 +1,5 @@
+pr: 134887
+summary: Avoid holding references to `SearchExecutionContext` in `SourceConfirmedTextQuery`
+area: Mapping
+type: bug
+issues: []

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
@@ -295,9 +295,9 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
                 String name = storedFieldNameForSyntheticSource();
                 return storedFieldFetcher(name);
             }
+            ValueFetcher valueFetcher = valueFetcher(searchExecutionContext, null);
+            SourceProvider sourceProvider = searchExecutionContext.lookup();
             return context -> {
-                ValueFetcher valueFetcher = valueFetcher(searchExecutionContext, null);
-                SourceProvider sourceProvider = searchExecutionContext.lookup();
                 valueFetcher.setNextReader(context);
                 return docID -> {
                     try {


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Avoid holding references to SearchExecutionContext in SourceConfirmedTextQuery (#134887)