### PR TITLE
Disable utf-8 parsing optimization

### DIFF
--- a/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/json/JsonXContentParser.java
+++ b/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/json/JsonXContentParser.java
@@ -16,7 +16,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.exc.InputCoercionException;
 import com.fasterxml.jackson.core.exc.StreamConstraintsException;
-import com.fasterxml.jackson.core.filter.FilteringParserDelegate;
 import com.fasterxml.jackson.core.io.JsonEOFException;
 
 import org.elasticsearch.core.IOUtils;
@@ -27,7 +26,6 @@ import org.elasticsearch.xcontent.XContentParseException;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentString;
 import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xcontent.provider.OptimizedTextCapable;
 import org.elasticsearch.xcontent.provider.XContentParserConfigurationImpl;
 import org.elasticsearch.xcontent.support.AbstractXContentParser;
 

--- a/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/json/JsonXContentParser.java
+++ b/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/json/JsonXContentParser.java
@@ -145,19 +145,7 @@ public class JsonXContentParser extends AbstractXContentParser {
 
     @Override
     public XContentString optimizedText() throws IOException {
-        if (currentToken().isValue() == false) {
-            throwOnNoText();
-        }
-        var parser = this.parser;
-        if (parser instanceof FilteringParserDelegate delegate) {
-            parser = delegate.delegate();
-        }
-        if (parser instanceof OptimizedTextCapable optimizedTextCapableParser) {
-            var bytesRef = optimizedTextCapableParser.getValueAsText();
-            if (bytesRef != null) {
-                return bytesRef;
-            }
-        }
+        // TODO: enable utf-8 parsing optimization once verified it is completely safe
         return new Text(text());
     }
 

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -618,48 +618,12 @@ tests:
 - class: org.elasticsearch.search.vectors.CachingEnableFilterQueryTests
   method: testBooleanQuery
   issue: https://github.com/elastic/elasticsearch/issues/135124
-- class: org.elasticsearch.xpack.logsdb.qa.LogsDbVersusLogsDbReindexedIntoStandardModeChallengeRestIT
-  method: testEsqlTermsAggregationByMethod
-  issue: https://github.com/elastic/elasticsearch/issues/135125
-- class: org.elasticsearch.xpack.logsdb.qa.BulkStoredSourceChallengeRestIT
-  method: testEsqlTermsAggregationByMethod
-  issue: https://github.com/elastic/elasticsearch/issues/135126
-- class: org.elasticsearch.xpack.logsdb.qa.StandardVersusStandardReindexedIntoLogsDbChallengeRestIT
-  method: testEsqlTermsAggregationByMethod
-  issue: https://github.com/elastic/elasticsearch/issues/135127
-- class: org.elasticsearch.xpack.logsdb.qa.BulkChallengeRestIT
-  method: testEsqlTermsAggregationByMethod
-  issue: https://github.com/elastic/elasticsearch/issues/135128
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=transform/transforms_start_stop/Test stop transform with force and wait_for_checkpoint true}
   issue: https://github.com/elastic/elasticsearch/issues/135135
 - class: org.elasticsearch.compute.aggregation.SampleIntAggregatorFunctionTests
   method: testSimpleWithCranky
   issue: https://github.com/elastic/elasticsearch/issues/135137
