### PR TITLE
[DOCS] Add security advisory for 8.18.8 release notes

### DIFF
--- a/docs/reference/release-notes/8.18.8.asciidoc
+++ b/docs/reference/release-notes/8.18.8.asciidoc
@@ -5,6 +5,12 @@ coming[8.18.8]
 
 Also see <<breaking-changes-8.18,Breaking changes in 8.18>>.
 
+[IMPORTANT]
+====
+The 8.18.8 release contains fixes for potential security vulnerabilities.
+Please see our https://discuss.elastic.co/c/announcements/security-announcements/31[security advisory] for more details.
+====
+
 [[bug-8.18.8]]
 [float]
 === Bug fixes


### PR DESCRIPTION
This PR adds security advisory for the 8.18.8 release notes.
