### PR TITLE
[ML] Add .reindexed-v7-ml-anomalies-* to anomaly results template index pattern

### DIFF
--- a/docs/changelog/135270.yaml
+++ b/docs/changelog/135270.yaml
@@ -1,0 +1,5 @@
+pr: 135270
+summary: Add .reindexed-v7-ml-anomalies-* to anomaly results template index pattern
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/core/template-resources/src/main/resources/ml/anomalydetection/results_index_template.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/ml/anomalydetection/results_index_template.json
@@ -2,7 +2,7 @@
   "priority": 2147483647,
   "version" : ${xpack.ml.version.id},
   "index_patterns" : [
-    ".ml-anomalies-*"
+    ".ml-anomalies-*", ".reindexed-v7-ml-anomalies-*"
   ],
   "template" : {
     "settings" : {


### PR DESCRIPTION
Anomaly detection results indices created in a version 6 Elasticsearch get reindexed and renamed with the prefix `.reindexed-v7` in version 7 by the upgrade assistant. In 8.18 and 8.19, those version 7 indices are rolled over in preparation for the version 9 upgrade, unfortunately because the index name starts with `.reindexed-v7-` they do not pick up the ml results index mappings from the template. If the correct mappings are not used it can break anomaly detection.

This PR fixes that by adding  `.reindexed-v7-ml-anomalies-*` to the template index patterns
