### PR TITLE
[9.2] Use assertBusy for waiting on file settings watching in readiness test (#136131)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/readiness/ReadinessClusterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/readiness/ReadinessClusterIT.java
@@ -106,7 +106,6 @@ public class ReadinessClusterIT extends ESIntegTestCase {
         return Collections.unmodifiableList(plugins);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/108613")
     public void testReadinessDuringRestarts() throws Exception {
         internalCluster().setBootstrapMasterNodeIndex(0);
         writeFileSettings(testJSON);
@@ -258,7 +257,7 @@ public class ReadinessClusterIT extends ESIntegTestCase {
 
         FileSettingsService masterFileSettingsService = internalCluster().getInstance(FileSettingsService.class, masterNode);
 
-        assertTrue(masterFileSettingsService.watching());
+        assertBusy(() -> assertTrue(masterFileSettingsService.watching()));
         assertFalse(dataFileSettingsService.watching());
 
         boolean awaitSuccessful = savedClusterState.await(20, TimeUnit.SECONDS);
@@ -315,7 +314,7 @@ public class ReadinessClusterIT extends ESIntegTestCase {
 
         FileSettingsService masterFileSettingsService = internalCluster().getInstance(FileSettingsService.class, masterNode);
 
-        assertTrue(masterFileSettingsService.watching());
+        assertBusy(() -> assertTrue(masterFileSettingsService.watching()));
 
         boolean awaitSuccessful = savedClusterState.v1().await(20, TimeUnit.SECONDS);
         assertTrue(awaitSuccessful);
@@ -369,7 +368,7 @@ public class ReadinessClusterIT extends ESIntegTestCase {
 
         FileSettingsService masterFileSettingsService = internalCluster().getInstance(FileSettingsService.class, masterNode);
 
-        assertTrue(masterFileSettingsService.watching());
+        assertBusy(() -> assertTrue(masterFileSettingsService.watching()));
         assertFalse(dataFileSettingsService.watching());
 
         boolean awaitSuccessful = savedClusterState.v1().await(20, TimeUnit.SECONDS);


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Use assertBusy for waiting on file settings watching in readiness test (#136131)