### PR TITLE
[8.18] [ML] Gracefully shutdown model deployment when node is removed from assignment routing (#134673)

### DIFF
--- a/docs/changelog/134673.yaml
+++ b/docs/changelog/134673.yaml
@@ -1,0 +1,6 @@
+pr: 134673
+summary: Gracefully shutdown model deployment when node is removed from assignment
+  routing
+area: Machine Learning
+type: bug
+issues: []


### PR DESCRIPTION
Backports the following commits to 8.18:
 - [ML] Gracefully shutdown model deployment when node is removed from assignment routing (#134673)