### PR TITLE
rest-api-spec: add project.tags API

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/project.tags.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/project.tags.json
@@ -1,0 +1,21 @@
+{
+  "project.tags": {
+    "documentation": {
+      "url": "",
+      "description": "Return tags defined for the project"
+    },
+    "stability": "experimental",
+    "visibility": "public",
+    "headers": {
+      "accept": ["application/json"]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_project/tags",
+          "methods": ["GET"]
+        }
+      ]
+    }
+  }
+}

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/project.tags.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/project.tags.json
@@ -1,7 +1,7 @@
 {
   "project.tags": {
     "documentation": {
-      "url": "",
+      "url": null,
       "description": "Return tags defined for the project"
     },
     "stability": "experimental",


### PR DESCRIPTION
While this API was added to the Elasticsearch specification in https://github.com/elastic/elasticsearch-specification/pull/5293, the Elasticsearch repository is still the source of truth for the rest-api-spec, and not having this API here breaks our current automation. (We're actively working towards fixing that, though.)

I realize this is a serverless endpoint, but we still want language clients to be able to call it.