### PR TITLE
[9.2] Fix lucene compat tests by keeping asserts disabled (#136094)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -633,45 +633,12 @@ tests:
 - class: org.elasticsearch.xpack.logsdb.qa.BulkDynamicMappingChallengeRestIT
   method: testMatchAllQuery
   issue: https://github.com/elastic/elasticsearch/issues/135820
-- class: org.elasticsearch.upgrades.FullClusterRestartDownsampleIT
-  method: testRollupIndex {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/135906
-- class: org.elasticsearch.upgrades.FullClusterRestartIT
-  method: testSingleDoc {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/135908
-- class: org.elasticsearch.upgrades.FullClusterRestartIT
-  method: testRollover {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/135952
 - class: org.elasticsearch.datastreams.DataStreamIndexSettingsProviderTests
   method: testGetAdditionalIndexSettingsMappingsMerging
   issue: https://github.com/elastic/elasticsearch/issues/135884
 - class: org.elasticsearch.xpack.esql.action.CrossClusterAsyncQueryStopIT
   method: testStopQueryInlineStats
   issue: https://github.com/elastic/elasticsearch/issues/135032
-- class: org.elasticsearch.upgrades.FullClusterRestartIT
-  method: testResize {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/135909
-- class: org.elasticsearch.upgrades.FullClusterRestartIT
-  method: testSearchTimeSeriesMode {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/135963
-- class: org.elasticsearch.upgrades.FullClusterRestartIT
-  method: testClusterState {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/135960
-- class: org.elasticsearch.upgrades.FullClusterRestartIT
-  method: testForbidDisableSoftDeletesOnRestore {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/135937
-- class: org.elasticsearch.upgrades.FullClusterRestartIT
-  method: testRomanianAnalyzerBWC {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/135948
-- class: org.elasticsearch.upgrades.FullClusterRestartIT
-  method: testRecovery {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/135953
-- class: org.elasticsearch.upgrades.FullClusterRestartIT
-  method: testHistoryUUIDIsAdded {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/135957
-- class: org.elasticsearch.upgrades.FullClusterRestartIT
-  method: testSnapshotRestore {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/135933
 
 # Examples:
 #

--- a/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/FullClusterRestartDownsampleIT.java
+++ b/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/FullClusterRestartDownsampleIT.java
@@ -57,7 +57,7 @@ public class FullClusterRestartDownsampleIT extends ParameterizedFullClusterRest
             .apply(() -> clusterConfig)
             .feature(FeatureFlag.TIME_SERIES_MODE);
 
-        if (oldVersion.before(Version.fromString("8.18.0"))) {
+        if (oldVersion.before(Version.fromString("8.18.0")) || isOldClusterDetachedVersion()) {
             cluster.jvmArg("-da:org.elasticsearch.index.mapper.DocumentMapper");
             cluster.jvmArg("-da:org.elasticsearch.index.mapper.MapperService");
         }

--- a/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -118,7 +118,7 @@ public class FullClusterRestartIT extends ParameterizedFullClusterRestartTestCas
             .apply(() -> clusterConfig)
             .feature(FeatureFlag.TIME_SERIES_MODE);
 
-        if (oldVersion.before(Version.fromString("8.18.0"))) {
+        if (oldVersion.before(Version.fromString("8.18.0")) || isOldClusterDetachedVersion()) {
             cluster.jvmArg("-da:org.elasticsearch.index.mapper.DocumentMapper");
             cluster.jvmArg("-da:org.elasticsearch.index.mapper.MapperService");
         }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Fix lucene compat tests by keeping asserts disabled (#136094)](https://github.com/elastic/elasticsearch/pull/136094)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)