### PR TITLE
[9.1] [ML] Add .reindexed-v7-ml-anomalies-* to anomaly results template index pattern (#135270)

### DIFF
--- a/docs/changelog/135270.yaml
+++ b/docs/changelog/135270.yaml
@@ -1,0 +1,5 @@
+pr: 135270
+summary: Add .reindexed-v7-ml-anomalies-* to anomaly results template index pattern
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/core/template-resources/src/main/resources/ml/anomalydetection/results_index_template.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/ml/anomalydetection/results_index_template.json
@@ -2,7 +2,7 @@
   "priority": 2147483647,
   "version" : ${xpack.ml.version.id},
   "index_patterns" : [
-    ".ml-anomalies-*"
+    ".ml-anomalies-*", ".reindexed-v7-ml-anomalies-*"
   ],
   "template" : {
     "settings" : {


### PR DESCRIPTION
Backports the following commits to 9.1:
 - [ML] Add .reindexed-v7-ml-anomalies-* to anomaly results template index pattern (#135270)