### PR TITLE
[9.1] [CI] Handle git snapshot BWC versions correctly when calculating jdk fallback (#135399)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionDownloadPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionDownloadPlugin.java
@@ -113,6 +113,9 @@ public class InternalDistributionDownloadPlugin implements Plugin<Project> {
             String versionProperty = System.getProperty("tests.bwc.main.version");
             // We use this phony version as a placeholder for the real version
             if (distribution.getVersion().equals("0.0.0")) {
+                if (versionProperty == null) {
+                    throw new GradleException("System property 'tests.bwc.main.version' expected for building bwc version.");
+                }
                 BwcVersions.UnreleasedVersionInfo unreleasedVersionInfo = new BwcVersions.UnreleasedVersionInfo(
                     Version.fromString(versionProperty),
                     "main",

--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/TestClustersPluginFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/TestClustersPluginFuncTest.groovy
@@ -250,7 +250,7 @@ class TestClustersPluginFuncTest extends AbstractGradleFuncTest {
 
         buildFile << """
             testClusters {
-              myCluster {
+              myCluster1 {
                 testDistribution = 'default'
                 version = '8.10.4'
               }

--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/TestClustersPluginFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/TestClustersPluginFuncTest.groovy
@@ -250,7 +250,7 @@ class TestClustersPluginFuncTest extends AbstractGradleFuncTest {
 
         buildFile << """
             testClusters {
-              myCluster1 {
+              myCluster {
                 testDistribution = 'default'
                 version = '8.10.4'
               }

--- a/build-tools/src/main/java/org/elasticsearch/gradle/util/OsUtils.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/util/OsUtils.java
@@ -38,7 +38,7 @@ public final class OsUtils {
       * This method returns true if the given version of the JDK is known to be incompatible
       */
     public static boolean jdkIsIncompatibleWithOS(Version version) {
-        return version.onOrBefore("8.10.4") && isUbuntu2404OrLater();
+        return version.after("0.0.0") && version.onOrBefore("8.10.4") && isUbuntu2404OrLater();
     }
 
     private static boolean isUbuntu2404OrLater() {

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalClusterFactory.java
@@ -82,7 +82,7 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
     private static final String ENABLE_DEBUG_JVM_ARGS = "-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=";
     private static final String ENTITLEMENT_POLICY_YAML = "entitlement-policy.yaml";
     private static final String PLUGIN_DESCRIPTOR_PROPERTIES = "plugin-descriptor.properties";
-    public static final String DISTRO_WITH_JDK_LOWER_21 = "8.11.0";
+    public static final String FIRST_DISTRO_WITH_JDK_21 = "8.11.0";
 
     private final DistributionResolver distributionResolver;
 
@@ -869,7 +869,7 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
         private Map<String, String> getEnvironmentVariables() {
             Map<String, String> environment = new HashMap<>(spec.resolveEnvironment());
             String esFallbackJavaHome = System.getenv("ES_FALLBACK_JAVA_HOME");
-            if (spec.getVersion().before(DISTRO_WITH_JDK_LOWER_21) && esFallbackJavaHome != null && esFallbackJavaHome.isEmpty() == false) {
+            if (jdkIsIncompatible(spec.getVersion()) && esFallbackJavaHome != null && esFallbackJavaHome.isEmpty() == false) {
                 environment.put("ES_JAVA_HOME", esFallbackJavaHome);
             }
             environment.put("ES_PATH_CONF", configDir.toString());
@@ -920,6 +920,10 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
             environment.put("CLI_JAVA_OPTS", cliJavaOpts);
 
             return environment;
+        }
+
+        private boolean jdkIsIncompatible(Version version) {
+            return version.after("0.0.0") && version.before(FIRST_DISTRO_WITH_JDK_21);
         }
 
         private record ReplacementKey(String key, String fallback) {


### PR DESCRIPTION
Backports the following commits to 9.1:
 - [CI] Handle git snapshot BWC versions correctly when calculating jdk fallback (#135399)