### PR TITLE
[9.2] Removing elastic reranker chunking feature flag and allow return_documents to be false (#136045)

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/FeatureFlag.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/FeatureFlag.java
@@ -25,8 +25,7 @@ public enum FeatureFlag {
         "es.index_dimensions_tsid_optimization_feature_flag_enabled=true",
         Version.fromString("9.2.0"),
         null
-    ),
-    ELASTIC_RERANKER_CHUNKING("es.elastic_reranker_chunking_long_documents=true", Version.fromString("9.2.0"), null);
+    );
 
     public final String systemProperty;
     public final Version from;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/chunking/RerankRequestChunker.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/chunking/RerankRequestChunker.java
@@ -53,10 +53,13 @@ public class RerankRequestChunker {
         return chunkedInputs;
     }
 
-    public ActionListener<InferenceServiceResults> parseChunkedRerankResultsListener(ActionListener<InferenceServiceResults> listener) {
+    public ActionListener<InferenceServiceResults> parseChunkedRerankResultsListener(
+        ActionListener<InferenceServiceResults> listener,
+        boolean returnDocuments
+    ) {
         return ActionListener.wrap(results -> {
             if (results instanceof RankedDocsResults rankedDocsResults) {
-                listener.onResponse(parseRankedDocResultsForChunks(rankedDocsResults));
+                listener.onResponse(parseRankedDocResultsForChunks(rankedDocsResults, returnDocuments));
 
             } else {
                 listener.onFailure(new IllegalArgumentException("Expected RankedDocsResults but got: " + results.getClass()));
@@ -65,7 +68,7 @@ public class RerankRequestChunker {
         }, listener::onFailure);
     }
 
-    private RankedDocsResults parseRankedDocResultsForChunks(RankedDocsResults rankedDocsResults) {
+    private RankedDocsResults parseRankedDocResultsForChunks(RankedDocsResults rankedDocsResults, boolean returnDocuments) {
         List<RankedDocsResults.RankedDoc> topRankedDocs = new ArrayList<>();
         Set<Integer> docIndicesSeen = new HashSet<>();
 
@@ -80,7 +83,7 @@ public class RerankRequestChunker {
                 RankedDocsResults.RankedDoc updatedRankedDoc = new RankedDocsResults.RankedDoc(
                     docIndex,
                     rankedDoc.relevanceScore(),
-                    inputs.get(docIndex)
+                    returnDocuments ? inputs.get(docIndex) : null
                 );
                 topRankedDocs.add(updatedRankedDoc);
                 docIndicesSeen.add(docIndex);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticRerankerServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticRerankerServiceSettings.java
@@ -22,7 +22,6 @@ import java.util.Map;
 
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalEnum;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalPositiveInteger;
-import static org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalService.ELASTIC_RERANKER_CHUNKING;
 import static org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalService.RERANKER_ID;
 
 public class ElasticRerankerServiceSettings extends ElasticsearchInternalServiceSettings {
@@ -102,30 +101,26 @@ public class ElasticRerankerServiceSettings extends ElasticsearchInternalService
         ValidationException validationException = new ValidationException();
         var baseSettings = ElasticsearchInternalServiceSettings.fromMap(map, validationException);
 
-        LongDocumentStrategy longDocumentStrategy = null;
-        Integer maxChunksPerDoc = null;
-        if (ELASTIC_RERANKER_CHUNKING.isEnabled()) {
-            longDocumentStrategy = extractOptionalEnum(
-                map,
-                LONG_DOCUMENT_STRATEGY,
-                ModelConfigurations.SERVICE_SETTINGS,
-                LongDocumentStrategy::fromString,
-                EnumSet.allOf(LongDocumentStrategy.class),
-                validationException
-            );
+        LongDocumentStrategy longDocumentStrategy = extractOptionalEnum(
+            map,
+            LONG_DOCUMENT_STRATEGY,
+            ModelConfigurations.SERVICE_SETTINGS,
+            LongDocumentStrategy::fromString,
+            EnumSet.allOf(LongDocumentStrategy.class),
+            validationException
+        );
 
-            maxChunksPerDoc = extractOptionalPositiveInteger(
-                map,
-                MAX_CHUNKS_PER_DOC,
-                ModelConfigurations.SERVICE_SETTINGS,
-                validationException
-            );
+        Integer maxChunksPerDoc = extractOptionalPositiveInteger(
+            map,
+            MAX_CHUNKS_PER_DOC,
+            ModelConfigurations.SERVICE_SETTINGS,
+            validationException
+        );
 
-            if (maxChunksPerDoc != null && (longDocumentStrategy == null || longDocumentStrategy == LongDocumentStrategy.TRUNCATE)) {
-                validationException.addValidationError(
-                    "The [" + MAX_CHUNKS_PER_DOC + "] setting requires [" + LONG_DOCUMENT_STRATEGY + "] to be set to [chunk]"
-                );
-            }
+        if (maxChunksPerDoc != null && (longDocumentStrategy == null || longDocumentStrategy == LongDocumentStrategy.TRUNCATE)) {
+            validationException.addValidationError(
+                "The [" + MAX_CHUNKS_PER_DOC + "] setting requires [" + LONG_DOCUMENT_STRATEGY + "] to be set to [chunk]"
+            );
         }
 
         if (validationException.validationErrors().isEmpty() == false) {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/chunking/RerankRequestChunkerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/chunking/RerankRequestChunkerTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.inference.results.RankedDocsResults;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static java.lang.Math.max;
@@ -111,7 +112,8 @@ public class RerankRequestChunkerTests extends ESTestCase {
             ActionListener.wrap(
                 results -> fail("Expected failure but got: " + results.getClass()),
                 e -> assertTrue(e instanceof IllegalArgumentException && e.getMessage().contains("Expected RankedDocsResults"))
-            )
+            ),
+            randomBoolean()
         );
 
         listener.onResponse(new InferenceServiceResults() {
@@ -124,120 +126,152 @@ public class RerankRequestChunkerTests extends ESTestCase {
             assertThat(results, instanceOf(RankedDocsResults.class));
             var rankedDocResults = (RankedDocsResults) results;
             assertEquals(0, rankedDocResults.getRankedDocs().size());
-        }, e -> fail("Expected successful parsing but got failure: " + e)));
+        }, e -> fail("Expected successful parsing but got failure: " + e)), randomBoolean());
         listener.onResponse(new RankedDocsResults(List.of()));
     }
 
     public void testParseChunkedRerankResultsListener_SingleInputWithoutChunking() {
         var inputs = List.of(generateTestText(10));
         var chunker = new RerankRequestChunker(TEST_SENTENCE, inputs, null);
+        var returnDocuments = randomBoolean();
+        var relevanceScores = generateRelevanceScores(1);
         var listener = chunker.parseChunkedRerankResultsListener(ActionListener.wrap(results -> {
             assertThat(results, instanceOf(RankedDocsResults.class));
             var rankedDocResults = (RankedDocsResults) results;
-            assertEquals(1, rankedDocResults.getRankedDocs().size());
-        }, e -> fail("Expected successful parsing but got failure: " + e)));
+            var expectedRankedDocs = List.of(
+                new RankedDocsResults.RankedDoc(0, relevanceScores.get(0), returnDocuments ? inputs.get(0) : null)
+            );
+            assertEquals(expectedRankedDocs, rankedDocResults.getRankedDocs());
+        }, e -> fail("Expected successful parsing but got failure: " + e)), returnDocuments);
 
         var chunkedInputs = chunker.getChunkedInputs();
         assertEquals(1, chunkedInputs.size());
-        listener.onResponse(new RankedDocsResults(List.of(new RankedDocsResults.RankedDoc(0, 1.0f, chunkedInputs.get(0)))));
+        listener.onResponse(
+            new RankedDocsResults(List.of(new RankedDocsResults.RankedDoc(0, relevanceScores.get(0), chunkedInputs.get(0))))
+        );
     }
 
-    public void testParseChunkedRerankResultsListener_SingleInputWithChunking() {
+    public void testParseChunkedRerankResultsListener_SingleInputWithChunkingWithFirstChunkRelevanceScoreHighest() {
         var inputs = List.of(generateTestText(100));
-        var relevanceScore1 = randomFloatBetween(0, 1, true);
-        var relevanceScore2 = randomFloatBetween(0, 1, true);
+        var relevanceScores = List.of(1f, 0.5f, 0.3f);
         var chunker = new RerankRequestChunker(TEST_SENTENCE, inputs, null);
+        var returnDocuments = randomBoolean();
         var listener = chunker.parseChunkedRerankResultsListener(ActionListener.wrap(results -> {
             assertThat(results, instanceOf(RankedDocsResults.class));
             var rankedDocResults = (RankedDocsResults) results;
-            assertEquals(1, rankedDocResults.getRankedDocs().size());
-            var expectedRankedDocs = List.of(new RankedDocsResults.RankedDoc(0, max(relevanceScore1, relevanceScore2), inputs.get(0)));
+            var expectedRankedDocs = List.of(
+                new RankedDocsResults.RankedDoc(0, relevanceScores.get(0), returnDocuments ? inputs.get(0) : null)
+            );
             assertEquals(expectedRankedDocs, rankedDocResults.getRankedDocs());
-        }, e -> fail("Expected successful parsing but got failure: " + e)));
+        }, e -> fail("Expected successful parsing but got failure: " + e)), returnDocuments);
 
         var chunkedInputs = chunker.getChunkedInputs();
         assertEquals(3, chunkedInputs.size());
