### PR TITLE
[ES|QL] Permit text becoming keyword in TS aggs grouping

### DIFF
--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
@@ -78,8 +78,7 @@ public abstract class GenerativeRestTest extends ESRestTestCase implements Query
         "time_series aggregate.* can only be used with the TS command",
         "Invalid call to dataType on an unresolved object \\?LASTOVERTIME", // https://github.com/elastic/elasticsearch/issues/134791
         // https://github.com/elastic/elasticsearch/issues/134793
-        "class org.elasticsearch.compute.data..*Block cannot be cast to class org.elasticsearch.compute.data..*Block",
-        "Output has changed from \\[.*\\] to \\[.*\\]" // https://github.com/elastic/elasticsearch/issues/134794
+        "class org.elasticsearch.compute.data..*Block cannot be cast to class org.elasticsearch.compute.data..*Block"
     );
 
     public static final Set<Pattern> ALLOWED_ERROR_PATTERNS = ALLOWED_ERRORS.stream()

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries.csv-spec
@@ -547,3 +547,19 @@ cnt:long | cluster:keyword | pod:keyword
 1        | prod            | two
 1        | prod            | three
 ;
+
+tsCommandGroupingOnTextField
+required_capability: ts_command_v0
+TS k8s
+| STATS count = count_distinct(network.eth0.currently_connected_clients) BY event_log, bucket = bucket(@timestamp,1hour)
+| SORT count, event_log
+| LIMIT 5
+;
+
+count:long | event_log:keyword                                                                                                                                                                                                                    | bucket:datetime
+1          | Aenean himenaeos urna                                                                                                                                                                                                                | 2024-05-10T00:00:00.000Z
+1          | Cubilia lacinia luctus tincidunt convallis ridiculus habitant vel potenti, arcu pellentesque semper sociis ac felis. Vitae sagittis natoque mollis arcu diam lacus sociosqu, lacinia suspendisse quisque tristique cursus phasellus. | 2024-05-10T00:00:00.000Z
+1          | Lorem ipsum dolor sit amet consectetur adipiscing elit nulla ut in                                                                                                                                                                   | 2024-05-10T00:00:00.000Z
+1          | Lorem ipsum dolor sit amet consectetur adipiscing elit nulla ut in nullam tristique viverra penatibus ac integer                                                                                                                     | 2024-05-10T00:00:00.000Z
+1          | Nunc                                                                                                                                                                                                                                 | 2024-05-10T00:00:00.000Z
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries.csv-spec
@@ -547,20 +547,3 @@ cnt:long | cluster:keyword | pod:keyword
 1        | prod            | two
 1        | prod            | three
 ;
-
-tsCommandGroupingOnTextField
-required_capability: ts_command_v0
-required_capability: ts_permit_text_becoming_keyword_when_grouped_on
-TS k8s
-| STATS count = count_distinct(network.eth0.currently_connected_clients) BY event_log, bucket = bucket(@timestamp,1hour)
-| SORT count, event_log
-| LIMIT 5
-;
-
-count:long | event_log:keyword                                                                                                                                                                                                                    | bucket:datetime
-1          | Aenean himenaeos urna                                                                                                                                                                                                                | 2024-05-10T00:00:00.000Z
-1          | Cubilia lacinia luctus tincidunt convallis ridiculus habitant vel potenti, arcu pellentesque semper sociis ac felis. Vitae sagittis natoque mollis arcu diam lacus sociosqu, lacinia suspendisse quisque tristique cursus phasellus. | 2024-05-10T00:00:00.000Z
-1          | Lorem ipsum dolor sit amet consectetur adipiscing elit nulla ut in                                                                                                                                                                   | 2024-05-10T00:00:00.000Z
-1          | Lorem ipsum dolor sit amet consectetur adipiscing elit nulla ut in nullam tristique viverra penatibus ac integer                                                                                                                     | 2024-05-10T00:00:00.000Z
-1          | Nunc                                                                                                                                                                                                                                 | 2024-05-10T00:00:00.000Z
-;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries.csv-spec
@@ -550,6 +550,7 @@ cnt:long | cluster:keyword | pod:keyword
 
 tsCommandGroupingOnTextField
 required_capability: ts_command_v0
