### PR TITLE
ES|QL: fix 60_usage.yml tests

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_usage.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_usage.yml
@@ -239,7 +239,7 @@ setup:
 
   # There's one of these per function but that's a ton of things to check. So we just spot check that a few exist.
   - not_exists: esql.functions.delay
-  - not_exists: esql.functions.idelta
+  - exists: esql.functions.idelta
   - exists: esql.functions.mv_sum
   - exists: esql.functions.to_dateperiod
 


### PR DESCRIPTION
Fixing telemetry tests for `idelta` function.

That's not registered as a snapshot function in FunctionRegistry, even though the [docs in the function](https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Idelta.java#L51) say it is. 
@dnhatn that comment is the same for all the ts functions apparently, maybe we should change it or move these functions to snapshot in the registry?

Fixes: https://github.com/elastic/elasticsearch/issues/135253
Fixes: https://github.com/elastic/elasticsearch/issues/135254
Fixes: https://github.com/elastic/elasticsearch/issues/135255