### PR TITLE
Fixing ChunkingSettingsBuilder test for generating rerank chunking settings (#135965)

### DIFF
--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/chunking/ChunkingSettingsBuilderTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/chunking/ChunkingSettingsBuilderTests.java
@@ -54,7 +54,7 @@ public class ChunkingSettingsBuilderTests extends ESTestCase {
     public void testBuildChunkingSettingsForElasticReranker_QueryTokenCountLessThanHalfOfTokenLimit() {
         // Generate a word count for a non-empty query that takes up less than half the token limit
         int maxQueryTokenCount = (ELASTIC_RERANKER_TOKEN_LIMIT - ELASTIC_RERANKER_EXTRA_TOKEN_COUNT) / 2;
-        int queryWordCount = randomIntBetween(1, (int) (maxQueryTokenCount * WORDS_PER_TOKEN));
+        int queryWordCount = randomIntBetween(1, (int) (maxQueryTokenCount * WORDS_PER_TOKEN) - 1);
         var queryTokenCount = Math.ceil(queryWordCount / WORDS_PER_TOKEN);
         ChunkingSettings chunkingSettings = ChunkingSettingsBuilder.buildChunkingSettingsForElasticRerank(queryWordCount);
         assertTrue(chunkingSettings instanceof SentenceBoundaryChunkingSettings);


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch/pull/135965

Test has not been muted in this branch so this change removes the unmute changes.