### PR TITLE
[8.19] Use ubuntu24 for java periodic builds 

### DIFF
--- a/.buildkite/pipelines/periodic.template.yml
+++ b/.buildkite/pipelines/periodic.template.yml
@@ -44,7 +44,6 @@ steps:
         matrix:
           setup:
             ES_RUNTIME_JAVA:
-              - openjdk17
               - adoptopenjdk17
             GRADLE_TASK:
               - checkPart1
@@ -56,7 +55,7 @@ steps:
               - checkRestCompat
         agents:
           provider: gcp
-          image: family/elasticsearch-ubuntu-2204
+          image: family/elasticsearch-ubuntu-2404
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
         env:
@@ -68,12 +67,11 @@ steps:
         matrix:
           setup:
             ES_RUNTIME_JAVA:
-              - openjdk17
               - adoptopenjdk17
             BWC_VERSION: $BWC_LIST
         agents:
           provider: gcp
-          image: family/elasticsearch-ubuntu-2204
+          image: family/elasticsearch-ubuntu-2404
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
         env:
@@ -88,7 +86,6 @@ steps:
           setup:
             ES_RUNTIME_JAVA:
               - graalvm-ce17
-              - openjdk17
               - adoptopenjdk17
               - openjdk21
               - openjdk22
@@ -103,7 +100,7 @@ steps:
               - checkRestCompat
         agents:
           provider: gcp
-          image: family/elasticsearch-ubuntu-2204
+          image: family/elasticsearch-ubuntu-2404
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
         env:
@@ -116,7 +113,6 @@ steps:
           setup:
             ES_RUNTIME_JAVA:
               - graalvm-ce17
-              - openjdk17
               - adoptopenjdk17
               - openjdk21
               - openjdk22
@@ -124,7 +120,7 @@ steps:
             BWC_VERSION: $BWC_LIST
         agents:
           provider: gcp
-          image: family/elasticsearch-ubuntu-2204
+          image: family/elasticsearch-ubuntu-2404
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
         env:

--- a/.buildkite/pipelines/periodic.yml
+++ b/.buildkite/pipelines/periodic.yml
@@ -767,7 +767,6 @@ steps:
         matrix:
           setup:
             ES_RUNTIME_JAVA:
-              - openjdk17
               - adoptopenjdk17
             GRADLE_TASK:
               - checkPart1
@@ -779,7 +778,7 @@ steps:
               - checkRestCompat
         agents:
           provider: gcp
-          image: family/elasticsearch-ubuntu-2204
+          image: family/elasticsearch-ubuntu-2404
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
         env:
@@ -791,12 +790,11 @@ steps:
         matrix:
           setup:
             ES_RUNTIME_JAVA:
-              - openjdk17
               - adoptopenjdk17
             BWC_VERSION: ["7.17.30", "8.18.8", "8.19.5"]
         agents:
           provider: gcp
-          image: family/elasticsearch-ubuntu-2204
+          image: family/elasticsearch-ubuntu-2404
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
         env:
@@ -811,7 +809,6 @@ steps:
           setup:
             ES_RUNTIME_JAVA:
               - graalvm-ce17
-              - openjdk17
               - adoptopenjdk17
               - openjdk21
               - openjdk22
@@ -826,7 +823,7 @@ steps:
               - checkRestCompat
         agents:
           provider: gcp
-          image: family/elasticsearch-ubuntu-2204
+          image: family/elasticsearch-ubuntu-2404
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
         env:
@@ -839,7 +836,6 @@ steps:
           setup:
             ES_RUNTIME_JAVA:
               - graalvm-ce17
-              - openjdk17
               - adoptopenjdk17
               - openjdk21
               - openjdk22
@@ -847,7 +843,7 @@ steps:
             BWC_VERSION: ["7.17.30", "8.18.8", "8.19.5"]
         agents:
           provider: gcp
-          image: family/elasticsearch-ubuntu-2204
+          image: family/elasticsearch-ubuntu-2404
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
         env:


### PR DESCRIPTION
Only rely on adoptjdk17 instead of openjdk17 as ladder is incompatible with newer ubuntu versions.