### PR TITLE
[9.0] Store full path in _ignored when ignoring dynamic array field (#136315)

### DIFF
--- a/docs/changelog/136315.yaml
+++ b/docs/changelog/136315.yaml
@@ -1,0 +1,5 @@
+pr: 136315
+summary: Store full path in `_ignored` when ignoring dynamic array field
+area: Mapping
+type: bug
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/DynamicMappingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/DynamicMappingIT.java
@@ -382,6 +382,14 @@ public class DynamicMappingIT extends ESIntegTestCase {
         });
     }
 
+    public void testIgnoreDynamicBeyondLimitObjectArrayField() {
+        indexIgnoreDynamicBeyond(2, orderedMap("a", orderedMap("b", 1, "c", List.of(2, 3, 4))), fields -> {
+            assertThat(fields.keySet(), equalTo(Set.of("a.b", "_ignored")));
+            assertThat(fields.get("a.b").getValues(), Matchers.contains(1L));
+            assertThat(fields.get("_ignored").getValues(), Matchers.contains("a.c"));
+        });
+    }
+
     public void testIgnoreDynamicBeyondLimitRuntimeFields() {
         indexIgnoreDynamicBeyond(1, orderedMap("field1", 1, "field2", List.of(1, 2)), Map.of("dynamic", "runtime"), fields -> {
             assertThat(fields.keySet(), equalTo(Set.of("field1", "_ignored")));

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -659,7 +659,7 @@ public final class DocumentParser {
                         throw new IllegalArgumentException("failed to parse field [" + currentFieldName + " ]", e);
                     }
                 }
-                context.addIgnoredField(currentFieldName);
+                context.addIgnoredField(context.path().pathAsText(currentFieldName));
                 return;
             }
             parseNonDynamicArray(context, objectMapperFromTemplate, currentFieldName, currentFieldName);


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Store full path in _ignored when ignoring dynamic array field (#136315)