### PR TITLE
Defer Semantic Text Failures on Pre-8.11 Indices

### DIFF
--- a/docs/changelog/135845.yaml
+++ b/docs/changelog/135845.yaml
@@ -1,0 +1,5 @@
+pr: 135845
+summary: Defer Semantic Text Failures on Pre-8.11 Indices
+area: Relevance
+type: bug
+issues: []

--- a/docs/changelog/135845.yaml
+++ b/docs/changelog/135845.yaml
@@ -1,5 +1,5 @@
 pr: 135845
 summary: Defer Semantic Text Failures on Pre-8.11 Indices
-area: Relevance
+area: Mapping
 type: bug
 issues: []

--- a/docs/changelog/135845.yaml
+++ b/docs/changelog/135845.yaml
@@ -1,5 +1,5 @@
 pr: 135845
-summary: Defer Semantic Text Failures on Pre-8.11 Indices
+summary: Fix for creating semantic_text fields on pre-8.11 indices crashing Elasticsearch
 area: Mapping
 type: bug
 issues: []

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
@@ -67,7 +67,6 @@ import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat.DEFAUL
 import static org.apache.lucene.tests.index.BaseKnnVectorsFormatTestCase.randomNormalizedVector;
 import static org.elasticsearch.index.codec.vectors.diskbbq.ES920DiskBBQVectorsFormat.DYNAMIC_VISIT_RATIO;
 import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.DEFAULT_OVERSAMPLE;
-import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.INDEXED_BY_DEFAULT_INDEX_VERSION;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -106,7 +105,7 @@ public class DenseVectorFieldMapperTests extends SyntheticVectorsMapperTestCase 
         if (elementType != ElementType.FLOAT) {
             b.field("element_type", elementType.toString());
         }
