### PR TITLE
[9.2] Avoid rewrite round_to with expensive queries (#135987)

### DIFF
--- a/docs/changelog/135987.yaml
+++ b/docs/changelog/135987.yaml
@@ -1,0 +1,5 @@
+pr: 135987
+summary: Avoid rewrite `round_to` with expensive queries
+area: ES|QL
+type: bug
+issues: []


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Avoid rewrite round_to with expensive queries (#135987)