### PR TITLE
Provide performant and reliable extraction of the executorName for EsThreads

### DIFF
--- a/qa/evil-tests/src/test/java/org/elasticsearch/threadpool/EvilThreadPoolTests.java
+++ b/qa/evil-tests/src/test/java/org/elasticsearch/threadpool/EvilThreadPoolTests.java
@@ -65,7 +65,7 @@ public class EvilThreadPoolTests extends ESTestCase {
             "test",
             1,
             1,
-            EsExecutors.daemonThreadFactory("test"),
+            EsExecutors.daemonThreadFactory("nodename", "test", false),
             threadPool.getThreadContext(),
             randomFrom(TaskTrackingConfig.DEFAULT, TaskTrackingConfig.DO_NOT_TRACK)
         );
@@ -85,7 +85,7 @@ public class EvilThreadPoolTests extends ESTestCase {
             10,
             TimeUnit.SECONDS,
             randomBoolean(),
-            EsExecutors.daemonThreadFactory("test"),
+            EsExecutors.daemonThreadFactory("nodename", "test", false),
             threadPool.getThreadContext()
         );
         try {
@@ -99,7 +99,7 @@ public class EvilThreadPoolTests extends ESTestCase {
     public void testExecutionErrorOnSinglePrioritizingThreadPoolExecutor() throws InterruptedException {
         final PrioritizedEsThreadPoolExecutor prioritizedExecutor = EsExecutors.newSinglePrioritizing(
             "test",
-            EsExecutors.daemonThreadFactory("test"),
+            EsExecutors.daemonThreadFactory("nodename", "test", false),
             threadPool.getThreadContext(),
             threadPool.scheduler()
         );
@@ -174,7 +174,7 @@ public class EvilThreadPoolTests extends ESTestCase {
             "test",
             1,
             1,
-            EsExecutors.daemonThreadFactory("test"),
+            EsExecutors.daemonThreadFactory("nodename", "test", false),
             threadPool.getThreadContext(),
             randomFrom(TaskTrackingConfig.DEFAULT, TaskTrackingConfig.DO_NOT_TRACK)
         );
@@ -194,7 +194,7 @@ public class EvilThreadPoolTests extends ESTestCase {
             10,
             TimeUnit.SECONDS,
             randomBoolean(),
-            EsExecutors.daemonThreadFactory("test"),
+            EsExecutors.daemonThreadFactory("nodename", "test", false),
             threadPool.getThreadContext()
         );
         try {
@@ -208,7 +208,7 @@ public class EvilThreadPoolTests extends ESTestCase {
     public void testExecutionExceptionOnSinglePrioritizingThreadPoolExecutor() throws InterruptedException {
         final PrioritizedEsThreadPoolExecutor prioritizedExecutor = EsExecutors.newSinglePrioritizing(
             "test",
-            EsExecutors.daemonThreadFactory("test"),
+            EsExecutors.daemonThreadFactory("nodename", "test", false),
             threadPool.getThreadContext(),
             threadPool.scheduler()
         );

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
@@ -10,10 +10,12 @@
 package org.elasticsearch.common.util.concurrent;
 
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.Processors;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.node.Node;
 
@@ -322,91 +324,81 @@ public class EsExecutors {
      */
     public static final ExecutorService DIRECT_EXECUTOR_SERVICE = new DirectExecutorService();
 
-    public static String threadName(Settings settings, String namePrefix) {
-        if (Node.NODE_NAME_SETTING.exists(settings)) {
-            return threadName(Node.NODE_NAME_SETTING.get(settings), namePrefix);
-        } else {
-            // TODO this should only be allowed in tests
-            return threadName("", namePrefix);
-        }
+    public static String threadName(Settings settings, String executorName) {
+        var nodeName = Node.NODE_NAME_SETTING.get(settings);
+        assert Strings.hasLength(nodeName) : "node.name must be set";
+        return "elasticsearch[" + nodeName + "][" + executorName + "]";
     }
 
-    public static String threadName(final String nodeName, final String namePrefix) {
-        // TODO missing node names should only be allowed in tests
-        return nodeName.isEmpty() == false ? "elasticsearch[" + nodeName + "][" + namePrefix + "]" : "elasticsearch[" + namePrefix + "]";
-    }
-
-    public static String executorName(String threadName) {
-        // subtract 2 to avoid the `]` of the thread number part.
-        int executorNameEnd = threadName.lastIndexOf(']', threadName.length() - 2);
-        int executorNameStart = threadName.lastIndexOf('[', executorNameEnd);
-        if (executorNameStart == -1
-            || executorNameEnd - executorNameStart <= 1
-            || threadName.startsWith("TEST-")
-            || threadName.startsWith("LuceneTestCase")) {
-            return null;
-        }
-        return threadName.substring(executorNameStart + 1, executorNameEnd);
+    private static String threadName(final String nodeName, final String executorName, int threadNumber) {
+        var threadNum = Integer.toString(threadNumber);
+        return Strings.hasLength(nodeName)
+            ? "elasticsearch[" + nodeName + "][" + executorName + "][T#" + threadNum + "]"
+            : "elasticsearch[" + executorName + "][T#" + threadNum + "]";
     }
 
     public static String executorName(Thread thread) {
-        return executorName(thread.getName());
+        return EsThread.executorName(thread);
     }
 
-    public static ThreadFactory daemonThreadFactory(Settings settings, String namePrefix) {
-        return createDaemonThreadFactory(threadName(settings, namePrefix), false);
+    public static ThreadFactory daemonThreadFactory(Settings settings, String executorName) {
+        // TODO required nodeName to be non empty if not in test
+        var nodeName = Node.NODE_NAME_SETTING.get(settings);
+        return new EsThreadFactory(nodeName, executorName, false);
     }
 
-    public static ThreadFactory daemonThreadFactory(String nodeName, String namePrefix) {
-        return daemonThreadFactory(nodeName, namePrefix, false);
+    public static ThreadFactory daemonThreadFactory(String nodeName, String executorName) {
+        return daemonThreadFactory(nodeName, executorName, false);
     }
 
-    public static ThreadFactory daemonThreadFactory(String nodeName, String namePrefix, boolean isSystemThread) {
+    public static ThreadFactory daemonThreadFactory(String nodeName, String executorName, boolean isSystemThread) {
         assert nodeName != null && false == nodeName.isEmpty();
-        return createDaemonThreadFactory(threadName(nodeName, namePrefix), isSystemThread);
+        return new EsThreadFactory(nodeName, executorName, isSystemThread);
     }
 
-    public static ThreadFactory daemonThreadFactory(String name) {
-        assert name != null && name.isEmpty() == false;
-        return createDaemonThreadFactory(name, false);
-    }
-
-    private static ThreadFactory createDaemonThreadFactory(String namePrefix, boolean isSystemThread) {
-        return new EsThreadFactory(namePrefix, isSystemThread);
-    }
-
-    static class EsThreadFactory implements ThreadFactory {
+    private static class EsThreadFactory implements ThreadFactory {
 
         final ThreadGroup group;
         final AtomicInteger threadNumber = new AtomicInteger(1);
-        final String namePrefix;
+        final String nodeName;
+        final String executorName;
         final boolean isSystem;
 
-        EsThreadFactory(String namePrefix, boolean isSystem) {
-            this.namePrefix = namePrefix;
-            SecurityManager s = System.getSecurityManager();
-            group = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
+        EsThreadFactory(String nodeName, String executorName, boolean isSystem) {
+            this.nodeName = nodeName;
+            this.executorName = executorName;
+            this.group = Thread.currentThread().getThreadGroup();
             this.isSystem = isSystem;
         }
 
         @Override
         public Thread newThread(Runnable r) {
-            Thread t = new EsThread(group, r, namePrefix + "[T#" + threadNumber.getAndIncrement() + "]", 0, isSystem);
+            String threadName = threadName(nodeName, executorName, threadNumber.getAndIncrement());
+            Thread t = new EsThread(group, r, threadName, 0, executorName, isSystem);
             t.setDaemon(true);
             return t;
         }
     }
 
     public static class EsThread extends Thread {
+        private final String executorName;
         private final boolean isSystem;
 
-        EsThread(ThreadGroup group, Runnable target, String name, long stackSize, boolean isSystem) {
+        EsThread(ThreadGroup group, Runnable target, String name, long stackSize, String executorName, boolean isSystem) {
             super(group, target, name, stackSize);
+            this.executorName = executorName;
             this.isSystem = isSystem;
         }
 
         public boolean isSystem() {
             return isSystem;
+        }
+
+        private static @Nullable String executorName(Thread thread) {
+            if (thread instanceof EsThread esThread) {
+                return esThread.executorName;
+            }
+            return null;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -1107,11 +1107,11 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler, 
     }
 
     public static boolean assertCurrentThreadPool(String... permittedThreadPoolNames) {
-        final var threadName = Thread.currentThread().getName();
-        final var executorName = EsExecutors.executorName(threadName);
+        Thread thread = Thread.currentThread();
+        final var threadName = thread.getName();
         assert threadName.startsWith("TEST-")
             || threadName.startsWith("LuceneTestCase")
-            || Arrays.asList(permittedThreadPoolNames).contains(executorName)
+            || Arrays.asList(permittedThreadPoolNames).contains(EsExecutors.executorName(thread))
             : threadName + " not in " + Arrays.toString(permittedThreadPoolNames) + " nor a test thread";
         return true;
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TaskManagerTestCase.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TaskManagerTestCase.java
@@ -34,6 +34,7 @@ import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.elasticsearch.node.Node;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskCancellationService;
 import org.elasticsearch.tasks.TaskManager;
@@ -173,6 +174,9 @@ public abstract class TaskManagerTestCase extends ESTestCase {
 
     public static class TestNode implements Releasable {
         public TestNode(String name, ThreadPool threadPool, Settings settings) {
+            if (Node.NODE_NAME_SETTING.exists(settings) == false) {
+                settings = Settings.builder().put(settings).put(Node.NODE_NAME_SETTING.getKey(), name).build();
+            }
             final Function<BoundTransportAddress, DiscoveryNode> boundTransportAddressDiscoveryNodeFunction = address -> {
                 discoveryNode.set(DiscoveryNodeUtils.create(name, address.publishAddress(), emptyMap(), emptySet()));
                 return discoveryNode.get();

--- a/server/src/test/java/org/elasticsearch/action/search/QueryPhaseResultConsumerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/QueryPhaseResultConsumerTests.java
@@ -90,7 +90,7 @@ public class QueryPhaseResultConsumerTests extends ESTestCase {
             "test",
             1,
             10,
-            EsExecutors.daemonThreadFactory("test"),
+            EsExecutors.daemonThreadFactory("nodename", "test", false),
             threadPool.getThreadContext(),
             randomFrom(TaskTrackingConfig.DEFAULT, TaskTrackingConfig.DO_NOT_TRACK)
         );

--- a/server/src/test/java/org/elasticsearch/action/search/SearchPhaseControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchPhaseControllerTests.java
@@ -134,7 +134,7 @@ public class SearchPhaseControllerTests extends ESTestCase {
             "test",
             1,
             10,
-            EsExecutors.daemonThreadFactory("test"),
+            EsExecutors.daemonThreadFactory("nodename", "test", false),
             threadPool.getThreadContext(),
             randomFrom(TaskTrackingConfig.DEFAULT, TaskTrackingConfig.DO_NOT_TRACK)
         );

--- a/server/src/test/java/org/elasticsearch/action/support/RefCountingRunnableTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/RefCountingRunnableTests.java
@@ -105,7 +105,7 @@ public class RefCountingRunnableTests extends ESTestCase {
             10,
             TimeUnit.SECONDS,
             true,
-            EsExecutors.daemonThreadFactory("test"),
+            EsExecutors.daemonThreadFactory("nodename", "test", false),
             new ThreadContext(Settings.EMPTY)
         );
         final var asyncPermits = new Semaphore(between(0, 1000));

--- a/server/src/test/java/org/elasticsearch/action/support/SubscribableListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/SubscribableListenerTests.java
@@ -241,15 +241,15 @@ public class SubscribableListenerTests extends ESTestCase {
         }
 
         final var completion = new AtomicBoolean();
-        final var executorThreadPrefix = randomAlphaOfLength(10);
+        final var executorName = randomAlphaOfLength(10);
         final var executor = EsExecutors.newScaling(
-            executorThreadPrefix,
+            executorName,
             1,
             1,
             10,
             TimeUnit.SECONDS,
             true,
-            EsExecutors.daemonThreadFactory(executorThreadPrefix),
+            EsExecutors.daemonThreadFactory("node", executorName),
             threadContext
         );
 
@@ -265,7 +265,8 @@ public class SubscribableListenerTests extends ESTestCase {
                 threadContext.putHeader(headerName, headerValue);
                 listener.addListener(ActionListener.releaseAfter(assertingListener.map(result -> {
                     assertNotSame(testThread, Thread.currentThread());
-                    assertThat(Thread.currentThread().getName(), containsString(executorThreadPrefix));
+                    assertThat(Thread.currentThread().getName(), containsString(executorName));
+                    assertEquals(EsExecutors.executorName(Thread.currentThread()), executorName);
                     assertEquals(headerValue, threadContext.getHeader(headerName));
                     return result;
                 }), refs.acquire()), executor, threadContext);

--- a/server/src/test/java/org/elasticsearch/action/support/UnsafePlainActionFutureTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/UnsafePlainActionFutureTests.java
@@ -51,7 +51,7 @@ public class UnsafePlainActionFutureTests extends ESTestCase {
     }
 
     private static Thread getThread(String executorName) {
-        Thread t = new Thread("[" + executorName + "][]");
+        var t = EsExecutors.daemonThreadFactory("node", executorName).newThread(() -> {});
         assertThat(EsExecutors.executorName(t), equalTo(executorName));
         return t;
     }

--- a/server/src/test/java/org/elasticsearch/common/component/LifecycleTests.java
+++ b/server/src/test/java/org/elasticsearch/common/component/LifecycleTests.java
@@ -93,7 +93,7 @@ public class LifecycleTests extends ESTestCase {
                 10,
                 TimeUnit.SECONDS,
                 true,
-                EsExecutors.daemonThreadFactory("test"),
+                EsExecutors.daemonThreadFactory("nodename", "test", false),
                 new ThreadContext(Settings.EMPTY)
             );
         }

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/AbstractThrottledTaskRunnerTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/AbstractThrottledTaskRunnerTests.java
@@ -29,7 +29,7 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public class AbstractThrottledTaskRunnerTests extends ESTestCase {
 
-    private static final ThreadFactory threadFactory = EsExecutors.daemonThreadFactory("test");
+    private static final ThreadFactory threadFactory = EsExecutors.daemonThreadFactory("nodename", "test", false);
     private static final ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
 
     private ExecutorService executor;

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/EsExecutorsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/EsExecutorsTests.java
@@ -45,7 +45,6 @@ import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
-import static org.hamcrest.Matchers.nullValue;
 
 /**
  * Tests for EsExecutors and its components like EsAbortPolicy.
@@ -67,7 +66,7 @@ public class EsExecutorsTests extends ESTestCase {
             getName(),
             1,
             1,
-            EsExecutors.daemonThreadFactory("test"),
+            EsExecutors.daemonThreadFactory("nodename", "test", false),
             threadContext,
             randomFrom(DEFAULT, DO_NOT_TRACK)
         );
@@ -136,7 +135,7 @@ public class EsExecutorsTests extends ESTestCase {
             getName(),
             1,
             1,
-            EsExecutors.daemonThreadFactory("test"),
+            EsExecutors.daemonThreadFactory("nodename", "test", false),
             threadContext,
             randomFrom(DEFAULT, DO_NOT_TRACK)
         );
@@ -204,7 +203,7 @@ public class EsExecutorsTests extends ESTestCase {
             between(1, 100),
             randomTimeUnit(),
             randomBoolean(),
-            EsExecutors.daemonThreadFactory("test"),
+            EsExecutors.daemonThreadFactory("nodename", "test", false),
             threadContext
         );
         assertThat("Min property", pool.getCorePoolSize(), equalTo(min));
@@ -242,7 +241,7 @@ public class EsExecutorsTests extends ESTestCase {
             between(1, 100),
             TimeUnit.MILLISECONDS,
             randomBoolean(),
-            EsExecutors.daemonThreadFactory("test"),
+            EsExecutors.daemonThreadFactory("nodename", "test", false),
             threadContext
         );
         assertThat("Min property", pool.getCorePoolSize(), equalTo(min));
@@ -281,7 +280,7 @@ public class EsExecutorsTests extends ESTestCase {
             getName(),
             pool,
             queue,
-            EsExecutors.daemonThreadFactory("dummy"),
+            EsExecutors.daemonThreadFactory("nodename", "dummy", false),
             threadContext,
             randomFrom(DEFAULT, DO_NOT_TRACK)
         );
@@ -388,7 +387,7 @@ public class EsExecutorsTests extends ESTestCase {
             getName(),
             pool,
             queue,
-            EsExecutors.daemonThreadFactory("dummy"),
+            EsExecutors.daemonThreadFactory("nodename", "dummy", false),
             threadContext,
             randomFrom(DEFAULT, DO_NOT_TRACK)
         );
@@ -425,7 +424,7 @@ public class EsExecutorsTests extends ESTestCase {
             getName(),
             pool,
             queue,
-            EsExecutors.daemonThreadFactory("dummy"),
+            EsExecutors.daemonThreadFactory("nodename", "dummy", false),
             threadContext,
             randomFrom(DEFAULT, DO_NOT_TRACK)
         );
@@ -529,7 +528,7 @@ public class EsExecutorsTests extends ESTestCase {
             60,
             TimeUnit.SECONDS,
             randomBoolean(),
-            EsExecutors.daemonThreadFactory("test"),
+            EsExecutors.daemonThreadFactory("nodename", "test", false),
             new ThreadContext(Settings.EMPTY)
         );
         try {
@@ -564,7 +563,7 @@ public class EsExecutorsTests extends ESTestCase {
             60,
             TimeUnit.SECONDS,
             false,
-            EsExecutors.daemonThreadFactory(getName()),
+            EsExecutors.daemonThreadFactory("nodename", getName(), false),
             new ThreadContext(Settings.EMPTY)
         );
         ThreadPool.terminate(executor, 10, TimeUnit.SECONDS);
@@ -606,7 +605,7 @@ public class EsExecutorsTests extends ESTestCase {
                 60,
                 TimeUnit.SECONDS,
                 true,
-                EsExecutors.daemonThreadFactory(getName()),
+                EsExecutors.daemonThreadFactory("nodename", getName(), false),
                 new ThreadContext(Settings.EMPTY)
             )
         );
@@ -618,7 +617,7 @@ public class EsExecutorsTests extends ESTestCase {
                 getName(),
                 between(1, 5),
                 between(1, 5),
-                EsExecutors.daemonThreadFactory(getName()),
+                EsExecutors.daemonThreadFactory("nodename", getName(), false),
                 threadContext,
                 randomFrom(DEFAULT, DO_NOT_TRACK)
             )
@@ -631,7 +630,7 @@ public class EsExecutorsTests extends ESTestCase {
                 getName(),
                 between(1, 5),
                 -1,
-                EsExecutors.daemonThreadFactory(getName()),
+                EsExecutors.daemonThreadFactory("nodename", getName(), false),
                 threadContext,
                 randomFrom(DEFAULT, DO_NOT_TRACK)
             )
@@ -659,11 +658,7 @@ public class EsExecutorsTests extends ESTestCase {
 
         final var thread = threadFactory.newThread(() -> {});
         try {
-            assertThat(EsExecutors.executorName(thread.getName()), equalTo(executorName));
             assertThat(EsExecutors.executorName(thread), equalTo(executorName));
-            assertThat(EsExecutors.executorName("TEST-" + thread.getName()), is(nullValue()));
-            assertThat(EsExecutors.executorName("LuceneTestCase" + thread.getName()), is(nullValue()));
-            assertThat(EsExecutors.executorName("LuceneTestCase" + thread.getName()), is(nullValue()));
             assertThat(((EsExecutors.EsThread) thread).isSystem(), equalTo(isSystem));
         } finally {
             thread.join();
@@ -683,7 +678,7 @@ public class EsExecutorsTests extends ESTestCase {
                 between(1, 100),
                 randomTimeUnit(),
                 randomBoolean(),
-                EsExecutors.daemonThreadFactory("test"),
+                EsExecutors.daemonThreadFactory("nodename", "test", false),
                 threadContext,
                 randomBoolean()
                     ? EsExecutors.TaskTrackingConfig.builder().trackOngoingTasks().trackExecutionTime(executionTimeEwma).build()
@@ -700,7 +695,7 @@ public class EsExecutorsTests extends ESTestCase {
                 between(1, 100),
                 randomTimeUnit(),
                 randomBoolean(),
-                EsExecutors.daemonThreadFactory("test"),
+                EsExecutors.daemonThreadFactory("nodename", "test", false),
                 threadContext
             );
             assertThat(pool, instanceOf(EsThreadPoolExecutor.class));
@@ -714,7 +709,7 @@ public class EsExecutorsTests extends ESTestCase {
                 between(1, 100),
                 randomTimeUnit(),
                 randomBoolean(),
-                EsExecutors.daemonThreadFactory("test"),
+                EsExecutors.daemonThreadFactory("nodename", "test", false),
                 threadContext,
                 DO_NOT_TRACK
             );
@@ -774,7 +769,7 @@ public class EsExecutorsTests extends ESTestCase {
                 0,
                 TimeUnit.MILLISECONDS,
                 true,
-                EsExecutors.daemonThreadFactory(getTestName()),
+                EsExecutors.daemonThreadFactory("nodename", getTestName(), false),
                 threadContext
             )
         );
@@ -789,7 +784,7 @@ public class EsExecutorsTests extends ESTestCase {
                 1,
                 TimeUnit.MILLISECONDS,
                 true,
-                EsExecutors.daemonThreadFactory(getTestName()),
+                EsExecutors.daemonThreadFactory("nodename", getTestName(), false),
                 threadContext
             )
         );
@@ -804,7 +799,7 @@ public class EsExecutorsTests extends ESTestCase {
                 0,
                 TimeUnit.MILLISECONDS,
                 true,
-                EsExecutors.daemonThreadFactory(getTestName()),
+                EsExecutors.daemonThreadFactory("nodename", getTestName(), false),
                 threadContext
             )
         );
@@ -819,7 +814,7 @@ public class EsExecutorsTests extends ESTestCase {
                 1,
                 TimeUnit.MILLISECONDS,
                 true,
-                EsExecutors.daemonThreadFactory(getTestName()),
+                EsExecutors.daemonThreadFactory("nodename", getTestName(), false),
                 threadContext
             )
         );
@@ -835,7 +830,7 @@ public class EsExecutorsTests extends ESTestCase {
                 0,
                 TimeUnit.MILLISECONDS,
                 new EsExecutors.ExecutorScalingQueue<>(),
-                EsExecutors.daemonThreadFactory(getTestName()),
+                EsExecutors.daemonThreadFactory("nodename", getTestName(), false),
                 new EsExecutors.ForceQueuePolicy(true, true),
                 threadContext
             )
@@ -852,7 +847,7 @@ public class EsExecutorsTests extends ESTestCase {
                 1,
                 TimeUnit.MILLISECONDS,
                 new EsExecutors.ExecutorScalingQueue<>(),
-                EsExecutors.daemonThreadFactory(getTestName()),
+                EsExecutors.daemonThreadFactory("nodename", getTestName(), false),
                 new EsExecutors.ForceQueuePolicy(true, true),
                 threadContext
             )

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/EsThreadPoolExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/EsThreadPoolExecutorTests.java
@@ -145,7 +145,7 @@ public class EsThreadPoolExecutorTests extends ESSingleNodeTestCase {
                 public boolean offer(Runnable r) {
                     throw exception;
                 }
-            }, EsExecutors.daemonThreadFactory("test"), new ThreadContext(Settings.EMPTY));
+            }, EsExecutors.daemonThreadFactory("nodename", "test", false), new ThreadContext(Settings.EMPTY));
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/ListenableFutureTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/ListenableFutureTests.java
@@ -82,7 +82,7 @@ public class ListenableFutureTests extends ESTestCase {
             "testConcurrentListenerRegistrationAndCompletion",
             numberOfThreads,
             1000,
-            EsExecutors.daemonThreadFactory("listener"),
+            EsExecutors.daemonThreadFactory("nodename", "listener", false),
             threadContext,
             EsExecutors.TaskTrackingConfig.DO_NOT_TRACK
         );
@@ -157,7 +157,7 @@ public class ListenableFutureTests extends ESTestCase {
             "testRejection",
             1,
             1,
-            EsExecutors.daemonThreadFactory("testRejection"),
+            EsExecutors.daemonThreadFactory("nodename", "testRejection", false),
             threadContext,
             EsExecutors.TaskTrackingConfig.DO_NOT_TRACK
         );

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/PrioritizedExecutorsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/PrioritizedExecutorsTests.java
@@ -61,7 +61,7 @@ public class PrioritizedExecutorsTests extends ESTestCase {
     public void testSubmitPrioritizedExecutorWithRunnables() throws Exception {
         ExecutorService executor = EsExecutors.newSinglePrioritizing(
             getName(),
-            EsExecutors.daemonThreadFactory(getTestName()),
+            EsExecutors.daemonThreadFactory("nodename", getTestName(), false),
             holder,
             null
         );
@@ -95,7 +95,7 @@ public class PrioritizedExecutorsTests extends ESTestCase {
     public void testExecutePrioritizedExecutorWithRunnables() throws Exception {
         ExecutorService executor = EsExecutors.newSinglePrioritizing(
             getName(),
-            EsExecutors.daemonThreadFactory(getTestName()),
+            EsExecutors.daemonThreadFactory("nodename", getTestName(), false),
             holder,
             null
         );
@@ -129,7 +129,7 @@ public class PrioritizedExecutorsTests extends ESTestCase {
     public void testSubmitPrioritizedExecutorWithCallables() throws Exception {
         ExecutorService executor = EsExecutors.newSinglePrioritizing(
             getName(),
-            EsExecutors.daemonThreadFactory(getTestName()),
+            EsExecutors.daemonThreadFactory("nodename", getTestName(), false),
             holder,
             null
         );
@@ -163,7 +163,7 @@ public class PrioritizedExecutorsTests extends ESTestCase {
     public void testSubmitPrioritizedExecutorWithMixed() throws Exception {
         ExecutorService executor = EsExecutors.newSinglePrioritizing(
             getTestName(),
-            EsExecutors.daemonThreadFactory(getTestName()),
+            EsExecutors.daemonThreadFactory("nodename", getTestName(), false),
             holder,
             null
         );
@@ -195,10 +195,12 @@ public class PrioritizedExecutorsTests extends ESTestCase {
     }
 
     public void testTimeout() throws Exception {
-        ScheduledExecutorService timer = Executors.newSingleThreadScheduledExecutor(EsExecutors.daemonThreadFactory(getTestName()));
+        ScheduledExecutorService timer = Executors.newSingleThreadScheduledExecutor(
+            EsExecutors.daemonThreadFactory("nodename", getTestName(), false)
+        );
         PrioritizedEsThreadPoolExecutor executor = EsExecutors.newSinglePrioritizing(
             getName(),
-            EsExecutors.daemonThreadFactory(getTestName()),
+            EsExecutors.daemonThreadFactory("nodename", getTestName(), false),
             holder,
             timer
         );
@@ -265,7 +267,7 @@ public class PrioritizedExecutorsTests extends ESTestCase {
         final AtomicBoolean timeoutCalled = new AtomicBoolean();
         PrioritizedEsThreadPoolExecutor executor = EsExecutors.newSinglePrioritizing(
             getName(),
-            EsExecutors.daemonThreadFactory(getTestName()),
+            EsExecutors.daemonThreadFactory("nodename", getTestName(), false),
             holder,
             timer
         );

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/PrioritizedThrottledTaskRunnerTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/PrioritizedThrottledTaskRunnerTests.java
@@ -29,7 +29,7 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public class PrioritizedThrottledTaskRunnerTests extends ESTestCase {
 
-    private static final ThreadFactory threadFactory = EsExecutors.daemonThreadFactory("test");
+    private static final ThreadFactory threadFactory = EsExecutors.daemonThreadFactory("nodename", "test", false);
     private static final ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
 
     private ExecutorService executor;

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/TaskExecutionTimeTrackingEsThreadPoolExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/TaskExecutionTimeTrackingEsThreadPoolExecutorTests.java
@@ -48,7 +48,7 @@ public class TaskExecutionTimeTrackingEsThreadPoolExecutorTests extends ESTestCa
             TimeUnit.MILLISECONDS,
             ConcurrentCollections.newBlockingQueue(),
             settableWrapper(TimeUnit.NANOSECONDS.toNanos(100)),
-            EsExecutors.daemonThreadFactory("queuetest"),
+            EsExecutors.daemonThreadFactory("nodename", "queuetest", false),
             new EsAbortPolicy(),
             context,
             randomBoolean()
@@ -116,7 +116,7 @@ public class TaskExecutionTimeTrackingEsThreadPoolExecutorTests extends ESTestCa
             TimeUnit.MILLISECONDS,
             ConcurrentCollections.newBlockingQueue(),
             (runnable) -> adjustableTimedRunnable,
-            EsExecutors.daemonThreadFactory("queue-latency-test"),
+            EsExecutors.daemonThreadFactory("nodename", "queue-latency-test", false),
             new EsAbortPolicy(),
             context,
             randomBoolean()
@@ -183,7 +183,7 @@ public class TaskExecutionTimeTrackingEsThreadPoolExecutorTests extends ESTestCa
             TimeUnit.MILLISECONDS,
             ConcurrentCollections.newBlockingQueue(),
             (runnable) -> adjustableTimedRunnable,
-            EsExecutors.daemonThreadFactory("queue-latency-test"),
+            EsExecutors.daemonThreadFactory("nodename", "queue-latency-test", false),
             new EsAbortPolicy(),
             context,
             randomBoolean()
@@ -233,7 +233,7 @@ public class TaskExecutionTimeTrackingEsThreadPoolExecutorTests extends ESTestCa
             TimeUnit.MILLISECONDS,
             ConcurrentCollections.newBlockingQueue(),
             exceptionalWrapper(),
-            EsExecutors.daemonThreadFactory("queuetest"),
+            EsExecutors.daemonThreadFactory("nodename", "queuetest", false),
             new EsAbortPolicy(),
             context,
             randomBoolean()
@@ -269,7 +269,7 @@ public class TaskExecutionTimeTrackingEsThreadPoolExecutorTests extends ESTestCa
             TimeUnit.MILLISECONDS,
             ConcurrentCollections.newBlockingQueue(),
             TimedRunnable::new,
-            EsExecutors.daemonThreadFactory("queuetest"),
+            EsExecutors.daemonThreadFactory("nodename", "queuetest", false),
             new EsAbortPolicy(),
             context,
             EsExecutors.TaskTrackingConfig.builder()
@@ -306,7 +306,7 @@ public class TaskExecutionTimeTrackingEsThreadPoolExecutorTests extends ESTestCa
             TimeUnit.MILLISECONDS,
             ConcurrentCollections.newBlockingQueue(),
             TimedRunnable::new,
-            EsExecutors.daemonThreadFactory("queuetest"),
+            EsExecutors.daemonThreadFactory("nodename", "queuetest", false),
             new EsAbortPolicy(),
             new ThreadContext(Settings.EMPTY),
             EsExecutors.TaskTrackingConfig.builder()

--- a/server/src/test/java/org/elasticsearch/index/shard/RefreshListenersTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/RefreshListenersTests.java
@@ -58,6 +58,7 @@ import org.elasticsearch.index.store.Store;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.index.translog.TranslogConfig;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.elasticsearch.node.Node;
 import org.elasticsearch.plugins.internal.XContentMeteringParserDecorator;
 import org.elasticsearch.test.DummyShardLock;
 import org.elasticsearch.test.ESTestCase;
@@ -107,6 +108,7 @@ public class RefreshListenersTests extends ESTestCase {
         threadPool = new TestThreadPool(getTestName());
         Settings settings = Settings.builder()
             .put(ThreadPoolMergeScheduler.USE_THREAD_POOL_MERGE_SCHEDULER_SETTING.getKey(), randomBoolean())
+            .put(Node.NODE_NAME_SETTING.getKey(), "nodename")
             .build();
         IndexSettings indexSettings = IndexSettingsModule.newIndexSettings("index", settings);
         nodeEnvironment = newNodeEnvironment(settings);

--- a/server/src/test/java/org/elasticsearch/threadpool/ScalingThreadPoolTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/ScalingThreadPoolTests.java
@@ -205,7 +205,7 @@ public class ScalingThreadPoolTests extends ESThreadPoolTestCase {
             randomLongBetween(0, 100),
             TimeUnit.MILLISECONDS,
             rejectAfterShutdown,
-            EsExecutors.daemonThreadFactory(getTestName().toLowerCase(Locale.ROOT)),
+            EsExecutors.daemonThreadFactory("nodename", getTestName().toLowerCase(Locale.ROOT), false),
             new ThreadContext(Settings.EMPTY)
         );
         try {
@@ -308,7 +308,7 @@ public class ScalingThreadPoolTests extends ESThreadPoolTestCase {
             randomLongBetween(0, 100),
             TimeUnit.MILLISECONDS,
             true,
-            EsExecutors.daemonThreadFactory(getTestName().toLowerCase(Locale.ROOT)),
+            EsExecutors.daemonThreadFactory("nodename", getTestName().toLowerCase(Locale.ROOT), false),
             new ThreadContext(Settings.EMPTY)
         );
         try {

--- a/server/src/test/java/org/elasticsearch/transport/SingleResultDeduplicatorTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/SingleResultDeduplicatorTests.java
@@ -110,7 +110,7 @@ public class SingleResultDeduplicatorTests extends ESTestCase {
                     "test",
                     threads,
                     0,
-                    EsExecutors.daemonThreadFactory("test"),
+                    EsExecutors.daemonThreadFactory("nodename", "test", false),
                     threadContext,
                     EsExecutors.TaskTrackingConfig.DO_NOT_TRACK
                 );

--- a/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpFixture.java
+++ b/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpFixture.java
@@ -89,7 +89,7 @@ public class S3HttpFixture extends ExternalResource {
                 30,
                 TimeUnit.SECONDS,
                 true,
-                EsExecutors.daemonThreadFactory("s3-http-fixture"),
+                EsExecutors.daemonThreadFactory("nodename", "s3-http-fixture", false),
                 new ThreadContext(Settings.EMPTY)
             );
 

--- a/test/framework/src/main/java/org/elasticsearch/common/lucene/store/ESIndexInputTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/lucene/store/ESIndexInputTestCase.java
@@ -44,7 +44,7 @@ public class ESIndexInputTestCase extends ESTestCase {
             name,
             10,
             0,
-            EsExecutors.daemonThreadFactory(name),
+            EsExecutors.daemonThreadFactory("test-node", name),
             new ThreadContext(Settings.EMPTY),
             EsExecutors.TaskTrackingConfig.DO_NOT_TRACK
         );

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESMockAPIBasedRepositoryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESMockAPIBasedRepositoryIntegTestCase.java
@@ -86,7 +86,7 @@ public abstract class ESMockAPIBasedRepositoryIntegTestCase extends ESBlobStoreR
     @BeforeClass
     public static void startHttpServer() throws Exception {
         httpServer = MockHttpServer.createHttp(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
-        ThreadFactory threadFactory = EsExecutors.daemonThreadFactory("[" + ESMockAPIBasedRepositoryIntegTestCase.class.getName() + "]");
+        ThreadFactory threadFactory = EsExecutors.daemonThreadFactory("mock-node", ESMockAPIBasedRepositoryIntegTestCase.class.getName());
         // the EncryptedRepository can require more than one connection open at one time
         executorService = EsExecutors.newScaling(
             ESMockAPIBasedRepositoryIntegTestCase.class.getName(),

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
@@ -306,7 +306,7 @@ public class MockTransportService extends TransportService {
             30,
             TimeUnit.SECONDS,
             true,
-            EsExecutors.daemonThreadFactory("mock-transport"),
+            EsExecutors.daemonThreadFactory("mock-node", "mock-transport"),
             threadPool.getThreadContext()
         );
     }

--- a/test/framework/src/test/java/org/elasticsearch/common/logging/TestThreadInfoPatternConverterTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/common/logging/TestThreadInfoPatternConverterTests.java
@@ -9,7 +9,9 @@
 
 package org.elasticsearch.common.logging;
 
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.BeforeClass;
 
@@ -29,7 +31,8 @@ public class TestThreadInfoPatternConverterTests extends ESTestCase {
         var nodeName = randomAlphaOfLength(5);
         var prefix = randomAlphaOfLength(20);
         var thread = "T#" + between(0, 1000);
-        var threadName = EsExecutors.threadName(nodeName, prefix) + "[" + thread + "]";
+        Settings settings = Settings.builder().put(Node.NODE_NAME_SETTING.getKey(), nodeName).build();
+        var threadName = EsExecutors.threadName(settings, prefix) + "[" + thread + "]";
         assertThat(threadInfo(threadName), equalTo(nodeName + "][" + prefix + "][" + thread));
     }
 

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngineTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngineTests.java
@@ -123,8 +123,12 @@ public class FollowingEngineTests extends ESTestCase {
         super.tearDown();
     }
 
+    private static Settings.Builder nodeIndexSettingsBuilder() {
+        return indexSettings(IndexVersion.current(), 1, 0).put("node.name", "testnode");
+    }
+
     public void testFollowingEngineRejectsNonFollowingIndex() throws IOException {
-        final Settings.Builder builder = indexSettings(IndexVersion.current(), 1, 0);
+        final Settings.Builder builder = nodeIndexSettingsBuilder();
         if (randomBoolean()) {
             builder.put("index.xpack.ccr.following_index", false);
         }
@@ -152,7 +156,7 @@ public class FollowingEngineTests extends ESTestCase {
      * ensures that these semantics are maintained.
      */
     public void testOutOfOrderDocuments() throws IOException {
-        final Settings settings = indexSettings(IndexVersion.current(), 1, 0).put("index.xpack.ccr.following_index", true).build();
+        final Settings settings = nodeIndexSettingsBuilder().put("index.xpack.ccr.following_index", true).build();
         final IndexMetadata indexMetadata = IndexMetadata.builder(index.getName()).settings(settings).build();
         final IndexSettings indexSettings = new IndexSettings(indexMetadata, settings);
         try (Store store = createStore(shardId, indexSettings, newDirectory())) {
@@ -171,7 +175,7 @@ public class FollowingEngineTests extends ESTestCase {
         final Engine.Operation.Origin origin,
         final CheckedBiConsumer<FollowingEngine, Engine.Index, IOException> consumer
     ) throws IOException {
-        final Settings settings = indexSettings(IndexVersion.current(), 1, 0).put("index.xpack.ccr.following_index", true).build();
+        final Settings settings = nodeIndexSettingsBuilder().put("index.xpack.ccr.following_index", true).build();
         final IndexMetadata indexMetadata = IndexMetadata.builder(index.getName()).settings(settings).build();
         final IndexSettings indexSettings = new IndexSettings(indexMetadata, settings);
         try (Store store = createStore(shardId, indexSettings, newDirectory())) {
@@ -197,7 +201,7 @@ public class FollowingEngineTests extends ESTestCase {
         final Engine.Operation.Origin origin,
         final CheckedBiConsumer<FollowingEngine, Engine.Delete, IOException> consumer
     ) throws IOException {
-        final Settings settings = indexSettings(IndexVersion.current(), 1, 0).put("index.xpack.ccr.following_index", true).build();
+        final Settings settings = nodeIndexSettingsBuilder().put("index.xpack.ccr.following_index", true).build();
         final IndexMetadata indexMetadata = IndexMetadata.builder(index.getName()).settings(settings).build();
         final IndexSettings indexSettings = new IndexSettings(indexMetadata, settings);
         try (Store store = createStore(shardId, indexSettings, newDirectory())) {
@@ -223,7 +227,7 @@ public class FollowingEngineTests extends ESTestCase {
     }
 
     public void testDoNotFillSeqNoGaps() throws Exception {
-        final Settings settings = indexSettings(IndexVersion.current(), 1, 0).put("index.xpack.ccr.following_index", true).build();
+        final Settings settings = nodeIndexSettingsBuilder().put("index.xpack.ccr.following_index", true).build();
         final IndexMetadata indexMetadata = IndexMetadata.builder(index.getName()).settings(settings).build();
         final IndexSettings indexSettings = new IndexSettings(indexMetadata, settings);
         try (Store store = createStore(shardId, indexSettings, newDirectory())) {
@@ -525,7 +529,7 @@ public class FollowingEngineTests extends ESTestCase {
 
     public void testConcurrentIndexOperationsWithDeletesCanAdvanceMaxSeqNoOfUpdates() throws Exception {
         // See #72527 for more details
-        Settings followerSettings = indexSettings(IndexVersion.current(), 1, 0).put("index.xpack.ccr.following_index", true).build();
+        Settings followerSettings = nodeIndexSettingsBuilder().put("index.xpack.ccr.following_index", true).build();
 
         IndexMetadata followerIndexMetadata = IndexMetadata.builder(index.getName()).settings(followerSettings).build();
         IndexSettings followerIndexSettings = new IndexSettings(followerIndexMetadata, Settings.EMPTY);
@@ -638,7 +642,7 @@ public class FollowingEngineTests extends ESTestCase {
             }
         };
 
-        Settings leaderSettings = indexSettings(IndexVersion.current(), 1, 0).build();
+        Settings leaderSettings = nodeIndexSettingsBuilder().build();
         IndexMetadata leaderIndexMetadata = IndexMetadata.builder(index.getName()).settings(leaderSettings).build();
         IndexSettings leaderIndexSettings = new IndexSettings(leaderIndexMetadata, leaderSettings);
         try (Store leaderStore = createStore(shardId, leaderIndexSettings, newDirectory())) {
@@ -654,7 +658,7 @@ public class FollowingEngineTests extends ESTestCase {
             );
             try (InternalEngine leaderEngine = new InternalEngine(leaderConfig)) {
                 leaderEngine.skipTranslogRecovery();
-                Settings followerSettings = indexSettings(IndexVersion.current(), 1, 0).put("index.xpack.ccr.following_index", true)
+                Settings followerSettings = nodeIndexSettingsBuilder().put("index.xpack.ccr.following_index", true)
                     .build();
                 IndexMetadata followerIndexMetadata = IndexMetadata.builder(index.getName()).settings(followerSettings).build();
                 IndexSettings followerIndexSettings = new IndexSettings(followerIndexMetadata, leaderSettings);
@@ -778,7 +782,7 @@ public class FollowingEngineTests extends ESTestCase {
     }
 
     public void testProcessOnceOnPrimary() throws Exception {
-        final Settings.Builder settingsBuilder = indexSettings(IndexVersion.current(), 1, 0).put("index.xpack.ccr.following_index", true);
+        final Settings.Builder settingsBuilder = nodeIndexSettingsBuilder().put("index.xpack.ccr.following_index", true);
         switch (indexMode) {
             case STANDARD:
                 break;
@@ -916,7 +920,7 @@ public class FollowingEngineTests extends ESTestCase {
     }
 
     public void testMaxSeqNoInCommitUserData() throws Exception {
-        final Settings settings = indexSettings(IndexVersion.current(), 1, 0).put("index.xpack.ccr.following_index", true).build();
+        final Settings settings = nodeIndexSettingsBuilder().put("index.xpack.ccr.following_index", true).build();
         final IndexMetadata indexMetadata = IndexMetadata.builder(index.getName()).settings(settings).build();
         final IndexSettings indexSettings = new IndexSettings(indexMetadata, settings);
         try (Store store = createStore(shardId, indexSettings, newDirectory())) {

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngineTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngineTests.java
@@ -658,8 +658,7 @@ public class FollowingEngineTests extends ESTestCase {
             );
             try (InternalEngine leaderEngine = new InternalEngine(leaderConfig)) {
                 leaderEngine.skipTranslogRecovery();
-                Settings followerSettings = nodeIndexSettingsBuilder().put("index.xpack.ccr.following_index", true)
-                    .build();
+                Settings followerSettings = nodeIndexSettingsBuilder().put("index.xpack.ccr.following_index", true).build();
                 IndexMetadata followerIndexMetadata = IndexMetadata.builder(index.getName()).settings(followerSettings).build();
                 IndexSettings followerIndexSettings = new IndexSettings(followerIndexMetadata, leaderSettings);
                 try (Store followerStore = createStore(shardId, followerIndexSettings, newDirectory())) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/RequestBasedTaskRunner.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/RequestBasedTaskRunner.java
@@ -41,7 +41,7 @@ class RequestBasedTaskRunner {
      */
     public void requestNextRun() {
         if (isRunning.get() && loopCount.getAndIncrement() == 0) {
-            var currentThreadPool = EsExecutors.executorName(Thread.currentThread().getName());
+            var currentThreadPool = EsExecutors.executorName(Thread.currentThread());
             if (executorServiceName.equalsIgnoreCase(currentThreadPool)) {
                 run();
             } else {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/client/AmazonBedrockStreamingChatProcessor.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/client/AmazonBedrockStreamingChatProcessor.java
@@ -151,7 +151,7 @@ class AmazonBedrockStreamingChatProcessor implements Flow.Processor<ConverseStre
         }
 
         private void requestOnMlThread(long n) {
-            var currentThreadPool = EsExecutors.executorName(Thread.currentThread().getName());
+            var currentThreadPool = EsExecutors.executorName(Thread.currentThread());
             if (UTILITY_THREAD_POOL_NAME.equalsIgnoreCase(currentThreadPool)) {
                 upstream.request(n);
             } else {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/AbstractNativeProcessTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/AbstractNativeProcessTests.java
@@ -77,7 +77,7 @@ public class AbstractNativeProcessTests extends ESTestCase {
             "test",
             1,
             1,
-            EsExecutors.daemonThreadFactory("test"),
+            EsExecutors.daemonThreadFactory("nodename", "test", false),
             new ThreadContext(Settings.EMPTY),
             EsExecutors.TaskTrackingConfig.DO_NOT_TRACK
         );


### PR DESCRIPTION
This replaces the current thread name based extraction of the executor name with a more reliable and performant approach simply storing the executor name in `EsThread`.

For reviews, focus on [the first commit](https://github.com/elastic/elasticsearch/commit/92e2e551bf443e244c5c6ca74d6265408c0d064f), the 2nd one just fixes factory usages of `daemonThreadFactory` in tests.