### PR TITLE
[8.19] [ML] Fix YAMl test to use correct query parameter type (#134999)

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/jobs_get_result_overall_buckets.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/jobs_get_result_overall_buckets.yml
@@ -602,7 +602,7 @@ setup:
       ml.get_overall_buckets:
         job_id: "jobs-get-result-overall-buckets-*"
         bucket_span: "2h"
-        overall_score: "41.0"
+        overall_score: 41.0
 
   - match: { count: 1 }
   - match: { overall_buckets.0.timestamp: 1464746400000 }
@@ -624,7 +624,7 @@ setup:
       ml.get_overall_buckets:
         job_id: "jobs-that-do-not-exist-*"
         bucket_span: "2h"
-        overall_score: "41.0"
+        overall_score: 41.0
         allow_no_match: true
 
   - match: { count: 0 }


### PR DESCRIPTION
Backports the following commits to 8.19:
 - [ML] Fix YAMl test to use correct query parameter type (#134999)