### PR TITLE
[Test] Fix ShardsCapacityHealthIndicatorServiceStatelessTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -627,9 +627,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeForkIT
   method: test {csv-spec:string.SpaceNegative}
   issue: https://github.com/elastic/elasticsearch/issues/136249
-- class: org.elasticsearch.health.node.ShardsCapacityHealthIndicatorServiceStatelessTests
-  method: testIndicatorYieldsGreenInCaseThereIsRoom
-  issue: https://github.com/elastic/elasticsearch/issues/136303
 - class: org.elasticsearch.index.store.AsyncDirectIODirectoryTests
   method: testIsLoadedOnSlice
   issue: https://github.com/elastic/elasticsearch/issues/136331

--- a/server/src/test/java/org/elasticsearch/health/node/ShardsCapacityHealthIndicatorServiceStatelessTests.java
+++ b/server/src/test/java/org/elasticsearch/health/node/ShardsCapacityHealthIndicatorServiceStatelessTests.java
@@ -145,7 +145,7 @@ public class ShardsCapacityHealthIndicatorServiceStatelessTests extends ESTestCa
     }
 
     private static int randomValidMaxShards() {
-        return randomIntBetween(10, 100);
+        return randomIntBetween(15, 100);
     }
 
     private Map<String, Object> xContentToMap(ToXContent xcontent) throws IOException {


### PR DESCRIPTION
Ensure the lower-bound of the randomness is valid for test.

Resolves: #136303
