### PR TITLE
[8.18] [9.0][Build]Remove superflous ironbank docker test (#136170)

### DIFF
--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -1181,23 +1181,6 @@ public class DockerTests extends PackagingTestCase {
     }
 
     /**
-     * Check that the Iron Bank image doesn't define extra labels
-     */
-    public void test310IronBankImageHasNoAdditionalLabels() throws Exception {
-        assumeTrue(distribution.packaging == Packaging.DOCKER_IRON_BANK);
-
-        final Map<String, String> labels = getImageLabels(distribution);
-
-        final Set<String> labelKeys = labels.keySet();
-
-        // We can't just assert that the labels map is empty, because it can inherit labels from its base.
-        // This is certainly the case when we build the Iron Bank image using a UBI base. It is unknown
-        // if that is true for genuine Iron Bank builds.
-        assertFalse(labelKeys.stream().anyMatch(l -> l.startsWith("org.label-schema.")));
-        assertFalse(labelKeys.stream().anyMatch(l -> l.startsWith("org.opencontainers.")));
-    }
-
-    /**
      * Check that the Cloud image contains the required Beats
      */
     public void test400CloudImageBundlesBeats() {


### PR DESCRIPTION
# Backport

This will backport the following commits from `9.0` to `8.18`:
 - [[9.0][Build]Remove superflous ironbank docker test (#136170)](https://github.com/elastic/elasticsearch/pull/136170)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)