### PR TITLE
logstashbridge: map ES logging to log4j backend

### DIFF
--- a/docs/changelog/135854.yaml
+++ b/docs/changelog/135854.yaml
@@ -1,0 +1,5 @@
+pr: 135854
+summary: "Logstashbridge: map ES logging to log4j backend"
+area: Bridge
+type: tech debt
+issues: []

--- a/docs/changelog/135854.yaml
+++ b/docs/changelog/135854.yaml
@@ -1,5 +1,5 @@
 pr: 135854
 summary: "Logstashbridge: map ES logging to log4j backend"
-area: Bridge
-type: tech debt
+area: Ingest
+type: enhancement
 issues: []

--- a/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/common/LoggingBridge.java
+++ b/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/common/LoggingBridge.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.logstashbridge.common;
+
+import org.elasticsearch.common.logging.LogConfigurator;
+
+/**
+ * An external bridge for the logging subsystem, exposing the minimum necessary
+ * to wire up the log4j-based implementation that is present in Logstash.
+ */
+public class LoggingBridge {
+    private LoggingBridge() {}
+
+    public static void initialize() {
+        // wires up the ES logging front-end to a Log4j backend
+        LogConfigurator.configureESLogging();
+    }
+}


### PR DESCRIPTION
Adds a method to the Logstash bridge so that the Elastic Integration filter for Logstash can wire up ES-internal logging to Logstash's Log4j supplier.