### PR TITLE
ES|QL: Set FUSE to execute on coordinator

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/fuse.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/fuse.csv-spec
@@ -762,6 +762,7 @@ required_capability: fuse_v6
 
 ROW _id = ["a", "b", "c"], _score = 0.0, _index = "my_index", my_fork = "foo"
 | MV_EXPAND _id
+| LIMIT 10
 | FUSE LINEAR GROUP BY my_fork WITH { "normalizer": "l2_norm" }
 | SORT _id
 | KEEP _id, _score
@@ -779,6 +780,7 @@ required_capability: fuse_v6
 
 ROW _id = ["a", "b", "c"], _score = 0.0, _index = "my_index", my_fork = "foo"
 | MV_EXPAND _id
+| LIMIT 10
 | FUSE LINEAR GROUP BY my_fork WITH { "normalizer": "minmax" }
 | SORT _id
 | KEEP _id, _score

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/fuse/Fuse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/fuse/Fuse.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.plan.logical.ExecutesOn;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.UnaryPlan;
 
@@ -26,7 +27,7 @@ import java.util.List;
 
 import static org.elasticsearch.xpack.esql.common.Failure.fail;
 
-public class Fuse extends UnaryPlan implements TelemetryAware, PostAnalysisVerificationAware {
+public class Fuse extends UnaryPlan implements TelemetryAware, PostAnalysisVerificationAware, ExecutesOn.Coordinator {
     private final Attribute score;
     private final Attribute discriminator;
     private final List<NamedExpression> keys;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/fuse/FuseScoreEval.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/fuse/FuseScoreEval.java
@@ -26,7 +26,9 @@ import org.elasticsearch.xpack.esql.core.expression.MapExpression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.plan.logical.ExecutesOn;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.PipelineBreaker;
 import org.elasticsearch.xpack.esql.plan.logical.UnaryPlan;
 
 import java.io.IOException;
@@ -36,7 +38,12 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
-public class FuseScoreEval extends UnaryPlan implements LicenseAware, PostAnalysisVerificationAware {
+public class FuseScoreEval extends UnaryPlan
+    implements
+        LicenseAware,
+        PostAnalysisVerificationAware,
+        ExecutesOn.Coordinator,
+        PipelineBreaker {
     private final Attribute discriminatorAttr;
     private final Attribute scoreAttr;
     private final Fuse.FuseType fuseType;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -2681,6 +2681,11 @@ public class VerifierTests extends ESTestCase {
             error(queryPrefix + " | fuse linear KEY BY _score"),
             containsString("expected KEY BY field [_score] to be KEYWORD or TEXT, not DOUBLE")
         );
+
+        assertThat(
+            error("FROM test METADATA _index, _score, _id | EVAL _fork = \"fork1\" | FUSE"),
+            containsString("FUSE can only be used on a limited number of rows. Consider adding a LIMIT before FUSE.")
+        );
     }
 
     public void testNoMetricInStatsByClause() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/OptimizerVerificationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/OptimizerVerificationTests.java
@@ -24,7 +24,6 @@ import java.util.List;
 import static org.elasticsearch.xpack.core.enrich.EnrichPolicy.MATCH_TYPE;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_VERIFIER;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.paramAsConstant;
-import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.FUSE_V6;
 import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.INLINE_STATS;
 import static org.elasticsearch.xpack.esql.analysis.AnalyzerTestUtils.defaultLookupResolution;
 import static org.elasticsearch.xpack.esql.analysis.AnalyzerTestUtils.loadEnrichPolicyResolution;
@@ -358,16 +357,6 @@ public class OptimizerVerificationTests extends AbstractLogicalPlanOptimizerTest
 
         // Since FORK, RERANK, COMPLETION and CHANGE_POINT are not supported on remote indices, we can't check them here against the remote
         // LOOKUP JOIN
-
-        if (FUSE_V6.isEnabled()) {
-            assertEquals("5:3: LOOKUP JOIN with remote indices can't be executed after [FUSE GROUP BY my_key]@3:3", error("""
-                FROM test,remote:test METADATA _id, _index, _score
-                | EVAL my_key = "foo"
-                | FUSE GROUP BY my_key
-                | EVAL language_code = languages
-                | LOOKUP JOIN languages_lookup ON language_code
-                | LIMIT 2""", analyzer));
-        }
     }
 
     public void testRemoteEnrichAfterLookupJoinWithPipelineBreaker() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/OptimizerVerificationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/OptimizerVerificationTests.java
@@ -357,6 +357,14 @@ public class OptimizerVerificationTests extends AbstractLogicalPlanOptimizerTest
 
         // Since FORK, RERANK, COMPLETION and CHANGE_POINT are not supported on remote indices, we can't check them here against the remote
         // LOOKUP JOIN
+
+        assertEquals("5:3: LOOKUP JOIN with remote indices can't be executed after [FUSE GROUP BY my_key]@3:3", error("""
+            FROM test,remote:test METADATA _id, _index, _score
+            | EVAL my_key = "foo"
+            | FUSE GROUP BY my_key
+            | EVAL language_code = languages
+            | LOOKUP JOIN languages_lookup ON language_code
+            | LIMIT 2""", analyzer));
     }
 
     public void testRemoteEnrichAfterLookupJoinWithPipelineBreaker() {


### PR DESCRIPTION
Tracked in https://github.com/elastic/elasticsearch/issues/123389

FUSE supports RRF and linear combination as the two method to assign new relevance scores.
FUSE cannot be pushed down to the data nodes, it needs to see the whole result set in order to assign new scores.

Because of this we need to:
1. Ensure that FUSE can only be executed on the coordinator: we add the `ExecutesOn.Coordinator` and `PipelineBreaker` to `FuseScoreEval`.
2. We want to make sure the input of FUSE is always limited - this makes sense in practice, since using RRF or linear combination is used with limited results sets. We don't use RRF or score normalization on results set of millions of docs.
What this means practically is that the we are looking for another `PipelineBreaker` exists before FUSE.


