### PR TITLE
Ignore non-transport changes when auto-committing in CI

### DIFF
--- a/.buildkite/scripts/update-transport-versions.sh
+++ b/.buildkite/scripts/update-transport-versions.sh
@@ -31,8 +31,8 @@ fi
 
 .ci/scripts/run-gradle.sh generateTransportVersion --backport-branches="${backport_branches}"
 
-if git diff --exit-code; then
-  echo "No changes found after updating transport versions. Don't need to auto commit."
+if git diff --quiet -- "server/src/main/resources/transport/**"; then
+  echo "No transport version changes found after update. Skipping auto commit."
   exit 0
 fi
 


### PR DESCRIPTION
Updates our CI script to update transport version to ignore any local unstaged changes outside the transport version state files directory.