### PR TITLE
DiskBBQ - missing min competitive similarity check on tail docs

### DIFF
--- a/docs/changelog/135851.yaml
+++ b/docs/changelog/135851.yaml
@@ -1,0 +1,5 @@
+pr: 135851
+summary: DiskBBQ - missing min competitive similarity check on tail docs
+area: Vector Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/ES920DiskBBQVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/ES920DiskBBQVectorsReader.java
@@ -566,7 +566,9 @@ public class ES920DiskBBQVectorsReader extends IVFVectorsReader {
                         qcDist
                     );
                     scoredDocs++;
-                    knnCollector.collect(doc, score);
+                    if (knnCollector.minCompetitiveSimilarity() < score) {
+                        knnCollector.collect(doc, score);
+                    }
                 } else {
                     indexInput.skipBytes(quantizedByteLength);
                 }


### PR DESCRIPTION
This looks like a missing check on minimum competitive similarity for the `KnnCollector` to collect docs.