### PR TITLE
[8.18] Ignore ASM labels for figuring out transport version constant strings (#135659)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/CollectTransportVersionReferencesTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/CollectTransportVersionReferencesTask.java
@@ -102,6 +102,12 @@ public abstract class CollectTransportVersionReferencesTask extends DefaultTask 
                     }
 
                     @Override
+                    public void visitLabel(Label label) {
+                        // asm uses many debug labels that we do not want to consider
+                        // so we ignore labels so they do not become part of the instructions list
+                    }
+
+                    @Override
                     public void visitMethodInsn(int opcode, String owner, String name, String descriptor, boolean isInterface) {
                         if (owner.equals(TRANSPORT_VERSION_SET_CLASS) && name.equals(TRANSPORT_VERSION_SET_METHOD_NAME)) {
                             var abstractInstruction = this.instructions.getLast();


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Ignore ASM labels for figuring out transport version constant strings (#135659)