### PR TITLE
[9.2] Apply source excludes early when retrieving the _inference_fields (#135897)

### DIFF
--- a/docs/changelog/135897.yaml
+++ b/docs/changelog/135897.yaml
@@ -1,0 +1,5 @@
+pr: 135897
+summary: Apply source excludes early when retrieving the `_inference_fields`
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
+++ b/server/src/main/java/org/elasticsearch/index/get/ShardGetService.java
@@ -426,6 +426,14 @@ public final class ShardGetService extends AbstractIndexShardComponent {
 
     public static boolean shouldExcludeInferenceFieldsFromSource(IndexSettings indexSettings, FetchSourceContext fetchSourceContext) {
         var explicit = shouldExcludeInferenceFieldsFromSourceExplicit(fetchSourceContext);
+        var filter = fetchSourceContext != null ? fetchSourceContext.filter() : null;
+        if (filter != null) {
+            if (filter.isPathFiltered(InferenceMetadataFieldsMapper.NAME, true)) {
+                return true;
+            } else if (filter.isExplicitlyIncluded(InferenceMetadataFieldsMapper.NAME)) {
+                return false;
+            }
+        }
         return explicit != null ? explicit : INDEX_MAPPING_EXCLUDE_SOURCE_VECTORS_SETTING.get(indexSettings.getSettings());
     }
 

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchSourcePhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchSourcePhase.java
@@ -19,6 +19,7 @@ import org.elasticsearch.search.fetch.StoredFieldsSpec;
 import org.elasticsearch.search.lookup.Source;
 import org.elasticsearch.search.lookup.SourceFilter;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public final class FetchSourcePhase implements FetchSubPhase {
@@ -99,6 +100,10 @@ public final class FetchSourcePhase implements FetchSubPhase {
                     return source;
                 }
                 var newSource = source.source();
+                if (newSource instanceof HashMap == false) {
+                    // the map is not mutable
+                    newSource = new HashMap<>(newSource);
+                }
                 newSource.put(InferenceMetadataFieldsMapper.NAME, field.getValues().get(0));
                 return Source.fromMap(newSource, source.sourceContentType());
             }

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/30_semantic_text_inference.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/30_semantic_text_inference.yml
@@ -1385,4 +1385,42 @@ setup:
   - match: { hits.hits.0._source._inference_fields.dense_field.inference.chunks.dense_field.0.start_offset: 0 }
   - match: { hits.hits.0._source._inference_fields.dense_field.inference.chunks.dense_field.0.end_offset: 22 }
 
+  - do:
+      search:
+        index: test-index
+        body:
+          _source:
+            exclude_vectors: false
+            excludes: ["*"]
+          query:
+            term:
+              _id: doc_1
+
+  - match:  { hits.total.value: 1 }
+  - length: { hits.hits.0._source: 0}
+
+  - do:
+      search:
+        index: test-index
+        body:
+          _source:
+            exclude_vectors: false
+            excludes: ["*_field"]
+          query:
+            term:
+              _id: doc_1
+
+  - match:  { hits.total.value: 1 }
+  - length: { hits.hits.0._source: 1}
+  - length: { hits.hits.0._source._inference_fields.sparse_field.inference.chunks: 1 }
+  - length: { hits.hits.0._source._inference_fields.sparse_field.inference.chunks.sparse_field: 1 }
+  - exists:   hits.hits.0._source._inference_fields.sparse_field.inference.chunks.sparse_field.0.embeddings
+  - match:  { hits.hits.0._source._inference_fields.sparse_field.inference.chunks.sparse_field.0.start_offset: 0 }
+  - match:  { hits.hits.0._source._inference_fields.sparse_field.inference.chunks.sparse_field.0.end_offset: 14 }
+  - length: { hits.hits.0._source._inference_fields.dense_field.inference.chunks.dense_field: 1 }
+  - exists:   hits.hits.0._source._inference_fields.dense_field.inference.chunks.dense_field.0.embeddings
+  - match:  { hits.hits.0._source._inference_fields.dense_field.inference.chunks.dense_field.0.start_offset: 0 }
+  - match:  { hits.hits.0._source._inference_fields.dense_field.inference.chunks.dense_field.0.end_offset: 22 }
+
+
 


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Apply source excludes early when retrieving the _inference_fields (#135897)