### PR TITLE
[9.2] Fix misleading error message in tests BreakerTestUtil (#136069)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/BreakerTestUtil.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/BreakerTestUtil.java
@@ -53,7 +53,7 @@ public class BreakerTestUtil {
         try {
             c.accept(onePastLimit);
         } catch (CircuitBreakingException e) {
-            throw new IllegalArgumentException("expected runnable to break under a limit of " + onePastLimit + " bytes");
+            throw new IllegalArgumentException("expected runnable to *not* break under a limit of " + onePastLimit + " bytes");
         }
         return limit;
     }


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Fix misleading error message in tests BreakerTestUtil (#136069)