### PR TITLE
[8.19][CI] Add extra coverage for adoptopenjdk17 for periodic builds

### DIFF
--- a/.buildkite/pipelines/periodic.template.yml
+++ b/.buildkite/pipelines/periodic.template.yml
@@ -45,6 +45,7 @@ steps:
           setup:
             ES_RUNTIME_JAVA:
               - openjdk17
+              - adoptopenjdk17
             GRADLE_TASK:
               - checkPart1
               - checkPart2
@@ -68,6 +69,7 @@ steps:
           setup:
             ES_RUNTIME_JAVA:
               - openjdk17
+              - adoptopenjdk17
             BWC_VERSION: $BWC_LIST
         agents:
           provider: gcp
@@ -87,6 +89,7 @@ steps:
             ES_RUNTIME_JAVA:
               - graalvm-ce17
               - openjdk17
+              - adoptopenjdk17
               - openjdk21
               - openjdk22
               - openjdk23
@@ -114,6 +117,7 @@ steps:
             ES_RUNTIME_JAVA:
               - graalvm-ce17
               - openjdk17
+              - adoptopenjdk17
               - openjdk21
               - openjdk22
               - openjdk23

--- a/.buildkite/pipelines/periodic.yml
+++ b/.buildkite/pipelines/periodic.yml
@@ -768,6 +768,7 @@ steps:
           setup:
             ES_RUNTIME_JAVA:
               - openjdk17
+              - adoptopenjdk17
             GRADLE_TASK:
               - checkPart1
               - checkPart2
@@ -791,6 +792,7 @@ steps:
           setup:
             ES_RUNTIME_JAVA:
               - openjdk17
+              - adoptopenjdk17
             BWC_VERSION: ["7.17.30", "8.18.8", "8.19.5"]
         agents:
           provider: gcp
@@ -810,6 +812,7 @@ steps:
             ES_RUNTIME_JAVA:
               - graalvm-ce17
               - openjdk17
+              - adoptopenjdk17
               - openjdk21
               - openjdk22
               - openjdk23
@@ -837,6 +840,7 @@ steps:
             ES_RUNTIME_JAVA:
               - graalvm-ce17
               - openjdk17
+              - adoptopenjdk17
               - openjdk21
               - openjdk22
               - openjdk23

--- a/.ci/matrix-runtime-javas-fips.yml
+++ b/.ci/matrix-runtime-javas-fips.yml
@@ -3,3 +3,4 @@
 
 ES_RUNTIME_JAVA:
   - openjdk17
+  - adoptopenjdk17

--- a/.ci/matrix-runtime-javas.yml
+++ b/.ci/matrix-runtime-javas.yml
@@ -3,10 +3,11 @@
 
 # This axis of the build matrix represents the versions of Java on
 # which Elasticsearch will be tested.  Valid Java versions are 'java'
-# or 'openjdk' followed by the major release number.
+# 'openjdk' or `adoptopenjdk` followed by the major release number.
 
 ES_RUNTIME_JAVA:
   - graalvm-ce17
+  - adoptopenjdk17
   - openjdk17
   - openjdk18
   - openjdk19


### PR DESCRIPTION
- Due to a bug in openjdk17 we are moving our coverage to use adoptjdk17 for ubuntu2404
- Adding adoptjdk17 to the matrix files results is required for have adoptjdk17 installed on our ci images
- The additional coverage is temporally and we will remove opendjdk17 coverage will be removed once newer ci images are available.