### PR TITLE
[8.19] [ML] Make the Cohere service Model Id field is required (#136017)

### DIFF
--- a/docs/changelog/136017.yaml
+++ b/docs/changelog/136017.yaml
@@ -1,0 +1,5 @@
+pr: 136017
+summary: Cohere service Model Id field is required
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/CohereService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/CohereService.java
@@ -367,7 +367,7 @@ public class CohereService extends SenderService {
                         "The name of the model to use for the inference task."
                     )
                         .setLabel("Model ID")
-                        .setRequired(false)
+                        .setRequired(true)
                         .setSensitive(false)
                         .setUpdatable(false)
                         .setType(SettingsConfigurationFieldType.STRING)

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/CohereServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/CohereServiceTests.java
@@ -1555,7 +1555,7 @@ public class CohereServiceTests extends ESTestCase {
                             "model_id": {
                                 "description": "The name of the model to use for the inference task.",
                                 "label": "Model ID",
-                                "required": false,
+                                "required": true,
                                 "sensitive": false,
                                 "updatable": false,
                                 "type": "str",


### PR DESCRIPTION
Backports the following commits to 8.19:
 - [ML] Make the Cohere service Model Id field is required (#136017)