+required_capability: ts_permit_text_becoming_keyword_when_grouped_on
 TS k8s
 | STATS count = count_distinct(network.eth0.currently_connected_clients) BY event_log, bucket = bucket(@timestamp,1hour)
 | SORT count, event_log

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1479,6 +1479,12 @@ public class EsqlCapabilities {
         METADATA_TSID_FIELD,
 
         /**
+         * Permit the data type of a field changing from TEXT to KEYWORD
+         * when being grouped on in aggregations on the TS command.
+         */
+        TS_PERMIT_TEXT_BECOMING_KEYWORD_WHEN_GROUPED_ON,
+
+        /**
          * Fix management of plans with no columns
          * https://github.com/elastic/elasticsearch/issues/120272
          */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/PostOptimizationPhasePlanVerifier.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/PostOptimizationPhasePlanVerifier.java
@@ -8,9 +8,13 @@
 package org.elasticsearch.xpack.esql.optimizer;
 
 import org.elasticsearch.xpack.esql.common.Failures;
+import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Values;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.ProjectAwayColumns;
 import org.elasticsearch.xpack.esql.plan.QueryPlan;
+import org.elasticsearch.xpack.esql.plan.logical.TimeSeriesAggregate;
 import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
 
 import java.util.List;
@@ -72,7 +76,14 @@ public abstract class PostOptimizationPhasePlanVerifier<P extends QueryPlan<P>> 
             // We perform an optimizer run on every fragment. LookupJoinExec also contains such a fragment,
             // and currently it only contains an EsQueryExec after optimization.
             boolean hasLookupJoinExec = optimizedPlan instanceof EsQueryExec esQueryExec && esQueryExec.indexMode() == LOOKUP;
-            boolean ignoreError = hasProjectAwayColumns || hasLookupJoinExec;
+            // If we group on a text field when using the TS command, we create an Alias that wraps the text field
+            // in a Values aggregation. Aggregations will return Keywords as opposed to Text types, so we want to
+            // permit the output type changing here.
+            boolean hasTextGroupingInTimeSeries = optimizedPlan.anyMatch(
+                a -> a instanceof TimeSeriesAggregate ts
+                    && ts.aggregates().stream().anyMatch(g -> Alias.unwrap(g) instanceof Values v && v.field().dataType() == DataType.TEXT)
+            );
+            boolean ignoreError = hasProjectAwayColumns || hasLookupJoinExec || hasTextGroupingInTimeSeries;
             if (ignoreError == false) {
                 failures.add(
                     fail(

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_tsdb.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_tsdb.yml
@@ -244,7 +244,7 @@ cast counter then filter:
         - method: POST
           path: /_query
           parameters: [ ]
-          capabilities: [ aggregate_metric_double_convert_to ]
+          capabilities: [ aggregate_metric_double_v0 ]
       reason: "Uses TO_AGGREGATE_METRIC_DOUBLE"
   - do:
       esql.query:
@@ -268,7 +268,7 @@ sort on counter without cast:
         - method: POST
           path: /_query
           parameters: []
-          capabilities: [sorting_on_source_and_counters_forbidden, aggregate_metric_double_convert_to]
+          capabilities: [sorting_on_source_and_counters_forbidden, aggregate_metric_double_v0]
       reason: "Sorting on counters shouldn't have been possible"
   - do:
       catch: /cannot sort on counter_long/
@@ -788,3 +788,100 @@ avg of aggregate_metric_double:
   - match: {columns.0.name: "avg"}
   - match: {columns.0.type: "double"}
   - match: {values.0.0: 4.904761904761905}
+
+---
+TS Command grouping on text field:
+  - requires:
+      test_runner_features: [ capabilities ]
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: [ ]
+          capabilities: [ ts_permit_text_becoming_keyword_when_grouped_on, ts_command_v0 ]
+      reason: "fix grouping on text fields with TS command"
+
+  - do:
+      indices.create:
+        index: test-text-field
+        body:
+          settings:
+            index:
+              mode: time_series
+              routing_path: [metricset, k8s.pod.uid]
+              time_series:
+                start_time: 2021-04-28T00:00:00Z
+                end_time: 2021-04-29T00:00:00Z
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+              metricset:
+                type: keyword
+                time_series_dimension: true
+              k8s:
+                properties:
+                  pod:
+                    properties:
+                      uid:
+                        type: keyword
+                        time_series_dimension: true
+                      name:
+                        type: keyword
+                      ip:
+                        type: ip
+                      network:
+                        properties:
+                          tx:
+                            type: integer
+                          rx:
+                            type: integer
+              text_field:
+                type: text
+  - do:
+      bulk:
+        refresh: true
+        index: test-text-field
+        body:
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T16:50:04.467Z", "metricset": "pod", "k8s": {"pod": {"name": "cat", "uid":"947e4ced-1786-4e53-9e0c-5c447e959507", "ip": "10.10.55.1", "network": {"tx": 2001818691, "rx": 802133794}}}, "text_field": "some text"}'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T17:50:24.467Z", "metricset": "pod", "k8s": {"pod": {"name": "cat", "uid":"947e4ced-1786-4e53-9e0c-5c447e959507", "ip": "10.10.55.1", "network": {"tx": 2005177954, "rx": 801479970}}}, "text_field": "even more text"}'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:50:44.467Z", "metricset": "pod", "k8s": {"pod": {"name": "cat", "uid":"947e4ced-1786-4e53-9e0c-5c447e959507", "ip": "10.10.55.1", "network": {"tx": 2006223737, "rx": 802337279}}}, "text_field": "wow i cant believe theres still text"}'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T19:51:04.467Z", "metricset": "pod", "k8s": {"pod": {"name": "cat", "uid":"947e4ced-1786-4e53-9e0c-5c447e959507", "ip": "10.10.55.2", "network": {"tx": 2012916202, "rx": 803685721}}}, "text_field": "who knew there could be so much text"}'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T16:50:03.142Z", "metricset": "pod", "k8s": {"pod": {"name": "dog", "uid":"df3145b3-0563-4d3b-a0f7-897eb2876ea9", "ip": "10.10.55.3", "network": {"tx": 1434521831, "rx": 530575198}}}, "text_field": "we are just overflowing with text"}'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T17:50:23.142Z", "metricset": "pod", "k8s": {"pod": {"name": "dog", "uid":"df3145b3-0563-4d3b-a0f7-897eb2876ea9", "ip": "10.10.55.3", "network": {"tx": 1434577921, "rx": 530600088}}}, "text_field": "is this text?"}'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:50:53.142Z", "metricset": "pod", "k8s": {"pod": {"name": "dog", "uid":"df3145b3-0563-4d3b-a0f7-897eb2876ea9", "ip": "10.10.55.3", "network": {"tx": 1434587694, "rx": 530604797}}}, "text_field": "why cant i hold all these text"}'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T19:51:03.142Z", "metricset": "pod", "k8s": {"pod": {"name": "dog", "uid":"df3145b3-0563-4d3b-a0f7-897eb2876ea9", "ip": "10.10.55.3", "network": {"tx": 1434595272, "rx": 530605511}}}, "text_field": "peak text"}'
+
+  - do:
+      esql.query:
+        body:
+          query: |
+            TS test-text-field
+            | STATS max = max(k8s.pod.network.rx) BY text_field, bucket = bucket(@timestamp,1hour)
+            | SORT max, text_field
+            | LIMIT 3
+
+  - length: {values: 3}
+  - length: {values.0: 3}
+  - match: {columns.0.name: "max"}
+  - match: {columns.0.type: "integer"}
+  - match: {columns.1.name: "text_field"}
+  - match: {columns.1.type: "keyword"}
+  - match: {columns.2.name: "bucket"}
+  - match: {columns.2.type: "date"}
+  - match: {values.0.0: 530575198}
+  - match: {values.0.1: "we are just overflowing with text"}
+  - match: {values.0.2: "2021-04-28T16:00:00.000Z"}
+  - match: {values.1.0: 530600088}
+  - match: {values.1.1: "is this text?"}
+  - match: {values.1.2: "2021-04-28T17:00:00.000Z"}
+  - match: {values.2.0: 530604797}
+  - match: {values.2.1: "why cant i hold all these text"}
+  - match: {values.2.2: "2021-04-28T18:00:00.000Z"}


### PR DESCRIPTION
When running aggregations under the TS command and grouping by a text field, the FieldAttribute representing the text field gets replaced by a ReferenceAttribute containing an Alias to `Values(text_field)`, which is an aggregation. Aggregations will always return KEYWORD types rather than TEXT types, so we want to allow this change in types in this specific circumstance.

Closes #134794