### PR TITLE
Updates FailedToCommitClusterStateException javadoc

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/FailedToCommitClusterStateException.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/FailedToCommitClusterStateException.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 
 /**
  * Exception indicating a cluster state update was published and may or may not have been committed.
- * This exception can only be thrown by master nodes.
+ * This exception can only be thrown by the master node.
  * <p>
  * If this exception is thrown, then the cluster state update was published, but is not guaranteed
  * to be committed, including the next master node. This exception should only be thrown when there is

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/FailedToCommitClusterStateException.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/FailedToCommitClusterStateException.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 
 /**
  * Exception indicating a cluster state update was published and may or may not have been committed.
+ * This exception can only be thrown by master nodes.
  * <p>
  * If this exception is thrown, then the cluster state update was published, but is not guaranteed
  * to be committed, including the next master node. This exception should only be thrown when there is


### PR DESCRIPTION
Update the `FailedToCommitClusterStateException` javadoc to specify that it can only be thrown by master nodes.

Relates to: ES-13061