### PR TITLE
Remove BulkVectorScorer implementations

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/BulkScorableByteVectorValues.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/BulkScorableByteVectorValues.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.index.codec.vectors;
 
+import org.apache.lucene.search.VectorScorer;
+
 import java.io.IOException;
 
 /**
@@ -16,14 +18,14 @@ import java.io.IOException;
  */
 public interface BulkScorableByteVectorValues extends BulkScorableVectorValues {
     /**
-     * Returns a {@link BulkVectorScorer} that can score against the provided {@code target} vector.
+     * Returns a {@link VectorScorer} that can score against the provided {@code target} vector.
      * It will score to the fastest speed possible, potentially sacrificing some fidelity.
      */
-    BulkVectorScorer scorer(byte[] target) throws IOException;
+    VectorScorer scorer(byte[] target) throws IOException;
 
     /**
-     * Returns a {@link BulkVectorScorer} that can rescore against the provided {@code target} vector.
+     * Returns a {@link VectorScorer} that can rescore against the provided {@code target} vector.
      * It will score to the highest fidelity possible, potentially sacrificing some speed.
      */
-    BulkVectorScorer rescorer(byte[] target) throws IOException;
+    VectorScorer rescorer(byte[] target) throws IOException;
 }

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/BulkScorableFloatVectorValues.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/BulkScorableFloatVectorValues.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.index.codec.vectors;
 
+import org.apache.lucene.search.VectorScorer;
+
 import java.io.IOException;
 
 /**
@@ -16,14 +18,14 @@ import java.io.IOException;
  */
 public interface BulkScorableFloatVectorValues extends BulkScorableVectorValues {
     /**
-     * Returns a {@link BulkVectorScorer} that can score against the provided {@code target} vector.
+     * Returns a {@link VectorScorer} that can score against the provided {@code target} vector.
      * It will score to the fastest speed possible, potentially sacrificing some fidelity.
      */
-    BulkVectorScorer scorer(float[] target) throws IOException;
+    VectorScorer scorer(float[] target) throws IOException;
 
     /**
-     * Returns a {@link BulkVectorScorer} that can rescore against the provided {@code target} vector.
+     * Returns a {@link VectorScorer} that can rescore against the provided {@code target} vector.
      * It will score to the highest fidelity possible, potentially sacrificing some speed.
      */
-    BulkVectorScorer rescorer(float[] target) throws IOException;
+    VectorScorer rescorer(float[] target) throws IOException;
 }

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/BulkScorableVectorValues.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/BulkScorableVectorValues.java
@@ -9,30 +9,7 @@
 
 package org.elasticsearch.index.codec.vectors;
 
-import org.apache.lucene.search.DocAndFloatFeatureBuffer;
-import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.search.VectorScorer;
-import org.apache.lucene.util.Bits;
-
-import java.io.IOException;
-
 /**
  * Extension to {@link org.apache.lucene.search.VectorScorer} that can score in bulk
  */
-public interface BulkScorableVectorValues {
-    interface BulkVectorScorer extends VectorScorer {
-
-        /**
-         * Returns a {@link Bulk} scorer that can score in bulk the provided {@code matchingDocs}.
-         */
-        Bulk bulk(DocIdSetIterator matchingDocs) throws IOException;
-
-        interface Bulk {
-            /**
-             * Scores up to {@code nextCount} docs in the provided {@code buffer}.
-             * Returns the maxScore of docs scored.
-             */
-            float nextDocsAndScores(int nextCount, Bits liveDocs, DocAndFloatFeatureBuffer buffer) throws IOException;
-        }
-    }
-}
+public interface BulkScorableVectorValues {}

--- a/server/src/main/java/org/elasticsearch/search/vectors/RescoreKnnVectorQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/RescoreKnnVectorQuery.java
@@ -27,8 +27,8 @@ import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.VectorScorer;
 import org.elasticsearch.index.codec.vectors.BulkScorableFloatVectorValues;
-import org.elasticsearch.index.codec.vectors.BulkScorableVectorValues;
 import org.elasticsearch.search.profile.query.QueryProfiler;
 
 import java.io.IOException;
@@ -317,9 +317,9 @@ public abstract class RescoreKnnVectorQuery extends Query implements QueryProfil
             List<ScoreDoc> queue,
             DocIdSetIterator filterIterator
         ) throws IOException {
-            BulkScorableVectorValues.BulkVectorScorer vectorReScorer = rescorableVectorValues.rescorer(floatTarget);
+            VectorScorer vectorReScorer = rescorableVectorValues.rescorer(floatTarget);
             var iterator = vectorReScorer.iterator();
-            BulkScorableVectorValues.BulkVectorScorer.Bulk bulkScorer = vectorReScorer.bulk(filterIterator);
+            VectorScorer.Bulk bulkScorer = vectorReScorer.bulk(filterIterator);
             DocAndFloatFeatureBuffer buffer = new DocAndFloatFeatureBuffer();
             while (iterator.docID() != DocIdSetIterator.NO_MORE_DOCS) {
                 // iterator already takes live docs into account


### PR DESCRIPTION
There's now bulk scoring methods in Lucene