### PR TITLE
[8.19] [CI] Fix packaging tests by patching system java home

### DIFF
--- a/.ci/scripts/packaging-test.sh
+++ b/.ci/scripts/packaging-test.sh
@@ -69,6 +69,22 @@ sudo mkdir -p /elasticsearch/qa/ && sudo chown jenkins /elasticsearch/qa/ && ln 
 # See: https://git-scm.com/docs/git-config/2.35.2#Documentation/git-config.txt-safedirectory
 git config --global --add safe.directory $WORKSPACE
 
+# Older versions of openjdk are incompatible to newer kernel of ubuntu. Use adoptopenjdk17 instead
+resolve_system_java_home() {
+  if [[ "$BUILD_JAVA_HOME" == *"openjdk17"* ]]; then
+    if [ -f "/etc/os-release" ]; then
+        . /etc/os-release
+        if [[ "$ID" == "ubuntu" && "$VERSION_ID" == "24.04" ]]; then
+          echo "$HOME/.java/adoptopenjdk17"
+          return
+        fi
+      fi
+  fi
+
+  echo "$(readlink -f -n $BUILD_JAVA_HOME)"
+}
+
+
 # sudo sets it's own PATH thus we use env to override that and call sudo annother time so we keep the secure root PATH
 # run with --continue to run both bats and java tests even if one fails
 # be explicit about Gradle home dir so we use the same even with sudo
@@ -76,7 +92,7 @@ sudo -E env \
   PATH=$BUILD_JAVA_HOME/bin:`sudo bash -c 'echo -n $PATH'` \
   --unset=ES_JAVA_HOME \
   --unset=JAVA_HOME \
-  SYSTEM_JAVA_HOME=`readlink -f -n $BUILD_JAVA_HOME` \
+  SYSTEM_JAVA_HOME=$(resolve_system_java_home) \
   DOCKER_CONFIG="${HOME}/.docker" \
   ./gradlew -g $HOME/.gradle --console=plain --scan --parallel --build-cache -Dorg.elasticsearch.build.cache.url=https://gradle-enterprise.elastic.co/cache/ --continue $@
 

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/PackageUpgradeTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/PackageUpgradeTests.java
@@ -60,8 +60,6 @@ public class PackageUpgradeTests extends PackagingTestCase {
     }
 
     public void test12SetupBwcVersion() throws Exception {
-        patchIncompatibleJavaVersion();
-
         startElasticsearch();
 
         // create indexes explicitly with 0 replicas so when restarting we can reach green state
@@ -89,9 +87,7 @@ public class PackageUpgradeTests extends PackagingTestCase {
         );
 
         assertDocsExist();
-
         stopElasticsearch();
-        sh.getEnv().remove("ES_JAVA_HOME");
     }
 
     private void patchIncompatibleJavaVersion() {

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/PackageUpgradeTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/PackageUpgradeTests.java
@@ -90,14 +90,6 @@ public class PackageUpgradeTests extends PackagingTestCase {
         stopElasticsearch();
     }
 
-    private void patchIncompatibleJavaVersion() {
-        Version bwcVersion = Version.fromString(bwcDistribution.baseVersion);
-        if (bwcVersion.onOrAfter(Version.V_8_0_0) && bwcVersion.onOrBefore(Version.V_8_4_3)) {
-            final String systemJavaHome = sh.run("echo $SYSTEM_JAVA_HOME").stdout().trim();
-            sh.getEnv().put("ES_JAVA_HOME", systemJavaHome);
-        }
-    }
-
     public void test20InstallUpgradedVersion() throws Exception {
         if (bwcDistribution.path.equals(distribution.path)) {
             // the old and new distributions are the same, so we are testing force upgrading

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/PackageUpgradeTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/PackageUpgradeTests.java
@@ -60,6 +60,8 @@ public class PackageUpgradeTests extends PackagingTestCase {
     }
 
     public void test12SetupBwcVersion() throws Exception {
+        patchIncompatibleJavaVersion();
+
         startElasticsearch();
 
         // create indexes explicitly with 0 replicas so when restarting we can reach green state
@@ -89,6 +91,15 @@ public class PackageUpgradeTests extends PackagingTestCase {
         assertDocsExist();
 
         stopElasticsearch();
+        sh.getEnv().remove("ES_JAVA_HOME");
+    }
+
+    private void patchIncompatibleJavaVersion() {
+        Version bwcVersion = Version.fromString(bwcDistribution.baseVersion);
+        if (bwcVersion.onOrAfter(Version.V_8_0_0) && bwcVersion.onOrBefore(Version.V_8_4_3)) {
+            final String systemJavaHome = sh.run("echo $SYSTEM_JAVA_HOME").stdout().trim();
+            sh.getEnv().put("ES_JAVA_HOME", systemJavaHome);
+        }
     }
 
     public void test20InstallUpgradedVersion() throws Exception {

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/Packages.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/Packages.java
@@ -113,8 +113,10 @@ public class Packages {
         if (distribution.hasJdk == false) {
             return true;
         }
-        Version version = Version.fromString(distribution.version);
-        return Platforms.isUbuntu24() && (version.onOrAfter(Version.V_8_0_0) && version.onOrBefore(Version.V_8_4_3));
+        Version version = Version.fromString(distribution.baseVersion);
+        boolean requiresPatch = Platforms.isUbuntu24() && (version.onOrAfter(Version.V_8_0_0) && version.onOrBefore(Version.V_8_4_3));
+        System.out.println("requiresPatch = " + requiresPatch);
+        return requiresPatch;
     }
 
     private static String captureElasticPasswordFromOutput(Result result) {

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/Platforms.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/Platforms.java
@@ -53,6 +53,15 @@ public class Platforms {
         return new Shell().runIgnoreExitCode("which docker").isSuccess();
     }
 
+    public static boolean isUbuntu24() {
+        if (LINUX) {
+            String osRelease = getOsRelease();
+            return osRelease.contains("id=ubuntu") && osRelease.contains("VERSION_ID=\"24.04\"");
+        } else {
+            return false;
+        }
+    }
+
     public static void onWindows(PlatformAction action) throws Exception {
         if (WINDOWS) {
             action.run();

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/Platforms.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/Platforms.java
@@ -28,6 +28,15 @@ public class Platforms {
         }
     }
 
+    public static boolean isUbuntu24() {
+        if (LINUX) {
+            String osRelease = getOsRelease();
+            return osRelease.contains("ID=ubuntu") && osRelease.contains("VERSION_ID=\"24.04\"");
+        } else {
+            return false;
+        }
+    }
+
     public static boolean isDPKG() {
         if (WINDOWS) {
             return false;
@@ -51,15 +60,6 @@ public class Platforms {
 
     public static boolean isDocker() {
         return new Shell().runIgnoreExitCode("which docker").isSuccess();
-    }
-
-    public static boolean isUbuntu24() {
-        if (LINUX) {
-            String osRelease = getOsRelease();
-            return osRelease.contains("id=ubuntu") && osRelease.contains("VERSION_ID=\"24.04\"");
-        } else {
-            return false;
-        }
     }
 
     public static void onWindows(PlatformAction action) throws Exception {


### PR DESCRIPTION
Older version of openjdk17 are incompatible with newer ubuntu versions. 
Packaging tests swap out bundled jdk for the minimum jdk for a few tests. 
On ubuntu24 we now replace openjdk17 with adoptopenjdk17 in these cases.

