### PR TITLE
[9.2] rest-api-spec: add project.tags API (#135844)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/project.tags.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/project.tags.json
@@ -1,0 +1,21 @@
+{
+  "project.tags": {
+    "documentation": {
+      "url": null,
+      "description": "Return tags defined for the project"
+    },
+    "stability": "experimental",
+    "visibility": "public",
+    "headers": {
+      "accept": ["application/json"]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_project/tags",
+          "methods": ["GET"]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Backports the following commits to 9.2:
 - rest-api-spec: add project.tags API (#135844)