### PR TITLE
Fix testDateHistogramAggregation by limiting number docs to avoid OOM

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -492,9 +492,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeForkIT
   method: test {csv-spec:spatial_shapes.ConvertFromStringParseError}
   issue: https://github.com/elastic/elasticsearch/issues/134254
-- class: org.elasticsearch.xpack.logsdb.qa.BulkDynamicMappingChallengeRestIT
-  method: testDateHistogramAggregation
-  issue: https://github.com/elastic/elasticsearch/issues/134389
 - class: org.elasticsearch.xpack.esql.expression.function.scalar.score.DecayTests
   method: "testEvaluateBlockWithNulls {TestCase=<double>, <double>, <double>, <_source> #11}"
   issue: https://github.com/elastic/elasticsearch/issues/134447

--- a/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/qa/StandardVersusLogsIndexModeChallengeRestIT.java
+++ b/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/qa/StandardVersusLogsIndexModeChallengeRestIT.java
@@ -239,7 +239,7 @@ public abstract class StandardVersusLogsIndexModeChallengeRestIT extends Abstrac
     }
 
     public void testDateHistogramAggregation() throws IOException {
-        int numberOfDocuments = ESTestCase.randomIntBetween(20, 80);
+        int numberOfDocuments = ESTestCase.randomIntBetween(20, 70);
         final List<XContentBuilder> documents = generateDocuments(numberOfDocuments);
 
         indexDocuments(documents);


### PR DESCRIPTION
Test is failing due to OOM. The seed that is causing failure is producing 80 documents, which is the max. Reducing this to 70 avoids an OOM

Fixes https://github.com/elastic/elasticsearch/issues/134389