### PR TITLE
[9.0] Fix lucene compat tests by keeping asserts disabled (#136094)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -259,9 +259,6 @@ tests:
 - class: org.elasticsearch.gradle.LoggedExecFuncTest
   method: failed tasks output logged to console when spooling true
   issue: https://github.com/elastic/elasticsearch/issues/119509
-- class: org.elasticsearch.upgrades.FullClusterRestartDownsampleIT
-  method: testRollupIndex {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/135906
 
 # Examples:
 #

--- a/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/FullClusterRestartDownsampleIT.java
+++ b/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/FullClusterRestartDownsampleIT.java
@@ -58,7 +58,7 @@ public class FullClusterRestartDownsampleIT extends ParameterizedFullClusterRest
             .feature(FeatureFlag.TIME_SERIES_MODE)
             .feature(FeatureFlag.FAILURE_STORE_ENABLED);
 
-        if (oldVersion.before(Version.fromString("8.18.0"))) {
+        if (oldVersion.before(Version.fromString("8.18.0")) || isOldClusterDetachedVersion()) {
             cluster.jvmArg("-da:org.elasticsearch.index.mapper.DocumentMapper");
             cluster.jvmArg("-da:org.elasticsearch.index.mapper.MapperService");
         }

--- a/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -119,7 +119,7 @@ public class FullClusterRestartIT extends ParameterizedFullClusterRestartTestCas
             .feature(FeatureFlag.TIME_SERIES_MODE)
             .feature(FeatureFlag.FAILURE_STORE_ENABLED);
 
-        if (oldVersion.before(Version.fromString("8.18.0"))) {
+        if (oldVersion.before(Version.fromString("8.18.0")) || isOldClusterDetachedVersion()) {
             cluster.jvmArg("-da:org.elasticsearch.index.mapper.DocumentMapper");
             cluster.jvmArg("-da:org.elasticsearch.index.mapper.MapperService");
         }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Fix lucene compat tests by keeping asserts disabled (#136094)](https://github.com/elastic/elasticsearch/pull/136094)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)