### PR TITLE
[ES|QL] Use Double.BYTES instead of Long in double encoder

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/DefaultUnsortableTopNEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/DefaultUnsortableTopNEncoder.java
@@ -143,7 +143,7 @@ public final class DefaultUnsortableTopNEncoder implements TopNEncoder {
     public void encodeDouble(double value, BreakingBytesRefBuilder bytesRefBuilder) {
         bytesRefBuilder.grow(bytesRefBuilder.length() + Double.BYTES);
         DOUBLE.set(bytesRefBuilder.bytes(), bytesRefBuilder.length(), value);
-        bytesRefBuilder.setLength(bytesRefBuilder.length() + Long.BYTES);
+        bytesRefBuilder.setLength(bytesRefBuilder.length() + Double.BYTES);
     }
 
     @Override


### PR DESCRIPTION
Caught this typo while investigating a bug. It works because Long.BYTES
and Double.BYTES are both 8, but we probably should use Double for the
double encoder.
