### PR TITLE
unmute ESVectorUtilTests#testSoarDistance on 9.1

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -449,9 +449,6 @@ tests:
 - class: org.elasticsearch.aggregations.bucket.AggregationReductionCircuitBreakingIT
   method: testCBTrippingOnReduction
   issue: https://github.com/elastic/elasticsearch/issues/134902
-- class: org.elasticsearch.simdvec.ESVectorUtilTests
-  method: testSoarDistance
-  issue: https://github.com/elastic/elasticsearch/issues/135139
 
 # Examples:
 #


### PR DESCRIPTION
Unmute `ESVectorUtilTests#testSoarDistance` as the [fix](https://github.com/elastic/elasticsearch/pull/131700) has been merged.