### PR TITLE
[Sampling] Add put sample config action

### DIFF
--- a/docs/changelog/136148.yaml
+++ b/docs/changelog/136148.yaml
@@ -1,5 +1,0 @@
-pr: 136148
-summary: Add put sample config action
-area: Indices APIs
-type: feature
-issues: []

--- a/docs/changelog/136148.yaml
+++ b/docs/changelog/136148.yaml
@@ -1,0 +1,5 @@
+pr: 136148
+summary: Add put sample config action
+area: Indices APIs
+type: feature
+issues: []

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_sample_configuration.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_sample_configuration.json
@@ -1,0 +1,49 @@
+{
+  "indices.put_sample_configuration": {
+    "documentation": {
+      "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-put-sample-configuration",
+      "description": "Configure sampling for an index or data stream"
+    },
+    "stability": "experimental",
+    "visibility": "public",
+    "headers": {
+      "accept": [
+        "application/json"
+      ],
+      "content_type": [
+        "application/json"
+      ]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/{index}/_sample/config",
+          "methods": [
+            "PUT"
+          ],
+          "parts": {
+            "index": {
+              "type": "string",
+              "description": "The name of a data stream or index"
+            }
+          }
+        }
+      ]
+    },
+    "params": {
+      "master_timeout": {
+        "type": "time",
+        "description": "Timeout for connection to master node"
+      },
+      "timeout": {
+        "type": "time",
+        "description": "Timeout for the request"
+      }
+    },
+    "body": {
+      "description": "The sampling configuration",
+      "required": true
+    }
+  }
+}
+

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.put_sample_configuration/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.put_sample_configuration/10_basic.yml
@@ -8,7 +8,7 @@ setup:
 teardown:
   - do:
       indices.delete:
-        index: "test-*"
+        index: "*test*"
         ignore_unavailable: true
         allow_no_indices: true
 
@@ -159,3 +159,53 @@ teardown:
           time_to_live: "1d"
 
   - match: { acknowledged: true }
