### PR TITLE
Mute org.elasticsearch.xpack.esql.plugin.DataNodeRequestSenderIT.testSearchWhileRelocating

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -427,3 +427,6 @@ tests:
   - class: org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT
     method: test {yaml=reference/search/retriever/line_983}
     issue: https://github.com/elastic/elasticsearch/issues/132854
+  - class: org.elasticsearch.xpack.esql.plugin.DataNodeRequestSenderIT
+    method: testSearchWhileRelocating
+    issue: https://github.com/elastic/elasticsearch/issues/128500


### PR DESCRIPTION
Issue already open #128500
This test has been already muted on main.