### PR TITLE
Fix and unmute `testTsdbTemplatesNoKeywordFieldType`

### DIFF
--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/TSDBIndexingIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/TSDBIndexingIT.java
@@ -325,20 +325,16 @@ public class TSDBIndexingIT extends ESSingleNodeTestCase {
               }
             }""";
         var request = new TransportPutComposableIndexTemplateAction.Request("id");
+        Settings.Builder settingsBuilder = Settings.builder()
+            .put("index.mode", "time_series")
+            .put("index.dimensions_tsid_strategy_enabled", randomDouble() < 0.8);
+        if (randomBoolean()) {
+            settingsBuilder.put("index.routing_path", "metricset");
+        }
         request.indexTemplate(
             ComposableIndexTemplate.builder()
                 .indexPatterns(List.of("k8s*"))
-                .template(
-                    new Template(
-                        Settings.builder()
-                            .put("index.mode", "time_series")
-                            .put("index.routing_path", randomBoolean() ? null : "metricset")
-                            .put("index.dimensions_tsid_strategy_enabled", randomDouble() < 0.8)
-                            .build(),
-                        new CompressedXContent(mappingTemplate),
-                        null
-                    )
-                )
+                .template(new Template(settingsBuilder.build(), new CompressedXContent(mappingTemplate), null))
                 .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate(false, false))
                 .build()
         );

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -579,9 +579,6 @@ tests:
 - class: org.elasticsearch.indices.recovery.IndexRecoveryIT
   method: testUsesFileBasedRecoveryIfOperationsBasedRecoveryWouldBeUnreasonable
   issue: https://github.com/elastic/elasticsearch/issues/135737
-- class: org.elasticsearch.datastreams.TSDBIndexingIT
-  method: testTsdbTemplatesNoKeywordFieldType
-  issue: https://github.com/elastic/elasticsearch/issues/135746
 - class: org.elasticsearch.xpack.esql.expression.function.aggregate.IncreaseTests
   method: testGroupingAggregate {TestCase=<small positive doubles>}
   issue: https://github.com/elastic/elasticsearch/issues/135752


### PR DESCRIPTION
This following was problematic:

```java
.put("index.routing_path", randomBoolean() ? null : "metricset")
```

Because it set an explicit `null` as the routing path`.

In cases where the following evaluates to `false`, this leads to an error rightfully complaining that the routing path is required:

```java
.put("index.dimensions_tsid_strategy_enabled", randomDouble() < 0.8)
```