### PR TITLE
allocation: fix typo in balancing round interval setting

### DIFF
--- a/docs/changelog/136342.yaml
+++ b/docs/changelog/136342.yaml
@@ -1,0 +1,5 @@
+pr: 136342
+summary: "Allocation: fix typo in balancing round interval setting"
+area: Allocation
+type: bug
+issues: []

--- a/docs/changelog/136342.yaml
+++ b/docs/changelog/136342.yaml
@@ -1,5 +1,0 @@
-pr: 136342
-summary: "Allocation: fix typo in balancing round interval setting"
-area: Allocation
-type: bug
-issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/AllocationBalancingRoundSummaryService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/AllocationBalancingRoundSummaryService.java
@@ -47,7 +47,7 @@ public class AllocationBalancingRoundSummaryService {
 
     /** Controls how frequently in time balancer round summaries are logged. */
     public static final Setting<TimeValue> BALANCER_ROUND_SUMMARIES_LOG_INTERVAL_SETTING = Setting.timeSetting(
-        "cluster.routing.allocation.desired_balance.balanace_round_summaries_interval",
+        "cluster.routing.allocation.desired_balance.balancer_round_summaries_interval",
         TimeValue.timeValueSeconds(10),
         TimeValue.ZERO,
         Setting.Property.NodeScope,


### PR DESCRIPTION
The AllocationBalancingRoundSummaryService has an interval setting,
balancer_round_summaries_interval, that was previously named with a typo
(balanace). This 2 character change fixes this typo.
