### PR TITLE
[8.19] Split null/empty chunking_settings YAML tests (#136023)

### DIFF
--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/25_semantic_text_field_mapping_chunking.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/25_semantic_text_field_mapping_chunking.yml
@@ -188,7 +188,7 @@ setup:
   - match: { "none-chunking-dense.mappings.properties.inference_field.chunking_settings.strategy": "none" }
 
 ---
-"We do not set custom chunking settings for null or empty specified chunking settings":
+"We do not set custom chunking settings for null chunking settings":
 
   - do:
       indices.create:
@@ -207,6 +207,8 @@ setup:
 
   - not_exists: null-chunking.mappings.properties.inference_field.chunking_settings
 
+---
+"We do not set custom chunking settings for empty specified chunking settings":
 
   - do:
       indices.create:

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/25_semantic_text_field_mapping_chunking_bwc.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/25_semantic_text_field_mapping_chunking_bwc.yml
@@ -198,7 +198,7 @@ setup:
   - match: { "none-chunking-dense.mappings.properties.inference_field.chunking_settings.strategy": "none" }
 
 ---
-"We do not set custom chunking settings for null or empty specified chunking settings":
+"We do not set custom chunking settings for null chunking settings":
 
   - do:
       indices.create:
@@ -219,6 +219,8 @@ setup:
 
   - not_exists: null-chunking.mappings.properties.inference_field.chunking_settings
 
+---
+"We do not set custom chunking settings for empty specified chunking settings":
 
   - do:
       indices.create:


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Split null/empty chunking_settings YAML tests (#136023)