### PR TITLE
Add APM metrics for duration of search phases at the coordinating node 

### DIFF
--- a/docs/changelog/135868.yaml
+++ b/docs/changelog/135868.yaml
@@ -1,0 +1,5 @@
+pr: 135868
+summary: Add APM metrics for duration of search phases at the coordinating node
+area: Search
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhase.java
+++ b/server/src/main/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhase.java
@@ -184,6 +184,7 @@ final class CanMatchPreFilterSearchPhase {
     private void runCoordinatorRewritePhase() {
         // TODO: the index filter (i.e, `_index:patten`) should be prefiltered on the coordinator
         assert assertSearchCoordinationThread();
+        final long coordinatorStartTimeNanos = timeProvider.relativeCurrentNanosProvider().getAsLong();
         final List<SearchShardIterator> matchedShardLevelRequests = new ArrayList<>();
         for (SearchShardIterator searchShardIterator : shardsIts) {
             final CanMatchNodeRequest canMatchNodeRequest = new CanMatchNodeRequest(

--- a/server/src/main/java/org/elasticsearch/action/search/DfsQueryPhase.java
+++ b/server/src/main/java/org/elasticsearch/action/search/DfsQueryPhase.java
@@ -66,6 +66,7 @@ class DfsQueryPhase extends SearchPhase {
 
     // protected for testing
     protected SearchPhase nextPhase(AggregatedDfs dfs) {
+        context.recordPhaseTookTime(getName());
         return SearchQueryThenFetchAsyncAction.nextPhase(client, context, queryResult, dfs);
     }
 

--- a/server/src/main/java/org/elasticsearch/action/search/ExpandSearchPhase.java
+++ b/server/src/main/java/org/elasticsearch/action/search/ExpandSearchPhase.java
@@ -182,6 +182,7 @@ class ExpandSearchPhase extends SearchPhase {
     }
 
     private void onPhaseDone() {
+        context.recordPhaseTookTime(getName());
         context.executeNextPhase(NAME, this::nextPhase);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/search/FetchLookupFieldsPhase.java
+++ b/server/src/main/java/org/elasticsearch/action/search/FetchLookupFieldsPhase.java
@@ -144,6 +144,7 @@ final class FetchLookupFieldsPhase extends SearchPhase {
     }
 
     private void sendResponse() {
+        context.recordPhaseTookTime(getName());
         context.sendSearchResponse(searchResponse, queryResults);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/search/FetchSearchPhase.java
+++ b/server/src/main/java/org/elasticsearch/action/search/FetchSearchPhase.java
@@ -260,6 +260,7 @@ class FetchSearchPhase extends SearchPhase {
         AtomicArray<? extends SearchPhaseResult> fetchResultsArr,
         SearchPhaseController.ReducedQueryPhase reducedQueryPhase
     ) {
+        context.recordPhaseTookTime(getName());
         context.executeNextPhase(NAME, () -> {
             var resp = SearchPhaseController.merge(context.getRequest().scroll() != null, reducedQueryPhase, fetchResultsArr);
             context.addReleasable(resp);

--- a/server/src/main/java/org/elasticsearch/action/search/RankFeaturePhase.java
+++ b/server/src/main/java/org/elasticsearch/action/search/RankFeaturePhase.java
@@ -193,6 +193,7 @@ public class RankFeaturePhase extends SearchPhase {
                         reducedQueryPhase,
                         topResults
                     );
+                    context.recordPhaseTookTime(getName());
                     moveToNextPhase(rankPhaseResults, reducedRankFeaturePhase);
                 }
 

--- a/server/src/main/java/org/elasticsearch/action/search/SearchDfsQueryThenFetchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchDfsQueryThenFetchAsyncAction.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.index.search.stats.CoordinatorSearchPhaseAPMMetrics;
 import org.elasticsearch.search.SearchPhaseResult;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.dfs.DfsSearchResult;
@@ -47,7 +48,8 @@ final class SearchDfsQueryThenFetchAsyncAction extends AbstractSearchAsyncAction
         ClusterState clusterState,
         SearchTask task,
         SearchResponse.Clusters clusters,
-        Client client
+        Client client,
+        CoordinatorSearchPhaseAPMMetrics coordinatorSearchPhaseAPMMetrics
     ) {
         super(
             "dfs",
@@ -66,7 +68,8 @@ final class SearchDfsQueryThenFetchAsyncAction extends AbstractSearchAsyncAction
             task,
             new ArraySearchPhaseResults<>(shardsIts.size()),
             request.getMaxConcurrentShardRequests(),
-            clusters
+            clusters,
+            coordinatorSearchPhaseAPMMetrics
         );
         this.queryPhaseResultConsumer = queryPhaseResultConsumer;
         addReleasable(queryPhaseResultConsumer);

--- a/server/src/main/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncAction.java
@@ -34,6 +34,7 @@ import org.elasticsearch.common.util.concurrent.ListenableFuture;
 import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.SimpleRefCounted;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.search.stats.CoordinatorSearchPhaseAPMMetrics;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.search.SearchPhaseResult;
 import org.elasticsearch.search.SearchService;
@@ -108,7 +109,8 @@ public class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<S
         SearchTask task,
         SearchResponse.Clusters clusters,
         Client client,
-        boolean batchQueryPhase
+        boolean batchQueryPhase,
+        CoordinatorSearchPhaseAPMMetrics coordinatorSearchPhaseAPMMetrics
     ) {
         super(
             "query",
@@ -127,7 +129,8 @@ public class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<S
             task,
             resultConsumer,
             request.getMaxConcurrentShardRequests(),
-            clusters
+            clusters,
+            coordinatorSearchPhaseAPMMetrics
         );
         this.topDocsSize = getTopDocsSize(request);
         this.trackTotalHitsUpTo = request.resolveTrackTotalHitsUpTo();

--- a/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
@@ -182,7 +182,8 @@ public class TransportOpenPointInTimeAction extends HandledTransportAction<OpenP
                     timeProvider,
                     task,
                     false,
-                    searchService.getCoordinatorRewriteContextProvider(timeProvider::absoluteStartMillis)
+                    searchService.getCoordinatorRewriteContextProvider(timeProvider::absoluteStartMillis),
+                    coordinatorSearchPhaseAPMMetrics
                 )
                     .addListener(
                         listener.delegateFailureAndWrap(

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -67,6 +67,7 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.Rewriteable;
+import org.elasticsearch.index.search.stats.CoordinatorSearchPhaseAPMMetrics;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardNotFoundException;
 import org.elasticsearch.indices.ExecutorSelector;
@@ -170,6 +171,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
     private final UsageService usageService;
     private final boolean collectCCSTelemetry;
     private final TimeValue forceConnectTimeoutSecs;
+    private final CoordinatorSearchPhaseAPMMetrics coordinatorSearchPhaseAPMMetrics;
 
     @Inject
     public TransportSearchAction(
@@ -188,7 +190,8 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         ExecutorSelector executorSelector,
         SearchResponseMetrics searchResponseMetrics,
         Client client,
-        UsageService usageService
+        UsageService usageService,
+        CoordinatorSearchPhaseAPMMetrics coordinatorSearchPhaseAPMMetrics
     ) {
         super(TYPE.name(), transportService, actionFilters, SearchRequest::new, EsExecutors.DIRECT_EXECUTOR_SERVICE);
         this.threadPool = threadPool;
@@ -218,6 +221,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         this.searchResponseMetrics = searchResponseMetrics;
         this.client = client;
         this.usageService = usageService;
+        this.coordinatorSearchPhaseAPMMetrics = coordinatorSearchPhaseAPMMetrics;
         forceConnectTimeoutSecs = settings.getAsTime("search.ccs.force_connect_timeout", null);
     }
 
@@ -1682,7 +1686,8 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                         clusterState,
                         task,
                         clusters,
-                        client
+                        client,
+                        coordinatorSearchPhaseAPMMetrics
                     );
                 } else {
                     assert searchRequest.searchType() == QUERY_THEN_FETCH : searchRequest.searchType();
@@ -1703,7 +1708,8 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                         task,
                         clusters,
                         client,
-                        searchService.batchQueryPhase()
+                        searchService.batchQueryPhase(),
+                        coordinatorSearchPhaseAPMMetrics
                     );
                 }
                 success = true;

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -1627,7 +1627,8 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                     timeProvider,
                     task,
                     requireAtLeastOneMatch,
-                    searchService.getCoordinatorRewriteContextProvider(timeProvider::absoluteStartMillis)
+                    searchService.getCoordinatorRewriteContextProvider(timeProvider::absoluteStartMillis),
+                    coordinatorSearchPhaseAPMMetrics
                 )
                     .addListener(
                         listener.delegateFailureAndWrap(

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchShardsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchShardsAction.java
@@ -24,6 +24,7 @@ import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.query.Rewriteable;
+import org.elasticsearch.index.search.stats.CoordinatorSearchPhaseAPMMetrics;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.search.SearchService;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -60,6 +61,7 @@ public class TransportSearchShardsAction extends HandledTransportAction<SearchSh
     private final ProjectResolver projectResolver;
     private final IndexNameExpressionResolver indexNameExpressionResolver;
     private final ThreadPool threadPool;
+    private final CoordinatorSearchPhaseAPMMetrics coordinatorSearchPhaseAPMMetrics;
 
     @Inject
     public TransportSearchShardsAction(
@@ -70,7 +72,8 @@ public class TransportSearchShardsAction extends HandledTransportAction<SearchSh
         TransportSearchAction transportSearchAction,
         SearchTransportService searchTransportService,
         ProjectResolver projectResolver,
-        IndexNameExpressionResolver indexNameExpressionResolver
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        CoordinatorSearchPhaseAPMMetrics coordinatorSearchPhaseAPMMetrics
     ) {
         super(
             TYPE.name(),
@@ -88,6 +91,7 @@ public class TransportSearchShardsAction extends HandledTransportAction<SearchSh
         this.projectResolver = projectResolver;
         this.indexNameExpressionResolver = indexNameExpressionResolver;
         this.threadPool = transportService.getThreadPool();
+        this.coordinatorSearchPhaseAPMMetrics = coordinatorSearchPhaseAPMMetrics;
     }
 
     @Override
@@ -175,7 +179,8 @@ public class TransportSearchShardsAction extends HandledTransportAction<SearchSh
                         timeProvider,
                         (SearchTask) task,
                         false,
-                        searchService.getCoordinatorRewriteContextProvider(timeProvider::absoluteStartMillis)
+                        searchService.getCoordinatorRewriteContextProvider(timeProvider::absoluteStartMillis),
+                        coordinatorSearchPhaseAPMMetrics
                     )
                         .addListener(
                             delegate.map(

--- a/server/src/main/java/org/elasticsearch/index/search/stats/CoordinatorSearchPhaseAPMMetrics.java
+++ b/server/src/main/java/org/elasticsearch/index/search/stats/CoordinatorSearchPhaseAPMMetrics.java
@@ -34,12 +34,9 @@ public class CoordinatorSearchPhaseAPMMetrics {
     }
 
     public void onCoordinatorPhaseDone(String phaseName, long tookInNanos) {
-        LongHistogram histogram = histogramsCache.computeIfAbsent(phaseName, this::createHistogram);
-        if (histogram != null) {
-            recordPhaseLatency(histogram, tookInNanos);
-        } else {
-            throw new IllegalStateException("phase [" + phaseName + "] not found");
-        }
+        String cleanedPhaseName = phaseName.toLowerCase(Locale.ROOT).replace('-', '_');
+        LongHistogram histogram = histogramsCache.computeIfAbsent(cleanedPhaseName, this::createHistogram);
+        recordPhaseLatency(histogram, tookInNanos);
     }
 
     private LongHistogram createHistogram(String phaseName) {

--- a/server/src/main/java/org/elasticsearch/index/search/stats/CoordinatorSearchPhaseAPMMetrics.java
+++ b/server/src/main/java/org/elasticsearch/index/search/stats/CoordinatorSearchPhaseAPMMetrics.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.search.stats;
+
+import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
+import org.elasticsearch.telemetry.metric.LongHistogram;
+import org.elasticsearch.telemetry.metric.MeterRegistry;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Coordinator level APM metrics for search phases. Records phase execution times as histograms.
+ * Assumes that this is a singleton shared by all searches running on the coordinating node.
+ */
+public class CoordinatorSearchPhaseAPMMetrics {
+
+    private static final String metricNameFormat = "es.search.coordinator.phases.%s.duration.histogram";
+    public static final CoordinatorSearchPhaseAPMMetrics NOOP = new CoordinatorSearchPhaseAPMMetrics(MeterRegistry.NOOP);
+
+    private final Map<String, LongHistogram> histogramsCache = ConcurrentCollections.newConcurrentMap();
+    private final MeterRegistry meterRegistry;
+
+    public CoordinatorSearchPhaseAPMMetrics(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    public void onCoordinatorPhaseDone(String phaseName, long tookInNanos) {
+        LongHistogram histogram = histogramsCache.computeIfAbsent(phaseName, this::createHistogram);
+        if (histogram != null) {
+            recordPhaseLatency(histogram, tookInNanos);
+        } else {
+            throw new IllegalStateException("phase [" + phaseName + "] not found");
+        }
+    }
+
+    private LongHistogram createHistogram(String phaseName) {
+        return meterRegistry.registerLongHistogram(
+            String.format(Locale.ROOT, metricNameFormat, phaseName),
+            String.format(
+                Locale.ROOT,
+                "%s phase execution times at the coordinator level, expressed as a histogram",
+                phaseName.toUpperCase(Locale.ROOT)
+            ),
+            "ms"
+        );
+    }
+
+    protected void recordPhaseLatency(LongHistogram histogramMetric, long tookInNanos) {
+        histogramMetric.record(TimeUnit.NANOSECONDS.toMillis(tookInNanos));
+    }
+}

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -122,6 +122,7 @@ import org.elasticsearch.index.mapper.DefaultRootObjectMapperNamespaceValidator;
 import org.elasticsearch.index.mapper.MapperMetrics;
 import org.elasticsearch.index.mapper.RootObjectMapperNamespaceValidator;
 import org.elasticsearch.index.mapper.SourceFieldMetrics;
+import org.elasticsearch.index.search.stats.CoordinatorSearchPhaseAPMMetrics;
 import org.elasticsearch.index.search.stats.ShardSearchPhaseAPMMetrics;
 import org.elasticsearch.index.shard.SearchOperationListener;
 import org.elasticsearch.indices.ExecutorSelector;
@@ -863,6 +864,10 @@ class NodeConstruction {
             new ShardSearchPhaseAPMMetrics(telemetryProvider.getMeterRegistry())
         );
 
+        CoordinatorSearchPhaseAPMMetrics coordinatorSearchPhaseAPMMetrics = new CoordinatorSearchPhaseAPMMetrics(
+            telemetryProvider.getMeterRegistry()
+        );
+
         List<? extends SlowLogFieldProvider> slowLogFieldProviders = pluginsService.loadServiceProviders(SlowLogFieldProvider.class);
         // NOTE: the response of index/search slow log fields below must be calculated dynamically on every call
         // because the responses may change dynamically at runtime
@@ -1360,6 +1365,7 @@ class NodeConstruction {
             b.bind(ShutdownPrepareService.class).toInstance(shutdownPrepareService);
             b.bind(OnlinePrewarmingService.class).toInstance(onlinePrewarmingService);
             b.bind(MergeMetrics.class).toInstance(mergeMetrics);
+            b.bind(CoordinatorSearchPhaseAPMMetrics.class).toInstance(coordinatorSearchPhaseAPMMetrics);
         });
 
         if (ReadinessService.enabled(environment)) {

--- a/server/src/test/java/org/elasticsearch/action/search/AbstractSearchAsyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/AbstractSearchAsyncActionTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
+import org.elasticsearch.index.search.stats.CoordinatorSearchPhaseAPMMetrics;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.search.SearchPhaseResult;
 import org.elasticsearch.search.SearchShardTarget;
@@ -88,7 +89,8 @@ public class AbstractSearchAsyncActionTests extends ESTestCase {
             null,
             results,
             request.getMaxConcurrentShardRequests(),
-            SearchResponse.Clusters.EMPTY
+            SearchResponse.Clusters.EMPTY,
+            CoordinatorSearchPhaseAPMMetrics.NOOP
         ) {
             @Override
             protected SearchPhase getNextPhase() {

--- a/server/src/test/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhaseTests.java
@@ -39,6 +39,7 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
+import org.elasticsearch.index.search.stats.CoordinatorSearchPhaseAPMMetrics;
 import org.elasticsearch.index.shard.IndexLongFieldRange;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardLongFieldRange;
@@ -161,7 +162,8 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
             timeProvider,
             null,
             true,
-            EMPTY_CONTEXT_PROVIDER
+            EMPTY_CONTEXT_PROVIDER,
+            CoordinatorSearchPhaseAPMMetrics.NOOP
         ).addListener(ActionTestUtils.assertNoFailureListener(iter -> {
             result.set(iter);
             latch.countDown();
@@ -256,7 +258,8 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
             timeProvider,
             null,
             true,
-            EMPTY_CONTEXT_PROVIDER
+            EMPTY_CONTEXT_PROVIDER,
+            CoordinatorSearchPhaseAPMMetrics.NOOP
         ).addListener(ActionTestUtils.assertNoFailureListener(iter -> {
             result.set(iter);
             latch.countDown();
@@ -347,7 +350,8 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
                 timeProvider,
                 null,
                 true,
-                EMPTY_CONTEXT_PROVIDER
+                EMPTY_CONTEXT_PROVIDER,
+                CoordinatorSearchPhaseAPMMetrics.NOOP
             ).addListener(ActionTestUtils.assertNoFailureListener(iter -> {
                 result.set(iter);
                 latch.countDown();
@@ -446,7 +450,8 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
                 timeProvider,
                 null,
                 shardsIter.size() > shardToSkip.size(),
-                EMPTY_CONTEXT_PROVIDER
+                EMPTY_CONTEXT_PROVIDER,
+                CoordinatorSearchPhaseAPMMetrics.NOOP
             ).addListener(ActionTestUtils.assertNoFailureListener(iter -> {
                 result.set(iter);
                 latch.countDown();
@@ -1418,7 +1423,8 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
                 timeProvider,
                 null,
                 true,
-                contextProvider
+                contextProvider,
+                CoordinatorSearchPhaseAPMMetrics.NOOP
             ),
             requests
         );

--- a/server/src/test/java/org/elasticsearch/action/search/MockSearchPhaseContext.java
+++ b/server/src/test/java/org/elasticsearch/action/search/MockSearchPhaseContext.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.search.stats.CoordinatorSearchPhaseAPMMetrics;
 import org.elasticsearch.search.SearchPhaseResult;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.internal.ShardSearchContextId;
@@ -66,7 +67,8 @@ public final class MockSearchPhaseContext extends AbstractSearchAsyncAction<Sear
             new SearchTask(0, "n/a", "n/a", () -> "test", null, Collections.emptyMap()),
             new ArraySearchPhaseResults<>(numShards),
             5,
-            null
+            null,
+            CoordinatorSearchPhaseAPMMetrics.NOOP
         );
         this.numShards = numShards;
         numSuccess = new AtomicInteger(numShards);

--- a/server/src/test/java/org/elasticsearch/action/search/SearchAsyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchAsyncActionTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.index.search.stats.CoordinatorSearchPhaseAPMMetrics;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.SearchPhaseResult;
@@ -111,7 +112,8 @@ public class SearchAsyncActionTests extends ESTestCase {
             null,
             new ArraySearchPhaseResults<>(shardsIter.size()),
             request.getMaxConcurrentShardRequests(),
-            SearchResponse.Clusters.EMPTY
+            SearchResponse.Clusters.EMPTY,
+            CoordinatorSearchPhaseAPMMetrics.NOOP
         ) {
 
             @Override
@@ -218,7 +220,8 @@ public class SearchAsyncActionTests extends ESTestCase {
                 null,
                 results,
                 request.getMaxConcurrentShardRequests(),
-                SearchResponse.Clusters.EMPTY
+                SearchResponse.Clusters.EMPTY,
+                CoordinatorSearchPhaseAPMMetrics.NOOP
             ) {
 
                 @Override
@@ -334,7 +337,8 @@ public class SearchAsyncActionTests extends ESTestCase {
                 null,
                 results,
                 request.getMaxConcurrentShardRequests(),
-                SearchResponse.Clusters.EMPTY
+                SearchResponse.Clusters.EMPTY,
+                CoordinatorSearchPhaseAPMMetrics.NOOP
             ) {
 
                 @Override
@@ -464,7 +468,8 @@ public class SearchAsyncActionTests extends ESTestCase {
                 null,
                 new ArraySearchPhaseResults<>(shardsIter.size()),
                 request.getMaxConcurrentShardRequests(),
-                SearchResponse.Clusters.EMPTY
+                SearchResponse.Clusters.EMPTY,
+                CoordinatorSearchPhaseAPMMetrics.NOOP
             ) {
                 @Override
                 protected void executePhaseOnShard(
@@ -572,7 +577,8 @@ public class SearchAsyncActionTests extends ESTestCase {
                 null,
                 results,
                 request.getMaxConcurrentShardRequests(),
-                SearchResponse.Clusters.EMPTY
+                SearchResponse.Clusters.EMPTY,
+                CoordinatorSearchPhaseAPMMetrics.NOOP
             ) {
 
                 @Override
@@ -670,7 +676,8 @@ public class SearchAsyncActionTests extends ESTestCase {
             null,
             new ArraySearchPhaseResults<>(searchShardIterators.size()),
             request.getMaxConcurrentShardRequests(),
-            SearchResponse.Clusters.EMPTY
+            SearchResponse.Clusters.EMPTY,
+            CoordinatorSearchPhaseAPMMetrics.NOOP
         ) {
 
             @Override

--- a/server/src/test/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncActionTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.search.TopDocsAndMaxScore;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.search.stats.CoordinatorSearchPhaseAPMMetrics;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.lucene.grouping.TopFieldGroups;
 import org.elasticsearch.search.DocValueFormat;
@@ -211,7 +212,8 @@ public class SearchQueryThenFetchAsyncActionTests extends ESTestCase {
                 task,
                 SearchResponse.Clusters.EMPTY,
                 null,
-                false
+                false,
+                CoordinatorSearchPhaseAPMMetrics.NOOP
             ) {
                 @Override
                 protected SearchPhase getNextPhase() {
@@ -407,7 +409,8 @@ public class SearchQueryThenFetchAsyncActionTests extends ESTestCase {
                 task,
                 SearchResponse.Clusters.EMPTY,
                 null,
-                false
+                false,
+                CoordinatorSearchPhaseAPMMetrics.NOOP
             ) {
                 @Override
                 protected SearchPhase getNextPhase() {

--- a/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
@@ -61,6 +61,7 @@ import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.index.query.TermsQueryBuilder;
+import org.elasticsearch.index.search.stats.CoordinatorSearchPhaseAPMMetrics;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.TestIndexNameExpressionResolver;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
@@ -1810,7 +1811,8 @@ public class TransportSearchActionTests extends ESTestCase {
                 null,
                 new SearchResponseMetrics(TelemetryProvider.NOOP.getMeterRegistry()),
                 client,
-                new UsageService()
+                new UsageService(),
+                CoordinatorSearchPhaseAPMMetrics.NOOP
             );
 
             CountDownLatch latch = new CountDownLatch(1);

--- a/server/src/test/java/org/elasticsearch/search/TelemetryMetrics/CoordinatorSearchPhaseAPMMetricsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/TelemetryMetrics/CoordinatorSearchPhaseAPMMetricsTests.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.search.TelemetryMetrics;
+
+import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.indices.ExecutorNames;
+import org.elasticsearch.indices.SystemIndexDescriptor;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.PluginsService;
+import org.elasticsearch.plugins.SystemIndexPlugin;
+import org.elasticsearch.telemetry.InstrumentType;
+import org.elasticsearch.telemetry.Measurement;
+import org.elasticsearch.telemetry.TestTelemetryPlugin;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
+import static org.elasticsearch.index.query.QueryBuilders.simpleQueryStringQuery;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHitsWithoutFailures;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasSize;
+
+public class CoordinatorSearchPhaseAPMMetricsTests extends ESSingleNodeTestCase {
+    private static final String indexName = "test_coordinator_search_phase_metrics";
+    private final int num_primaries = randomIntBetween(128, 133);
+
+    private final Set<String> expectedMetrics = Set.of(
+        "es.search.coordinator.phases.fetch_lookup_fields.duration.histogram",
+        "es.search.coordinator.phases.fetch.duration.histogram",
+        "es.search.coordinator.phases.expand.duration.histogram",
+        "es.search.coordinator.phases.query.duration.histogram"
+    );
+
+    private final Set<String> expectedMetricsWithDfs = Set.of(
+        "es.search.coordinator.phases.fetch_lookup_fields.duration.histogram",
+        "es.search.coordinator.phases.fetch.duration.histogram",
+        "es.search.coordinator.phases.expand.duration.histogram",
+        "es.search.coordinator.phases.dfs_query.duration.histogram",
+        "es.search.coordinator.phases.dfs.duration.histogram"
+    );
+
+    @Override
+    protected boolean resetNodeAfterTest() {
+        return true;
+    }
+
+    @Before
+    private void setUpIndex() throws Exception {
+        createIndex(
+            indexName,
+            Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, num_primaries)
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                .build()
+        );
+        ensureGreen(indexName);
+
+        prepareIndex(indexName).setId("1").setSource("body", "doc1").setRefreshPolicy(IMMEDIATE).get();
+        prepareIndex(indexName).setId("2").setSource("body", "doc2").setRefreshPolicy(IMMEDIATE).get();
+
+        prepareIndex(CoordinatorSearchPhaseAPMMetricsTests.TestSystemIndexPlugin.INDEX_NAME).setId("1")
+            .setSource("body", "doc1")
+            .setRefreshPolicy(IMMEDIATE)
+            .get();
+        prepareIndex(CoordinatorSearchPhaseAPMMetricsTests.TestSystemIndexPlugin.INDEX_NAME).setId("2")
+            .setSource("body", "doc2")
+            .setRefreshPolicy(IMMEDIATE)
+            .get();
+    }
+
+    @After
+    private void afterTest() {
+        resetMeter();
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return pluginList(TestTelemetryPlugin.class, CoordinatorSearchPhaseAPMMetricsTests.TestSystemIndexPlugin.class);
+    }
+
+    public void testMetricsDfsQueryThenFetch() throws InterruptedException {
+        checkMetricsDfsQueryThenFetch(indexName);
+    }
+
+    private void checkMetricsDfsQueryThenFetch(String indexName) throws InterruptedException {
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch(indexName).setSearchType(SearchType.DFS_QUERY_THEN_FETCH).setQuery(simpleQueryStringQuery("doc1")),
+            "1"
+        );
+
+        var coordinatorMetrics = filterForCoordinatorMetrics(getTestTelemetryPlugin().getRegisteredMetrics(InstrumentType.LONG_HISTOGRAM));
+        assertThat(coordinatorMetrics, hasSize(5));
+        assertThat(coordinatorMetrics, equalTo(expectedMetricsWithDfs));
+        for (var metricName : coordinatorMetrics) {
+            List<Measurement> measurements = getTestTelemetryPlugin().getLongHistogramMeasurement(metricName);
+            assertThat(measurements, hasSize(1));
+            assertThat(measurements.getFirst().getLong(), greaterThanOrEqualTo(0L));
+        }
+    }
+
+    public void testSearchTransportMetricsQueryThenFetch() throws InterruptedException {
+        checkSearchTransportMetricsQueryThenFetch(indexName);
+    }
+
+    private void checkSearchTransportMetricsQueryThenFetch(String indexName) throws InterruptedException {
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch(indexName).setSearchType(SearchType.QUERY_THEN_FETCH).setQuery(simpleQueryStringQuery("doc1")),
+            "1"
+        );
+
+        var coordinatorMetrics = filterForCoordinatorMetrics(getTestTelemetryPlugin().getRegisteredMetrics(InstrumentType.LONG_HISTOGRAM));
+        assertThat(coordinatorMetrics, hasSize(4));
+        assertThat(coordinatorMetrics, equalTo(expectedMetrics));
+    }
+
+    private void resetMeter() {
+        getTestTelemetryPlugin().resetMeter();
+    }
+
+    private TestTelemetryPlugin getTestTelemetryPlugin() {
+        return getInstanceFromNode(PluginsService.class).filterPlugins(TestTelemetryPlugin.class).toList().get(0);
+    }
+
+    private Set<String> filterForCoordinatorMetrics(List<String> registeredMetrics) {
+        return registeredMetrics.stream().filter(m -> m.startsWith("es.search.coordinator")).collect(Collectors.toSet());
+    }
+
+    public static class TestSystemIndexPlugin extends Plugin implements SystemIndexPlugin {
+
+        static final String INDEX_NAME = ".test-system-index";
+
+        public TestSystemIndexPlugin() {}
+
+        @Override
+        public Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings settings) {
+            return List.of(
+                SystemIndexDescriptor.builder()
+                    .setIndexPattern(INDEX_NAME + "*")
+                    .setPrimaryIndex(INDEX_NAME)
+                    .setSettings(
+                        Settings.builder()
+                            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                            .build()
+                    )
+                    .setMappings("""
+                          {
+                            "_meta": {
+                              "version": "8.0.0",
+                              "managed_index_mappings_version": 3
+                            },
+                            "properties": {
+                              "body": { "type": "keyword" }
+                            }
+                          }
+                        """)
+                    .setThreadPools(ExecutorNames.DEFAULT_SYSTEM_INDEX_THREAD_POOLS)
+                    .setOrigin(ShardSearchPhaseAPMMetricsTests.class.getSimpleName())
+                    .build()
+            );
+        }
+
+        @Override
+        public String getFeatureName() {
+            return ShardSearchPhaseAPMMetricsTests.class.getSimpleName();
+        }
+
+        @Override
+        public String getFeatureDescription() {
+            return "test plugin";
+        }
+    }
+
+}

--- a/server/src/test/java/org/elasticsearch/search/TelemetryMetrics/CoordinatorSearchPhaseAPMMetricsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/TelemetryMetrics/CoordinatorSearchPhaseAPMMetricsTests.java
@@ -9,14 +9,37 @@
 
 package org.elasticsearch.search.TelemetryMetrics;
 
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.search.SearchPhaseController;
 import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.indices.ExecutorNames;
 import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.plugins.SystemIndexPlugin;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.query.QuerySearchResult;
+import org.elasticsearch.search.rank.RankBuilder;
+import org.elasticsearch.search.rank.RankDoc;
+import org.elasticsearch.search.rank.RankShardResult;
+import org.elasticsearch.search.rank.TestRankBuilder;
+import org.elasticsearch.search.rank.TestRankShardResult;
+import org.elasticsearch.search.rank.context.QueryPhaseRankCoordinatorContext;
+import org.elasticsearch.search.rank.context.QueryPhaseRankShardContext;
+import org.elasticsearch.search.rank.context.RankFeaturePhaseRankCoordinatorContext;
+import org.elasticsearch.search.rank.context.RankFeaturePhaseRankShardContext;
+import org.elasticsearch.search.rank.feature.RankFeatureDoc;
+import org.elasticsearch.search.rank.feature.RankFeatureShardResult;
 import org.elasticsearch.telemetry.InstrumentType;
 import org.elasticsearch.telemetry.Measurement;
 import org.elasticsearch.telemetry.TestTelemetryPlugin;
@@ -24,13 +47,18 @@ import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.junit.After;
 import org.junit.Before;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.elasticsearch.index.query.QueryBuilders.simpleQueryStringQuery;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertScrollResponsesAndHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHitsWithoutFailures;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -38,21 +66,30 @@ import static org.hamcrest.Matchers.hasSize;
 
 public class CoordinatorSearchPhaseAPMMetricsTests extends ESSingleNodeTestCase {
     private static final String indexName = "test_coordinator_search_phase_metrics";
-    private final int num_primaries = randomIntBetween(128, 133);
+    private final int num_primaries = randomIntBetween(2, 7);
 
     private final Set<String> expectedMetrics = Set.of(
-        "es.search.coordinator.phases.fetch_lookup_fields.duration.histogram",
-        "es.search.coordinator.phases.fetch.duration.histogram",
+        "es.search.coordinator.phases.can_match.duration.histogram",
         "es.search.coordinator.phases.expand.duration.histogram",
+        "es.search.coordinator.phases.fetch.duration.histogram",
+        "es.search.coordinator.phases.fetch_lookup_fields.duration.histogram",
         "es.search.coordinator.phases.query.duration.histogram"
     );
 
     private final Set<String> expectedMetricsWithDfs = Set.of(
-        "es.search.coordinator.phases.fetch_lookup_fields.duration.histogram",
-        "es.search.coordinator.phases.fetch.duration.histogram",
-        "es.search.coordinator.phases.expand.duration.histogram",
+        "es.search.coordinator.phases.dfs.duration.histogram",
         "es.search.coordinator.phases.dfs_query.duration.histogram",
-        "es.search.coordinator.phases.dfs.duration.histogram"
+        "es.search.coordinator.phases.expand.duration.histogram",
+        "es.search.coordinator.phases.fetch.duration.histogram",
+        "es.search.coordinator.phases.fetch_lookup_fields.duration.histogram"
+    );
+
+    private final Set<String> expectedMetricsWithRanking = Set.of(
+        "es.search.coordinator.phases.expand.duration.histogram",
+        "es.search.coordinator.phases.fetch.duration.histogram",
+        "es.search.coordinator.phases.fetch_lookup_fields.duration.histogram",
+        "es.search.coordinator.phases.query.duration.histogram",
+        "es.search.coordinator.phases.rank_feature.duration.histogram"
     );
 
     @Override
@@ -95,38 +132,195 @@ public class CoordinatorSearchPhaseAPMMetricsTests extends ESSingleNodeTestCase 
     }
 
     public void testMetricsDfsQueryThenFetch() throws InterruptedException {
-        checkMetricsDfsQueryThenFetch(indexName);
-    }
-
-    private void checkMetricsDfsQueryThenFetch(String indexName) throws InterruptedException {
         assertSearchHitsWithoutFailures(
             client().prepareSearch(indexName).setSearchType(SearchType.DFS_QUERY_THEN_FETCH).setQuery(simpleQueryStringQuery("doc1")),
             "1"
         );
 
         var coordinatorMetrics = filterForCoordinatorMetrics(getTestTelemetryPlugin().getRegisteredMetrics(InstrumentType.LONG_HISTOGRAM));
-        assertThat(coordinatorMetrics, hasSize(5));
         assertThat(coordinatorMetrics, equalTo(expectedMetricsWithDfs));
-        for (var metricName : coordinatorMetrics) {
-            List<Measurement> measurements = getTestTelemetryPlugin().getLongHistogramMeasurement(metricName);
-            assertThat(measurements, hasSize(1));
-            assertThat(measurements.getFirst().getLong(), greaterThanOrEqualTo(0L));
-        }
+        assertMeasurements(expectedMetricsWithDfs);
     }
 
     public void testSearchTransportMetricsQueryThenFetch() throws InterruptedException {
-        checkSearchTransportMetricsQueryThenFetch(indexName);
-    }
-
-    private void checkSearchTransportMetricsQueryThenFetch(String indexName) throws InterruptedException {
         assertSearchHitsWithoutFailures(
-            client().prepareSearch(indexName).setSearchType(SearchType.QUERY_THEN_FETCH).setQuery(simpleQueryStringQuery("doc1")),
+            client().prepareSearch(indexName)
+                .setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setPreFilterShardSize(1)
+                .setQuery(simpleQueryStringQuery("doc1")),
             "1"
         );
 
         var coordinatorMetrics = filterForCoordinatorMetrics(getTestTelemetryPlugin().getRegisteredMetrics(InstrumentType.LONG_HISTOGRAM));
-        assertThat(coordinatorMetrics, hasSize(4));
         assertThat(coordinatorMetrics, equalTo(expectedMetrics));
+        assertMeasurements(expectedMetrics);
+    }
+
+    public void testSearchMultipleIndices() {
+        assertSearchHitsWithoutFailures(
+            client().prepareSearch(indexName, ShardSearchPhaseAPMMetricsTests.TestSystemIndexPlugin.INDEX_NAME)
+                .setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setPreFilterShardSize(1)
+                .setQuery(simpleQueryStringQuery("doc1")),
+            "1",
+            "1"
+        );
+        var coordinatorMetrics = filterForCoordinatorMetrics(getTestTelemetryPlugin().getRegisteredMetrics(InstrumentType.LONG_HISTOGRAM));
+        assertThat(coordinatorMetrics, equalTo(expectedMetrics));
+        assertMeasurements(expectedMetrics);
+    }
+
+    public void testSearchTransportMetricsScroll() {
+        assertScrollResponsesAndHitCount(
+            client(),
+            TimeValue.timeValueSeconds(60),
+            client().prepareSearch(indexName).setSize(1).setPreFilterShardSize(1).setQuery(simpleQueryStringQuery("doc1 doc2")),
+            2,
+            (respNum, response) -> {}
+        );
+        var coordinatorMetrics = filterForCoordinatorMetrics(getTestTelemetryPlugin().getRegisteredMetrics(InstrumentType.LONG_HISTOGRAM));
+        assertThat(coordinatorMetrics, equalTo(expectedMetrics));
+        assertMeasurements(expectedMetrics);
+
+    }
+
+    public void testSearchRanking() {
+        final String indexName = "index";
+        final String rankFeatureFieldName = "field";
+        final String searchFieldName = "search_field";
+        final String searchFieldValue = "some_value";
+        final String fetchFieldName = "fetch_field";
+        final String fetchFieldValue = "fetch_value";
+
+        final int minDocs = 3;
+        final int maxDocs = 10;
+        int numDocs = between(minDocs, maxDocs);
+        createIndex(indexName);
+        // index some documents
+        for (int i = 0; i < numDocs; i++) {
+            prepareIndex(indexName).setId(String.valueOf(i))
+                .setSource(
+                    rankFeatureFieldName,
+                    "aardvark_" + i,
+                    searchFieldName,
+                    searchFieldValue,
+                    fetchFieldName,
+                    fetchFieldValue + "_" + i
+                )
+                .get();
+        }
+        indicesAdmin().prepareRefresh(indexName).get();
+
+        var response = client().prepareSearch(indexName)
+            .setSource(
+                new SearchSourceBuilder().query(new TermQueryBuilder(searchFieldName, searchFieldValue))
+                    .size(2)
+                    .from(2)
+                    .fetchField(fetchFieldName)
+                    .rankBuilder(new TestRankBuilder(RankBuilder.DEFAULT_RANK_WINDOW_SIZE) {
+
+                        // no need for more than one queries
+                        @Override
+                        public boolean isCompoundBuilder() {
+                            return false;
+                        }
+
+                        @Override
+                        public RankFeaturePhaseRankCoordinatorContext buildRankFeaturePhaseCoordinatorContext(
+                            int size,
+                            int from,
+                            Client client
+                        ) {
+                            return new RankFeaturePhaseRankCoordinatorContext(size, from, DEFAULT_RANK_WINDOW_SIZE, false) {
+                                @Override
+                                protected void computeScores(RankFeatureDoc[] featureDocs, ActionListener<float[]> scoreListener) {
+                                    float[] scores = new float[featureDocs.length];
+                                    for (int i = 0; i < featureDocs.length; i++) {
+                                        scores[i] = featureDocs[i].score;
+                                    }
+                                    scoreListener.onResponse(scores);
+                                }
+                            };
+                        }
+
+                        @Override
+                        public QueryPhaseRankCoordinatorContext buildQueryPhaseCoordinatorContext(int size, int from) {
+                            return new QueryPhaseRankCoordinatorContext(RankBuilder.DEFAULT_RANK_WINDOW_SIZE) {
+                                @Override
+                                public ScoreDoc[] rankQueryPhaseResults(
+                                    List<QuerySearchResult> querySearchResults,
+                                    SearchPhaseController.TopDocsStats topDocStats
+                                ) {
+                                    List<RankDoc> rankDocs = new ArrayList<>();
+                                    for (int i = 0; i < querySearchResults.size(); i++) {
+                                        QuerySearchResult querySearchResult = querySearchResults.get(i);
+                                        TestRankShardResult shardResult = (TestRankShardResult) querySearchResult.getRankShardResult();
+                                        for (RankDoc trd : shardResult.testRankDocs) {
+                                            trd.shardIndex = i;
+                                            rankDocs.add(trd);
+                                        }
+                                    }
+                                    rankDocs.sort(Comparator.comparing((RankDoc doc) -> doc.score).reversed());
+                                    RankDoc[] topResults = rankDocs.stream().limit(rankWindowSize).toArray(RankDoc[]::new);
+                                    topDocStats.fetchHits = topResults.length;
+                                    return topResults;
+                                }
+                            };
+                        }
+
+                        @Override
+                        public QueryPhaseRankShardContext buildQueryPhaseShardContext(List<Query> queries, int from) {
+                            return new QueryPhaseRankShardContext(queries, from) {
+
+                                @Override
+                                public int rankWindowSize() {
+                                    return DEFAULT_RANK_WINDOW_SIZE;
+                                }
+
+                                @Override
+                                public RankShardResult combineQueryPhaseResults(List<TopDocs> rankResults) {
+                                    // we know we have just 1 query, so return all the docs from it
+                                    return new TestRankShardResult(
+                                        Arrays.stream(rankResults.getFirst().scoreDocs)
+                                            .map(x -> new RankDoc(x.doc, x.score, x.shardIndex))
+                                            .limit(rankWindowSize())
+                                            .toArray(RankDoc[]::new)
+                                    );
+                                }
+                            };
+                        }
+
+                        @Override
+                        public RankFeaturePhaseRankShardContext buildRankFeaturePhaseShardContext() {
+                            return new RankFeaturePhaseRankShardContext(rankFeatureFieldName) {
+                                @Override
+                                public RankShardResult buildRankFeatureShardResult(SearchHits hits, int shardId) {
+                                    RankFeatureDoc[] rankFeatureDocs = new RankFeatureDoc[hits.getHits().length];
+                                    for (int i = 0; i < hits.getHits().length; i++) {
+                                        SearchHit hit = hits.getHits()[i];
+                                        rankFeatureDocs[i] = new RankFeatureDoc(hit.docId(), hit.getScore(), shardId);
+                                        rankFeatureDocs[i].featureData(parseFeatureData(hit, rankFeatureFieldName));
+                                        rankFeatureDocs[i].score = randomFloat();
+                                        rankFeatureDocs[i].rank = i + 1;
+                                    }
+                                    return new RankFeatureShardResult(rankFeatureDocs);
+                                }
+                            };
+                        }
+                    })
+            )
+            .get();
+        assertNoFailures(response);
+        var coordinatorMetrics = filterForCoordinatorMetrics(getTestTelemetryPlugin().getRegisteredMetrics(InstrumentType.LONG_HISTOGRAM));
+        assertThat(coordinatorMetrics, equalTo(expectedMetricsWithRanking));
+        assertMeasurements(expectedMetricsWithRanking);
+    }
+
+    private List<String> parseFeatureData(SearchHit hit, String fieldName) {
+        Object fieldValue = hit.getFields().get(fieldName).getValue();
+        @SuppressWarnings("unchecked")
+        List<String> fieldValues = fieldValue instanceof List ? (List<String>) fieldValue : List.of(String.valueOf(fieldValue));
+        return fieldValues;
     }
 
     private void resetMeter() {
@@ -139,6 +333,14 @@ public class CoordinatorSearchPhaseAPMMetricsTests extends ESSingleNodeTestCase 
 
     private Set<String> filterForCoordinatorMetrics(List<String> registeredMetrics) {
         return registeredMetrics.stream().filter(m -> m.startsWith("es.search.coordinator")).collect(Collectors.toSet());
+    }
+
+    private void assertMeasurements(Collection<String> metricNames) {
+        for (var metricName : metricNames) {
+            List<Measurement> measurements = getTestTelemetryPlugin().getLongHistogramMeasurement(metricName);
+            assertThat(measurements, hasSize(1));
+            assertThat(measurements.getFirst().getLong(), greaterThanOrEqualTo(0L));
+        }
     }
 
     public static class TestSystemIndexPlugin extends Plugin implements SystemIndexPlugin {

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -148,6 +148,7 @@ import org.elasticsearch.index.analysis.AnalysisRegistry;
 import org.elasticsearch.index.engine.MergeMetrics;
 import org.elasticsearch.index.mapper.MapperMetrics;
 import org.elasticsearch.index.mapper.MapperRegistry;
+import org.elasticsearch.index.search.stats.CoordinatorSearchPhaseAPMMetrics;
 import org.elasticsearch.index.seqno.GlobalCheckpointSyncAction;
 import org.elasticsearch.index.seqno.RetentionLeaseSyncer;
 import org.elasticsearch.index.shard.PrimaryReplicaSyncer;
@@ -2771,7 +2772,8 @@ public class SnapshotResiliencyTests extends ESTestCase {
                         EmptySystemIndices.INSTANCE.getExecutorSelector(),
                         new SearchResponseMetrics(TelemetryProvider.NOOP.getMeterRegistry()),
                         client,
-                        usageService
+                        usageService,
+                        CoordinatorSearchPhaseAPMMetrics.NOOP
                     )
                 );
                 actions.put(


### PR DESCRIPTION
New metrics created: 

- es.search.coordinator.phases.can_match.duration.histogram
- es.search.coordinator.phases.dfs.duration.histogram
- es.search.coordinator.phases.dfs_query.duration.histogram
- es.search.coordinator.phases.expand.duration.histogram
- es.search.coordinator.phases.fetch.duration.histogram
- es.search.coordinator.phases.fetch_lookup_fields.duration.histogram
- es.search.coordinator.phases.rank_feature.duration.histogram