### PR TITLE
make it cheaper when there is no path in ContentPath

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/ContentPath.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ContentPath.java
@@ -58,6 +58,9 @@ public final class ContentPath {
     }
 
     public String pathAsText(String name) {
+        if (index == 0) {
+            return name;
+        }
         sb.setLength(0);
         for (int i = 0; i < index; i++) {
             sb.append(path[i]).append(DELIMITER);


### PR DESCRIPTION
This makes a bit cheaper to call `ContentPath#pathAsText` when there is actually no path as we are not copying the string into the string buffer.