### PR TITLE
[9.1] Add streams YAML tests to rest-resources-zip (#134869)

### DIFF
--- a/modules/streams/build.gradle
+++ b/modules/streams/build.gradle
@@ -25,7 +25,7 @@ restResources {
 }
 
 configurations {
-  basicRestSpecs {
+  restTests {
     attributes {
       attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.DIRECTORY_TYPE)
     }
@@ -33,7 +33,7 @@ configurations {
 }
 
 artifacts {
-  basicRestSpecs(new File(projectDir, "src/yamlRestTest/resources/rest-api-spec/test"))
+  restTests(new File(projectDir, "src/yamlRestTest/resources/rest-api-spec/test"))
 }
 
 dependencies {

--- a/x-pack/qa/multi-project/core-rest-tests-with-multiple-projects/build.gradle
+++ b/x-pack/qa/multi-project/core-rest-tests-with-multiple-projects/build.gradle
@@ -31,7 +31,7 @@ dependencies {
   restTestConfig project(path: ':modules:data-streams', configuration: "restTests")
   restTestConfig project(path: ':modules:ingest-common', configuration: "basicRestSpecs")
   restTestConfig project(path: ':modules:reindex', configuration: "basicRestSpecs")
-  restTestConfig project(path: ':modules:streams', configuration: "basicRestSpecs")
+  restTestConfig project(path: ':modules:streams', configuration: "restTests")
 }
 
 // let the yamlRestTests see the classpath of test

--- a/x-pack/rest-resources-zip/build.gradle
+++ b/x-pack/rest-resources-zip/build.gradle
@@ -22,6 +22,7 @@ dependencies {
   freeTests project(path: ':modules:analysis-common', configuration: 'restTests')
   freeTests project(path: ':modules:data-streams', configuration: 'restTests')
   freeTests project(path: ':modules:ingest-geoip', configuration: 'restTests')
+  freeTests project(path: ':modules:streams', configuration: 'restTests')
   compatApis project(path: ':rest-api-spec', configuration: 'restCompatSpecs')
   compatApis project(path: ':x-pack:plugin', configuration: 'restCompatSpecs')
   freeCompatTests project(path: ':rest-api-spec', configuration: 'restCompatTests')


### PR DESCRIPTION
Backports the following commits to 9.1:
 - Add streams YAML tests to rest-resources-zip (#134869)