### PR TITLE
[8.19] [Transform] Reset health status on successful noop (#135653)

### DIFF
--- a/docs/changelog/135653.yaml
+++ b/docs/changelog/135653.yaml
@@ -1,0 +1,6 @@
+pr: 135653
+summary: Reset health status on successful empty checkpoint
+area: Machine Learning
+type: bug
+issues:
+ - 135650

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformIT.java
@@ -217,7 +217,6 @@ public class TransformIT extends TransformRestTestCase {
      * Verify the basic stats API, which includes state, health, and optionally progress (if it exists).
      * These are required for Kibana 8.13+.
      */
-    @SuppressWarnings("unchecked")
     public void testBasicContinuousTransformStats() throws Exception {
         var transformId = "transform-continuous-basic-stats";
         createContinuousTransform("continuous-basic-stats-reviews", transformId, "reviews-by-user-business-day");
@@ -232,6 +231,50 @@ public class TransformIT extends TransformRestTestCase {
 
         stopTransform(transformId);
         deleteTransform(transformId);
+    }
+
+    public void testEmptySourceIndexClearsErrors() throws Exception {
+        var sourceIndexName = "source-empty-reviews";
+        var destIndexName = "destination-empty-reviews";
+        var transformId = "transform-empty-source-index";
+
+        createReviewsIndexMappings(sourceIndexName, null);
+
+        var config = createTransformConfigBuilder(transformId, destIndexName, QueryConfig.matchAll(), sourceIndexName).setPivotConfig(
+            createPivotConfig(groupByUserOnly(), aggregateScoresAndTimes())
+        )
+            .setSyncConfig(new TimeSyncConfig("timestamp", TimeValue.timeValueSeconds(1)))
+            .setSettings(new SettingsConfig.Builder().setUnattended(true).build())
+            .build();
+
+        putTransform(transformId, Strings.toString(config), RequestOptions.DEFAULT);
+        startTransform(config.getId(), RequestOptions.DEFAULT);
+
+        waitUntilCheckpoint(config.getId(), 1L);
+        assertEquals("green", getTransformHealthStatus(transformId));
+
+        // this will cause the transform to fail to search
+        assertAcknowledged(adminClient().performRequest(new Request("PUT", sourceIndexName + "/_block/read")));
+        assertBusy(() -> assertThat(getTransformHealthStatus(transformId), oneOf("yellow", "red")), 30, TimeUnit.SECONDS);
+
+        // unblock reads on the search index and the transform should recover
+        assertAcknowledged(adminClient().performRequest(new Request("DELETE", sourceIndexName + "/_block/read")));
+        assertBusy(() -> assertEquals("green", getTransformHealthStatus(transformId)), 30, TimeUnit.SECONDS);
+
+        stopTransform(transformId);
+        deleteTransform(transformId);
+        deleteIndex(sourceIndexName);
+        deleteIndex(destIndexName);
+    }
+
+    private Map<String, SingleGroupSource> groupByUserOnly() {
+        return Map.of("by-user", new TermsGroupSource("user_id", null, false));
+    }
+
+    private AggregatorFactories.Builder aggregateScoresAndTimes() {
+        return AggregatorFactories.builder()
+            .addAggregator(AggregationBuilders.avg("review_score").field("stars"))
+            .addAggregator(AggregationBuilders.max("timestamp").field("timestamp"));
     }
 
     public void testDestinationIndexBlocked() throws Exception {
@@ -385,12 +428,8 @@ public class TransformIT extends TransformRestTestCase {
         String indexName = "continuous-reviews-update";
         createReviewsIndex(indexName, 10, NUM_USERS, TransformIT::getUserIdForRow, TransformIT::getDateStringForRow);
 
-        Map<String, SingleGroupSource> groups = new HashMap<>();
-        groups.put("by-user", new TermsGroupSource("user_id", null, false));
-
-        AggregatorFactories.Builder aggs = AggregatorFactories.builder()
-            .addAggregator(AggregationBuilders.avg("review_score").field("stars"))
-            .addAggregator(AggregationBuilders.max("timestamp").field("timestamp"));
+        var groups = groupByUserOnly();
+        var aggs = aggregateScoresAndTimes();
 
         String id = "transform-to-update";
         String dest = "reviews-by-user-business-day-to-update";
@@ -481,8 +520,7 @@ public class TransformIT extends TransformRestTestCase {
         String dest = "retention-policy-dest";
         createReviewsIndex(indexName, 10, NUM_USERS, TransformIT::getUserIdForRow, TransformIT::getDateStringForRow);
 
-        Map<String, SingleGroupSource> groups = new HashMap<>();
-        groups.put("by-user", new TermsGroupSource("user_id", null, false));
+        var groups = groupByUserOnly();
 
         AggregatorFactories.Builder aggs = AggregatorFactories.builder()
             .addAggregator(AggregationBuilders.max("timestamp").field("timestamp"));

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformIT.java
@@ -258,7 +258,11 @@ public class TransformIT extends TransformRestTestCase {
         assertBusy(() -> assertThat(getTransformHealthStatus(transformId), oneOf("yellow", "red")), 30, TimeUnit.SECONDS);
 
         // unblock reads on the search index and the transform should recover
-        assertAcknowledged(adminClient().performRequest(new Request("DELETE", sourceIndexName + "/_block/read")));
+        var request = new Request("PUT", sourceIndexName + "/_settings");
+        request.setJsonEntity("""
+                { "blocks.read": false }
+            """);
+        assertAcknowledged(adminClient().performRequest(request));
         assertBusy(() -> assertEquals("green", getTransformHealthStatus(transformId)), 30, TimeUnit.SECONDS);
 
         stopTransform(transformId);

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -483,6 +483,7 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
             if (context.shouldStopAtCheckpoint()) {
                 stop();
             }
+            context.resetReasonAndFailureCounter();
             listener.onResponse(null);
             return;
         }


### PR DESCRIPTION
Backports the following commits to 8.19:
 - [Transform] Reset health status on successful noop (#135653)
  - Approval for test changes on https://github.com/elastic/elasticsearch/pull/135658