### PR TITLE
Add XPath to XmlUtils

### DIFF
--- a/build-tools-internal/src/main/resources/forbidden/jdk-signatures.txt
+++ b/build-tools-internal/src/main/resources/forbidden/jdk-signatures.txt
@@ -128,3 +128,9 @@ javax.xml.validation.SchemaFactory#newInstance(java.lang.String, java.lang.Strin
 
 @defaultMessage Validator should not be used directly. Use XmlUtils#getHardenedValidator() instead
 javax.xml.validation.Schema#newValidator()
+
+@defaultMessage XPathFactory should not be used directly. Use XmlUtils#getHardenedXPath() instead
+javax.xml.xpath.XPathFactory#newDefaultInstance()
+javax.xml.xpath.XPathFactory#newInstance()
+javax.xml.xpath.XPathFactory#newInstance(java.lang.String)
+javax.xml.xpath.XPathFactory#newInstance(java.lang.String, java.lang.String, java.lang.ClassLoader)

--- a/libs/core/src/main/java/org/elasticsearch/core/XmlUtils.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/XmlUtils.java
@@ -30,6 +30,7 @@ import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathFactory;
+import javax.xml.xpath.XPathFactoryConfigurationException;
 
 public class XmlUtils {
 
@@ -137,14 +138,13 @@ public class XmlUtils {
     }
 
     /**
-     * Constructs an XPath configured to be secure (not really though!)
+     * Constructs an XPath configured to be secure
      */
     @SuppressForbidden(reason = "This is the only allowed way to construct an XPath")
-    public static XPath getHardenedXPath() {
+    public static XPath getHardenedXPath() throws XPathFactoryConfigurationException {
         XPathFactory xPathFactory = XPathFactory.newInstance();
-        XPath xpath = xPathFactory.newXPath();
-        // n.b. not actually hardened yet!
-        return xpath;
+        xPathFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        return xPathFactory.newXPath();
     }
 
     private static class ErrorHandler implements org.xml.sax.ErrorHandler {

--- a/libs/core/src/main/java/org/elasticsearch/core/XmlUtils.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/XmlUtils.java
@@ -28,6 +28,8 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathFactory;
 
 public class XmlUtils {
 
@@ -132,6 +134,17 @@ public class XmlUtils {
         saxParserFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
         saxParserFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         return saxParserFactory;
+    }
+
+    /**
+     * Constructs an XPath configured to be secure (not really though!)
+     */
+    @SuppressForbidden(reason = "This is the only allowed way to construct an XPath")
+    public static XPath getHardenedXPath() {
+        XPathFactory xPathFactory = XPathFactory.newInstance();
+        XPath xpath = xPathFactory.newXPath();
+        // n.b. not actually hardened yet!
+        return xpath;
     }
 
     private static class ErrorHandler implements org.xml.sax.ErrorHandler {

--- a/libs/core/src/main/java/org/elasticsearch/core/XmlUtils.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/XmlUtils.java
@@ -126,13 +126,11 @@ public class XmlUtils {
     public static SAXParserFactory getHardenedSaxParserFactory() throws SAXNotSupportedException, SAXNotRecognizedException,
         ParserConfigurationException {
         var saxParserFactory = SAXParserFactory.newInstance();
-
         saxParserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         saxParserFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
         saxParserFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
         saxParserFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
         saxParserFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-
         return saxParserFactory;
     }
 

--- a/x-pack/plugin/identity-provider/qa/idp-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/idp/IdentityProviderAuthenticationIT.java
+++ b/x-pack/plugin/identity-provider/qa/idp-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/idp/IdentityProviderAuthenticationIT.java
@@ -42,7 +42,6 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathFactory;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
@@ -170,8 +169,7 @@ public class IdentityProviderAuthenticationIT extends IdpRestTestCase {
         Document document = builder.parse(new InputSource(new StringReader(samlResponse)));
 
         // Create XPath evaluator
-        XPathFactory xPathFactory = XPathFactory.newInstance();
-        XPath xpath = xPathFactory.newXPath();
+        XPath xpath = XmlUtils.getHardenedXPath();
 
         // Validate SAML Response structure
         Element responseElement = (Element) xpath.evaluate("//*[local-name()='Response']", document, XPathConstants.NODE);


### PR DESCRIPTION
At the moment there's only a test caller, but #130337 will add a non-test caller. This PR is related to the recent #133644 in that this is adding yet another method to `XmlUtils` (and that PR introduced the `XmlUtils` class to begin with).

So far all I've found is that we probably do indeed want to set `XMLConstants.FEATURE_SECURE_PROCESSING` to `true` -- there may be other options that we also want to set, but I haven't found them yet. If you know better than I do please speak up.