### PR TITLE
[8.19] Fix InternalCategorizationAggregationTests.testReduceRandom (#135533)

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/categorization/InternalCategorizationAggregationTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/categorization/InternalCategorizationAggregationTests.java
@@ -46,12 +46,6 @@ public class InternalCategorizationAggregationTests extends InternalMultiBucketA
         return MachineLearningTests.createTrialLicensedMachineLearning(Settings.EMPTY);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/87240")
-    public void testReduceRandom() {
-        // The bug is in the assertReduced() method immediately below that the base class testReduceRandom() calls.
-        // To unmute after the bug is fixed, simply delete this entire method so that the base class method is used again.
-    }
-
     @Override
     protected void assertReduced(InternalCategorizationAggregation reduced, List<InternalCategorizationAggregation> inputs) {
         Map<Object, Long> reducedCounts = toCounts(reduced.getBuckets().stream());
@@ -80,7 +74,7 @@ public class InternalCategorizationAggregationTests extends InternalMultiBucketA
             name,
             randomIntBetween(10, 100),
             randomLongBetween(1, 10),
-            randomIntBetween(1, 100),
+            randomIntBetween(50, 100),
             metadata,
             buckets
         );


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Fix InternalCategorizationAggregationTests.testReduceRandom (#135533)