### PR TITLE
Respect include/exclude patterns when applying `exclude_vectors`

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/240_source_synthetic_dense_vectors.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/240_source_synthetic_dense_vectors.yml
@@ -153,7 +153,6 @@ setup:
         index: test
         body:
           _source:
-            exclude_vectors: false
             includes: nested.vector
           sort: ["name"]
 

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/250_source_synthetic_sparse_vectors.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/250_source_synthetic_sparse_vectors.yml
@@ -165,7 +165,6 @@ setup:
         index: test
         body:
           _source:
-            exclude_vectors: false
             includes: nested.emb
           sort: ["name"]
 
@@ -173,7 +172,7 @@ setup:
   - length:          { hits.hits.0._source: 0}
 
   - match:           { hits.hits.1._id: "2"}
-  - length:          { hits.hits.3._source: 1 }
+  - length:          { hits.hits.1._source: 1 }
   - length:          { hits.hits.1._source.nested: 3 }
   - exists:            hits.hits.1._source.nested.0.emb
   - not_exists:        hits.hits.1._source.nested.0.paragraph_id
@@ -194,6 +193,62 @@ setup:
   - exists:            hits.hits.3._source.nested.1.emb
   - length:          { hits.hits.3._source.nested.1.emb: 1 }
   - not_exists:        hits.hits.3._source.nested.1.paragraph_id
+
+  - do:
+      search:
+        index: test
+        body:
+          _source:
+            exclude_vectors: true
+            includes: nested.emb
+          sort: ["name"]
+
+  - match:           { hits.hits.0._id: "1"}
+  - length:          { hits.hits.0._source: 0}
+
+  - match:           { hits.hits.1._id: "2"}
+  - length:          { hits.hits.1._source: 1 }
+  - length:          { hits.hits.1._source.nested: 3 }
+  - exists:            hits.hits.1._source.nested.0.emb
+  - not_exists:        hits.hits.1._source.nested.0.paragraph_id
+  - exists:            hits.hits.1._source.nested.1.emb
+  - not_exists:        hits.hits.1._source.nested.1.paragraph_id
+  - exists:            hits.hits.1._source.nested.2.emb
+  - not_exists:        hits.hits.1._source.nested.2.paragraph_id
+
+  - match:           { hits.hits.2._id: "3" }
+  - length:          { hits.hits.2._source: 0}
+
+  - match:           { hits.hits.3._id: "4" }
+  - length:          { hits.hits.3._source: 1 }
+  - length:          { hits.hits.3._source.nested: 2 }
+  - exists:            hits.hits.3._source.nested.0.emb
+  - length:          { hits.hits.3._source.nested.0.emb: 3 }
+  - not_exists:        hits.hits.3._source.nested.0.paragraph_id
+  - exists:            hits.hits.3._source.nested.1.emb
+  - length:          { hits.hits.3._source.nested.1.emb: 1 }
+  - not_exists:        hits.hits.3._source.nested.1.paragraph_id
+
+  - do:
+      search:
+        index: test
+        body:
+          _source:
+            exclude_vectors: true
+            includes: nested.emb
+            excludes: nested*
+          sort: ["name"]
+
+  - match:           { hits.hits.0._id: "1"}
+  - length:          { hits.hits.0._source: 0}
+
+  - match:           { hits.hits.1._id: "2"}
+  - length:          { hits.hits.1._source: 0 }
+  - match:           { hits.hits.2._id: "3" }
+  - length:          { hits.hits.2._source: 0}
+
+  - match:           { hits.hits.3._id: "4" }
+  - length:          { hits.hits.3._source: 0 }
 
   - do:
       headers:

--- a/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
+++ b/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
@@ -458,8 +458,14 @@ public final class ShardGetService extends AbstractIndexShardComponent {
             )
             : null;
 
+        SourceFilter filter = fetchSourceContext != null ? fetchSourceContext.filter() : null;
+
         List<String> lateExcludes = new ArrayList<>();
         var excludes = mappingLookup.getFullNameToFieldType().values().stream().filter(MappedFieldType::isVectorEmbedding).filter(f -> {
+            // Keep the vector fields that are explicitly included and not explicitly excluded
+            if (filter != null && filter.isExplicitlyIncluded(f.name())) {
+                return filter.isPathFiltered(f.name(), false);
+            }
             // Exclude the field specified by the `fields` option
             if (fetchFieldsAut != null && fetchFieldsAut.run(f.name())) {
                 lateExcludes.add(f.name());

--- a/server/src/main/java/org/elasticsearch/search/lookup/SourceFilter.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/SourceFilter.java
@@ -69,6 +69,26 @@ public final class SourceFilter {
     }
 
     /**
+     * Checks if the given path matches at least one explicitly defined include pattern.
+     * <p>
+     * If no include patterns are defined, this method always returns {@code false}.
+     *
+     * @param fullPath the full path to evaluate
+     * @return {@code true} if the path matches any explicitly defined include pattern,
+     *         {@code false} otherwise
+     */
+    public boolean isExplicitlyIncluded(String fullPath) {
+        if (includes.length == 0) {
+            return false;
+        }
+        if (includeAut == null) {
+            includeAut = XContentMapValues.compileAutomaton(includes, new CharacterRunAutomaton(Automata.makeAnyString()));
+        }
+        int state = step(includeAut, fullPath, 0);
+        return state != -1 && includeAut.isAccept(state);
+    }
+
+    /**
      * Determines whether the given full path should be filtered out.
      *
      * @param fullPath The full path to evaluate.
@@ -77,7 +97,7 @@ public final class SourceFilter {
      */
     public boolean isPathFiltered(String fullPath, boolean isObject) {
         final boolean included;
-        if (includes != null) {
+        if (includes.length > 0) {
             if (includeAut == null) {
                 includeAut = XContentMapValues.compileAutomaton(includes, new CharacterRunAutomaton(Automata.makeAnyString()));
             }
@@ -87,7 +107,7 @@ public final class SourceFilter {
             included = true;
         }
 
-        if (excludes != null) {
+        if (excludes.length > 0) {
             if (excludeAut == null) {
                 excludeAut = XContentMapValues.compileAutomaton(excludes, new CharacterRunAutomaton(Automata.makeEmpty()));
             }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rank_vectors/rank_vectors_synthetic_vectors.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/rank_vectors/rank_vectors_synthetic_vectors.yml
@@ -154,7 +154,6 @@ setup:
         index: test
         body:
           _source:
-            exclude_vectors: false
             includes: nested.vector
           sort: ["name"]
 


### PR DESCRIPTION
This change ensures that the `_source` `include` and `exclude` patterns are applied as exceptions when `exclude_vectors` is enabled.

Previously, `exclude_vectors` was enforced independently of any explicitly defined `include` or `exclude` rules.

With this update, queries like:

```json
{
  "_source": {
    "exclude_vectors": true,
    "includes": ["my_vector_field"]
  }
}
```
will correctly include my_vector_field, overriding the exclude_vectors parameter.