### PR TITLE
[9.0] [Build] Aggressively increase gradle based Test Cluster startup timeout (#135672)

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchCluster.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchCluster.java
@@ -65,7 +65,7 @@ import static org.elasticsearch.gradle.testclusters.TestClustersPlugin.BUNDLE_AT
 public class ElasticsearchCluster implements TestClusterConfiguration, Named {
 
     private static final Logger LOGGER = Logging.getLogger(ElasticsearchNode.class);
-    private static final int CLUSTER_UP_TIMEOUT = 40;
+    private static final int CLUSTER_UP_TIMEOUT = 120;
     private static final TimeUnit CLUSTER_UP_TIMEOUT_UNIT = TimeUnit.SECONDS;
 
     private final AtomicBoolean configurationFrozen = new AtomicBoolean(false);


### PR DESCRIPTION
Backports the following commits to 9.0:
 - [Build] Aggressively increase gradle based Test Cluster startup timeout (#135672)