### PR TITLE
[8.19] rest-api-spec: Add missing default values from Elasticsearch specification (#136191)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/async_search.status.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/async_search.status.json
@@ -30,6 +30,7 @@
     "params": {
       "keep_alive": {
         "type": "time",
+        "default": "5d",
         "description": "Specify the time interval in which the results (partial or final) for this search will be available"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/async_search.submit.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/async_search.submit.json
@@ -59,6 +59,7 @@
       },
       "request_cache": {
         "type": "boolean",
+        "default": true,
         "description": "Specify if request cache should be used for this request or not, defaults to true"
       },
       "analyzer": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/autoscaling.delete_autoscaling_policy.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/autoscaling.delete_autoscaling_policy.json
@@ -35,6 +35,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for acknowledgement of update from all nodes in cluster"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/autoscaling.put_autoscaling_policy.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/autoscaling.put_autoscaling_policy.json
@@ -38,6 +38,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for acknowledgement of update from all nodes in cluster"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/bulk.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/bulk.json
@@ -41,6 +41,7 @@
     "params": {
       "wait_for_active_shards": {
         "type": "string",
+        "default": "1",
         "description": "Sets the number of shard copies that must be active before proceeding with the bulk operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)"
       },
       "refresh": {
@@ -50,6 +51,7 @@
           "false",
           "wait_for"
         ],
+        "default": "false",
         "description": "If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes."
       },
       "routing": {
@@ -58,6 +60,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "1m",
         "description": "Explicit operation timeout"
       },
       "_source": {
@@ -78,18 +81,22 @@
       },
       "require_alias": {
         "type": "boolean",
-        "description": "Sets require_alias for all incoming documents. Defaults to unset (false)"
+        "default": false,
+        "description": "If true, the request's actions must target an index alias. Defaults to false."
       },
       "require_data_stream": {
         "type": "boolean",
-        "description": "When true, requires the destination to be a data stream (existing or to-be-created). Default is false"
+        "default": false,
+        "description": "If true, the request's actions must target a data stream (existing or to-be-created). Default to false"
       },
       "list_executed_pipelines": {
         "type": "boolean",
+        "default": false,
         "description": "Sets list_executed_pipelines for all incoming documents. Defaults to unset (false)"
       },
       "include_source_on_error": {
         "type": "boolean",
+        "default": true,
         "description": "True or false if to include the document source in the error message in case of parsing errors. Defaults to true."
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.allocation.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.allocation.json
@@ -67,6 +67,7 @@
       },
       "local": {
         "type": "boolean",
+        "default": false,
         "description": "Return local information, do not retrieve the state from master node (default: false)"
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.component_templates.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.component_templates.json
@@ -42,6 +42,7 @@
       },
       "local": {
         "type": "boolean",
+        "default": false,
         "description": "Return local information, do not retrieve the state from master node (default: false)"
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.master.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.master.json
@@ -30,6 +30,7 @@
       },
       "local": {
         "type": "boolean",
+        "default": false,
         "description": "Return local information, do not retrieve the state from master node (default: false)"
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_data_frame_analytics.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_data_frame_analytics.json
@@ -37,6 +37,7 @@
     "params": {
       "allow_no_match": {
         "type": "boolean",
+        "default": false,
         "description": "Whether to ignore if a wildcard expression matches no configs. (This includes `_all` string or when no configs have been specified)"
       },
       "bytes": {
@@ -58,6 +59,7 @@
       },
       "h": {
         "type": "list",
+        "default": "create_time,id,state,type",
         "description": "Comma-separated list of column names to display"
       },
       "help": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_datafeeds.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_datafeeds.json
@@ -37,6 +37,7 @@
     "params": {
       "allow_no_match": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)"
       },
       "format": {
@@ -46,6 +47,7 @@
       },
       "h": {
         "type": "list",
+        "default": "['bc', 'id', 'sc', 's']",
         "description": "Comma-separated list of column names to display"
       },
       "help": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_jobs.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.ml_jobs.json
@@ -37,6 +37,7 @@
     "params": {
       "allow_no_match": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
       },
       "bytes": {
@@ -58,6 +59,7 @@
       },
       "h": {
         "type": "list",
+        "default": "buckets.count,data.processed_records,forecasts.total,id,model.bytes,model.memory_status,state",
         "description": "Comma-separated list of column names to display"
       },
       "help": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodeattrs.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodeattrs.json
@@ -30,6 +30,7 @@
       },
       "local": {
         "type": "boolean",
+        "default": false,
         "description": "Return local information, do not retrieve the state from master node (default: false)"
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodes.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.nodes.json
@@ -42,6 +42,7 @@
       },
       "full_id": {
         "type": "boolean",
+        "default": false,
         "description": "Return the full node ID instead of the shortened version (default: false)"
       },
       "master_timeout": {
@@ -51,6 +52,7 @@
       },
       "h": {
         "type": "list",
+        "default": "ip,hp,rp,r,m,n,cpu,l",
         "description": "Comma-separated list of column names to display"
       },
       "help": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.pending_tasks.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.pending_tasks.json
@@ -30,6 +30,7 @@
       },
       "local": {
         "type": "boolean",
+        "default": false,
         "description": "Return local information, do not retrieve the state from master node (default: false)"
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.plugins.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.plugins.json
@@ -30,6 +30,7 @@
       },
       "local": {
         "type": "boolean",
+        "default": false,
         "description": "Return local information, do not retrieve the state from master node (default: false)"
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.recovery.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.recovery.json
@@ -64,6 +64,7 @@
       },
       "h": {
         "type": "list",
+        "default": "ip,hp,rp,r,m,n,cpu,l",
         "description": "Comma-separated list of column names to display"
       },
       "help": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segments.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segments.json
@@ -42,6 +42,7 @@
       },
       "local": {
         "type": "boolean",
+        "default": false,
         "description": "Return local information, do not retrieve the state from master node (default: false)"
       },
       "master_timeout": {
@@ -63,6 +64,7 @@
       },
       "h": {
         "type": "list",
+        "default": "ip,hp,rp,r,m,n,cpu,l",
         "description": "Comma-separated list of column names to display"
       },
       "help": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.snapshots.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.snapshots.json
@@ -52,6 +52,7 @@
       },
       "h": {
         "type": "list",
+        "default": "ip,hp,rp,r,m,n,cpu,l",
         "description": "Comma-separated list of column names to display"
       },
       "help": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.tasks.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.tasks.json
@@ -38,6 +38,7 @@
       },
       "detailed": {
         "type": "boolean",
+        "default": false,
         "description": "Return detailed task information (default: false)"
       },
       "parent_task_id": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.templates.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.templates.json