-- class: org.elasticsearch.xpack.logsdb.qa.BulkStoredSourceChallengeRestIT
-  method: testTermsAggregation
-  issue: https://github.com/elastic/elasticsearch/issues/135140
-- class: org.elasticsearch.xpack.logsdb.qa.LogsDbVersusLogsDbReindexedIntoStandardModeChallengeRestIT
-  method: testTermsAggregation
-  issue: https://github.com/elastic/elasticsearch/issues/135141
-- class: org.elasticsearch.xpack.logsdb.qa.BulkChallengeRestIT
-  method: testTermsAggregation
-  issue: https://github.com/elastic/elasticsearch/issues/135142
-- class: org.elasticsearch.xpack.logsdb.qa.StandardVersusStandardReindexedIntoLogsDbChallengeRestIT
-  method: testTermsAggregation
-  issue: https://github.com/elastic/elasticsearch/issues/135143
-- class: org.elasticsearch.xpack.logsdb.qa.BulkStoredSourceChallengeRestIT
-  method: testMatchAllQuery
-  issue: https://github.com/elastic/elasticsearch/issues/135144
-- class: org.elasticsearch.xpack.logsdb.qa.BulkChallengeRestIT
-  method: testMatchAllQuery
-  issue: https://github.com/elastic/elasticsearch/issues/135145
-- class: org.elasticsearch.xpack.logsdb.qa.LogsDbVersusLogsDbReindexedIntoStandardModeChallengeRestIT
-  method: testMatchAllQuery
-  issue: https://github.com/elastic/elasticsearch/issues/135146
-- class: org.elasticsearch.xpack.logsdb.qa.StandardVersusStandardReindexedIntoLogsDbChallengeRestIT
-  method: testMatchAllQuery
-  issue: https://github.com/elastic/elasticsearch/issues/135147
 - class: org.elasticsearch.lucene.RollingUpgradeSearchableSnapshotIndexCompatibilityIT
   method: testSearchableSnapshotUpgrade {p0=[9.2.0, 9.2.0, 9.2.0]}
   issue: https://github.com/elastic/elasticsearch/issues/135150
@@ -669,18 +633,6 @@ tests:
 - class: org.elasticsearch.discovery.ClusterDisruptionIT
   method: testAckedIndexing
   issue: https://github.com/elastic/elasticsearch/issues/117024
-- class: org.elasticsearch.xpack.logsdb.qa.BulkChallengeRestIT
-  method: testHistogramAggregation
-  issue: https://github.com/elastic/elasticsearch/issues/135153
-- class: org.elasticsearch.xpack.logsdb.qa.LogsDbVersusLogsDbReindexedIntoStandardModeChallengeRestIT
-  method: testHistogramAggregation
-  issue: https://github.com/elastic/elasticsearch/issues/135154
-- class: org.elasticsearch.xpack.logsdb.qa.StandardVersusStandardReindexedIntoLogsDbChallengeRestIT
-  method: testHistogramAggregation
-  issue: https://github.com/elastic/elasticsearch/issues/135155
-- class: org.elasticsearch.xpack.logsdb.qa.BulkStoredSourceChallengeRestIT
-  method: testHistogramAggregation
-  issue: https://github.com/elastic/elasticsearch/issues/135156
 - class: org.elasticsearch.compute.aggregation.SampleBytesRefAggregatorFunctionTests
   method: testSimpleWithCranky
   issue: https://github.com/elastic/elasticsearch/issues/135157

--- a/server/src/test/java/org/elasticsearch/common/xcontent/json/JsonXContentTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/json/JsonXContentTests.java
@@ -59,7 +59,8 @@ public class JsonXContentTests extends BaseXContentTestCase {
             assertSame(XContentParser.Token.FIELD_NAME, parser.nextToken());
             assertTrue(parser.nextToken().isValue());
             Text text = (Text) parser.optimizedText();
-            assertTrue(text.hasBytes());
+            // TODO: uncomment after utf8 optimized parsing has been enabled again:
+//            assertTrue(text.hasBytes());
             assertThat(text.string(), equalTo("foo"));
         }
     }

--- a/server/src/test/java/org/elasticsearch/common/xcontent/json/JsonXContentTests.java
+++ b/server/src/test/java/org/elasticsearch/common/xcontent/json/JsonXContentTests.java
@@ -60,7 +60,7 @@ public class JsonXContentTests extends BaseXContentTestCase {
             assertTrue(parser.nextToken().isValue());
             Text text = (Text) parser.optimizedText();
             // TODO: uncomment after utf8 optimized parsing has been enabled again:
-//            assertTrue(text.hasBytes());
+            // assertTrue(text.hasBytes());
             assertThat(text.string(), equalTo("foo"));
         }
     }


### PR DESCRIPTION
A yet to be understood issue has emerged with the utf8 parsing optimization and the meantime we should disable the optimization. It looks like the wrong values are returned for fields. In the case of the test failures here, that surfaced as unable to the parse fields with IPs and causing index request to fail. However the impact could be larger.

Closes #135156
Closes #135155
Closes #135154
Closes #135153
Closes #135147
Closes #135146
Closes #135145
Closes #135144
Closes #135143
Closes #135142
Closes #135141
Closes #135140
Closes #135134
Closes #135127
Closes #135126
Closes #135125