### PR TITLE
[9.0] Use lowercase sort order in geo_line YAML tests (#135690)

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/spatial/120_position_geo_line.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/spatial/120_position_geo_line.yml
@@ -82,7 +82,7 @@ setup:
                       field: location
                     sort:
                       field: "@timestamp"
-                    sort_order: ASC
+                    sort_order: asc
   - match: { hits.total: 10 }
   - length: { aggregations.by_time_series.buckets: 3 }
   - match:
@@ -135,7 +135,7 @@ setup:
                       field: location
                     sort:
                       field: "@timestamp"
-                    sort_order: DESC
+                    sort_order: desc
   - match: { hits.total: 10 }
   - length: { aggregations.by_time_series.buckets: 3 }
   - match:


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Use lowercase sort order in geo_line YAML tests (#135690)