@@ -42,6 +42,7 @@
       },
       "local": {
         "type": "boolean",
+        "default": false,
         "description": "Return local information, do not retrieve the state from master node (default: false)"
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.thread_pool.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.thread_pool.json
@@ -55,6 +55,7 @@
       },
       "local": {
         "type": "boolean",
+        "default": false,
         "description": "Return local information, do not retrieve the state from master node (default: false)"
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.transforms.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.transforms.json
@@ -37,14 +37,17 @@
     "params": {
       "from": {
         "type": "int",
+        "default": 0,
         "description": "skips a number of transform configs, defaults to 0"
       },
       "size": {
         "type": "int",
+        "default": 100,
         "description": "specifies a max number of transforms to get, defaults to 100"
       },
       "allow_no_match": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard expression matches no transforms. (This includes `_all` string or when no transforms have been specified)"
       },
       "format": {
@@ -54,6 +57,7 @@
       },
       "h": {
         "type": "list",
+        "default": "changes_last_detection_time,checkpoint,checkpoint_progress,documents_processed,id,last_search_time,state",
         "description": "Comma-separated list of column names to display"
       },
       "help": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ccr.follow_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ccr.follow_stats.json
@@ -30,6 +30,7 @@
     "params": {
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ccr.forget_follower.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ccr.forget_follower.json
@@ -33,6 +33,7 @@
     "params": {
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ccr.stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ccr.stats.json
@@ -24,6 +24,7 @@
     "params": {
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.allocation_explain.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.allocation_explain.json
@@ -33,10 +33,12 @@
       },
       "include_yes_decisions": {
         "type": "boolean",
+        "default": false,
         "description": "Return 'YES' decisions in explanation (default: false)"
       },
       "include_disk_info": {
         "type": "boolean",
+        "default": false,
         "description": "Return information about disk usage and shard sizes (default: false)"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.delete_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.delete_component_template.json
@@ -30,6 +30,7 @@
     "params": {
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.exists_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.exists_component_template.json
@@ -35,6 +35,7 @@
       },
       "local": {
         "type": "boolean",
+        "default": false,
         "description": "Return local information, do not retrieve the state from master node (default: false)"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_component_template.json
@@ -41,14 +41,17 @@
       },
       "local": {
         "type": "boolean",
+        "default": false,
         "description": "Return local information, do not retrieve the state from master node (default: false)"
       },
       "include_defaults": {
         "type": "boolean",
+        "default": false,
         "description": "Return all default configurations for the component template (default: false)"
       },
       "flat_settings": {
         "type": "boolean",
+        "default": false,
         "description": "Return settings in flat format (default: false)"
       },
       "settings_filter": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_settings.json
@@ -24,6 +24,7 @@
     "params": {
       "flat_settings": {
         "type": "boolean",
+        "default": false,
         "description": "Return settings in flat format (default: false)"
       },
       "master_timeout": {
@@ -33,6 +34,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       },
       "include_defaults": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.health.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.health.json
@@ -58,6 +58,7 @@
       },
       "local": {
         "type": "boolean",
+        "default": false,
         "description": "Return local information, do not retrieve the state from master node (default: false)"
       },
       "master_timeout": {
@@ -67,10 +68,12 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       },
       "wait_for_active_shards": {
         "type": "string",
+        "default": "0",
         "description": "Wait until the specified number of shards is active"
       },
       "wait_for_nodes": {
@@ -91,10 +94,12 @@
       },
       "wait_for_no_relocating_shards": {
         "type": "boolean",
+        "default": false,
         "description": "Whether to wait until there are no relocating shards in the cluster"
       },
       "wait_for_no_initializing_shards": {
         "type": "boolean",
+        "default": false,
         "description": "Whether to wait until there are no initializing shards in the cluster"
       },
       "wait_for_status": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.pending_tasks.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.pending_tasks.json
@@ -24,6 +24,7 @@
     "params": {
       "local": {
         "type": "boolean",
+        "default": false,
         "description": "Return local information, do not retrieve the state from master node (default: false)"
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_settings.json
@@ -36,6 +36,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.reroute.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.reroute.json
@@ -27,14 +27,17 @@
     "params": {
       "dry_run": {
         "type": "boolean",
+        "default": false,
         "description": "Simulate the operation only and return the resulting state"
       },
       "explain": {
         "type": "boolean",
+        "default": false,
         "description": "Return an explanation of why the commands can or cannot be executed"
       },
       "retry_failed": {
         "type": "boolean",
+        "default": false,
         "description": "Retries allocation of shards that are blocked due to too many subsequent allocation failures"
       },
       "metric": {
@@ -49,6 +52,7 @@
           "master_node",
           "version"
         ],
+        "default": "all",
         "description": "Limit the information returned to the specified metrics. Defaults to all but metadata"
       },
       "master_timeout": {
@@ -58,6 +62,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.state.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.state.json
@@ -72,6 +72,7 @@
     "params": {
       "local": {
         "type": "boolean",
+        "default": false,
         "description": "Return local information, do not retrieve the state from master node (default: false)"
       },
       "master_timeout": {
@@ -81,6 +82,7 @@
       },
       "flat_settings": {
         "type": "boolean",
+        "default": false,
         "description": "Return settings in flat format (default: false)"
       },
       "wait_for_metadata_version": {
@@ -93,10 +95,12 @@
       },
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.stats.json
@@ -36,6 +36,7 @@
     "params": {
       "include_remotes": {
         "type": "boolean",
+        "default": false,
         "description": "Include remote cluster data into the response (default: false)"
       },
       "timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/count.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/count.json
@@ -41,14 +41,17 @@
     "params": {
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "ignore_throttled": {
         "type": "boolean",
+        "default": true,
         "description": "Whether specified concrete, expanded or aliased indices should be ignored when throttled"
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
@@ -85,6 +88,7 @@
       },
       "analyze_wildcard": {
         "type": "boolean",
+        "default": false,
         "description": "Specify whether wildcard and prefix queries should be analyzed (default: false)"
       },
       "default_operator": {
@@ -102,6 +106,7 @@
       },
       "lenient": {
         "type": "boolean",
+        "default": false,
         "description": "Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"
       },
       "terminate_after": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/create.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/create.json
@@ -38,6 +38,7 @@
     "params": {
       "wait_for_active_shards": {
         "type": "string",
+        "default": "1",
         "description": "Sets the number of shard copies that must be active before proceeding with the index operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)"
       },
       "refresh": {
@@ -47,6 +48,7 @@
           "false",
           "wait_for"
         ],
+        "default": "false",
         "description": "If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes."
       },
       "routing": {
@@ -55,6 +57,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "1m",
         "description": "Explicit operation timeout"
       },
       "version": {
@@ -76,14 +79,17 @@
       },
       "include_source_on_error": {
         "type": "boolean",
+        "default": true,
         "description": "True or false if to include the document source in the error message in case of parsing errors. Defaults to true."
       },
       "require_alias": {
         "type": "boolean",
+        "default": false,
         "description": "When true, requires destination to be an alias. Default is false"
       },
       "require_data_stream": {
         "type": "boolean",
+        "default": false,
         "description": "When true, requires destination to be a data stream (existing or to be created). Default is false"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete.json
@@ -34,6 +34,7 @@
     "params": {
       "wait_for_active_shards": {
         "type": "string",
+        "default": "1",
         "description": "Sets the number of shard copies that must be active before proceeding with the delete operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)"
       },
       "refresh": {
@@ -43,6 +44,7 @@
           "false",
           "wait_for"
         ],
+        "default": "false",
         "description": "If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes."
       },
       "routing": {
@@ -51,6 +53,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "1m",
         "description": "Explicit operation timeout"
       },
       "if_seq_no": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
@@ -37,6 +37,7 @@
       },
       "analyze_wildcard": {
         "type": "boolean",
+        "default": false,
         "description": "Specify whether wildcard and prefix queries should be analyzed (default: false)"
       },
       "default_operator": {
@@ -54,14 +55,17 @@
       },
       "from": {
         "type": "number",
+        "default": 0,
         "description": "Starting offset (default: 0)"
       },
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "conflicts": {
@@ -87,6 +91,7 @@
       },
       "lenient": {
         "type": "boolean",
+        "default": false,
         "description": "Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"
       },
       "preference": {
@@ -143,6 +148,7 @@
       },
       "refresh": {
         "type": "boolean",
+        "default": false,
         "description": "Should the affected indexes be refreshed?"
       },
       "timeout": {
@@ -152,11 +158,12 @@
       },
       "wait_for_active_shards": {
         "type": "string",
+        "default": "1",
         "description": "Sets the number of shard copies that must be active before proceeding with the delete by query operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)"
       },
       "scroll_size": {
         "type": "number",
-        "default": 100,
+        "default": 1000,
         "description": "Size on the scroll request powering the delete by query"
       },
       "wait_for_completion": {
@@ -166,7 +173,7 @@
       },
       "requests_per_second": {
         "type": "number",
-        "default": 0,
+        "default": -1,
         "description": "The throttle for this request in sub-requests per second. -1 means no throttle."
       },
       "slices": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_script.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_script.json
@@ -30,6 +30,7 @@
     "params": {
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/eql.search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/eql.search.json
@@ -63,10 +63,12 @@
       },
       "ignore_unavailable": {
         "type": "boolean",
+        "default": true,
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/esql.async_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/esql.async_query.json
@@ -32,7 +32,7 @@
       "delimiter": {
         "type": "string",
         "description": "The character to use between values within a CSV row. Only valid for the csv format.",
-        "default": false
+        "default": ","
       },
       "drop_null_columns": {
         "type": "boolean",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/esql.async_query_stop.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/esql.async_query_stop.json
@@ -26,6 +26,13 @@
           }
         }
       ]
+    },
+    "params": {
+      "drop_null_columns": {
+        "type": "boolean",
+        "default": false,
+        "description": "Indicates whether columns that are entirely `null` will be removed from the `columns` and `values` portion of the results."
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/esql.query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/esql.query.json
@@ -32,7 +32,7 @@
       "delimiter": {
         "type": "string",
         "description": "The character to use between values within a CSV row. Only valid for the csv format.",
-        "default": false
+        "default": ","
       },
       "drop_null_columns": {
         "type": "boolean",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/exists.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/exists.json
@@ -42,10 +42,12 @@
       },
       "realtime": {
         "type": "boolean",
+        "default": true,
         "description": "Specify whether to perform the operation in realtime or search mode"
       },
       "refresh": {
         "type": "boolean",
+        "default": false,
         "description": "Refresh the shard containing the document before performing the operation"
       },
       "routing": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/exists_source.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/exists_source.json
@@ -38,10 +38,12 @@
       },
       "realtime": {
         "type": "boolean",
+        "default": true,
         "description": "Specify whether to perform the operation in realtime or search mode"
       },
       "refresh": {
         "type": "boolean",
+        "default": false,
         "description": "Refresh the shard containing the document before performing the operation"
       },
       "routing": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/explain.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/explain.json
@@ -38,6 +38,7 @@
     "params": {
       "analyze_wildcard": {
         "type": "boolean",
+        "default": false,
         "description": "Specify whether wildcards and prefix queries in the query string query should be analyzed (default: false)"
       },
       "analyzer": {
@@ -63,6 +64,7 @@
       },
       "lenient": {
         "type": "boolean",
+        "default": false,
         "description": "Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"
       },
       "preference": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/field_caps.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/field_caps.json
@@ -45,10 +45,12 @@
       },
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/fleet.global_checkpoints.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/fleet.global_checkpoints.json
@@ -34,12 +34,12 @@
       "wait_for_advance": {
         "type": "boolean",
         "description": "Whether to wait for the global checkpoint to advance past the specified current checkpoints",
-        "default": "false"
+        "default": false
       },
       "wait_for_index": {
         "type": "boolean",
         "description": "Whether to wait for the target index to exist and all primary shards be active",
-        "default": "false"
+        "default": false
       },
       "checkpoints": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/get.json
@@ -48,10 +48,12 @@
       },
       "realtime": {
         "type": "boolean",
+        "default": true,
         "description": "Specify whether to perform the operation in realtime or search mode"
       },
       "refresh": {
         "type": "boolean",
+        "default": false,
         "description": "Refresh the shard containing the document before performing the operation"
       },
       "routing": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/get_source.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/get_source.json
@@ -38,10 +38,12 @@
       },
       "realtime": {
         "type": "boolean",
+        "default": true,
         "description": "Specify whether to perform the operation in realtime or search mode"
       },
       "refresh": {
         "type": "boolean",
+        "default": false,
         "description": "Refresh the shard containing the document before performing the operation"
       },
       "routing": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.delete_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.delete_lifecycle.json
@@ -35,6 +35,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.get_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.get_lifecycle.json
@@ -41,6 +41,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.migrate_to_data_tiers.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.migrate_to_data_tiers.json
@@ -27,6 +27,7 @@
     "params": {
       "dry_run": {
         "type": "boolean",
+        "default": false,
         "description": "If set to true it will simulate the migration, providing a way to retrieve the ILM policies and indices that need to be migrated. The default is false"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.put_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.put_lifecycle.json
@@ -38,6 +38,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.start.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.start.json
@@ -29,6 +29,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.stop.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.stop.json
@@ -29,6 +29,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/index.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/index.json
@@ -50,6 +50,7 @@
     "params": {
       "wait_for_active_shards": {
         "type": "string",
+        "default": "1",
         "description": "Sets the number of shard copies that must be active before proceeding with the index operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)"
       },
       "op_type": {
@@ -67,6 +68,7 @@
           "false",
           "wait_for"
         ],
+        "default": "false",
         "description": "If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes."
       },
       "routing": {
@@ -75,6 +77,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "1m",
         "description": "Explicit operation timeout"
       },
       "version": {
@@ -104,14 +107,17 @@
       },
       "require_alias": {
         "type": "boolean",
+        "default": false,
         "description": "When true, requires destination to be an alias. Default is false"
       },
       "require_data_stream": {
         "type": "boolean",
+        "default": false,
         "description": "When true, requires the destination to be a data stream (existing or to-be-created). Default is false"
       },
       "include_source_on_error": {
         "type": "boolean",
+        "default": true,
         "description": "True or false if to include the document source in the error message in case of parsing errors. Defaults to true."
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.add_block.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.add_block.json
@@ -34,6 +34,7 @@
     "params": {
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       },
       "master_timeout": {
@@ -43,10 +44,12 @@
       },
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.clear_cache.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.clear_cache.json
@@ -48,10 +48,12 @@
       },
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.clone.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.clone.json
@@ -38,6 +38,7 @@
     "params": {
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       },
       "master_timeout": {
@@ -47,6 +48,7 @@
       },
       "wait_for_active_shards": {
         "type": "string",
+        "default": "1",
         "description": "Set the number of active shards to wait for on the cloned index before the operation returns."
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.close.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.close.json
@@ -30,6 +30,7 @@
     "params": {
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       },
       "master_timeout": {
@@ -39,10 +40,12 @@
       },
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
@@ -59,6 +62,7 @@
       },
       "wait_for_active_shards": {
         "type": "string",
+        "default": "1",
         "description": "Sets the number of active shards to wait for before the operation returns."
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.create.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.create.json
@@ -33,10 +33,12 @@
     "params": {
       "wait_for_active_shards": {
         "type": "string",
+        "default": "1",
         "description": "Set the number of active shards to wait for before the operation returns."
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.create_data_stream.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.create_data_stream.json
@@ -30,6 +30,7 @@
     "params": {
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for acknowledging the cluster state update"
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete.json
@@ -30,6 +30,7 @@
     "params": {
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       },
       "master_timeout": {
@@ -39,10 +40,12 @@
       },
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Ignore unavailable indexes (default: false)"
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": true,
         "description": "Ignore if a wildcard expression resolves to no concrete indices (default: false)"
       },
       "expand_wildcards": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_alias.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_alias.json
@@ -50,6 +50,7 @@
     "params": {
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit timestamp for the document"
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_index_template.json
@@ -30,6 +30,7 @@
     "params": {
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_template.json
@@ -30,6 +30,7 @@
     "params": {
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.disk_usage.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.disk_usage.json
@@ -30,18 +30,22 @@
     "params": {
       "run_expensive_tasks": {
         "type": "boolean",
+        "default": false,
         "description": "Must be set to [true] in order for the task to be performed. Defaults to false."
       },
       "flush": {
         "type": "boolean",
+        "default": true,
         "description": "Whether flush or not before analyzing the index disk usage. Defaults to true"
       },
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists.json
@@ -30,14 +30,17 @@
     "params": {
       "local": {
         "type": "boolean",
+        "default": false,
         "description": "Return local information, do not retrieve the state from master node (default: false)"
       },
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Ignore unavailable indexes (default: false)"
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": true,
         "description": "Ignore if a wildcard expression resolves to no concrete indices (default: false)"
       },
       "expand_wildcards": {
@@ -54,6 +57,7 @@
       },
       "flat_settings": {
         "type": "boolean",
+        "default": false,
         "description": "Return settings in flat format (default: false)"
       },
       "include_defaults": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_alias.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_alias.json
@@ -46,10 +46,12 @@
     "params": {
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_index_template.json
@@ -30,6 +30,7 @@
     "params": {
       "flat_settings": {
         "type": "boolean",
+        "default": false,
         "description": "Return settings in flat format (default: false)"
       },
       "master_timeout": {
@@ -39,6 +40,7 @@
       },
       "local": {
         "type": "boolean",
+        "default": false,
         "description": "Return local information, do not retrieve the state from master node (default: false)"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_template.json
@@ -30,6 +30,7 @@
     "params": {
       "flat_settings": {
         "type": "boolean",
+        "default": false,
         "description": "Return settings in flat format (default: false)"
       },
       "master_timeout": {
@@ -39,6 +40,7 @@
       },
       "local": {
         "type": "boolean",
+        "default": false,
         "description": "Return local information, do not retrieve the state from master node (default: false)"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.field_usage_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.field_usage_stats.json
@@ -34,6 +34,7 @@
       },
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "allow_no_indices": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.flush.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.flush.json
@@ -38,18 +38,22 @@
     "params": {
       "force": {
         "type": "boolean",
+        "default": true,
         "description": "Whether a flush should be forced even if it is not necessarily needed ie. if no changes will be committed to the index. This is useful if transaction log IDs should be incremented even if no uncommitted changes are present. (This setting can be considered as internal)"
       },
       "wait_if_ongoing": {
         "type": "boolean",
+        "default": true,
         "description": "If set to true the flush operation will block until the flush can be executed if another flush operation is already executing. The default is true. If set to false the flush will be skipped iff if another flush operation is already running."
       },
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get.json
@@ -30,14 +30,17 @@
     "params": {
       "local": {
         "type": "boolean",
+        "default": false,
         "description": "Return local information, do not retrieve the state from master node (default: false)"
       },
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Ignore unavailable indexes (default: false)"
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": true,
         "description": "Ignore if a wildcard expression resolves to no concrete indices (default: false)"
       },
       "expand_wildcards": {
@@ -64,6 +67,7 @@
       },
       "flat_settings": {
         "type": "boolean",
+        "default": false,
         "description": "Return settings in flat format (default: false)"
       },
       "include_defaults": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_alias.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_alias.json
@@ -64,10 +64,12 @@
     "params": {
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_lifecycle.json
@@ -42,6 +42,7 @@
       },
       "include_defaults": {
         "type": "boolean",
+        "default": false,
         "description": "Return all relevant default configurations for the data stream (default: false)"
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_stream.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_stream.json
@@ -48,6 +48,7 @@
       },
       "include_defaults": {
         "type": "boolean",
+        "default": false,
         "description": "Return all relevant default configurations for the data stream (default: false)"
       },
       "master_timeout": {
@@ -57,6 +58,7 @@
       },
       "verbose": {
         "type": "boolean",
+        "default": false,
         "description": "Whether the maximum timestamp for each data stream should be calculated and returned (default: false)"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_field_mapping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_field_mapping.json
@@ -46,14 +46,17 @@
     "params": {
       "include_defaults": {
         "type": "boolean",
+        "default": false,
         "description": "Whether the default mapping values should be returned as well"
       },
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_index_template.json
@@ -36,6 +36,7 @@
     "params": {
       "flat_settings": {
         "type": "boolean",
+        "default": false,
         "description": "Return settings in flat format (default: false)"
       },
       "master_timeout": {
@@ -45,10 +46,12 @@
       },
       "local": {
         "type": "boolean",
+        "default": false,
         "description": "Return local information, do not retrieve the state from master node (default: false)"
       },
       "include_defaults": {
         "type": "boolean",
+        "default": false,
         "description": "Return all relevant default configurations for the index template (default: false)"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_mapping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_mapping.json
@@ -36,10 +36,12 @@
     "params": {
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
@@ -61,6 +63,7 @@
       },
       "local": {
         "type": "boolean",
+        "default": false,
         "description": "Return local information, do not retrieve the state from master node (default: false)",
         "deprecated": {
           "version": "7.8.0",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_settings.json
@@ -69,10 +69,12 @@
       },
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
@@ -89,10 +91,12 @@
       },
       "flat_settings": {
         "type": "boolean",
+        "default": false,
         "description": "Return settings in flat format (default: false)"
       },
       "local": {
         "type": "boolean",
+        "default": false,
         "description": "Return local information, do not retrieve the state from master node (default: false)"
       },
       "include_defaults": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_template.json
@@ -36,6 +36,7 @@
     "params": {
       "flat_settings": {
         "type": "boolean",
+        "default": false,
         "description": "Return settings in flat format (default: false)"
       },
       "master_timeout": {
@@ -45,6 +46,7 @@
       },
       "local": {
         "type": "boolean",
+        "default": false,
         "description": "Return local information, do not retrieve the state from master node (default: false)"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.migrate_to_data_stream.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.migrate_to_data_stream.json
@@ -30,6 +30,7 @@
     "params": {
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Specify timeout for acknowledging the cluster state update"
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.open.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.open.json
@@ -30,6 +30,7 @@
     "params": {
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       },
       "master_timeout": {
@@ -39,10 +40,12 @@
       },
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
@@ -59,6 +62,7 @@
       },
       "wait_for_active_shards": {
         "type": "string",
+        "default": "1",
         "description": "Sets the number of active shards to wait for before the operation returns."
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_alias.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_alias.json
@@ -55,6 +55,7 @@
     "params": {
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit timestamp for the document"
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_data_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_data_lifecycle.json
@@ -45,6 +45,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit timestamp for the document"
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_data_stream_options.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_data_stream_options.json
@@ -45,6 +45,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit timestamp for the document"
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_data_stream_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_data_stream_settings.json
@@ -35,6 +35,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Period to wait for a response"
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_index_template.json
@@ -40,7 +40,7 @@
       "cause": {
         "type": "string",
         "description": "User defined reason for creating/updating the index template",
-        "default": false
+        "default": "api"
       },
       "master_timeout": {
         "type": "time",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_mapping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_mapping.json
@@ -34,6 +34,7 @@
     "params": {
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       },
       "master_timeout": {
@@ -43,10 +44,12 @@
       },
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_settings.json
@@ -44,22 +44,27 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       },
       "preserve_existing": {
         "type": "boolean",
+        "default": false,
         "description": "Whether to update existing settings. If set to `true` existing settings on an index remain unchanged, the default is `false`"
       },
       "reopen": {
         "type": "boolean",
+        "default": false,
         "description": "Whether to close and reopen the index to apply non-dynamic settings. If set to `true` the indices to which the settings are being applied will be closed temporarily and then reopened in order to apply the changes. The default is `false`"
       },
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": false,
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
@@ -76,6 +81,7 @@
       },
       "flat_settings": {
         "type": "boolean",
+        "default": false,
         "description": "Return settings in flat format (default: false)"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.refresh.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.refresh.json
@@ -38,10 +38,12 @@
     "params": {
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.resolve_cluster.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.resolve_cluster.json
@@ -36,14 +36,17 @@
     "params": {
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed). Only allowed when providing an index expression."
       },
       "ignore_throttled": {
         "type": "boolean",
+        "default": false,
         "description": "Whether specified concrete, expanded or aliased indices should be ignored when throttled. Only allowed when providing an index expression."
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified). Only allowed when providing an index expression."
       },
       "expand_wildcards": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.rollover.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.rollover.json
@@ -49,10 +49,12 @@
     "params": {
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       },
       "dry_run": {
         "type": "boolean",
+        "default": false,
         "description": "If set to true the rollover action will only be validated but not actually performed even if a condition matches. The default is false"
       },
       "master_timeout": {
@@ -62,11 +64,12 @@
       },
       "wait_for_active_shards": {
         "type": "string",
+        "default": "1",
         "description": "Set the number of active shards to wait for on the newly created rollover index before the operation returns."
       },
       "lazy": {
         "type": "boolean",
-        "default": "false",
+        "default": false,
         "description": "If set to true, the rollover action will only mark a data stream to signal that it needs to be rolled over at the next write. Only allowed on data streams."
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.segments.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.segments.json
@@ -36,10 +36,12 @@
     "params": {
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.shard_stores.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.shard_stores.json
@@ -46,6 +46,7 @@
       },
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "allow_no_indices": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.shrink.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.shrink.json
@@ -38,6 +38,7 @@
     "params": {
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       },
       "master_timeout": {
@@ -47,6 +48,7 @@
       },
       "wait_for_active_shards": {
         "type": "string",
+        "default": "1",
         "description": "Set the number of active shards to wait for on the shrunken index before the operation returns."
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.simulate_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.simulate_index_template.json
@@ -39,7 +39,7 @@
       "cause": {
         "type": "string",
         "description": "User defined reason for dry-run creating the new template for simulation purposes",
-        "default": false
+        "default": "false"
       },
       "master_timeout": {
         "type": "time",
@@ -48,6 +48,7 @@
       },
       "include_defaults": {
         "type": "boolean",
+        "default": false,
         "description": "Return all relevant default configurations for this index template simulation (default: false)"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.simulate_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.simulate_template.json
@@ -45,7 +45,7 @@
       "cause": {
         "type": "string",
         "description": "User defined reason for dry-run creating the new template for simulation purposes",
-        "default": false
+        "default": "false"
       },
       "master_timeout": {
         "type": "time",
@@ -54,6 +54,7 @@
       },
       "include_defaults": {
         "type": "boolean",
+        "default": false,
         "description": "Return all relevant default configurations for this template simulation (default: false)"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.split.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.split.json
@@ -38,6 +38,7 @@
     "params": {
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       },
       "master_timeout": {
@@ -47,6 +48,7 @@
       },
       "wait_for_active_shards": {
         "type": "string",
+        "default": "1",
         "description": "Set the number of active shards to wait for on the shrunken index before the operation returns."
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.unfreeze.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.unfreeze.json
@@ -34,6 +34,7 @@
     "params": {
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       },
       "master_timeout": {
@@ -43,10 +44,12 @@
       },
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.update_aliases.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.update_aliases.json
@@ -27,6 +27,7 @@
     "params": {
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Request timeout"
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.validate_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.validate_query.json
@@ -41,14 +41,17 @@
     "params": {
       "explain": {
         "type": "boolean",
+        "default": false,
         "description": "Return detailed information about the error"
       },
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
@@ -73,6 +76,7 @@
       },
       "analyze_wildcard": {
         "type": "boolean",
+        "default": false,
         "description": "Specify whether wildcard and prefix queries should be analyzed (default: false)"
       },
       "default_operator": {
@@ -90,14 +94,17 @@
       },
       "lenient": {
         "type": "boolean",
+        "default": false,
         "description": "Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"
       },
       "rewrite": {
         "type": "boolean",
+        "default": false,
         "description": "Provide a more detailed explanation showing the actual Lucene query that will be executed."
       },
       "all_shards": {
         "type": "boolean",
+        "default": false,
         "description": "Execute validation on all shards instead of one random shard per index"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.delete.json
@@ -46,10 +46,12 @@
     "params": {
       "dry_run": {
         "type": "boolean",
+        "default": false,
         "description": "If true the endpoint will not be deleted and a list of ingest processors which reference this endpoint will be returned."
       },
       "force": {
         "type": "boolean",
+        "default": false,
         "description": "If true the endpoint will be forcefully stopped (regardless of whether or not it is referenced by any ingest processors or semantic text fields)."
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.delete_geoip_database.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.delete_geoip_database.json
@@ -35,6 +35,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.delete_ip_location_database.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.delete_ip_location_database.json
@@ -35,6 +35,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.delete_pipeline.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.delete_pipeline.json
@@ -35,6 +35,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.get_pipeline.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.get_pipeline.json
@@ -36,6 +36,7 @@
     "params": {
       "summary": {
         "type": "boolean",
+        "default": false,
         "description": "Return pipelines without their definitions (default: false)"
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_geoip_database.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_geoip_database.json
@@ -38,6 +38,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_ip_location_database.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_ip_location_database.json
@@ -38,6 +38,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_pipeline.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ingest.put_pipeline.json
@@ -42,6 +42,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/license.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/license.delete.json
@@ -29,6 +29,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for acknowledgement of update from all nodes in cluster"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/license.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/license.get.json
@@ -24,12 +24,14 @@
     "params": {
       "local": {
         "type": "boolean",
+        "default": true,
         "description": "Return local information, do not retrieve the state from master node (default: false)"
       },
       "accept_enterprise": {
         "type": "boolean",
-        "description": "Supported for backwards compatibility with 7.x. If this param is used it must be set to true",
-        "deprecated": true
+        "deprecated": true,
+        "default": true,
+        "description": "Supported for backwards compatibility with 7.x. If this param is used it must be set to true"
       }
     }
   }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/license.post.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/license.post.json
@@ -28,6 +28,7 @@
     "params": {
       "acknowledge": {
         "type": "boolean",
+        "default": false,
         "description": "whether the user has acknowledged acknowledge messages (default: false)"
       },
       "master_timeout": {
@@ -37,6 +38,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for acknowledgement of update from all nodes in cluster"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/license.post_start_basic.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/license.post_start_basic.json
@@ -33,6 +33,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for acknowledgement of update from all nodes in cluster"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/mget.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/mget.json
@@ -47,6 +47,7 @@
       },
       "stored_fields": {
         "type": "list",
+        "default": "false",
         "description": "A comma-separated list of stored fields to return in the response"
       },
       "preference": {
@@ -55,10 +56,12 @@
       },
       "realtime": {
         "type": "boolean",
+        "default": true,
         "description": "Specify whether to perform the operation in realtime or search mode"
       },
       "refresh": {
         "type": "boolean",
+        "default": false,
         "description": "Refresh the shard containing the document before performing the operation"
       },
       "routing": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.close_job.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.close_job.json
@@ -33,14 +33,17 @@
     "params": {
       "allow_no_match": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
       },
       "force": {
         "type": "boolean",
+        "default": false,
         "description": "True if the job should be forcefully closed"
       },
       "timeout": {
         "type": "time",
+        "default": "30m",
         "description": "Controls the time to wait until a job has closed. Default to 30 minutes"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.delete_data_frame_analytics.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.delete_data_frame_analytics.json
@@ -35,6 +35,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "1m",
         "description": "Controls the time to wait until a job is deleted. Defaults to 1 minute"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.delete_expired_data.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.delete_expired_data.json
@@ -43,6 +43,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "8h",
         "description": "How long can the underlying delete processes run until they are canceled"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.delete_forecast.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.delete_forecast.json
@@ -46,10 +46,12 @@
     "params": {
       "allow_no_forecasts": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if `_all` matches no forecasts"
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Controls the time to wait until the forecast(s) are deleted. Default to 30 seconds"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.forecast.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.forecast.json
@@ -33,14 +33,17 @@
     "params": {
       "duration": {
         "type": "time",
+        "default": "1d",
         "description": "The duration of the forecast"
       },
       "expires_in": {
         "type": "time",
+        "default": "14d",
         "description": "The time interval after which the forecast expires. Expired forecasts will be deleted at the first opportunity."
       },
       "max_model_memory": {
         "type": "string",
+        "default": "20mb",
         "description": "The max memory able to be used by the forecast. Default is 20mb."
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_buckets.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_buckets.json
@@ -51,38 +51,47 @@
     "params": {
       "expand": {
         "type": "boolean",
+        "default": false,
         "description": "Include anomaly records"
       },
       "exclude_interim": {
         "type": "boolean",
+        "default": false,
         "description": "Exclude interim results"
       },
       "from": {
         "type": "int",
+        "default": 0,
         "description": "skips a number of buckets"
       },
       "size": {
         "type": "int",
+        "default": 100,
         "description": "specifies a max number of buckets to get"
       },
       "start": {
         "type": "string",
+        "default": "-1",
         "description": "Start time filter for buckets"
       },
       "end": {
         "type": "string",
+        "default": "-1",
         "description": "End time filter for buckets"
       },
       "anomaly_score": {
         "type": "double",
+        "default": 0,
         "description": "Filter for the most anomalous buckets"
       },
       "sort": {
         "type": "string",
+        "default": "timestamp",
         "description": "Sort buckets by a particular field"
       },
       "desc": {
         "type": "boolean",
+        "default": false,
         "description": "Set the sort direction"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_calendar_events.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_calendar_events.json
@@ -42,10 +42,12 @@
       },
       "from": {
         "type": "int",
+        "default": 0,
         "description": "Skips a number of events"
       },
       "size": {
         "type": "int",
+        "default": 100,
         "description": "Specifies a max number of events to get"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_calendars.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_calendars.json
@@ -41,10 +41,12 @@
     "params": {
       "from": {
         "type": "int",
+        "default": 0,
         "description": "skips a number of calendars"
       },
       "size": {
         "type": "int",
+        "default": 10000,
         "description": "specifies a max number of calendars to get"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_categories.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_categories.json
@@ -51,10 +51,12 @@
     "params": {
       "from": {
         "type": "int",
+        "default": 0,
         "description": "skips a number of categories"
       },
       "size": {
         "type": "int",
+        "default": 100,
         "description": "specifies a max number of categories to get"
       },
       "partition_field_value": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_filters.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_filters.json
@@ -36,10 +36,12 @@
     "params": {
       "from": {
         "type": "int",
+        "default": 0,
         "description": "skips a number of filters"
       },
       "size": {
         "type": "int",
+        "default": 100,
         "description": "specifies a max number of filters to get"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_influencers.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_influencers.json
@@ -34,26 +34,32 @@
     "params": {
       "exclude_interim": {
         "type": "boolean",
+        "default": false,
         "description": "Exclude interim results"
       },
       "from": {
         "type": "int",
+        "default": 0,
         "description": "skips a number of influencers"
       },
       "size": {
         "type": "int",
+        "default": 100,
         "description": "specifies a max number of influencers to get"
       },
       "start": {
         "type": "string",
+        "default": "-1",
         "description": "start timestamp for the requested influencers"
       },
       "end": {
         "type": "string",
+        "default": "-1",
         "description": "end timestamp for the requested influencers"
       },
       "influencer_score": {
         "type": "double",
+        "default": 0,
         "description": "influencer score threshold for the requested influencers"
       },
       "sort": {
@@ -62,6 +68,7 @@
       },
       "desc": {
         "type": "boolean",
+        "default": false,
         "description": "whether the results should be sorted in decending order"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_job_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_job_stats.json
@@ -36,6 +36,7 @@
     "params": {
       "allow_no_match": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_jobs.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_jobs.json
@@ -36,6 +36,7 @@
     "params": {
       "allow_no_match": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
       },
       "exclude_generated": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_memory_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_memory_stats.json
@@ -41,6 +41,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_model_snapshots.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_model_snapshots.json
@@ -51,10 +51,12 @@
     "params": {
       "from": {
         "type": "int",
+        "default": 0,
         "description": "Skips a number of documents"
       },
       "size": {
         "type": "int",
+        "default": 100,
         "description": "The default number of documents returned in queries as a string."
       },
       "start": {
@@ -71,6 +73,7 @@
       },
       "desc": {
         "type": "boolean",
+        "default": false,
         "description": "True if the results should be sorted in descending order"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_overall_buckets.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_overall_buckets.json
@@ -34,6 +34,7 @@
     "params": {
       "top_n": {
         "type": "int",
+        "default": 1,
         "description": "The number of top job bucket scores to be used in the overall_score calculation"
       },
       "bucket_span": {
@@ -46,6 +47,7 @@
       },
       "exclude_interim": {
         "type": "boolean",
+        "default": false,
         "description": "If true overall buckets that include interim buckets will be excluded"
       },
       "start": {
@@ -58,6 +60,7 @@
       },
       "allow_no_match": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_records.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_records.json
@@ -34,34 +34,42 @@
     "params": {
       "exclude_interim": {
         "type": "boolean",
+        "default": false,
         "description": "Exclude interim results"
       },
       "from": {
         "type": "int",
+        "default": 0,
         "description": "skips a number of records"
       },
       "size": {
         "type": "int",
+        "default": 100,
         "description": "specifies a max number of records to get"
       },
       "start": {
         "type": "string",
+        "default": "-1",
         "description": "Start time filter for records"
       },
       "end": {
         "type": "string",
+        "default": "-1",
         "description": "End time filter for records"
       },
       "record_score": {
         "type": "double",
+        "default": 0,
         "description": "Returns records with anomaly scores greater or equal than this value"
       },
       "sort": {
         "type": "string",
+        "default": "record_score",
         "description": "Sort records by a particular field"
       },
       "desc": {
         "type": "boolean",
+        "default": false,
         "description": "Set the sort direction"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_datafeed.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_datafeed.json
@@ -37,14 +37,17 @@
     "params": {
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Ignore unavailable indexes (default: false)"
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": true,
         "description": "Ignore if the source indices expressions resolves to no concrete indices (default: true)"
       },
       "ignore_throttled": {
         "type": "boolean",
+        "default": true,
         "description": "Ignore indices that are marked as throttled (default: true)"
       },
       "expand_wildcards": {
@@ -56,6 +59,7 @@
           "none",
           "all"
         ],
+        "default": "open",
         "description": "Whether source index expressions should get expanded to open or closed indices (default: open)"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_job.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_job.json
@@ -33,14 +33,17 @@
     "params": {
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Ignore unavailable indexes (default: false). Only set if datafeed_config is provided."
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": true,
         "description": "Ignore if the source indices expressions resolves to no concrete indices (default: true). Only set if datafeed_config is provided."
       },
       "ignore_throttled": {
         "type": "boolean",
+        "default": true,
         "description": "Ignore indices that are marked as throttled (default: true). Only set if datafeed_config is provided."
       },
       "expand_wildcards": {
@@ -52,6 +55,7 @@
           "none",
           "all"
         ],
+        "default": "open",
         "description": "Whether source index expressions should get expanded to open or closed indices (default: open). Only set if datafeed_config is provided."
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_trained_model_alias.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_trained_model_alias.json
@@ -37,6 +37,7 @@
     "params": {
       "reassign": {
         "type": "boolean",
+        "default": false,
         "description": "If the model_alias already exists and points to a separate model_id, this parameter must be true. Defaults to false."
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.revert_model_snapshot.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.revert_model_snapshot.json
@@ -37,6 +37,7 @@
     "params": {
       "delete_intervening_results": {
         "type": "boolean",
+        "default": false,
         "description": "Should we reset the results back to the time of the snapshot?"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.set_upgrade_mode.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.set_upgrade_mode.json
@@ -24,10 +24,12 @@
     "params": {
       "enabled": {
         "type": "boolean",
+        "default": false,
         "description": "Whether to enable upgrade_mode ML setting or not. Defaults to false."
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Controls the time to wait before action times out. Defaults to 30 seconds"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.start_data_frame_analytics.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.start_data_frame_analytics.json
@@ -33,6 +33,7 @@
     "params": {
       "timeout": {
         "type": "time",
+        "default": "20s",
         "description": "Controls the time to wait until the task has started. Defaults to 20 seconds"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.start_datafeed.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.start_datafeed.json
@@ -41,6 +41,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "20s",
         "description": "Controls the time to wait until a datafeed has started. Default to 20 seconds"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.stop_data_frame_analytics.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.stop_data_frame_analytics.json
@@ -33,14 +33,17 @@
     "params": {
       "allow_no_match": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard expression matches no data frame analytics. (This includes `_all` string or when no data frame analytics have been specified)"
       },
       "force": {
         "type": "boolean",
+        "default": false,
         "description": "True if the data frame analytics should be forcefully stopped"
       },
       "timeout": {
         "type": "time",
+        "default": "20s",
         "description": "Controls the time to wait until the task has stopped. Defaults to 20 seconds"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.stop_datafeed.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.stop_datafeed.json
@@ -33,14 +33,17 @@
     "params": {
       "allow_no_match": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)"
       },
       "force": {
         "type": "boolean",
+        "default": false,
         "description": "True if the datafeed should be forcefully stopped."
       },
       "timeout": {
         "type": "time",
+        "default": "20s",
         "description": "Controls the time to wait until a datafeed has stopped. Default to 20 seconds"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.stop_trained_model_deployment.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.stop_trained_model_deployment.json
@@ -34,10 +34,12 @@
     "params": {
       "allow_no_match": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard expression matches no deployments. (This includes `_all` string or when no deployments have been specified)"
       },
       "force": {
         "type": "boolean",
+        "default": false,
         "description": "True if the deployment should be forcefully stopped"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.update_datafeed.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.update_datafeed.json
@@ -37,14 +37,17 @@
     "params": {
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Ignore unavailable indexes (default: false)"
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": true,
         "description": "Ignore if the source indices expressions resolves to no concrete indices (default: true)"
       },
       "ignore_throttled": {
         "type": "boolean",
+        "default": true,
         "description": "Ignore indices that are marked as throttled (default: true)"
       },
       "expand_wildcards": {
@@ -56,6 +59,7 @@
           "none",
           "all"
         ],
+        "default": "open",
         "description": "Whether source index expressions should get expanded to open or closed indices (default: open)"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.update_trained_model_deployment.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.update_trained_model_deployment.json
@@ -33,6 +33,7 @@
     "params": {
       "number_of_allocations": {
         "type": "int",
+        "default": 1,
         "description": "Update the model deployment to this number of allocations."
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.upgrade_job_snapshot.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.upgrade_job_snapshot.json
@@ -34,10 +34,12 @@
     "params": {
       "timeout": {
         "type": "time",
+        "default": "30m",
         "description": "How long should the API wait for the job to be opened and the old snapshot to be loaded."
       },
       "wait_for_completion": {
         "type": "boolean",
+        "default": false,
         "description": "Should the request wait until the task is complete before responding to the caller. Default is false."
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/msearch.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/msearch.json
@@ -72,7 +72,7 @@
       "ccs_minimize_roundtrips": {
         "type": "boolean",
         "description": "Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution",
-        "default": "true"
+        "default": true
       },
       "index": {
         "type": "list",
@@ -80,12 +80,14 @@
       },
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "ignore_throttled": {
         "type": "boolean",
-        "description": "Whether specified concrete, expanded or aliased indices should be ignored when throttled",
-        "deprecated": true
+        "deprecated": true,
+        "default": false,
+        "description": "Whether specified concrete, expanded or aliased indices should be ignored when throttled"
       },
       "allow_no_indices": {
         "type": "boolean",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/msearch_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/msearch_template.json
@@ -49,6 +49,7 @@
       },
       "typed_keys": {
         "type": "boolean",
+        "default": false,
         "description": "Specify whether aggregation and suggester names should be prefixed by their respective types in the response"
       },
       "max_concurrent_searches": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/mtermvectors.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/mtermvectors.json
@@ -82,6 +82,7 @@
       },
       "realtime": {
         "type": "boolean",
+        "default": true,
         "description": "Specifies if requests are real-time as opposed to near-real-time (default: true)."
       },
       "version": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.hot_threads.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.hot_threads.json
@@ -36,18 +36,22 @@
     "params": {
       "interval": {
         "type": "time",
+        "default": "500ms",
         "description": "The interval for the second sampling of threads"
       },
       "snapshots": {
         "type": "number",
+        "default": 10,
         "description": "Number of samples of thread stacktrace (default: 10)"
       },
       "threads": {
         "type": "number",
+        "default": 3,
         "description": "Specify the number of threads to provide information for (default: 3)"
       },
       "ignore_idle_threads": {
         "type": "boolean",
+        "default": true,
         "description": "Don't show threads that are in known-idle places, such as waiting on a socket select or pulling from an empty task queue (default: true)"
       },
       "type": {
@@ -58,6 +62,7 @@
           "block",
           "mem"
         ],
+        "default": "cpu",
         "description": "The type to sample (default: cpu)"
       },
       "sort": {
@@ -70,6 +75,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.info.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.info.json
@@ -92,10 +92,12 @@
     "params": {
       "flat_settings": {
         "type": "boolean",
+        "default": false,
         "description": "Return settings in flat format (default: false)"
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.reload_secure_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.reload_secure_settings.json
@@ -39,6 +39,7 @@
     "params": {
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.stats.json
@@ -226,6 +226,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       },
       "include_segment_file_sizes": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.usage.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.usage.json
@@ -72,6 +72,7 @@
     "params": {
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/open_point_in_time.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/open_point_in_time.json
@@ -41,6 +41,7 @@
       },
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "expand_wildcards": {
@@ -62,6 +63,7 @@
       },
       "allow_partial_search_results": {
         "type": "boolean",
+        "default": false,
         "description": "Specify whether to tolerate shards missing when creating the point-in-time, or otherwise throw an exception. (default: false)"
       },
       "max_concurrent_shard_requests": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/put_script.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/put_script.json
@@ -51,6 +51,7 @@
     "params": {
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/rank_eval.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/rank_eval.json
@@ -41,10 +41,12 @@
     "params": {
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/reindex.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/reindex.json
@@ -27,6 +27,7 @@
     "params": {
       "refresh": {
         "type": "boolean",
+        "default": false,
         "description": "Should the affected indexes be refreshed?"
       },
       "timeout": {
@@ -36,6 +37,7 @@
       },
       "wait_for_active_shards": {
         "type": "string",
+        "default": "1",
         "description": "Sets the number of shard copies that must be active before proceeding with the reindex operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)"
       },
       "wait_for_completion": {
@@ -45,7 +47,7 @@
       },
       "requests_per_second": {
         "type": "number",
-        "default": 0,
+        "default": -1,
         "description": "The throttle to set on this request in sub-requests per second. -1 means no throttle."
       },
       "scroll": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.stop_job.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.stop_job.json
@@ -30,10 +30,12 @@
     "params": {
       "wait_for_completion": {
         "type": "boolean",
+        "default": false,
         "description": "True if the API should block until the job has fully stopped, false if should be executed async. Defaults to false."
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Block for (at maximum) the specified duration while waiting for the job to stop.  Defaults to 30s."
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/scroll.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/scroll.json
@@ -46,6 +46,7 @@
     "params": {
       "scroll": {
         "type": "time",
+        "default": "1d",
         "description": "Specify how long a consistent view of the index should be maintained for scrolled search"
       },
       "scroll_id": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
@@ -45,12 +45,13 @@
       },
       "analyze_wildcard": {
         "type": "boolean",
+        "default": false,
         "description": "Specify whether wildcard and prefix queries should be analyzed (default: false)"
       },
       "ccs_minimize_roundtrips": {
         "type": "boolean",
         "description": "Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution",
-        "default": "true"
+        "default": true
       },
       "default_operator": {
         "type": "enum",
@@ -67,6 +68,7 @@
       },
       "explain": {
         "type": "boolean",
+        "default": false,
         "description": "Specify whether to return detailed information about score computation as part of a hit"
       },
       "stored_fields": {
@@ -79,6 +81,7 @@
       },
       "from": {
         "type": "number",
+        "default": 0,
         "description": "Starting offset (default: 0)"
       },
       "force_synthetic_source": {
@@ -89,14 +92,17 @@
       },
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "ignore_throttled": {
         "type": "boolean",
+        "default": true,
         "description": "Whether specified concrete, expanded or aliased indices should be ignored when throttled"
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
@@ -113,6 +119,7 @@
       },
       "lenient": {
         "type": "boolean",
+        "default": false,
         "description": "Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"
       },
       "preference": {
@@ -141,6 +148,7 @@
       },
       "size": {
         "type": "number",
+        "default": 10,
         "description": "Number of hits to return (default: 10)"
       },
       "sort": {
@@ -149,6 +157,7 @@
       },
       "_source": {
         "type": "list",
+        "default": "true",
         "description": "True or false to return the _source field or not, or a list of fields to return"
       },
       "_source_excludes": {
@@ -161,6 +170,7 @@
       },
       "terminate_after": {
         "type": "number",
+        "default": 0,
         "description": "The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early."
       },
       "stats": {
@@ -195,10 +205,12 @@
       },
       "track_scores": {
         "type": "boolean",
+        "default": false,
         "description": "Whether to calculate and return scores even if they are not used for sorting"
       },
       "track_total_hits": {
         "type": "boolean|long",
+        "default": "10000",
         "description": "Indicate if the number of documents that match the query should be tracked. A number can also be specified, to accurately track the total hit count up to the number."
       },
       "allow_partial_search_results": {
@@ -208,10 +220,12 @@
       },
       "typed_keys": {
         "type": "boolean",
+        "default": false,
         "description": "Specify whether aggregation and suggester names should be prefixed by their respective types in the response"
       },
       "version": {
         "type": "boolean",
+        "default": false,
         "description": "Specify whether to return document version as part of a hit"
       },
       "seq_no_primary_term": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.list.json
@@ -28,6 +28,7 @@
       },
       "from": {
         "type": "int",
+        "default": 0,
         "description": "Starting offset (default: 0)"
       },
       "size": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.put.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.put.json
@@ -33,6 +33,7 @@
     "params": {
       "create": {
         "type": "boolean",
+        "default": false,
         "description": "If true, requires that a search application with the specified resource_id does not already exist. (default: false)"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_mvt.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_mvt.json
@@ -89,6 +89,7 @@
       },
       "track_total_hits": {
         "type": "boolean|long",
+        "default": "10000",
         "description": "Indicate if the number of documents that match the query should be tracked. A number can also be specified, to accurately track the total hit count up to the number."
       },
       "with_labels": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_shards.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_shards.json
@@ -46,14 +46,17 @@
       },
       "local": {
         "type": "boolean",
+        "default": false,
         "description": "Return local information, do not retrieve the state from master node (default: false)"
       },
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": false,
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_template.json
@@ -41,14 +41,17 @@
     "params": {
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "ignore_throttled": {
         "type": "boolean",
+        "default": true,
         "description": "Whether specified concrete, expanded or aliased indices should be ignored when throttled"
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
@@ -85,14 +88,17 @@
       },
       "explain": {
         "type": "boolean",
+        "default": false,
         "description": "Specify whether to return detailed information about score computation as part of a hit"
       },
       "profile": {
         "type": "boolean",
+        "default": false,
         "description": "Specify whether to profile the query execution"
       },
       "typed_keys": {
         "type": "boolean",
+        "default": false,
         "description": "Specify whether aggregation and suggester names should be prefixed by their respective types in the response"
       },
       "rest_total_hits_as_int": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/searchable_snapshots.clear_cache.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/searchable_snapshots.clear_cache.json
@@ -47,6 +47,7 @@
         "options": [
           "open",
           "closed",
+          "hidden",
           "none",
           "all"
         ],

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/searchable_snapshots.mount.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/searchable_snapshots.mount.json
@@ -48,7 +48,7 @@
       "storage": {
         "type": "string",
         "description": "Selects the kind of local storage used to accelerate searches. Experimental, and defaults to `full_copy`",
-        "default": false
+        "default": "full_copy"
       }
     },
     "body": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.disable_user_profile.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.disable_user_profile.json
@@ -36,6 +36,7 @@
           "false",
           "wait_for"
         ],
+        "default": "false",
         "description": "If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` (the default) then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes."
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.enable_user_profile.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.enable_user_profile.json
@@ -36,6 +36,7 @@
           "false",
           "wait_for"
         ],
+        "default": "false",
         "description": "If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` (the default) then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes."
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.grant_api_key.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.grant_api_key.json
@@ -32,6 +32,7 @@
           "false",
           "wait_for"
         ],
+        "default": "false",
         "description": "If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes."
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.put_user.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.put_user.json
@@ -39,6 +39,7 @@
           "false",
           "wait_for"
         ],
+        "default": "true",
         "description": "If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes."
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.update_user_profile_data.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.update_user_profile_data.json
@@ -47,6 +47,7 @@
           "false",
           "wait_for"
         ],
+        "default": "false",
         "description": "If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes."
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/shutdown.delete_node.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/shutdown.delete_node.json
@@ -38,6 +38,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/shutdown.put_node.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/shutdown.put_node.json
@@ -38,6 +38,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/slm.delete_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/slm.delete_lifecycle.json
@@ -35,6 +35,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/slm.execute_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/slm.execute_lifecycle.json
@@ -35,6 +35,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/slm.execute_retention.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/slm.execute_retention.json
@@ -29,6 +29,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/slm.get_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/slm.get_lifecycle.json
@@ -41,6 +41,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/slm.get_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/slm.get_stats.json
@@ -29,6 +29,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/slm.get_status.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/slm.get_status.json
@@ -29,6 +29,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/slm.put_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/slm.put_lifecycle.json
@@ -38,6 +38,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/slm.start.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/slm.start.json
@@ -29,6 +29,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for acknowledgement of update from all nodes in cluster"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/slm.stop.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/slm.stop.json
@@ -29,6 +29,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for acknowledgement of update from all nodes in cluster"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.cleanup_repository.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.cleanup_repository.json
@@ -35,6 +35,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.create_repository.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.create_repository.json
@@ -39,10 +39,12 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       },
       "verify": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to verify the repository after creation"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.delete_repository.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.delete_repository.json
@@ -35,6 +35,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.get.json
@@ -39,18 +39,22 @@
       },
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Whether to ignore unavailable snapshots, defaults to false which means a SnapshotMissingException is thrown"
       },
       "index_names": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to include the name of each index in the snapshot. Defaults to true."
       },
       "index_details": {
         "type": "boolean",
+        "default": false,
         "description": "Whether to include details of each index in the snapshot, if those details are available. Defaults to false."
       },
       "include_repository": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to include the repository name in the snapshot info. Defaults to true."
       },
       "sort": {
@@ -69,6 +73,7 @@
       },
       "size": {
         "type": "integer",
+        "default": 0,
         "description": "Maximum number of snapshots to return. Defaults to 0 which means return all that match without limit."
       },
       "order": {
@@ -90,6 +95,7 @@
       },
       "offset": {
         "type": "integer",
+        "default": 0,
         "description": "Numeric offset to start pagination based on the snapshots matching the request. Defaults to 0"
       },
       "slm_policy_filter": {
@@ -98,6 +104,7 @@
       },
       "verbose": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to show verbose snapshot info or only show the basic info found in the repository index blob"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.get_repository.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.get_repository.json
@@ -41,6 +41,7 @@
       },
       "local": {
         "type": "boolean",
+        "default": false,
         "description": "Return local information, do not retrieve the state from master node (default: false)"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.repository_analyze.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.repository_analyze.json
@@ -30,22 +30,27 @@
     "params": {
       "blob_count": {
         "type": "number",
+        "default": 100,
         "description": "Number of blobs to create during the test. Defaults to 100."
       },
       "concurrency": {
         "type": "number",
+        "default": 10,
         "description": "Number of operations to run concurrently during the test. Defaults to 10."
       },
       "register_operation_count": {
         "type": "number",
+        "default": 10,
         "description": "The minimum number of linearizable register operations to perform in total. Defaults to 10."
       },
       "read_node_count": {
         "type": "number",
+        "default": 10,
         "description": "Number of nodes on which to read a blob after writing. Defaults to 10."
       },
       "early_read_node_count": {
         "type": "number",
+        "default": 2,
         "description": "Number of nodes on which to perform an early read on a blob, i.e. before writing has completed. Early reads are rare actions so the 'rare_action_probability' parameter is also relevant. Defaults to 2."
       },
       "seed": {
@@ -54,26 +59,32 @@
       },
       "rare_action_probability": {
         "type": "number",
+        "default": 0,
         "description": "Probability of taking a rare action such as an early read or an overwrite. Defaults to 0.02."
       },
       "max_blob_size": {
         "type": "string",
+        "default": "10mb",
         "description": "Maximum size of a blob to create during the test, e.g '1gb' or '100mb'. Defaults to '10mb'."
       },
       "max_total_data_size": {
         "type": "string",
+        "default": "1gb",
         "description": "Maximum total size of all blobs to create during the test, e.g '1tb' or '100gb'. Defaults to '1gb'."
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout. Defaults to '30s'."
       },
       "detailed": {
         "type": "boolean",
+        "default": false,
         "description": "Whether to return detailed results or a summary. Defaults to 'false' so that only the summary is returned."
       },
       "rarely_abort_writes": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to rarely abort writes before they complete. Defaults to 'true'."
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.repository_verify_integrity.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.repository_verify_integrity.json
@@ -30,34 +30,42 @@
     "params": {
       "meta_thread_pool_concurrency": {
         "type": "number",
+        "default": 0,
         "description": "Number of threads to use for reading metadata"
       },
       "blob_thread_pool_concurrency": {
         "type": "number",
+        "default": 1,
         "description": "Number of threads to use for reading blob contents"
       },
       "snapshot_verification_concurrency": {
         "type": "number",
+        "default": 0,
         "description": "Number of snapshots to verify concurrently"
       },
       "index_verification_concurrency": {
         "type": "number",
+        "default": 0,
         "description": "Number of indices to verify concurrently"
       },
       "index_snapshot_verification_concurrency": {
         "type": "number",
+        "default": 1,
         "description": "Number of snapshots to verify concurrently within each index"
       },
       "max_failed_shard_snapshots": {
         "type": "number",
+        "default": 10000,
         "description": "Maximum permitted number of failed shard snapshots"
       },
       "verify_blob_contents": {
         "type": "boolean",
+        "default": false,
         "description": "Whether to verify the contents of individual blobs"
       },
       "max_bytes_per_sec": {
         "type": "string",
+        "default": "10mb",
         "description": "Rate limit for individual blob verification"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.status.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.status.json
@@ -57,6 +57,7 @@
       },
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Whether to ignore unavailable snapshots, defaults to false which means a SnapshotMissingException is thrown"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.verify_repository.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.verify_repository.json
@@ -35,6 +35,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/streams.logs_disable.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/streams.logs_disable.json
@@ -26,6 +26,7 @@
     "params": {
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error."
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/streams.logs_enable.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/streams.logs_enable.json
@@ -26,6 +26,7 @@
     "params": {
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error."
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/streams.status.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/streams.status.json
@@ -22,6 +22,12 @@
         }
       ]
     },
-    "params": {}
+    "params": {
+      "master_timeout": {
+        "type": "time",
+        "default": "30s",
+        "description": "Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error."
+      }
+    }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.cancel.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.cancel.json
@@ -48,6 +48,7 @@
       },
       "wait_for_completion": {
         "type": "boolean",
+        "default": false,
         "description": "Should the request block until the cancellation of the task and its descendant tasks is completed. Defaults to false"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.get.json
@@ -30,10 +30,12 @@
     "params": {
       "wait_for_completion": {
         "type": "boolean",
+        "default": false,
         "description": "Wait for the matching tasks to complete (default: false)"
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/tasks.list.json
@@ -32,6 +32,7 @@
       },
       "detailed": {
         "type": "boolean",
+        "default": false,
         "description": "Return detailed task information (default: false)"
       },
       "parent_task_id": {
@@ -40,6 +41,7 @@
       },
       "wait_for_completion": {
         "type": "boolean",
+        "default": false,
         "description": "Wait for the matching tasks to complete (default: false)"
       },
       "group_by": {
@@ -54,6 +56,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/termvectors.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/termvectors.json
@@ -88,6 +88,7 @@
       },
       "realtime": {
         "type": "boolean",
+        "default": true,
         "description": "Specifies if request is real-time as opposed to near-real-time (default: true)."
       },
       "version": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/text_structure.find_field_structure.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/text_structure.find_field_structure.json
@@ -74,6 +74,7 @@
       },
       "ecs_compatibility": {
         "type": "string",
+        "default": "disabled",
         "description": "Optional parameter to specify the compatibility mode with ECS Grok patterns - may be either 'v1' or 'disabled'"
       },
       "timestamp_field": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/text_structure.find_message_structure.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/text_structure.find_message_structure.json
@@ -63,6 +63,7 @@
       },
       "ecs_compatibility": {
         "type": "string",
+        "default": "disabled",
         "description": "Optional parameter to specify the compatibility mode with ECS Grok patterns - may be either 'v1' or 'disabled'"
       },
       "timestamp_field": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/text_structure.find_structure.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/text_structure.find_structure.json
@@ -80,6 +80,7 @@
       },
       "ecs_compatibility": {
         "type": "string",
+        "default": "disabled",
         "description": "Optional parameter to specify the compatibility mode with ECS Grok patterns - may be either 'v1' or 'disabled'"
       },
       "timestamp_field": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/text_structure.test_grok_pattern.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/text_structure.test_grok_pattern.json
@@ -28,6 +28,7 @@
     "params": {
       "ecs_compatibility": {
         "type": "string",
+        "default": "disabled",
         "description": "Optional parameter to specify the compatibility mode with ECS Grok patterns - may be either 'v1' or 'disabled'"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.delete_transform.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.delete_transform.json
@@ -30,14 +30,17 @@
     "params": {
       "force": {
         "type": "boolean",
+        "default": false,
         "description": "When `true`, the transform is deleted regardless of its current state. The default value is `false`, meaning that the transform must be `stopped` before it can be deleted."
       },
       "delete_dest_index": {
         "type": "boolean",
+        "default": false,
         "description": "When `true`, the destination index is deleted together with the transform. The default value is `false`, meaning that the destination index will not be deleted."
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Controls the time to wait for the transform deletion"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.get_transform.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.get_transform.json
@@ -36,14 +36,17 @@
     "params": {
       "from": {
         "type": "int",
+        "default": 0,
         "description": "skips a number of transform configs, defaults to 0"
       },
       "size": {
         "type": "int",
+        "default": 100,
         "description": "specifies a max number of transforms to get, defaults to 100"
       },
       "allow_no_match": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard expression matches no transforms. (This includes `_all` string or when no transforms have been specified)"
       },
       "exclude_generated": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.get_transform_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.get_transform_stats.json
@@ -30,10 +30,12 @@
     "params": {
       "from": {
         "type": "number",
+        "default": 0,
         "description": "skips a number of transform stats, defaults to 0"
       },
       "size": {
         "type": "number",
+        "default": 100,
         "description": "specifies a max number of transform stats to get, defaults to 100"
       },
       "timeout": {
@@ -42,6 +44,7 @@
       },
       "allow_no_match": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard expression matches no transforms. (This includes `_all` string or when no transforms have been specified)"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.preview_transform.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.preview_transform.json
@@ -41,6 +41,7 @@
     "params": {
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Controls the time to wait for the preview"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.put_transform.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.put_transform.json
@@ -33,10 +33,12 @@
     "params": {
       "defer_validation": {
         "type": "boolean",
+        "default": false,
         "description": "If validations should be deferred until transform starts, defaults to false."
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Controls the time to wait for the transform to start"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.reset_transform.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.reset_transform.json
@@ -30,10 +30,12 @@
     "params": {
       "force": {
         "type": "boolean",
+        "default": false,
         "description": "When `true`, the transform is reset regardless of its current state. The default value is `false`, meaning that the transform must be `stopped` before it can be reset."
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Controls the time to wait for the transform to reset"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.schedule_now_transform.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.schedule_now_transform.json
@@ -34,6 +34,7 @@
     "params": {
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Controls the time to wait for the scheduling to take place"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.set_upgrade_mode.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.set_upgrade_mode.json
@@ -24,10 +24,12 @@
     "params": {
       "enabled": {
         "type": "boolean",
+        "default": false,
         "description": "Whether to enable upgrade_mode Transform setting or not. Defaults to false."
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Controls the time to wait before action times out. Defaults to 30 seconds"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.start_transform.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.start_transform.json
@@ -34,6 +34,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Controls the time to wait for the transform to start"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.stop_transform.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.stop_transform.json
@@ -30,22 +30,27 @@
     "params": {
       "force": {
         "type": "boolean",
+        "default": false,
         "description": "Whether to force stop a failed transform or not. Default to false"
       },
       "wait_for_completion": {
         "type": "boolean",
+        "default": false,
         "description": "Whether to wait for the transform to fully stop before returning or not. Default to false"
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Controls the time to wait until the transform has stopped. Default to 30 seconds"
       },
       "allow_no_match": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard expression matches no transforms. (This includes `_all` string or when no transforms have been specified)"
       },
       "wait_for_checkpoint": {
         "type": "boolean",
+        "default": false,
         "description": "Whether to wait for the transform to reach a checkpoint before stopping. Default to false"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.update_transform.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.update_transform.json
@@ -38,6 +38,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Controls the time to wait for the update"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.upgrade_transforms.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.upgrade_transforms.json
@@ -27,10 +27,12 @@
     "params": {
       "dry_run": {
         "type": "boolean",
+        "default": false,
         "description": "Whether to only check for updates but don't execute"
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Controls the time to wait for the upgrade"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update.json
@@ -37,10 +37,12 @@
     "params": {
       "wait_for_active_shards": {
         "type": "string",
+        "default": "1",
         "description": "Sets the number of shard copies that must be active before proceeding with the update operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)"
       },
       "_source": {
         "type": "list",
+        "default": "true",
         "description": "True or false to return the _source field or not, or a list of fields to return"
       },
       "_source_excludes": {
@@ -53,6 +55,7 @@
       },
       "lang": {
         "type": "string",
+        "default": "painless",
         "description": "The script language (default: painless)"
       },
       "refresh": {
@@ -62,10 +65,12 @@
           "false",
           "wait_for"
         ],
+        "default": "false",
         "description": "If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes."
       },
       "retry_on_conflict": {
         "type": "number",
+        "default": 0,
         "description": "Specify how many times should the operation be retried when a conflict occurs (default: 0)"
       },
       "routing": {
@@ -74,6 +79,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "1m",
         "description": "Explicit operation timeout"
       },
       "if_seq_no": {
@@ -86,10 +92,12 @@
       },
       "require_alias": {
         "type": "boolean",
+        "default": false,
         "description": "When true, requires destination is an alias. Default is false"
       },
       "include_source_on_error": {
         "type": "boolean",
+        "default": true,
         "description": "True or false if to include the document source in the error message in case of parsing errors. Defaults to true."
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
@@ -37,6 +37,7 @@
       },
       "analyze_wildcard": {
         "type": "boolean",
+        "default": false,
         "description": "Specify whether wildcard and prefix queries should be analyzed (default: false)"
       },
       "default_operator": {
@@ -54,14 +55,17 @@
       },
       "from": {
         "type": "number",
+        "default": 0,
         "description": "Starting offset (default: 0)"
       },
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "conflicts": {
@@ -87,6 +91,7 @@
       },
       "lenient": {
         "type": "boolean",
+        "default": false,
         "description": "Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"
       },
       "pipeline": {
@@ -107,6 +112,7 @@
       },
       "scroll": {
         "type": "time",
+        "default": "5m",
         "description": "Specify how long a consistent view of the index should be maintained for scrolled search"
       },
       "search_type": {
@@ -151,6 +157,7 @@
       },
       "refresh": {
         "type": "boolean",
+        "default": false,
         "description": "Should the affected indexes be refreshed?"
       },
       "timeout": {
@@ -160,11 +167,12 @@
       },
       "wait_for_active_shards": {
         "type": "string",
+        "default": "1",
         "description": "Sets the number of shard copies that must be active before proceeding with the update by query operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)"
       },
       "scroll_size": {
         "type": "number",
-        "default": 100,
+        "default": 1000,
         "description": "Size on the scroll request powering the update by query"
       },
       "wait_for_completion": {
@@ -174,7 +182,7 @@
       },
       "requests_per_second": {
         "type": "number",
-        "default": 0,
+        "default": -1,
         "description": "The throttle to set on this request in sub-requests per second. -1 means no throttle."
       },
       "slices": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query_rethrottle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query_rethrottle.json
@@ -31,6 +31,7 @@
       "requests_per_second": {
         "type": "number",
         "required": true,
+        "default": -1,
         "description": "The throttle to set on this request in floating sub-requests per second. -1 means set no throttle."
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/watcher.execute_watch.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/watcher.execute_watch.json
@@ -41,6 +41,7 @@
     "params": {
       "debug": {
         "type": "boolean",
+        "default": false,
         "description": "indicates whether the watch should execute in debug mode"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/watcher.put_watch.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/watcher.put_watch.json
@@ -34,6 +34,7 @@
     "params": {
       "active": {
         "type": "boolean",
+        "default": true,
         "description": "Specify whether the watch is in/active by default"
       },
       "version": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/watcher.stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/watcher.stats.json
@@ -52,6 +52,7 @@
       },
       "emit_stacktraces": {
         "type": "boolean",
+        "default": false,
         "description": "Emits stack traces of currently running watches"
       }
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [rest-api-spec: Add missing default values from Elasticsearch specification (#136191)](https://github.com/elastic/elasticsearch/pull/136191)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)