### PR TITLE
[9.0] [CI] Handle caching bwc dependencies more gracefully (#135417)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -338,7 +338,15 @@ allprojects {
   tasks.register('resolveAllDependencies', ResolveAllDependencies) {
     def ignoredPrefixes = [DistributionDownloadPlugin.ES_DISTRO_CONFIG_PREFIX, "jdbcDriver"]
     configs = project.configurations.matching { config -> ignoredPrefixes.any { config.name.startsWith(it) } == false }
-    resolveJavaToolChain = true
+
+    if (project.path == ':') {
+      resolveJavaToolChain = true
+    }
+    // ensure we have best possible caching of bwc builds
+    if(project.path.startsWith(":distribution:bwc:")) {
+      dependsOn project.tasks.matching { it.name == 'buildBwcLinuxTar' }
+    }
+
     if (project.path.contains("fixture")) {
       dependsOn tasks.withType(ComposePull)
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[CI] Handle caching bwc dependencies more gracefully (#135417)](https://github.com/elastic/elasticsearch/pull/135417)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)