### PR TITLE
[8.19] Fix assertion error when executing invalid row query with filter (#135761)

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
@@ -39,6 +39,7 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.extras.MapperExtrasPlugin;
 import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.index.shard.IndexShard;
@@ -151,11 +152,27 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
     public void testRowWithFilter() {
         long value = randomLongBetween(0, Long.MAX_VALUE);
         EsqlQueryRequest request = syncEsqlQueryRequest();
-        request.query("row " + value);
-        request.filter(new BoolQueryBuilder().boost(1.0f));
+        request.query("ROW " + value);
+        request.filter(randomQueryFilter());
         try (EsqlQueryResponse response = run(request)) {
             assertEquals(List.of(List.of(value)), getValuesList(response));
         }
+    }
+
+    public void testInvalidRowWithFilter() {
+        long value = randomLongBetween(0, Long.MAX_VALUE);
+        EsqlQueryRequest request = syncEsqlQueryRequest();
+        request.query("ROW " + value + " | EVAL x==NULL");
+        request.filter(randomQueryFilter());
+        expectThrows(
+            VerificationException.class,
+            containsString("Unknown column [x]"),
+            () -> run(request)
+        );
+    }
+
+    private static QueryBuilder randomQueryFilter() {
+        return randomFrom(new MatchAllQueryBuilder(), new BoolQueryBuilder().boost(1.0f));
     }
 
     public void testFromStatsGroupingAvgWithSort() {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
@@ -164,11 +164,7 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
         EsqlQueryRequest request = syncEsqlQueryRequest();
         request.query("ROW " + value + " | EVAL x==NULL");
         request.filter(randomQueryFilter());
-        expectThrows(
-            VerificationException.class,
-            containsString("Unknown column [x]"),
-            () -> run(request)
-        );
+        expectThrows(VerificationException.class, containsString("Unknown column [x]"), () -> run(request));
     }
 
     private static QueryBuilder randomQueryFilter() {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlCCSUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlCCSUtils.java
@@ -201,6 +201,9 @@ public class EsqlCCSUtils {
         IndexResolution indexResolution,
         boolean usedFilter
     ) {
+        if (executionInfo.clusterInfo.isEmpty()) {
+            return;
+        }
         // Get the clusters which are still running, and we will check whether they have any matching indices.
         // NOTE: we assume that updateExecutionInfoWithUnavailableClusters() was already run and took care of unavailable clusters.
         final Set<String> clustersWithNoMatchingIndices = executionInfo.getClusterStates(Cluster.Status.RUNNING)

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
@@ -568,9 +568,7 @@ public class EsqlSession {
             if (result.indices.isValid() || requestFilter != null) {
                 // We won't run this check with no filter and no valid indices since this may lead to false positive - missing index report
                 // when the resolution result is not valid for a different reason.
-                if (executionInfo.clusterInfo.isEmpty() == false) {
-                    EsqlCCSUtils.updateExecutionInfoWithClustersWithNoMatchingIndices(executionInfo, result.indices, requestFilter != null);
-                }
+                EsqlCCSUtils.updateExecutionInfoWithClustersWithNoMatchingIndices(executionInfo, result.indices, requestFilter != null);
             }
             plan = analyzeAction.apply(result);
         } catch (Exception e) {


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Fix assertion error when executing invalid row query with filter (#135761)