### PR TITLE
[9.1] Fix DiscoveryDisruptionIT.testElectMasterWithLatestVersion (#135396)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/DiscoveryDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/DiscoveryDisruptionIT.java
@@ -147,7 +147,8 @@ public class DiscoveryDisruptionIT extends AbstractDisruptionTestCase {
         isolateAllNodes.stopDisrupting();
 
         awaitMasterNode();
-        final ClusterState state = clusterAdmin().prepareState(TEST_REQUEST_TIMEOUT).get().getState();
+        final var masterNodeAdminClient = client(internalCluster().getMasterName()).admin().cluster();
+        final ClusterState state = masterNodeAdminClient.prepareState(TEST_REQUEST_TIMEOUT).get().getState();
         if (state.metadata().getProject().hasIndex("test") == false) {
             fail("index 'test' was lost. current cluster state: " + state);
         }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Fix DiscoveryDisruptionIT.testElectMasterWithLatestVersion (#135396)](https://github.com/elastic/elasticsearch/pull/135396)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)