### PR TITLE
Guard inlinestats tests in release builds

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractCrossClusterTestCase.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractCrossClusterTestCase.java
@@ -45,6 +45,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.INLINESTATS_SUPPORTS_REMOTE;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -366,5 +367,9 @@ public abstract class AbstractCrossClusterTestCase extends AbstractMultiClusters
             new ResourceNotFoundException("exchange sink was not found"),
             new EsRejectedExecutionException("node is shutting down")
         );
+    }
+
+    protected static String randomStats() {
+        return INLINESTATS_SUPPORTS_REMOTE.isEnabled() ? randomFrom("STATS", "INLINESTATS") : "STATS";
     }
 }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterCancellationIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterCancellationIT.java
@@ -84,7 +84,7 @@ public class CrossClusterCancellationIT extends AbstractCrossClusterTestCase {
     public void testCancel() throws Exception {
         createRemoteIndex(between(10, 100));
         EsqlQueryRequest request = EsqlQueryRequest.syncEsqlQueryRequest();
-        String stats = randomFrom("STATS", "INLINESTATS");
+        String stats = randomStats();
         request.query("FROM *:test | " + stats + " total=sum(const) | LIMIT 1");
         request.pragmas(randomPragmas());
         PlainActionFuture<EsqlQueryResponse> requestFuture = new PlainActionFuture<>();
@@ -162,7 +162,7 @@ public class CrossClusterCancellationIT extends AbstractCrossClusterTestCase {
     public void testTasks() throws Exception {
         createRemoteIndex(between(10, 100));
         EsqlQueryRequest request = EsqlQueryRequest.syncEsqlQueryRequest();
-        String stats = randomFrom("STATS", "INLINESTATS");
+        String stats = randomStats();
         request.query("FROM *:test | " + stats + " total=sum(const) | LIMIT 1");
         request.pragmas(randomPragmas());
         ActionFuture<EsqlQueryResponse> requestFuture = client().execute(EsqlQueryAction.INSTANCE, request);
@@ -201,7 +201,7 @@ public class CrossClusterCancellationIT extends AbstractCrossClusterTestCase {
     public void testCancelSkipUnavailable() throws Exception {
         createRemoteIndex(between(10, 100));
         EsqlQueryRequest request = EsqlQueryRequest.syncEsqlQueryRequest();
-        String stats = randomFrom("STATS", "INLINESTATS");
+        String stats = randomStats();
         request.query("FROM *:test | " + stats + " total=sum(const) | LIMIT 1");
         request.pragmas(randomPragmas());
         request.includeCCSMetadata(true);

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterQueryIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterQueryIT.java
@@ -791,6 +791,7 @@ public class CrossClusterQueryIT extends AbstractCrossClusterTestCase {
     }
 
     public void testRemoteFailureInlinestats() throws IOException {
+        assumeTrue("requires inlinestats", EsqlCapabilities.Cap.INLINESTATS_SUPPORTS_REMOTE.isEnabled());
         Map<String, Object> testClusterInfo = setupFailClusters();
         String localIndex = (String) testClusterInfo.get("local.index");
         String remote1Index = (String) testClusterInfo.get("remote.index");

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterQueryUnavailableRemotesIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterQueryUnavailableRemotesIT.java
@@ -159,6 +159,7 @@ public class CrossClusterQueryUnavailableRemotesIT extends AbstractCrossClusterT
     }
 
     public void testCCSAgainstDisconnectedRemoteWithSkipUnavailableTrueInlinestats() throws Exception {
+        assumeTrue("requires inlinestats", EsqlCapabilities.Cap.INLINESTATS_SUPPORTS_REMOTE.isEnabled());
         int numClusters = 3;
         Map<String, Object> testClusterInfo = setupClusters(numClusters);
         int localNumShards = (Integer) testClusterInfo.get("local.num_shards");
@@ -289,7 +290,7 @@ public class CrossClusterQueryUnavailableRemotesIT extends AbstractCrossClusterT
             Boolean requestIncludeMeta = includeCCSMetadata.v1();
             boolean responseExpectMeta = includeCCSMetadata.v2();
 
-            String stats = randomFrom("STATS", "INLINESTATS");
+            String stats = randomStats();
             // query only the REMOTE_CLUSTER_1
             try (
                 EsqlQueryResponse resp = runQuery(
@@ -379,7 +380,7 @@ public class CrossClusterQueryUnavailableRemotesIT extends AbstractCrossClusterT
             Tuple<Boolean, Boolean> includeCCSMetadata = randomIncludeCCSMetadata();
             Boolean requestIncludeMeta = includeCCSMetadata.v1();
 
-            String stats = randomFrom("STATS", "INLINESTATS");
+            String stats = randomStats();
             final Exception exception = expectThrows(
                 Exception.class,
                 () -> runQuery("FROM logs-*,*:logs-* | " + stats + " sum (v) | SORT v", requestIncludeMeta)
@@ -399,7 +400,7 @@ public class CrossClusterQueryUnavailableRemotesIT extends AbstractCrossClusterT
         try {
             Tuple<Boolean, Boolean> includeCCSMetadata = randomIncludeCCSMetadata();
             Boolean requestIncludeMeta = includeCCSMetadata.v1();
-            String stats = randomFrom("STATS", "INLINESTATS");
+            String stats = randomStats();
             {
                 // close the remote cluster so that it is unavailable
                 cluster(REMOTE_CLUSTER_1).close();


### PR DESCRIPTION
Some InlineStats tests failed in release builds (see #134768). We need to guard these tests with capability checks.