### PR TITLE
[9.0] Fix transport version tests on windows (#134739)

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/AbstractTransportVersionFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/AbstractTransportVersionFuncTest.groovy
@@ -155,7 +155,11 @@ class AbstractTransportVersionFuncTest extends AbstractGradleFuncTest {
         """
 
         setupLocalGitRepo()
-        execute("git checkout -b main")
+        String currentBranch = execute("git branch --show-current")
+        if (currentBranch.strip().equals("main") == false) {
+            // make sure a main branch exists, some CI doesn't have main set as the default branch
+            execute("git checkout -b main")
+        }
         execute("git checkout -b test")
     }
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionResourcesService.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionResourcesService.java
@@ -122,7 +122,8 @@ public abstract class TransportVersionResourcesService implements BuildService<T
     /** Get the definition names which have local changes relative to upstream */
     List<String> getChangedReferableDefinitionNames() {
         List<String> changedDefinitions = new ArrayList<>();
-        String referablePrefix = REFERABLE_DIR.toString();
+        // make sure the prefix is git style paths, always forward slashes
+        String referablePrefix = REFERABLE_DIR.toString().replace('\\', '/');
         for (String changedPath : getChangedResources()) {
             if (changedPath.contains(referablePrefix) == false) {
                 continue;
@@ -304,7 +305,7 @@ public abstract class TransportVersionResourcesService implements BuildService<T
             synchronized (changedResources) {
                 HashSet<String> resources = new HashSet<>();
 
-                String diffOutput = gitCommand("diff", "--name-only", getUpstreamRefName(), ".");
+                String diffOutput = gitCommand("diff", "--name-only", "--relative", getUpstreamRefName(), ".");
                 if (diffOutput.strip().isEmpty() == false) {
                     Collections.addAll(resources, diffOutput.split("\n")); // git always outputs LF
                 }


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Fix transport version tests on windows (#134739)