### PR TITLE
Split on line feed when parsing transport files in the build

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionDefinition.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionDefinition.java
@@ -22,9 +22,11 @@ record TransportVersionDefinition(String name, List<TransportVersionId> ids, boo
 
         String idsLine = null;
         if (contents.isEmpty() == false) {
-            String[] lines = contents.split(System.lineSeparator());
+            // Regardless of whether windows newlines exist (they could be added by git), we split on line feed.
+            // All we care about skipping lines with the comment character, so the remaining \r won't matter
+            String[] lines = contents.split("\n");
             for (String line : lines) {
-                line = line.replaceAll("\\s+", "");
+                line = line.strip();
                 if (line.startsWith("#") == false) {
                     idsLine = line;
                     break;

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionUpperBound.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/TransportVersionUpperBound.java
@@ -24,9 +24,11 @@ record TransportVersionUpperBound(String name, String definitionName, TransportV
         String branch = filename.substring(slashIndex == -1 ? 0 : (slashIndex + 1), filename.length() - 4);
 
         String idsLine = null;
-        String[] lines = contents.split(System.lineSeparator());
+        // Regardless of whether windows newlines exist (they could be added by git), we split on line feed.
+        // All we care about skipping lines with the comment character, so the remaining \r won't matter
+        String[] lines = contents.split("\n");
         for (String line : lines) {
-            line = line.replaceAll("\\s+", "");
+            line = line.strip();
             if (line.startsWith("#") == false) {
                 idsLine = line;
                 break;


### PR DESCRIPTION
When parsing transport files that may contain comments we split on newline. On windows systems these files _might_ have the line feed replaced by CRLF. This commit adjusts the parsing to only split on line feed so that regardless of what the system line separator is we will split the lines as needed.