### PR TITLE
[9.2] Fix testStopQueryInlineStats - allow wider range of values (#135812)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -507,9 +507,6 @@ tests:
 - class: org.elasticsearch.repositories.blobstore.testkit.analyze.MinioRepositoryAnalysisRestIT
   method: testRepositoryAnalysis
   issue: https://github.com/elastic/elasticsearch/issues/134853
-- class: org.elasticsearch.xpack.esql.action.CrossClusterAsyncQueryStopIT
-  method: testStopQueryInlinestats
-  issue: https://github.com/elastic/elasticsearch/issues/134854
 - class: org.elasticsearch.xpack.esql.action.CrossClusterCancellationIT
   method: testCancelSkipUnavailable
   issue: https://github.com/elastic/elasticsearch/issues/134865
@@ -525,9 +522,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
   method: test {csv-spec:stats.CountDistinctWithConditions}
   issue: https://github.com/elastic/elasticsearch/issues/134993
-- class: org.elasticsearch.xpack.esql.action.CrossClusterAsyncQueryStopIT
-  method: testStopQueryInlineStats
-  issue: https://github.com/elastic/elasticsearch/issues/135032
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
   method: test {csv-spec:fork.ForkBeforeStatsWithWhere}
   issue: https://github.com/elastic/elasticsearch/issues/135041

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterAsyncQueryStopIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterAsyncQueryStopIT.java
@@ -314,9 +314,13 @@ public class CrossClusterAsyncQueryStopIT extends AbstractCrossClusterTestCase {
                 assertThat(asyncResponse.columns().size(), equalTo(2));
                 AtomicInteger i = new AtomicInteger(0);
                 asyncResponse.values().forEachRemaining(row -> {
-                    // We will have all rows here but total will be null since we stopped the inline stats before it could complete
-                    assertThat(row.next(), equalTo(null));
                     var v = row.next();
+                    // The sum could be null, if the stats did not manage to compute anything before being stopped
+                    // Or it could be 45L if it managed to add 0-9
+                    if (v != null) {
+                        assertThat((long) v, equalTo(45L));
+                    }
+                    v = row.next();
                     if (v != null) {
                         assertThat((long) v, lessThanOrEqualTo(10L));
                     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Fix testStopQueryInlineStats - allow wider range of values (#135812)](https://github.com/elastic/elasticsearch/pull/135812)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)