### PR TITLE
Fix logsdb rolling upgrade tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -588,12 +588,6 @@ tests:
 - class: org.elasticsearch.search.sort.FieldSortIT
   method: testSortMixedFieldTypes
   issue: https://github.com/elastic/elasticsearch/issues/129445
-- class: org.elasticsearch.upgrades.SyntheticSourceRollingUpgradeIT
-  method: testIndexing {upgradedNodes=3}
-  issue: https://github.com/elastic/elasticsearch/issues/135338
-- class: org.elasticsearch.upgrades.SyntheticSourceRollingUpgradeIT
-  method: testIndexing {upgradedNodes=2}
-  issue: https://github.com/elastic/elasticsearch/issues/135344
 - class: org.elasticsearch.xpack.esql.expression.function.scalar.score.DecayTests
   method: "testEvaluateInManyThreads {TestCase=<double>, <double>, <double>, <_source> #17}"
   issue: https://github.com/elastic/elasticsearch/issues/135357
@@ -606,45 +600,12 @@ tests:
 - class: org.elasticsearch.xpack.esql.session.SessionUtilsTests
   method: testFromPages
   issue: https://github.com/elastic/elasticsearch/issues/135377
-- class: org.elasticsearch.upgrades.LogsUsageRollingUpgradeIT
-  method: testUsage {upgradedNodes=3}
-  issue: https://github.com/elastic/elasticsearch/issues/135312
-- class: org.elasticsearch.upgrades.NoLogsUsageRollingUpgradeIT
-  method: testUsage {upgradedNodes=3}
-  issue: https://github.com/elastic/elasticsearch/issues/135316
-- class: org.elasticsearch.upgrades.NoLogsUsageRollingUpgradeIT
-  method: testUsage {upgradedNodes=2}
-  issue: https://github.com/elastic/elasticsearch/issues/135319
 - class: org.elasticsearch.xpack.esql.expression.function.scalar.score.DecayTests
   method: "testEvaluateBlockWithoutNulls {TestCase=<date_nanos>, <date_nanos>, <time_duration>, <_source> #12}"
   issue: https://github.com/elastic/elasticsearch/issues/135394
-- class: org.elasticsearch.upgrades.LogsdbIndexingRollingUpgradeIT
-  method: testIndexing {upgradedNodes=2}
-  issue: https://github.com/elastic/elasticsearch/issues/135327
-- class: org.elasticsearch.upgrades.LogsdbIndexingRollingUpgradeIT
-  method: testIndexing {upgradedNodes=3}
-  issue: https://github.com/elastic/elasticsearch/issues/135320
-- class: org.elasticsearch.upgrades.StandardToLogsDbIndexModeRollingUpgradeIT
-  method: testLogsIndexing {upgradedNodes=3}
-  issue: https://github.com/elastic/elasticsearch/issues/135315
-- class: org.elasticsearch.upgrades.StandardToLogsDbIndexModeRollingUpgradeIT
-  method: testLogsIndexing {upgradedNodes=2}
-  issue: https://github.com/elastic/elasticsearch/issues/135314
 - class: org.elasticsearch.xpack.esql.session.SessionUtilsTests
   method: testCheckPagesBelowSize
   issue: https://github.com/elastic/elasticsearch/issues/135398
-- class: org.elasticsearch.upgrades.TextRollingUpgradeIT
-  method: testIndexing {upgradedNodes=3}
-  issue: https://github.com/elastic/elasticsearch/issues/135237
-- class: org.elasticsearch.upgrades.MatchOnlyTextRollingUpgradeIT
-  method: testIndexing {upgradedNodes=3}
-  issue: https://github.com/elastic/elasticsearch/issues/135324
-- class: org.elasticsearch.upgrades.MatchOnlyTextRollingUpgradeIT
-  method: testIndexing {upgradedNodes=2}
-  issue: https://github.com/elastic/elasticsearch/issues/135325
-- class: org.elasticsearch.upgrades.TextRollingUpgradeIT
-  method: testIndexing {upgradedNodes=2}
-  issue: https://github.com/elastic/elasticsearch/issues/135238
 - class: org.elasticsearch.upgrades.DataStreamsUpgradeIT
   method: testDataStreamValidationDoesNotBreakUpgrade
   issue: https://github.com/elastic/elasticsearch/issues/135406
@@ -654,9 +615,6 @@ tests:
 - class: org.elasticsearch.upgrades.QueryableBuiltInRolesUpgradeIT
   method: testBuiltInRolesSyncedOnClusterUpgrade
   issue: https://github.com/elastic/elasticsearch/issues/135194
