### PR TITLE
Unmute `mapping/30_multi_field_keyword/Keyword with escaped characters as multi-field`

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -446,9 +446,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/134407
-- class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
-  method: test {yaml=mapping/30_multi_field_keyword/Keyword with escaped characters as multi-field}
-  issue: https://github.com/elastic/elasticsearch/issues/134928
 - class: org.elasticsearch.aggregations.bucket.AggregationReductionCircuitBreakingIT
   method: testCBTrippingOnReduction
   issue: https://github.com/elastic/elasticsearch/issues/134902


### PR DESCRIPTION
The root cause of this failure is that the `8.19` backport was merged before the `9.1`.

Fixes: #134928