### PR TITLE
OOB fix in reranker constructing object parsing

### DIFF
--- a/docs/changelog/135945.yaml
+++ b/docs/changelog/135945.yaml
@@ -1,0 +1,5 @@
+pr: 135945
+summary: OOB fix in reranker constructing object parsing
+area: Relevance
+type: bug
+issues: []

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankRetrieverBuilder.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankRetrieverBuilder.java
@@ -79,9 +79,9 @@ public class TextSimilarityRankRetrieverBuilder extends CompoundRetrieverBuilder
 
     private static final ConstructingObjectParser<ChunkScorerConfig, RetrieverParserContext> CHUNK_SCORER_PARSER =
         new ConstructingObjectParser<>(CHUNK_RESCORER_FIELD.getPreferredName(), true, args -> {
-            Integer size = (Integer) args[0];
+            Integer size = args.size > 0 ? (Integer) args[0] : null;
             @SuppressWarnings("unchecked")
-            Map<String, Object> chunkingSettingsMap = (Map<String, Object>) args[1];
+            Map<String, Object> chunkingSettingsMap = args.size > 1 ? (Map<String, Object>) args[1] : null;
             ChunkingSettings chunkingSettings = ChunkScorerConfig.chunkingSettingsFromMap(chunkingSettingsMap);
             return new ChunkScorerConfig(size, chunkingSettings);
         });


### PR DESCRIPTION
In serverless, the following calls: 
```
DELETE my-index 

PUT my-index/_doc/1
{
  "text": "foo"
}


POST my-index/_search?error_trace
{
  "track_total_hits": true,
  "fields": [
    "text"
  ],
  "retriever": {
    "text_similarity_reranker": {
      "retriever": {
        "standard": {
          "query": {
            "match": {
              "text": "What is the capital of the USA?"
            }
          }
        }
      },
      "field": "text",
      "chunk_rescorer": {
        "size": 3,
        "chunking_settings": {
          "strategy": "sentence",
          "max_chunk_size": 25,
          "sentence_overlap": 0
        }
      },
      "rank_window_size": 10,
      "inference_text": "What is the capital of the USA?"
    }
  }
}
```

