### PR TITLE
[9.1] Initialize `TermsEnum` eagerly (#136279)

### DIFF
--- a/docs/changelog/136279.yaml
+++ b/docs/changelog/136279.yaml
@@ -1,0 +1,5 @@
+pr: 136279
+summary: Initialize `TermsEnum` eagerly
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.util.Constants;
 import org.apache.lucene.util.StringHelper;
 import org.apache.lucene.util.VectorUtil;
@@ -203,6 +204,8 @@ class Elasticsearch {
         IfConfig.logIfNecessary();
 
         ensureInitialized(
+            // See https://github.com/elastic/elasticsearch/issues/136268
+            TermsEnum.class,
             // ReleaseVersions does nontrivial static initialization which should always succeed but load it now (before SM) to be sure
             ReleaseVersions.class,
             // ReferenceDocs class does nontrivial static initialization which should always succeed but load it now (before SM) to be sure


### PR DESCRIPTION
Backports the following commits to 9.1:
 - Initialize `TermsEnum` eagerly (#136279)