### PR TITLE
[ES|QL] Refactor AggregateMetricDoubleLiteral and adjust tests

### DIFF
--- a/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DownsampleIT.java
+++ b/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DownsampleIT.java
@@ -347,7 +347,6 @@ public class DownsampleIT extends DownsamplingIntegTestCase {
             }
             // tests on non-downsampled index
             // TODO: combine with above when support for aggregate_metric_double + implicit casting is added
-            // TODO: add to counter tests below when support for counters is added
             for (String innerCommand : List.of("first_over_time", "last_over_time")) {
                 String command = outerCommand + " (" + innerCommand + "(cpu))";
                 try (var resp = esqlCommand("TS " + secondIndex + " | STATS " + command + " by cluster, bucket(@timestamp, 1 hour)")) {
@@ -368,7 +367,7 @@ public class DownsampleIT extends DownsamplingIntegTestCase {
             }
 
             // tests on counter types
-            for (String innerCommand : List.of("rate")) {
+            for (String innerCommand : List.of("rate", "first_over_time", "last_over_time")) {
                 String command = outerCommand + " (" + innerCommand + "(request))";
                 String esqlQuery = "TS " + dataStreamName + " | STATS " + command + " by cluster, bucket(@timestamp, 1 hour)";
                 try (

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AggregateMetricDoubleBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AggregateMetricDoubleBlock.java
@@ -105,4 +105,28 @@ public sealed interface AggregateMetricDoubleBlock extends Block permits Aggrega
     IntBlock countBlock();
 
     Block getMetricBlock(int index);
+
+    default AggregateMetricDoubleLiteral getAggregateMetricDoubleLiteral(int index) {
+        boolean minAvailable = minBlock().isNull(index) == false;
+        boolean maxAvailable = maxBlock().isNull(index) == false;
+        boolean sumAvailable = sumBlock().isNull(index) == false;
+        boolean countAvailable = countBlock().isNull(index) == false;
+        double min = 0.0;
+        double max = 0.0;
+        double sum = 0.0;
+        int count = 0;
+        if (minAvailable) {
+            min = minBlock().getDouble(index);
+        }
+        if (maxAvailable) {
+            max = maxBlock().getDouble(index);
+        }
+        if (sumAvailable) {
+            sum = sumBlock().getDouble(index);
+        }
+        if (countAvailable) {
+            count = countBlock().getInt(index);
+        }
+        return new AggregateMetricDoubleLiteral(min, max, sum, count, minAvailable, maxAvailable, sumAvailable, countAvailable);
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AggregateMetricDoubleBlockBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AggregateMetricDoubleBlockBuilder.java
@@ -7,15 +7,8 @@
 
 package org.elasticsearch.compute.data;
 
-import org.elasticsearch.TransportVersion;
-import org.elasticsearch.common.io.stream.GenericNamedWriteable;
-import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.index.mapper.BlockLoader;
-
-import java.io.IOException;
 
 public class AggregateMetricDoubleBlockBuilder extends AbstractBlockBuilder implements BlockLoader.AggregateMetricDoubleBuilder {
 
@@ -205,75 +198,24 @@ public class AggregateMetricDoubleBlockBuilder extends AbstractBlockBuilder impl
         }
     }
 
-    /**
-     * Literal to represent AggregateMetricDouble and primarily used for testing and during folding.
-     * For all other purposes it is preferred to use the individual builders over the literal for generating blocks when possible.
-     */
-    public record AggregateMetricDoubleLiteral(Double min, Double max, Double sum, Integer count) implements GenericNamedWriteable {
-
-        private static final TransportVersion ESQL_AGGREGATE_METRIC_DOUBLE_LITERAL = TransportVersion.fromName(
-            "esql_aggregate_metric_double_literal"
-        );
-
-        public AggregateMetricDoubleLiteral {
-            min = (min == null || min.isNaN()) ? null : min;
-            max = (max == null || max.isNaN()) ? null : max;
-            sum = (sum == null || sum.isNaN()) ? null : sum;
-        }
-
-        public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
-            GenericNamedWriteable.class,
-            "AggregateMetricDoubleLiteral",
-            AggregateMetricDoubleLiteral::new
-        );
-
-        @Override
-        public String getWriteableName() {
-            return "AggregateMetricDoubleLiteral";
-        }
-
-        public AggregateMetricDoubleLiteral(StreamInput input) throws IOException {
-            this(input.readOptionalDouble(), input.readOptionalDouble(), input.readOptionalDouble(), input.readOptionalInt());
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            out.writeOptionalDouble(min);
-            out.writeOptionalDouble(max);
-            out.writeOptionalDouble(sum);
-            out.writeOptionalInt(count);
-        }
-
-        @Override
-        public boolean supportsVersion(TransportVersion version) {
-            return version.supports(ESQL_AGGREGATE_METRIC_DOUBLE_LITERAL);
-        }
-
-        @Override
-        public TransportVersion getMinimalSupportedVersion() {
-            assert false : "must not be called when overriding supportsVersion";
-            throw new UnsupportedOperationException("must not be called when overriding supportsVersion");
-        }
-    }
-
     public AggregateMetricDoubleBlockBuilder appendLiteral(AggregateMetricDoubleLiteral literal) {
-        if (literal.min != null) {
-            minBuilder.appendDouble(literal.min);
+        if (literal.isMinAvailable()) {
+            minBuilder.appendDouble(literal.getMin());
         } else {
             minBuilder.appendNull();
         }
-        if (literal.max != null) {
-            maxBuilder.appendDouble(literal.max);
+        if (literal.isMaxAvailable()) {
+            maxBuilder.appendDouble(literal.getMax());
         } else {
             maxBuilder.appendNull();
         }
-        if (literal.sum != null) {
-            sumBuilder.appendDouble(literal.sum);
+        if (literal.isSumAvailable()) {
+            sumBuilder.appendDouble(literal.getSum());
         } else {
             sumBuilder.appendNull();
         }
-        if (literal.count != null) {
-            countBuilder.appendInt(literal.count);
+        if (literal.isCountAvailable()) {
+            countBuilder.appendInt(literal.getCount());
         } else {
             countBuilder.appendNull();
         }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AggregateMetricDoubleLiteral.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AggregateMetricDoubleLiteral.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.common.io.stream.GenericNamedWriteable;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Java Object representation of AggregateMetricDouble in ES|QL.
+ */
+public class AggregateMetricDoubleLiteral implements GenericNamedWriteable {
+    private static final TransportVersion ESQL_AGGREGATE_METRIC_DOUBLE_LITERAL = TransportVersion.fromName(
+        "esql_aggregate_metric_double_literal"
+    );
+
+    private final double min;
+    private final double max;
+    private final double sum;
+    private final int count;
+    private final boolean minAvailable;
+    private final boolean maxAvailable;
+    private final boolean sumAvailable;
+    private final boolean countAvailable;
+
+    public AggregateMetricDoubleLiteral(
+        double min,
+        double max,
+        double sum,
+        int count,
+        boolean minAvailable,
+        boolean maxAvailable,
+        boolean sumAvailable,
+        boolean countAvailable
+    ) {
+        this.min = min;
+        this.max = max;
+        this.sum = sum;
+        this.count = count;
+        this.minAvailable = minAvailable;
+        this.maxAvailable = maxAvailable;
+        this.sumAvailable = sumAvailable;
+        this.countAvailable = countAvailable;
+    }
+
+    public AggregateMetricDoubleLiteral(double min, double max, double sum, int count) {
+        this.min = min;
+        this.max = max;
+        this.sum = sum;
+        this.count = count;
+        this.minAvailable = true;
+        this.maxAvailable = true;
+        this.sumAvailable = true;
+        this.countAvailable = true;
+    }
+
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        GenericNamedWriteable.class,
+        "AggregateMetricDoubleLiteral",
+        AggregateMetricDoubleLiteral::new
+    );
+
+    @Override
+    public String getWriteableName() {
+        return "AggregateMetricDoubleLiteral";
+    }
+
+    public AggregateMetricDoubleLiteral(StreamInput input) throws IOException {
+        if (input.readBoolean()) {
+            this.min = input.readDouble();
+            this.minAvailable = true;
+        } else {
+            this.min = 0.0;
+            this.minAvailable = false;
+        }
+        if (input.readBoolean()) {
+            this.max = input.readDouble();
+            this.maxAvailable = true;
+        } else {
+            this.max = 0.0;
+            this.maxAvailable = false;
+        }
+        if (input.readBoolean()) {
+            this.sum = input.readDouble();
+            this.sumAvailable = true;
+        } else {
+            this.sum = 0.0;
+            this.sumAvailable = false;
+        }
+        if (input.readBoolean()) {
+            this.count = input.readInt();
+            this.countAvailable = true;
+        } else {
+            this.count = 0;
+            this.countAvailable = false;
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        if (minAvailable) {
+            out.writeBoolean(true);
+            out.writeDouble(min);
+        } else {
+            out.writeBoolean(false);
+        }
+        if (maxAvailable) {
+            out.writeBoolean(true);
+            out.writeDouble(max);
+        } else {
+            out.writeBoolean(false);
+        }
+        if (sumAvailable) {
+            out.writeBoolean(true);
+            out.writeDouble(sum);
+        } else {
+            out.writeBoolean(false);
+        }
+        if (countAvailable) {
+            out.writeBoolean(true);
+            out.writeInt(count);
+        } else {
+            out.writeBoolean(false);
+        }
+    }
+
+    @Override
+    public boolean supportsVersion(TransportVersion version) {
+        return version.supports(ESQL_AGGREGATE_METRIC_DOUBLE_LITERAL);
+    }
+
+    @Override
+    public TransportVersion getMinimalSupportedVersion() {
+        assert false : "must not be called when overriding supportsVersion";
+        throw new UnsupportedOperationException("must not be called when overriding supportsVersion");
+    }
+
+    public double getMin() {
+        return min;
+    }
+
+    public double getMax() {
+        return max;
+    }
+
+    public double getSum() {
+        return sum;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public boolean isMinAvailable() {
+        return minAvailable;
+    }
+
+    public boolean isMaxAvailable() {
+        return maxAvailable;
+    }
+
+    public boolean isSumAvailable() {
+        return sumAvailable;
+    }
+
+    public boolean isCountAvailable() {
+        return countAvailable;
+    }
+
+    @Override
+    public String toString() {
+        return "AggregateMetricDoubleLiteral("
+            + (minAvailable ? "min: " + min + ", " : "")
+            + (maxAvailable ? "max: " + max + ", " : "")
+            + (sumAvailable ? "sum: " + sum + ", " : "")
+            + (countAvailable ? "count: " + count : "")
+            + ")";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof AggregateMetricDoubleLiteral == false) {
+            return false;
+        }
+        var that = (AggregateMetricDoubleLiteral) o;
+        return Double.compare(min, that.min) == 0
+            && Double.compare(max, that.max) == 0
+            && Double.compare(sum, that.sum) == 0
+            && count == that.count
+            && minAvailable == that.minAvailable
+            && maxAvailable == that.maxAvailable
+            && sumAvailable == that.sumAvailable
+            && countAvailable == that.countAvailable;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(min, max, sum, count, minAvailable, maxAvailable, sumAvailable, countAvailable);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
@@ -436,32 +436,11 @@ public class BlockFactory {
         return new AggregateMetricDoubleBlockBuilder(estimatedSize, this);
     }
 
-    public final AggregateMetricDoubleBlock newConstantAggregateMetricDoubleBlock(
-        AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral value,
-        int positions
-    ) {
+    public final AggregateMetricDoubleBlock newConstantAggregateMetricDoubleBlock(AggregateMetricDoubleLiteral value, int positions) {
         try (AggregateMetricDoubleBlockBuilder builder = newAggregateMetricDoubleBlockBuilder(positions)) {
+            // TODO: make ConstantAggregateMetricDoubleBlock
             for (int i = 0; i < positions; i++) {
-                if (value.min() != null) {
-                    builder.min().appendDouble(value.min());
-                } else {
-                    builder.min().appendNull();
-                }
-                if (value.max() != null) {
-                    builder.max().appendDouble(value.max());
-                } else {
-                    builder.max().appendNull();
-                }
-                if (value.sum() != null) {
-                    builder.sum().appendDouble(value.sum());
-                } else {
-                    builder.sum().appendNull();
-                }
-                if (value.count() != null) {
-                    builder.count().appendInt(value.count());
-                } else {
-                    builder.count().appendNull();
-                }
+                builder.appendLiteral(value);
             }
             return builder.build();
         }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockUtils.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockUtils.java
@@ -10,7 +10,6 @@ package org.elasticsearch.compute.data;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
-import org.elasticsearch.compute.data.AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 
@@ -297,15 +296,7 @@ public final class BlockUtils {
                 yield new Doc(v.shards().getInt(offset), v.segments().getInt(offset), v.docs().getInt(offset));
             }
             case COMPOSITE -> throw new IllegalArgumentException("can't read values from composite blocks");
-            case AGGREGATE_METRIC_DOUBLE -> {
-                AggregateMetricDoubleBlock aggBlock = (AggregateMetricDoubleBlock) block;
-                yield new AggregateMetricDoubleLiteral(
-                    aggBlock.minBlock().getDouble(offset),
-                    aggBlock.maxBlock().getDouble(offset),
-                    aggBlock.sumBlock().getDouble(offset),
-                    aggBlock.countBlock().getInt(offset)
-                );
-            }
+            case AGGREGATE_METRIC_DOUBLE -> ((AggregateMetricDoubleBlock) block).getAggregateMetricDoubleLiteral(offset);
             case UNKNOWN -> throw new IllegalArgumentException("can't read values from [" + block + "]");
         };
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ElementType.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ElementType.java
@@ -111,7 +111,7 @@ public enum ElementType {
             elementType = BYTES_REF;
         } else if (type == Boolean.class) {
             elementType = BOOLEAN;
-        } else if (type == AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral.class) {
+        } else if (type == AggregateMetricDoubleLiteral.class) {
             elementType = AGGREGATE_METRIC_DOUBLE;
         } else if (type == null || type == Void.class) {
             elementType = NULL;

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/AggregateMetricDoubleBlockEqualityTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/AggregateMetricDoubleBlockEqualityTests.java
@@ -41,10 +41,7 @@ public class AggregateMetricDoubleBlockEqualityTests extends ComputeTestCase {
             blockFactory.newAggregateMetricDoubleBlockBuilder(0).build(),
             blockFactory.newAggregateMetricDoubleBlockBuilder(0).appendNull().build().filter(),
             partialMetricBuilder.build().filter(),
-            blockFactory.newConstantAggregateMetricDoubleBlock(
-                new AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral(0.0, 0.0, 0.0, 0),
-                0
-            ).filter(),
+            blockFactory.newConstantAggregateMetricDoubleBlock(new AggregateMetricDoubleLiteral(0.0, 0.0, 0.0, 0), 0).filter(),
             (ConstantNullBlock) blockFactory.newConstantNullBlock(0)
         );
 
@@ -72,11 +69,17 @@ public class AggregateMetricDoubleBlockEqualityTests extends ComputeTestCase {
         appendValues(builder3, 582.1, 10942, 209301.4, 25);
         appendValues(builder3, 8952.564, 30921.23, 18592950.14, 1000);
         builder3.appendNull();
+        AggregateMetricDoubleBlockBuilder builder4 = blockFactory.newAggregateMetricDoubleBlockBuilder(4);
+        builder4.appendLiteral(new AggregateMetricDoubleLiteral(1.23, 68392.1, 99999.1, 5));
+        builder4.appendLiteral(new AggregateMetricDoubleLiteral(1, 1, 1, 1, false, false, true, true));
+        builder4.appendLiteral(new AggregateMetricDoubleLiteral(582.1, 10942, 209301.4, 25));
+        builder4.appendLiteral(new AggregateMetricDoubleLiteral(8952.564, 30921.23, 18592950.14, 1000, true, true, true, true));
 
         List<AggregateMetricDoubleBlock> blocks = List.of(
             builder1.build(),
             builder2.build().filter(0, 2, 5),
-            builder3.build().filter(2, 3, 4)
+            builder3.build().filter(2, 3, 4),
+            builder4.build().filter(0, 2, 3)
         );
         assertAllEquals(blocks);
     }
@@ -122,14 +125,8 @@ public class AggregateMetricDoubleBlockEqualityTests extends ComputeTestCase {
             builder2.build().filter(0, 2),
             AggregateMetricDoubleArrayBlock.fromCompositeBlock(compositeBlock1),
             AggregateMetricDoubleArrayBlock.fromCompositeBlock(compositeBlock2).filter(2, 3),
-            blockFactory.newConstantAggregateMetricDoubleBlock(
-                new AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral(12.3, 987.6, 4821.3, 6),
-                4
-            ).filter(1, 3),
-            blockFactory.newConstantAggregateMetricDoubleBlock(
-                new AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral(12.3, 987.6, 4821.3, 6),
-                2
-            )
+            blockFactory.newConstantAggregateMetricDoubleBlock(new AggregateMetricDoubleLiteral(12.3, 987.6, 4821.3, 6), 4).filter(1, 3),
+            blockFactory.newConstantAggregateMetricDoubleBlock(new AggregateMetricDoubleLiteral(12.3, 987.6, 4821.3, 6), 2)
         );
         assertAllEquals(moreBlocks);
     }
@@ -215,14 +212,8 @@ public class AggregateMetricDoubleBlockEqualityTests extends ComputeTestCase {
             builder5.build(),
             builder6.build(),
             builder7.build(),
-            blockFactory.newConstantAggregateMetricDoubleBlock(
-                new AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral(1.1, 6.1, 7.2, 2),
-                1
-            ),
-            blockFactory.newConstantAggregateMetricDoubleBlock(
-                new AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral(1.1, 6.1, 7.2, 2),
-                3
-            )
+            blockFactory.newConstantAggregateMetricDoubleBlock(new AggregateMetricDoubleLiteral(1.1, 6.1, 7.2, 2), 1),
+            blockFactory.newConstantAggregateMetricDoubleBlock(new AggregateMetricDoubleLiteral(1.1, 6.1, 7.2, 2), 3)
         );
         assertAllNotEquals(notEqualBlocks);
     }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicPageTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicPageTests.java
@@ -163,12 +163,7 @@ public class BasicPageTests extends SerializationTestCase {
                     positions
                 );
                 case 9 -> blockFactory.newConstantAggregateMetricDoubleBlock(
-                    new AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral(
-                        randomDouble(),
-                        randomDouble(),
-                        randomDouble(),
-                        randomInt()
-                    ),
+                    new AggregateMetricDoubleLiteral(randomDouble(), randomDouble(), randomDouble(), randomInt()),
                     positions
                 );
 
@@ -237,12 +232,7 @@ public class BasicPageTests extends SerializationTestCase {
             blockFactory.newConstantDoubleBlockWith(randomDouble(), 10),
             blockFactory.newConstantBytesRefBlockWith(new BytesRef(Integer.toHexString(randomInt())), 10),
             blockFactory.newConstantAggregateMetricDoubleBlock(
-                new AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral(
-                    randomDouble(),
-                    randomDouble(),
-                    randomDouble(),
-                    randomInt()
-                ),
+                new AggregateMetricDoubleLiteral(randomDouble(), randomDouble(), randomDouble(), randomInt()),
                 10
             ),
             toFilter.filter(5, 6, 7, 8, 9, 10, 11, 12, 13, 14).asBlock()
@@ -291,12 +281,7 @@ public class BasicPageTests extends SerializationTestCase {
                 blockFactory.newLongArrayVector(randomLongs(positions).toArray(), positions).asBlock(),
                 blockFactory.newConstantDoubleBlockWith(randomInt(), positions),
                 blockFactory.newConstantAggregateMetricDoubleBlock(
-                    new AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral(
-                        randomDouble(),
-                        randomDouble(),
-                        randomDouble(),
-                        randomInt()
-                    ),
+                    new AggregateMetricDoubleLiteral(randomDouble(), randomDouble(), randomDouble(), randomInt()),
                     positions
                 )
             ),

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockValueAsserter.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockValueAsserter.java
@@ -109,12 +109,11 @@ public class BlockValueAsserter {
         List<Object> expectedRowValues
     ) {
         for (int valueIndex = 0; valueIndex < valueCount; valueIndex++) {
-            AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral expectedValue =
-                (AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral) expectedRowValues.get(valueIndex);
-            assertThat(block.minBlock().getDouble(firstValueIndex + valueIndex), is(equalTo(expectedValue.min())));
-            assertThat(block.maxBlock().getDouble(firstValueIndex + valueIndex), is(equalTo(expectedValue.max())));
-            assertThat(block.sumBlock().getDouble(firstValueIndex + valueIndex), is(equalTo(expectedValue.sum())));
-            assertThat(block.countBlock().getInt(firstValueIndex + valueIndex), is(equalTo(expectedValue.count())));
+            AggregateMetricDoubleLiteral expectedValue = (AggregateMetricDoubleLiteral) expectedRowValues.get(valueIndex);
+            assertThat(block.minBlock().getDouble(firstValueIndex + valueIndex), is(equalTo(expectedValue.getMin())));
+            assertThat(block.maxBlock().getDouble(firstValueIndex + valueIndex), is(equalTo(expectedValue.getMax())));
+            assertThat(block.sumBlock().getDouble(firstValueIndex + valueIndex), is(equalTo(expectedValue.getSum())));
+            assertThat(block.countBlock().getInt(firstValueIndex + valueIndex), is(equalTo(expectedValue.getCount())));
         }
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/ExtractorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/ExtractorTests.java
@@ -13,7 +13,7 @@ import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
-import org.elasticsearch.compute.data.AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral;
+import org.elasticsearch.compute.data.AggregateMetricDoubleLiteral;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BlockUtils;
@@ -246,14 +246,15 @@ public class ExtractorTests extends ESTestCase {
     }
 
     public static AggregateMetricDoubleLiteral randomAggregateMetricDouble(boolean allMetrics) {
-        if (allMetrics) {
-            return new AggregateMetricDoubleLiteral(randomDouble(), randomDouble(), randomDouble(), randomInt());
-        }
         return new AggregateMetricDoubleLiteral(
-            randomBoolean() ? randomDouble() : null,
-            randomBoolean() ? randomDouble() : null,
-            randomBoolean() ? randomDouble() : null,
-            randomBoolean() ? randomInt() : null
+            randomDouble(),
+            randomDouble(),
+            randomDouble(),
+            randomInt(),
+            allMetrics || randomBoolean(),
+            allMetrics || randomBoolean(),
+            allMetrics || randomBoolean(),
+            allMetrics || randomBoolean()
         );
     }
 }

--- a/x-pack/plugin/esql/compute/test/src/main/java/org/elasticsearch/compute/test/RandomBlock.java
+++ b/x-pack/plugin/esql/compute/test/src/main/java/org/elasticsearch/compute/test/RandomBlock.java
@@ -9,6 +9,7 @@ package org.elasticsearch.compute.test;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.AggregateMetricDoubleBlockBuilder;
+import org.elasticsearch.compute.data.AggregateMetricDoubleLiteral;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BooleanBlock;
@@ -149,11 +150,9 @@ public record RandomBlock(List<List<Object>> values, Block block) {
                             double max = ESTestCase.randomDouble();
                             double sum = ESTestCase.randomDouble();
                             int count = ESTestCase.randomNonNegativeInt();
-                            b.min().appendDouble(min);
-                            b.max().appendDouble(max);
-                            b.sum().appendDouble(sum);
-                            b.count().appendInt(count);
-                            valuesAtPosition.add(new AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral(min, max, sum, count));
+                            AggregateMetricDoubleLiteral aggLiteral = new AggregateMetricDoubleLiteral(min, max, sum, count);
+                            b.appendLiteral(aggLiteral);
+                            valuesAtPosition.add(aggLiteral);
                         }
                         default -> throw new IllegalArgumentException("unsupported element type [" + elementType + "]");
                     }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvAssert.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvAssert.java
@@ -10,7 +10,7 @@ package org.elasticsearch.xpack.esql;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.time.DateFormatter;
-import org.elasticsearch.compute.data.AggregateMetricDoubleBlockBuilder;
+import org.elasticsearch.compute.data.AggregateMetricDoubleLiteral;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.geometry.utils.Geohash;
 import org.elasticsearch.h3.H3;
@@ -428,8 +428,8 @@ public final class CsvAssert {
             case UNSIGNED_LONG -> rebuildExpected(expectedValue, Long.class, x -> unsignedLongAsNumber((long) x));
             case AGGREGATE_METRIC_DOUBLE -> rebuildExpected(
                 expectedValue,
-                AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral.class,
-                x -> aggregateMetricDoubleLiteralToString((AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral) x)
+                AggregateMetricDoubleLiteral.class,
+                x -> aggregateMetricDoubleLiteralToString((AggregateMetricDoubleLiteral) x)
             );
             default -> expectedValue;
         };

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestUtils.java
@@ -15,13 +15,8 @@ import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.time.DateFormatters;
 import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.compute.data.AggregateMetricDoubleBlockBuilder;
-import org.elasticsearch.compute.data.Block;
-import org.elasticsearch.compute.data.BlockFactory;
-import org.elasticsearch.compute.data.BlockUtils;
+import org.elasticsearch.compute.data.*;
 import org.elasticsearch.compute.data.BlockUtils.BuilderWrapper;
-import org.elasticsearch.compute.data.ElementType;
-import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
@@ -493,10 +488,7 @@ public final class CsvTestUtils {
         GEOHASH(x -> x == null ? null : Geohash.longEncode(x), Long.class),
         GEOTILE(x -> x == null ? null : GeoTileUtils.longEncode(x), Long.class),
         GEOHEX(x -> x == null ? null : H3.stringToH3(x), Long.class),
-        AGGREGATE_METRIC_DOUBLE(
-            x -> x == null ? null : stringToAggregateMetricDoubleLiteral(x),
-            AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral.class
-        ),
+        AGGREGATE_METRIC_DOUBLE(x -> x == null ? null : stringToAggregateMetricDoubleLiteral(x), AggregateMetricDoubleLiteral.class),
         DENSE_VECTOR(Float::parseFloat, Float.class, false),
         UNSUPPORTED(Type::convertUnsupported, Void.class);
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
@@ -28,7 +28,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.xcontent.XContentHelper;
-import org.elasticsearch.compute.data.AggregateMetricDoubleBlockBuilder;
+import org.elasticsearch.compute.data.AggregateMetricDoubleLiteral;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BlockFactoryProvider;
 import org.elasticsearch.compute.data.BlockUtils;
@@ -891,12 +891,7 @@ public final class EsqlTestUtils {
                 randomIntBetween(0, GeoTileUtils.MAX_ZOOM)
             );
             case GEOHEX -> StGeohex.unboundedGrid.calculateGridId(GeometryTestUtils.randomPoint(), randomIntBetween(0, H3.MAX_H3_RES));
-            case AGGREGATE_METRIC_DOUBLE -> new AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral(
-                randomDouble(),
-                randomDouble(),
-                randomDouble(),
-                randomInt()
-            );
+            case AGGREGATE_METRIC_DOUBLE -> new AggregateMetricDoubleLiteral(randomDouble(), randomDouble(), randomDouble(), randomInt());
             case NULL -> null;
             case SOURCE -> {
                 try {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/ExpressionWritables.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/ExpressionWritables.java
@@ -8,7 +8,7 @@
 package org.elasticsearch.xpack.esql.expression;
 
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
-import org.elasticsearch.compute.data.AggregateMetricDoubleBlockBuilder;
+import org.elasticsearch.compute.data.AggregateMetricDoubleLiteral;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.xpack.esql.core.expression.ExpressionCoreWritables;
 import org.elasticsearch.xpack.esql.expression.function.UnsupportedAttribute;
@@ -274,11 +274,6 @@ public class ExpressionWritables {
     }
 
     public static List<SearchPlugin.GenericNamedWriteableSpec> literals() {
-        return List.of(
-            new SearchPlugin.GenericNamedWriteableSpec(
-                "AggregateMetricDoubleLiteral",
-                AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral::new
-            )
-        );
+        return List.of(new SearchPlugin.GenericNamedWriteableSpec("AggregateMetricDoubleLiteral", AggregateMetricDoubleLiteral::new));
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/SerializationTestUtils.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/SerializationTestUtils.java
@@ -14,7 +14,7 @@ import org.elasticsearch.common.io.stream.GenericNamedWriteable;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.compute.data.AggregateMetricDoubleBlockBuilder;
+import org.elasticsearch.compute.data.AggregateMetricDoubleLiteral;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.ExistsQueryBuilder;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
@@ -119,8 +119,8 @@ public class SerializationTestUtils {
         entries.add(
             new NamedWriteableRegistry.Entry(
                 GenericNamedWriteable.class,
-                AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral.ENTRY.name,
-                AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral::new
+                AggregateMetricDoubleLiteral.ENTRY.name,
+                AggregateMetricDoubleLiteral::new
             )
         );
         return new NamedWriteableRegistry(entries);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/MultiRowTestCaseSupplier.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/MultiRowTestCaseSupplier.java
@@ -11,7 +11,7 @@ import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.network.InetAddresses;
-import org.elasticsearch.compute.data.AggregateMetricDoubleBlockBuilder;
+import org.elasticsearch.compute.data.AggregateMetricDoubleLiteral;
 import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.geo.ShapeTestUtils;
 import org.elasticsearch.geometry.Geometry;
@@ -561,12 +561,7 @@ public final class MultiRowTestCaseSupplier {
                 maxRows,
                 "0 aggregate metric double with positive count",
                 DataType.AGGREGATE_METRIC_DOUBLE,
-                () -> new AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral(
-                    0.0,
-                    0.0,
-                    0.0,
-                    ESTestCase.randomIntBetween(1, Integer.MAX_VALUE)
-                )
+                () -> new AggregateMetricDoubleLiteral(0.0, 0.0, 0.0, randomIntBetween(1, Integer.MAX_VALUE))
             );
             addSuppliers(
                 cases,
@@ -574,7 +569,7 @@ public final class MultiRowTestCaseSupplier {
                 maxRows,
                 "0 aggregate metric double with count 0",
                 DataType.AGGREGATE_METRIC_DOUBLE,
-                () -> new AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral(0.0, 0.0, 0.0, 0)
+                () -> new AggregateMetricDoubleLiteral(0.0, 0.0, 0.0, 0)
             );
         }
 
@@ -585,7 +580,7 @@ public final class MultiRowTestCaseSupplier {
             double generatedMax = Math.max(v1, v2);
             int count = randomIntBetween(1, Integer.MAX_VALUE);
             double sum = generateAggregateMetricDoubleSum(generatedMin, generatedMax);
-            return new AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral(generatedMin, generatedMax, sum, count);
+            return new AggregateMetricDoubleLiteral(generatedMin, generatedMax, sum, count);
         });
 
         if (min < 0) {
@@ -596,7 +591,7 @@ public final class MultiRowTestCaseSupplier {
                 double generatedMax = Math.max(v1, v2);
                 int count = randomIntBetween(1, Integer.MAX_VALUE);
                 double sum = generateAggregateMetricDoubleSum(generatedMin, generatedMax);
-                return new AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral(generatedMin, generatedMax, sum, count);
+                return new AggregateMetricDoubleLiteral(generatedMin, generatedMax, sum, count);
             });
         }
         if (max > 0) {
@@ -607,7 +602,7 @@ public final class MultiRowTestCaseSupplier {
                 double generatedMax = Math.max(v1, v2);
                 int count = randomIntBetween(1, Integer.MAX_VALUE);
                 double sum = generateAggregateMetricDoubleSum(generatedMin, generatedMax);
-                return new AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral(generatedMin, generatedMax, sum, count);
+                return new AggregateMetricDoubleLiteral(generatedMin, generatedMax, sum, count);
             });
         }
         if (min < 0 && max > 0) {
@@ -616,7 +611,7 @@ public final class MultiRowTestCaseSupplier {
                 var generatedMax = randomDoubleBetween(0, max, false);
                 int count = randomIntBetween(1, Integer.MAX_VALUE);
                 double sum = generateAggregateMetricDoubleSum(generatedMin, generatedMax);
-                return new AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral(generatedMin, generatedMax, sum, count);
+                return new AggregateMetricDoubleLiteral(generatedMin, generatedMax, sum, count);
             });
         }
         return cases;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/TestCaseSupplier.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/TestCaseSupplier.java
@@ -13,7 +13,7 @@ import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.time.DateUtils;
-import org.elasticsearch.compute.data.AggregateMetricDoubleBlockBuilder;
+import org.elasticsearch.compute.data.AggregateMetricDoubleLiteral;
 import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.geo.ShapeTestUtils;
 import org.elasticsearch.geometry.Point;
@@ -54,7 +54,7 @@ import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
-import static org.elasticsearch.test.ESTestCase.randomDouble;
+import static org.elasticsearch.test.ESTestCase.randomDoubleBetween;
 import static org.elasticsearch.test.ESTestCase.randomFloatBetween;
 import static org.elasticsearch.test.ESTestCase.randomIntBetween;
 import static org.elasticsearch.test.ESTestCase.randomNonNegativeInt;
@@ -855,7 +855,7 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
         List<TestCaseSupplier> suppliers,
         String expectedEvaluatorToString,
         DataType expectedType,
-        Function<AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral, Object> expectedValue,
+        Function<AggregateMetricDoubleLiteral, Object> expectedValue,
         List<String> warnings
     ) {
         unary(
@@ -863,7 +863,7 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
             expectedEvaluatorToString,
             aggregateMetricDoubleCases(),
             expectedType,
-            v -> expectedValue.apply((AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral) v),
+            v -> expectedValue.apply((AggregateMetricDoubleLiteral) v),
             warnings
         );
     }
@@ -1495,10 +1495,10 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
         return List.of(
             new TypedDataSupplier(
                 "<random aggregate metric double>",
-                () -> new AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral(
-                    randomDouble(),
-                    randomDouble(),
-                    randomDouble(),
+                () -> new AggregateMetricDoubleLiteral(
+                    randomDoubleBetween(-Double.MAX_VALUE, Double.MAX_VALUE, true),
+                    randomDoubleBetween(-Double.MAX_VALUE, Double.MAX_VALUE, true),
+                    randomDoubleBetween(-Double.MAX_VALUE, Double.MAX_VALUE, true),
                     randomNonNegativeInt()
                 ),
                 DataType.AGGREGATE_METRIC_DOUBLE

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountTests.java
@@ -10,7 +10,7 @@ package org.elasticsearch.xpack.esql.expression.function.aggregate;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
-import org.elasticsearch.compute.data.AggregateMetricDoubleBlockBuilder;
+import org.elasticsearch.compute.data.AggregateMetricDoubleLiteral;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -106,13 +106,7 @@ public class CountTests extends AbstractAggregationTestCase {
             var fieldTypedData = fieldSupplier.get();
             long count;
             if (fieldSupplier.type() == DataType.AGGREGATE_METRIC_DOUBLE) {
-                count = fieldTypedData.multiRowData().stream().mapToLong(data -> {
-                    var aggMetric = (AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral) data;
-                    if (aggMetric.count() != null) {
-                        return aggMetric.count();
-                    }
-                    return 0;
-                }).sum();
+                count = fieldTypedData.multiRowData().stream().mapToLong(data -> ((AggregateMetricDoubleLiteral) data).getCount()).sum();
             } else {
                 count = fieldTypedData.multiRowData().stream().filter(Objects::nonNull).count();
             }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/MaxTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/MaxTests.java
@@ -13,7 +13,7 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.network.InetAddresses;
-import org.elasticsearch.compute.data.AggregateMetricDoubleBlockBuilder;
+import org.elasticsearch.compute.data.AggregateMetricDoubleLiteral;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -183,17 +183,12 @@ public class MaxTests extends AbstractAggregationTestCase {
                     );
                 }),
                 new TestCaseSupplier(List.of(DataType.AGGREGATE_METRIC_DOUBLE), () -> {
-                    var value = new AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral(
-                        randomDouble(),
-                        randomDouble(),
-                        randomDouble(),
-                        randomNonNegativeInt()
-                    );
+                    var value = new AggregateMetricDoubleLiteral(randomDouble(), randomDouble(), randomDouble(), randomNonNegativeInt());
                     return new TestCaseSupplier.TestCase(
                         List.of(TestCaseSupplier.TypedData.multiRow(List.of(value), DataType.AGGREGATE_METRIC_DOUBLE, "field")),
                         standardAggregatorName("Max", DataType.AGGREGATE_METRIC_DOUBLE),
                         DataType.DOUBLE,
-                        equalTo(value.max())
+                        equalTo(value.getMax())
                     );
 
                 })
@@ -217,10 +212,7 @@ public class MaxTests extends AbstractAggregationTestCase {
             if (fieldSupplier.type() == DataType.AGGREGATE_METRIC_DOUBLE) {
                 expected = fieldTypedData.multiRowData()
                     .stream()
-                    .map(
-                        v -> (Comparable<
-                            ? super Comparable<?>>) ((Object) ((AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral) v).max())
-                    )
+                    .map(v -> (Comparable<? super Comparable<?>>) ((Object) ((AggregateMetricDoubleLiteral) v).getMax()))
                     .max(Comparator.naturalOrder())
                     .orElse(null);
             } else {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/MinTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/MinTests.java
@@ -13,7 +13,7 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.network.InetAddresses;
-import org.elasticsearch.compute.data.AggregateMetricDoubleBlockBuilder;
+import org.elasticsearch.compute.data.AggregateMetricDoubleLiteral;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -183,17 +183,12 @@ public class MinTests extends AbstractAggregationTestCase {
                     );
                 }),
                 new TestCaseSupplier(List.of(DataType.AGGREGATE_METRIC_DOUBLE), () -> {
-                    var value = new AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral(
-                        randomDouble(),
-                        randomDouble(),
-                        randomDouble(),
-                        randomNonNegativeInt()
-                    );
+                    var value = new AggregateMetricDoubleLiteral(randomDouble(), randomDouble(), randomDouble(), randomNonNegativeInt());
                     return new TestCaseSupplier.TestCase(
                         List.of(TestCaseSupplier.TypedData.multiRow(List.of(value), DataType.AGGREGATE_METRIC_DOUBLE, "field")),
                         standardAggregatorName("Min", DataType.AGGREGATE_METRIC_DOUBLE),
                         DataType.DOUBLE,
-                        equalTo(value.min())
+                        equalTo(value.getMin())
                     );
 
                 })
@@ -217,10 +212,7 @@ public class MinTests extends AbstractAggregationTestCase {
             if (fieldSupplier.type() == DataType.AGGREGATE_METRIC_DOUBLE) {
                 expected = fieldTypedData.multiRowData()
                     .stream()
-                    .map(
-                        v -> (Comparable<
-                            ? super Comparable<?>>) ((Object) ((AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral) v).min())
-                    )
+                    .map(v -> (Comparable<? super Comparable<?>>) ((Object) ((AggregateMetricDoubleLiteral) v).getMin()))
                     .min(Comparator.naturalOrder())
                     .orElse(null);
             } else {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SumTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SumTests.java
@@ -10,7 +10,7 @@ package org.elasticsearch.xpack.esql.expression.function.aggregate;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
-import org.elasticsearch.compute.data.AggregateMetricDoubleBlockBuilder;
+import org.elasticsearch.compute.data.AggregateMetricDoubleLiteral;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -78,17 +78,12 @@ public class SumTests extends AbstractAggregationTestCase {
                     )
                 ),
                 new TestCaseSupplier(List.of(DataType.AGGREGATE_METRIC_DOUBLE), () -> {
-                    var value = new AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral(
-                        randomDouble(),
-                        randomDouble(),
-                        randomDouble(),
-                        randomNonNegativeInt()
-                    );
+                    var value = new AggregateMetricDoubleLiteral(randomDouble(), randomDouble(), randomDouble(), randomNonNegativeInt());
                     return new TestCaseSupplier.TestCase(
                         List.of(TestCaseSupplier.TypedData.multiRow(List.of(value), DataType.AGGREGATE_METRIC_DOUBLE, "field")),
                         standardAggregatorName("Sum", DataType.AGGREGATE_METRIC_DOUBLE),
                         DataType.DOUBLE,
-                        equalTo(value.sum())
+                        equalTo(value.getSum())
                     );
 
                 })

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FromAggregateMetricDoubleTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/FromAggregateMetricDoubleTests.java
@@ -11,6 +11,7 @@ import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.elasticsearch.compute.data.AggregateMetricDoubleBlockBuilder;
+import org.elasticsearch.compute.data.AggregateMetricDoubleLiteral;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -42,16 +43,16 @@ public class FromAggregateMetricDoubleTests extends AbstractScalarFunctionTestCa
         for (int i = 0; i < 4; i++) {
             int index = i;
             suppliers.add(new TestCaseSupplier(List.of(dataType, DataType.INTEGER), () -> {
-                var agg_metric = new AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral(
-                    randomDoubleBetween(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, true),
-                    randomDoubleBetween(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, true),
-                    randomDoubleBetween(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, true),
+                var agg_metric = new AggregateMetricDoubleLiteral(
+                    randomDoubleBetween(-Double.MAX_VALUE, Double.MAX_VALUE, true),
+                    randomDoubleBetween(-Double.MAX_VALUE, Double.MAX_VALUE, true),
+                    randomDoubleBetween(-Double.MAX_VALUE, Double.MAX_VALUE, true),
                     randomIntBetween(Integer.MIN_VALUE, Integer.MAX_VALUE)
                 );
-                Double expectedValue = index == AggregateMetricDoubleBlockBuilder.Metric.MIN.getIndex() ? agg_metric.min()
-                    : index == AggregateMetricDoubleBlockBuilder.Metric.MAX.getIndex() ? agg_metric.max()
-                    : index == AggregateMetricDoubleBlockBuilder.Metric.SUM.getIndex() ? agg_metric.sum()
-                    : (Double) agg_metric.count().doubleValue();
+                double expectedValue = index == AggregateMetricDoubleBlockBuilder.Metric.MIN.getIndex() ? agg_metric.getMin()
+                    : index == AggregateMetricDoubleBlockBuilder.Metric.MAX.getIndex() ? agg_metric.getMax()
+                    : index == AggregateMetricDoubleBlockBuilder.Metric.SUM.getIndex() ? agg_metric.getSum()
+                    : agg_metric.getCount();
 
                 return new TestCaseSupplier.TestCase(
                     List.of(
@@ -60,8 +61,8 @@ public class FromAggregateMetricDoubleTests extends AbstractScalarFunctionTestCa
                     ),
                     "FromAggregateMetricDoubleEvaluator[field=Attribute[channel=0],subfieldIndex=" + index + "]",
                     index == AggregateMetricDoubleBlockBuilder.Metric.COUNT.getIndex() ? DataType.INTEGER : DataType.DOUBLE,
-                    index == AggregateMetricDoubleBlockBuilder.Metric.COUNT.getIndex() ? Matchers.equalTo(agg_metric.count())
-                        : expectedValue == null ? Matchers.nullValue()
+                    index == AggregateMetricDoubleBlockBuilder.Metric.COUNT.getIndex()
+                        ? Matchers.equalTo(agg_metric.getCount())
                         : Matchers.closeTo(expectedValue, Math.abs(expectedValue * 0.00001))
                 );
             }));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToAggregateMetricDoubleTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToAggregateMetricDoubleTests.java
@@ -10,7 +10,7 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
-import org.elasticsearch.compute.data.AggregateMetricDoubleBlockBuilder;
+import org.elasticsearch.compute.data.AggregateMetricDoubleLiteral;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -49,7 +49,7 @@ public class ToAggregateMetricDoubleTests extends AbstractScalarFunctionTestCase
             suppliers,
             evaluatorStringLeft + "Int" + evaluatorStringRight,
             DataType.AGGREGATE_METRIC_DOUBLE,
-            i -> new AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral((double) i, (double) i, (double) i, 1),
+            i -> new AggregateMetricDoubleLiteral((double) i, (double) i, (double) i, 1),
             Integer.MIN_VALUE,
             Integer.MAX_VALUE,
             emptyList()
@@ -58,7 +58,7 @@ public class ToAggregateMetricDoubleTests extends AbstractScalarFunctionTestCase
             suppliers,
             evaluatorStringLeft + "Long" + evaluatorStringRight,
             DataType.AGGREGATE_METRIC_DOUBLE,
-            l -> new AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral((double) l, (double) l, (double) l, 1),
+            l -> new AggregateMetricDoubleLiteral((double) l, (double) l, (double) l, 1),
             Long.MIN_VALUE,
             Long.MAX_VALUE,
             emptyList()
@@ -69,7 +69,7 @@ public class ToAggregateMetricDoubleTests extends AbstractScalarFunctionTestCase
             DataType.AGGREGATE_METRIC_DOUBLE,
             ul -> {
                 var newVal = ul.doubleValue();
-                return new AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral(newVal, newVal, newVal, 1);
+                return new AggregateMetricDoubleLiteral(newVal, newVal, newVal, 1);
             },
             BigInteger.ZERO,
             UNSIGNED_LONG_MAX,
@@ -79,9 +79,9 @@ public class ToAggregateMetricDoubleTests extends AbstractScalarFunctionTestCase
             suppliers,
             evaluatorStringLeft + "Double" + evaluatorStringRight,
             DataType.AGGREGATE_METRIC_DOUBLE,
-            d -> new AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral(d, d, d, 1),
-            Double.NEGATIVE_INFINITY,
-            Double.POSITIVE_INFINITY,
+            d -> new AggregateMetricDoubleLiteral(d, d, d, 1),
+            -Double.MAX_VALUE,
+            Double.MAX_VALUE,
             emptyList()
         );
         TestCaseSupplier.forUnaryAggregateMetricDouble(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/AbstractPhysicalPlanSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/physical/AbstractPhysicalPlanSerializationTests.java
@@ -9,7 +9,7 @@ package org.elasticsearch.xpack.esql.plan.physical;
 
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.compute.data.AggregateMetricDoubleBlockBuilder;
+import org.elasticsearch.compute.data.AggregateMetricDoubleLiteral;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.xpack.esql.core.tree.Node;
 import org.elasticsearch.xpack.esql.expression.ExpressionWritables;
@@ -54,7 +54,7 @@ public abstract class AbstractPhysicalPlanSerializationTests<T extends PhysicalP
         entries.addAll(ExpressionWritables.binaryComparisons());
         entries.addAll(new SearchModule(Settings.EMPTY, List.of()).getNamedWriteables()); // Query builders
         entries.add(Add.ENTRY); // Used by the eval tests
-        entries.add(AggregateMetricDoubleBlockBuilder.AggregateMetricDoubleLiteral.ENTRY);
+        entries.add(AggregateMetricDoubleLiteral.ENTRY);
         entries.add(LookupJoinExec.ENTRY);
         return new NamedWriteableRegistry(entries);
     }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/46_downsample.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/46_downsample.yml
@@ -270,7 +270,7 @@ setup:
         - method: POST
           path: /_query
           parameters: []
-          capabilities: [aggregate_metric_double_v0]
+          capabilities: [aggregate_metric_double_v0, ts_command_v0]
       reason: "Support for casting aggregate metric double implicitly when present in aggregations"
 
   - do:
@@ -380,6 +380,34 @@ setup:
   - match: {columns.0.name: "max"}
   - match: {columns.0.type: "double"}
   - match: {values.0.0: 803685.0}
+
+  - do:
+      esql.query:
+        body:
+          query: |
+            TS test-*
+            | EVAL a = TO_AGGREGATE_METRIC_DOUBLE(1)  // Temporary workaround to enable aggregate_metric_double
+            | WHERE k8s.pod.uid == "947e4ced-1786-4e53-9e0c-5c447e959507"
+            | STATS max(k8s.pod.network.rx), min(k8s.pod.network.rx), sum(k8s.pod.network.rx), count(k8s.pod.network.rx), avg(k8s.pod.network.rx)
+            | LIMIT 100
+
+  - length: {values: 1}
+  - length: {values.0: 5}
+  - match: {columns.0.name: "max(k8s.pod.network.rx)"}
+  - match: {columns.0.type: "double"}
+  - match: {columns.1.name: "min(k8s.pod.network.rx)"}
+  - match: {columns.1.type: "double"}
+  - match: {columns.2.name: "sum(k8s.pod.network.rx)"}
+  - match: {columns.2.type: "double"}
+  - match: {columns.3.name: "count(k8s.pod.network.rx)"}
+  - match: {columns.3.type: "long"}
+  - match: {columns.4.name: "avg(k8s.pod.network.rx)"}
+  - match: {columns.4.type: "double"}
+  - match: {values.0.0: 800479.0}
+  - match: {values.0.1: 800479.0}
+  - match: {values.0.2: 800479.0}
+  - match: {values.0.3: 1}
+  - match: {values.0.4: 800479.0}
 
 ---
 "Over time functions from downsampled and non-downsampled indices simultaneously, no grouping":


### PR DESCRIPTION
This commit adjusts AggregateMetricDoubleLiteral to use the primitive versions of doubles and ints, allowing it to be used more freely in ES|QL code. This will also allow for handling AggregateMetricDoubles on a per-value basis (as opposed to being forced to handle each metric individually)