Result in an error: 
```
{
  "error": {
    "root_cause": [
      {
        "type": "x_content_parse_exception",
        "reason": "Failed to build [chunk_rescorer] after last required field arrived",
        "stack_trace": """org.elasticsearch.ElasticsearchException$1: Failed to build [chunk_rescorer] after last required field arrived
	at org.elasticsearch.server@9.2.0/org.elasticsearch.ElasticsearchException.guessRootCauses(ElasticsearchException.java:798)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.ElasticsearchException.guessRootCauses(ElasticsearchException.java:794)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.ElasticsearchException.generateFailureXContent(ElasticsearchException.java:712)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.RestResponse.build(RestResponse.java:202)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.RestResponse.<init>(RestResponse.java:161)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.RestResponse.<init>(RestResponse.java:122)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.RestController.sendFailure(RestController.java:514)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.RestController$1.onFailure(RestController.java:496)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.RestController$1.onResponse(RestController.java:488)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.RestController$1.onResponse(RestController.java:480)
	at org.elasticsearch.security@9.2.0/org.elasticsearch.xpack.security.rest.SecurityRestFilter.doHandleRequest(SecurityRestFilter.java:105)
	at org.elasticsearch.security@9.2.0/org.elasticsearch.xpack.security.rest.SecurityRestFilter.lambda$intercept$0(SecurityRestFilter.java:90)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.action.ActionListener$2.onResponse(ActionListener.java:258)
	at org.elasticsearch.security@9.2.0/org.elasticsearch.xpack.security.authc.support.SecondaryAuthenticator.lambda$authenticateAndAttachToContext$3(SecondaryAuthenticator.java:99)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.action.ActionListenerImplementations$ResponseWrappingActionListener.onResponse(ActionListenerImplementations.java:261)
	at org.elasticsearch.security@9.2.0/org.elasticsearch.xpack.security.authc.support.SecondaryAuthenticator.authenticate(SecondaryAuthenticator.java:109)
	at org.elasticsearch.security@9.2.0/org.elasticsearch.xpack.security.authc.support.SecondaryAuthenticator.authenticateAndAttachToContext(SecondaryAuthenticator.java:90)
	at org.elasticsearch.security@9.2.0/org.elasticsearch.xpack.security.rest.SecurityRestFilter.lambda$intercept$2(SecurityRestFilter.java:80)
	at org.elasticsearch.security@9.2.0/org.elasticsearch.xpack.security.rest.SecurityRestFilter.intercept(SecurityRestFilter.java:96)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.RestController.dispatchRequest(RestController.java:480)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.RestController.lambda$maybeAggregateAndDispatchRequest$4(RestController.java:404)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.RestContentAggregator$AggregationChunkHandler.onNext(RestContentAggregator.java:78)
	at org.elasticsearch.transport.netty4@9.2.0/org.elasticsearch.http.netty4.Netty4HttpRequestBodyStream.handleNettyContent(Netty4HttpRequestBodyStream.java:87)
	at org.elasticsearch.transport.netty4@9.2.0/org.elasticsearch.http.netty4.Netty4HttpPipeliningHandler.channelRead(Netty4HttpPipeliningHandler.java:146)
	at io.netty.transport@4.1.126.Final/io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
	at io.netty.transport@4.1.126.Final/io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.transport@4.1.126.Final/io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.handler@4.1.126.Final/io.netty.handler.flow.FlowControlHandler.dequeue(FlowControlHandler.java:202)
	at io.netty.handler@4.1.126.Final/io.netty.handler.flow.FlowControlHandler.read(FlowControlHandler.java:139)
	at io.netty.transport@4.1.126.Final/io.netty.channel.AbstractChannelHandlerContext.invokeRead(AbstractChannelHandlerContext.java:847)
	at io.netty.transport@4.1.126.Final/io.netty.channel.AbstractChannelHandlerContext.read(AbstractChannelHandlerContext.java:824)
	at io.netty.common@4.1.126.Final/io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173)
	at io.netty.common@4.1.126.Final/io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166)
	at io.netty.common@4.1.126.Final/io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472)
	at io.netty.transport@4.1.126.Final/io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569)
	at io.netty.common@4.1.126.Final/io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:998)
	at io.netty.common@4.1.126.Final/io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at java.base/java.lang.Thread.run(Thread.java:1474)
Caused by: org.elasticsearch.xcontent.XContentParseException: Failed to build [chunk_rescorer] after last required field arrived
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ConstructingObjectParser$Target.buildTarget(ConstructingObjectParser.java:593)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ConstructingObjectParser$Target.finish(ConstructingObjectParser.java:570)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ConstructingObjectParser.parse(ConstructingObjectParser.java:167)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ObjectParser.lambda$declareField$10(ObjectParser.java:435)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ObjectParser.parseValue(ObjectParser.java:613)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ObjectParser.parseSub(ObjectParser.java:633)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ObjectParser.parse(ObjectParser.java:316)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ConstructingObjectParser.parse(ConstructingObjectParser.java:167)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ConstructingObjectParser.apply(ConstructingObjectParser.java:159)
	at org.elasticsearch.inference@9.2.0/org.elasticsearch.xpack.inference.rank.textsimilarity.TextSimilarityRankRetrieverBuilder.fromXContent(TextSimilarityRankRetrieverBuilder.java:117)
	at org.elasticsearch.inference@9.2.0/org.elasticsearch.xpack.inference.InferencePlugin.lambda$getRetrievers$23(InferencePlugin.java:641)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.search.SearchModule.lambda$registerRetriever$24(SearchModule.java:1274)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.NamedXContentRegistry.parseNamedObject(NamedXContentRegistry.java:149)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.search.retriever.RetrieverBuilder$1.namedObject(RetrieverBuilder.java:83)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.search.retriever.RetrieverBuilder.parseInnerRetrieverBuilder(RetrieverBuilder.java:123)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.search.retriever.RetrieverBuilder.parseTopLevelRetrieverBuilder(RetrieverBuilder.java:87)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.search.builder.SearchSourceBuilder.parseXContent(SearchSourceBuilder.java:1439)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.search.builder.SearchSourceBuilder.parseXContent(SearchSourceBuilder.java:1343)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.action.search.RestSearchAction.parseSearchRequest(RestSearchAction.java:187)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.action.search.RestSearchAction.lambda$prepareRequest$1(RestSearchAction.java:131)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.RestRequest.withContentOrSourceParamParserOrNull(RestRequest.java:621)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.action.search.RestSearchAction.prepareRequest(RestSearchAction.java:130)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.BaseRestHandler.handleRequest(BaseRestHandler.java:99)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.RestController$1.onResponse(RestController.java:486)
	... 29 more
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0
	at org.elasticsearch.inference@9.2.0/org.elasticsearch.xpack.inference.rank.textsimilarity.TextSimilarityRankRetrieverBuilder.lambda$static$1(TextSimilarityRankRetrieverBuilder.java:82)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ConstructingObjectParser.lambda$new$2(ConstructingObjectParser.java:130)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ConstructingObjectParser$Target.buildTarget(ConstructingObjectParser.java:576)
	... 52 more
"""
      }
    ],
    "type": "x_content_parse_exception",
    "reason": "[1:489] [text_similarity_reranker] failed to parse field [chunk_rescorer]",
    "caused_by": {
      "type": "x_content_parse_exception",
      "reason": "Failed to build [chunk_rescorer] after last required field arrived",
      "caused_by": {
        "type": "array_index_out_of_bounds_exception",
        "reason": "Index 0 out of bounds for length 0",
        "stack_trace": """java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0
	at org.elasticsearch.inference@9.2.0/org.elasticsearch.xpack.inference.rank.textsimilarity.TextSimilarityRankRetrieverBuilder.lambda$static$1(TextSimilarityRankRetrieverBuilder.java:82)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ConstructingObjectParser.lambda$new$2(ConstructingObjectParser.java:130)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ConstructingObjectParser$Target.buildTarget(ConstructingObjectParser.java:576)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ConstructingObjectParser$Target.finish(ConstructingObjectParser.java:570)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ConstructingObjectParser.parse(ConstructingObjectParser.java:167)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ObjectParser.lambda$declareField$10(ObjectParser.java:435)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ObjectParser.parseValue(ObjectParser.java:613)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ObjectParser.parseSub(ObjectParser.java:633)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ObjectParser.parse(ObjectParser.java:316)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ConstructingObjectParser.parse(ConstructingObjectParser.java:167)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ConstructingObjectParser.apply(ConstructingObjectParser.java:159)
	at org.elasticsearch.inference@9.2.0/org.elasticsearch.xpack.inference.rank.textsimilarity.TextSimilarityRankRetrieverBuilder.fromXContent(TextSimilarityRankRetrieverBuilder.java:117)
	at org.elasticsearch.inference@9.2.0/org.elasticsearch.xpack.inference.InferencePlugin.lambda$getRetrievers$23(InferencePlugin.java:641)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.search.SearchModule.lambda$registerRetriever$24(SearchModule.java:1274)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.NamedXContentRegistry.parseNamedObject(NamedXContentRegistry.java:149)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.search.retriever.RetrieverBuilder$1.namedObject(RetrieverBuilder.java:83)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.search.retriever.RetrieverBuilder.parseInnerRetrieverBuilder(RetrieverBuilder.java:123)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.search.retriever.RetrieverBuilder.parseTopLevelRetrieverBuilder(RetrieverBuilder.java:87)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.search.builder.SearchSourceBuilder.parseXContent(SearchSourceBuilder.java:1439)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.search.builder.SearchSourceBuilder.parseXContent(SearchSourceBuilder.java:1343)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.action.search.RestSearchAction.parseSearchRequest(RestSearchAction.java:187)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.action.search.RestSearchAction.lambda$prepareRequest$1(RestSearchAction.java:131)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.RestRequest.withContentOrSourceParamParserOrNull(RestRequest.java:621)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.action.search.RestSearchAction.prepareRequest(RestSearchAction.java:130)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.BaseRestHandler.handleRequest(BaseRestHandler.java:99)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.RestController$1.onResponse(RestController.java:486)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.RestController$1.onResponse(RestController.java:480)
	at org.elasticsearch.security@9.2.0/org.elasticsearch.xpack.security.rest.SecurityRestFilter.doHandleRequest(SecurityRestFilter.java:105)
	at org.elasticsearch.security@9.2.0/org.elasticsearch.xpack.security.rest.SecurityRestFilter.lambda$intercept$0(SecurityRestFilter.java:90)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.action.ActionListener$2.onResponse(ActionListener.java:258)
	at org.elasticsearch.security@9.2.0/org.elasticsearch.xpack.security.authc.support.SecondaryAuthenticator.lambda$authenticateAndAttachToContext$3(SecondaryAuthenticator.java:99)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.action.ActionListenerImplementations$ResponseWrappingActionListener.onResponse(ActionListenerImplementations.java:261)
	at org.elasticsearch.security@9.2.0/org.elasticsearch.xpack.security.authc.support.SecondaryAuthenticator.authenticate(SecondaryAuthenticator.java:109)
	at org.elasticsearch.security@9.2.0/org.elasticsearch.xpack.security.authc.support.SecondaryAuthenticator.authenticateAndAttachToContext(SecondaryAuthenticator.java:90)
	at org.elasticsearch.security@9.2.0/org.elasticsearch.xpack.security.rest.SecurityRestFilter.lambda$intercept$2(SecurityRestFilter.java:80)
	at org.elasticsearch.security@9.2.0/org.elasticsearch.xpack.security.rest.SecurityRestFilter.intercept(SecurityRestFilter.java:96)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.RestController.dispatchRequest(RestController.java:480)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.RestController.lambda$maybeAggregateAndDispatchRequest$4(RestController.java:404)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.RestContentAggregator$AggregationChunkHandler.onNext(RestContentAggregator.java:78)
	at org.elasticsearch.transport.netty4@9.2.0/org.elasticsearch.http.netty4.Netty4HttpRequestBodyStream.handleNettyContent(Netty4HttpRequestBodyStream.java:87)
	at org.elasticsearch.transport.netty4@9.2.0/org.elasticsearch.http.netty4.Netty4HttpPipeliningHandler.channelRead(Netty4HttpPipeliningHandler.java:146)
	at io.netty.transport@4.1.126.Final/io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
	at io.netty.transport@4.1.126.Final/io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.transport@4.1.126.Final/io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.handler@4.1.126.Final/io.netty.handler.flow.FlowControlHandler.dequeue(FlowControlHandler.java:202)
	at io.netty.handler@4.1.126.Final/io.netty.handler.flow.FlowControlHandler.read(FlowControlHandler.java:139)
	at io.netty.transport@4.1.126.Final/io.netty.channel.AbstractChannelHandlerContext.invokeRead(AbstractChannelHandlerContext.java:847)
	at io.netty.transport@4.1.126.Final/io.netty.channel.AbstractChannelHandlerContext.read(AbstractChannelHandlerContext.java:824)
	at io.netty.common@4.1.126.Final/io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173)
	at io.netty.common@4.1.126.Final/io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166)
	at io.netty.common@4.1.126.Final/io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472)
	at io.netty.transport@4.1.126.Final/io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569)
	at io.netty.common@4.1.126.Final/io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:998)
	at io.netty.common@4.1.126.Final/io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at java.base/java.lang.Thread.run(Thread.java:1474)
"""
      },
      "stack_trace": """org.elasticsearch.xcontent.XContentParseException: Failed to build [chunk_rescorer] after last required field arrived
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ConstructingObjectParser$Target.buildTarget(ConstructingObjectParser.java:593)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ConstructingObjectParser$Target.finish(ConstructingObjectParser.java:570)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ConstructingObjectParser.parse(ConstructingObjectParser.java:167)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ObjectParser.lambda$declareField$10(ObjectParser.java:435)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ObjectParser.parseValue(ObjectParser.java:613)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ObjectParser.parseSub(ObjectParser.java:633)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ObjectParser.parse(ObjectParser.java:316)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ConstructingObjectParser.parse(ConstructingObjectParser.java:167)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ConstructingObjectParser.apply(ConstructingObjectParser.java:159)
	at org.elasticsearch.inference@9.2.0/org.elasticsearch.xpack.inference.rank.textsimilarity.TextSimilarityRankRetrieverBuilder.fromXContent(TextSimilarityRankRetrieverBuilder.java:117)
	at org.elasticsearch.inference@9.2.0/org.elasticsearch.xpack.inference.InferencePlugin.lambda$getRetrievers$23(InferencePlugin.java:641)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.search.SearchModule.lambda$registerRetriever$24(SearchModule.java:1274)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.NamedXContentRegistry.parseNamedObject(NamedXContentRegistry.java:149)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.search.retriever.RetrieverBuilder$1.namedObject(RetrieverBuilder.java:83)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.search.retriever.RetrieverBuilder.parseInnerRetrieverBuilder(RetrieverBuilder.java:123)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.search.retriever.RetrieverBuilder.parseTopLevelRetrieverBuilder(RetrieverBuilder.java:87)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.search.builder.SearchSourceBuilder.parseXContent(SearchSourceBuilder.java:1439)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.search.builder.SearchSourceBuilder.parseXContent(SearchSourceBuilder.java:1343)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.action.search.RestSearchAction.parseSearchRequest(RestSearchAction.java:187)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.action.search.RestSearchAction.lambda$prepareRequest$1(RestSearchAction.java:131)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.RestRequest.withContentOrSourceParamParserOrNull(RestRequest.java:621)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.action.search.RestSearchAction.prepareRequest(RestSearchAction.java:130)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.BaseRestHandler.handleRequest(BaseRestHandler.java:99)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.RestController$1.onResponse(RestController.java:486)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.RestController$1.onResponse(RestController.java:480)
	at org.elasticsearch.security@9.2.0/org.elasticsearch.xpack.security.rest.SecurityRestFilter.doHandleRequest(SecurityRestFilter.java:105)
	at org.elasticsearch.security@9.2.0/org.elasticsearch.xpack.security.rest.SecurityRestFilter.lambda$intercept$0(SecurityRestFilter.java:90)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.action.ActionListener$2.onResponse(ActionListener.java:258)
	at org.elasticsearch.security@9.2.0/org.elasticsearch.xpack.security.authc.support.SecondaryAuthenticator.lambda$authenticateAndAttachToContext$3(SecondaryAuthenticator.java:99)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.action.ActionListenerImplementations$ResponseWrappingActionListener.onResponse(ActionListenerImplementations.java:261)
	at org.elasticsearch.security@9.2.0/org.elasticsearch.xpack.security.authc.support.SecondaryAuthenticator.authenticate(SecondaryAuthenticator.java:109)
	at org.elasticsearch.security@9.2.0/org.elasticsearch.xpack.security.authc.support.SecondaryAuthenticator.authenticateAndAttachToContext(SecondaryAuthenticator.java:90)
	at org.elasticsearch.security@9.2.0/org.elasticsearch.xpack.security.rest.SecurityRestFilter.lambda$intercept$2(SecurityRestFilter.java:80)
	at org.elasticsearch.security@9.2.0/org.elasticsearch.xpack.security.rest.SecurityRestFilter.intercept(SecurityRestFilter.java:96)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.RestController.dispatchRequest(RestController.java:480)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.RestController.lambda$maybeAggregateAndDispatchRequest$4(RestController.java:404)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.RestContentAggregator$AggregationChunkHandler.onNext(RestContentAggregator.java:78)
	at org.elasticsearch.transport.netty4@9.2.0/org.elasticsearch.http.netty4.Netty4HttpRequestBodyStream.handleNettyContent(Netty4HttpRequestBodyStream.java:87)
	at org.elasticsearch.transport.netty4@9.2.0/org.elasticsearch.http.netty4.Netty4HttpPipeliningHandler.channelRead(Netty4HttpPipeliningHandler.java:146)
	at io.netty.transport@4.1.126.Final/io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
	at io.netty.transport@4.1.126.Final/io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.transport@4.1.126.Final/io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.handler@4.1.126.Final/io.netty.handler.flow.FlowControlHandler.dequeue(FlowControlHandler.java:202)
	at io.netty.handler@4.1.126.Final/io.netty.handler.flow.FlowControlHandler.read(FlowControlHandler.java:139)
	at io.netty.transport@4.1.126.Final/io.netty.channel.AbstractChannelHandlerContext.invokeRead(AbstractChannelHandlerContext.java:847)
	at io.netty.transport@4.1.126.Final/io.netty.channel.AbstractChannelHandlerContext.read(AbstractChannelHandlerContext.java:824)
	at io.netty.common@4.1.126.Final/io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173)
	at io.netty.common@4.1.126.Final/io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166)
	at io.netty.common@4.1.126.Final/io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472)
	at io.netty.transport@4.1.126.Final/io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569)
	at io.netty.common@4.1.126.Final/io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:998)
	at io.netty.common@4.1.126.Final/io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at java.base/java.lang.Thread.run(Thread.java:1474)
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0
	at org.elasticsearch.inference@9.2.0/org.elasticsearch.xpack.inference.rank.textsimilarity.TextSimilarityRankRetrieverBuilder.lambda$static$1(TextSimilarityRankRetrieverBuilder.java:82)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ConstructingObjectParser.lambda$new$2(ConstructingObjectParser.java:130)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ConstructingObjectParser$Target.buildTarget(ConstructingObjectParser.java:576)
	... 52 more
"""
    },
    "stack_trace": """org.elasticsearch.xcontent.XContentParseException: [1:489] [text_similarity_reranker] failed to parse field [chunk_rescorer]
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ObjectParser.throwFailedToParse(ObjectParser.java:620)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ObjectParser.parseValue(ObjectParser.java:615)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ObjectParser.parseSub(ObjectParser.java:633)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ObjectParser.parse(ObjectParser.java:316)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ConstructingObjectParser.parse(ConstructingObjectParser.java:167)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ConstructingObjectParser.apply(ConstructingObjectParser.java:159)
	at org.elasticsearch.inference@9.2.0/org.elasticsearch.xpack.inference.rank.textsimilarity.TextSimilarityRankRetrieverBuilder.fromXContent(TextSimilarityRankRetrieverBuilder.java:117)
	at org.elasticsearch.inference@9.2.0/org.elasticsearch.xpack.inference.InferencePlugin.lambda$getRetrievers$23(InferencePlugin.java:641)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.search.SearchModule.lambda$registerRetriever$24(SearchModule.java:1274)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.NamedXContentRegistry.parseNamedObject(NamedXContentRegistry.java:149)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.search.retriever.RetrieverBuilder$1.namedObject(RetrieverBuilder.java:83)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.search.retriever.RetrieverBuilder.parseInnerRetrieverBuilder(RetrieverBuilder.java:123)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.search.retriever.RetrieverBuilder.parseTopLevelRetrieverBuilder(RetrieverBuilder.java:87)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.search.builder.SearchSourceBuilder.parseXContent(SearchSourceBuilder.java:1439)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.search.builder.SearchSourceBuilder.parseXContent(SearchSourceBuilder.java:1343)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.action.search.RestSearchAction.parseSearchRequest(RestSearchAction.java:187)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.action.search.RestSearchAction.lambda$prepareRequest$1(RestSearchAction.java:131)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.RestRequest.withContentOrSourceParamParserOrNull(RestRequest.java:621)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.action.search.RestSearchAction.prepareRequest(RestSearchAction.java:130)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.BaseRestHandler.handleRequest(BaseRestHandler.java:99)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.RestController$1.onResponse(RestController.java:486)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.RestController$1.onResponse(RestController.java:480)
	at org.elasticsearch.security@9.2.0/org.elasticsearch.xpack.security.rest.SecurityRestFilter.doHandleRequest(SecurityRestFilter.java:105)
	at org.elasticsearch.security@9.2.0/org.elasticsearch.xpack.security.rest.SecurityRestFilter.lambda$intercept$0(SecurityRestFilter.java:90)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.action.ActionListener$2.onResponse(ActionListener.java:258)
	at org.elasticsearch.security@9.2.0/org.elasticsearch.xpack.security.authc.support.SecondaryAuthenticator.lambda$authenticateAndAttachToContext$3(SecondaryAuthenticator.java:99)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.action.ActionListenerImplementations$ResponseWrappingActionListener.onResponse(ActionListenerImplementations.java:261)
	at org.elasticsearch.security@9.2.0/org.elasticsearch.xpack.security.authc.support.SecondaryAuthenticator.authenticate(SecondaryAuthenticator.java:109)
	at org.elasticsearch.security@9.2.0/org.elasticsearch.xpack.security.authc.support.SecondaryAuthenticator.authenticateAndAttachToContext(SecondaryAuthenticator.java:90)
	at org.elasticsearch.security@9.2.0/org.elasticsearch.xpack.security.rest.SecurityRestFilter.lambda$intercept$2(SecurityRestFilter.java:80)
	at org.elasticsearch.security@9.2.0/org.elasticsearch.xpack.security.rest.SecurityRestFilter.intercept(SecurityRestFilter.java:96)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.RestController.dispatchRequest(RestController.java:480)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.RestController.lambda$maybeAggregateAndDispatchRequest$4(RestController.java:404)
	at org.elasticsearch.server@9.2.0/org.elasticsearch.rest.RestContentAggregator$AggregationChunkHandler.onNext(RestContentAggregator.java:78)
	at org.elasticsearch.transport.netty4@9.2.0/org.elasticsearch.http.netty4.Netty4HttpRequestBodyStream.handleNettyContent(Netty4HttpRequestBodyStream.java:87)
	at org.elasticsearch.transport.netty4@9.2.0/org.elasticsearch.http.netty4.Netty4HttpPipeliningHandler.channelRead(Netty4HttpPipeliningHandler.java:146)
	at io.netty.transport@4.1.126.Final/io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
	at io.netty.transport@4.1.126.Final/io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.transport@4.1.126.Final/io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.handler@4.1.126.Final/io.netty.handler.flow.FlowControlHandler.dequeue(FlowControlHandler.java:202)
	at io.netty.handler@4.1.126.Final/io.netty.handler.flow.FlowControlHandler.read(FlowControlHandler.java:139)
	at io.netty.transport@4.1.126.Final/io.netty.channel.AbstractChannelHandlerContext.invokeRead(AbstractChannelHandlerContext.java:847)
	at io.netty.transport@4.1.126.Final/io.netty.channel.AbstractChannelHandlerContext.read(AbstractChannelHandlerContext.java:824)
	at io.netty.common@4.1.126.Final/io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173)
	at io.netty.common@4.1.126.Final/io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166)
	at io.netty.common@4.1.126.Final/io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472)
	at io.netty.transport@4.1.126.Final/io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569)
	at io.netty.common@4.1.126.Final/io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:998)
	at io.netty.common@4.1.126.Final/io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at java.base/java.lang.Thread.run(Thread.java:1474)
Caused by: org.elasticsearch.xcontent.XContentParseException: Failed to build [chunk_rescorer] after last required field arrived
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ConstructingObjectParser$Target.buildTarget(ConstructingObjectParser.java:593)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ConstructingObjectParser$Target.finish(ConstructingObjectParser.java:570)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ConstructingObjectParser.parse(ConstructingObjectParser.java:167)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ObjectParser.lambda$declareField$10(ObjectParser.java:435)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ObjectParser.parseValue(ObjectParser.java:613)
	... 48 more
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0
	at org.elasticsearch.inference@9.2.0/org.elasticsearch.xpack.inference.rank.textsimilarity.TextSimilarityRankRetrieverBuilder.lambda$static$1(TextSimilarityRankRetrieverBuilder.java:82)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ConstructingObjectParser.lambda$new$2(ConstructingObjectParser.java:130)
	at org.elasticsearch.xcontent@9.2.0/org.elasticsearch.xcontent.ConstructingObjectParser$Target.buildTarget(ConstructingObjectParser.java:576)
	... 52 more
"""
  },
  "status": 400
}
```

This attempts to resolve that error 