### PR TITLE
Mute text embedding CSV tests.

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -687,7 +687,7 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeForkIT
   method: test {csv-spec:math.LeastGreatestMany}
   issue: https://github.com/elastic/elasticsearch/issues/136161
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeForkIT
+- class: org.elasticsearch.xpack.esql.qa.*.EsqlSpecIT
   method: test {csv-spec:text-embedding.*}
   issue: https://github.com/elastic/elasticsearch/issues/136090
 

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -642,12 +642,6 @@ tests:
 - class: org.elasticsearch.xpack.security.authz.microsoft.MicrosoftGraphAuthzPluginIT
   method: testConcurrentAuthentication
   issue: https://github.com/elastic/elasticsearch/issues/135777
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecIT
-  method: test {csv-spec:math.NegateIntLongDouble}
-  issue: https://github.com/elastic/elasticsearch/issues/136089
-- class: org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecIT
-  method: test {csv-spec:text-embedding.Text_embedding with multiple knn queries in fork}
-  issue: https://github.com/elastic/elasticsearch/issues/136090
 - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
   method: test {csv-spec:fork.ForkBranchWithInlineStats}
   issue: https://github.com/elastic/elasticsearch/issues/136091
@@ -675,9 +669,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeForkIT
   method: test {csv-spec:text-embedding.Text_embedding with knn (inline) on semantic_text_dense_field}
   issue: https://github.com/elastic/elasticsearch/issues/136142
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {csv-spec:text-embedding.Text_embedding with multiple knn queries in fork}
-  issue: https://github.com/elastic/elasticsearch/issues/136090
 - class: org.elasticsearch.versioning.ConcurrentSeqNoVersioningIT
   method: testSeqNoCASLinearizability
   issue: https://github.com/elastic/elasticsearch/issues/117249

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -697,7 +697,7 @@ tests:
   method: test {csv-spec:math.LeastGreatestMany}
   issue: https://github.com/elastic/elasticsearch/issues/136161
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeForkIT
-  method: test {csv-spec:Text_embedding*}
+  method: test {csv-spec:text-embedding.*}
   issue: https://github.com/elastic/elasticsearch/issues/136090
 
 # Examples:

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -696,6 +696,9 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeForkIT
   method: test {csv-spec:math.LeastGreatestMany}
   issue: https://github.com/elastic/elasticsearch/issues/136161
+- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeForkIT
+  method: test {csv-spec:Text_embedding*}
+  issue: https://github.com/elastic/elasticsearch/issues/136090
 
 # Examples:
 #


### PR DESCRIPTION
Text embedding CSV specs are causing some trouble to other CSV tests.

https://github.com/elastic/elasticsearch/issues/136089
https://github.com/elastic/elasticsearch/issues/136090