### PR TITLE
[Gradle/BWC] Patch bundled OpenJdk17 with Adoptium Jdk17 for older ES Distros

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestBasePlugin.java
@@ -44,10 +44,14 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.internal.artifacts.dependencies.ProjectDependencyInternal;
+import org.gradle.api.plugins.JvmToolchainsPlugin;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.ClasspathNormalizer;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.util.PatternFilterable;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
+import org.gradle.jvm.toolchain.JavaToolchainService;
+import org.gradle.jvm.toolchain.JvmVendorSpec;
 
 import java.util.Collection;
 import java.util.Iterator;
@@ -59,6 +63,7 @@ import java.util.Optional;
 import javax.inject.Inject;
 
 import static org.elasticsearch.gradle.internal.util.ParamsUtils.loadBuildParams;
+import static org.elasticsearch.gradle.util.OsUtils.jdkIsIncompatibleWithOS;
 
 /**
  * Base plugin used for wiring up build tasks to REST testing tasks using new JUnit rule-based test clusters framework.
@@ -94,6 +99,7 @@ public class RestTestBasePlugin implements Plugin<Project> {
     public void apply(Project project) {
         project.getPluginManager().apply(ElasticsearchJavaBasePlugin.class);
         project.getPluginManager().apply(InternalDistributionDownloadPlugin.class);
+        project.getPluginManager().apply(JvmToolchainsPlugin.class);
         var bwcVersions = loadBuildParams(project).get().getBwcVersions();
 
         // Register integ-test and default distributions
@@ -236,6 +242,17 @@ public class RestTestBasePlugin implements Plugin<Project> {
                     String versionString = version.toString();
                     ElasticsearchDistribution bwcDistro = createDistribution(project, "bwc_" + versionString, versionString);
 
+                    if (jdkIsIncompatibleWithOS(Version.fromString(versionString))) {
+                        var toolChainService = project.getExtensions().getByType(JavaToolchainService.class);
+                        var fallbackJdk17Launcher = toolChainService.launcherFor(spec -> {
+                            spec.getVendor().set(JvmVendorSpec.ADOPTIUM);
+                            spec.getLanguageVersion().set(JavaLanguageVersion.of(17));
+                        });
+                        task.environment(
+                            "ES_FALLBACK_JAVA_HOME",
+                            fallbackJdk17Launcher.get().getMetadata().getInstallationPath().getAsFile().getPath()
+                        );
+                    }
                     task.dependsOn(bwcDistro);
                     registerDistributionInputs(task, bwcDistro);
 

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchCluster.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchCluster.java
@@ -37,6 +37,7 @@ import org.gradle.api.tasks.Sync;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 import org.gradle.api.tasks.bundling.Zip;
+import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.process.ExecOperations;
 
 import java.io.File;
@@ -84,6 +85,7 @@ public class ElasticsearchCluster implements TestClusterConfiguration, Named {
     private int nodeIndex = 0;
 
     private final ConfigurableFileCollection pluginAndModuleConfiguration;
+    private final Provider<JavaLauncher> jdk17FallbackLauncher;
 
     private boolean shared = false;
 
@@ -101,7 +103,8 @@ public class ElasticsearchCluster implements TestClusterConfiguration, Named {
         FileOperations fileOperations,
         File workingDirBase,
         Provider<File> runtimeJava,
-        Function<Version, Boolean> isReleasedVersion
+        Function<Version, Boolean> isReleasedVersion,
+        Provider<JavaLauncher> jdk17FallbackLauncher
     ) {
         this.path = path;
         this.clusterName = clusterName;
@@ -117,6 +120,7 @@ public class ElasticsearchCluster implements TestClusterConfiguration, Named {
         this.isReleasedVersion = isReleasedVersion;
         this.nodes = project.container(ElasticsearchNode.class);
         this.pluginAndModuleConfiguration = project.getObjects().fileCollection();
+        this.jdk17FallbackLauncher = jdk17FallbackLauncher;
         this.nodes.add(
             new ElasticsearchNode(
                 safeName(clusterName),
@@ -131,7 +135,8 @@ public class ElasticsearchCluster implements TestClusterConfiguration, Named {
                 fileOperations,
                 workingDirBase,
                 runtimeJava,
-                isReleasedVersion
+                isReleasedVersion,
+                jdk17FallbackLauncher
             )
         );
 
@@ -189,7 +194,8 @@ public class ElasticsearchCluster implements TestClusterConfiguration, Named {
                     fileOperations,
                     workingDirBase,
                     runtimeJava,
-                    isReleasedVersion
+                    isReleasedVersion,
+                    jdk17FallbackLauncher
                 )
             );
         }

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -49,6 +49,7 @@ import org.gradle.api.tasks.Sync;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.Zip;
 import org.gradle.api.tasks.util.PatternFilterable;
+import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.process.ExecOperations;
 
 import java.io.ByteArrayInputStream;
@@ -94,6 +95,7 @@ import java.util.stream.Stream;
 
 import static java.util.Objects.requireNonNull;
 import static java.util.Optional.ofNullable;
+import static org.elasticsearch.gradle.util.OsUtils.jdkIsIncompatibleWithOS;
 
 public class ElasticsearchNode implements TestClusterConfiguration {
 
@@ -166,6 +168,7 @@ public class ElasticsearchNode implements TestClusterConfiguration {
     private final Path tmpDir;
     private final Provider<File> runtimeJava;
     private final Function<Version, Boolean> isReleasedVersion;
+    private final Provider<JavaLauncher> jdk17FallbackLauncher;
     private final List<ElasticsearchDistribution> distributions = new ArrayList<>();
     private int currentDistro = 0;
     private TestDistribution testDistribution;
@@ -190,7 +193,8 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         FileOperations fileOperations,
         File workingDirBase,
         Provider<File> runtimeJava,
-        Function<Version, Boolean> isReleasedVersion
+        Function<Version, Boolean> isReleasedVersion,
+        Provider<JavaLauncher> jdk17FallbackLauncher
     ) {
         this.path = path;
         this.name = name;
@@ -203,6 +207,7 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         this.fileOperations = fileOperations;
         this.runtimeJava = runtimeJava;
         this.isReleasedVersion = isReleasedVersion;
+        this.jdk17FallbackLauncher = jdk17FallbackLauncher;
         workingDir = workingDirBase.toPath().resolve(safeName(name)).toAbsolutePath();
         confPathRepo = workingDir.resolve("repo");
         configFile = workingDir.resolve("config/elasticsearch.yml");
@@ -751,6 +756,48 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         featureFlags.add(new FeatureFlag(feature, from, until));
     }
 
+    private boolean isUbuntu2404OrLater() {
+        try {
+            if (OS.current() != OS.LINUX) {
+                return false;
+            }
+
+            // Read /etc/os-release file to get distribution info
+            Path osRelease = Path.of("/etc/os-release");
+            if (!Files.exists(osRelease)) {
+                return false;
+            }
+
+            String content = Files.readString(osRelease);
+            boolean isUbuntu = content.contains("ID=ubuntu");
+
+            if (!isUbuntu) {
+                return false;
+            }
+
+            // Extract version
+            String versionLine = content.lines().filter(line -> line.startsWith("VERSION_ID=")).findFirst().orElse("");
+
+            if (versionLine.isEmpty()) {
+                return false;
+            }
+
+            String version = versionLine.substring("VERSION_ID=".length()).replace("\"", "");
+            String[] parts = version.split("\\.");
+
+            if (parts.length >= 2) {
+                int major = Integer.parseInt(parts[0]);
+                int minor = Integer.parseInt(parts[1]);
+                return major > 24 || (major == 24 && minor >= 4);
+            }
+
+            return false;
+        } catch (Exception e) {
+            LOGGER.debug("Failed to detect Ubuntu version", e);
+            return false;
+        }
+    }
+
     private void runElasticsearchBinScriptWithInput(String input, String tool, CharSequence... args) {
         if (Files.exists(getDistroDir().resolve("bin").resolve(tool)) == false
             && Files.exists(getDistroDir().resolve("bin").resolve(tool + ".bat")) == false) {
@@ -793,7 +840,19 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         if (getTestDistribution() == TestDistribution.INTEG_TEST || getVersion().equals(VersionProperties.getElasticsearchVersion())) {
             defaultEnv.put("ES_JAVA_HOME", runtimeJava.get().getAbsolutePath());
         }
+        // Older distributions ship with openjdk versions that are not compatible with newer kernels of ubuntu 24.04 and later
+        // Therefore we pass explicitly the runtime java to use the adoptium jdk that is maintained longer and compatible
+        // with newer kernels.
+        // 8.10.4 is the last version shipped with jdk < 21. We configure these cluster to run with jdk 17 adoptium as 17 was
+        // the last LTS release before 21
+        else if (jdkIsIncompatibleWithOS(getVersion())) {
+            defaultEnv.put(
+                "ES_JAVA_HOME",
+                jdk17FallbackLauncher.map(j -> j.getMetadata().getInstallationPath().getAsFile().getAbsolutePath()).get()
+            );
+        }
         defaultEnv.put("ES_PATH_CONF", configFile.getParent().toString());
+
         String systemPropertiesString = "";
         if (systemProperties.isEmpty() == false) {
             systemPropertiesString = " " + systemProperties.entrySet().stream().peek(entry -> {

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -756,48 +756,6 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         featureFlags.add(new FeatureFlag(feature, from, until));
     }
 
-    private boolean isUbuntu2404OrLater() {
-        try {
-            if (OS.current() != OS.LINUX) {
-                return false;
-            }
-
-            // Read /etc/os-release file to get distribution info
-            Path osRelease = Path.of("/etc/os-release");
-            if (!Files.exists(osRelease)) {
-                return false;
-            }
-
-            String content = Files.readString(osRelease);
-            boolean isUbuntu = content.contains("ID=ubuntu");
-
-            if (!isUbuntu) {
-                return false;
-            }
-
-            // Extract version
-            String versionLine = content.lines().filter(line -> line.startsWith("VERSION_ID=")).findFirst().orElse("");
-
-            if (versionLine.isEmpty()) {
-                return false;
-            }
-
-            String version = versionLine.substring("VERSION_ID=".length()).replace("\"", "");
-            String[] parts = version.split("\\.");
-
-            if (parts.length >= 2) {
-                int major = Integer.parseInt(parts[0]);
-                int minor = Integer.parseInt(parts[1]);
-                return major > 24 || (major == 24 && minor >= 4);
-            }
-
-            return false;
-        } catch (Exception e) {
-            LOGGER.debug("Failed to detect Ubuntu version", e);
-            return false;
-        }
-    }
-
     private void runElasticsearchBinScriptWithInput(String input, String tool, CharSequence... args) {
         if (Files.exists(getDistroDir().resolve("bin").resolve(tool)) == false
             && Files.exists(getDistroDir().resolve("bin").resolve(tool + ".bat")) == false) {

--- a/build-tools/src/main/java/org/elasticsearch/gradle/util/OsUtils.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/util/OsUtils.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.gradle.util;
+
+import org.elasticsearch.gradle.OS;
+import org.elasticsearch.gradle.Version;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public final class OsUtils {
+
+    private static final Logger LOGGER = Logging.getLogger(OsUtils.class);
+
+    static {
+        // Trigger static initialization of OS class
+        OS current = OS.current();
+        LOGGER.debug("Detected operating system: {}", current);
+    }
+
+    private OsUtils() {}
+
+    /**
+      * OpenJDK 17 that we ship with for older ES distributions is incompatible with Ubuntu 24.04 and newer due to
+      * a change in newer kernel versions that causes JVM crashes.
+      * <p>
+      * See <a href="https://github.com/oracle/graal/issues/4831">https://github.com/oracle/graal/issues/4831</a> that exposes a similar issue with GraalVM.
+      * <p>
+      * It can be reproduced using Jshell on Ubuntu 24.04+ with:
+      * <pre>
+      * jshell&gt; java.lang.management.ManagementFactory.getOperatingSystemMXBean()
+      * |  Exception java.lang.NullPointerException: Cannot invoke "jdk.internal.platform.CgroupInfo.getMountPoint()" because "anyController" is null
+      * </pre>
+      * <p>
+      * This method returns true if the given version of the JDK is known to be incompatible
+      */
+    public static boolean jdkIsIncompatibleWithOS(Version version) {
+        return version.onOrBefore("8.10.4") && isUbuntu2404OrLater();
+    }
+
+    private static boolean isUbuntu2404OrLater() {
+        try {
+            if (OS.current() != OS.LINUX) {
+                return false;
+            }
+
+            // try reading kernel info from System properties first to make this better testable
+            String osKernelString = System.getProperty("os.version");
+            Version kernelVersion = Version.fromString(osKernelString, Version.Mode.RELAXED);
+            if (kernelVersion.onOrAfter("6.14.0")) {
+                return true;
+            }
+
+            // Read /etc/os-release file to get distribution info
+            Path osRelease = Path.of("/etc/os-release");
+            if (Files.exists(osRelease) == false) {
+                return false;
+            }
+
+            String content = Files.readString(osRelease);
+            boolean isUbuntu = content.contains("ID=ubuntu");
+
+            if (isUbuntu == false) {
+                return false;
+            }
+
+            // Extract version
+            String versionLine = content.lines().filter(line -> line.startsWith("VERSION_ID=")).findFirst().orElse("");
+
+            if (versionLine.isEmpty()) {
+                return false;
+            }
+
+            String version = versionLine.substring("VERSION_ID=".length()).replace("\"", "");
+            String[] parts = version.split("\\.");
+
+            if (parts.length >= 2) {
+                int major = Integer.parseInt(parts[0]);
+                int minor = Integer.parseInt(parts[1]);
+                return major > 24 || (major == 24 && minor >= 4);
+            }
+
+            return false;
+        } catch (Exception e) {
+            LOGGER.debug("Failed to detect Ubuntu version", e);
+            return false;
+        }
+    }
+
+}

