### PR TITLE
[8.19] Update bundled JDK to 25 (#134910)

### DIFF
--- a/build-tools-internal/src/main/resources/fips_java.security
+++ b/build-tools-internal/src/main/resources/fips_java.security
@@ -49,3 +49,6 @@ jdk.xml.dsig.secureValidationPolicy=\
     noRetrievalMethodLoops
 jceks.key.serialFilter = java.base/java.lang.Enum;java.base/java.security.KeyRep;\
   java.base/java.security.KeyRep$Type;java.base/javax.crypto.spec.SecretKeySpec;!*
+
+# Needed since JDK25 to match the default config in the out-of-the-box java.security
+jdk.includeInExceptions=hostInfoExclSocket

--- a/build-tools-internal/src/main/resources/fips_java_oracle.security
+++ b/build-tools-internal/src/main/resources/fips_java_oracle.security
@@ -50,3 +50,6 @@ jdk.xml.dsig.secureValidationPolicy=\
     noRetrievalMethodLoops
 jceks.key.serialFilter = java.base/java.lang.Enum;java.base/java.security.KeyRep;\
   java.base/java.security.KeyRep$Type;java.base/javax.crypto.spec.SecretKeySpec;!*
+
+# Needed since JDK25 to match the default config in the out-of-the-box java.security
+jdk.includeInExceptions=hostInfoExclSocket

--- a/build-tools-internal/version.properties
+++ b/build-tools-internal/version.properties
@@ -2,7 +2,7 @@ elasticsearch     = 8.19.5
 lucene            = 9.12.2
 
 bundled_jdk_vendor = openjdk
-bundled_jdk = 24.0.2+12@fdc5d0102fe0414db21410ad5834341f
+bundled_jdk = 25+36@bd75d5f9689641da8e1daabeccb5528b
 # optional dependencies
 spatial4j         = 0.7
 jts               = 1.15.0

--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientMultipleHostsIntegTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientMultipleHostsIntegTests.java
@@ -49,6 +49,7 @@ import static org.elasticsearch.client.RestClientTestUtil.getAllStatusCodes;
 import static org.elasticsearch.client.RestClientTestUtil.randomErrorNoRetryStatusCode;
 import static org.elasticsearch.client.RestClientTestUtil.randomOkStatusCode;
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -314,7 +315,7 @@ public class RestClientMultipleHostsIntegTests extends RestClientTestCase {
                     } catch (ConnectException e) {
                         // Windows isn't consistent here. Sometimes the message is even null!
                         if (false == System.getProperty("os.name").startsWith("Windows")) {
-                            assertEquals("Connection refused", e.getMessage());
+                            assertThat(e.getMessage(), startsWith("Connection refused"));
                         }
                     }
                 } else {

--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientTests.java
@@ -44,6 +44,7 @@ import java.util.function.Supplier;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
@@ -105,7 +106,7 @@ public class RestClientTests extends RestClientTestCase {
                 public void onFailure(Exception exception) {
                     try {
                         assertThat(exception, instanceOf(IllegalArgumentException.class));
-                        assertEquals("Expected scheme name at index 0: ::http:///", exception.getMessage());
+                        assertThat(exception.getMessage(), startsWith(("Expected scheme name")));
                     } finally {
                         latch.countDown();
                     }

--- a/test/test-clusters/src/main/resources/fips/fips_java.security
+++ b/test/test-clusters/src/main/resources/fips/fips_java.security
@@ -49,3 +49,6 @@ jdk.xml.dsig.secureValidationPolicy=\
     noRetrievalMethodLoops
 jceks.key.serialFilter = java.base/java.lang.Enum;java.base/java.security.KeyRep;\
   java.base/java.security.KeyRep$Type;java.base/javax.crypto.spec.SecretKeySpec;!*
+
+# Needed since JDK25 to match the default config in the out-of-the-box java.security
+jdk.includeInExceptions=hostInfoExclSocket

--- a/test/test-clusters/src/main/resources/fips/fips_java_oracle.security
+++ b/test/test-clusters/src/main/resources/fips/fips_java_oracle.security
@@ -50,3 +50,7 @@ jdk.xml.dsig.secureValidationPolicy=\
     noRetrievalMethodLoops
 jceks.key.serialFilter = java.base/java.lang.Enum;java.base/java.security.KeyRep;\
   java.base/java.security.KeyRep$Type;java.base/javax.crypto.spec.SecretKeySpec;!*
+
+# Needed since JDK25 to match the default config in the out-of-the-box java.security
+jdk.includeInExceptions=hostInfoExclSocket
+

--- a/x-pack/plugin/esql/build.gradle
+++ b/x-pack/plugin/esql/build.gradle
@@ -86,6 +86,11 @@ interface Injected {
 }
 
 tasks.named("test").configure {
+  // prevent empty stacktraces on JDK 25 for intrinsic Math.*Exact invocations
+  // https://bugs.openjdk.org/browse/JDK-8367990
+  // https://github.com/elastic/elasticsearch/issues/135009
+  jvmArgs '-XX:-OmitStackTraceInFastThrow'
+
   if (buildParams.ci == false) {
     systemProperty 'generateDocs', true
     def injected = project.objects.newInstance(Injected)

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/custom/CustomRequestManagerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/custom/CustomRequestManagerTests.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityPool;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.Mockito.mock;
 
 public class CustomRequestManagerTests extends ESTestCase {
@@ -81,6 +82,6 @@ public class CustomRequestManagerTests extends ESTestCase {
         var exception = expectThrows(ElasticsearchStatusException.class, () -> listener.actionGet(TimeValue.timeValueSeconds(30)));
 
         assertThat(exception.getMessage(), is("Failed to construct the custom service request"));
-        assertThat(exception.getCause().getMessage(), is("Failed to build URI, error: Illegal character in path at index 0: ^"));
+        assertThat(exception.getCause().getMessage(), startsWith("Failed to build URI, error: Illegal character in path"));
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/custom/request/CustomRequestTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/custom/request/CustomRequestTests.java
@@ -40,6 +40,7 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
 
 public class CustomRequestTests extends ESTestCase {
 
@@ -390,7 +391,7 @@ public class CustomRequestTests extends ESTestCase {
             IllegalStateException.class,
             () -> new CustomRequest(RerankParameters.of(new QueryAndDocsInputs("query string", List.of("abc", "123"))), model)
         );
-        assertThat(exception.getMessage(), is("Failed to build URI, error: Illegal character in path at index 0: ^"));
+        assertThat(exception.getMessage(), startsWith("Failed to build URI, error: Illegal character in path"));
     }
 
     private static String convertToString(InputStream inputStream) throws IOException {

--- a/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/JdbcConfigurationTests.java
+++ b/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/JdbcConfigurationTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.sql.client.SslConfig;
 import org.elasticsearch.xpack.sql.client.SuppressForbidden;
+import org.hamcrest.Matchers;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -43,12 +44,7 @@ public class JdbcConfigurationTests extends ESTestCase {
 
     public void testInvalidUrl() {
         JdbcSQLException e = expectThrows(JdbcSQLException.class, () -> ci("jdbc:es://localhost9200/?ssl=#5#"));
-        assertEquals(
-            "Invalid URL: Invalid connection configuration: Illegal character in fragment at index 28: "
-                + "http://localhost9200/?ssl=#5#; format should be "
-                + "[jdbc:[es|elasticsearch]://[[http|https]://]?[host[:port]]?/[prefix]?[\\?[option=value]&]*]",
-            e.getMessage()
-        );
+        assertThat(e.getMessage(), Matchers.startsWith("Invalid URL: Invalid connection configuration: Illegal character in fragment"));
     }
 
     public void testJustThePrefix() throws Exception {

--- a/x-pack/plugin/sql/sql-client/src/test/java/org/elasticsearch/xpack/sql/client/UriUtilsTests.java
+++ b/x-pack/plugin/sql/sql-client/src/test/java/org/elasticsearch/xpack/sql/client/UriUtilsTests.java
@@ -16,6 +16,7 @@ import static org.elasticsearch.xpack.sql.client.UriUtils.CredentialsRedaction.r
 import static org.elasticsearch.xpack.sql.client.UriUtils.appendSegmentToPath;
 import static org.elasticsearch.xpack.sql.client.UriUtils.parseURI;
 import static org.elasticsearch.xpack.sql.client.UriUtils.removeQuery;
+import static org.hamcrest.Matchers.matchesPattern;
 
 public class UriUtilsTests extends ESTestCase {
 
@@ -89,9 +90,10 @@ public class UriUtilsTests extends ESTestCase {
     }
 
     public void testMalformedWhiteSpace() throws Exception {
-        assertEquals(
-            "Invalid connection configuration: Illegal character in authority at index 7: http:// ",
-            expectThrows(IllegalArgumentException.class, () -> parseURI(" ", DEFAULT_URI)).getMessage()
+        assertThat(
+            expectThrows(IllegalArgumentException.class, () -> parseURI(" ", DEFAULT_URI)).getMessage(),
+            // Use a lenient regex here since later JDKs trim exception message whitespace
+            matchesPattern("^Invalid connection configuration: Illegal character in authority at index 7: http:// ?")
         );
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Update bundled JDK to 25 (#134910)](https://github.com/elastic/elasticsearch/pull/134910)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)