### PR TITLE
Add time range bucketing attribute to APM shard search latency metrics

### DIFF
--- a/docs/changelog/135524.yaml
+++ b/docs/changelog/135524.yaml
@@ -1,0 +1,5 @@
+pr: 135524
+summary: Add time range bucketing attribute to APM shard search latency metrics
+area: Search
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -25,6 +25,7 @@ import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.IndexSortSortedNumericDocValuesRangeQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
@@ -747,33 +748,34 @@ public final class DateFieldMapper extends FieldMapper {
             if (relation == ShapeRelation.DISJOINT) {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] does not support DISJOINT ranges");
             }
-            DateMathParser parser;
-            if (forcedDateParser == null) {
-                if (lowerTerm instanceof Number || upperTerm instanceof Number) {
-                    // force epoch_millis
-                    parser = EPOCH_MILLIS_PARSER;
-                } else {
-                    parser = dateMathParser;
-                }
-            } else {
-                parser = forcedDateParser;
-            }
-            return dateRangeQuery(lowerTerm, upperTerm, includeLower, includeUpper, timeZone, parser, context, resolution, (l, u) -> {
-                Query query;
-                if (isIndexed()) {
-                    query = LongPoint.newRangeQuery(name(), l, u);
-                    if (hasDocValues()) {
-                        Query dvQuery = SortedNumericDocValuesField.newSlowRangeQuery(name(), l, u);
-                        query = new IndexOrDocValuesQuery(query, dvQuery);
+            DateMathParser parser = resolveDateMathParser(forcedDateParser, lowerTerm, upperTerm);
+            return dateRangeQuery(
+                lowerTerm,
+                upperTerm,
+                includeLower,
+                includeUpper,
+                timeZone,
+                parser,
+                context,
+                resolution,
+                name(),
+                (l, u) -> {
+                    Query query;
+                    if (isIndexed()) {
+                        query = LongPoint.newRangeQuery(name(), l, u);
+                        if (hasDocValues()) {
+                            Query dvQuery = SortedNumericDocValuesField.newSlowRangeQuery(name(), l, u);
+                            query = new IndexOrDocValuesQuery(query, dvQuery);
+                        }
+                    } else {
+                        query = SortedNumericDocValuesField.newSlowRangeQuery(name(), l, u);
                     }
-                } else {
-                    query = SortedNumericDocValuesField.newSlowRangeQuery(name(), l, u);
+                    if (hasDocValues() && context.indexSortedOnField(name())) {
+                        query = new IndexSortSortedNumericDocValuesRangeQuery(name(), l, u, query);
+                    }
+                    return query;
                 }
-                if (hasDocValues() && context.indexSortedOnField(name())) {
-                    query = new IndexSortSortedNumericDocValuesRangeQuery(name(), l, u, query);
-                }
-                return query;
-            });
+            );
         }
 
         public static Query dateRangeQuery(
@@ -785,6 +787,7 @@ public final class DateFieldMapper extends FieldMapper {
             DateMathParser parser,
             SearchExecutionContext context,
             Resolution resolution,
+            String fieldName,
             BiFunction<Long, Long, Query> builder
         ) {
             return handleNow(context, nowSupplier -> {
@@ -795,6 +798,9 @@ public final class DateFieldMapper extends FieldMapper {
                     l = parseToLong(lowerTerm, includeLower == false, timeZone, parser, nowSupplier, resolution);
                     if (includeLower == false) {
                         ++l;
+                    }
+                    if (fieldName.equals(DataStream.TIMESTAMP_FIELD_NAME)) {
+                        context.setRangeTimestampFrom(l);
                     }
                 }
                 if (upperTerm == null) {
@@ -951,6 +957,17 @@ public final class DateFieldMapper extends FieldMapper {
             return isFieldWithinQuery(minValue, maxValue, from, to, includeLower, includeUpper, timeZone, dateParser, context);
         }
 
+        public DateMathParser resolveDateMathParser(DateMathParser dateParser, Object from, Object to) {
+            if (dateParser == null) {
+                if (from instanceof Number || to instanceof Number) {
+                    // force epoch_millis
+                    return EPOCH_MILLIS_PARSER;
+                }
+                return this.dateMathParser;
+            }
+            return dateParser;
+        }
+
         public Relation isFieldWithinQuery(
             long minValue,
             long maxValue,
@@ -962,14 +979,7 @@ public final class DateFieldMapper extends FieldMapper {
             DateMathParser dateParser,
             QueryRewriteContext context
         ) {
-            if (dateParser == null) {
-                if (from instanceof Number || to instanceof Number) {
-                    // force epoch_millis
-                    dateParser = EPOCH_MILLIS_PARSER;
-                } else {
-                    dateParser = this.dateMathParser;
-                }
-            }
+            dateParser = resolveDateMathParser(dateParser, from, to);
 
             long fromInclusive = Long.MIN_VALUE;
             if (from != null) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateScriptFieldType.java
@@ -297,6 +297,7 @@ public class DateScriptFieldType extends AbstractScriptFieldType<DateFieldScript
             parser,
             context,
             DateFieldMapper.Resolution.MILLISECONDS,
+            name(),
             (l, u) -> new LongScriptFieldRangeQuery(script, leafFactory(context)::newInstance, name(), l, u)
         );
     }

--- a/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
@@ -238,9 +238,6 @@ public class SearchExecutionContext extends QueryRewriteContext {
             source.requestSize,
             source.mapperMetrics
         );
-        // TODO address this
-        // setRangeEventIngestedFrom(source.rangeEventIngestedFrom);
-        // setRangeTimestampFrom(source.rangeTimestampFrom);
     }
 
     private SearchExecutionContext(

--- a/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
@@ -109,6 +109,8 @@ public class SearchExecutionContext extends QueryRewriteContext {
     private final Integer requestSize;
     private final MapperMetrics mapperMetrics;
 
+    private Long rangeTimestampFrom;
+
     /**
      * Build a {@linkplain SearchExecutionContext}.
      */
@@ -236,6 +238,9 @@ public class SearchExecutionContext extends QueryRewriteContext {
             source.requestSize,
             source.mapperMetrics
         );
+        // TODO address this
+        // setRangeEventIngestedFrom(source.rangeEventIngestedFrom);
+        // setRangeTimestampFrom(source.rangeTimestampFrom);
     }
 
     private SearchExecutionContext(
@@ -300,6 +305,7 @@ public class SearchExecutionContext extends QueryRewriteContext {
         this.lookup = null;
         this.namedQueries.clear();
         this.nestedScope = new NestedScope();
+
     }
 
     // Set alias filter, so it can be applied for queries that need it (e.g. knn query)
@@ -741,5 +747,23 @@ public class SearchExecutionContext extends QueryRewriteContext {
      */
     public boolean rewriteToNamedQuery() {
         return rewriteToNamedQueries;
+    }
+
+    /**
+     * Returns the minimum lower bound across the time ranges filters against the @timestamp field included in the query
+     */
+    public Long getRangeTimestampFrom() {
+        return rangeTimestampFrom;
+    }
+
+    /**
+     * Records the lower bound of a time range filter against the @timestamp field included in the query. For telemetry purposes.
+     */
+    public void setRangeTimestampFrom(Long rangeTimestampFrom) {
+        if (this.rangeTimestampFrom == null) {
+            this.rangeTimestampFrom = rangeTimestampFrom;
+        } else {
+            this.rangeTimestampFrom = Math.min(rangeTimestampFrom, this.rangeTimestampFrom);
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/search/SearchRequestAttributesExtractorTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchRequestAttributesExtractorTests.java
@@ -361,4 +361,56 @@ public class SearchRequestAttributesExtractorTests extends ESTestCase {
             assertAttributes(stringObjectMap, "user", "_score", "hits_only", false, false, false, null);
         }
     }
+
+    public void testIntrospectTimeRange() {
+        long nowInMillis = System.currentTimeMillis();
+        assertEquals("15_minutes", SearchRequestAttributesExtractor.introspectTimeRange(nowInMillis, nowInMillis));
+
+        long fifteenMinutesAgo = nowInMillis - (15 * 60 * 1000);
+        assertEquals(
+            "15_minutes",
+            SearchRequestAttributesExtractor.introspectTimeRange(randomLongBetween(fifteenMinutesAgo, nowInMillis), nowInMillis)
+        );
+
+        long oneHourAgo = nowInMillis - (60 * 60 * 1000);
+        assertEquals(
+            "1_hour",
+            SearchRequestAttributesExtractor.introspectTimeRange(randomLongBetween(oneHourAgo, fifteenMinutesAgo), nowInMillis)
+        );
+
+        long twelveHoursAgo = nowInMillis - (12 * 60 * 60 * 1000);
+        assertEquals(
+            "12_hours",
+            SearchRequestAttributesExtractor.introspectTimeRange(randomLongBetween(twelveHoursAgo, oneHourAgo), nowInMillis)
+        );
+
+        long oneDayAgo = nowInMillis - (24 * 60 * 60 * 1000);
+        assertEquals(
+            "1_day",
+            SearchRequestAttributesExtractor.introspectTimeRange(randomLongBetween(oneDayAgo, twelveHoursAgo), nowInMillis)
+        );
+
+        long threeDaysAgo = nowInMillis - (3 * 24 * 60 * 60 * 1000);
+        assertEquals(
+            "3_days",
+            SearchRequestAttributesExtractor.introspectTimeRange(randomLongBetween(threeDaysAgo, oneDayAgo), nowInMillis)
+        );
+
+        long sevenDaysAgo = nowInMillis - (7 * 24 * 60 * 60 * 1000);
+        assertEquals(
+            "7_days",
+            SearchRequestAttributesExtractor.introspectTimeRange(randomLongBetween(sevenDaysAgo, threeDaysAgo), nowInMillis)
+        );
+
+        long fourteenDaysAgo = nowInMillis - (14 * 24 * 60 * 60 * 1000);
+        assertEquals(
+            "14_days",
+            SearchRequestAttributesExtractor.introspectTimeRange(randomLongBetween(fourteenDaysAgo, sevenDaysAgo), nowInMillis)
+        );
+
+        assertEquals(
+            "older_than_14_days",
+            SearchRequestAttributesExtractor.introspectTimeRange(randomLongBetween(0, fourteenDaysAgo), nowInMillis)
+        );
+    }
 }

--- a/server/src/test/java/org/elasticsearch/search/TelemetryMetrics/ShardSearchPhaseAPMMetricsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/TelemetryMetrics/ShardSearchPhaseAPMMetricsTests.java
@@ -279,12 +279,13 @@ public class ShardSearchPhaseAPMMetricsTests extends ESSingleNodeTestCase {
     private static void assertTimeRangeAttributes(List<Measurement> measurements, String target, boolean isSystem) {
         for (Measurement measurement : measurements) {
             Map<String, Object> attributes = measurement.attributes();
-            assertEquals(5, attributes.size());
+            assertEquals(6, attributes.size());
             assertEquals(target, attributes.get("target"));
             assertEquals("hits_only", attributes.get("query_type"));
             assertEquals("_score", attributes.get("sort"));
             assertEquals(true, attributes.get("range_timestamp"));
             assertEquals(isSystem, attributes.get(SearchRequestAttributesExtractor.SYSTEM_THREAD_ATTRIBUTE_NAME));
+            assertEquals("older_than_14_days", attributes.get("timestamp_range_filter"));
         }
     }
 


### PR DESCRIPTION
We recently added relevant attributes to the existing shard search latency metrics (#134798). This commit introduces an additional attribute that analyzes the parsed time range filter against the @timestamp field and reports back whether it is within the last 15 minutes, last hour, last 12 hours, last day, last three days, last seven days, or last 14 days.