### PR TITLE
Improved validation and added option to include incubator modules for API Extractor tool

### DIFF
--- a/libs/entitlement/tools/jdk-api-extractor/README.md
+++ b/libs/entitlement/tools/jdk-api-extractor/README.md
@@ -13,7 +13,10 @@ Usage example:
 diff libs/entitlement/tools/jdk-api-extractor/api-jdk24.tsv libs/entitlement/tools/jdk-api-extractor/api-jdk25.tsv
 ```
 
-To review the diff of deprecations (by means of `@Deprecated`), use `--deprecations-only` as 2nd argument.
+### Optional arguments:
+
+- `--deprecations-only`: reports public deprecations (by means of `@Deprecated`)
+- `--include-incubator`: include incubator modules (e.g. `jdk.incubator.vector`)
 
 ```bash
 ./gradlew :libs:entitlement:tools:jdk-api-extractor:run -Druntime.java=24 --args="deprecations-jdk24.tsv --deprecations-only"

--- a/libs/entitlement/tools/jdk-api-extractor/build.gradle
+++ b/libs/entitlement/tools/jdk-api-extractor/build.gradle
@@ -16,8 +16,16 @@ ext {
   javaMainClass = "org.elasticsearch.entitlement.tools.jdkapi.JdkApiExtractor"
 }
 
+def addIncubatorModules = {
+  file("${buildParams.runtimeJavaHome.get()}/jmods")
+    .listFiles()
+    .findAll { it.name.endsWith('.jmod') && it.name.contains('.incubator.') }
+    .collectMany { ['--add-modules', it.name[0..-6]] }
+}
+
 application {
   mainClass.set(javaMainClass)
+  applicationDefaultJvmArgs = addIncubatorModules()
 }
 
 tasks.named("run").configure {


### PR DESCRIPTION
This adds a few improvements to the api-extractor tool.
- validation of input params is more robust
- a new option allows to include incubator modules

I've also investigated the value of observing changes in the localedata module. But I don't think there's much use to do this with this approach. The significant changes we're interested in are hidden in the CLDR xml files. Extracting useful information of changes there would be independent and has to be developed from scratch.

Relates to ES-11757