-- class: org.elasticsearch.upgrades.StandardToLogsDbIndexModeRollingUpgradeIT
-  method: testLogsIndexing {upgradedNodes=1}
-  issue: https://github.com/elastic/elasticsearch/issues/135313
 - class: org.elasticsearch.gradle.TestClustersPluginFuncTest
   method: override jdk usage via ES_JAVA_HOME for known jdk os incompatibilities
   issue: https://github.com/elastic/elasticsearch/issues/135413

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -51,6 +51,7 @@ public class MapperFeatures implements FeatureSpecification {
     static final NodeFeature PATTERN_TEXT = new NodeFeature("mapper.patterned_text");
     static final NodeFeature IGNORED_SOURCE_FIELDS_PER_ENTRY = new NodeFeature("mapper.ignored_source_fields_per_entry");
     public static final NodeFeature MULTI_FIELD_UNICODE_OPTIMISATION_FIX = new NodeFeature("mapper.multi_field.unicode_optimisation_fix");
+    static final NodeFeature PATTERN_TEXT_RENAME = new NodeFeature("mapper.pattern_text_rename");
 
     @Override
     public Set<NodeFeature> getTestFeatures() {
@@ -87,7 +88,8 @@ public class MapperFeatures implements FeatureSpecification {
             PATTERN_TEXT,
             IGNORED_SOURCE_FIELDS_PER_ENTRY,
             MULTI_FIELD_UNICODE_OPTIMISATION_FIX,
-            MATCH_ONLY_TEXT_BLOCK_LOADER_FIX
+            MATCH_ONLY_TEXT_BLOCK_LOADER_FIX,
+            PATTERN_TEXT_RENAME
         );
     }
 }

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/LogsUsageRollingUpgradeIT.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/LogsUsageRollingUpgradeIT.java
@@ -11,7 +11,9 @@ package org.elasticsearch.upgrades;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 
+import org.elasticsearch.Build;
 import org.elasticsearch.client.Request;
