### PR TITLE
[8.19] [Example Builds] Fix Jarhell in example build due to version conflict (#135598)

### DIFF
--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -11,15 +11,6 @@ import org.elasticsearch.gradle.internal.info.BuildParams;
 apply plugin: 'elasticsearch.build'
 apply plugin: 'elasticsearch.publish'
 
-configurations {
-  // we do not want to expose a version conflict in transitive dependencies by
-  // bringing in different versions of hamcrest and hamcrest-core.
-  // Therefore we exclude transitive deps on hamcrest-core here as we have a direct
-  // dependency on a newer version.
-  runtimeElements {
-    exclude group: 'org.hamcrest', module: 'hamcrest-core'
-  }
-}
 dependencies {
   api project(":client:rest")
   api project(':modules:transport-netty4')
@@ -27,13 +18,22 @@ dependencies {
   api project(":server")
   api project(":libs:cli")
   api project(":libs:entitlement:bridge")
-  api "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
-  api("junit:junit:${versions.junit}") {
-//    exclude group: 'org.hamcrest'
+  api ("com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}") {
+    exclude group: "junit", module: "junit"
   }
+
+  // we do not want to expose a version conflict in transitive dependencies by
+  // bringing in different versions of dependencies.
+  // Therefore we exclude mismatches in our transitive dependencies explicitly.
+  // This also avoids jarHell issues with different hamcrest related dependencies
+  // like hamcrest and hamcrest-core
   api "org.hamcrest:hamcrest:${versions.hamcrest}"
+  api("junit:junit:${versions.junit}") {
+    exclude group: 'org.hamcrest', module: 'hamcrest-core'
+  }
   api("org.apache.lucene:lucene-test-framework:${versions.lucene}") {
-//    exclude group: 'org.hamcrest'
+    exclude group: "junit", module: "junit"
+    exclude group: 'com.carrotsearch.randomizedtesting', module: 'randomizedtesting-runner'
   }
   api "org.apache.lucene:lucene-codecs:${versions.lucene}"
   api "commons-logging:commons-logging:${versions.commonslogging}"


### PR DESCRIPTION
Backports the following commits to 8.19:
 - [Example Builds] Fix Jarhell in example build due to version conflict (#135598)