### PR TITLE
Fixed TextRollingUpgradeIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -452,15 +452,6 @@ tests:
 - class: org.elasticsearch.simdvec.ESVectorUtilTests
   method: testSoarDistance
   issue: https://github.com/elastic/elasticsearch/issues/135139
-- class: org.elasticsearch.upgrades.TextRollingUpgradeIT
-  method: testIndexing {upgradedNodes=1}
-  issue: https://github.com/elastic/elasticsearch/issues/135236
-- class: org.elasticsearch.upgrades.TextRollingUpgradeIT
-  method: testIndexing {upgradedNodes=3}
-  issue: https://github.com/elastic/elasticsearch/issues/135237
-- class: org.elasticsearch.upgrades.TextRollingUpgradeIT
-  method: testIndexing {upgradedNodes=2}
-  issue: https://github.com/elastic/elasticsearch/issues/135238
 
 # Examples:
 #

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/TextRollingUpgradeIT.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/TextRollingUpgradeIT.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.upgrades;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
+
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/TextRollingUpgradeIT.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/TextRollingUpgradeIT.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.upgrades;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
-
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
@@ -81,7 +80,7 @@ public class TextRollingUpgradeIT extends AbstractRollingUpgradeWithSecurityTest
         }""";
 
     // when sorted, this message will appear at the top and hence can be used to validate query results
-    private String smallestMessage;
+    private static String smallestMessage;
 
     public TextRollingUpgradeIT(@Name("upgradedNodes") int upgradedNodes) {
         super(upgradedNodes);


### PR DESCRIPTION
I somehow missed getting this fix into the 9.1 branch. 

`main` already has this change: https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/TextRollingUpgradeIT.java#L86

This addresses https://github.com/elastic/elasticsearch/issues/135236.

No backport is needed.