### PR TITLE
[9.2] Cardinality Aggregator Throws UnsupportedOperationException When Field Type is Vector (#135994)

### DIFF
--- a/docs/changelog/135994.yaml
+++ b/docs/changelog/135994.yaml
@@ -1,0 +1,6 @@
+pr: 135994
+summary: Cardinality Aggregator Throws `UnsupportedOperationException` When Field
+  Type is Vector
+area: Vector Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/VectorDVLeafFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/VectorDVLeafFieldData.java
@@ -60,7 +60,7 @@ final class VectorDVLeafFieldData implements LeafFieldData {
 
     @Override
     public SortedBinaryDocValues getBytesValues() {
-        throw new UnsupportedOperationException("String representation of doc values for vector fields is not supported");
+        throw new IllegalArgumentException("String representation of doc values for vector fields is not supported");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregator.java
@@ -32,6 +32,8 @@ import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.NumericDoubleValues;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
+import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
+import org.elasticsearch.index.mapper.vectors.SparseVectorFieldMapper;
 import org.elasticsearch.search.aggregations.AggregationExecutionContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -73,6 +75,11 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
     ) throws IOException {
         super(name, context, parent, metadata);
         assert valuesSourceConfig.hasValues();
+        if (valuesSourceConfig.fieldContext() != null
+            && (valuesSourceConfig.fieldContext().fieldType() instanceof DenseVectorFieldMapper.DenseVectorFieldType
+                || valuesSourceConfig.fieldContext().fieldType() instanceof SparseVectorFieldMapper.SparseVectorFieldType)) {
+            throw new IllegalArgumentException("Cardinality aggregation [" + name + "] does not support vector fields");
+        }
         this.valuesSource = valuesSourceConfig.getValuesSource();
         this.precision = precision;
         this.counts = new HyperLogLogPlusPlus(precision, context.bigArrays(), 1);


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Cardinality Aggregator Throws UnsupportedOperationException When Field Type is Vector (#135994)