### PR TITLE
Added required Google Workspace Scopes for es-connectors-gmail.md

### DIFF
--- a/docs/reference/search-connectors/es-connectors-gmail.md
+++ b/docs/reference/search-connectors/es-connectors-gmail.md
@@ -132,6 +132,8 @@ To get started, log into [Google Cloud Platform](https://cloud.google.com) and g
     You need to grant the following **OAuth Scopes** to your service account:
 
     * `https://www.googleapis.com/auth/admin.directory.user.readonly`
+    * `https://www.googleapis.com/auth/admin.directory.group.readonly`
+    * `https://www.googleapis.com/auth/gmail.readonly`
 
     This step allows the connector to access user data and their group memberships in your Google Workspace organization.
 


### PR DESCRIPTION
In addition to the directory user read-only scope, ES needs the Group Directory read only as well as the gmail readonly.


