### PR TITLE
Allow `reindex.remote.whitelist` to be set to `*`

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/ReindexValidator.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/ReindexValidator.java
@@ -101,15 +101,6 @@ public class ReindexValidator {
         }
         Automaton automaton = Regex.simpleMatchToAutomaton(whitelist.toArray(Strings.EMPTY_ARRAY));
         automaton = Operations.determinize(automaton, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
-        if (Operations.isTotal(automaton)) {
-            throw new IllegalArgumentException(
-                "Refusing to start because whitelist "
-                    + whitelist
-                    + " accepts all addresses. "
-                    + "This would allow users to reindex-from-remote any URL they like effectively having Elasticsearch make HTTP GETs "
-                    + "for them."
-            );
-        }
         return new CharacterRunAutomaton(automaton);
     }
 

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexFromRemoteWhitelistTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexFromRemoteWhitelistTests.java
@@ -16,7 +16,6 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
@@ -112,33 +111,10 @@ public class ReindexFromRemoteWhitelistTests extends ESTestCase {
         assertEquals("[not in list:" + port + "] not whitelisted in reindex.remote.whitelist", e.getMessage());
     }
 
-    public void testRejectMatchAll() {
-        assertMatchesTooMuch(singletonList("*"));
-        assertMatchesTooMuch(singletonList("**"));
-        assertMatchesTooMuch(singletonList("***"));
-        assertMatchesTooMuch(Arrays.asList("realstuff", "*"));
-        assertMatchesTooMuch(Arrays.asList("*", "realstuff"));
-        List<String> random = randomWhitelist();
-        random.add("*");
-        assertMatchesTooMuch(random);
-    }
-
     public void testIPv6Address() {
         List<String> whitelist = randomWhitelist();
         whitelist.add("[::1]:*");
         checkRemoteWhitelist(buildRemoteWhitelist(whitelist), newRemoteInfo("[::1]", 9200));
-    }
-
-    private void assertMatchesTooMuch(List<String> whitelist) {
-        Exception e = expectThrows(IllegalArgumentException.class, () -> buildRemoteWhitelist(whitelist));
-        assertEquals(
-            "Refusing to start because whitelist "
-                + whitelist
-                + " accepts all addresses. "
-                + "This would allow users to reindex-from-remote any URL they like effectively having Elasticsearch make HTTP GETs "
-                + "for them.",
-            e.getMessage()
-        );
     }
 
     private List<String> randomWhitelist() {


### PR DESCRIPTION
Prior to this change, ES would refuse to start if the `reindex.remote.whitelist` node setting was `*` (or anything else which matches every string). This removes that restriction.

The logic did not provide any real security, since it would accept a setting value of `*:*`, which would effectively match everything since the string checked against it was always of the form `<host>:<port>`. It has been agreed that users should be allowed to whitelist everything if they choose, so there is no value to just making it more awkward for them to figure out how to do so.