### PR TITLE
Fix failing LuceneFilesExtensionsTests testIsLuceneExtension case

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -558,9 +558,6 @@ tests:
 - class: org.elasticsearch.action.search.BatchedQueryPhaseIT
   method: testNumReducePhases
   issue: https://github.com/elastic/elasticsearch/issues/134943
-- class: org.elasticsearch.index.store.LuceneFilesExtensionsTests
-  method: testIsLuceneExtension
-  issue: https://github.com/elastic/elasticsearch/issues/134970
 - class: org.elasticsearch.reservedstate.service.RepositoriesFileSettingsIT
   method: testSettingsApplied
   issue: https://github.com/elastic/elasticsearch/issues/126748

--- a/qa/evil-tests/src/test/java/org/elasticsearch/index/store/LuceneFilesExtensionsTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/index/store/LuceneFilesExtensionsTests.java
@@ -51,7 +51,7 @@ public class LuceneFilesExtensionsTests extends ESTestCase {
         assertFalse(LuceneFilesExtensions.isLuceneExtension("bcde"));
         String randomStringWithLuceneExtension = randomAlphanumericOfLength(10)
             + "."
-            + LuceneFilesExtensions.values()[randomInt(LuceneFilesExtensions.values().length) - 1].getExtension();
+            + LuceneFilesExtensions.values()[randomInt(LuceneFilesExtensions.values().length - 1)].getExtension();
         String extension = IndexFileNames.getExtension(randomStringWithLuceneExtension);
         assertTrue(extension + " should be considered a Lucene extension", LuceneFilesExtensions.isLuceneExtension(extension));
         String upperCaseExtension = extension.toUpperCase(Locale.ROOT);


### PR DESCRIPTION
This fixes a small randomization issue leading to occasional AOOB in this test.

Closes #134970
