### PR TITLE
[9.0] [ESQL] Docs clarify counts are approximate in count_distinct docs (#135600)

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/functions/description/count_distinct.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/description/count_distinct.md
@@ -4,3 +4,8 @@
 
 Returns the approximate number of distinct values.
 
+::::{note}
+[Counts are approximate](/reference/query-languages/esql/functions-operators/aggregation-functions.md#esql-agg-count-distinct-approximate).
+::::
+
+

--- a/docs/reference/query-languages/esql/kibana/definition/functions/count_distinct.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/count_distinct.json
@@ -3,6 +3,7 @@
   "type" : "agg",
   "name" : "count_distinct",
   "description" : "Returns the approximate number of distinct values.",
+  "note" : "Counts are approximate.",
   "signatures" : [
     {
       "params" : [

--- a/docs/reference/query-languages/esql/kibana/docs/functions/count_distinct.md
+++ b/docs/reference/query-languages/esql/kibana/docs/functions/count_distinct.md
@@ -3,6 +3,8 @@
 ### COUNT DISTINCT
 Returns the approximate number of distinct values.
 
+Note: [Counts are approximate](https://www.elastic.co/docs/reference/query-languages/esql/functions-operators/aggregation-functions#esql-agg-count-distinct-approximate).
+
 ```esql
 FROM hosts
 | STATS COUNT_DISTINCT(ip0), COUNT_DISTINCT(ip1)

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinct.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinct.java
@@ -78,6 +78,8 @@ public class CountDistinct extends AggregateFunction implements OptionalArgument
     @FunctionInfo(
         returnType = "long",
         description = "Returns the approximate number of distinct values.",
+        note = "[Counts are approximate](/reference/query-languages/esql/functions-operators/"
+            + "aggregation-functions.md#esql-agg-count-distinct-approximate).",
         appendix = """
             ### Counts are approximate [esql-agg-count-distinct-approximate]
 


### PR DESCRIPTION
Backports the following commits to 9.0:
 - [ESQL] Docs clarify counts are approximate in count_distinct docs (#135600)