### PR TITLE
[8.18] [ML] Ensure queued AbstractRunnables are notified when executor stops (#135966)

### DIFF
--- a/docs/changelog/135966.yaml
+++ b/docs/changelog/135966.yaml
@@ -1,0 +1,6 @@
+pr: 135966
+summary: Ensure queued `AbstractRunnables` are notified when executor stops
+area: Machine Learning
+type: bug
+issues:
+ - 134651


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[ML] Ensure queued AbstractRunnables are notified when executor stops (#135966)](https://github.com/elastic/elasticsearch/pull/135966)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)