### PR TITLE
[8.18] Use consistent version of asm for painless and tools

### DIFF
--- a/libs/entitlement/tools/securitymanager-scanner/build.gradle
+++ b/libs/entitlement/tools/securitymanager-scanner/build.gradle
@@ -46,8 +46,8 @@ repositories {
 
 dependencies {
   compileOnly(project(':libs:core'))
-  implementation 'org.ow2.asm:asm:9.7.1'
-  implementation 'org.ow2.asm:asm-util:9.7.1'
+  implementation 'org.ow2.asm:asm:9.8'
+  implementation 'org.ow2.asm:asm-util:9.8'
   implementation(project(':libs:entitlement:tools:common'))
 }
 

--- a/modules/lang-expression/build.gradle
+++ b/modules/lang-expression/build.gradle
@@ -19,10 +19,10 @@ dependencies {
   api "org.apache.lucene:lucene-expressions:${versions.lucene}"
   runtimeOnly "org.apache.lucene:lucene-codecs:${versions.lucene}"
   runtimeOnly "org.antlr:antlr4-runtime:${versions.antlr4}"
-  runtimeOnly 'org.ow2.asm:asm:7.2'
-  runtimeOnly 'org.ow2.asm:asm-commons:7.2'
-  runtimeOnly 'org.ow2.asm:asm-tree:7.2'
-  runtimeOnly 'org.ow2.asm:asm-analysis:7.2'
+  runtimeOnly 'org.ow2.asm:asm:9.8'
+  runtimeOnly 'org.ow2.asm:asm-commons:9.8'
+  runtimeOnly 'org.ow2.asm:asm-tree:9.8'
+  runtimeOnly 'org.ow2.asm:asm-analysis:9.8'
 }
 restResources {
   restApi {

--- a/modules/lang-painless/build.gradle
+++ b/modules/lang-painless/build.gradle
@@ -37,11 +37,11 @@ configurations {
 
 dependencies {
     api "org.antlr:antlr4-runtime:${versions.antlr4}"
-    api 'org.ow2.asm:asm-util:7.2'
-    api 'org.ow2.asm:asm-tree:7.2'
-    api 'org.ow2.asm:asm-commons:7.2'
-    api 'org.ow2.asm:asm-analysis:7.2'
-    api 'org.ow2.asm:asm:7.2'
+    api 'org.ow2.asm:asm-util:9.8'
+    api 'org.ow2.asm:asm-tree:9.8'
+    api 'org.ow2.asm:asm-commons:9.8'
+    api 'org.ow2.asm:asm-analysis:9.8'
+    api 'org.ow2.asm:asm:9.8'
     spi project('spi')
     clusterModules project(':modules:mapper-extras')
 }


### PR DESCRIPTION
Manual backport of https://github.com/elastic/elasticsearch/pull/135086

Relates to ES-12644, https://github.com/elastic/elasticsearch/pull/133938