### PR TITLE
[9.0] Fixes testSnapshotShutdownProgressTracker (#134926)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotShutdownIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotShutdownIT.java
@@ -488,6 +488,7 @@ public class SnapshotShutdownIT extends AbstractSnapshotIntegTestCase {
         final var otherNode = internalCluster().startDataOnlyNode();
         final var otherIndex = randomIdentifier();
         createIndexWithContent(otherIndex, indexSettings(numShards, 0).put(REQUIRE_NODE_NAME_SETTING, otherNode).build());
+        indexAllShardsToAnEqualOrGreaterMinimumSize(otherIndex, ByteSizeValue.of(2, ByteSizeUnit.KB).getBytes());
         blockDataNode(repoName, otherNode);
 
         final var nodeForRemoval = internalCluster().startDataOnlyNode(
@@ -498,6 +499,7 @@ public class SnapshotShutdownIT extends AbstractSnapshotIntegTestCase {
         final var indexName = randomIdentifier();
         createIndexWithContent(indexName, indexSettings(numShards, 0).put(REQUIRE_NODE_NAME_SETTING, nodeForRemoval).build());
         indexAllShardsToAnEqualOrGreaterMinimumSize(indexName, ByteSizeValue.of(2, ByteSizeUnit.KB).getBytes());
+        logger.info("---> nodeForRemovalId: " + nodeForRemovalId + ", numShards: " + numShards);
 
         // Start the snapshot with blocking in place on the data node not to allow shard snapshots to finish yet.
         final var clusterService = internalCluster().getCurrentMasterNodeInstance(ClusterService.class);
@@ -507,7 +509,21 @@ public class SnapshotShutdownIT extends AbstractSnapshotIntegTestCase {
 
         waitForBlock(otherNode, repoName);
 
-        logger.info("---> nodeForRemovalId: " + nodeForRemovalId + ", numShards: " + numShards);
+        // Block on the master when a shard snapshot request comes in, until we can verify that the Tracker saw the outgoing request.
+        final CountDownLatch snapshotStatusUpdateLatch = new CountDownLatch(1);
+        final var masterTransportService = MockTransportService.getInstance(internalCluster().getMasterName());
+        masterTransportService.addRequestHandlingBehavior(
+            SnapshotsService.UPDATE_SNAPSHOT_STATUS_ACTION_NAME,
+            (handler, request, channel, task) -> masterTransportService.getThreadPool().generic().execute(() -> {
+                safeAwait(snapshotStatusUpdateLatch);
+                try {
+                    handler.messageReceived(request, channel, task);
+                } catch (Exception e) {
+                    fail(e);
+                }
+            })
+        );
+
         mockLog.addExpectation(
             new MockLog.SeenEventExpectation(
                 "SnapshotShutdownProgressTracker start log message",
@@ -552,21 +568,6 @@ public class SnapshotShutdownIT extends AbstractSnapshotIntegTestCase {
         // Check that the SnapshotShutdownProgressTracker is tracking the active (not yet paused) shard snapshots.
         mockLog.awaitAllExpectationsMatched();
         resetMockLog();
-
-        // Block on the master when a shard snapshot request comes in, until we can verify that the Tracker saw the outgoing request.
-        final CountDownLatch snapshotStatusUpdateLatch = new CountDownLatch(1);
-        final var masterTransportService = MockTransportService.getInstance(internalCluster().getMasterName());
-        masterTransportService.addRequestHandlingBehavior(
-            SnapshotsService.UPDATE_SNAPSHOT_STATUS_ACTION_NAME,
-            (handler, request, channel, task) -> masterTransportService.getThreadPool().generic().execute(() -> {
-                safeAwait(snapshotStatusUpdateLatch);
-                try {
-                    handler.messageReceived(request, channel, task);
-                } catch (Exception e) {
-                    fail(e);
-                }
-            })
-        );
 
         mockLog.addExpectation(
             new MockLog.SeenEventExpectation(


### PR DESCRIPTION
Backports https://github.com/elastic/elasticsearch/pull/134926 to `9.0`
---

I was able to reproduce the error by following the steps outlined by @JeremyDahlgren [here](https://github.com/elastic/elasticsearch/issues/134620#issuecomment-3310130797)

The error occurs due to the following sequence of events:

1. One of the snapshot threads has a sleep when executing snapshot tasks
2. The other is not delayed, so it will get blocked in the repository to allow the test to get to the `putShutdownForRemovalMetadata()` call
3. After the delays the first thread processes the other snapshot tasks, which are now paused, which throws a `PausedSnapshotException`, and then immediately notifies the master with the failure
4. The first four `SnapshotShutdownProgressTracker` log messages are verified in the test and then the `masterTransportService.addRequestHandlingBehavior()` is called to block the notifications
5. The repo is unblocked on the `nodeForRemoval`, but by this time it is too late and one or more updates have already been sent, possibly leaving only the single blocked shard, causing the assertion at 581 to fail

The proposed change:
1. Ensures that there are `n` shards on `otherNode` with data. At the moment, there is only 1.
2. I have reordered the blocking on the master node to come earlier. This is so we are always capturing the notifications back to the master, either by the snapshot thread being blocked, or if there was some delay on a thread due to other concurrent scheduling. 

A full explanation of the changes can be found [here](https://github.com/elastic/elasticsearch/issues/134620#issuecomment-3310130797)

---
#### Testing

- Having been able to reproducible make the test fail, it now succeeds 100 times in a row
- The original gradle command `./gradlew ":server:internalClusterTest" --tests "org.elasticsearch.snapshots.SnapshotShutdownIT.testSnapshotShutdownProgressTracker" -Dtests.seed=C44FB8C3BA8AC78E -Dtests.locale=dz -Dtests.timezone=Australia/Queensland -Druntime.java=23` succeeds
- CI passes


<!--
Addresses a mocklog assertion inside the `testSnapshotShutdownProgressTracker`. 

On occasion, some shards enter the state `PAUSED_FOR_NODE_REMOVAL` *before* this mocklog assertion, and so asserting on a log statement that includes all `numShards` in one line is incorrect. I have modified it to wait for all shards to *eventually* be paused. 

This is explained further by the sample log lines below.

On a successful test run:
```
// There are 6 shards

[2025-09-18T12:10:32,800][INFO ][o.e.s.SnapshotShutdownProgressTracker][node_s4][generic][T#5] 
Current active shard snapshot stats on data node [Ohs6ibUPRpasAQU55gSrjw]. Node shutdown cluster 
state update received at [54538210 millis]. Finished signalling shard snapshots to pause at [54538210 millis]. 
Number shard snapshots running [6]. 
Number shard snapshots waiting for master node reply to status update request [0] 
Shard snapshot completion stats since shutdown began: Done [0]; Failed [0]; Aborted [0]; Paused [0]

...

[2025-09-18T12:10:33,211][INFO ][o.e.s.SnapshotShutdownProgressTracker][node_s4][generic][T#2] 
Current active shard snapshot stats on data node [Ohs6ibUPRpasAQU55gSrjw]. Node shutdown cluster 
state update received at [54538210 millis]. Finished signalling shard snapshots to pause at [54538210 millis]. 
Number shard snapshots running [0]. 
Number shard snapshots waiting for master node reply to status update request [6] 
Shard snapshot completion stats since shutdown began: Done [0]; Failed [0]; Aborted [0]; Paused [6]

```

Note that on a successful run, *all* six shards were paused at the same time, and this is what the mocklog assertion was expecting. However, eventually, all six shards end up paused.

On a failed run:
```
// There are 8 shards

[2025-09-18T12:10:45,954][INFO ][o.e.s.SnapshotShutdownProgressTracker][node_s4][generic][T#5] 
Current active shard snapshot stats on data node [Ohs6ibUPRpasAQU55gSrjw]. Node shutdown cluster 
state update received at [54551358 millis]. Finished signalling shard snapshots to pause at [54551358 millis]. 
Number shard snapshots running [1]. 
Number shard snapshots waiting for master node reply to status update request [0] 
Shard snapshot completion stats since shutdown began: Done [0]; Failed [0]; Aborted [0]; Paused [7]

[2025-09-18T12:10:46,360][INFO ][o.e.s.SnapshotShutdownProgressTracker][node_s4][generic][T#3] 
Current active shard snapshot stats on data node [Ohs6ibUPRpasAQU55gSrjw]. Node shutdown cluster 
state update received at [54551358 millis]. Finished signalling shard snapshots to pause at [54551358 millis]. 
Number shard snapshots running [0]. 
Number shard snapshots waiting for master node reply to status update request [1] 
Shard snapshot completion stats since shutdown began: Done [0]; Failed [0]; Aborted [0]; Paused [8]
```

Note that this time, some shards were *already* paused before we start asserting on this log statement, due to a race condition alluded to [here](https://github.com/elastic/elasticsearch/blob/main/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotShutdownIT.java#L538-L539). Therefore, the mocklog assertion that expected to see `Number shard snapshots waiting for master node reply to status update request [8] ` would see `Number shard snapshots waiting for master node reply to status update request [7] ` earlier in the code, and `Number shard snapshots waiting for master node reply to status update request [1] ` now, which is failing.

However, the same as for the successful case, eventually all `numShards` end up paused, and so it makes sense to modify the mocklog assertion to assert on this instead. If for whatever reason not all shards get paused, then the test should rightly fail. We should not count it as a failure however if the shards get paused incrementally. 


---

### Testing

Running:
```
./gradlew ":server:internalClusterTest" --tests "org.elasticsearch.snapshots.SnapshotShutdownIT.testSnapshotShutdownProgressTracker" -Dtests.seed=6518B19EFC01D7C7 -Dtests.locale=mgh-Latn-MZ -Dtests.timezone=Europe/Sofia -Druntime.java=24 -Dtests.iters=10 --rerun
```
before the fix resulted in a 60% fail rate.  

After the fix I ran it for 100 times and it succeeded 100%.

---

-->




Resolves: #134620

