### PR TITLE
[8.18] Delete unsupported tests 

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLErrorMessageFileTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLErrorMessageFileTests.java
@@ -114,26 +114,6 @@ public class SSLErrorMessageFileTests extends ESTestCase {
         checkUnreadableTrustManagerResource("ca1.crt", "PEM certificate_authorities", "certificate_authorities");
     }
 
-    public void testMessageForKeyStoreOutsideConfigDir() throws Exception {
-        checkBlockedKeyManagerResource("[jks] keystore", "keystore.path", null);
-    }
-
-    public void testMessageForPemCertificateOutsideConfigDir() throws Exception {
-        checkBlockedKeyManagerResource("PEM certificate", "certificate", withKey("cert1a.key"));
-    }
-
-    public void testMessageForPemKeyOutsideConfigDir() throws Exception {
-        checkBlockedKeyManagerResource("PEM private key", "key", withCertificate("cert1a.crt"));
-    }
-
-    public void testMessageForTrustStoreOutsideConfigDir() throws Exception {
-        checkBlockedTrustManagerResource("[jks] keystore (as a truststore)", "truststore.path");
-    }
-
-    public void testMessageForCertificateAuthoritiesOutsideConfigDir() throws Exception {
-        checkBlockedTrustManagerResource("PEM certificate_authorities", "certificate_authorities");
-    }
-
     public void testMessageForTransportSslEnabledWithoutKeys() throws Exception {
         final String prefix = "xpack.security.transport.ssl";
         final Settings.Builder settings = Settings.builder();


### PR DESCRIPTION
# Backport

This will backport the following commits from `9.0` to `8.18`:
 - [These tests are being deleted off the 9.0 branch because they require entitlements framework to be backported to work. As discussed here (https://github.com/elastic/elasticsearch/issues/127191#issuecomment-3087229116) we will not be doing that backport. The tests continue to exist and work with the new entitlements framework in main. (#131936)](https://github.com/elastic/elasticsearch/pull/131936)

<!--- Backport version: 9.5.1 -->

Resolves: https://github.com/elastic/elasticsearch/issues/134046, https://github.com/elastic/elasticsearch/issues/134045, https://github.com/elastic/elasticsearch/issues/134044, https://github.com/elastic/elasticsearch/issues/132182, https://github.com/elastic/elasticsearch/issues/132181, https://github.com/elastic/elasticsearch/issues/132114

>We are not backporting unit tests support for entitlement to 8.18/9.0, so these test there will never work.

See [this comment](https://github.com/elastic/elasticsearch/pull/131342#issuecomment-3088965627) for details.