### PR TITLE
Make SecureString comparisons constant time

### DIFF
--- a/docs/changelog/135053.yaml
+++ b/docs/changelog/135053.yaml
@@ -1,0 +1,5 @@
+pr: 135053
+summary: Make `SecureString` comparisons constant time
+area: Infra/Core
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/common/settings/SecureString.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/SecureString.java
@@ -59,7 +59,7 @@ public final class SecureString implements CharSequence, Releasable {
     public synchronized boolean equals(CharSequence that) {
         ensureNotClosed();
         // This is intentional to make sure the check is constant time relative to the length of the comparison string
-        return compareChars(0, that, 0, that.length()) && this.length() == that.length();
+        return that != null && compareChars(0, that, 0, that.length()) && this.length() == that.length();
     }
 
     public boolean startsWith(CharSequence other) {

--- a/server/src/main/java/org/elasticsearch/common/settings/SecureString.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/SecureString.java
@@ -43,25 +43,27 @@ public final class SecureString implements CharSequence, Releasable {
         this(s.toCharArray());
     }
 
-    /** Constant time equality to avoid potential timing attacks. */
     @Override
     public synchronized boolean equals(Object o) {
-        ensureNotClosed();
-        if (this == o) return true;
-        if (o == null || o instanceof CharSequence == false) return false;
-        CharSequence that = (CharSequence) o;
-        if (chars.length != that.length()) {
+        if (this == o) {
+            return true;
+        }
+        if (o instanceof CharSequence cs) {
+            return equals(cs);
+        } else {
             return false;
         }
+    }
 
-        return compareChars(0, that, 0, chars.length);
+    /** Constant time equality to avoid potential timing attacks. */
+    public synchronized boolean equals(CharSequence that) {
+        ensureNotClosed();
+        // This is intentional to make sure the check is constant time relative to the length of the comparison string
+        return compareChars(0, that, 0, that.length()) && this.length() == that.length();
     }
 
     public boolean startsWith(CharSequence other) {
         ensureNotClosed();
-        if (this.length() < other.length()) {
-            return false;
-        }
         return compareChars(0, other, 0, other.length());
     }
 
@@ -79,8 +81,9 @@ public final class SecureString implements CharSequence, Releasable {
         }
 
         // Perform some calculations as long to prevent overflow
-        if (thisOffset + (long) len > this.length() || otherOffset + (long) len > other.length()) {
-            // cannot compare a region that runs past the end of the source
+        if (otherOffset + (long) len > other.length()) {
+            // cannot compare a region that runs past the end of the comparison string
+            // we don't check the length of our string because we want to run in constant time
             return false;
         }
 
@@ -99,13 +102,12 @@ public final class SecureString implements CharSequence, Releasable {
      * Constant time comparison of a range from {@link #chars} against an identical length range from {@code other}
      */
     private boolean compareChars(int thisOffset, CharSequence other, int otherOffset, int len) {
-        assert len <= this.chars.length : "len is longer that secure-string: " + len + " vs " + this.chars.length;
         assert len <= other.length() : "len is longer that comparison string: " + len + " vs " + other.length();
 
         int equals = 0;
         for (int i = 0; i < len; i++) {
-            final char t = chars[thisOffset + i];
             final char o = other.charAt(otherOffset + i);
+            final int t = thisOffset + i < chars.length ? chars[thisOffset + i] : (Character.MAX_VALUE + 1);
             equals |= t ^ o;
         }
 

--- a/server/src/test/java/org/elasticsearch/common/settings/SecureStringTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SecureStringTests.java
@@ -12,6 +12,7 @@ package org.elasticsearch.common.settings;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Arrays;
+import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.containsString;
@@ -76,16 +77,80 @@ public class SecureStringTests extends ESTestCase {
     }
 
     public void testEquals() {
-        final String string = randomAlphaOfLengthBetween(8, 128);
-        final SecureString secureString = new SecureString(string.toCharArray());
-        final StringBuilder stringBuilder = new StringBuilder(string);
+        final List<String> strings = List.of(
+            randomAlphaOfLengthBetween(8, 128),
+            (char) 0 + randomAlphanumericOfLength(9),
+            Character.MAX_VALUE + randomAlphanumericOfLength(10),
+            randomAlphanumericOfLength(11) + (char) 0,
+            randomAlphanumericOfLength(12) + Character.MAX_VALUE,
+            randomAlphanumericOfLength(3) + (char) 0 + randomAlphanumericOfLength(10),
+            randomAlphanumericOfLength(4) + Character.MAX_VALUE + randomAlphanumericOfLength(10)
+        );
+        for (var string : strings) {
+            final SecureString secureString = new SecureString(string.toCharArray());
 
-        assertThat(secureString.equals(string), is(true));
-        assertThat(secureString.equals(stringBuilder), is(true));
+            verifyEquals(secureString, string, true);
 
-        final int split = randomIntBetween(1, string.length() - 1);
-        final String altString = string.substring(0, split) + randomAlphanumericOfLength(1) + string.substring(split);
-        assertThat(secureString.equals(altString), is(false));
+            // Comparison has extra character in the middle
+            final int split = randomIntBetween(1, string.length() - 1);
+            final String altString = string.substring(0, split) + randomAlphanumericOfLength(1) + string.substring(split);
+            verifyEquals(secureString, altString, false);
+
+            // Comparison has extra characters at beginning
+            verifyEquals(secureString, randomAlphanumericOfLength(1) + string, false);
+            verifyEquals(secureString, randomAlphaOfLengthBetween(2, 8) + string, false);
+            verifyEquals(secureString, "\0" + string, false);
+            verifyEquals(secureString, (char) -1 + string, false);
+
+            // Comparison has extra characters at end
+            verifyEquals(secureString, string + randomAlphanumericOfLength(1), false);
+            verifyEquals(secureString, string + randomAlphaOfLengthBetween(2, 8), false);
+            verifyEquals(secureString, string + '\0', false);
+            verifyEquals(secureString, string + (char) -1, false);
+
+            // Comparison is missing characters at beginning
+            verifyEquals(secureString, string.substring(1), false);
+            verifyEquals(secureString, string.substring(randomIntBetween(2, string.length() - 2)), false);
+
+            // Comparison is missing characters at end
+            verifyEquals(secureString, string.substring(0, string.length() - 1), false);
+            verifyEquals(secureString, string.substring(0, string.length() - randomIntBetween(2, string.length() - 2)), false);
+
+            // Comparison has different character at beginning
+            verifyEquals(
+                secureString,
+                randomValueOtherThan(string.substring(0, 1), () -> randomAlphanumericOfLength(1)) + string.substring(1),
+                false
+            );
+            if (string.charAt(0) != 0) {
+                verifyEquals(secureString, "\0" + string.substring(1), false);
+            }
+            if (string.charAt(0) != (char) -1) {
+                verifyEquals(secureString, (char) -1 + string.substring(1), false);
+            }
+            // Comparison has different character at end
+            verifyEquals(
+                secureString,
+                string.substring(0, string.length() - 1) + randomValueOtherThan(
+                    string.substring(string.length() - 1),
+                    () -> randomAlphanumericOfLength(1)
+                ),
+                false
+            );
+            if (string.endsWith("\0") == false) {
+                verifyEquals(secureString, string.substring(0, string.length() - 1) + '\0', false);
+            }
+            if (string.charAt(string.length() - 1) != (char) -1) {
+                verifyEquals(secureString, string.substring(0, string.length() - 1) + (char) -1, false);
+            }
+        }
+    }
+
+    private void verifyEquals(SecureString secure, String string, boolean expected) {
+        // Verify that we get the same result for different types of CharSequence
+        assertThat(secure + " == " + string, secure.equals(string), is(expected));
+        assertThat(secure.equals(new SecureString(string.toCharArray())), is(expected));
+        assertThat(secure.equals(new StringBuilder(string)), is(expected));
     }
 
     public void testStartsWith() {

--- a/server/src/test/java/org/elasticsearch/common/settings/SecureStringTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SecureStringTests.java
@@ -143,14 +143,25 @@ public class SecureStringTests extends ESTestCase {
             if (string.charAt(string.length() - 1) != (char) -1) {
                 verifyEquals(secureString, string.substring(0, string.length() - 1) + (char) -1, false);
             }
+
+            assertThat(secureString.equals(""), is(false));
+            final Object obj = null;
+            // noinspection ConstantValue
+            assertThat(secureString.equals(obj), is(false));
+
+            final CharSequence cs = null;
+            assertThat(secureString.equals(cs), is(false));
         }
+
     }
 
+    @SuppressWarnings("EqualsBetweenInconvertibleTypes")
     private void verifyEquals(SecureString secure, String string, boolean expected) {
         // Verify that we get the same result for different types of CharSequence
         assertThat(secure + " == " + string, secure.equals(string), is(expected));
         assertThat(secure.equals(new SecureString(string.toCharArray())), is(expected));
         assertThat(secure.equals(new StringBuilder(string)), is(expected));
+        assertThat(secure.equals((Object) string), is(expected));
     }
 
     public void testStartsWith() {


### PR DESCRIPTION
Changes the SecureString methods `equals` `startsWith` and `regionMatches` to operate in constant time relative to the length of that comparison string, regardless of the length of the secure string.

That is, the time to perform each of these comparisons should be the same (even though some of them _could_ be computed more efficiently)

    new SecureString("a").equals("abcdefghijklmn")
    new SecureString("abcdefghijklmn").equals("abcdefghijklmn")
    new SecureString("abcdefghijklmn").equals("##############")
    new SecureString("abcdefghijklmX").equals("abcdefghijklmn")
    new SecureString("X".repeat(5000)).equals("ababababababab")

And similarly for `startsWith` and `regionMatches`
