### PR TITLE
Use unmodifiableMap for shardSizes in ClusterInfo

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
@@ -26,6 +26,7 @@ import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
@@ -98,7 +99,7 @@ public class ClusterInfo implements ChunkedToXContent, Writeable {
     ) {
         this.leastAvailableSpaceUsage = Map.copyOf(leastAvailableSpaceUsage);
         this.mostAvailableSpaceUsage = Map.copyOf(mostAvailableSpaceUsage);
-        this.shardSizes = Map.copyOf(shardSizes);
+        this.shardSizes = Collections.unmodifiableMap(shardSizes); // intentional use unmodifiableMap to avoid expensive copying
         this.shardDataSetSizes = Map.copyOf(shardDataSetSizes);
         this.dataPath = Map.copyOf(dataPath);
         this.reservedSpace = Map.copyOf(reservedSpace);

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterInfoSimulator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterInfoSimulator.java
@@ -159,7 +159,7 @@ public class ClusterInfoSimulator {
         return new ClusterInfo(
             leastAvailableSpaceUsage,
             mostAvailableSpaceUsage,
-            shardSizes.toImmutableMap(),
+            shardSizes,
             shardDataSetSizes,
             dataPath,
             Map.of(),


### PR DESCRIPTION
To avoid copying potentially large shardSizes which shows performance issue.

Relates: ES-12723
