### PR TITLE
[8.18] [8.19][DOCS] GeoIP processor: add clarification about using a reverse proxy endpoint (#135537)

### DIFF
--- a/docs/reference/ingest/processors/geoip.asciidoc
+++ b/docs/reference/ingest/processors/geoip.asciidoc
@@ -343,17 +343,19 @@ GET /my_ip_locations/_search
 If you can't <<geoip-automatic-updates,automatically update>> your IP geolocation databases
 from the Elastic endpoint, you have a few other options:
 
-* <<use-proxy-geoip-endpoint,Use a proxy endpoint>>
+* <<use-proxy-geoip-endpoint,Use a reverse proxy endpoint>>
 * <<use-custom-geoip-endpoint,Use a custom endpoint>>
 * <<manually-update-geoip-databases,Manually update your IP geolocation databases>>
 
 [[use-proxy-geoip-endpoint]]
-**Use a proxy endpoint**
+**Use a reverse proxy endpoint**
 
 If you can't connect directly to the Elastic GeoIP endpoint, consider setting up
-a secure proxy. You can then specify the proxy endpoint URL in the
+a secure reverse proxy. You can then specify the reverse proxy endpoint URL in the
 <<ingest-geoip-downloader-endpoint,`ingest.geoip.downloader.endpoint`>> setting
 of each node’s `elasticsearch.yml` file.
+
+NOTE: True HTTP proxy support for GeoIP database downloads is not currently available in {es}.
 
 In a strict setup the following domains may need to be added to the allowed
 domains list:


### PR DESCRIPTION
Backports the following commits to 8.18:
 - [8.19][DOCS] GeoIP processor: add clarification about using a reverse proxy endpoint (#135537)