### PR TITLE
Improve SingleValueMatchQuery

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneCountOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneCountOperator.java
@@ -214,11 +214,22 @@ public class LuceneCountOperator extends LuceneOperator {
         sb.append(", remainingDocs=").append(remainingDocs);
     }
 
-    private class PerTagsState implements LeafCollector {
+    private final class PerTagsState implements LeafCollector {
         long totalHits;
 
         @Override
         public void setScorer(Scorable scorer) {}
+
+        @Override
+        public void collectRange(int min, int max) throws IOException {
+            // Default collectRange(min, max) delegates to collect(DocIdStream),
+            // overwriting this saves creating a DocIdStream instance.
+            if (remainingDocs > 0) {
+                int count = Math.min(max - min, remainingDocs);
+                totalHits += count;
+                remainingDocs -= count;
+            }
+        }
 
         @Override
         public void collect(DocIdStream stream) throws IOException {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/querydsl/query/SingleValueMatchQuery.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/querydsl/query/SingleValueMatchQuery.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.compute.querydsl.query;
 
 import org.apache.lucene.index.DocValues;
-import org.apache.lucene.index.DocValuesSkipper;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.PointValues;


### PR DESCRIPTION
Three changes:
* Check singleton.docIDRunEnd() == maxDoc in order to determine if a field is dense in SingleValueMatchQuery
* Let DocIdSetIteratorScorerSupplier extend from ConstantScoreScorerSupplier, so bulk scoring gets activated.
* overwrite collectRange(...) in PerTagsState