+
+---
+"Put sampling configuration rejects multiple indices":
+  - do:
+      indices.create:
+        index: test-multi-index-1
+        body:
+          settings:
+            number_of_shards: 1
+
+  - do:
+      indices.create:
+        index: test-multi-index-2
+        body:
+          settings:
+            number_of_shards: 1
+
+  - do:
+      catch: bad_request
+      indices.put_sample_configuration:
+        index: "test-multi-index-1,test-multi-index-2"
+        body:
+          rate: 0.5
+          max_samples: 100
+
+  - match: { error.type: "action_request_validation_exception" }
+
+---
+"Put sampling configuration rejects wildcard matching multiple indices":
+  - do:
+      indices.create:
+        index: wildcard-test-1
+        body:
+          settings:
+            number_of_shards: 1
+
+  - do:
+      indices.create:
+        index: wildcard-test-2
+        body:
+          settings:
+            number_of_shards: 1
+
+  - do:
+      catch: missing
+      indices.put_sample_configuration:
+        index: "wildcard-test-*"
+        body:
+          rate: 0.3
+          max_samples: 50

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.put_sample_configuration/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.put_sample_configuration/10_basic.yml
@@ -1,0 +1,161 @@
+---
+setup:
+  - requires:
+      cluster_features: [ "random_sampling" ]
+      reason: requires feature 'random_sampling' to get random samples
+
+---
+teardown:
+  - do:
+      indices.delete:
+        index: "test-*"
+        ignore_unavailable: true
+        allow_no_indices: true
+
+---
+"Test Put sampling configuration with JSON body":
+  - do:
+      indices.create:
+        index: test-index
+        body:
+          settings:
+            number_of_shards: 1
+
+  - do:
+      indices.put_sample_configuration:
+        index: test-index
+        body:
+          rate: 0.5
+          max_samples: 100
+          max_size: "10mb"
+          time_to_live: "1h"
+
+  - match: { acknowledged: true }
+
+---
+"Put sampling configuration with condition":
+  - do:
+      indices.create:
+        index: test-condition-index
+
+  - do:
+      indices.put_sample_configuration:
+        index: test-condition-index
+        body:
+          rate: 1.0
+          max_samples: 50
+          if: "ctx?.field == 'sample_me'"
+
+  - match: { acknowledged: true }
+
+---
+"Put sampling configuration with minimal parameters":
+  - do:
+      indices.create:
+        index: test-minimal-index
+
+  - do:
+      indices.put_sample_configuration:
+        index: test-minimal-index
+        body:
+          rate: 0.1
+
+  - match: { acknowledged: true }
+
+---
+"Put sampling configuration overwrites existing":
+  - do:
+      indices.create:
+        index: test-overwrite-index
+
+  # First configuration
+  - do:
+      indices.put_sample_configuration:
+        index: test-overwrite-index
+        body:
+          rate: 0.3
+          max_samples: 25
+
+  - match: { acknowledged: true }
+
+  # Overwrite with new configuration
+  - do:
+      indices.put_sample_configuration:
+        index: test-overwrite-index
+        body:
+          rate: 0.8
+          max_samples: 75
+          max_size: "5mb"
+
+  - match: { acknowledged: true }
+
+---
+"Put sampling configuration for non-existent index":
+  - do:
+      catch: missing
+      indices.put_sample_configuration:
+        index: non-existent-index
+        body:
+          rate: 0.6
+          max_samples: 150
+
+---
+"Put sampling configuration with timeout parameters":
+  - do:
+      indices.create:
+        index: test-timeout-index
+
+  - do:
+      indices.put_sample_configuration:
+        index: test-timeout-index
+        master_timeout: "30s"
+        timeout: "10s"
+        body:
+          rate: 0.4
+          max_samples: 80
+
+  - match: { acknowledged: true }
+
+---
+"Put sampling configuration with invalid rate fails":
+  - do:
+      indices.create:
+        index: test-invalid-rate-index
+
+  - do:
+      catch: bad_request
+      indices.put_sample_configuration:
+        index: test-invalid-rate-index
+        body:
+          rate: 1.5  # Invalid rate > 1.0
+          max_samples: 100
+
+---
+"Put sampling configuration with missing rate fails":
+  - do:
+      indices.create:
+        index: test-missing-rate-index
+
+  - do:
+      catch: bad_request
+      indices.put_sample_configuration:
+        index: test-missing-rate-index
+        body:
+          max_samples: 100  # Missing required rate parameter
+
+---
+"Put sampling configuration with human readable values":
+  - do:
+      indices.create:
+        index: test-human-readable-index
+
+  - do:
+      indices.put_sample_configuration:
+        index: test-human-readable-index
+        body:
+          rate: ".05"
+          max_samples: 1000
+          max_size: "10mb"
+          time_to_live: "1d"
+
+  - match: { acknowledged: true }

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/sampling/PutSampleConfigurationActionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/sampling/PutSampleConfigurationActionIT.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.action.admin.indices.sampling;
+
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.metadata.ProjectMetadata;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.ingest.SamplingService;
+import org.elasticsearch.test.ESIntegTestCase;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+public class PutSampleConfigurationActionIT extends ESIntegTestCase {
+
+    public void testPutSampleConfiguration() throws Exception {
+        assumeTrue("Requires the sampling feature flag to be enabled", SamplingService.RANDOM_SAMPLING_FEATURE_FLAG);
+
+        String indexName = randomIdentifier();
+        createIndex(indexName);
+
+        // Initially no sampling configuration should exist
+        assertSamplingConfigurationNotExists(indexName);
+
+        // Create a sampling configuration
+        SamplingConfiguration config = new SamplingConfiguration(0.5d, 50, ByteSizeValue.ofMb(10), TimeValue.timeValueHours(1), null);
+        PutSampleConfigurationAction.Request request = new PutSampleConfigurationAction.Request(
+            config,
+            TimeValue.timeValueSeconds(30),
+            TimeValue.timeValueSeconds(10)
+        );
+        request.indices(indexName);
+
+        AcknowledgedResponse response = client().execute(PutSampleConfigurationAction.INSTANCE, request).actionGet();
+        assertTrue("Put sampling configuration should be acknowledged", response.isAcknowledged());
+
+        // Verify the configuration was stored
+        assertSamplingConfigurationExists(indexName, config);
+    }
+
+    public void testPutSampleConfigurationOverwritesExisting() throws Exception {
+        assumeTrue("Requires the sampling feature flag to be enabled", SamplingService.RANDOM_SAMPLING_FEATURE_FLAG);
+
+        String indexName = randomIdentifier();
+        createIndex(indexName);
+
+        // Create initial configuration
+        SamplingConfiguration initialConfig = new SamplingConfiguration(
+            0.3d,
+            30,
+            ByteSizeValue.ofMb(5),
+            TimeValue.timeValueMinutes(30),
+            null
+        );
+        PutSampleConfigurationAction.Request initialRequest = new PutSampleConfigurationAction.Request(
+            initialConfig,
+            TimeValue.timeValueSeconds(30),
+            TimeValue.timeValueSeconds(10)
+        );
+        initialRequest.indices(indexName);
+
+        AcknowledgedResponse initialResponse = client().execute(PutSampleConfigurationAction.INSTANCE, initialRequest).actionGet();
+        assertTrue("Initial put should be acknowledged", initialResponse.isAcknowledged());
+        assertSamplingConfigurationExists(indexName, initialConfig);
+
+        // Overwrite with new configuration
+        SamplingConfiguration newConfig = new SamplingConfiguration(0.8d, 80, ByteSizeValue.ofMb(20), TimeValue.timeValueHours(2), null);
+        PutSampleConfigurationAction.Request updateRequest = new PutSampleConfigurationAction.Request(
+            newConfig,
+            TimeValue.timeValueSeconds(30),
+            TimeValue.timeValueSeconds(10)
+        );
+        updateRequest.indices(indexName);
+
+        AcknowledgedResponse updateResponse = client().execute(PutSampleConfigurationAction.INSTANCE, updateRequest).actionGet();
+        assertTrue("Update put should be acknowledged", updateResponse.isAcknowledged());
+
+        // Verify the configuration was overwritten
+        assertSamplingConfigurationExists(indexName, newConfig);
+    }
+
+    public void testPutSampleConfigurationWithCondition() throws Exception {
+        assumeTrue("Requires the sampling feature flag to be enabled", SamplingService.RANDOM_SAMPLING_FEATURE_FLAG);
+
+        String indexName = randomIdentifier();
+        createIndex(indexName);
+
+        // Create configuration with condition
+        String condition = "ctx?.field == 'sample_me'";
+        SamplingConfiguration configWithCondition = new SamplingConfiguration(
+            1.0d,
+            100,
+            ByteSizeValue.ofMb(15),
+            TimeValue.timeValueHours(3),
+            condition
+        );
+        PutSampleConfigurationAction.Request request = new PutSampleConfigurationAction.Request(
+            configWithCondition,
+            TimeValue.timeValueSeconds(30),
+            TimeValue.timeValueSeconds(10)
+        );
+        request.indices(indexName);
+
+        AcknowledgedResponse response = client().execute(PutSampleConfigurationAction.INSTANCE, request).actionGet();
+        assertTrue("Put sampling configuration with condition should be acknowledged", response.isAcknowledged());
+
+        // Verify the configuration with condition was stored
+        assertSamplingConfigurationExists(indexName, configWithCondition);
+    }
+
+    public void testPutSampleConfigurationMultipleIndices() throws Exception {
+        assumeTrue("Requires the sampling feature flag to be enabled", SamplingService.RANDOM_SAMPLING_FEATURE_FLAG);
+
+        String indexName1 = randomIdentifier();
+        String indexName2 = randomIdentifier();
+        createIndex(indexName1);
+        createIndex(indexName2);
+
+        // According to the transport action implementation, only the first index should be used
+        SamplingConfiguration config = new SamplingConfiguration(0.7d, 70, ByteSizeValue.ofMb(12), TimeValue.timeValueMinutes(90), null);
+        PutSampleConfigurationAction.Request request = new PutSampleConfigurationAction.Request(
+            config,
+            TimeValue.timeValueSeconds(30),
+            TimeValue.timeValueSeconds(10)
+        );
+        request.indices(indexName1, indexName2);
+
+        AcknowledgedResponse response = client().execute(PutSampleConfigurationAction.INSTANCE, request).actionGet();
+        assertTrue("Put sampling configuration should be acknowledged", response.isAcknowledged());
+
+        // Only the first index should have the configuration
+        assertSamplingConfigurationExists(indexName1, config);
+        assertSamplingConfigurationNotExists(indexName2);
+    }
+
+    public void testPutSampleConfigurationNonExistentIndex() throws Exception {
+        assumeTrue("Requires the sampling feature flag to be enabled", SamplingService.RANDOM_SAMPLING_FEATURE_FLAG);
+
+        String nonExistentIndex = randomIdentifier();
+
+        // Don't create the index - test that we cannot set sampling config for non-existent indices
+        SamplingConfiguration config = new SamplingConfiguration(0.6d, 60, ByteSizeValue.ofMb(8), TimeValue.timeValueMinutes(45), null);
+        PutSampleConfigurationAction.Request request = new PutSampleConfigurationAction.Request(
+            config,
+            TimeValue.timeValueSeconds(30),
+            TimeValue.timeValueSeconds(10)
+        );
+        request.indices(nonExistentIndex);
+
+        // This should now fail - sampling configs cannot be set for non-existent indices
+        expectThrows(Exception.class, () -> { client().execute(PutSampleConfigurationAction.INSTANCE, request).actionGet(); });
+
+        // Verify no configuration was stored
+        assertSamplingConfigurationNotExists(nonExistentIndex);
+
+        // Now create the index and verify the config can be set
+        createIndex(nonExistentIndex);
+
+        AcknowledgedResponse response = client().execute(PutSampleConfigurationAction.INSTANCE, request).actionGet();
+        assertTrue("Put sampling configuration should be acknowledged for existing index", response.isAcknowledged());
+        assertSamplingConfigurationExists(nonExistentIndex, config);
+    }
+
+    public void testPutSampleConfigurationPersistsAcrossClusterStateUpdates() throws Exception {
+        assumeTrue("Requires the sampling feature flag to be enabled", SamplingService.RANDOM_SAMPLING_FEATURE_FLAG);
+
+        String indexName = randomIdentifier();
+        createIndex(indexName);
+
+        // Store sampling configuration
+        SamplingConfiguration config = new SamplingConfiguration(0.9d, 90, ByteSizeValue.ofMb(25), TimeValue.timeValueHours(4), null);
+        PutSampleConfigurationAction.Request request = new PutSampleConfigurationAction.Request(
+            config,
+            TimeValue.timeValueSeconds(30),
+            TimeValue.timeValueSeconds(10)
+        );
+        request.indices(indexName);
+
+        AcknowledgedResponse response = client().execute(PutSampleConfigurationAction.INSTANCE, request).actionGet();
+        assertTrue("Put sampling configuration should be acknowledged", response.isAcknowledged());
+        assertSamplingConfigurationExists(indexName, config);
+
+        // Trigger cluster state updates by creating additional indices
+        for (int i = 0; i < 3; i++) {
+            createIndex("dummy-index-" + i);
+        }
+
+        // Verify sampling configuration still exists after cluster state changes
+        assertSamplingConfigurationExists(indexName, config);
+    }
+
+    public void testPutSampleConfigurationWithSamplingIntegration() throws Exception {
+        assumeTrue("Requires the sampling feature flag to be enabled", SamplingService.RANDOM_SAMPLING_FEATURE_FLAG);
+
+        String indexName = randomIdentifier();
+        createIndex(indexName);
+
+        // Put a sampling configuration that samples everything
+        SamplingConfiguration config = new SamplingConfiguration(1.0d, 100, ByteSizeValue.ofMb(50), TimeValue.timeValueDays(1), null);
+        PutSampleConfigurationAction.Request putRequest = new PutSampleConfigurationAction.Request(
+            config,
+            TimeValue.timeValueSeconds(30),
+            TimeValue.timeValueSeconds(10)
+        );
+        putRequest.indices(indexName);
+
+        AcknowledgedResponse putResponse = client().execute(PutSampleConfigurationAction.INSTANCE, putRequest).actionGet();
+        assertTrue("Put sampling configuration should be acknowledged", putResponse.isAcknowledged());
+
+        // Index some documents
+        int docsToIndex = randomIntBetween(5, 15);
+        for (int i = 0; i < docsToIndex; i++) {
+            indexDoc(indexName, "doc-" + i, "field1", "value" + i);
+        }
+
+        // Verify the sampling configuration works by getting samples
+        GetSampleAction.Request getSampleRequest = new GetSampleAction.Request(indexName);
+        GetSampleAction.Response getSampleResponse = client().execute(GetSampleAction.INSTANCE, getSampleRequest).actionGet();
+
+        // Since we're sampling at 100%, we should get all documents sampled
+        assertEquals("All documents should be sampled", docsToIndex, getSampleResponse.getSample().size());
+    }
+
+    private void assertSamplingConfigurationExists(String indexName, SamplingConfiguration expectedConfig) {
+        ClusterService clusterService = internalCluster().getCurrentMasterNodeInstance(ClusterService.class);
+        ClusterState clusterState = clusterService.state();
+        ProjectMetadata projectMetadata = clusterState.metadata().getProject(ProjectId.DEFAULT);
+        assertThat("Project metadata should exist", projectMetadata, notNullValue());
+
+        SamplingMetadata samplingMetadata = projectMetadata.custom(SamplingMetadata.TYPE);
+        assertThat("Sampling metadata should exist", samplingMetadata, notNullValue());
+
+        Map<String, SamplingConfiguration> configMap = samplingMetadata.getIndexToSamplingConfigMap();
+        assertTrue("Configuration should exist for index " + indexName, configMap.containsKey(indexName));
+
+        SamplingConfiguration actualConfig = configMap.get(indexName);
+        assertThat("Configuration should match expected for index " + indexName, actualConfig, equalTo(expectedConfig));
+    }
+
+    private void assertSamplingConfigurationNotExists(String indexName) {
+        ClusterService clusterService = internalCluster().getCurrentMasterNodeInstance(ClusterService.class);
+        ClusterState clusterState = clusterService.state();
+        ProjectMetadata projectMetadata = clusterState.metadata().getProject(ProjectId.DEFAULT);
+
+        if (projectMetadata == null) {
+            return; // No project metadata means no sampling config
+        }
+
+        SamplingMetadata samplingMetadata = projectMetadata.custom(SamplingMetadata.TYPE);
+        if (samplingMetadata == null) {
+            return; // No sampling metadata means no sampling config
+        }
+
+        Map<String, SamplingConfiguration> configMap = samplingMetadata.getIndexToSamplingConfigMap();
+        assertThat("Configuration should not exist for index " + indexName, configMap.get(indexName), nullValue());
+    }
+}

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/sampling/PutSampleConfigurationActionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/sampling/PutSampleConfigurationActionIT.java
@@ -138,9 +138,7 @@ public class PutSampleConfigurationActionIT extends ESIntegTestCase {
         );
 
         // Setting multiple indices should fail
