### PR TITLE
Fix and unmute tests in DataStreamIndexSettingsProviderTests

### DIFF
--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProviderTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProviderTests.java
@@ -71,7 +71,9 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
         String dataStreamName = "logs-app1";
 
         Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Settings settings = Settings.EMPTY;
+        Settings settings = Settings.builder()
+            .put("index.dimensions_tsid_strategy_enabled", indexDimensionsTsidStrategyEnabledSetting)
+            .build();
         String mapping = """
             {
                 "_doc": {
@@ -117,11 +119,8 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
         Settings result = additionalSettings.build();
         // The index.time_series.end_time setting requires index.mode to be set to time_series adding it here so that we read this setting:
         // (in production the index.mode setting is usually provided in an index or component template)
-        result = builder().put(result)
-            .put("index.mode", "time_series")
-            .put("index.dimensions_tsid_strategy_enabled", indexDimensionsTsidStrategyEnabledSetting)
-            .build();
-        assertThat(result.size(), equalTo(5));
+        result = builder().put(result).put("index.mode", "time_series").build();
+        assertThat(result.size(), equalTo(4));
         assertThat(IndexSettings.MODE.get(result), equalTo(IndexMode.TIME_SERIES));
         assertThat(IndexSettings.TIME_SERIES_START_TIME.get(result), equalTo(now.minusMillis(DEFAULT_LOOK_BACK_TIME.getMillis())));
         assertThat(IndexSettings.TIME_SERIES_END_TIME.get(result), equalTo(now.plusMillis(DEFAULT_LOOK_AHEAD_TIME.getMillis())));
@@ -187,7 +186,9 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
         String dataStreamName = "logs-app1";
 
         Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        Settings settings = Settings.EMPTY;
+        Settings settings = Settings.builder()
+            .put("index.dimensions_tsid_strategy_enabled", indexDimensionsTsidStrategyEnabledSetting)
+            .build();
         String mapping1 = """
             {
                 "_doc": {
@@ -251,9 +252,8 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
         // (in production the index.mode setting is usually provided in an index or component template)
         result = builder().put(result)
             .put("index.mode", "time_series")
-            .put("index.dimensions_tsid_strategy_enabled", indexDimensionsTsidStrategyEnabledSetting)
             .build();
-        assertThat(result.size(), equalTo(5));
+        assertThat(result.size(), equalTo(4));
         assertThat(IndexSettings.MODE.get(result), equalTo(IndexMode.TIME_SERIES));
         assertThat(IndexSettings.TIME_SERIES_START_TIME.get(result), equalTo(now.minusMillis(DEFAULT_LOOK_BACK_TIME.getMillis())));
         assertThat(IndexSettings.TIME_SERIES_END_TIME.get(result), equalTo(now.plusMillis(DEFAULT_LOOK_AHEAD_TIME.getMillis())));

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProviderTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProviderTests.java
@@ -250,9 +250,7 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
         Settings result = additionalSettings.build();
         // The index.time_series.end_time setting requires index.mode to be set to time_series adding it here so that we read this setting:
         // (in production the index.mode setting is usually provided in an index or component template)
-        result = builder().put(result)
-            .put("index.mode", "time_series")
-            .build();
+        result = builder().put(result).put("index.mode", "time_series").build();
         assertThat(result.size(), equalTo(4));
         assertThat(IndexSettings.MODE.get(result), equalTo(IndexMode.TIME_SERIES));
         assertThat(IndexSettings.TIME_SERIES_START_TIME.get(result), equalTo(now.minusMillis(DEFAULT_LOOK_BACK_TIME.getMillis())));

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -612,15 +612,9 @@ tests:
 - class: org.elasticsearch.xpack.esql.action.CrossClusterQueryWithPartialResultsIT
   method: testOneRemoteClusterPartial
   issue: https://github.com/elastic/elasticsearch/issues/124055
-- class: org.elasticsearch.datastreams.DataStreamIndexSettingsProviderTests
-  method: testGetAdditionalIndexSettingsMappingsMerging
-  issue: https://github.com/elastic/elasticsearch/issues/135884
 - class: org.elasticsearch.xpack.esql.action.EsqlActionBreakerIT
   method: testTopNPushedToLuceneOnSortedIndex
   issue: https://github.com/elastic/elasticsearch/issues/135939
-- class: org.elasticsearch.datastreams.DataStreamIndexSettingsProviderTests
-  method: testGetAdditionalIndexSettings
-  issue: https://github.com/elastic/elasticsearch/issues/135972
 - class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
   method: test {yaml=indices.get_sample/10_basic/Test get sample for index with no sample config}
   issue: https://github.com/elastic/elasticsearch/issues/135975


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch/issues/135972 and https://github.com/elastic/elasticsearch/issues/135884

(I've tested the whole `DataStreamIndexSettingsProviderTests` locally with 100 iterations)