### PR TITLE
Make packaging test deletes robust for Windows

### DIFF
--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/Cleanup.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/Cleanup.java
@@ -13,12 +13,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Consumer;
 
 import static org.elasticsearch.packaging.test.PackagingTestCase.getRootTempDir;
 import static org.elasticsearch.packaging.util.FileUtils.lsGlob;

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/Cleanup.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/Cleanup.java
@@ -75,11 +75,9 @@ public class Cleanup {
         // when we run es as a role user on windows, add the equivalent here
         // delete files that may still exist
 
-        lsGlob(getRootTempDir(), "elasticsearch*").forEach(Platforms.WINDOWS ? FileUtils::rmWithRetries : FileUtils::rm);
+        lsGlob(getRootTempDir(), "elasticsearch*").forEach(FileUtils::rm);
         final List<String> filesToDelete = Platforms.WINDOWS ? ELASTICSEARCH_FILES_WINDOWS : ELASTICSEARCH_FILES_LINUX;
-        // windows needs leniency due to asinine releasing of file locking async from a process exiting
-        Consumer<? super Path> rm = Platforms.WINDOWS ? FileUtils::rmWithRetries : FileUtils::rm;
-        filesToDelete.stream().map(Paths::get).filter(Files::exists).forEach(rm);
+        filesToDelete.stream().map(Paths::get).filter(Files::exists).forEach(FileUtils::rm);
     }
 
     private static void purgePackagesLinux() {


### PR DESCRIPTION
Windows has crazy file locking behavior. This commit adjusts the rm utility method used by many tests to internally allow retries when on Windows, rather than explicitly needing to call rmWithRetries which can be missed.

relates #113177