### PR TITLE
Use supplier in `validateForReservedState`

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/delete/TransportDeleteRepositoryAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/delete/TransportDeleteRepositoryAction.java
@@ -95,7 +95,7 @@ public class TransportDeleteRepositoryAction extends AcknowledgedTransportMaster
             ProjectStateRegistry.get(state).reservedStateMetadata(projectResolver.getProjectId()).values(),
             reservedStateHandlerName().get(),
             modifiedKeys(request),
-            request.toString()
+            request::toString
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/delete/TransportDeleteComposableIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/delete/TransportDeleteComposableIndexTemplateAction.java
@@ -99,7 +99,7 @@ public class TransportDeleteComposableIndexTemplateAction extends AcknowledgedTr
             ProjectStateRegistry.get(state).reservedStateMetadata(projectResolver.getProjectId()).values(),
             reservedStateHandlerName().get(),
             modifiedKeys(request),
-            request.toString()
+            request::toString
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutComponentTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutComponentTemplateAction.java
@@ -134,7 +134,7 @@ public class TransportPutComponentTemplateAction extends AcknowledgedTransportMa
             ProjectStateRegistry.get(state).reservedStateMetadata(projectResolver.getProjectId()).values(),
             reservedStateHandlerName().get(),
             modifiedKeys(request),
-            request.toString()
+            request::toString
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutComposableIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutComposableIndexTemplateAction.java
@@ -145,7 +145,7 @@ public class TransportPutComposableIndexTemplateAction extends AcknowledgedTrans
             ProjectStateRegistry.get(state).reservedStateMetadata(projectResolver.getProjectId()).values(),
             reservedStateHandlerName().get(),
             modifiedKeys(request),
-            request.toString()
+            request::toString
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/action/ingest/PutPipelineTransportAction.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/PutPipelineTransportAction.java
@@ -84,7 +84,7 @@ public class PutPipelineTransportAction extends AcknowledgedTransportMasterNodeA
             ProjectStateRegistry.get(state).reservedStateMetadata(projectResolver.getProjectId()).values(),
             reservedStateHandlerName().get(),
             modifiedKeys(request),
-            request.toString()
+            request::toString
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/support/ReservedStateAwareHandledTransportAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/ReservedStateAwareHandledTransportAction.java
@@ -53,7 +53,7 @@ public abstract class ReservedStateAwareHandledTransportAction<Request extends A
             clusterService.state().metadata().reservedStateMetadata().values(),
             reservedStateHandlerName().get(),
             modifiedKeys(request),
-            request.toString()
+            request::toString
         );
         doExecuteProtected(task, request, listener);
     }

--- a/server/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
@@ -143,7 +143,7 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
             state.metadata().reservedStateMetadata().values(),
             handlerName.get(),
             modifiedKeys(request),
-            request.toString()
+            request::toString
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/reservedstate/ActionWithReservedState.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/ActionWithReservedState.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import static org.elasticsearch.core.Strings.format;
 
@@ -53,13 +54,13 @@ public interface ActionWithReservedState<T> {
      * @param reservedStateMetadata the metadata to check
      * @param handlerName the name of the reserved state handler related to this implementation
      * @param modified the set of modified keys by the related request
-     * @param request a string representation of the request for error reporting purposes
+     * @param requestSupplier a supplier for a string representation of the request for error reporting purposes
      */
     default void validateForReservedState(
         Collection<ReservedStateMetadata> reservedStateMetadata,
         String handlerName,
         Set<String> modified,
-        String request
+        Supplier<String> requestSupplier
     ) {
         List<String> errors = new ArrayList<>();
 
@@ -72,7 +73,7 @@ public interface ActionWithReservedState<T> {
 
         if (errors.isEmpty() == false) {
             throw new IllegalArgumentException(
-                format("Failed to process request [%s] with errors: [%s]", request, String.join(", ", errors))
+                format("Failed to process request [%s] with errors: [%s]", requestSupplier.get(), String.join(", ", errors))
             );
         }
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/template/reservedstate/ReservedComposableIndexTemplateActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/template/reservedstate/ReservedComposableIndexTemplateActionTests.java
@@ -963,7 +963,7 @@ public class ReservedComposableIndexTemplateActionTests extends ESTestCase {
                     withReservedState.reservedStateMetadata(projectId).values(),
                     ReservedComposableIndexTemplateAction.NAME,
                     modifiedKeys,
-                    pr.name()
+                    pr::name
                 )
             ).getMessage()
         );
@@ -979,7 +979,7 @@ public class ReservedComposableIndexTemplateActionTests extends ESTestCase {
             withReservedState.reservedStateMetadata(projectId).values(),
             ReservedComposableIndexTemplateAction.NAME,
             modifiedKeysOK,
-            prOK.name()
+            prOK::name
         );
     }
 


### PR DESCRIPTION
We only use the request string in case the validation failed, but serializing the whole request class can be relatively expensive (e.g. if a component template has many mappings, the `CompressedXContent` needs to be converted to string). Therefore, it makes more sense to use a `Supplier` which only gets invoked when validation failed.