### PR TITLE
[9.1] [ML] Add .ml indices to the DoPrefixValidator exceptions (#135171)

### DIFF
--- a/modules/dot-prefix-validation/src/main/java/org/elasticsearch/validation/DotPrefixValidator.java
+++ b/modules/dot-prefix-validation/src/main/java/org/elasticsearch/validation/DotPrefixValidator.java
@@ -61,16 +61,14 @@ public abstract class DotPrefixValidator<RequestType> implements MappedActionFil
      * .ml-* is used by ML
      * .slo-observability-* is used by Observability
      */
-    private static Set<String> IGNORED_INDEX_NAMES = Set.of(
-        ".elastic-connectors-v1",
-        ".elastic-connectors-sync-jobs-v1",
-        ".ml-state",
-        ".ml-anomalies-unrelated"
-    );
+    private static Set<String> IGNORED_INDEX_NAMES = Set.of(".elastic-connectors-v1", ".elastic-connectors-sync-jobs-v1", ".ml-state");
     public static final Setting<List<String>> IGNORED_INDEX_PATTERNS_SETTING = Setting.stringListSetting(
         "cluster.indices.validate_ignored_dot_patterns",
         List.of(
+            "\\.ml-anomalies-.*",
+            "\\.ml-annotations-\\d+",
             "\\.ml-state-\\d+",
+            "\\.ml-stats-\\d+",
             "\\.slo-observability\\.sli-v\\d+.*",
             "\\.slo-observability\\.summary-v\\d+.*",
             "\\.entities\\.v\\d+\\.latest\\..*",

--- a/modules/dot-prefix-validation/src/test/java/org/elasticsearch/validation/DotPrefixValidatorTests.java
+++ b/modules/dot-prefix-validation/src/test/java/org/elasticsearch/validation/DotPrefixValidatorTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.BeforeClass;
@@ -27,8 +28,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class DotPrefixValidatorTests extends ESTestCase {
-    private final OperatorValidator<?> opV = new OperatorValidator<>();
-    private final NonOperatorValidator<?> nonOpV = new NonOperatorValidator<>();
+    private final OperatorValidator<?> opV = new OperatorValidator<>(true);
+    private final NonOperatorValidator<?> nonOpV = new NonOperatorValidator<>(true);
 
     private static ClusterService clusterService;
 
@@ -58,14 +59,19 @@ public class DotPrefixValidatorTests extends ESTestCase {
         opV.validateIndices(Set.of(".regular"));
         assertFails(Set.of("first", ".second"));
         assertFails(Set.of("<.regular-{MM-yy-dd}>"));
+        assertFails(Set.of(".this_index_contains_an_excepted_pattern.ml-annotations-1"));
 
         // Test ignored names
         nonOpV.validateIndices(Set.of(".elastic-connectors-v1"));
         nonOpV.validateIndices(Set.of(".elastic-connectors-sync-jobs-v1"));
         nonOpV.validateIndices(Set.of(".ml-state"));
+        nonOpV.validateIndices(Set.of(".ml-state-000001"));
+        nonOpV.validateIndices(Set.of(".ml-stats-000001"));
         nonOpV.validateIndices(Set.of(".ml-anomalies-unrelated"));
 
         // Test ignored patterns
+        nonOpV.validateIndices(Set.of(".ml-annotations-21309"));
+        nonOpV.validateIndices(Set.of(".ml-annotations-2"));
         nonOpV.validateIndices(Set.of(".ml-state-21309"));
         nonOpV.validateIndices(Set.of("<.ml-state-21309>"));
         nonOpV.validateIndices(Set.of(".slo-observability.sli-v2"));
@@ -96,7 +102,8 @@ public class DotPrefixValidatorTests extends ESTestCase {
     }
 
     private void assertFails(Set<String> indices) {
-        nonOpV.validateIndices(indices);
+        var validator = new NonOperatorValidator<>(false);
+        validator.validateIndices(indices);
         assertWarnings(
             "Index ["
                 + indices.stream().filter(i -> i.startsWith(".") || i.startsWith("<.")).toList().get(0)
@@ -104,10 +111,13 @@ public class DotPrefixValidatorTests extends ESTestCase {
         );
     }
 
-    private static class NonOperatorValidator<R> extends DotPrefixValidator<R> {
+    private class NonOperatorValidator<R> extends DotPrefixValidator<R> {
 
-        private NonOperatorValidator() {
+        private final boolean assertNoWarnings;
+
+        private NonOperatorValidator(boolean assertNoWarnings) {
             super(new ThreadContext(Settings.EMPTY), clusterService);
+            this.assertNoWarnings = assertNoWarnings;
         }
 
         @Override
@@ -121,12 +131,24 @@ public class DotPrefixValidatorTests extends ESTestCase {
         }
 
         @Override
+        void validateIndices(@Nullable Set<String> indices) {
+            super.validateIndices(indices);
+            if (assertNoWarnings) {
+                assertWarnings();
+            }
+        }
+
+        @Override
         boolean isInternalRequest() {
             return false;
         }
     }
 
-    private static class OperatorValidator<R> extends NonOperatorValidator<R> {
+    private class OperatorValidator<R> extends NonOperatorValidator<R> {
+        private OperatorValidator(boolean assertNoWarnings) {
+            super(assertNoWarnings);
+        }
+
         @Override
         boolean isInternalRequest() {
             return true;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[ML] Add .ml indices to the DoPrefixValidator exceptions (#135171)](https://github.com/elastic/elasticsearch/pull/135171)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)