### PR TITLE
[8.18] Updates Logstash pipeline ID description to point out the restrictions/acceptance. (#135557)

### DIFF
--- a/docs/reference/rest-api/logstash/put-pipeline.asciidoc
+++ b/docs/reference/rest-api/logstash/put-pipeline.asciidoc
@@ -36,7 +36,9 @@ replaced.
 ==== {api-path-parms-title}
 
 `<pipeline_id>`::
-  (Required, string) Identifier for the pipeline.
+(Required, string)
+Identifier for the pipeline.
+It must begin with a letter or underscore and can contain only letters, underscores, dashes, hyphens, and numbers.
 
 [[logstash-api-put-pipeline-request-body]]
 ==== {api-request-body-title}


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.19` to `8.18`:
 - [Updates Logstash pipeline ID description to point out the restrictions/acceptance. (#135557)](https://github.com/elastic/elasticsearch/pull/135557)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)