### PR TITLE
Appropriately delegate for skipping async prefetching directIO

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -630,9 +630,6 @@ tests:
 - class: org.elasticsearch.cluster.coordination.NodeJoiningIT
   method: testNodeTriesToJoinClusterAndThenSameMasterIsElected
   issue: https://github.com/elastic/elasticsearch/issues/136332
-- class: org.elasticsearch.index.store.AsyncDirectIODirectoryTests
-  method: testSeekPastEOFAndRead
-  issue: https://github.com/elastic/elasticsearch/issues/136351
 - class: org.elasticsearch.xpack.restart.FullClusterRestartIT
   method: testDataStreams {cluster=UPGRADED}
   issue: https://github.com/elastic/elasticsearch/issues/136353

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -627,9 +627,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeForkIT
   method: test {csv-spec:string.SpaceNegative}
   issue: https://github.com/elastic/elasticsearch/issues/136249
-- class: org.elasticsearch.index.store.AsyncDirectIODirectoryTests
-  method: testIsLoadedOnSlice
-  issue: https://github.com/elastic/elasticsearch/issues/136331
 - class: org.elasticsearch.cluster.coordination.NodeJoiningIT
   method: testNodeTriesToJoinClusterAndThenSameMasterIsElected
   issue: https://github.com/elastic/elasticsearch/issues/136332

--- a/server/src/main/java/org/elasticsearch/index/store/FsDirectoryFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/store/FsDirectoryFactory.java
@@ -325,7 +325,7 @@ public class FsDirectoryFactory implements IndexStorePlugin.DirectoryFactory {
             if (asyncPrefetchLimit > 0) {
                 return new AsyncDirectIOIndexInput(getDirectory().resolve(name), blockSize, 8192, asyncPrefetchLimit);
             } else {
-                return in.openInput(name, context);
+                return super.openInput(name, context);
             }
         }
     }


### PR DESCRIPTION
This shouldn't delegate to `in` (which might be MMAP). Instead it should delegate to `super` (DirectIO) which will open a regular directIO input.

This fixes the two recent test failures:

closes: https://github.com/elastic/elasticsearch/issues/136351
closes: https://github.com/elastic/elasticsearch/issues/136331