### PR TITLE
Fix over-aggressive usage of EMPTY in ExtendedSearchUsageStats

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -591,9 +591,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/134407
-- class: org.elasticsearch.action.admin.cluster.stats.SearchUsageStatsTests
-  method: testToXContent
-  issue: https://github.com/elastic/elasticsearch/issues/135558
 - class: org.elasticsearch.search.ccs.SparseVectorQueryBuilderCrossClusterSearchIT
   method: testSparseVectorQueryWithCcsMinimizeRoundTripsFalse
   issue: https://github.com/elastic/elasticsearch/issues/135559

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/SearchUsageStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/SearchUsageStats.java
@@ -51,7 +51,7 @@ public final class SearchUsageStats implements Writeable, ToXContentFragment {
         this.sections = new HashMap<>();
         this.rescorers = new HashMap<>();
         this.retrievers = new HashMap<>();
-        this.extendedSearchUsageStats = ExtendedSearchUsageStats.EMPTY;
+        this.extendedSearchUsageStats = new ExtendedSearchUsageStats();
     }
 
     /**


### PR DESCRIPTION
Resolves https://github.com/elastic/elasticsearch/issues/135558 