-        var rankedDocsResults = List.of(
-            new RankedDocsResults.RankedDoc(0, relevanceScore1, chunkedInputs.get(0)),
-            new RankedDocsResults.RankedDoc(1, relevanceScore2, chunkedInputs.get(1))
-        );
-        // TODO: Sort this so that the assumption that the results are in order holds
-        listener.onResponse(new RankedDocsResults(rankedDocsResults));
+        listener.onResponse(new RankedDocsResults(generateRankedDocs(relevanceScores, chunkedInputs)));
     }
 
-    public void testParseChunkedRerankResultsListener_MultipleInputsWithoutChunking() {
-        var inputs = List.of(generateTestText(10), generateTestText(10));
+    public void testParseChunkedRerankResultsListener_SingleInputWithChunkingWithMiddleChunkRelevanceScoreHighest() {
+        var inputs = List.of(generateTestText(100));
+        var relevanceScores = List.of(0.5f, 1f, 0.5f);
         var chunker = new RerankRequestChunker(TEST_SENTENCE, inputs, null);
+        var returnDocuments = randomBoolean();
         var listener = chunker.parseChunkedRerankResultsListener(ActionListener.wrap(results -> {
             assertThat(results, instanceOf(RankedDocsResults.class));
             var rankedDocResults = (RankedDocsResults) results;
-            assertEquals(2, rankedDocResults.getRankedDocs().size());
-            var sortedResults = new ArrayList<>(rankedDocResults.getRankedDocs());
-            sortedResults.sort((r1, r2) -> Float.compare(r2.relevanceScore(), r1.relevanceScore()));
-            assertEquals(sortedResults, rankedDocResults.getRankedDocs());
-        }, e -> fail("Expected successful parsing but got failure: " + e)));
+            var expectedRankedDocs = List.of(
+                new RankedDocsResults.RankedDoc(0, relevanceScores.get(1), returnDocuments ? inputs.get(0) : null)
+            );
+            assertEquals(expectedRankedDocs, rankedDocResults.getRankedDocs());
+        }, e -> fail("Expected successful parsing but got failure: " + e)), returnDocuments);
+
+        var chunkedInputs = chunker.getChunkedInputs();
+        assertEquals(3, chunkedInputs.size());
+        listener.onResponse(new RankedDocsResults(generateRankedDocs(relevanceScores, chunkedInputs)));
+    }
+
+    public void testParseChunkedRerankResultsListener_SingleInputWithChunkingWithLastChunkRelevanceScoreHighest() {
+        var inputs = List.of(generateTestText(100));
+        var relevanceScores = List.of(0.5f, 0.3f, 1f);
+        var chunker = new RerankRequestChunker(TEST_SENTENCE, inputs, null);
+        var returnDocuments = randomBoolean();
+        var listener = chunker.parseChunkedRerankResultsListener(ActionListener.wrap(results -> {
+            assertThat(results, instanceOf(RankedDocsResults.class));
+            var rankedDocResults = (RankedDocsResults) results;
+            var expectedRankedDocs = List.of(
+                new RankedDocsResults.RankedDoc(0, relevanceScores.get(2), returnDocuments ? inputs.get(0) : null)
+            );
+            assertEquals(expectedRankedDocs, rankedDocResults.getRankedDocs());
+        }, e -> fail("Expected successful parsing but got failure: " + e)), returnDocuments);
+
+        var chunkedInputs = chunker.getChunkedInputs();
+        assertEquals(3, chunkedInputs.size());
+        listener.onResponse(new RankedDocsResults(generateRankedDocs(relevanceScores, chunkedInputs)));
+    }
+
+    public void testParseChunkedRerankResultsListener_MultipleInputsWithoutChunking() {
+        var inputs = List.of(generateTestText(10), generateTestText(20));
+        var chunker = new RerankRequestChunker(TEST_SENTENCE, inputs, null);
+        var returnDocuments = randomBoolean();
+        var relevanceScores = generateRelevanceScores(2);
+        var listener = chunker.parseChunkedRerankResultsListener(ActionListener.wrap(results -> {
+            assertThat(results, instanceOf(RankedDocsResults.class));
+            var rankedDocResults = (RankedDocsResults) results;
+            var expectedRankedDocs = new ArrayList<RankedDocsResults.RankedDoc>();
+            expectedRankedDocs.add(new RankedDocsResults.RankedDoc(0, relevanceScores.get(0), returnDocuments ? inputs.get(0) : null));
+            expectedRankedDocs.add(new RankedDocsResults.RankedDoc(1, relevanceScores.get(1), returnDocuments ? inputs.get(1) : null));
+            expectedRankedDocs.sort((r1, r2) -> Float.compare(r2.relevanceScore(), r1.relevanceScore()));
+            assertEquals(expectedRankedDocs, rankedDocResults.getRankedDocs());
+        }, e -> fail("Expected successful parsing but got failure: " + e)), returnDocuments);
 
         var chunkedInputs = chunker.getChunkedInputs();
         assertEquals(2, chunkedInputs.size());
-        listener.onResponse(
-            new RankedDocsResults(
-                List.of(
-                    new RankedDocsResults.RankedDoc(0, randomFloatBetween(0, 1, true), chunkedInputs.get(0)),
-                    new RankedDocsResults.RankedDoc(1, randomFloatBetween(0, 1, true), chunkedInputs.get(1))
-                )
-            )
-        );
+        listener.onResponse(new RankedDocsResults(generateRankedDocs(relevanceScores, chunkedInputs)));
     }
 
     public void testParseChunkedRerankResultsListener_MultipleInputsWithSomeChunking() {
         var inputs = List.of(generateTestText(10), generateTestText(100));
         var chunker = new RerankRequestChunker(TEST_SENTENCE, inputs, null);
+        var returnDocuments = randomBoolean();
+        var relevanceScores = generateRelevanceScores(4);
         var listener = chunker.parseChunkedRerankResultsListener(ActionListener.wrap(results -> {
             assertThat(results, instanceOf(RankedDocsResults.class));
             var rankedDocResults = (RankedDocsResults) results;
-            assertEquals(2, rankedDocResults.getRankedDocs().size());
-            var sortedResults = new ArrayList<>(rankedDocResults.getRankedDocs());
-            sortedResults.sort((r1, r2) -> Float.compare(r2.relevanceScore(), r1.relevanceScore()));
-            assertEquals(sortedResults, rankedDocResults.getRankedDocs());
-        }, e -> fail("Expected successful parsing but got failure: " + e)));
+            var expectedRankedDocs = new ArrayList<RankedDocsResults.RankedDoc>();
+            expectedRankedDocs.add(new RankedDocsResults.RankedDoc(0, relevanceScores.get(0), returnDocuments ? inputs.get(0) : null));
+            expectedRankedDocs.add(
+                new RankedDocsResults.RankedDoc(1, Collections.max(relevanceScores.subList(1, 4)), returnDocuments ? inputs.get(1) : null)
+            );
+            expectedRankedDocs.sort((r1, r2) -> Float.compare(r2.relevanceScore(), r1.relevanceScore()));
+            assertEquals(expectedRankedDocs, rankedDocResults.getRankedDocs());
+        }, e -> fail("Expected successful parsing but got failure: " + e)), returnDocuments);
 
         var chunkedInputs = chunker.getChunkedInputs();
         assertEquals(4, chunkedInputs.size());
