### PR TITLE
Fix `SampleXXXAggregatorFunctionTests.testSimpleWithCranky` test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -555,9 +555,6 @@ tests:
 - class: org.elasticsearch.reservedstate.service.RepositoriesFileSettingsIT
   method: testSettingsApplied
   issue: https://github.com/elastic/elasticsearch/issues/126748
-- class: org.elasticsearch.compute.aggregation.SampleLongAggregatorFunctionTests
-  method: testSimpleWithCranky
-  issue: https://github.com/elastic/elasticsearch/issues/134978
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
   method: test {csv-spec:stats.CountDistinctWithConditions}
   issue: https://github.com/elastic/elasticsearch/issues/134984
@@ -594,9 +591,6 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=transform/transforms_start_stop/Test stop transform with force and wait_for_checkpoint true}
   issue: https://github.com/elastic/elasticsearch/issues/135135
-- class: org.elasticsearch.compute.aggregation.SampleIntAggregatorFunctionTests
-  method: testSimpleWithCranky
-  issue: https://github.com/elastic/elasticsearch/issues/135137
 - class: org.elasticsearch.lucene.RollingUpgradeSearchableSnapshotIndexCompatibilityIT
   method: testSearchableSnapshotUpgrade {p0=[9.2.0, 9.2.0, 9.2.0]}
   issue: https://github.com/elastic/elasticsearch/issues/135150
@@ -606,18 +600,12 @@ tests:
 - class: org.elasticsearch.discovery.ClusterDisruptionIT
   method: testAckedIndexing
   issue: https://github.com/elastic/elasticsearch/issues/117024
-- class: org.elasticsearch.compute.aggregation.SampleBytesRefAggregatorFunctionTests
-  method: testSimpleWithCranky
-  issue: https://github.com/elastic/elasticsearch/issues/135157
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=analytics/nested_top_metrics_sort/terms order by top metrics numeric not null double values}
   issue: https://github.com/elastic/elasticsearch/issues/135159
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=analytics/nested_top_metrics_sort/terms order by top metrics numeric not null integer values}
   issue: https://github.com/elastic/elasticsearch/issues/135162
-- class: org.elasticsearch.compute.aggregation.SampleBooleanAggregatorFunctionTests
-  method: testSimpleWithCranky
-  issue: https://github.com/elastic/elasticsearch/issues/135163
 - class: org.elasticsearch.test.rest.yaml.CcsCommonYamlTestSuiteIT
   method: test {p0=search/160_exists_query/Test exists query on mapped geo_point field with no doc values}
   issue: https://github.com/elastic/elasticsearch/issues/135164
@@ -627,9 +615,6 @@ tests:
 - class: org.elasticsearch.compute.operator.topn.TopNOperatorTests
   method: testSimpleWithCranky
   issue: https://github.com/elastic/elasticsearch/issues/135224
-- class: org.elasticsearch.compute.aggregation.SampleDoubleAggregatorFunctionTests
-  method: testSimpleWithCranky
-  issue: https://github.com/elastic/elasticsearch/issues/135239
 
 # Examples:
 #

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -555,9 +555,6 @@ tests:
 - class: org.elasticsearch.reservedstate.service.RepositoriesFileSettingsIT
   method: testSettingsApplied
   issue: https://github.com/elastic/elasticsearch/issues/126748
-- class: org.elasticsearch.compute.aggregation.SampleLongAggregatorFunctionTests
-  method: testSimpleWithCranky
-  issue: https://github.com/elastic/elasticsearch/issues/134978
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
   method: test {csv-spec:stats.CountDistinctWithConditions}
   issue: https://github.com/elastic/elasticsearch/issues/134984
@@ -594,9 +591,6 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=transform/transforms_start_stop/Test stop transform with force and wait_for_checkpoint true}
   issue: https://github.com/elastic/elasticsearch/issues/135135
-- class: org.elasticsearch.compute.aggregation.SampleIntAggregatorFunctionTests
-  method: testSimpleWithCranky
-  issue: https://github.com/elastic/elasticsearch/issues/135137
 - class: org.elasticsearch.lucene.RollingUpgradeSearchableSnapshotIndexCompatibilityIT
   method: testSearchableSnapshotUpgrade {p0=[9.2.0, 9.2.0, 9.2.0]}
   issue: https://github.com/elastic/elasticsearch/issues/135150
@@ -606,18 +600,12 @@ tests:
 - class: org.elasticsearch.discovery.ClusterDisruptionIT
   method: testAckedIndexing
   issue: https://github.com/elastic/elasticsearch/issues/117024
-- class: org.elasticsearch.compute.aggregation.SampleBytesRefAggregatorFunctionTests
-  method: testSimpleWithCranky
-  issue: https://github.com/elastic/elasticsearch/issues/135157
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=analytics/nested_top_metrics_sort/terms order by top metrics numeric not null double values}
   issue: https://github.com/elastic/elasticsearch/issues/135159
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=analytics/nested_top_metrics_sort/terms order by top metrics numeric not null integer values}
   issue: https://github.com/elastic/elasticsearch/issues/135162
-- class: org.elasticsearch.compute.aggregation.SampleBooleanAggregatorFunctionTests
-  method: testSimpleWithCranky
-  issue: https://github.com/elastic/elasticsearch/issues/135163
 - class: org.elasticsearch.test.rest.yaml.CcsCommonYamlTestSuiteIT
   method: test {p0=search/160_exists_query/Test exists query on mapped geo_point field with no doc values}
   issue: https://github.com/elastic/elasticsearch/issues/135164
@@ -627,9 +615,6 @@ tests:
 - class: org.elasticsearch.compute.operator.topn.TopNOperatorTests
   method: testSimpleWithCranky
   issue: https://github.com/elastic/elasticsearch/issues/135224
-- class: org.elasticsearch.compute.aggregation.SampleDoubleAggregatorFunctionTests
-  method: testSimpleWithCranky
-  issue: https://github.com/elastic/elasticsearch/issues/135239
 - class: org.elasticsearch.compute.operator.topn.TopNOperatorTests
   method: testSimpleCircuitBreaking
   issue: https://github.com/elastic/elasticsearch/issues/135260

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/sort/BytesRefBucketedSort.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/sort/BytesRefBucketedSort.java
@@ -203,8 +203,9 @@ public class BytesRefBucketedSort implements Releasable {
                 if (size == 1) {
                     try (BreakingBytesRefBuilder bytes = values.get(start)) {
                         builder.appendBytesRef(bytes.bytesRefView());
+                    } finally {
+                        values.set(start, null);
                     }
-                    values.set(start, null);
                     continue;
                 }
 
@@ -218,8 +219,9 @@ public class BytesRefBucketedSort implements Releasable {
                 for (int i = 0; i < size; i++) {
                     try (BreakingBytesRefBuilder bytes = values.get(start + i)) {
                         builder.appendBytesRef(bytes.bytesRefView());
+                    } finally {
+                        values.set(start + i, null);
                     }
-                    values.set(start + i, null);
                 }
                 builder.endPositionEntry();
             }


### PR DESCRIPTION
5 instances of `SampleXXXAggregatorFunctionTests.testSimpleWithCranky` test started failing after merging https://github.com/elastic/elasticsearch/pull/134140.
This PR fixes it by making sure the memory clearing line:
```
                        values.set(start, null);
```
is performed under `finally` block of the try-with-resources statement.

Fixes https://github.com/elastic/elasticsearch/issues/134918

Marking `>non-issue` as this is a fix for a change (#134140) that has not been released yet.