### PR TITLE
[9.1] rest-api-spec: fix master_timeout typo (#135167)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/streams.status.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/streams.status.json
@@ -23,7 +23,7 @@
       ]
     },
     "params": {
-      "mater_timeout": {
+      "master_timeout": {
         "type": "time",
         "description": "Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error."
       }


### PR DESCRIPTION
Backports the following commits to 9.1:
 - rest-api-spec: fix master_timeout typo (#135167)