### PR TITLE
[9.2] [ML] Ensure queued AbstractRunnables are notified when executor stops (#135966)

### DIFF
--- a/docs/changelog/135966.yaml
+++ b/docs/changelog/135966.yaml
@@ -1,0 +1,6 @@
+pr: 135966
+summary: Ensure queued `AbstractRunnables` are notified when executor stops
+area: Machine Learning
+type: bug
+issues:
+ - 134651

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/AbstractProcessWorkerExecutorService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/AbstractProcessWorkerExecutorService.java
@@ -125,11 +125,12 @@ public abstract class AbstractProcessWorkerExecutorService<T extends Runnable> e
                     running.set(false);
                 }
             }
-
-            notifyQueueRunnables();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         } finally {
+            // If we're throwing an exception, shutdown() may not have been called, so call it here
+            shutdown();
+            notifyQueueRunnables();
             Runnable onComplete = onCompletion.get();
             if (onComplete != null) {
                 onComplete.run();
@@ -155,17 +156,18 @@ public abstract class AbstractProcessWorkerExecutorService<T extends Runnable> e
                 format("[%s] notifying [%d] queued requests that have not been processed before shutdown", processName, queue.size())
             );
 
-            List<Runnable> notExecuted = new ArrayList<>();
+            List<T> notExecuted = new ArrayList<>();
             queue.drainTo(notExecuted);
 
-            String msg = "unable to process as " + processName + " worker service has shutdown";
             Exception ex = error.get();
-            for (Runnable runnable : notExecuted) {
-                if (runnable instanceof AbstractRunnable ar) {
+            for (T runnable : notExecuted) {
+                if (runnable instanceof AbstractRunnable abstractRunnable) {
                     if (ex != null) {
-                        ar.onFailure(ex);
+                        abstractRunnable.onFailure(ex);
                     } else {
-                        ar.onRejection(new EsRejectedExecutionException(msg, true));
+                        abstractRunnable.onRejection(
+                            new EsRejectedExecutionException("unable to process as " + processName + " worker service has shutdown", true)
+                        );
                     }
                 }
             }


### PR DESCRIPTION
Backports the following commits to 9.2:
 - [ML] Ensure queued AbstractRunnables are notified when executor stops (#135966)