### PR TITLE
[Sampling] Avoid running SamplingServiceTests if sampling feature flag is missing

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -612,18 +612,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/135787
-- class: org.elasticsearch.ingest.SamplingServiceTests
-  method: testMaybeSampleWithLowRate
-  issue: https://github.com/elastic/elasticsearch/issues/135808
-- class: org.elasticsearch.ingest.SamplingServiceTests
-  method: testMaybeSample
-  issue: https://github.com/elastic/elasticsearch/issues/135809
-- class: org.elasticsearch.ingest.SamplingServiceTests
-  method: testMaybeSampleWithCondition
-  issue: https://github.com/elastic/elasticsearch/issues/135810
-- class: org.elasticsearch.ingest.SamplingServiceTests
-  method: testMaybeSampleMaxSamples
-  issue: https://github.com/elastic/elasticsearch/issues/135811
 - class: org.elasticsearch.xpack.esql.expression.function.aggregate.IrateTests
   method: testGroupingAggregate {TestCase=<positive ints>}
   issue: https://github.com/elastic/elasticsearch/issues/135814

--- a/server/src/main/java/org/elasticsearch/ingest/SamplingService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/SamplingService.java
@@ -232,6 +232,9 @@ public class SamplingService implements ClusterStateListener {
      */
     public SampleStats getLocalSampleStats(ProjectId projectId, String index) {
         SoftReference<SampleInfo> sampleInfoReference = samples.get(new ProjectIndex(projectId, index));
+        if (sampleInfoReference == null) {
+            return new SampleStats();
+        }
         SampleInfo sampleInfo = sampleInfoReference.get();
         return sampleInfo == null ? new SampleStats() : sampleInfo.stats;
     }

--- a/server/src/test/java/org/elasticsearch/ingest/SamplingServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/SamplingServiceTests.java
@@ -34,18 +34,21 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.ingest.SamplingService.RANDOM_SAMPLING_FEATURE_FLAG;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assume.assumeTrue;
 
 public class SamplingServiceTests extends ESTestCase {
 
     private static final String TEST_CONDITIONAL_SCRIPT = "ctx?.foo == 'bar'";
 
     public void testMaybeSample() {
+        assumeTrue("Requires sampling feature flag", RANDOM_SAMPLING_FEATURE_FLAG);
         SamplingService samplingService = getTestSamplingService();
 
         // First, test with a project that has no sampling config:
@@ -101,6 +104,7 @@ public class SamplingServiceTests extends ESTestCase {
     }
 
     public void testMaybeSampleWithCondition() {
+        assumeTrue("Requires sampling feature flag", RANDOM_SAMPLING_FEATURE_FLAG);
         SamplingService samplingService = getTestSamplingService();
         String indexName = randomIdentifier();
         ProjectMetadata.Builder projectBuilder = ProjectMetadata.builder(ProjectId.DEFAULT)
@@ -147,6 +151,7 @@ public class SamplingServiceTests extends ESTestCase {
     }
 
     public void testMaybeSampleWithLowRate() {
+        assumeTrue("Requires sampling feature flag", RANDOM_SAMPLING_FEATURE_FLAG);
         SamplingService samplingService = getTestSamplingService();
         String indexName = randomIdentifier();
         ProjectMetadata.Builder projectBuilder = ProjectMetadata.builder(ProjectId.DEFAULT)
@@ -185,6 +190,7 @@ public class SamplingServiceTests extends ESTestCase {
     }
 
     public void testMaybeSampleMaxSamples() {
+        assumeTrue("Requires sampling feature flag", RANDOM_SAMPLING_FEATURE_FLAG);
         SamplingService samplingService = getTestSamplingService();
         String indexName = randomIdentifier();
         int maxSamples = randomIntBetween(1, 1000);


### PR DESCRIPTION
The SamplingServiceTests fail when running in non-snapshot mode. This is because we do not do any sampling if the sampling feature flag is not enabled. This adds an assumption to all of those tests that the feature flag is enabled. It also fixes a potential NullPointerException that happens if you attempt to get the sampling service stats with the sampling feature flag disabled.
Closes #135808 
Closes #135809
Closes #135810
Closes #135811