+import org.junit.Before;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -27,6 +29,13 @@ public class LogsUsageRollingUpgradeIT extends AbstractRollingUpgradeWithSecurit
 
     public LogsUsageRollingUpgradeIT(@Name("upgradedNodes") int upgradedNodes) {
         super(upgradedNodes);
+    }
+
+    @Before
+    public void checkFeatures() {
+        if (Build.current().isSnapshot()) {
+            assumeTrue("rename of pattern_text mapper", oldClusterHasFeature("mapper.pattern_text_rename"));
+        }
     }
 
     public void testUsage() throws Exception {

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/LogsdbIndexingRollingUpgradeIT.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/LogsdbIndexingRollingUpgradeIT.java
@@ -11,6 +11,7 @@ package org.elasticsearch.upgrades;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 
+import org.elasticsearch.Build;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
@@ -20,6 +21,7 @@ import org.elasticsearch.common.time.FormatNames;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.test.rest.ObjectPath;
 import org.elasticsearch.xcontent.XContentType;
+import org.junit.Before;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -72,6 +74,13 @@ public class LogsdbIndexingRollingUpgradeIT extends AbstractRollingUpgradeWithSe
 
     public LogsdbIndexingRollingUpgradeIT(@Name("upgradedNodes") int upgradedNodes) {
         super(upgradedNodes);
+    }
+
+    @Before
+    public void checkFeatures() {
+        if (Build.current().isSnapshot()) {
+            assumeTrue("rename of pattern_text mapper", oldClusterHasFeature("mapper.pattern_text_rename"));
+        }
     }
 
     public void testIndexing() throws Exception {

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MatchOnlyTextRollingUpgradeIT.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/MatchOnlyTextRollingUpgradeIT.java
@@ -11,6 +11,7 @@ package org.elasticsearch.upgrades;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 
+import org.elasticsearch.Build;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
@@ -21,6 +22,7 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.index.mapper.MapperFeatures;
 import org.elasticsearch.test.rest.ObjectPath;
 import org.elasticsearch.xcontent.XContentType;
+import org.junit.Before;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -88,6 +90,13 @@ public class MatchOnlyTextRollingUpgradeIT extends AbstractRollingUpgradeWithSec
 
     public MatchOnlyTextRollingUpgradeIT(@Name("upgradedNodes") int upgradedNodes) {
         super(upgradedNodes);
+    }
+
+    @Before
+    public void checkFeatures() {
+        if (Build.current().isSnapshot()) {
+            assumeTrue("rename of pattern_text mapper", oldClusterHasFeature("mapper.pattern_text_rename"));
+        }
     }
 
     public void testIndexing() throws Exception {

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/NoLogsUsageRollingUpgradeIT.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/NoLogsUsageRollingUpgradeIT.java
@@ -11,6 +11,9 @@ package org.elasticsearch.upgrades;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 
+import org.elasticsearch.Build;
+import org.junit.Before;
+
 import java.time.Instant;
 import java.util.Map;
 
@@ -24,6 +27,13 @@ public class NoLogsUsageRollingUpgradeIT extends AbstractRollingUpgradeWithSecur
 
     public NoLogsUsageRollingUpgradeIT(@Name("upgradedNodes") int upgradedNodes) {
         super(upgradedNodes);
+    }
+
+    @Before
+    public void checkFeatures() {
+        if (Build.current().isSnapshot()) {
+            assumeTrue("rename of pattern_text mapper", oldClusterHasFeature("mapper.pattern_text_rename"));
+        }
     }
 
     public void testUsage() throws Exception {

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/StandardToLogsDbIndexModeRollingUpgradeIT.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/StandardToLogsDbIndexModeRollingUpgradeIT.java
@@ -11,6 +11,7 @@ package org.elasticsearch.upgrades;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 
+import org.elasticsearch.Build;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
@@ -24,6 +25,7 @@ import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
+import org.junit.Before;
 import org.junit.ClassRule;
 
 import java.io.IOException;
@@ -113,6 +115,13 @@ public class StandardToLogsDbIndexModeRollingUpgradeIT extends AbstractRollingUp
             }
           }
         }""";
+
+    @Before
+    public void checkFeatures() {
+        if (Build.current().isSnapshot()) {
+            assumeTrue("rename of pattern_text mapper", oldClusterHasFeature("mapper.pattern_text_rename"));
+        }
+    }
 
     public void testLogsIndexing() throws IOException {
         if (isOldCluster()) {

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/SyntheticSourceRollingUpgradeIT.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/SyntheticSourceRollingUpgradeIT.java
@@ -11,9 +11,11 @@ package org.elasticsearch.upgrades;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 
+import org.elasticsearch.Build;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.test.rest.ObjectPath;
 import org.hamcrest.Matchers;
+import org.junit.Before;
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -68,6 +70,13 @@ public class SyntheticSourceRollingUpgradeIT extends AbstractRollingUpgradeWithS
 
     public SyntheticSourceRollingUpgradeIT(@Name("upgradedNodes") int upgradedNodes) {
         super(upgradedNodes);
+    }
+
+    @Before
+    public void checkFeatures() {
+        if (Build.current().isSnapshot()) {
+            assumeTrue("rename of pattern_text mapper", oldClusterHasFeature("mapper.pattern_text_rename"));
+        }
     }
 
     public void testIndexing() throws Exception {

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/TextRollingUpgradeIT.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/TextRollingUpgradeIT.java
@@ -9,6 +9,7 @@ package org.elasticsearch.upgrades;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 
+import org.elasticsearch.Build;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
@@ -18,6 +19,7 @@ import org.elasticsearch.common.time.FormatNames;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.test.rest.ObjectPath;
 import org.elasticsearch.xcontent.XContentType;
+import org.junit.Before;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -85,6 +87,13 @@ public class TextRollingUpgradeIT extends AbstractRollingUpgradeWithSecurityTest
 
     public TextRollingUpgradeIT(@Name("upgradedNodes") int upgradedNodes) {
         super(upgradedNodes);
+    }
+
+    @Before
+    public void checkFeatures() {
+        if (Build.current().isSnapshot()) {
+            assumeTrue("rename of pattern_text mapper", oldClusterHasFeature("mapper.pattern_text_rename"));
+        }
     }
 
     public void testIndexing() throws Exception {


### PR DESCRIPTION
These tests were failing because we renamed the setting `index.mapping.patterned_text.disable_templating` to `index.mapping.pattern_text.disable_templating`. The old node would create an index using the old name, then the new node would try to load the index with the old setting and throw an error because the old name was unrecognized.

This is not an issue in production because the setting is gated behind a feature flag.

This patch adds a node feature representing the rename, then updates the rolling upgrade tests to only run if the rename is present on the old cluster as well.

Fixes #135338
Fixes #135344
Fixes #135312
Fixes #135316
Fixes #135319
Fixes #135327
Fixes #135320
Fixes #135315
Fixes #135314
Fixes #135237
Fixes #135324
Fixes #135325
Fixes #135238
Fixes #135313