### PR TITLE
Fixing conditional processor mutability bugs

### DIFF
--- a/docs/changelog/134936.yaml
+++ b/docs/changelog/134936.yaml
@@ -1,0 +1,5 @@
+pr: 134936
+summary: Fixing conditional processor mutability bugs
+area: Ingest Node
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/ingest/ConditionalProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/ConditionalProcessor.java
@@ -158,6 +158,8 @@ public class ConditionalProcessor extends AbstractProcessor implements WrappingP
             return new UnmodifiableIngestData((Map<String, Object>) raw);
         } else if (raw instanceof List) {
             return new UnmodifiableIngestList((List<Object>) raw);
+        } else if (raw instanceof Set<?> rawSet) {
+            return new UnmodifiableIngestSet((Set<Object>) rawSet);
         } else if (raw instanceof byte[] bytes) {
             return bytes.clone();
         }
@@ -287,23 +289,7 @@ public class ConditionalProcessor extends AbstractProcessor implements WrappingP
 
         @Override
         public Iterator<Object> iterator() {
-            Iterator<Object> wrapped = data.iterator();
-            return new Iterator<Object>() {
-                @Override
-                public boolean hasNext() {
-                    return wrapped.hasNext();
-                }
-
-                @Override
-                public Object next() {
-                    return wrapped.next();
-                }
-
-                @Override
-                public void remove() {
-                    throw unmodifiableException();
-                }
-            };
+            return new UnmodifiableIterator(data.iterator());
         }
 
         @Override
@@ -463,6 +449,102 @@ public class ConditionalProcessor extends AbstractProcessor implements WrappingP
             public void add(final Object o) {
                 throw unmodifiableException();
             }
+        }
+    }
+
+    private static final class UnmodifiableIngestSet implements Set<Object> {
+        private final Set<Object> data;
+
+        UnmodifiableIngestSet(Set<Object> data) {
+            this.data = data;
+        }
+
+        @Override
+        public int size() {
+            return data.size();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return data.isEmpty();
+        }
+
+        @Override
+        public boolean contains(Object o) {
+            return data.contains(o);
+        }
+
+        @Override
+        public Iterator<Object> iterator() {
+            return new UnmodifiableIterator(data.iterator());
+        }
+
+        @Override
+        public Object[] toArray() {
+            return data.toArray();
+        }
+
+        @Override
+        public <T> T[] toArray(T[] a) {
+            return data.toArray(a);
+        }
+
+        @Override
+        public boolean add(Object o) {
+            throw unmodifiableException();
+        }
+
+        @Override
+        public boolean remove(Object o) {
+            throw unmodifiableException();
+        }
+
+        @Override
+        public boolean containsAll(Collection<?> c) {
+            return data.containsAll(c);
+        }
+
+        @Override
+        public boolean addAll(Collection<?> c) {
+            throw unmodifiableException();
+        }
+
+        @Override
+        public boolean retainAll(Collection<?> c) {
+            throw unmodifiableException();
+        }
+
+        @Override
+        public boolean removeAll(Collection<?> c) {
+            throw unmodifiableException();
+        }
+
+        @Override
+        public void clear() {
+            throw unmodifiableException();
+        }
+    }
+
+    private static final class UnmodifiableIterator implements Iterator<Object> {
+        private final Iterator<Object> it;
+
+        UnmodifiableIterator(Iterator<Object> it) {
+            this.it = it;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return it.hasNext();
+        }
+
+        @Override
+        public Object next() {
+            return wrapUnmodifiable(it.next());
+        }
+
+        @Override
+        public void remove() {
+            throw unmodifiableException();
         }
     }
 }


### PR DESCRIPTION
ConditionalProcessor attempts to prevent users from modifying the underlying IngestDocument data from within an "if" script. It wraps Maps, Lists, and byte arrays with unmodifiable versions. But it is also possible to have Sets in the data (and many of our integrations do). We do not ensure that Sets are unmodifiable. This PR fixes that loophole, preventing users from accidentally modifying IngestDocument data in a ConditionalProcessor.