-        listener.onResponse(
-            new RankedDocsResults(
-                List.of(
-                    new RankedDocsResults.RankedDoc(0, randomFloatBetween(0, 1, true), chunkedInputs.get(0)),
-                    new RankedDocsResults.RankedDoc(1, randomFloatBetween(0, 1, true), chunkedInputs.get(1)),
-                    new RankedDocsResults.RankedDoc(2, randomFloatBetween(0, 1, true), chunkedInputs.get(2))
-                )
-            )
-        );
+        listener.onResponse(new RankedDocsResults(generateRankedDocs(relevanceScores, chunkedInputs)));
     }
 
     public void testParseChunkedRerankResultsListener_MultipleInputsWithAllRequiringChunking() {
-        var inputs = List.of(generateTestText(100), generateTestText(100));
+        var inputs = List.of(generateTestText(100), generateTestText(105));
         var chunker = new RerankRequestChunker(TEST_SENTENCE, inputs, null);
+        var returnDocuments = randomBoolean();
+        var relevanceScores = generateRelevanceScores(6);
         var listener = chunker.parseChunkedRerankResultsListener(ActionListener.wrap(results -> {
             assertThat(results, instanceOf(RankedDocsResults.class));
             var rankedDocResults = (RankedDocsResults) results;
-            assertEquals(2, rankedDocResults.getRankedDocs().size());
-            var sortedResults = new ArrayList<>(rankedDocResults.getRankedDocs());
-            sortedResults.sort((r1, r2) -> Float.compare(r2.relevanceScore(), r1.relevanceScore()));
-            assertEquals(sortedResults, rankedDocResults.getRankedDocs());
-        }, e -> fail("Expected successful parsing but got failure: " + e)));
+            var expectedRankedDocs = new ArrayList<RankedDocsResults.RankedDoc>();
+            expectedRankedDocs.add(
+                new RankedDocsResults.RankedDoc(0, Collections.max(relevanceScores.subList(0, 3)), returnDocuments ? inputs.get(0) : null)
+            );
+            expectedRankedDocs.add(
+                new RankedDocsResults.RankedDoc(1, Collections.max(relevanceScores.subList(3, 6)), returnDocuments ? inputs.get(1) : null)
+            );
+            expectedRankedDocs.sort((r1, r2) -> Float.compare(r2.relevanceScore(), r1.relevanceScore()));
+            assertEquals(expectedRankedDocs, rankedDocResults.getRankedDocs());
+        }, e -> fail("Expected successful parsing but got failure: " + e)), returnDocuments);
 
         var chunkedInputs = chunker.getChunkedInputs();
         assertEquals(6, chunkedInputs.size());
