### PR TITLE
[8.17] Move the mapping update to a new index created upfront (#132581)

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_unsupported_types.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_unsupported_types.yml
@@ -107,6 +107,35 @@ setup:
             "some_doc": { "foo": "xy", "bar": 12 }
           }
 
+  - do:
+      indices.create:
+        index: test2
+        body:
+          settings:
+            number_of_shards: 5
+          mappings:
+            properties:
+              name:
+                type: keyword
+              nested:
+                type: nested
+              find_me:
+                type: long
+
+  - do:
+      bulk:
+        index: test2
+        refresh: true
+        body:
+          - { "index": { } }
+          - {
+            "find_me": 1,
+            "nested": {
+              "foo": 1,
+              "bar": "bar",
+              "baz": 1.9
+            }
+          }
 ---
 unsupported:
   - requires:
@@ -412,27 +441,12 @@ unsupported with sort:
 ---
 nested declared inline:
   - do:
-      bulk:
-        index: test
-        refresh: true
-        body:
-          - { "index": { } }
-          - {
-            "find_me": 1,
-            "nested": {
-              "foo": 1,
-              "bar": "bar",
-              "baz": 1.9
-            }
-          }
-
-  - do:
       allowed_warnings_regex:
         - "Field \\[.*\\] cannot be retrieved, it is unsupported or not indexed; returning null"
         - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
-          query: 'FROM test | WHERE find_me == 1 | KEEP n*'
+          query: 'FROM test2 | WHERE find_me == 1 | KEEP n*'
 
   # The `nested` field is not visible, nor are any of it's subfields.
   - match: { columns: [{name: name, type: keyword}] }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [Move the mapping update to a new index created upfront (#132581)](https://github.com/elastic/elasticsearch/pull/132581)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)