### PR TITLE
OTLP: remove feature flag

### DIFF
--- a/docs/changelog/135401.yaml
+++ b/docs/changelog/135401.yaml
@@ -1,0 +1,5 @@
+pr: 135401
+summary: "OTLP: remove feature flag"
+area: TSDB
+type: enhancement
+issues: []

--- a/docs/changelog/135401.yaml
+++ b/docs/changelog/135401.yaml
@@ -1,5 +1,5 @@
 pr: 135401
-summary: "OTLP: remove feature flag"
+summary: "Adds an OTLP metrics endpoint (`_otlp/v1/metrics`) as tech preview"
 area: TSDB
 type: enhancement
 issues: []

--- a/x-pack/plugin/otel-data/src/javaRestTest/java/org/elasticsearch/xpack/oteldata/otlp/OTLPMetricsIndexingRestIT.java
+++ b/x-pack/plugin/otel-data/src/javaRestTest/java/org/elasticsearch/xpack/oteldata/otlp/OTLPMetricsIndexingRestIT.java
@@ -35,7 +35,6 @@ import org.elasticsearch.common.hash.BufferedMurmur3Hasher;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.rest.ESRestTestCase;
@@ -108,13 +107,6 @@ public class OTLPMetricsIndexingRestIT extends ESRestTestCase {
             )
             .build();
         assertBusy(() -> assertOK(client().performRequest(new Request("GET", "_index_template/metrics-otel@template"))));
-        boolean otlpEndpointEnabled = false;
-        try {
-            otlpEndpointEnabled = RestStatus.isSuccessful(
-                client().performRequest(new Request("POST", "/_otlp/v1/metrics")).getStatusLine().getStatusCode()
-            );
-        } catch (Exception ignore) {}
-        assumeTrue("Requires otlp_metrics feature flag to be enabled", otlpEndpointEnabled);
     }
 
     @Override

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/OTelPlugin.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/OTelPlugin.java
@@ -19,7 +19,6 @@ import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
-import org.elasticsearch.common.util.FeatureFlag;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.Plugin;
@@ -48,7 +47,6 @@ public class OTelPlugin extends Plugin implements ActionPlugin {
 
     private static final Logger logger = LogManager.getLogger(OTelPlugin.class);
 
-    private static final boolean OTLP_METRICS_ENABLED = new FeatureFlag("otlp_metrics").isEnabled();
     private final SetOnce<OTelIndexTemplateRegistry> registry = new SetOnce<>();
     private final boolean enabled;
 
@@ -68,11 +66,7 @@ public class OTelPlugin extends Plugin implements ActionPlugin {
         Supplier<DiscoveryNodes> nodesInCluster,
         Predicate<NodeFeature> clusterSupportsFeature
     ) {
-        if (OTLP_METRICS_ENABLED) {
-            return List.of(new OTLPMetricsRestAction());
-        } else {
-            return List.of();
-        }
+        return List.of(new OTLPMetricsRestAction());
     }
 
     @Override
@@ -103,10 +97,6 @@ public class OTelPlugin extends Plugin implements ActionPlugin {
 
     @Override
     public Collection<ActionHandler> getActions() {
-        if (OTLP_METRICS_ENABLED) {
-            return List.of(new ActionHandler(OTLPMetricsTransportAction.TYPE, OTLPMetricsTransportAction.class));
-        } else {
-            return List.of();
-        }
+        return List.of(new ActionHandler(OTLPMetricsTransportAction.TYPE, OTLPMetricsTransportAction.class));
     }
 }


### PR DESCRIPTION
Removes the feature flag for the OTLP metrics endpoint. This will make it available as tech preview in 9.2