-        listener.onResponse(
-            new RankedDocsResults(
-                List.of(
-                    new RankedDocsResults.RankedDoc(0, randomFloatBetween(0, 1, true), chunkedInputs.get(0)),
-                    new RankedDocsResults.RankedDoc(1, randomFloatBetween(0, 1, true), chunkedInputs.get(1)),
-                    new RankedDocsResults.RankedDoc(2, randomFloatBetween(0, 1, true), chunkedInputs.get(2)),
-                    new RankedDocsResults.RankedDoc(3, randomFloatBetween(0, 1, true), chunkedInputs.get(3))
-                )
-            )
-        );
+        listener.onResponse(new RankedDocsResults(generateRankedDocs(relevanceScores, chunkedInputs)));
     }
 
     private String generateTestText(int numSentences) {
@@ -246,5 +280,21 @@ public class RerankRequestChunkerTests extends ESTestCase {
             sb.append(TEST_SENTENCE);
         }
         return sb.toString();
+    }
+
+    private List<Float> generateRelevanceScores(int numScores) {
+        List<Float> scores = new ArrayList<>();
+        for (int i = 0; i < numScores; i++) {
+            scores.add(randomValueOtherThanMany(scores::contains, () -> randomFloatBetween(0, 1, true)));
+        }
+        return scores;
+    }
+
+    private List<RankedDocsResults.RankedDoc> generateRankedDocs(List<Float> relevanceScores, List<String> chunkedInputs) {
+        List<RankedDocsResults.RankedDoc> rankedDocs = new ArrayList<>();
+        for (int i = 0; i < max(relevanceScores.size(), chunkedInputs.size()); i++) {
+            rankedDocs.add(new RankedDocsResults.RankedDoc(i, relevanceScores.get(i), chunkedInputs.get(i)));
+        }
+        return rankedDocs;
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceTests.java
@@ -120,7 +120,6 @@ import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityExecutors;
 import static org.elasticsearch.xpack.inference.Utils.mockClusterService;
 import static org.elasticsearch.xpack.inference.chunking.ChunkingSettingsTests.createRandomChunkingSettingsMap;
 import static org.elasticsearch.xpack.inference.services.elasticsearch.BaseElasticsearchInternalService.notElasticsearchModelException;
-import static org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalService.ELASTIC_RERANKER_CHUNKING;
 import static org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalService.MULTILINGUAL_E5_SMALL_MODEL_ID;
 import static org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalService.MULTILINGUAL_E5_SMALL_MODEL_ID_LINUX_X86;
 import static org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalService.NAME;
@@ -1011,12 +1010,7 @@ public class ElasticsearchInternalServiceTests extends InferenceServiceTestCase 
         testInfer_ElasticReranker(model, generateTestDocs(randomIntBetween(2, 10), randomIntBetween(50, 100)));
     }
 
