### PR TITLE
Correctly apply field path to JSON processor when adding contents to document root

### DIFF
--- a/docs/changelog/135479.yaml
+++ b/docs/changelog/135479.yaml
@@ -1,0 +1,6 @@
+pr: 135479
+summary: Correctly apply field path to JSON processor when adding contents to document
+  root
+area: Ingest Node
+type: bug
+issues: []

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/JsonProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/JsonProcessor.java
@@ -188,12 +188,11 @@ public final class JsonProcessor extends AbstractProcessor {
 
     @Override
     public IngestDocument execute(IngestDocument document) throws Exception {
-        Object fieldValue = document.getFieldValue(field, Object.class);
         if (addToRoot) {
-            Object value = apply(fieldValue, allowDuplicateKeys, strictJsonParsing);
+            Object value = apply(document.getFieldValue(field, Object.class), allowDuplicateKeys, strictJsonParsing);
             mergeParsedJson(document.getSourceAndMetadata(), value, addToRootConflictStrategy);
         } else {
-            document.setFieldValue(targetField, apply(fieldValue, allowDuplicateKeys, strictJsonParsing));
+            document.setFieldValue(targetField, apply(document.getFieldValue(field, Object.class), allowDuplicateKeys, strictJsonParsing));
         }
         return document;
     }

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/JsonProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/JsonProcessor.java
@@ -149,6 +149,10 @@ public final class JsonProcessor extends AbstractProcessor {
         boolean strictJsonParsing
     ) {
         Object value = apply(ctx.get(fieldName), allowDuplicateKeys, strictJsonParsing);
+        mergeParsedJson(ctx, value, conflictStrategy);
+    }
+
+    private static void mergeParsedJson(Map<String, Object> ctx, Object value, ConflictStrategy conflictStrategy) {
         if (value instanceof Map) {
             @SuppressWarnings("unchecked")
             Map<String, Object> map = (Map<String, Object>) value;
@@ -185,7 +189,8 @@ public final class JsonProcessor extends AbstractProcessor {
     @Override
     public IngestDocument execute(IngestDocument document) throws Exception {
         if (addToRoot) {
-            apply(document.getSourceAndMetadata(), field, allowDuplicateKeys, addToRootConflictStrategy, strictJsonParsing);
+            Object value = apply(document.getFieldValue(field, Object.class), allowDuplicateKeys, strictJsonParsing);
+            mergeParsedJson(document.getSourceAndMetadata(), value, addToRootConflictStrategy);
         } else {
             document.setFieldValue(targetField, apply(document.getFieldValue(field, Object.class), allowDuplicateKeys, strictJsonParsing));
         }

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/JsonProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/JsonProcessor.java
@@ -188,11 +188,12 @@ public final class JsonProcessor extends AbstractProcessor {
 
     @Override
     public IngestDocument execute(IngestDocument document) throws Exception {
+        Object fieldValue = document.getFieldValue(field, Object.class);
         if (addToRoot) {
-            Object value = apply(document.getFieldValue(field, Object.class), allowDuplicateKeys, strictJsonParsing);
+            Object value = apply(fieldValue, allowDuplicateKeys, strictJsonParsing);
             mergeParsedJson(document.getSourceAndMetadata(), value, addToRootConflictStrategy);
         } else {
-            document.setFieldValue(targetField, apply(document.getFieldValue(field, Object.class), allowDuplicateKeys, strictJsonParsing));
+            document.setFieldValue(targetField, apply(fieldValue, allowDuplicateKeys, strictJsonParsing));
         }
         return document;
     }

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/JsonProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/JsonProcessor.java
@@ -188,11 +188,11 @@ public final class JsonProcessor extends AbstractProcessor {
 
     @Override
     public IngestDocument execute(IngestDocument document) throws Exception {
+        Object value = apply(document.getFieldValue(field, Object.class), allowDuplicateKeys, strictJsonParsing);
         if (addToRoot) {
-            Object value = apply(document.getFieldValue(field, Object.class), allowDuplicateKeys, strictJsonParsing);
             mergeParsedJson(document.getSourceAndMetadata(), value, addToRootConflictStrategy);
         } else {
-            document.setFieldValue(targetField, apply(document.getFieldValue(field, Object.class), allowDuplicateKeys, strictJsonParsing));
+            document.setFieldValue(targetField, value);
         }
         return document;
     }

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/JsonProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/JsonProcessorTests.java
@@ -12,6 +12,8 @@ package org.elasticsearch.ingest.common;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.ingest.IngestDocument;
+import org.elasticsearch.ingest.IngestPipelineFieldAccessPattern;
+import org.elasticsearch.ingest.IngestPipelineTestUtils;
 import org.elasticsearch.ingest.RandomDocumentPicks;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -159,6 +161,28 @@ public class JsonProcessorTests extends ESTestCase {
 
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
         jsonProcessor.execute(ingestDocument);
+
+        Map<String, Object> sourceAndMetadata = ingestDocument.getSourceAndMetadata();
+        assertEquals(1, sourceAndMetadata.get("a"));
+        assertEquals(2, sourceAndMetadata.get("b"));
+        assertEquals("see", sourceAndMetadata.get("c"));
+    }
+
+    public void testAddToRootNestedField() throws Exception {
+        String processorTag = randomAlphaOfLength(3);
+        String randomTargetField = randomAlphaOfLength(2);
+        JsonProcessor jsonProcessor = new JsonProcessor(processorTag, null, "a.b", randomTargetField, true, REPLACE, false);
+
+        String json = "{\"a\": 1, \"b\": 2}";
+        Map<String, Object> subfield = new HashMap<>();
+        subfield.put("b", json);
+
+        Map<String, Object> document = new HashMap<>();
+        document.put("a", subfield);
+        document.put("c", "see");
+
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+        ingestDocument = IngestPipelineTestUtils.runWithRandomAccessPattern(ingestDocument, jsonProcessor);
 
         Map<String, Object> sourceAndMetadata = ingestDocument.getSourceAndMetadata();
         assertEquals(1, sourceAndMetadata.get("a"));

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/JsonProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/JsonProcessorTests.java
@@ -12,7 +12,6 @@ package org.elasticsearch.ingest.common;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.ingest.IngestDocument;
-import org.elasticsearch.ingest.IngestPipelineFieldAccessPattern;
 import org.elasticsearch.ingest.IngestPipelineTestUtils;
 import org.elasticsearch.ingest.RandomDocumentPicks;
 import org.elasticsearch.test.ESTestCase;


### PR DESCRIPTION
The JSON processor has an option that merges the contents of a parsed json string to the root of the document. When operating in this way, the logic was simply gathering the json string directly from the root of the document. This means that nested fields would not be readable. This is likely because in painless, the exact same functionality is exposed as a built in processor function. In painless, field traversal can be done outside of the processor logic. When calling the method, it will add the contents to whichever map is provided. This is working as expected and should not change. When running in the ingest node, the processor handles all field lookups from the document. This is where the fix was applied.

Fixes:  https://github.com/elastic/elasticsearch/issues/135170

Since this is a long standing bug, I will try and get a backport to the 8.19 branch as well.