### PR TITLE
Apply source excludes early when retrieving the _inference_fields

### DIFF
--- a/docs/changelog/135897.yaml
+++ b/docs/changelog/135897.yaml
@@ -1,0 +1,5 @@
+pr: 135897
+summary: Apply source excludes early when retrieving the `_inference_fields`
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
+++ b/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
@@ -426,6 +426,14 @@ public final class ShardGetService extends AbstractIndexShardComponent {
 
     public static boolean shouldExcludeInferenceFieldsFromSource(IndexSettings indexSettings, FetchSourceContext fetchSourceContext) {
         var explicit = shouldExcludeInferenceFieldsFromSourceExplicit(fetchSourceContext);
+        var filter = fetchSourceContext != null ? fetchSourceContext.filter() : null;
+        if (filter != null) {
+            if (filter.isPathFiltered(InferenceMetadataFieldsMapper.NAME, true)) {
+                return true;
+            } else if (filter.isExplicitlyIncluded(InferenceMetadataFieldsMapper.NAME)) {
+                return false;
+            }
+        }
         return explicit != null ? explicit : INDEX_MAPPING_EXCLUDE_SOURCE_VECTORS_SETTING.get(indexSettings.getSettings());
     }
 

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchSourcePhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchSourcePhase.java
@@ -19,6 +19,7 @@ import org.elasticsearch.search.fetch.StoredFieldsSpec;
 import org.elasticsearch.search.lookup.Source;
 import org.elasticsearch.search.lookup.SourceFilter;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public final class FetchSourcePhase implements FetchSubPhase {
@@ -99,6 +100,10 @@ public final class FetchSourcePhase implements FetchSubPhase {
                     return source;
                 }
                 var newSource = source.source();
+                if (newSource instanceof HashMap == false) {
+                    // the map is not mutable
+                    newSource = new HashMap<>(newSource);
+                }
                 newSource.put(InferenceMetadataFieldsMapper.NAME, field.getValues().get(0));
                 return Source.fromMap(newSource, source.sourceContentType());
             }

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/30_semantic_text_inference.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/30_semantic_text_inference.yml
@@ -1385,4 +1385,42 @@ setup:
   - match: { hits.hits.0._source._inference_fields.dense_field.inference.chunks.dense_field.0.start_offset: 0 }
   - match: { hits.hits.0._source._inference_fields.dense_field.inference.chunks.dense_field.0.end_offset: 22 }
 
+  - do:
+      search:
+        index: test-index
+        body:
+          _source:
+            exclude_vectors: false
+            excludes: ["*"]
+          query:
+            term:
+              _id: doc_1
+
+  - match:  { hits.total.value: 1 }
+  - length: { hits.hits.0._source: 0}
+
+  - do:
+      search:
+        index: test-index
+        body:
+          _source:
+            exclude_vectors: false
+            excludes: ["*_field"]
+          query:
+            term:
+              _id: doc_1
+
+  - match:  { hits.total.value: 1 }
+  - length: { hits.hits.0._source: 1}
+  - length: { hits.hits.0._source._inference_fields.sparse_field.inference.chunks: 1 }
+  - length: { hits.hits.0._source._inference_fields.sparse_field.inference.chunks.sparse_field: 1 }
+  - exists:   hits.hits.0._source._inference_fields.sparse_field.inference.chunks.sparse_field.0.embeddings
+  - match:  { hits.hits.0._source._inference_fields.sparse_field.inference.chunks.sparse_field.0.start_offset: 0 }
+  - match:  { hits.hits.0._source._inference_fields.sparse_field.inference.chunks.sparse_field.0.end_offset: 14 }
+  - length: { hits.hits.0._source._inference_fields.dense_field.inference.chunks.dense_field: 1 }
+  - exists:   hits.hits.0._source._inference_fields.dense_field.inference.chunks.dense_field.0.embeddings
+  - match:  { hits.hits.0._source._inference_fields.dense_field.inference.chunks.dense_field.0.start_offset: 0 }
+  - match:  { hits.hits.0._source._inference_fields.dense_field.inference.chunks.dense_field.0.end_offset: 22 }
+
+
 


### PR DESCRIPTION
The inference fields is automatically retrieved when `exclude_vectors` is set to false. In this change, we apply the source exclude early, in case the _inference_fields is removed, to avoid loading it entirely. We also protect against immutable map when adding the _inference_fields in _source since we cannot ensure that the map is always mutable.

Example stack trace:
```
Failed to execute phase [fetch], all shards failed; shardFailures {[<id>][<index>][0]: org.elasticsearch.transport.RemoteTransportException: [<node>][<ip-address>:9300][indices:data/read/search[phase/fetch/id]]
Caused by: org.elasticsearch.search.fetch.FetchPhaseExecutionException: Fetch Failed [Error running fetch phase for doc [1]]
	at org.elasticsearch.server@9.2.0/org.elasticsearch.search.fetch.FetchPhaseDocsIterator.iterate(FetchPhaseDocsIterator.java:109)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.search.fetch.FetchPhase.buildSearchHits(FetchPhase.java:248)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.search.fetch.FetchPhase.execute(FetchPhase.java:91)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.search.SearchService.lambda$executeFetchPhase$16(SearchService.java:1212)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.action.ActionRunnable$3.accept(ActionRunnable.java:79)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.action.ActionRunnable$3.accept(ActionRunnable.java:76)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.action.ActionRunnable$4.doRun(ActionRunnable.java:101)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:27)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.common.util.concurrent.TimedRunnable.doRun(TimedRunnable.java:35)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:1067)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:27)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
Caused by: java.lang.UnsupportedOperationException
	at java.base/java.util.ImmutableCollections.uoe(ImmutableCollections.java:159)
	at java.base/java.util.ImmutableCollections$AbstractImmutableMap.put(ImmutableCollections.java:1318)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.search.fetch.subphase.FetchSourcePhase$1.replaceInferenceMetadataFields(FetchSourcePhase.java:102)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.search.fetch.subphase.FetchSourcePhase$1.hitExecute(FetchSourcePhase.java:83)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.search.fetch.subphase.FetchSourcePhase$1.process(FetchSourcePhase.java:58)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.search.fetch.FetchPhase$1.nextDoc(FetchPhase.java:231)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.search.fetch.FetchPhaseDocsIterator.iterate(FetchPhaseDocsIterator.java:90)
	... 13 more
```