### PR TITLE
[9.1] Fix lucene compat tests by keeping asserts disabled (#136094)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -449,33 +449,6 @@ tests:
 - class: org.elasticsearch.aggregations.bucket.AggregationReductionCircuitBreakingIT
   method: testCBTrippingOnReduction
   issue: https://github.com/elastic/elasticsearch/issues/134902
-- class: org.elasticsearch.upgrades.FullClusterRestartIT
-  method: testEmptyShard {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/135951
-- class: org.elasticsearch.upgrades.FullClusterRestartIT
-  method: testSearch {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/135927
-- class: org.elasticsearch.upgrades.FullClusterRestartIT
-  method: testPersianAnalyzerBWC {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/135930
-- class: org.elasticsearch.upgrades.FullClusterRestartDownsampleIT
-  method: testRollupIndex {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/135906
-- class: org.elasticsearch.upgrades.FullClusterRestartIT
-  method: testSystemIndexMetadataIsUpgraded {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/135923
-- class: org.elasticsearch.upgrades.FullClusterRestartIT
-  method: testNewReplicas {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/135956
-- class: org.elasticsearch.upgrades.FullClusterRestartIT
-  method: testPeerRecoveryRetentionLeases {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/135929
-- class: org.elasticsearch.upgrades.FullClusterRestartIT
-  method: testTurnOffTranslogRetentionAfterUpgraded {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/135958
-- class: org.elasticsearch.upgrades.FullClusterRestartIT
-  method: testOperationBasedRecovery {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/135944
 
 # Examples:
 #

--- a/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/FullClusterRestartDownsampleIT.java
+++ b/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/FullClusterRestartDownsampleIT.java
@@ -57,7 +57,7 @@ public class FullClusterRestartDownsampleIT extends ParameterizedFullClusterRest
             .apply(() -> clusterConfig)
             .feature(FeatureFlag.TIME_SERIES_MODE);
 
-        if (oldVersion.before(Version.fromString("8.18.0"))) {
+        if (oldVersion.before(Version.fromString("8.18.0")) || isOldClusterDetachedVersion()) {
             cluster.jvmArg("-da:org.elasticsearch.index.mapper.DocumentMapper");
             cluster.jvmArg("-da:org.elasticsearch.index.mapper.MapperService");
         }

--- a/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -118,7 +118,7 @@ public class FullClusterRestartIT extends ParameterizedFullClusterRestartTestCas
             .apply(() -> clusterConfig)
             .feature(FeatureFlag.TIME_SERIES_MODE);
 
-        if (oldVersion.before(Version.fromString("8.18.0"))) {
+        if (oldVersion.before(Version.fromString("8.18.0")) || isOldClusterDetachedVersion()) {
             cluster.jvmArg("-da:org.elasticsearch.index.mapper.DocumentMapper");
             cluster.jvmArg("-da:org.elasticsearch.index.mapper.MapperService");
         }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Fix lucene compat tests by keeping asserts disabled (#136094)](https://github.com/elastic/elasticsearch/pull/136094)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)