-    public void testInfer_ElasticRerankerFeatureFlagDisabledSucceedsWithTruncateConfiguration() {
-        assumeTrue(
-            "Only if 'elastic_reranker_chunking_long_documents' feature flag is disabled",
-            ELASTIC_RERANKER_CHUNKING.isEnabled() == false
-        );
-
+    public void testInfer_SucceedsWithTruncateLongDocumentStrategy() {
         var model = new ElasticRerankerModel(
             randomAlphaOfLength(10),
             TaskType.RERANK,
@@ -1031,46 +1025,7 @@ public class ElasticsearchInternalServiceTests extends InferenceServiceTestCase 
         testInfer_ElasticReranker(model, generateTestDocs(randomIntBetween(2, 10), randomIntBetween(50, 100)));
     }
 
-    public void testInfer_ElasticRerankerFeatureFlagDisabledSucceedsIgnoringChunkConfiguration() {
-        assumeTrue(
-            "Only if 'elastic_reranker_chunking_long_documents' feature flag is disabled",
-            ELASTIC_RERANKER_CHUNKING.isEnabled() == false
-        );
-
-        var model = new ElasticRerankerModel(
-            randomAlphaOfLength(10),
-            TaskType.RERANK,
-            NAME,
-            ElasticRerankerServiceSettingsTests.createRandomWithChunkingConfiguration(
-                ElasticRerankerServiceSettings.LongDocumentStrategy.CHUNK,
-                randomBoolean() ? randomIntBetween(1, 10) : null
-            ),
-            new RerankTaskSettings(randomBoolean())
-        );
-
-        testInfer_ElasticReranker(model, generateTestDocs(randomIntBetween(2, 10), randomIntBetween(50, 100)));
-    }
-
-    public void testInfer_ElasticRerankerFeatureFlagEnabledAndSucceedsWithTruncateStrategy() {
-        assumeTrue("Only if 'elastic_reranker_chunking_long_documents' feature flag is enabled", ELASTIC_RERANKER_CHUNKING.isEnabled());
-
-        var model = new ElasticRerankerModel(
-            randomAlphaOfLength(10),
-            TaskType.RERANK,
-            NAME,
-            ElasticRerankerServiceSettingsTests.createRandomWithChunkingConfiguration(
-                ElasticRerankerServiceSettings.LongDocumentStrategy.TRUNCATE,
-                null
-            ),
-            new RerankTaskSettings(randomBoolean())
-        );
-
-        testInfer_ElasticReranker(model, generateTestDocs(randomIntBetween(2, 10), randomIntBetween(50, 100)));
-    }
-
-    public void testInfer_ElasticRerankerFeatureFlagEnabledAndSucceedsWithChunkStrategy() {
-        assumeTrue("Only if 'elastic_reranker_chunking_long_documents' feature flag is enabled", ELASTIC_RERANKER_CHUNKING.isEnabled());
-
+    public void testInfer_SucceedsWithChunkLongDocumentStrategy() {
         var model = new ElasticRerankerModel(
             randomAlphaOfLength(10),
             TaskType.RERANK,
@@ -1090,8 +1045,7 @@ public class ElasticsearchInternalServiceTests extends InferenceServiceTestCase 
         var query = randomAlphaOfLength(10);
         var mlTrainedModelResults = new ArrayList<InferenceResults>();
         var numResults = inputs.size();
-        if (ELASTIC_RERANKER_CHUNKING.isEnabled()
-            && ElasticRerankerServiceSettings.LongDocumentStrategy.CHUNK.equals(model.getServiceSettings().getLongDocumentStrategy())) {
+        if (ElasticRerankerServiceSettings.LongDocumentStrategy.CHUNK.equals(model.getServiceSettings().getLongDocumentStrategy())) {
             var rerankRequestChunker = new RerankRequestChunker(query, inputs, model.getServiceSettings().getMaxChunksPerDoc());
             numResults = rerankRequestChunker.getChunkedInputs().size();
         }

--- a/x-pack/plugin/inference/src/yamlRestTest/java/org/elasticsearch/xpack/inference/InferenceRestIT.java
+++ b/x-pack/plugin/inference/src/yamlRestTest/java/org/elasticsearch/xpack/inference/InferenceRestIT.java
@@ -13,7 +13,6 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
-import org.elasticsearch.test.cluster.FeatureFlag;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
@@ -32,7 +31,6 @@ public class InferenceRestIT extends ESClientYamlSuiteTestCase {
         .setting("xpack.security.enabled", "false")
         .setting("xpack.security.http.ssl.enabled", "false")
         .setting("xpack.license.self_generated.type", "trial")
-        .feature(FeatureFlag.ELASTIC_RERANKER_CHUNKING)
         .plugin("inference-service-test")
         .distribution(DistributionType.DEFAULT)
         .build();


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Removing elastic reranker chunking feature flag and allow return_documents to be false (#136045)