### PR TITLE
Move can-match thread from transport thread to search coordinator thread

### DIFF
--- a/docs/changelog/135934.yaml
+++ b/docs/changelog/135934.yaml
@@ -1,0 +1,6 @@
+pr: 135934
+summary: Move can-match thread from transport thread to search coordinator thread
+area: Search
+type: bug
+issues:
+ - 134959


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/134959 
