### PR TITLE
Refactor `IndexAbstractionResolver`

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstractionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstractionResolver.java
@@ -48,92 +48,114 @@ public class IndexAbstractionResolver {
         boolean includeDataStreams
     ) {
         final ResolvedIndexExpressions.Builder resolvedExpressionsBuilder = ResolvedIndexExpressions.builder();
-
         boolean wildcardSeen = false;
         for (String index : indices) {
-            String indexAbstraction;
-            boolean minus = false;
-            if (index.charAt(0) == '-' && wildcardSeen) {
-                indexAbstraction = index.substring(1);
-                minus = true;
+            wildcardSeen = resolveIndexAbstraction(
+                resolvedExpressionsBuilder,
+                index,
+                indicesOptions,
+                projectMetadata,
+                allAuthorizedAndAvailableBySelector,
+                isAuthorized,
+                includeDataStreams,
+                wildcardSeen
+            );
+        }
+        return resolvedExpressionsBuilder.build();
+    }
+
+    private boolean resolveIndexAbstraction(
+        ResolvedIndexExpressions.Builder resolvedExpressionsBuilder,
+        String index,
+        IndicesOptions indicesOptions,
+        ProjectMetadata projectMetadata,
+        Function<IndexComponentSelector, Set<String>> allAuthorizedAndAvailableBySelector,
+        BiPredicate<String, IndexComponentSelector> isAuthorized,
+        boolean includeDataStreams,
+        boolean wildcardSeen
+    ) {
+        String indexAbstraction;
+        boolean minus = false;
+        if (index.charAt(0) == '-' && wildcardSeen) {
+            indexAbstraction = index.substring(1);
+            minus = true;
+        } else {
+            indexAbstraction = index;
+        }
+
+        // Always check to see if there's a selector on the index expression
+        final Tuple<String, String> expressionAndSelector = IndexNameExpressionResolver.splitSelectorExpression(indexAbstraction);
+        final String selectorString = expressionAndSelector.v2();
+        if (indicesOptions.allowSelectors() == false && selectorString != null) {
+            throw new UnsupportedSelectorException(indexAbstraction);
+        }
+        indexAbstraction = expressionAndSelector.v1();
+        IndexComponentSelector selector = IndexComponentSelector.getByKeyOrThrow(selectorString);
+
+        // we always need to check for date math expressions
+        indexAbstraction = IndexNameExpressionResolver.resolveDateMathExpression(indexAbstraction);
+
+        if (indicesOptions.expandWildcardExpressions() && Regex.isSimpleMatchPattern(indexAbstraction)) {
+            wildcardSeen = true;
+            final HashSet<String> resolvedIndices = new HashSet<>();
+            for (String authorizedIndex : allAuthorizedAndAvailableBySelector.apply(selector)) {
+                if (Regex.simpleMatch(indexAbstraction, authorizedIndex)
+                    && isIndexVisible(
+                        indexAbstraction,
+                        selectorString,
+                        authorizedIndex,
+                        indicesOptions,
+                        projectMetadata,
+                        indexNameExpressionResolver,
+                        includeDataStreams
+                    )) {
+                    resolveSelectorsAndCollect(authorizedIndex, selectorString, indicesOptions, resolvedIndices, projectMetadata);
+                }
+            }
+            if (resolvedIndices.isEmpty()) {
+                // es core honours allow_no_indices for each wildcard expression, we do the same here by throwing index not found.
+                if (indicesOptions.allowNoIndices() == false) {
+                    throw new IndexNotFoundException(indexAbstraction);
+                }
+                resolvedExpressionsBuilder.addLocalExpressions(index, new HashSet<>(), SUCCESS);
             } else {
-                indexAbstraction = index;
+                if (minus) {
+                    resolvedExpressionsBuilder.excludeFromLocalExpressions(resolvedIndices);
+                } else {
+                    resolvedExpressionsBuilder.addLocalExpressions(index, resolvedIndices, SUCCESS);
+                }
             }
-
-            // Always check to see if there's a selector on the index expression
-            final Tuple<String, String> expressionAndSelector = IndexNameExpressionResolver.splitSelectorExpression(indexAbstraction);
-            final String selectorString = expressionAndSelector.v2();
-            if (indicesOptions.allowSelectors() == false && selectorString != null) {
-                throw new UnsupportedSelectorException(indexAbstraction);
-            }
-            indexAbstraction = expressionAndSelector.v1();
-            IndexComponentSelector selector = IndexComponentSelector.getByKeyOrThrow(selectorString);
-
-            // we always need to check for date math expressions
-            indexAbstraction = IndexNameExpressionResolver.resolveDateMathExpression(indexAbstraction);
-
-            if (indicesOptions.expandWildcardExpressions() && Regex.isSimpleMatchPattern(indexAbstraction)) {
-                wildcardSeen = true;
-                final HashSet<String> resolvedIndices = new HashSet<>();
-                for (String authorizedIndex : allAuthorizedAndAvailableBySelector.apply(selector)) {
-                    if (Regex.simpleMatch(indexAbstraction, authorizedIndex)
+        } else {
+            final HashSet<String> resolvedIndices = new HashSet<>();
+            resolveSelectorsAndCollect(indexAbstraction, selectorString, indicesOptions, resolvedIndices, projectMetadata);
+            if (minus) {
+                resolvedExpressionsBuilder.excludeFromLocalExpressions(resolvedIndices);
+            } else {
+                final boolean authorized = isAuthorized.test(indexAbstraction, selector);
+                if (authorized) {
+                    final boolean visible = indexExists(projectMetadata, indexAbstraction)
                         && isIndexVisible(
                             indexAbstraction,
                             selectorString,
-                            authorizedIndex,
+                            indexAbstraction,
                             indicesOptions,
                             projectMetadata,
                             indexNameExpressionResolver,
                             includeDataStreams
-                        )) {
-                        resolveSelectorsAndCollect(authorizedIndex, selectorString, indicesOptions, resolvedIndices, projectMetadata);
-                    }
-                }
-                if (resolvedIndices.isEmpty()) {
-                    // es core honours allow_no_indices for each wildcard expression, we do the same here by throwing index not found.
-                    if (indicesOptions.allowNoIndices() == false) {
-                        throw new IndexNotFoundException(indexAbstraction);
-                    }
-                    resolvedExpressionsBuilder.addLocalExpressions(index, new HashSet<>(), SUCCESS);
+                        );
+                    final LocalIndexResolutionResult result = visible ? SUCCESS : CONCRETE_RESOURCE_NOT_VISIBLE;
+                    resolvedExpressionsBuilder.addLocalExpressions(index, resolvedIndices, result);
+                } else if (indicesOptions.ignoreUnavailable()) {
+                    // ignoreUnavailable implies that the request should not fail if an index is not authorized
+                    // so we map this expression to an empty list,
+                    resolvedExpressionsBuilder.addLocalExpressions(index, new HashSet<>(), CONCRETE_RESOURCE_UNAUTHORIZED);
                 } else {
-                    if (minus) {
-                        resolvedExpressionsBuilder.excludeFromLocalExpressions(resolvedIndices);
-                    } else {
-                        resolvedExpressionsBuilder.addLocalExpressions(index, resolvedIndices, SUCCESS);
-                    }
-                }
-            } else {
-                final HashSet<String> resolvedIndices = new HashSet<>();
-                resolveSelectorsAndCollect(indexAbstraction, selectorString, indicesOptions, resolvedIndices, projectMetadata);
-                if (minus) {
-                    resolvedExpressionsBuilder.excludeFromLocalExpressions(resolvedIndices);
-                } else {
-                    final boolean authorized = isAuthorized.test(indexAbstraction, selector);
-                    if (authorized) {
-                        final boolean visible = indexExists(projectMetadata, indexAbstraction)
-                            && isIndexVisible(
-                                indexAbstraction,
-                                selectorString,
-                                indexAbstraction,
-                                indicesOptions,
-                                projectMetadata,
-                                indexNameExpressionResolver,
-                                includeDataStreams
-                            );
-                        final LocalIndexResolutionResult result = visible ? SUCCESS : CONCRETE_RESOURCE_NOT_VISIBLE;
-                        resolvedExpressionsBuilder.addLocalExpressions(index, resolvedIndices, result);
-                    } else if (indicesOptions.ignoreUnavailable()) {
-                        // ignoreUnavailable implies that the request should not fail if an index is not authorized
-                        // so we map this expression to an empty list,
-                        resolvedExpressionsBuilder.addLocalExpressions(index, new HashSet<>(), CONCRETE_RESOURCE_UNAUTHORIZED);
-                    } else {
-                        // store the calculated expansion as unauthorized, it will be rejected later
-                        resolvedExpressionsBuilder.addLocalExpressions(index, resolvedIndices, CONCRETE_RESOURCE_UNAUTHORIZED);
-                    }
+                    // store the calculated expansion as unauthorized, it will be rejected later
+                    resolvedExpressionsBuilder.addLocalExpressions(index, resolvedIndices, CONCRETE_RESOURCE_UNAUTHORIZED);
                 }
             }
         }
-        return resolvedExpressionsBuilder.build();
+        return wildcardSeen;
     }
 
     private static void resolveSelectorsAndCollect(


### PR DESCRIPTION
Refactor `IndexAbstractionResolver` to make a single resource resolution step re-usable. Non-functional refactor in preparation for cross-project search index resolution (see [this](https://github.com/elastic/elasticsearch/pull/135346/files#diff-3e278f8a5f49993b4e491a25ddeaf382289d122a69492902cf61ede33589e9a6R53) PR).  