### PR TITLE
[9.2] Limit default allocated processors for the test cluster (#133633)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalTestClustersPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalTestClustersPlugin.java
@@ -11,9 +11,7 @@ package org.elasticsearch.gradle.internal;
 
 import org.elasticsearch.gradle.VersionProperties;
 import org.elasticsearch.gradle.internal.info.GlobalBuildInfoPlugin;
-import org.elasticsearch.gradle.testclusters.ElasticsearchCluster;
 import org.elasticsearch.gradle.testclusters.TestClustersPlugin;
-import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
@@ -33,17 +31,5 @@ public class InternalTestClustersPlugin implements Plugin<Project> {
             version -> (version.equals(VersionProperties.getElasticsearchVersion()) && buildParams.getSnapshotBuild() == false)
                 || buildParams.getBwcVersions().unreleasedInfo(version) == null
         );
-
-        NamedDomainObjectContainer<ElasticsearchCluster> testClusters = (NamedDomainObjectContainer<ElasticsearchCluster>) project
-            .getExtensions()
-            .getByName(TestClustersPlugin.EXTENSION_NAME);
-        // Limit the number of allocated processors for all nodes to 2 in the cluster by default.
-        // This is to ensure that the tests run consistently across different environments.
-        String processorCount = shouldConfigureTestClustersWithOneProcessor() ? "1" : "2";
-        testClusters.configureEach(elasticsearchCluster -> elasticsearchCluster.setting("node.processors", processorCount));
-    }
-
-    private boolean shouldConfigureTestClustersWithOneProcessor() {
-        return Boolean.parseBoolean(System.getProperty("tests.configure_test_clusters_with_one_processor", "false"));
     }
 }

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -1404,6 +1404,15 @@ public class ElasticsearchNode implements TestClusterConfiguration {
             baseConfig.put("cluster.service.slow_master_task_logging_threshold", "5s");
         }
 
+        // Limit the number of allocated processors for all nodes in the cluster by default.
+        // This is to ensure that the tests run consistently across different environments.
+        String processorCount = shouldConfigureTestClustersWithOneProcessor() ? "1" : "2";
+        if (getVersion().onOrAfter("7.6.0")) {
+            baseConfig.put("node.processors", processorCount);
+        } else {
+            baseConfig.put("processors", processorCount);
+        }
+
         baseConfig.put("action.destructive_requires_name", "false");
 
         HashSet<String> overriden = new HashSet<>(baseConfig.keySet());
@@ -1788,5 +1797,9 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         LinkCreationException(String message, IOException cause) {
             super(message, cause);
         }
+    }
+
+    private boolean shouldConfigureTestClustersWithOneProcessor() {
+        return Boolean.parseBoolean(System.getProperty("tests.configure_test_clusters_with_one_processor", "false"));
     }
 }

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultSettingsProvider.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultSettingsProvider.java
@@ -44,7 +44,11 @@ public class DefaultSettingsProvider implements SettingsProvider {
 
         // Limit the number of allocated processors for all nodes in the cluster by default.
         // This is to ensure that the tests run consistently across different environments.
-        settings.put("node.processors", "2");
+        if (nodeSpec.getVersion().onOrAfter("7.6.0")) {
+            settings.put("node.processors", "2");
+        } else {
+            settings.put("processors", "2");
+        }
 
         // Default the watermarks to absurdly low to prevent the tests from failing on nodes without enough disk space
         settings.put("cluster.routing.allocation.disk.watermark.low", "1b");


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Limit default allocated processors for the test cluster (#133633)](https://github.com/elastic/elasticsearch/pull/133633)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)