### PR TITLE
Fixing ReindexDatastreamIndexTransportActionIT.testTsdbStartEndSet to always provide index.routing_path

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -600,9 +600,6 @@ tests:
 - class: org.elasticsearch.test.rest.yaml.CcsCommonYamlTestSuiteIT
   method: test {p0=search/510_range_query_out_of_bounds/Test range query for half_float field with out of bounds upper limit}
   issue: https://github.com/elastic/elasticsearch/issues/135365
-- class: org.elasticsearch.xpack.migrate.action.ReindexDatastreamIndexTransportActionIT
-  method: testTsdbStartEndSet
-  issue: https://github.com/elastic/elasticsearch/issues/135366
 - class: org.elasticsearch.xpack.esql.session.SessionUtilsTests
   method: testFromPages
   issue: https://github.com/elastic/elasticsearch/issues/135377

--- a/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/ReindexDatastreamIndexTransportActionIT.java
+++ b/x-pack/plugin/migrate/src/internalClusterTest/java/org/elasticsearch/xpack/migrate/action/ReindexDatastreamIndexTransportActionIT.java
@@ -504,10 +504,7 @@ public class ReindexDatastreamIndexTransportActionIT extends ESIntegTestCase {
         """;
 
     public void testTsdbStartEndSet() throws Exception {
-        var templateSettings = Settings.builder().put("index.mode", "time_series");
-        if (randomBoolean()) {
-            templateSettings.put("index.routing_path", "metricset");
-        }
+        var templateSettings = Settings.builder().put("index.mode", "time_series").put("index.routing_path", "metricset");
         var mapping = new CompressedXContent(TSDB_MAPPING);
 
         // create template


### PR DESCRIPTION
As of #132566, `index.routing_path` is no longer optional for TSDB indices. This changes ReindexDatastreamIndexTransportActionIT.testTsdbStartEndSet to not randomly leave that unset.
Closes #135366