### PR TITLE
[8.18] Fix KQL case-sensitivity for keyword fields in ES|QL (#135776)

### DIFF
--- a/docs/changelog/135776.yaml
+++ b/docs/changelog/135776.yaml
@@ -1,0 +1,6 @@
+pr: 135776
+summary: Fix KQL case-sensitivity for keyword fields in ES|QL
+area: Search
+type: bug
+issues:
+ - 135772

--- a/x-pack/plugin/kql/src/main/java/org/elasticsearch/xpack/kql/query/KqlQueryBuilder.java
+++ b/x-pack/plugin/kql/src/main/java/org/elasticsearch/xpack/kql/query/KqlQueryBuilder.java
@@ -71,7 +71,7 @@ public class KqlQueryBuilder extends AbstractQueryBuilder<KqlQueryBuilder> {
     }
 
     private final String query;
-    private boolean caseInsensitive = true;
+    private boolean caseInsensitive = false;
     private ZoneId timeZone;
     private String defaultField;
 
@@ -152,7 +152,7 @@ public class KqlQueryBuilder extends AbstractQueryBuilder<KqlQueryBuilder> {
     }
 
     @Override
-    protected QueryBuilder doIndexMetadataRewrite(QueryRewriteContext context) throws IOException {
+    protected QueryBuilder doIndexMetadataRewrite(QueryRewriteContext context) {
         try {
             KqlParser parser = new KqlParser();
             QueryBuilder rewrittenQuery = parser.parseKqlQuery(query, createKqlParserContext(context));

--- a/x-pack/plugin/kql/src/test/java/org/elasticsearch/xpack/kql/query/KqlQueryBuilderTests.java
+++ b/x-pack/plugin/kql/src/test/java/org/elasticsearch/xpack/kql/query/KqlQueryBuilderTests.java
@@ -170,7 +170,7 @@ public class KqlQueryBuilderTests extends AbstractQueryTestCase<KqlQueryBuilder>
         for (boolean caseInsensitive : List.of(true, false)) {
             KqlQueryBuilder kqlQuery = new KqlQueryBuilder(KEYWORD_FIELD_NAME + ": foo*");
             // Check case case_insensitive is true by default
-            assertThat(kqlQuery.caseInsensitive(), equalTo(true));
+            assertThat(kqlQuery.caseInsensitive(), equalTo(false));
 
             kqlQuery.caseInsensitive(caseInsensitive);
 
@@ -190,7 +190,7 @@ public class KqlQueryBuilderTests extends AbstractQueryTestCase<KqlQueryBuilder>
         for (boolean caseInsensitive : List.of(true, false)) {
             KqlQueryBuilder kqlQuery = new KqlQueryBuilder(KEYWORD_FIELD_NAME + ": foo");
             // Check case case_insensitive is true by default
-            assertThat(kqlQuery.caseInsensitive(), equalTo(true));
+            assertThat(kqlQuery.caseInsensitive(), equalTo(false));
 
             kqlQuery.caseInsensitive(caseInsensitive);
 

--- a/x-pack/plugin/kql/src/yamlRestTest/resources/rest-api-spec/test/kql/20_kql_match_query.yml
+++ b/x-pack/plugin/kql/src/yamlRestTest/resources/rest-api-spec/test/kql/20_kql_match_query.yml
@@ -57,6 +57,17 @@ setup:
         rest_total_hits_as_int: true
         body: >
           {
+            "query": { "kql": { "query": "text_field: Bar" } }
+          }
+  - match: { hits.total: 1 }
+  - match: { hits.hits.0._id: "doc-1" }
+
+  - do:
+      search:
+        index: test-index
+        rest_total_hits_as_int: true
+        body: >
+          {
             "query": { "kql": { "query": "text_field: foo bar" } }
           }
   - match: { hits.total: 2 }
@@ -93,6 +104,16 @@ setup:
   - match: { hits.total: 1 }
   - match: { hits.hits.0._id: "doc-1" }
 
+  - do:
+      search:
+        index: test-index
+        rest_total_hits_as_int: true
+        body: >
+          {
+            "query": { "kql": { "query": "text_field: Bar*" } }
+          }
+  - match: { hits.total: 1 }
+  - match: { hits.hits.0._id: "doc-1" }
 
 ---
 "KQL match term queries (integer field)":
@@ -190,6 +211,16 @@ setup:
         rest_total_hits_as_int: true
         body: >
           {
+            "query": { "kql": { "query": "keyword_field: Foo bar" } }
+          }
+  - match: { hits.total: 0 }
+
+  - do:
+      search:
+        index: test-index
+        rest_total_hits_as_int: true
+        body: >
+          {
             "query": { "kql": { "query": "keyword_field: \"foo bar\"" } }
           }
   - match: { hits.total: 1 }
@@ -205,6 +236,15 @@ setup:
           }
   - match: { hits.total: 2 }
 
+  - do:
+      search:
+        index: test-index
+        rest_total_hits_as_int: true
+        body: >
+          {
+            "query": { "kql": { "query": "keyword_field: Foo ba*" } }
+          }
+  - match: { hits.total: 0 }
 
 ---
 "KQL match term queries (date field)":


### PR DESCRIPTION
Backports the following commits to 8.18:
 - Fix KQL case-sensitivity for keyword fields in ES|QL (#135776)