### PR TITLE
Fix bug with async direct IO fetching that caused misreading of bytes

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/store/AsyncDirectIODirectoryTests.java
+++ b/server/src/test/java/org/elasticsearch/index/store/AsyncDirectIODirectoryTests.java
@@ -44,6 +44,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.apache.lucene.store.FSDirectory.open;
+import static org.elasticsearch.test.ESTestCase.randomIntBetween;
 
 public class AsyncDirectIODirectoryTests extends BaseDirectoryTestCase {
 
@@ -74,7 +75,7 @@ public class AsyncDirectIODirectoryTests extends BaseDirectoryTestCase {
 
     @Override
     protected Directory getDirectory(Path path) throws IOException {
-        return new FsDirectoryFactory.AlwaysDirectIODirectory(open(path), 8192, 8192, 32);
+        return new FsDirectoryFactory.AlwaysDirectIODirectory(open(path), 8192, 8192, randomIntBetween(0, 32));
     }
 
     public void testIndexWriteRead() throws IOException {


### PR DESCRIPTION
This appeared on windows as the file block size was smaller, causing more prefetches to occur, and running out of prefetch slots, and queueing up future prefetches. 

When reading in from the queued prefetches, I didn't account for adjusting the reverse `slot -> pos` mapping as well as the `pos -> slot` mapping. This would break down stream logic, shifting around positions incorrectly. 

I have fixed the bug, adjusted the tests to randomly have few or many prefetching slots, and adding a consistency check when assertions are enabled. 

FYI, I verified on a previously failing windows box, that this is fixes the failure.

closes: https://github.com/elastic/elasticsearch/issues/136151

related: https://github.com/elastic/elasticsearch/pull/134803

marking as non-issue as this hasn't been deployed yet.