### PR TITLE
[9.1] Fix mergeExecutorThreadCount in ThreadPoolMergeExecutorServiceDiskSpaceTests (#134852)

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/engine/ThreadPoolMergeExecutorServiceDiskSpaceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/ThreadPoolMergeExecutorServiceDiskSpaceTests.java
@@ -83,7 +83,7 @@ public class ThreadPoolMergeExecutorServiceDiskSpaceTests extends ESTestCase {
         // use 2 data paths
         String[] paths = new String[] { path.resolve(aPathPart).toString(), path.resolve(bPathPart).toString() };
         // some tests hold one merge thread blocked, and need at least one other runnable
-        mergeExecutorThreadCount = randomIntBetween(2, 9);
+        mergeExecutorThreadCount = randomIntBetween(2, 8);
         Settings.Builder settingsBuilder = Settings.builder()
             .put(Environment.PATH_HOME_SETTING.getKey(), path)
             .putList(Environment.PATH_DATA_SETTING.getKey(), paths)


### PR DESCRIPTION
Backports the following commits to 9.1:
 - Fix mergeExecutorThreadCount in ThreadPoolMergeExecutorServiceDiskSpaceTests (#134852)