### PR TITLE
[ESQL][D0CS] Fix typo in aggregation functions list

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/lists/aggregation-functions.md
+++ b/docs/reference/query-languages/esql/_snippets/lists/aggregation-functions.md
@@ -8,7 +8,7 @@
 * [`PERCENTILE`](../../functions-operators/aggregation-functions.md#esql-percentile)
 * [`SAMPLE`](../../functions-operators/aggregation-functions.md#esql-sample)
 * {applies_to}`stack: preview` {applies_to}`serverless: preview` [`ST_CENTROID_AGG`](../../functions-operators/aggregation-functions.md#esql-st_centroid_agg)
-* [{applies_to}`stack: preview` {applies_to}`serverless: preview` [`ST_EXTENT_AGG`](../../functions-operators/aggregation-functions.md#esql-st_extent_agg)
+* {applies_to}`stack: preview` {applies_to}`serverless: preview` [`ST_EXTENT_AGG`](../../functions-operators/aggregation-functions.md#esql-st_extent_agg)
 * [`STD_DEV`](../../functions-operators/aggregation-functions.md#esql-std_dev)
 * [`SUM`](../../functions-operators/aggregation-functions.md#esql-sum)
 * [`TOP`](../../functions-operators/aggregation-functions.md#esql-top)


### PR DESCRIPTION
stray `[` all up in our business

h/t to @kkrik-es for catching this 

