### PR TITLE
Revert "[Transform] Unmute testAuditorWritesAudits (#135786)"

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -317,6 +317,9 @@ tests:
     issue: https://github.com/elastic/elasticsearch/issues/121117
   - class: org.elasticsearch.xpack.ml.integration.PyTorchModelIT
     issue: https://github.com/elastic/elasticsearch/issues/121165
+  - class: org.elasticsearch.xpack.transform.integration.TransformAuditorIT
+    method: testAuditorWritesAudits
+    issue: https://github.com/elastic/elasticsearch/issues/121241
   - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
     method: test {p0=nodes.stats/11_indices_metrics/indices mappings exact count test for indices level}
     issue: https://github.com/elastic/elasticsearch/issues/120950


### PR DESCRIPTION
This reverts commit 86e0aae039659873ed72c70a0daed32dacbad9a5.

The `TransformAuditorIT.testAuditorWritesAudits` test has failed the 8.19 intake build several times since it has been unmuted in #135786.
There is an issue still open on that so I'm not going to open another one: https://github.com/elastic/elasticsearch/issues/121241