### PR TITLE
Mark the create-index-from-source action as publicly available on Serverless

### DIFF
--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/rest/RestCreateIndexFromSourceAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/rest/RestCreateIndexFromSourceAction.java
@@ -10,6 +10,8 @@ package org.elasticsearch.xpack.migrate.rest;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.Scope;
+import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.migrate.action.CreateIndexFromSourceAction;
 
@@ -19,6 +21,7 @@ import java.util.List;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.rest.RestRequest.Method.PUT;
 
+@ServerlessScope(value = Scope.PUBLIC)
 public class RestCreateIndexFromSourceAction extends BaseRestHandler {
 
     @Override


### PR DESCRIPTION
This marks the `POST /_create_from/{source}/{index}` API, used to create a new index from a source index's settings and mappings, as publicly available on Serverless.

This API is useful for pre-creating an index prior to something like a reindex.