-        if (indexVersion.onOrAfter(INDEXED_BY_DEFAULT_INDEX_VERSION) || indexed) {
+        if (indexVersion.onOrAfter(DenseVectorFieldMapper.INDEXED_BY_DEFAULT_INDEX_VERSION) || indexed) {
             // Serialize if it's new index version, or it was not the default for previous indices
             b.field("index", indexed);
         }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
@@ -126,6 +126,7 @@ import static org.elasticsearch.xpack.inference.services.elasticsearch.Elasticse
  */
 public class SemanticTextFieldMapper extends FieldMapper implements InferenceFieldMapper {
     private static final Logger logger = LogManager.getLogger(SemanticTextFieldMapper.class);
+
     public static final NodeFeature SEMANTIC_TEXT_IN_OBJECT_FIELD_FIX = new NodeFeature("semantic_text.in_object_field_fix");
     public static final NodeFeature SEMANTIC_TEXT_SINGLE_FIELD_UPDATE_FIX = new NodeFeature("semantic_text.single_field_update_fix");
     public static final NodeFeature SEMANTIC_TEXT_DELETE_FIX = new NodeFeature("semantic_text.delete_fix");
@@ -150,6 +151,12 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
 
     public static final String CONTENT_TYPE = "semantic_text";
     public static final String DEFAULT_ELSER_2_INFERENCE_ID = DEFAULT_ELSER_ID;
+
+    public static final String UNSUPPORTED_INDEX_MESSAGE = "["
+        + CONTENT_TYPE
+        + "] is available on indices created with 8.11 or higher. Please create a new index to use ["
+        + CONTENT_TYPE
+        + "]";
 
     public static final float DEFAULT_RESCORE_OVERSAMPLE = 3.0f;
 
@@ -1243,6 +1250,10 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
         SemanticTextIndexOptions indexOptions,
         boolean useLegacyFormat
     ) {
+        if (indexVersionCreated.before(IndexVersions.NEW_SPARSE_VECTOR)) {
+            throw new UnsupportedOperationException(UNSUPPORTED_INDEX_MESSAGE);
+        }
+
         return switch (modelSettings.taskType()) {
             case SPARSE_EMBEDDING -> {
                 SparseVectorFieldMapper.Builder sparseVectorMapperBuilder = new SparseVectorFieldMapper.Builder(

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
@@ -100,7 +100,6 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import static org.elasticsearch.index.IndexVersions.NEW_SPARSE_VECTOR;
 import static org.elasticsearch.index.IndexVersions.SEMANTIC_TEXT_DEFAULTS_TO_BBQ;
 import static org.elasticsearch.index.IndexVersions.SEMANTIC_TEXT_DEFAULTS_TO_BBQ_BACKPORT_8_X;
 import static org.elasticsearch.inference.TaskType.SPARSE_EMBEDDING;
@@ -127,7 +126,6 @@ import static org.elasticsearch.xpack.inference.services.elasticsearch.Elasticse
  */
 public class SemanticTextFieldMapper extends FieldMapper implements InferenceFieldMapper {
     private static final Logger logger = LogManager.getLogger(SemanticTextFieldMapper.class);
-    public static final String UNSUPPORTED_INDEX_MESSAGE = "[semantic_text] is available on indices created with 8.11 or higher.";
     public static final NodeFeature SEMANTIC_TEXT_IN_OBJECT_FIELD_FIX = new NodeFeature("semantic_text.in_object_field_fix");
     public static final NodeFeature SEMANTIC_TEXT_SINGLE_FIELD_UPDATE_FIX = new NodeFeature("semantic_text.single_field_update_fix");
     public static final NodeFeature SEMANTIC_TEXT_DELETE_FIX = new NodeFeature("semantic_text.delete_fix");
@@ -166,9 +164,6 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
 
     public static BiConsumer<String, MappingParserContext> validateParserContext(String type) {
         return (n, c) -> {
-            if (c.getIndexSettings().getIndexVersionCreated().before(NEW_SPARSE_VECTOR)) {
-                throw new UnsupportedOperationException(UNSUPPORTED_INDEX_MESSAGE);
-            }
             if (InferenceMetadataFieldsMapper.isEnabled(c.getIndexSettings().getSettings()) == false) {
                 notInMultiFields(type).accept(n, c);
             }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapperTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapperTests.java
@@ -111,7 +111,6 @@ import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.getEmbe
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextFieldMapper.DEFAULT_ELSER_2_INFERENCE_ID;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextFieldMapper.DEFAULT_RESCORE_OVERSAMPLE;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextFieldMapper.INDEX_OPTIONS_FIELD;
-import static org.elasticsearch.xpack.inference.mapper.SemanticTextFieldMapper.UNSUPPORTED_INDEX_MESSAGE;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextFieldTests.generateRandomChunkingSettings;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextFieldTests.generateRandomChunkingSettingsOtherThan;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextFieldTests.randomSemanticText;
@@ -413,57 +412,6 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
             );
             assertThat(e.getMessage(), containsString("Wrong [task_type], expected text_embedding or sparse_embedding"));
         }
-    }
-
-    @Override
-    protected IndexVersion boostNotAllowedIndexVersion() {
-        return IndexVersions.NEW_SPARSE_VECTOR;
-    }
-
-    public void testOldIndexSemanticTextDenseVectorRaisesError() throws IOException {
-        final String fieldName = "field";
-        final XContentBuilder fieldMapping = fieldMapping(b -> {
-            b.field("type", "semantic_text");
-            b.field(INFERENCE_ID_FIELD, "test_inference_id");
-            b.startObject("model_settings");
-            b.field("task_type", "text_embedding");
-            b.field("dimensions", 384);
-            b.field("similarity", "cosine");
-            b.field("element_type", "float");
-            b.endObject();
-        });
-        assertOldIndexUnsupported(fieldMapping);
-    }
-
-    public void testOldIndexSemanticTextMinimalMappingRaisesError() throws IOException {
-        final XContentBuilder fieldMapping = fieldMapping(this::minimalMapping);
-        assertOldIndexUnsupported(fieldMapping);
-    }
-
-    public void testOldIndexSemanticTextSparseVersionRaisesError() throws IOException {
-        final XContentBuilder fieldMapping = fieldMapping(b -> {
-            b.field("type", "semantic_text");
-            b.field("inference_id", "another_inference_id");
-            b.startObject("model_settings");
-            b.field("task_type", "sparse_embedding");
-            b.endObject();
-        });
-        assertOldIndexUnsupported(fieldMapping);
-    }
-
-    private void assertOldIndexUnsupported(XContentBuilder fieldMapping) {
-
-        MapperParsingException exception = assertThrows(
-            MapperParsingException.class,
-            () -> createMapperService(
-                fieldMapping,
-                true,
-                IndexVersions.V_8_0_0,
-                IndexVersionUtils.getPreviousVersion(IndexVersions.NEW_SPARSE_VECTOR)
-            )
-        );
-        assertTrue(exception.getMessage().contains(UNSUPPORTED_INDEX_MESSAGE));
-        assertTrue(exception.getRootCause() instanceof UnsupportedOperationException);
     }
 
     public void testMultiFieldsSupport() throws IOException {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapperTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapperTests.java
@@ -1224,21 +1224,24 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
         );
         assertSemanticTextField(mapperService, fieldName, false, null, null);
 
-        MapperParsingException e = expectThrows(MapperParsingException.class, () -> merge(
-            mapperService,
-            mapping(
-                b -> b.startObject(fieldName)
-                    .field("type", "semantic_text")
-                    .field("inference_id", "test_model")
-                    .startObject("model_settings")
-                    .field("task_type", TaskType.TEXT_EMBEDDING.toString())
-                    .field("dimensions", 256)
-                    .field("similarity", SimilarityMeasure.COSINE.toString())
-                    .field("element_type", DenseVectorFieldMapper.ElementType.FLOAT)
-                    .endObject()
-                    .endObject()
+        MapperParsingException e = expectThrows(
+            MapperParsingException.class,
+            () -> merge(
+                mapperService,
+                mapping(
+                    b -> b.startObject(fieldName)
+                        .field("type", "semantic_text")
+                        .field("inference_id", "test_model")
+                        .startObject("model_settings")
+                        .field("task_type", TaskType.TEXT_EMBEDDING.toString())
+                        .field("dimensions", 256)
+                        .field("similarity", SimilarityMeasure.COSINE.toString())
+                        .field("element_type", DenseVectorFieldMapper.ElementType.FLOAT)
+                        .endObject()
+                        .endObject()
+                )
             )
-        ));
+        );
         assertThat(e.getMessage(), equalTo("Failed to parse mapping: " + UNSUPPORTED_INDEX_MESSAGE));
     }
 
@@ -1252,18 +1255,21 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
         );
         assertSemanticTextField(mapperService, fieldName, false, null, null);
 
-        MapperParsingException e = expectThrows(MapperParsingException.class, () -> merge(
-            mapperService,
-            mapping(
-                b -> b.startObject(fieldName)
-                    .field("type", "semantic_text")
-                    .field("inference_id", "test_model")
-                    .startObject("model_settings")
-                    .field("task_type", TaskType.SPARSE_EMBEDDING.toString())
-                    .endObject()
-                    .endObject()
+        MapperParsingException e = expectThrows(
+            MapperParsingException.class,
+            () -> merge(
+                mapperService,
+                mapping(
+                    b -> b.startObject(fieldName)
+                        .field("type", "semantic_text")
+                        .field("inference_id", "test_model")
+                        .startObject("model_settings")
+                        .field("task_type", TaskType.SPARSE_EMBEDDING.toString())
+                        .endObject()
+                        .endObject()
+                )
             )
-        ));
+        );
         assertThat(e.getMessage(), equalTo("Failed to parse mapping: " + UNSUPPORTED_INDEX_MESSAGE));
     }
 


### PR DESCRIPTION
Defer failures on `semantic_text` fields created in pre-8.11 indices to when the first document is ingested. This is accomplished by reverting #133080 and moving the index version check to when the document is parsed.