--- a/build-tools/src/main/java/org/elasticsearch/gradle/util/OsUtils.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/util/OsUtils.java
@@ -21,12 +21,6 @@ public final class OsUtils {
 
     private static final Logger LOGGER = Logging.getLogger(OsUtils.class);
 
-    static {
-        // Trigger static initialization of OS class
-        OS current = OS.current();
-        LOGGER.debug("Detected operating system: {}", current);
-    }
-
     private OsUtils() {}
 
     /**

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalClusterFactory.java
@@ -82,6 +82,7 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
     private static final String ENABLE_DEBUG_JVM_ARGS = "-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=";
     private static final String ENTITLEMENT_POLICY_YAML = "entitlement-policy.yaml";
     private static final String PLUGIN_DESCRIPTOR_PROPERTIES = "plugin-descriptor.properties";
+    public static final String DISTRO_WITH_JDK_LOWER_21 = "8.11.0";
 
     private final DistributionResolver distributionResolver;
 
@@ -867,6 +868,10 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
 
         private Map<String, String> getEnvironmentVariables() {
             Map<String, String> environment = new HashMap<>(spec.resolveEnvironment());
+            String esFallbackJavaHome = System.getenv("ES_FALLBACK_JAVA_HOME");
+            if (spec.getVersion().before(DISTRO_WITH_JDK_LOWER_21) && esFallbackJavaHome != null && esFallbackJavaHome.isEmpty() == false) {
+                environment.put("ES_JAVA_HOME", esFallbackJavaHome);
+            }
             environment.put("ES_PATH_CONF", configDir.toString());
             environment.put("ES_TMPDIR", workingDir.resolve("tmp").toString());
             // Windows requires this as it defaults to `c:\windows` despite ES_TMPDIR


### PR DESCRIPTION
Bundled OpenJDK 17 is incompatible with newer versions of Ubuntu 24.04 (Kernel 6.14.x).
We fix our bwc testing on ubuntu 24.04 to explicitly use adoptium jdk 17 in cases where the bundled JDK is
older than 21 which is not affected.