### PR TITLE
Set either index.dimensions or index.routing_path

### DIFF
--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/TSDBIndexingIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/TSDBIndexingIT.java
@@ -666,10 +666,11 @@ public class TSDBIndexingIT extends ESSingleNodeTestCase {
         assertAcked(client().execute(CreateDataStreamAction.INSTANCE, createDsRequest));
         if (INDEX_DIMENSIONS_TSID_OPTIMIZATION_FEATURE_FLAG) {
             assertThat(getSetting(dataStreamName, IndexMetadata.INDEX_DIMENSIONS), equalTo(List.of("metricset")));
+            assertThat(getSetting(dataStreamName, IndexMetadata.INDEX_ROUTING_PATH), empty());
         } else {
             assertThat(getSetting(dataStreamName, IndexMetadata.INDEX_DIMENSIONS), empty());
+            assertThat(getSetting(dataStreamName, IndexMetadata.INDEX_ROUTING_PATH), equalTo(List.of("metricset")));
         }
-        assertThat(getSetting(dataStreamName, IndexMetadata.INDEX_ROUTING_PATH), equalTo(List.of("metricset")));
 
         // put mapping with k8s.pod.uid as another time series dimension
         var putMappingRequest = new PutMappingRequest(dataStreamName).source("""
@@ -685,10 +686,35 @@ public class TSDBIndexingIT extends ESSingleNodeTestCase {
         assertAcked(client().execute(TransportPutMappingAction.TYPE, putMappingRequest).actionGet());
         if (INDEX_DIMENSIONS_TSID_OPTIMIZATION_FEATURE_FLAG) {
             assertThat(getSetting(dataStreamName, IndexMetadata.INDEX_DIMENSIONS), containsInAnyOrder("metricset", "k8s.pod.name"));
+            assertThat(getSetting(dataStreamName, IndexMetadata.INDEX_ROUTING_PATH), empty());
         } else {
             assertThat(getSetting(dataStreamName, IndexMetadata.INDEX_DIMENSIONS), empty());
+            assertThat(getSetting(dataStreamName, IndexMetadata.INDEX_ROUTING_PATH), equalTo(List.of("metricset")));
         }
-        assertThat(getSetting(dataStreamName, IndexMetadata.INDEX_ROUTING_PATH), equalTo(List.of("metricset")));
+
+        // put dynamic template defining time series dimensions
+        // we don't support index.dimensions in that case
+        putMappingRequest = new PutMappingRequest(dataStreamName).source("""
+            {
+              "dynamic_templates": [
+                {
+                  "labels": {
+                    "path_match": "labels.*",
+                    "mapping": {
+                      "type": "keyword",
+                      "time_series_dimension": true
+                    }
+                  }
+                }
+              ]
+            }
+            """, XContentType.JSON);
+        assertAcked(client().execute(TransportPutMappingAction.TYPE, putMappingRequest).actionGet());
+        assertThat(
+            getSetting(dataStreamName, IndexMetadata.INDEX_ROUTING_PATH),
+            containsInAnyOrder("metricset", "labels.*", "k8s.pod.name")
+        );
+        assertThat(getSetting(dataStreamName, IndexMetadata.INDEX_DIMENSIONS), empty());
 
         indexWithPodNames(dataStreamName, Instant.now(), Map.of(), "dog", "cat");
     }

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/TSDBPassthroughIndexingIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/TSDBPassthroughIndexingIT.java
@@ -186,11 +186,12 @@ public class TSDBPassthroughIndexingIT extends ESSingleNodeTestCase {
 
         // validate index:
         var getIndexResponse = client().admin().indices().getIndex(new GetIndexRequest(TEST_REQUEST_TIMEOUT).indices(index)).actionGet();
-        assertThat(getIndexResponse.getSettings().get(index).get("index.routing_path"), equalTo("[attributes.*]"));
         if (INDEX_DIMENSIONS_TSID_OPTIMIZATION_FEATURE_FLAG) {
             assertThat(getIndexResponse.getSettings().get(index).get("index.dimensions"), equalTo("[attributes.*]"));
+            assertThat(getIndexResponse.getSettings().get(index).get("index.routing_path"), nullValue());
         } else {
             assertThat(getIndexResponse.getSettings().get(index).get("index.dimensions"), nullValue());
+            assertThat(getIndexResponse.getSettings().get(index).get("index.routing_path"), equalTo("[attributes.*]"));
         }
         // validate mapping
         var mapping = getIndexResponse.mappings().get(index).getSourceAsMap();

--- a/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/DownsampleDataStreamTests.java
+++ b/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/DownsampleDataStreamTests.java
@@ -205,13 +205,14 @@ public class DownsampleDataStreamTests extends ESSingleNodeTestCase {
                             setting.getAsList(IndexMetadata.INDEX_DIMENSIONS.getKey()),
                             containsInAnyOrder("routing_field", "dimension")
                         );
+                        assertThat(setting.getAsList(IndexMetadata.INDEX_ROUTING_PATH.getKey()), empty());
                     } else {
                         assertThat(setting.getAsList(IndexMetadata.INDEX_DIMENSIONS.getKey()), empty());
+                        assertThat(
+                            setting.getAsList(IndexMetadata.INDEX_ROUTING_PATH.getKey()),
+                            containsInAnyOrder("routing_field", "dimension")
+                        );
                     }
-                    assertThat(
-                        setting.getAsList(IndexMetadata.INDEX_ROUTING_PATH.getKey()),
-                        containsInAnyOrder("routing_field", "dimension")
-                    );
                 }
             });
         });


### PR DESCRIPTION
This is to reduce size of the cluster state by avoiding unnecessary/redundant index settings.

Addresses this review comment: https://github.com/elastic/elasticsearch/pull/132566#discussion_r2366143253