### PR TITLE
[9.2] [ML] Remove rate limit field from services API for EIS (#135838)

### DIFF
--- a/docs/changelog/135838.yaml
+++ b/docs/changelog/135838.yaml
@@ -1,0 +1,5 @@
+pr: 135838
+summary: Remove rate limit field from services API for EIS
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceService.java
@@ -64,7 +64,6 @@ import org.elasticsearch.xpack.inference.services.elastic.rerank.ElasticInferenc
 import org.elasticsearch.xpack.inference.services.elastic.rerank.ElasticInferenceServiceRerankServiceSettings;
 import org.elasticsearch.xpack.inference.services.elastic.sparseembeddings.ElasticInferenceServiceSparseEmbeddingsModel;
 import org.elasticsearch.xpack.inference.services.elastic.sparseembeddings.ElasticInferenceServiceSparseEmbeddingsServiceSettings;
-import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 import org.elasticsearch.xpack.inference.telemetry.TraceContext;
 
 import java.util.EnumSet;
@@ -681,12 +680,6 @@ public class ElasticInferenceService extends SenderService {
                 .setUpdatable(false)
                 .setType(SettingsConfigurationFieldType.INTEGER)
                 .build()
-        );
-
-        configurationMap.putAll(
-            RateLimitSettings.toSettingsConfiguration(
-                EnumSet.of(TaskType.SPARSE_EMBEDDING, TaskType.CHAT_COMPLETION, TaskType.RERANK, TaskType.TEXT_EMBEDDING)
-            )
         );
 
         return new InferenceServiceConfiguration.Builder().setService(NAME)

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
@@ -971,15 +971,6 @@ public class ElasticInferenceServiceTests extends ESSingleNodeTestCase {
                        "name": "Elastic",
                        "task_types": ["sparse_embedding", "chat_completion", "text_embedding"],
                        "configurations": {
-                           "rate_limit.requests_per_minute": {
-                               "description": "Minimize the number of rate limit errors.",
-                               "label": "Rate Limit",
-                               "required": false,
-                               "sensitive": false,
-                               "updatable": false,
-                               "type": "int",
-                               "supported_task_types": ["text_embedding", "sparse_embedding" , "rerank", "chat_completion"]
-                           },
                            "model_id": {
                                "description": "The name of the model to use for the inference task.",
                                "label": "Model ID",
@@ -1028,15 +1019,6 @@ public class ElasticInferenceServiceTests extends ESSingleNodeTestCase {
                        "name": "Elastic",
                        "task_types": [],
                        "configurations": {
-                           "rate_limit.requests_per_minute": {
-                               "description": "Minimize the number of rate limit errors.",
-                               "label": "Rate Limit",
-                               "required": false,
-                               "sensitive": false,
-                               "updatable": false,
-                               "type": "int",
-                               "supported_task_types": ["text_embedding", "sparse_embedding" , "rerank", "chat_completion"]
-                           },
                            "model_id": {
                                "description": "The name of the model to use for the inference task.",
                                "label": "Model ID",


### PR DESCRIPTION
Backports the following commits to 9.2:
 - [ML] Remove rate limit field from services API for EIS (#135838)