### PR TITLE
[DOCS] Add security advisory for 9.0.8, 9.1.5 release notes

### DIFF
--- a/docs/release-notes/changelog-bundles/9.1.5.yml
+++ b/docs/release-notes/changelog-bundles/9.1.5.yml
@@ -68,10 +68,11 @@ changelogs:
       body: |-
         Queries using LIMIT followed by MV_EXPAND before a remote ENRICH can produce incorrect results due to distributed execution semantics.
         These queries are now unsupported and produce an error. Example:
-        [source,yaml]
-        ----------------------------
+        
+        ```yaml
         FROM *:events | SORT @timestamp | LIMIT 2 | MV_EXPAND ip | ENRICH _remote:clientip_policy ON ip
-        ----------------------------
+        ```
+
         To avoid this error, reorder your query, for example by moving ENRICH earlier in the pipeline.
       pr: 135051
   - pr: 135078

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -38,6 +38,10 @@ FROM *:events | SORT @timestamp | LIMIT 2 | MV_EXPAND ip | ENRICH _remote:client
 To avoid this error, reorder your query, for example by moving ENRICH earlier in the pipeline.
 ::::
 
+::::{dropdown} Security advisory
+The 9.1.5 release contains fixes for potential security vulnerabilities. Please see our [security advisory](https://discuss.elastic.co/c/announcements/security-announcements/31) for more details.
+::::
+
 ### Features and enhancements [elasticsearch-9.1.5-features-enhancements]
 
 Audit:
@@ -98,6 +102,12 @@ Transform:
 ```{applies_to}
 stack: ga 9.0.8
 ```
+
+### Highlights [elasticsearch-9.0.8-highlights]
+
+::::{dropdown} Security advisory
+The 9.0.8 release contains fixes for potential security vulnerabilities. Please see our [security advisory](https://discuss.elastic.co/c/announcements/security-announcements/31) for more details.
+::::
 
 ### Features and enhancements [elasticsearch-9.0.8-features-enhancements]
 


### PR DESCRIPTION
This PR adds security advisory for the 9.0.8 and 9.1.5 release notes.
