### PR TITLE
Add prefix to java util logging logger names

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -369,9 +369,6 @@ tests:
 - class: org.elasticsearch.xpack.sql.qa.mixed_node.SqlCompatIT
   method: testNullsOrderWithMissingOrderSupportQueryingNewNode
   issue: https://github.com/elastic/elasticsearch/issues/132249
-- class: org.elasticsearch.common.logging.JULBridgeTests
-  method: testThrowable
-  issue: https://github.com/elastic/elasticsearch/issues/132280
 - class: org.elasticsearch.xpack.ml.integration.AutodetectMemoryLimitIT
   method: testManyDistinctOverFields
   issue: https://github.com/elastic/elasticsearch/issues/132308

--- a/server/src/main/java/org/elasticsearch/common/logging/JULBridge.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/JULBridge.java
@@ -58,9 +58,18 @@ class JULBridge extends Handler {
 
     private JULBridge() {}
 
+    // package private for tests. Prefix log4j logger names with "jul" to distinguish from other loggers
+    static String loggerName(String julLoggerName) {
+        String loggerName = "jul";
+        if (julLoggerName.isEmpty() == false) {
+            loggerName += "." + julLoggerName;
+        }
+        return loggerName;
+    }
+
     @Override
     public void publish(LogRecord record) {
-        Logger logger = LogManager.getLogger(record.getLoggerName());
+        Logger logger = LogManager.getLogger(loggerName(record.getLoggerName()));
         Level level = translateJulLevel(record.getLevel());
         Throwable thrown = record.getThrown();
 

--- a/server/src/test/java/org/elasticsearch/common/logging/JULBridgeTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/JULBridgeTests.java
@@ -21,7 +21,6 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 
-import java.lang.invoke.MethodHandles;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Handler;
 
@@ -115,23 +114,27 @@ public class JULBridgeTests extends ESTestCase {
     public void testThrowable() {
         JULBridge.install();
         java.util.logging.Logger logger = java.util.logging.Logger.getLogger("");
-        assertLogged("", () -> logger.log(java.util.logging.Level.SEVERE, "error msg", new Exception("some error")), new LoggingExpectation() {
-            boolean matched = false;
+        assertLogged(
+            "",
+            () -> logger.log(java.util.logging.Level.SEVERE, "error msg", new Exception("some error")),
+            new LoggingExpectation() {
+                boolean matched = false;
 
-            @Override
-            public void match(LogEvent event) {
-                Throwable thrown = event.getThrown();
-                matched = event.getLoggerName().equals("jul")
-                    && event.getMessage().getFormattedMessage().equals("error msg")
-                    && thrown != null
-                    && thrown.getMessage().equals("some error");
-            }
+                @Override
+                public void match(LogEvent event) {
+                    Throwable thrown = event.getThrown();
+                    matched = event.getLoggerName().equals("jul")
+                        && event.getMessage().getFormattedMessage().equals("error msg")
+                        && thrown != null
+                        && thrown.getMessage().equals("some error");
+                }
 
-            @Override
-            public void assertMatched() {
-                assertThat("expected to see error message but did not", matched, equalTo(true));
+                @Override
+                public void assertMatched() {
+                    assertThat("expected to see error message but did not", matched, equalTo(true));
+                }
             }
-        });
+        );
     }
 
     public void testChildLogger() {
@@ -147,7 +150,8 @@ public class JULBridgeTests extends ESTestCase {
 
     public void testFormattedMessage() {
         JULBridge.install();
-        assertLogged("",
+        assertLogged(
+            "",
             () -> logger.log(java.util.logging.Level.INFO, "{0}", "a var"),
             new SeenEventExpectation("formatted msg", "jul", Level.INFO, "a var")
         );


### PR DESCRIPTION
The bridge between Java util logging and Log4j works by mapping each log message received in JUL to a log event in log4j. The JUL bridge tests check that messages of varying log levels are emitted.

Unfortunately this has a bad interaction with entitlements and tests. When a class (eg Regex, used by the test mock logger) is loaded, entitlements looks at that class to see if it should transform it. It then logs a trace message to say it will not be transformed. Yet if a class is loaded late, like Regex is, entitlements will emit this trace log message while log4j is already appending the original test log message. That in turn causes a status log message indicating a recursive call to the mock appender, which tests do not expect, and the test fails.

This commit sidesteps the issue by adding a special prefix, `jul`, to the mapping between logger names in JUL and log4j. By not setting the log level of the root log4j logger, the entitlements trace message is never emitted.