### PR TITLE
Use "node.processors" setting starting from 7.4.0

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -1407,7 +1407,7 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         // Limit the number of allocated processors for all nodes in the cluster by default.
         // This is to ensure that the tests run consistently across different environments.
         String processorCount = shouldConfigureTestClustersWithOneProcessor() ? "1" : "2";
-        if (getVersion().onOrAfter("7.6.0")) {
+        if (getVersion().onOrAfter("7.4.0")) {
             baseConfig.put("node.processors", processorCount);
         } else {
             baseConfig.put("processors", processorCount);

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultSettingsProvider.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultSettingsProvider.java
@@ -44,7 +44,7 @@ public class DefaultSettingsProvider implements SettingsProvider {
 
         // Limit the number of allocated processors for all nodes in the cluster by default.
         // This is to ensure that the tests run consistently across different environments.
-        if (nodeSpec.getVersion().onOrAfter("7.6.0")) {
+        if (nodeSpec.getVersion().onOrAfter("7.4.0")) {
             settings.put("node.processors", "2");
         } else {
             settings.put("processors", "2");


### PR DESCRIPTION
Setting `node.processor` has been introduced in 7.4.0 and `processors` has been deprecated at this version.
This change fixes failures of some tests caused by the deprecation message.