### PR TITLE
[9.0] Update periodic java-ea build to test java 26 pre-release (#134983)

### DIFF
--- a/.buildkite/pipelines/periodic-java-ea.template.yml
+++ b/.buildkite/pipelines/periodic-java-ea.template.yml
@@ -1,5 +1,5 @@
 env:
-  JAVA_EA_VERSION: "${JAVA_EA_VERSION:-25-pre}"
+  JAVA_EA_VERSION: "${JAVA_EA_VERSION:-26-pre}"
 
 steps:
   - group: bwc

--- a/.buildkite/pipelines/periodic-java-ea.yml
+++ b/.buildkite/pipelines/periodic-java-ea.yml
@@ -1,6 +1,6 @@
 # This file is auto-generated. See .buildkite/pipelines/periodic-java-ea.template.yml
 env:
-  JAVA_EA_VERSION: "${JAVA_EA_VERSION:-25-pre}"
+  JAVA_EA_VERSION: "${JAVA_EA_VERSION:-26-pre}"
 
 steps:
   - group: bwc


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Update periodic java-ea build to test java 26 pre-release (#134983)