-        Exception exception = expectThrows(IllegalArgumentException.class, () -> {
-            request.indices(indexName1, indexName2);
-        });
+        Exception exception = expectThrows(IllegalArgumentException.class, () -> { request.indices(indexName1, indexName2); });
         assertTrue(exception.getMessage().contains("Exactly one index or data stream must be specified"));
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/sampling/PutSampleConfigurationActionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/sampling/PutSampleConfigurationActionIT.java
@@ -122,26 +122,6 @@ public class PutSampleConfigurationActionIT extends ESIntegTestCase {
         assertSamplingConfigurationExists(indexName, configWithCondition);
     }
 
-    public void testPutSampleConfigurationMultipleIndices() throws Exception {
-        assumeTrue("Requires the sampling feature flag to be enabled", SamplingService.RANDOM_SAMPLING_FEATURE_FLAG);
-
-        String indexName1 = randomIdentifier();
-        String indexName2 = randomIdentifier();
-        createIndex(indexName1);
-        createIndex(indexName2);
-
-        SamplingConfiguration config = new SamplingConfiguration(0.7d, 70, ByteSizeValue.ofMb(12), TimeValue.timeValueMinutes(90), null);
-        PutSampleConfigurationAction.Request request = new PutSampleConfigurationAction.Request(
-            config,
-            TimeValue.timeValueSeconds(30),
-            TimeValue.timeValueSeconds(10)
-        );
-
-        // Setting multiple indices should fail
-        Exception exception = expectThrows(IllegalArgumentException.class, () -> { request.indices(indexName1, indexName2); });
-        assertTrue(exception.getMessage().contains("Exactly one index or data stream must be specified"));
-    }
-
     public void testPutSampleConfigurationNonExistentIndex() throws Exception {
         assumeTrue("Requires the sampling feature flag to be enabled", SamplingService.RANDOM_SAMPLING_FEATURE_FLAG);
 

--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -131,10 +131,13 @@ import org.elasticsearch.action.admin.indices.rollover.RolloverAction;
 import org.elasticsearch.action.admin.indices.rollover.TransportRolloverAction;
 import org.elasticsearch.action.admin.indices.sampling.GetSampleAction;
 import org.elasticsearch.action.admin.indices.sampling.GetSampleStatsAction;
+import org.elasticsearch.action.admin.indices.sampling.PutSampleConfigurationAction;
 import org.elasticsearch.action.admin.indices.sampling.RestGetSampleAction;
 import org.elasticsearch.action.admin.indices.sampling.RestGetSampleStatsAction;
+import org.elasticsearch.action.admin.indices.sampling.RestPutSampleConfigurationAction;
 import org.elasticsearch.action.admin.indices.sampling.TransportGetSampleAction;
 import org.elasticsearch.action.admin.indices.sampling.TransportGetSampleStatsAction;
+import org.elasticsearch.action.admin.indices.sampling.TransportPutSampleConfigurationAction;
 import org.elasticsearch.action.admin.indices.segments.IndicesSegmentsAction;
 import org.elasticsearch.action.admin.indices.segments.TransportIndicesSegmentsAction;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsAction;
@@ -824,6 +827,7 @@ public class ActionModule extends AbstractModule {
 
         if (RANDOM_SAMPLING_FEATURE_FLAG) {
             actions.register(GetSampleAction.INSTANCE, TransportGetSampleAction.class);
+            actions.register(PutSampleConfigurationAction.INSTANCE, TransportPutSampleConfigurationAction.class);
             actions.register(GetSampleStatsAction.INSTANCE, TransportGetSampleStatsAction.class);
         }
 
@@ -1057,6 +1061,7 @@ public class ActionModule extends AbstractModule {
 
         if (RANDOM_SAMPLING_FEATURE_FLAG) {
             registerHandler.accept(new RestGetSampleAction());
+            registerHandler.accept(new RestPutSampleConfigurationAction());
             registerHandler.accept(new RestGetSampleStatsAction());
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/sampling/PutSampleConfigurationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/sampling/PutSampleConfigurationAction.java
@@ -109,7 +109,7 @@ public class PutSampleConfigurationAction extends ActionType<AcknowledgedRespons
          */
         @Override
         public String[] indices() {
-            return index == null ? null : new String[]{index};
+            return index == null ? null : new String[] { index };
         }
 
         /**

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/sampling/PutSampleConfigurationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/sampling/PutSampleConfigurationAction.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.action.admin.indices.sampling;
+
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.tasks.CancellableTask;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Action for configuring sampling settings on indices.
+ * <p>
+ * This action allows administrators to configure sampling parameters for one or more indices,
+ * including sampling rate, maximum number of samples, maximum size constraints, time-to-live
+ * settings, and conditional sampling criteria.
+ * </p>
+ * <p>
+ * The action name is "indices:admin/sample/config/update" and it returns an {@link AcknowledgedResponse}
+ * to indicate whether the configuration was successfully applied.
+ * </p>
+ */
+public class PutSampleConfigurationAction extends ActionType<AcknowledgedResponse> {
+    /**
+     * The action name used to identify this action in the transport layer.
+     */
+    public static final String NAME = "indices:admin/sample/config/update";
+
+    /**
+     * Singleton instance of this action type.
+     */
+    public static final PutSampleConfigurationAction INSTANCE = new PutSampleConfigurationAction();
+
+    /**
+     * Constructs a new PutSampleConfigurationAction with the predefined action name.
+     */
+    public PutSampleConfigurationAction() {
+        super(NAME);
+    }
+
+    /**
+     * Request class for configuring sampling settings on indices.
+     * <p>
+     * This request encapsulates all the parameters needed to configure sampling on one or more indices,
+     * including the sampling configuration itself and the target indices. It implements
+     * {@link Replaceable} to support index name resolution and expansion.
+     * </p>
+     */
+    public static class Request extends AcknowledgedRequest<Request> implements IndicesRequest.Replaceable {
+        private final SamplingConfiguration samplingConfiguration;
+        private String[] indices = Strings.EMPTY_ARRAY;
+
+        /**
+         * Constructs a new request with the specified sampling configuration parameters.
+         *
+         * @param samplingConfiguration the sampling configuration to apply
+         * @param masterNodeTimeout the timeout for master node operations, or null for default
+         * @param ackTimeout the timeout for acknowledgment, or null for default
+         */
+        public Request(
+            @Nullable SamplingConfiguration samplingConfiguration,
+            @Nullable TimeValue masterNodeTimeout,
+            @Nullable TimeValue ackTimeout
+        ) {
+            super(masterNodeTimeout, ackTimeout);
+            this.samplingConfiguration = samplingConfiguration;
+        }
+
+        /**
+         * Constructs a new request by deserializing from a stream input.
+         *
+         * @param in the stream input to read from
+         * @throws IOException if an I/O error occurs during deserialization
+         */
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            this.indices = in.readStringArray();
+            this.samplingConfiguration = new SamplingConfiguration(in);
+        }
+
+        /**
+         * Serializes this request to a stream output.
+         *
+         * @param out the stream output to write to
+         * @throws IOException if an I/O error occurs during serialization
+         */
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeStringArray(indices);
+            samplingConfiguration.writeTo(out);
+        }
+
+        /**
+         * Returns the array of target indices for this sampling configuration request.
+         *
+         * @return an array of index names, never null but may be empty
+         */
+        @Override
+        public String[] indices() {
+            return indices;
+        }
+
+        /**
+         * Sets the target indices or data streams for this sampling configuration request.
+         *
+         * @param indices the names of indices or data streams to target
+         * @return this request instance for method chaining
+         */
+        @Override
+        public Request indices(String... indices) {
+            this.indices = indices;
+            return this;
+        }
+
+        /**
+         * Indicates whether this request should include data streams in addition to regular indices.
+         *
+         * @return true to include data streams
+         */
+        @Override
+        public boolean includeDataStreams() {
+            return true;
+        }
+
+        /**
+         * Returns the indices options for this request, which control how index names are resolved and expanded.
+         *
+         * @return the indices options, configured to be lenient and expand both open and closed indices
+         */
+        @Override
+        public IndicesOptions indicesOptions() {
+            return IndicesOptions.STRICT_SINGLE_INDEX_NO_EXPAND_FORBID_CLOSED_ALLOW_SELECTORS;
+        }
+
+        /**
+         * Creates a cancellable task for tracking the execution of this request.
+         *
+         * @param id the unique task identifier
+         * @param type the task type
+         * @param action the action name
+         * @param parentTaskId the parent task identifier, or null if this is a root task
+         * @param headers the request headers
+         * @return a new cancellable task instance
+         */
+        @Override
+        public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
+            return new CancellableTask(id, type, action, "Updates Sampling Configuration.", parentTaskId, headers);
+        }
+
+        /**
+         * Returns the sampling configuration encapsulated by this request.
+         *
+         * @return the sampling configuration
+         */
+        public SamplingConfiguration getSampleConfiguration() {
+            return samplingConfiguration;
+        }
+
+        /**
+         * Compares this request with another object for equality.
+         * <p>
+         * Two requests are considered equal if they have the same target indices and
+         * sampling configuration parameters.
+         * </p>
+         *
+         * @param o the object to compare with
+         * @return true if the objects are equal, false otherwise
+         */
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Request that = (Request) o;
+            return Arrays.equals(indices, that.indices)
+                && Objects.equals(samplingConfiguration, that.samplingConfiguration)
+                && Objects.equals(masterNodeTimeout(), that.masterNodeTimeout())
+                && Objects.equals(ackTimeout(), that.ackTimeout());
+        }
+
+        /**
+         * Returns the hash code for this request.
+         * <p>
+         * The hash code is computed based on the target indices, sampling configuration,
+         * master node timeout, and acknowledgment timeout.
+         * </p>
+         *
+         * @return the hash code value
+         */
+        @Override
+        public int hashCode() {
+            return Objects.hash(Arrays.hashCode(indices), samplingConfiguration, masterNodeTimeout(), ackTimeout());
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/sampling/PutSampleConfigurationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/sampling/PutSampleConfigurationAction.java
@@ -77,11 +77,7 @@ public class PutSampleConfigurationAction extends ActionType<AcknowledgedRespons
          * @param masterNodeTimeout the timeout for master node operations, or null for default
          * @param ackTimeout the timeout for acknowledgment, or null for default
          */
-        public Request(
-            SamplingConfiguration samplingConfiguration,
-            @Nullable TimeValue masterNodeTimeout,
-            @Nullable TimeValue ackTimeout
-        ) {
+        public Request(SamplingConfiguration samplingConfiguration, @Nullable TimeValue masterNodeTimeout, @Nullable TimeValue ackTimeout) {
             super(masterNodeTimeout, ackTimeout);
             Objects.requireNonNull(samplingConfiguration, "samplingConfiguration must not be null");
             this.samplingConfiguration = samplingConfiguration;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/sampling/PutSampleConfigurationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/sampling/PutSampleConfigurationAction.java
@@ -78,11 +78,12 @@ public class PutSampleConfigurationAction extends ActionType<AcknowledgedRespons
          * @param ackTimeout the timeout for acknowledgment, or null for default
          */
         public Request(
-            @Nullable SamplingConfiguration samplingConfiguration,
+            SamplingConfiguration samplingConfiguration,
             @Nullable TimeValue masterNodeTimeout,
             @Nullable TimeValue ackTimeout
         ) {
             super(masterNodeTimeout, ackTimeout);
+            Objects.requireNonNull(samplingConfiguration, "samplingConfiguration must not be null");
             this.samplingConfiguration = samplingConfiguration;
         }
 
@@ -129,6 +130,9 @@ public class PutSampleConfigurationAction extends ActionType<AcknowledgedRespons
          */
         @Override
         public Request indices(String... indices) {
+            if (indices.length != 1) {
+                throw new IllegalArgumentException("Exactly one index or data stream must be specified.");
+            }
             this.indices = indices;
             return this;
         }
@@ -146,7 +150,7 @@ public class PutSampleConfigurationAction extends ActionType<AcknowledgedRespons
         /**
          * Returns the indices options for this request, which control how index names are resolved and expanded.
          *
-         * @return the indices options, configured to be lenient and expand both open and closed indices
+         * @return the indices options, configured to be strict about single index, no expansion, forbid closed indices, and allow selectors
          */
         @Override
         public IndicesOptions indicesOptions() {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/sampling/PutSampleConfigurationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/sampling/PutSampleConfigurationAction.java
@@ -126,9 +126,6 @@ public class PutSampleConfigurationAction extends ActionType<AcknowledgedRespons
          */
         @Override
         public Request indices(String... indices) {
-            if (indices.length != 1) {
-                throw new IllegalArgumentException("Exactly one index or data stream must be specified.");
-            }
             this.indices = indices;
             return this;
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/sampling/RestPutSampleConfigurationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/sampling/RestPutSampleConfigurationAction.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.action.admin.indices.sampling;
+
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.Scope;
+import org.elasticsearch.rest.ServerlessScope;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.action.admin.indices.sampling.SamplingConfiguration.DEFAULT_MAX_SAMPLES;
+import static org.elasticsearch.rest.RestRequest.Method.PUT;
+import static org.elasticsearch.rest.RestUtils.getAckTimeout;
+import static org.elasticsearch.rest.RestUtils.getMasterNodeTimeout;
+
+/**
+ * REST action for updating sampling configurations for indices.
+ * <p>
+ * Handles PUT requests to /{index}/_sample/config endpoint and delegates
+ * to the PutSampleConfigurationAction transport action.
+ * </p>
+ *
+ * <p>Example usage:</p>
+ * <pre>{@code
+ * PUT /my-index/_sample/config
+ * {
+ *   "rate": ".05",
+ *   "max_samples": 1000,
+ *   "max_size": "10mb",
+ *   "time_to_live": "1d",
+ *   "if": "ctx?.network?.name == 'Guest'"
+ * }
+ * }</pre>
+ */
+@ServerlessScope(Scope.INTERNAL)
+public class RestPutSampleConfigurationAction extends BaseRestHandler {
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(PUT, "/{index}/_sample/config"));
+    }
+
+    @Override
+    public String getName() {
+        return "put_sample_configuration_action";
+    }
+
+    @Override
+    public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
+        String indexName = request.param("index");
+
+        PutSampleConfigurationAction.Request putRequest;
+
+        if (request.hasContent()) {
+            // Parse the sampling configuration from request body
+            try (XContentParser parser = request.contentParser()) {
+                SamplingConfiguration samplingConfig = SamplingConfiguration.fromXContent(parser);
+                putRequest = new PutSampleConfigurationAction.Request(
+                    samplingConfig,
+                    getMasterNodeTimeout(request),
+                    getAckTimeout(request)
+                );
+            }
+        } else {
+            // Use URL parameters if no request body provided
+            if (request.hasParam("rate") == false) {
+                throw new IllegalArgumentException("Missing required parameter: rate");
+            }
+            double rate = request.paramAsDouble("rate", 0); // required parameter, default won't be used
+            int maxSamples = request.paramAsInt("max_samples", DEFAULT_MAX_SAMPLES);
+            ByteSizeValue maxSize = request.paramAsSize("max_size", null);
+            TimeValue timeToLive = request.paramAsTime("time_to_live", null);
+            String condition = request.param("if", null);
+
+            putRequest = new PutSampleConfigurationAction.Request(
+                new SamplingConfiguration(rate, maxSamples, maxSize, timeToLive, condition),
+                getMasterNodeTimeout(request),
+                getAckTimeout(request)
+            );
+        }
+
+        // Set the target index
+        putRequest.indices(indexName);
+
+        return channel -> client.execute(PutSampleConfigurationAction.INSTANCE, putRequest, new RestToXContentListener<>(channel));
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/sampling/RestPutSampleConfigurationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/sampling/RestPutSampleConfigurationAction.java
@@ -77,6 +77,7 @@ public class RestPutSampleConfigurationAction extends BaseRestHandler {
         // Set the target index
         putRequest.indices(indexNames);
 
+        // TODO: Make this cancellable e.g. RestGetSampleStatsAction
         return channel -> client.execute(PutSampleConfigurationAction.INSTANCE, putRequest, new RestToXContentListener<>(channel));
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/sampling/TransportPutSampleConfigurationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/sampling/TransportPutSampleConfigurationAction.java
@@ -73,8 +73,8 @@ public class TransportPutSampleConfigurationAction extends AcknowledgedTransport
         ClusterState state,
         ActionListener<AcknowledgedResponse> listener
     ) throws Exception {
-        // throws IndexNotFoundException if any index does not exist
-        indexNameExpressionResolver.concreteIndexNames(clusterService.state(), request);
+        // throws IndexNotFoundException if any index does not exist or more than one index is resolved
+        indexNameExpressionResolver.concreteIndexNames(state, request);
 
         ProjectId projectId = projectResolver.getProjectId();
         samplingService.updateSampleConfiguration(

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/sampling/TransportPutSampleConfigurationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/sampling/TransportPutSampleConfigurationAction.java
@@ -85,7 +85,6 @@ public class TransportPutSampleConfigurationAction extends AcknowledgedTransport
             request.ackTimeout(),
             listener
         );
-        state.projectState(projectId).metadata().custom("sample_config");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/sampling/TransportPutSampleConfigurationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/sampling/TransportPutSampleConfigurationAction.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.action.admin.indices.sampling;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.action.support.master.AcknowledgedTransportMasterNodeAction;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.project.ProjectResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.ingest.SamplingService;
+import org.elasticsearch.injection.guice.Inject;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+/**
+ * Transport action for updating sampling configurations in cluster metadata.
+ * <p>
+ * This action handles the cluster state update required to store sampling configurations
+ * for the specified indices. It validates the request, resolves index names, and updates
+ * the cluster metadata with the new sampling configuration.
+ * </p>
+ */
+public class TransportPutSampleConfigurationAction extends AcknowledgedTransportMasterNodeAction<PutSampleConfigurationAction.Request> {
+    private static final Logger logger = LogManager.getLogger(TransportPutSampleConfigurationAction.class);
+    private final ProjectResolver projectResolver;
+    private final IndexNameExpressionResolver indexNameExpressionResolver;
+    private final SamplingService samplingService;
+
+    @Inject
+    public TransportPutSampleConfigurationAction(
+        TransportService transportService,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        ActionFilters actionFilters,
+        ProjectResolver projectResolver,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        SamplingService samplingService
+    ) {
+        super(
+            PutSampleConfigurationAction.NAME,
+            transportService,
+            clusterService,
+            threadPool,
+            actionFilters,
+            PutSampleConfigurationAction.Request::new,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE
+        );
+        this.projectResolver = projectResolver;
+        this.indexNameExpressionResolver = indexNameExpressionResolver;
+        this.samplingService = samplingService;
+    }
+
+    @Override
+    protected void masterOperation(
+        Task task,
+        PutSampleConfigurationAction.Request request,
+        ClusterState state,
+        ActionListener<AcknowledgedResponse> listener
+    ) throws Exception {
+        // throws IndexNotFoundException if any index does not exist
+        indexNameExpressionResolver.concreteIndexNames(clusterService.state(), request);
+
+        ProjectId projectId = projectResolver.getProjectId();
+        samplingService.updateSampleConfiguration(
+            projectId,
+            request.indices()[0],
+            request.getSampleConfiguration(),
+            request.masterNodeTimeout(),
+            request.ackTimeout(),
+            listener
+        );
+        state.projectState(projectId).metadata().custom("sample_config");
+    }
+
+    @Override
+    protected ClusterBlockException checkBlock(PutSampleConfigurationAction.Request request, ClusterState state) {
+        return null;
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/ingest/SamplingService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/SamplingService.java
@@ -517,7 +517,7 @@ public class SamplingService implements ClusterStateListener {
         }
 
         @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
             builder.startObject();
             builder.field("potential_samples", potentialSamples.longValue());
             builder.field("samples_rejected_for_max_samples_exceeded", samplesRejectedForMaxSamplesExceeded.longValue());

--- a/server/src/main/java/org/elasticsearch/ingest/SamplingService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/SamplingService.java
@@ -298,10 +298,10 @@ public class SamplingService implements ClusterStateListener {
             listener.onFailure(
                 new IllegalStateException(
                     "Cannot add sampling configuration for index ["
-                    + index
-                    + "]. Maximum number of sampling configurations ("
-                    + maxConfigurations
-                    + ") already reached."
+                        + index
+                        + "]. Maximum number of sampling configurations ("
+                        + maxConfigurations
+                        + ") already reached."
                 )
             );
             return;
@@ -812,7 +812,8 @@ public class SamplingService implements ClusterStateListener {
             );
 
             // Get sampling metadata
-            ProjectMetadata projectMetadata = clusterState.metadata().getProject(updateSamplingConfigurationTask.projectId);;
+            ProjectMetadata projectMetadata = clusterState.metadata().getProject(updateSamplingConfigurationTask.projectId);
+            ;
             SamplingMetadata samplingMetadata = projectMetadata.custom(SamplingMetadata.TYPE);
 
             boolean isNewConfiguration = samplingMetadata == null; // for logging
@@ -832,9 +833,10 @@ public class SamplingService implements ClusterStateListener {
 
             Integer maxConfigurations = MAX_CONFIGURATIONS_SETTING.get(clusterState.getMetadata().settings());
             // check if adding a new configuration would exceed the limit
-            boolean maxConfigLimitBreached =
-                samplingService.checkMaxConfigLimitBreached(
-                    updateSamplingConfigurationTask.projectId, updateSamplingConfigurationTask.indexName);
+            boolean maxConfigLimitBreached = samplingService.checkMaxConfigLimitBreached(
+                updateSamplingConfigurationTask.projectId,
+                updateSamplingConfigurationTask.indexName
+            );
             if (maxConfigLimitBreached) {
                 throw new IllegalStateException(
                     "Cannot add sampling configuration for index ["
@@ -843,7 +845,8 @@ public class SamplingService implements ClusterStateListener {
                         + maxConfigurations
                         + ") already reached."
                 );
-            }            updatedConfigMap.put(updateSamplingConfigurationTask.indexName, updateSamplingConfigurationTask.samplingConfiguration);
+            }
+            updatedConfigMap.put(updateSamplingConfigurationTask.indexName, updateSamplingConfigurationTask.samplingConfiguration);
 
             logger.trace(
                 "{} sampling configuration for index [{}], total configurations after update: {}",
@@ -864,7 +867,8 @@ public class SamplingService implements ClusterStateListener {
             logger.debug(
                 "Successfully {} sampling configuration for index [{}]",
                 isUpdate ? "updated" : "created",
-                updateSamplingConfigurationTask.indexName);
+                updateSamplingConfigurationTask.indexName
+            );
             return new Tuple<>(updatedClusterState, updateSamplingConfigurationTask);
         }
     }

--- a/server/src/main/java/org/elasticsearch/ingest/SamplingService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/SamplingService.java
@@ -771,7 +771,7 @@ public class SamplingService implements ClusterStateListener {
                 updateSamplingConfigurationTask.samplingConfiguration.condition()
 
             );
-            
+
             // Get sampling metadata
             ProjectMetadata projectMetadata = projectResolver.getProjectMetadata(clusterState);
             SamplingMetadata samplingMetadata = projectMetadata.custom(SamplingMetadata.TYPE);

--- a/server/src/main/java/org/elasticsearch/ingest/SamplingService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/SamplingService.java
@@ -752,7 +752,8 @@ public class SamplingService implements ClusterStateListener {
             ClusterState clusterState
         ) {
             logger.debug(
-                "Updating sampling configuration for index [{}] in project [{}] with rate [{}], maxSamples [{}], maxSize [{}], timeToLive [{}], condition[{}]",
+                "Updating sampling configuration for index [{}] in project [{}] with rate [{}],"
+                    + " maxSamples [{}], maxSize [{}], timeToLive [{}], condition[{}]",
                 updateSamplingConfigurationTask.indexName,
                 updateSamplingConfigurationTask.projectId,
                 updateSamplingConfigurationTask.samplingConfiguration.rate(),

--- a/server/src/main/java/org/elasticsearch/ingest/SamplingService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/SamplingService.java
@@ -71,7 +71,6 @@ public class SamplingService implements ClusterStateListener {
     private final LongSupplier statsTimeSupplier = System::nanoTime;
     private final MasterServiceTaskQueue<UpdateSamplingConfigurationTask> updateSamplingConfigurationTaskQueue;
 
-
     private static final Setting<Integer> MAX_CONFIGURATIONS_SETTING = Setting.intSetting(
         "sampling.max_configurations_per_project",
         100,

--- a/server/src/main/java/org/elasticsearch/ingest/SamplingService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/SamplingService.java
@@ -768,7 +768,7 @@ public class SamplingService implements ClusterStateListener {
             ProjectMetadata projectMetadata = projectResolver.getProjectMetadata(clusterState);
             SamplingMetadata samplingMetadata = projectMetadata.custom(SamplingMetadata.TYPE);
 
-            boolean isNewConfiguration = samplingMetadata == null;
+            boolean isNewConfiguration = samplingMetadata == null; // for logging
             int existingConfigCount = isNewConfiguration ? 0 : samplingMetadata.getIndexToSamplingConfigMap().size();
 
             logger.trace(
@@ -784,7 +784,7 @@ public class SamplingService implements ClusterStateListener {
                 updatedConfigMap.putAll(samplingMetadata.getIndexToSamplingConfigMap());
             }
 
-            boolean isUpdate = updatedConfigMap.containsKey(updateSamplingConfigurationTask.indexName);
+            boolean isUpdate = updatedConfigMap.containsKey(updateSamplingConfigurationTask.indexName); // for logging
             updatedConfigMap.put(updateSamplingConfigurationTask.indexName, updateSamplingConfigurationTask.samplingConfiguration);
 
             logger.trace(

--- a/server/src/main/java/org/elasticsearch/ingest/SamplingService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/SamplingService.java
@@ -771,13 +771,7 @@ public class SamplingService implements ClusterStateListener {
                 updateSamplingConfigurationTask.samplingConfiguration.condition()
 
             );
-
-            logger.debug(
-                "Configuration details: maxSize [{}], timeToLive [{}]",
-                updateSamplingConfigurationTask.samplingConfiguration.maxSize(),
-                updateSamplingConfigurationTask.samplingConfiguration.timeToLive()
-            );
-
+            
             // Get sampling metadata
             ProjectMetadata projectMetadata = projectResolver.getProjectMetadata(clusterState);
             SamplingMetadata samplingMetadata = projectMetadata.custom(SamplingMetadata.TYPE);

--- a/server/src/main/java/org/elasticsearch/ingest/SamplingService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/SamplingService.java
@@ -100,7 +100,7 @@ public class SamplingService implements ClusterStateListener {
         this.updateSamplingConfigurationTaskQueue = clusterService.createTaskQueue(
             "update-sampling-configuration",
             Priority.NORMAL,
-            new UpdateSamplingConfigurationExecutor(projectResolver, this)
+            new UpdateSamplingConfigurationExecutor()
         );
     }
 
@@ -293,9 +293,10 @@ public class SamplingService implements ClusterStateListener {
         ActionListener<AcknowledgedResponse> listener
     ) {
         // Early validation: check if adding a new configuration would exceed the limit
-        boolean maxConfigLimitBreached = checkMaxConfigLimitBreached(projectId, index);
+        ClusterState clusterState = clusterService.state();
+        boolean maxConfigLimitBreached = checkMaxConfigLimitBreached(projectId, index, clusterState);
         if (maxConfigLimitBreached) {
-            Integer maxConfigurations = MAX_CONFIGURATIONS_SETTING.get(clusterService.state().getMetadata().settings());
+            Integer maxConfigurations = MAX_CONFIGURATIONS_SETTING.get(clusterState.getMetadata().settings());
             listener.onFailure(
                 new IllegalStateException(
                     "Cannot add sampling configuration for index ["
@@ -349,8 +350,7 @@ public class SamplingService implements ClusterStateListener {
 
     // Checks whether the maximum number of sampling configurations has been reached for the given project.
     // If the limit is breached, it notifies the listener with an IllegalStateException and returns true.
-    private boolean checkMaxConfigLimitBreached(ProjectId projectId, String index) {
-        ClusterState currentState = clusterService.state();
+    private static boolean checkMaxConfigLimitBreached(ProjectId projectId, String index, ClusterState currentState) {
         Metadata currentMetadata = currentState.metadata();
         ProjectMetadata projectMetadata = currentMetadata.getProject(projectId);
 
@@ -789,13 +789,8 @@ public class SamplingService implements ClusterStateListener {
 
     static class UpdateSamplingConfigurationExecutor extends SimpleBatchedAckListenerTaskExecutor<UpdateSamplingConfigurationTask> {
         private static final Logger logger = LogManager.getLogger(UpdateSamplingConfigurationExecutor.class);
-        private final ProjectResolver projectResolver;
-        private final SamplingService samplingService;
 
-        UpdateSamplingConfigurationExecutor(ProjectResolver projectResolver, SamplingService samplingService) {
-            this.projectResolver = projectResolver;
-            this.samplingService = samplingService;
-        }
+        UpdateSamplingConfigurationExecutor() {}
 
         @Override
         public Tuple<ClusterState, ClusterStateAckListener> executeTask(
@@ -836,9 +831,10 @@ public class SamplingService implements ClusterStateListener {
 
             Integer maxConfigurations = MAX_CONFIGURATIONS_SETTING.get(metadata.settings());
             // check if adding a new configuration would exceed the limit
-            boolean maxConfigLimitBreached = samplingService.checkMaxConfigLimitBreached(
+            boolean maxConfigLimitBreached = checkMaxConfigLimitBreached(
                 updateSamplingConfigurationTask.projectId,
-                updateSamplingConfigurationTask.indexName
+                updateSamplingConfigurationTask.indexName,
+                clusterState
             );
             if (maxConfigLimitBreached) {
                 throw new IllegalStateException(

--- a/server/src/main/java/org/elasticsearch/ingest/SamplingService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/SamplingService.java
@@ -72,7 +72,7 @@ public class SamplingService implements ClusterStateListener {
     private final MasterServiceTaskQueue<UpdateSamplingConfigurationTask> updateSamplingConfigurationTaskQueue;
 
     private static final Setting<Integer> MAX_CONFIGURATIONS_SETTING = Setting.intSetting(
-        "sampling.max_configurations_per_project",
+        "sampling.max_configurations",
         100,
         1,
         Setting.Property.NodeScope,

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/sampling/PutSampleConfigurationActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/sampling/PutSampleConfigurationActionTests.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.action.admin.indices.sampling;
+
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.sameInstance;
+
+public class PutSampleConfigurationActionTests extends AbstractWireSerializingTestCase<PutSampleConfigurationAction.Request> {
+
+    @Override
+    protected Writeable.Reader<PutSampleConfigurationAction.Request> instanceReader() {
+        return PutSampleConfigurationAction.Request::new;
+    }
+
+    @Override
+    protected PutSampleConfigurationAction.Request createTestInstance() {
+        return createRandomRequest();
+    }
+
+    @Override
+    protected PutSampleConfigurationAction.Request mutateInstance(PutSampleConfigurationAction.Request instance) {
+        return switch (randomIntBetween(0, 1)) {
+            case 0 -> {
+                PutSampleConfigurationAction.Request mutated = new PutSampleConfigurationAction.Request(
+                    randomValueOtherThan(instance.getSampleConfiguration(), () -> createRandomSampleConfig()),
+                    instance.masterNodeTimeout(),
+                    instance.ackTimeout()
+                );
+                mutated.indices(instance.indices());
+                yield mutated;
+            }
+            case 1 -> {
+                PutSampleConfigurationAction.Request mutated = new PutSampleConfigurationAction.Request(
+                    instance.getSampleConfiguration(),
+                    instance.masterNodeTimeout(),
+                    instance.ackTimeout()
+                );
+                mutated.indices(
+                    randomValueOtherThan(
+                        instance.indices(),
+                        () -> randomArray(1, 5, String[]::new, () -> randomAlphaOfLengthBetween(1, 10))
+                    )
+                );
+                yield mutated;
+            }
+            default -> throw new IllegalStateException("Invalid mutation case");
+        };
+    }
+
+    private PutSampleConfigurationAction.Request createRandomRequest() {
+        PutSampleConfigurationAction.Request request = new PutSampleConfigurationAction.Request(
+            createRandomSampleConfig(),
+            TimeValue.timeValueSeconds(randomIntBetween(1, 60)),
+            TimeValue.timeValueSeconds(randomIntBetween(1, 60))
+        );
+
+        // Randomly set some indices
+        if (randomBoolean()) {
+            request.indices(randomArray(0, 3, String[]::new, () -> randomAlphaOfLengthBetween(1, 10)));
+        }
+
+        return request;
+    }
+
+    public void testActionName() {
+        assertThat(PutSampleConfigurationAction.NAME, equalTo("indices:admin/sample/config/update"));
+        assertThat(PutSampleConfigurationAction.INSTANCE.name(), equalTo(PutSampleConfigurationAction.NAME));
+    }
+
+    public void testActionInstance() {
+        assertThat(PutSampleConfigurationAction.INSTANCE, notNullValue());
+        assertThat(PutSampleConfigurationAction.INSTANCE, sameInstance(PutSampleConfigurationAction.INSTANCE));
+    }
+
+    public void testRequestIndicesOptions() {
+        PutSampleConfigurationAction.Request request = createRandomRequest();
+        assertThat(request.indicesOptions(), equalTo(IndicesOptions.STRICT_SINGLE_INDEX_NO_EXPAND_FORBID_CLOSED_ALLOW_SELECTORS));
+        assertThat(request.includeDataStreams(), is(true));
+    }
+
+    public void testRequestTaskCreation() {
+        PutSampleConfigurationAction.Request request = createRandomRequest();
+
+        long id = randomLong();
+        String type = randomAlphaOfLength(5);
+        String action = randomAlphaOfLength(10);
+        TaskId parentTaskId = randomBoolean() ? null : new TaskId(randomAlphaOfLength(5), randomLong());
+        Map<String, String> headers = Map.of("header1", "value1");
+
+        Task task = request.createTask(id, type, action, parentTaskId, headers);
+
+        assertThat(task, notNullValue());
+        assertThat(task.getId(), equalTo(id));
+        assertThat(task.getType(), equalTo(type));
+        assertThat(task.getAction(), equalTo(action));
+        assertThat(task.getParentTaskId(), equalTo(parentTaskId));
+        assertThat(task.headers(), equalTo(headers));
+    }
+
+    private static SamplingConfiguration createRandomSampleConfig() {
+        return new SamplingConfiguration(
+            randomDoubleBetween(0.0, 1.0, true),
+            randomBoolean() ? null : randomIntBetween(1, 1000),
+            randomBoolean() ? null : ByteSizeValue.ofGb(randomIntBetween(1, 5)),
+            randomBoolean() ? null : new TimeValue(randomIntBetween(1, 30), TimeUnit.DAYS),
+            randomBoolean() ? randomAlphaOfLength(10) : null
+        );
+    }
+
+}

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/sampling/PutSampleConfigurationActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/sampling/PutSampleConfigurationActionTests.java
@@ -55,12 +55,7 @@ public class PutSampleConfigurationActionTests extends AbstractWireSerializingTe
                     instance.masterNodeTimeout(),
                     instance.ackTimeout()
                 );
-                mutated.indices(
-                    randomValueOtherThan(
-                        instance.indices(),
-                        () -> new String[]{randomAlphaOfLengthBetween(1, 10)}
-                    )
-                );
+                mutated.indices(randomValueOtherThan(instance.indices(), () -> new String[] { randomAlphaOfLengthBetween(1, 10) }));
                 yield mutated;
             }
             default -> throw new IllegalStateException("Invalid mutation case");

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/sampling/PutSampleConfigurationActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/sampling/PutSampleConfigurationActionTests.java
@@ -58,7 +58,7 @@ public class PutSampleConfigurationActionTests extends AbstractWireSerializingTe
                 mutated.indices(
                     randomValueOtherThan(
                         instance.indices(),
-                        () -> randomArray(1, 5, String[]::new, () -> randomAlphaOfLengthBetween(1, 10))
+                        () -> new String[]{randomAlphaOfLengthBetween(1, 10)}
                     )
                 );
                 yield mutated;
@@ -75,9 +75,7 @@ public class PutSampleConfigurationActionTests extends AbstractWireSerializingTe
         );
 
         // Randomly set some indices
-        if (randomBoolean()) {
-            request.indices(randomArray(0, 3, String[]::new, () -> randomAlphaOfLengthBetween(1, 10)));
-        }
+        request.indices(randomAlphaOfLengthBetween(1, 10));
 
         return request;
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/sampling/TransportPutSampleConfigurationActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/sampling/TransportPutSampleConfigurationActionTests.java
@@ -189,7 +189,7 @@ public class TransportPutSampleConfigurationActionTests extends ESTestCase {
         assertThat(resultSamplingMetadata.getIndexToSamplingConfigMap(), hasKey(indexName));
         assertThat(resultSamplingMetadata.getIndexToSamplingConfigMap().get(indexName), equalTo(config));
     }
-    
+
     /**
      * Tests action name and configuration.
      */

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/sampling/TransportPutSampleConfigurationActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/sampling/TransportPutSampleConfigurationActionTests.java
@@ -189,23 +189,7 @@ public class TransportPutSampleConfigurationActionTests extends ESTestCase {
         assertThat(resultSamplingMetadata.getIndexToSamplingConfigMap(), hasKey(indexName));
         assertThat(resultSamplingMetadata.getIndexToSamplingConfigMap().get(indexName), equalTo(config));
     }
-
-    /**
-     * Tests checkBlock method (should return null for no blocks).
-     */
-    public void testCheckBlock() {
-        PutSampleConfigurationAction.Request request = new PutSampleConfigurationAction.Request(
-            createRandomSamplingConfiguration(),
-            randomTimeValue(100, 200),
-            randomTimeValue(100, 200)
-        );
-        request.indices(new String[] { randomIdentifier() });
-        ClusterState clusterState = ClusterState.EMPTY_STATE;
-
-        // checkBlock should return null (no blocks)
-        assertThat(action.checkBlock(request, clusterState), nullValue());
-    }
-
+    
     /**
      * Tests action name and configuration.
      */

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/sampling/TransportPutSampleConfigurationActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/sampling/TransportPutSampleConfigurationActionTests.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.action.admin.indices.sampling;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.metadata.ProjectMetadata;
+import org.elasticsearch.cluster.project.ProjectResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.ingest.SamplingService;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for TransportPutSampleConfigurationAction.
+ * Tests the logic in isolation using mocks for dependencies.
+ */
+public class TransportPutSampleConfigurationActionTests extends ESTestCase {
+
+    private ProjectResolver projectResolver;
+    private IndexNameExpressionResolver indexNameExpressionResolver;
+    private SamplingService samplingService;
+    private TransportPutSampleConfigurationAction action;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        TransportService transportService = mock(TransportService.class);
+        ClusterService clusterService = mock(ClusterService.class);
+        ThreadPool threadPool = mock(ThreadPool.class);
+        ActionFilters actionFilters = mock(ActionFilters.class);
+        projectResolver = mock(ProjectResolver.class);
+        indexNameExpressionResolver = mock(IndexNameExpressionResolver.class);
+        samplingService = mock(SamplingService.class);
+
+        // Mock thread context
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+
+        action = new TransportPutSampleConfigurationAction(
+            transportService,
+            clusterService,
+            threadPool,
+            actionFilters,
+            projectResolver,
+            indexNameExpressionResolver,
+            samplingService
+        );
+    }
+
+    /**
+     * Tests successful masterOperation execution and verifies sampling metadata updates.
+     */
+    public void testMasterOperationSuccess() throws Exception {
+        // Setup test data
+        ProjectId projectId = randomProjectIdOrDefault();
+        String indexName = randomIdentifier();
+        SamplingConfiguration config = createRandomSamplingConfiguration();
+        TimeValue masterNodeTimeout = randomTimeValue(100, 200);
+        TimeValue ackTimeout = randomTimeValue(100, 200);
+
+        PutSampleConfigurationAction.Request request = new PutSampleConfigurationAction.Request(config, masterNodeTimeout, ackTimeout);
+        request.indices(indexName);
+
+        // Create initial cluster state with project metadata
+        ProjectMetadata initialProjectMetadata = ProjectMetadata.builder(projectId).build();
+        ClusterState initialClusterState = ClusterState.builder(ClusterState.EMPTY_STATE)
+            .putProjectMetadata(initialProjectMetadata)
+            .build();
+
+        Task task = mock(Task.class);
+
+        // Setup mocks
+        when(projectResolver.getProjectId()).thenReturn(projectId);
+
+        // Create updated cluster state with sampling metadata
+        Map<String, SamplingConfiguration> indexToSampleConfigMap = new HashMap<>();
+        indexToSampleConfigMap.put(indexName, config);
+        SamplingMetadata samplingMetadata = new SamplingMetadata(indexToSampleConfigMap);
+
+        ProjectMetadata updatedProjectMetadata = ProjectMetadata.builder(projectId)
+            .putCustom(SamplingMetadata.TYPE, samplingMetadata)
+            .build();
+        ClusterState updatedClusterState = ClusterState.builder(initialClusterState).putProjectMetadata(updatedProjectMetadata).build();
+
+        // Mock samplingService to simulate the actual cluster state update
+        AtomicReference<ClusterState> capturedClusterState = new AtomicReference<>();
+        doAnswer(invocation -> {
+            ActionListener<AcknowledgedResponse> listener = invocation.getArgument(5);
+
+            // Simulate the sampling service updating cluster state and calling listener
+            capturedClusterState.set(updatedClusterState);
+            listener.onResponse(AcknowledgedResponse.TRUE);
+            return null;
+        }).when(samplingService)
+            .updateSampleConfiguration(
+                eq(projectId),
+                eq(indexName),
+                eq(config),
+                eq(request.masterNodeTimeout()),
+                eq(request.ackTimeout()),
+                any()
+            );
+
+        // Test execution with CountDownLatch to handle async operation
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<AcknowledgedResponse> responseRef = new AtomicReference<>();
+        AtomicReference<Exception> exceptionRef = new AtomicReference<>();
+
+        ActionListener<AcknowledgedResponse> testListener = new ActionListener<AcknowledgedResponse>() {
+            @Override
+            public void onResponse(AcknowledgedResponse response) {
+                responseRef.set(response);
+                latch.countDown();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                exceptionRef.set(e);
+                latch.countDown();
+            }
+        };
+
+        action.masterOperation(task, request, initialClusterState, testListener);
+
+        // Wait for async operation to complete
+        assertTrue("Operation should complete within timeout", latch.await(5, TimeUnit.SECONDS));
+
+        // Verify results
+        assertThat(responseRef.get(), not(nullValue()));
+        assertThat(responseRef.get().isAcknowledged(), equalTo(true));
+        assertThat(exceptionRef.get(), nullValue());
+
+        // Verify interactions
+        verify(projectResolver).getProjectId();
+        verify(samplingService).updateSampleConfiguration(
+            eq(projectId),
+            eq(indexName),
+            eq(config),
+            eq(request.masterNodeTimeout()),
+            eq(request.ackTimeout()),
+            any()
+        );
+
+        // Verify cluster state change
+        ClusterState resultClusterState = capturedClusterState.get();
+        assertThat(resultClusterState, not(nullValue()));
+
+        ProjectMetadata resultProjectMetadata = resultClusterState.getMetadata().getProject(projectId);
+        assertThat(resultProjectMetadata, not(nullValue()));
+
+        SamplingMetadata resultSamplingMetadata = resultProjectMetadata.custom(SamplingMetadata.TYPE);
+        assertThat(resultSamplingMetadata, not(nullValue()));
+        assertThat(resultSamplingMetadata.getIndexToSamplingConfigMap(), hasKey(indexName));
+        assertThat(resultSamplingMetadata.getIndexToSamplingConfigMap().get(indexName), equalTo(config));
+    }
+
+    /**
+     * Tests checkBlock method (should return null for no blocks).
+     */
+    public void testCheckBlock() {
+        PutSampleConfigurationAction.Request request = new PutSampleConfigurationAction.Request(
+            createRandomSamplingConfiguration(),
+            randomTimeValue(100, 200),
+            randomTimeValue(100, 200)
+        );
+        request.indices(new String[] { randomIdentifier() });
+        ClusterState clusterState = ClusterState.EMPTY_STATE;
+
+        // checkBlock should return null (no blocks)
+        assertThat(action.checkBlock(request, clusterState), nullValue());
+    }
+
+    /**
+     * Tests action name and configuration.
+     */
+    public void testActionConfiguration() {
+        // Verify action is properly configured
+        assertThat(action.actionName, equalTo(PutSampleConfigurationAction.NAME));
+    }
+
+    private SamplingConfiguration createRandomSamplingConfiguration() {
+        return new SamplingConfiguration(
+            randomDoubleBetween(0.0, 1.0, true),
+            randomBoolean() ? null : randomIntBetween(1, SamplingConfiguration.MAX_SAMPLES_LIMIT),
+            randomBoolean() ? null : ByteSizeValue.ofGb(randomLongBetween(1, SamplingConfiguration.MAX_SIZE_LIMIT_GIGABYTES)),
+            randomBoolean() ? null : TimeValue.timeValueDays(randomLongBetween(1, SamplingConfiguration.MAX_TIME_TO_LIVE_DAYS)),
+            randomBoolean() ? null : randomAlphaOfLength(10)
+        );
+    }
+}

--- a/server/src/test/java/org/elasticsearch/ingest/UpdateSamplingConfigurationExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/UpdateSamplingConfigurationExecutorTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.cluster.project.ProjectResolver;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
@@ -46,6 +47,10 @@ public class UpdateSamplingConfigurationExecutorTests extends ESTestCase {
         super.setUp();
         MockitoAnnotations.openMocks(this);
         executor = new SamplingService.UpdateSamplingConfigurationExecutor(projectResolver);
+
+        // Mock the cluster state metadata chain
+        when(clusterState.getMetadata()).thenReturn(metadata);
+        when(metadata.settings()).thenReturn(Settings.EMPTY);
     }
 
     public void testExecuteTaskWithUpperBoundLimit() {
@@ -92,3 +97,4 @@ public class UpdateSamplingConfigurationExecutorTests extends ESTestCase {
     }
 
 }
+

--- a/server/src/test/java/org/elasticsearch/ingest/UpdateSamplingConfigurationExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/UpdateSamplingConfigurationExecutorTests.java
@@ -34,7 +34,8 @@ public class UpdateSamplingConfigurationExecutorTests extends ESTestCase {
     @Mock
     private ProjectResolver projectResolver;
 
-    @Mock SamplingService samplingService;
+    @Mock
+    SamplingService samplingService;
 
     @Mock
     private ClusterState clusterState;

--- a/server/src/test/java/org/elasticsearch/ingest/UpdateSamplingConfigurationExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/UpdateSamplingConfigurationExecutorTests.java
@@ -91,11 +91,4 @@ public class UpdateSamplingConfigurationExecutorTests extends ESTestCase {
         assertThat(exception.getMessage(), containsString("Maximum number of sampling configurations (100) already reached"));
     }
 
-    private void assertDoesNotThrow(Runnable runnable) {
-        try {
-            runnable.run();
-        } catch (Exception e) {
-            fail("Expected no exception but got: " + e.getClass().getSimpleName() + " with message: " + e.getMessage());
-        }
-    }
 }

--- a/server/src/test/java/org/elasticsearch/ingest/UpdateSamplingConfigurationExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/UpdateSamplingConfigurationExecutorTests.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.ingest;
+
+import org.elasticsearch.action.admin.indices.sampling.SamplingConfiguration;
+import org.elasticsearch.action.admin.indices.sampling.SamplingMetadata;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.metadata.ProjectMetadata;
+import org.elasticsearch.cluster.project.ProjectResolver;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.ESTestCase;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.Mockito.when;
+
+public class UpdateSamplingConfigurationExecutorTests extends ESTestCase {
+
+    @Mock
+    private ProjectResolver projectResolver;
+
+    @Mock
+    private ClusterState clusterState;
+
+    @Mock
+    private Metadata metadata;
+
+    private SamplingService.UpdateSamplingConfigurationExecutor executor;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        MockitoAnnotations.openMocks(this);
+        executor = new SamplingService.UpdateSamplingConfigurationExecutor(projectResolver);
+    }
+
+    public void testExecuteTaskWithUpperBoundLimit() {
+        // Create a project metadata with 100 existing sampling configurations (the maximum)
+        Map<String, SamplingConfiguration> existingConfigs = new HashMap<>();
+        SamplingConfiguration defaultConfig = new SamplingConfiguration(
+            0.5d,
+            50,
+            ByteSizeValue.ofMb(10),
+            TimeValue.timeValueHours(1),
+            null
+        );
+
+        // Add 100 configurations to reach the limit
+        for (int i = 0; i < 100; i++) {
+            existingConfigs.put("existing-index-" + i, defaultConfig);
+        }
+
+        SamplingMetadata existingSamplingMetadata = new SamplingMetadata(existingConfigs);
+        ProjectMetadata projectMetadata = ProjectMetadata.builder(ProjectId.DEFAULT)
+            .putCustom(SamplingMetadata.TYPE, existingSamplingMetadata)
+            .build();
+
+        when(projectResolver.getProjectMetadata(clusterState)).thenReturn(projectMetadata);
+
+        // Try to add the 101st configuration - this should fail
+        String newIndexName = "new-index-101";
+        SamplingConfiguration newConfig = new SamplingConfiguration(0.8d, 80, ByteSizeValue.ofMb(20), TimeValue.timeValueHours(2), null);
+
+        SamplingService.UpdateSamplingConfigurationTask task = new SamplingService.UpdateSamplingConfigurationTask(
+            ProjectId.DEFAULT,
+            newIndexName,
+            newConfig,
+            TimeValue.timeValueSeconds(30),
+            null // ActionListener not needed for this test
+        );
+
+        // Execute the task and expect an IllegalStateException
+        IllegalStateException exception = expectThrows(IllegalStateException.class, () -> { executor.executeTask(task, clusterState); });
+
+        // Verify the exception message contains expected information
+        assertThat(exception.getMessage(), containsString("Cannot add sampling configuration for index [" + newIndexName + "]"));
+        assertThat(exception.getMessage(), containsString("Maximum number of sampling configurations (100) already reached"));
+    }
+
+    private void assertDoesNotThrow(Runnable runnable) {
+        try {
+            runnable.run();
+        } catch (Exception e) {
+            fail("Expected no exception but got: " + e.getClass().getSimpleName() + " with message: " + e.getMessage());
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/ingest/UpdateSamplingConfigurationExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/UpdateSamplingConfigurationExecutorTests.java
@@ -97,4 +97,3 @@ public class UpdateSamplingConfigurationExecutorTests extends ESTestCase {
     }
 
 }
-

--- a/server/src/test/java/org/elasticsearch/ingest/UpdateSamplingConfigurationExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/UpdateSamplingConfigurationExecutorTests.java
@@ -34,6 +34,8 @@ public class UpdateSamplingConfigurationExecutorTests extends ESTestCase {
     @Mock
     private ProjectResolver projectResolver;
 
+    @Mock SamplingService samplingService;
+
     @Mock
     private ClusterState clusterState;
 
@@ -46,7 +48,7 @@ public class UpdateSamplingConfigurationExecutorTests extends ESTestCase {
     public void setUp() throws Exception {
         super.setUp();
         MockitoAnnotations.openMocks(this);
-        executor = new SamplingService.UpdateSamplingConfigurationExecutor(projectResolver);
+        executor = new SamplingService.UpdateSamplingConfigurationExecutor(projectResolver, samplingService);
 
         // Mock the cluster state metadata chain
         when(clusterState.getMetadata()).thenReturn(metadata);

--- a/server/src/test/java/org/elasticsearch/ingest/UpdateSamplingConfigurationExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/UpdateSamplingConfigurationExecutorTests.java
@@ -52,7 +52,6 @@ public class UpdateSamplingConfigurationExecutorTests extends ESTestCase {
     @Mock
     private Metadata metadata;
 
-    private SamplingService samplingService;
     private SamplingService.UpdateSamplingConfigurationExecutor executor;
 
     @Override
@@ -61,8 +60,7 @@ public class UpdateSamplingConfigurationExecutorTests extends ESTestCase {
         MockitoAnnotations.openMocks(this);
 
         // Create a real SamplingService with mocked dependencies
-        samplingService = new SamplingService(scriptService, clusterService, projectResolver, timeSupplier);
-        executor = new SamplingService.UpdateSamplingConfigurationExecutor(projectResolver, samplingService);
+        executor = new SamplingService.UpdateSamplingConfigurationExecutor();
 
         // Set up settings with MAX_CONFIGURATIONS_SETTING = 100 (the default value)
         Settings settings = Settings.builder().put("sampling.max_configurations", 100).build();

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -659,6 +659,7 @@ public class Constants {
         "internal:admin/repository/verify",
         "internal:admin/repository/verify/coordinate",
         "indices:admin/sample",
+        "indices:admin/sample/config/update",
         "indices:admin/sample/stats"
     ).filter(Objects::nonNull).collect(Collectors.toUnmodifiableSet());
 }


### PR DESCRIPTION
This PR adds the PUT sampling config action to allow users to set sampling configs

Usage example:
```
PUT /<index>/_sample/config
{
  "rate": ".05", // required
  "max_samples": 20 // optional, buffer size, defaults to 10
  "max_size": 10mb, // optional, max size of documents, defaults to 1mb
  "time_to_live": 1d, // optional, time after which documents may be deleted, defaults to never
  "if": "ctx?.network?.name == 'Guest'" // optional, same syntax as pipeline conditional
}
```
After this call, the configuration will remain in place until it is deleted. The configuration is stored in a new custom section of the project metadata in the cluster state. The new custom section will contain a map of data stream or index name to sampling configuration. It will not be possible to have more than one configuration at a time for a single index or data stream. All Elasticsearch users will share the same configurations within a project. The total number of configurations that will be allowed to exist at any given time will be limited to a set number (exactly what that number will be is to be determined). Any time a configuration is updated using this API, its buffer is cleared out.
