### PR TITLE
[9.1] Cardinality Aggregator Throws UnsupportedOperationException When Field Type is Vector (#135994)

### DIFF
--- a/docs/changelog/135994.yaml
+++ b/docs/changelog/135994.yaml
@@ -1,0 +1,6 @@
+pr: 135994
+summary: Cardinality Aggregator Throws `UnsupportedOperationException` When Field
+  Type is Vector
+area: Vector Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/VectorDVLeafFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/VectorDVLeafFieldData.java
@@ -60,7 +60,7 @@ final class VectorDVLeafFieldData implements LeafFieldData {
 
     @Override
     public SortedBinaryDocValues getBytesValues() {
-        throw new UnsupportedOperationException("String representation of doc values for vector fields is not supported");
+        throw new IllegalArgumentException("String representation of doc values for vector fields is not supported");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregator.java
@@ -32,6 +32,8 @@ import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.NumericDoubleValues;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
+import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
+import org.elasticsearch.index.mapper.vectors.SparseVectorFieldMapper;
 import org.elasticsearch.search.aggregations.AggregationExecutionContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -73,6 +75,11 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
     ) throws IOException {
         super(name, context, parent, metadata);
         assert valuesSourceConfig.hasValues();
+        if (valuesSourceConfig.fieldContext() != null
+            && (valuesSourceConfig.fieldContext().fieldType() instanceof DenseVectorFieldMapper.DenseVectorFieldType
+                || valuesSourceConfig.fieldContext().fieldType() instanceof SparseVectorFieldMapper.SparseVectorFieldType)) {
+            throw new IllegalArgumentException("Cardinality aggregation [" + name + "] does not support vector fields");
+        }
         this.valuesSource = valuesSourceConfig.getValuesSource();
         this.precision = precision;
         this.counts = new HyperLogLogPlusPlus(precision, context.bigArrays(), 1);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.mapper.IpFieldMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
@@ -38,6 +39,8 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.RangeFieldMapper;
 import org.elasticsearch.index.mapper.RangeType;
+import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
+import org.elasticsearch.index.mapper.vectors.SparseVectorFieldMapper;
 import org.elasticsearch.script.MockScriptEngine;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptEngine;
@@ -215,6 +218,51 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
             assertEquals(0.0, card.getValue(), 0);
             assertFalse(AggregationInspectionHelper.hasValue(card));
         });
+    }
+
+    public void testVectorValueThrows() {
+        final CardinalityAggregationBuilder aggregationBuilder = new CardinalityAggregationBuilder("card_agg_name").field("vector_value");
+        final MappedFieldType mappedFieldTypes;
+        boolean isDense = randomBoolean();
+        if (isDense) {
+            mappedFieldTypes = new DenseVectorFieldMapper.DenseVectorFieldType(
+                "vector_value",
+                IndexVersion.current(),
+                DenseVectorFieldMapper.ElementType.FLOAT,
+                64,
+                true,
+                DenseVectorFieldMapper.VectorSimilarity.COSINE,
+                DenseVectorFieldMapper.VectorIndexType.FLAT.parseIndexOptions("vector_value", new HashMap<>(), IndexVersion.current()),
+                new HashMap<>(),
+                false
+            );
+        } else {
+            mappedFieldTypes = new SparseVectorFieldMapper.SparseVectorFieldType(
+                IndexVersion.current(),
+                "vector_value",
+                false,
+                new HashMap<>()
+            );
+        }
+
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
+                iw.addDocument(singleton(new SortedDocValuesField("vector_value", new BytesRef("one"))));
+                iw.addDocument(singleton(new SortedDocValuesField("unrelatedField", new BytesRef("two"))));
+                iw.addDocument(singleton(new SortedDocValuesField("str_value", new BytesRef("three"))));
+                iw.addDocument(singleton(new SortedDocValuesField("str_value", new BytesRef("one"))));
+            }, card -> {
+                assertEquals(2, card.getValue(), 0);
+                assertTrue(AggregationInspectionHelper.hasValue(card));
+            }, mappedFieldTypes)
+        );
+
+        if (isDense) {
+            assertEquals("Cardinality aggregation [card_agg_name] does not support vector fields", exception.getMessage());
+        } else {
+            assertEquals("[sparse_vector] fields do not support sorting, scripting or aggregating", exception.getMessage());
+        }
     }
 
     public void testSingleValuedString() throws IOException {


### PR DESCRIPTION
Backports the following commits to 9.1:
 - Cardinality Aggregator Throws UnsupportedOperationException When Field Type is Vector (#135994)