### PR TITLE
[ML] Auditor reset fix

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/ResetAuditorAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/ResetAuditorAction.java
@@ -35,8 +35,9 @@ public class ResetAuditorAction extends ActionType<TrainedModelCacheInfoAction.R
 
         public static Request RESET_AUDITOR_REQUEST = new Request();
 
-        private Request() {}
-
+        private Request() {
+            super(new String[] { "ml:true" }); // Only ml nodes. See DiscoveryNodes::resolveNodes
+        }
     }
 
     public static class NodeRequest extends AbstractTransportRequest {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/ResetAuditorAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/ResetAuditorAction.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.ml.action;
+
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.support.nodes.BaseNodeResponse;
+import org.elasticsearch.action.support.nodes.BaseNodesRequest;
+import org.elasticsearch.action.support.nodes.BaseNodesResponse;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.transport.AbstractTransportRequest;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+public class ResetAuditorAction extends ActionType<TrainedModelCacheInfoAction.Response> {
+
+    public static final ResetAuditorAction INSTANCE = new ResetAuditorAction();
+    public static final String NAME = "cluster:internal/xpack/ml/auditor/reset";
+
+    private ResetAuditorAction() {
+        super(NAME);
+    }
+
+    public static class Request extends BaseNodesRequest {
+
+        public static Request RESET_AUDITOR_REQUEST = new Request();
+
+        private Request() {}
+
+    }
+
+    public static class NodeRequest extends AbstractTransportRequest {
+
+        public NodeRequest(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        public NodeRequest() {}
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash();
+        }
+    }
+
+    public static class Response extends BaseNodesResponse<Response.ResetResponse> {
+
+        public Response(ClusterName clusterName, List<ResetResponse> nodes, List<FailedNodeException> failures) {
+            super(clusterName, nodes, failures);
+        }
+
+        protected Response(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        public static class ResetResponse extends BaseNodeResponse {
+            private final boolean acknowledged;
+
+            public ResetResponse(DiscoveryNode node, boolean acknowledged) {
+                super(node);
+                this.acknowledged = acknowledged;
+            }
+
+            public ResetResponse(StreamInput in) throws IOException {
+                super(in, null);
+                acknowledged = in.readBoolean();
+            }
+
+            public ResetResponse(StreamInput in, DiscoveryNode node) throws IOException {
+                super(in, node);
+                acknowledged = in.readBoolean();
+            }
+
+            public boolean isAcknowledged() {
+                return acknowledged;
+            }
+
+            @Override
+            public void writeTo(StreamOutput out) throws IOException {
+                super.writeTo(out);
+                out.writeBoolean(acknowledged);
+            }
+
+            @Override
+            public boolean equals(Object o) {
+                if (o == null || getClass() != o.getClass()) return false;
+                ResetResponse that = (ResetResponse) o;
+                return acknowledged == that.acknowledged;
+            }
+
+            @Override
+            public int hashCode() {
+                return Objects.hashCode(acknowledged);
+            }
+        }
+
+        @Override
+        protected List<Response.ResetResponse> readNodesFrom(StreamInput in) throws IOException {
+            return in.readCollectionAsList(ResetResponse::new);
+        }
+
+        @Override
+        protected void writeNodesTo(StreamOutput out, List<Response.ResetResponse> nodes) throws IOException {
+            out.writeCollection(nodes);
+        }
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/ResetAuditorAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/ResetAuditorAction.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
-public class ResetAuditorAction extends ActionType<TrainedModelCacheInfoAction.Response> {
+public class ResetAuditorAction extends ActionType<ResetAuditorAction.Response> {
 
     public static final ResetAuditorAction INSTANCE = new ResetAuditorAction();
     public static final String NAME = "cluster:internal/xpack/ml/auditor/reset";

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -161,6 +161,7 @@ import org.elasticsearch.xpack.core.ml.action.PutTrainedModelAction;
 import org.elasticsearch.xpack.core.ml.action.PutTrainedModelAliasAction;
 import org.elasticsearch.xpack.core.ml.action.PutTrainedModelDefinitionPartAction;
 import org.elasticsearch.xpack.core.ml.action.PutTrainedModelVocabularyAction;
+import org.elasticsearch.xpack.core.ml.action.ResetAuditorAction;
 import org.elasticsearch.xpack.core.ml.action.ResetJobAction;
 import org.elasticsearch.xpack.core.ml.action.RevertModelSnapshotAction;
 import org.elasticsearch.xpack.core.ml.action.SetResetModeAction;
@@ -271,6 +272,7 @@ import org.elasticsearch.xpack.ml.action.TransportPutTrainedModelAction;
 import org.elasticsearch.xpack.ml.action.TransportPutTrainedModelAliasAction;
 import org.elasticsearch.xpack.ml.action.TransportPutTrainedModelDefinitionPartAction;
 import org.elasticsearch.xpack.ml.action.TransportPutTrainedModelVocabularyAction;
+import org.elasticsearch.xpack.ml.action.TransportResetAuditorAction;
 import org.elasticsearch.xpack.ml.action.TransportResetJobAction;
 import org.elasticsearch.xpack.ml.action.TransportRevertModelSnapshotAction;
 import org.elasticsearch.xpack.ml.action.TransportSetResetModeAction;
@@ -785,7 +787,6 @@ public class MachineLearning extends Plugin
     public static final int MAX_LOW_PRIORITY_MODELS_PER_NODE = 100;
 
     private static final Logger logger = LogManager.getLogger(MachineLearning.class);
-    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(MachineLearning.class);
 
     private final Settings settings;
     private final boolean enabled;
@@ -1564,6 +1565,7 @@ public class MachineLearning extends Plugin
         actionHandlers.add(new ActionHandler(MlMemoryAction.INSTANCE, TransportMlMemoryAction.class));
         actionHandlers.add(new ActionHandler(SetUpgradeModeAction.INSTANCE, TransportSetUpgradeModeAction.class));
         actionHandlers.add(new ActionHandler(SetResetModeAction.INSTANCE, TransportSetResetModeAction.class));
+        actionHandlers.add(new ActionHandler(ResetAuditorAction.INSTANCE, TransportResetAuditorAction.class));
         // Included in this section as it's used by MlMemoryAction
         actionHandlers.add(new ActionHandler(TrainedModelCacheInfoAction.INSTANCE, TransportTrainedModelCacheInfoAction.class));
         actionHandlers.add(new ActionHandler(GetMlAutoscalingStats.INSTANCE, TransportGetMlAutoscalingStats.class));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportResetAuditorAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportResetAuditorAction.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.action;
+
+import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.nodes.TransportNodesAction;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.injection.guice.Inject;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.ml.action.ResetAuditorAction;
+import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
+import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
+import org.elasticsearch.xpack.ml.notifications.InferenceAuditor;
+
+import java.io.IOException;
+import java.util.List;
+
+public class TransportResetAuditorAction extends TransportNodesAction<
+    ResetAuditorAction.Request,
+    ResetAuditorAction.Response,
+    ResetAuditorAction.NodeRequest,
+    ResetAuditorAction.Response.ResetResponse,
+    Void> {
+
+    private final AnomalyDetectionAuditor anomalyDetectionAuditor;
+    private final DataFrameAnalyticsAuditor dfaAuditor;
+    private final InferenceAuditor inferenceAuditor;
+
+    @Inject
+    public TransportResetAuditorAction(
+        ThreadPool threadPool,
+        ClusterService clusterService,
+        TransportService transportService,
+        ActionFilters actionFilters,
+        AnomalyDetectionAuditor anomalyDetectionAuditor,
+        DataFrameAnalyticsAuditor dfaAuditor,
+        InferenceAuditor inferenceAuditor
+    ) {
+        super(
+            ResetAuditorAction.NAME,
+            clusterService,
+            transportService,
+            actionFilters,
+            ResetAuditorAction.NodeRequest::new,
+            threadPool.executor(ThreadPool.Names.MANAGEMENT)
+        );
+        this.anomalyDetectionAuditor = anomalyDetectionAuditor;
+        this.dfaAuditor = dfaAuditor;
+        this.inferenceAuditor = inferenceAuditor;
+    }
+
+    @Override
+    protected ResetAuditorAction.Response newResponse(
+        ResetAuditorAction.Request request,
+        List<ResetAuditorAction.Response.ResetResponse> resetResponses,
+        List<FailedNodeException> failures
+    ) {
+        return new ResetAuditorAction.Response(clusterService.getClusterName(), resetResponses, failures);
+    }
+
+    @Override
+    protected ResetAuditorAction.NodeRequest newNodeRequest(ResetAuditorAction.Request request) {
+        return new ResetAuditorAction.NodeRequest();
+    }
+
+    @Override
+    protected ResetAuditorAction.Response.ResetResponse newNodeResponse(StreamInput in, DiscoveryNode node) throws IOException {
+        return new ResetAuditorAction.Response.ResetResponse(in);
+    }
+
+    @Override
+    protected ResetAuditorAction.Response.ResetResponse nodeOperation(ResetAuditorAction.NodeRequest request, Task task) {
+        anomalyDetectionAuditor.reset();
+        dfaAuditor.reset();
+        inferenceAuditor.reset();
+        return new ResetAuditorAction.Response.ResetResponse(clusterService.localNode(), true);
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/notifications/AbstractMlAuditor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/notifications/AbstractMlAuditor.java
@@ -16,13 +16,11 @@ import org.elasticsearch.client.internal.OriginSettingClient;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.core.common.notifications.AbstractAuditMessage;
 import org.elasticsearch.xpack.core.common.notifications.AbstractAuditMessageFactory;
 import org.elasticsearch.xpack.core.common.notifications.AbstractAuditor;
-import org.elasticsearch.xpack.core.ml.MlMetadata;
 import org.elasticsearch.xpack.core.ml.notifications.NotificationsIndex;
 import org.elasticsearch.xpack.ml.MlIndexTemplateRegistry;
 
@@ -33,7 +31,6 @@ import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 abstract class AbstractMlAuditor<T extends AbstractAuditMessage> extends AbstractAuditor<T> {
 
     private static final Logger logger = LogManager.getLogger(AbstractMlAuditor.class);
-    private volatile boolean isResetMode;
 
     protected AbstractMlAuditor(
         Client client,
@@ -50,37 +47,6 @@ abstract class AbstractMlAuditor<T extends AbstractAuditMessage> extends Abstrac
             indexNameExpressionResolver,
             clusterService.threadPool().generic()
         );
-        clusterService.addListener(event -> {
-            if (event.metadataChanged()) {
-                setResetMode(MlMetadata.getMlMetadata(event.state()).isResetMode());
-            }
-        });
-    }
-
-    public void setResetMode(boolean value) {
-        isResetMode = value;
-        if (value) {
-            reset();
-        }
-    }
-
-    @Override
-    protected void indexDoc(ToXContent toXContent) {
-        if (isResetMode) {
-            logger.trace("Skipped writing the audit message backlog as reset_mode is enabled");
-        } else {
-            super.indexDoc(toXContent);
-        }
-    }
-
-    @Override
-    protected void writeBacklog() {
-        if (isResetMode) {
-            logger.trace("Skipped writing the audit message backlog as reset_mode is enabled");
-            clearBacklog();
-        } else {
-            super.writeBacklog();
-        }
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/notifications/AbstractMlAuditor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/notifications/AbstractMlAuditor.java
@@ -57,8 +57,11 @@ abstract class AbstractMlAuditor<T extends AbstractAuditMessage> extends Abstrac
         });
     }
 
-    private void setResetMode(boolean value) {
+    public void setResetMode(boolean value) {
         isResetMode = value;
+        if (value) {
+            reset();
+        }
     }
 
     @Override

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -329,6 +329,7 @@ public class Constants {
         "cluster:internal/xpack/inference",
         "cluster:internal/xpack/inference/rerankwindowsize/get",
         "cluster:internal/xpack/inference/unified",
+        "cluster:internal/xpack/ml/auditor/reset",
         "cluster:internal/xpack/ml/coordinatedinference",
         "cluster:internal/xpack/ml/datafeed/isolate",
         "cluster:internal/xpack/ml/datafeed/running_state",


### PR DESCRIPTION
Tests that assert certain messages are audited can fail because the test clean up can leak into the next test. When this happens the first few auditor messages of the current test are deleted by the reset request that has leaked from the previous test.

The fix is to add an explicit auditor reset action and call that rather than using the cluster state to communicate the reset request. This guarantees the auditor has been reset in the test clean up.


Closes #134001 #129457 #128166