### PR TITLE
[8.19] [ML] Tolerate mixed types in datafeed stats sort (#135096)

### DIFF
--- a/docs/changelog/135096.yaml
+++ b/docs/changelog/135096.yaml
@@ -1,0 +1,5 @@
+pr: 135096
+summary: Tolerate mixed types in datafeed stats sort
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
@@ -698,6 +698,7 @@ public class JobResultsProvider {
             .setQuery(QueryBuilders.idsQuery().addIds(DatafeedTimingStats.documentId(jobId)))
             .addSort(
                 SortBuilders.fieldSort(DatafeedTimingStats.TOTAL_SEARCH_TIME_MS.getPreferredName())
+                    .setNumericType("double")
                     .unmappedType("double")
                     .order(SortOrder.DESC)
             );


### PR DESCRIPTION
Backports the following commits to 8.19:
 - [ML] Tolerate mixed types in datafeed stats sort (#135096)