### PR TITLE
Properly guard assertion with feature flag

### DIFF
--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/TSDBIndexingIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/TSDBIndexingIT.java
@@ -716,10 +716,7 @@ public class TSDBIndexingIT extends ESSingleNodeTestCase {
                 containsInAnyOrder("metricset", "labels.*", "k8s.pod.name")
             );
         } else {
-            assertThat(
-                getSetting(dataStreamName, IndexMetadata.INDEX_ROUTING_PATH),
-                containsInAnyOrder("metricset")
-            );
+            assertThat(getSetting(dataStreamName, IndexMetadata.INDEX_ROUTING_PATH), containsInAnyOrder("metricset"));
         }
         assertThat(getSetting(dataStreamName, IndexMetadata.INDEX_DIMENSIONS), empty());
 

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/TSDBIndexingIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/TSDBIndexingIT.java
@@ -710,10 +710,17 @@ public class TSDBIndexingIT extends ESSingleNodeTestCase {
             }
             """, XContentType.JSON);
         assertAcked(client().execute(TransportPutMappingAction.TYPE, putMappingRequest).actionGet());
-        assertThat(
-            getSetting(dataStreamName, IndexMetadata.INDEX_ROUTING_PATH),
-            containsInAnyOrder("metricset", "labels.*", "k8s.pod.name")
-        );
+        if (INDEX_DIMENSIONS_TSID_OPTIMIZATION_FEATURE_FLAG) {
+            assertThat(
+                getSetting(dataStreamName, IndexMetadata.INDEX_ROUTING_PATH),
+                containsInAnyOrder("metricset", "labels.*", "k8s.pod.name")
+            );
+        } else {
+            assertThat(
+                getSetting(dataStreamName, IndexMetadata.INDEX_ROUTING_PATH),
+                containsInAnyOrder("metricset")
+            );
+        }
         assertThat(getSetting(dataStreamName, IndexMetadata.INDEX_DIMENSIONS), empty());
 
         indexWithPodNames(dataStreamName, Instant.now(), Map.of(), "dog", "cat");


### PR DESCRIPTION
Fixes a test case that didn't properly guard an assertion with a feature flag.

This made the release tests fail that set `build.snapshot=false`