### PR TITLE
[8.19] rest-api-spec: Enforce body "required" field (#136356)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/async_search.submit.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/async_search.submit.json
@@ -243,7 +243,8 @@
       }
     },
     "body": {
-      "description": "The search definition using the Query DSL"
+      "description": "The search definition using the Query DSL",
+      "required": false
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/clear_scroll.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/clear_scroll.json
@@ -44,7 +44,8 @@
     },
     "params": {},
     "body": {
-      "description": "A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter"
+      "description": "A comma-separated list of scroll IDs to clear if none was specified via the scroll_id parameter",
+      "required": false
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/close_point_in_time.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/close_point_in_time.json
@@ -26,7 +26,8 @@
     },
     "params": {},
     "body": {
-      "description": "a point-in-time id to close"
+      "description": "a point-in-time id to close",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.allocation_explain.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.allocation_explain.json
@@ -43,7 +43,8 @@
       }
     },
     "body": {
-      "description": "The index, shard, and primary flag to explain. Empty means 'explain a randomly-chosen unassigned shard'"
+      "description": "The index, shard, and primary flag to explain. Empty means 'explain a randomly-chosen unassigned shard'",
+      "required": false
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.reroute.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.reroute.json
@@ -67,7 +67,8 @@
       }
     },
     "body": {
-      "description": "The definition of `commands` to perform (`move`, `cancel`, `allocate`)"
+      "description": "The definition of `commands` to perform (`move`, `cancel`, `allocate`)",
+      "required": false
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/count.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/count.json
@@ -115,7 +115,8 @@
       }
     },
     "body": {
-      "description": "A query to restrict the results specified with the Query DSL (optional)"
+      "description": "A query to restrict the results specified with the Query DSL (optional)",
+      "required": false
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/explain.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/explain.json
@@ -93,7 +93,8 @@
       }
     },
     "body": {
-      "description": "The query definition using the Query DSL"
+      "description": "The query definition using the Query DSL",
+      "required": false
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/field_caps.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/field_caps.json
@@ -85,7 +85,8 @@
       }
     },
     "body": {
-      "description": "An index filter specified with the Query DSL"
+      "description": "An index filter specified with the Query DSL",
+      "required": false
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/fleet.search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/fleet.search.json
@@ -48,7 +48,8 @@
       }
     },
     "body": {
-      "description": "The search definition using the Query DSL"
+      "description": "The search definition using the Query DSL",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/graph.explore.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/graph.explore.json
@@ -42,7 +42,8 @@
       }
     },
     "body": {
-      "description": "Graph Query DSL"
+      "description": "Graph Query DSL",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.move_to_step.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.move_to_step.json
@@ -32,7 +32,8 @@
     },
     "params": {},
     "body": {
-      "description": "The new lifecycle step to move to"
+      "description": "The new lifecycle step to move to",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.put_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ilm.put_lifecycle.json
@@ -43,7 +43,8 @@
       }
     },
     "body": {
-      "description": "The lifecycle policy definition to register"
+      "description": "The lifecycle policy definition to register",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.analyze.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.analyze.json
@@ -45,7 +45,8 @@
       }
     },
     "body": {
-      "description": "Define analyzer/tokenizer parameters and the text on which the analysis should be performed"
+      "description": "Define analyzer/tokenizer parameters and the text on which the analysis should be performed",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.clone.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.clone.json
@@ -53,7 +53,8 @@
       }
     },
     "body": {
-      "description": "The configuration for the target index (`settings` and `aliases`)"
+      "description": "The configuration for the target index (`settings` and `aliases`)",
+      "required": false
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.create.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.create.json
@@ -48,7 +48,8 @@
       }
     },
     "body": {
-      "description": "The configuration for the index (`settings` and `mappings`)"
+      "description": "The configuration for the index (`settings` and `mappings`)",
+      "required": false
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_data_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_data_lifecycle.json
@@ -55,7 +55,8 @@
       }
     },
     "body": {
-      "description": "The data stream lifecycle configuration that consist of the data retention"
+      "description": "The data stream lifecycle configuration that consist of the data retention",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_data_stream_options.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_data_stream_options.json
@@ -55,7 +55,8 @@
       }
     },
     "body": {
-      "description": "The data stream options configuration that consist of the failure store configuration"
+      "description": "The data stream options configuration that consist of the failure store configuration",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.rollover.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.rollover.json
@@ -74,7 +74,8 @@
       }
     },
     "body": {
-      "description": "The conditions that needs to be met for executing rollover"
+      "description": "The conditions that needs to be met for executing rollover",
+      "required": false
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.shrink.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.shrink.json
@@ -53,7 +53,8 @@
       }
     },
     "body": {
-      "description": "The configuration for the target index (`settings` and `aliases`)"
+      "description": "The configuration for the target index (`settings` and `aliases`)",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.split.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.split.json
@@ -53,7 +53,8 @@
       }
     },
     "body": {
-      "description": "The configuration for the target index (`settings` and `aliases`)"
+      "description": "The configuration for the target index (`settings` and `aliases`)",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.validate_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.validate_query.json
@@ -109,7 +109,8 @@
       }
     },
     "body": {
-      "description": "The query definition specified with the Query DSL"
+      "description": "The query definition specified with the Query DSL",
+      "required": false
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.chat_completion_unified.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.chat_completion_unified.json
@@ -31,7 +31,8 @@
       ]
     },
     "body": {
-      "description": "The inference payload"
+      "description": "The inference payload",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.completion.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.completion.json
@@ -31,7 +31,8 @@
       ]
     },
     "body": {
-      "description": "The inference payload"
+      "description": "The inference payload",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.inference.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.inference.json
@@ -47,7 +47,8 @@
       ]
     },
     "body": {
-      "description": "The inference payload"
+      "description": "The inference payload",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put.json
@@ -47,7 +47,8 @@
       ]
     },
     "body": {
-      "description": "The inference endpoint's task and service settings"
+      "description": "The inference endpoint's task and service settings",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_alibabacloud.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_alibabacloud.json
@@ -35,7 +35,8 @@
       ]
     },
     "body": {
-      "description": "The inference endpoint's task and service settings"
+      "description": "The inference endpoint's task and service settings",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_amazonbedrock.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_amazonbedrock.json
@@ -35,7 +35,8 @@
       ]
     },
     "body": {
-      "description": "The inference endpoint's task and service settings"
+      "description": "The inference endpoint's task and service settings",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_amazonsagemaker.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_amazonsagemaker.json
@@ -35,7 +35,8 @@
       ]
     },
     "body": {
-      "description": "The inference endpoint's task and service settings"
+      "description": "The inference endpoint's task and service settings",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_anthropic.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_anthropic.json
@@ -35,7 +35,8 @@
       ]
     },
     "body": {
-      "description": "The inference endpoint's task and service settings"
+      "description": "The inference endpoint's task and service settings",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_azureaistudio.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_azureaistudio.json
@@ -35,7 +35,8 @@
       ]
     },
     "body": {
-      "description": "The inference endpoint's task and service settings"
+      "description": "The inference endpoint's task and service settings",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_azureopenai.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_azureopenai.json
@@ -35,7 +35,8 @@
       ]
     },
     "body": {
-      "description": "The inference endpoint's task and service settings"
+      "description": "The inference endpoint's task and service settings",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_cohere.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_cohere.json
@@ -35,7 +35,8 @@
       ]
     },
     "body": {
-      "description": "The inference endpoint's task and service settings"
+      "description": "The inference endpoint's task and service settings",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_custom.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_custom.json
@@ -35,7 +35,8 @@
       ]
     },
     "body": {
-      "description": "The inference endpoint's task and service settings"
+      "description": "The inference endpoint's task and service settings",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_deepseek.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_deepseek.json
@@ -35,7 +35,8 @@
       ]
     },
     "body": {
-      "description": "The inference endpoint's task and service settings"
+      "description": "The inference endpoint's task and service settings",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_elasticsearch.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_elasticsearch.json
@@ -35,7 +35,8 @@
       ]
     },
     "body": {
-      "description": "The inference endpoint's task and service settings"
+      "description": "The inference endpoint's task and service settings",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_elser.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_elser.json
@@ -39,7 +39,8 @@
       ]
     },
     "body": {
-      "description": "The inference endpoint's task and service settings"
+      "description": "The inference endpoint's task and service settings",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_googleaistudio.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_googleaistudio.json
@@ -35,7 +35,8 @@
       ]
     },
     "body": {
-      "description": "The inference endpoint's task and service settings"
+      "description": "The inference endpoint's task and service settings",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_googlevertexai.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_googlevertexai.json
@@ -35,7 +35,8 @@
       ]
     },
     "body": {
-      "description": "The inference endpoint's task and service settings"
+      "description": "The inference endpoint's task and service settings",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_hugging_face.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_hugging_face.json
@@ -35,7 +35,8 @@
       ]
     },
     "body": {
-      "description": "The inference endpoint's task and service settings"
+      "description": "The inference endpoint's task and service settings",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_jinaai.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_jinaai.json
@@ -35,7 +35,8 @@
       ]
     },
     "body": {
-      "description": "The inference endpoint's task and service settings"
+      "description": "The inference endpoint's task and service settings",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_mistral.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_mistral.json
@@ -35,7 +35,8 @@
       ]
     },
     "body": {
-      "description": "The inference endpoint's task and service settings"
+      "description": "The inference endpoint's task and service settings",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_openai.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_openai.json
@@ -35,7 +35,8 @@
       ]
     },
     "body": {
-      "description": "The inference endpoint's task and service settings"
+      "description": "The inference endpoint's task and service settings",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_voyageai.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_voyageai.json
@@ -35,7 +35,8 @@
       ]
     },
     "body": {
-      "description": "The inference endpoint's task and service settings"
+      "description": "The inference endpoint's task and service settings",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_watsonx.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_watsonx.json
@@ -35,7 +35,8 @@
       ]
     },
     "body": {
-      "description": "The inference endpoint's task and service settings"
+      "description": "The inference endpoint's task and service settings",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.rerank.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.rerank.json
@@ -31,7 +31,8 @@
       ]
     },
     "body": {
-      "description": "The inference payload"
+      "description": "The inference payload",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.sparse_embedding.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.sparse_embedding.json
@@ -31,7 +31,8 @@
       ]
     },
     "body": {
-      "description": "The inference payload"
+      "description": "The inference payload",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.stream_completion.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.stream_completion.json
@@ -31,7 +31,8 @@
       ]
     },
     "body": {
-      "description": "The inference payload"
+      "description": "The inference payload",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.text_embedding.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.text_embedding.json
@@ -31,7 +31,8 @@
       ]
     },
     "body": {
-      "description": "The inference payload"
+      "description": "The inference payload",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.update.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.update.json
@@ -47,7 +47,8 @@
       ]
     },
     "body": {
-      "description": "The inference endpoint's task and service settings"
+      "description": "The inference endpoint's task and service settings",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/knn_search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/knn_search.json
@@ -42,7 +42,8 @@
       }
     },
     "body": {
-      "description": "The search definition"
+      "description": "The search definition",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/license.post.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/license.post.json
@@ -43,7 +43,8 @@
       }
     },
     "body": {
-      "description": "licenses to be installed"
+      "description": "licenses to be installed",
+      "required": false
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.delete_expired_data.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.delete_expired_data.json
@@ -48,7 +48,8 @@
       }
     },
     "body": {
-      "description": "deleting expired data parameters"
+      "description": "deleting expired data parameters",
+      "required": false
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.flush_job.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.flush_job.json
@@ -53,7 +53,8 @@
       }
     },
     "body": {
-      "description": "Flush parameters"
+      "description": "Flush parameters",
+      "required": false
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_buckets.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_buckets.json
@@ -96,7 +96,8 @@
       }
     },
     "body": {
-      "description": "Bucket selection details if not provided in URI"
+      "description": "Bucket selection details if not provided in URI",
+      "required": false
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_calendars.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_calendars.json
@@ -51,7 +51,8 @@
       }
     },
     "body": {
-      "description": "The from and size parameters optionally sent in the body"
+      "description": "The from and size parameters optionally sent in the body",
+      "required": false
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_categories.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_categories.json
@@ -65,7 +65,8 @@
       }
     },
     "body": {
-      "description": "Category selection details if not provided in URI"
+      "description": "Category selection details if not provided in URI",
+      "required": false
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_influencers.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_influencers.json
@@ -73,7 +73,8 @@
       }
     },
     "body": {
-      "description": "Influencer selection criteria"
+      "description": "Influencer selection criteria",
+      "required": false
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_model_snapshots.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_model_snapshots.json
@@ -78,7 +78,8 @@
       }
     },
     "body": {
-      "description": "Model snapshot selection criteria"
+      "description": "Model snapshot selection criteria",
+      "required": false
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_overall_buckets.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_overall_buckets.json
@@ -65,7 +65,8 @@
       }
     },
     "body": {
-      "description": "Overall bucket selection details if not provided in URI"
+      "description": "Overall bucket selection details if not provided in URI",
+      "required": false
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_records.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_records.json
@@ -74,7 +74,8 @@
       }
     },
     "body": {
-      "description": "Record selection criteria"
+      "description": "Record selection criteria",
+      "required": false
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.revert_model_snapshot.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.revert_model_snapshot.json
@@ -42,7 +42,8 @@
       }
     },
     "body": {
-      "description": "Reversion options"
+      "description": "Reversion options",
+      "required": false
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.start_data_frame_analytics.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.start_data_frame_analytics.json
@@ -38,7 +38,8 @@
       }
     },
     "body": {
-      "description": "The start data frame analytics parameters"
+      "description": "The start data frame analytics parameters",
+      "required": false
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.start_datafeed.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.start_datafeed.json
@@ -46,7 +46,8 @@
       }
     },
     "body": {
-      "description": "The start datafeed parameters"
+      "description": "The start datafeed parameters",
+      "required": false
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.stop_data_frame_analytics.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.stop_data_frame_analytics.json
@@ -48,7 +48,8 @@
       }
     },
     "body": {
-      "description": "The stop data frame analytics parameters"
+      "description": "The stop data frame analytics parameters",
+      "required": false
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.stop_trained_model_deployment.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.stop_trained_model_deployment.json
@@ -44,7 +44,8 @@
       }
     },
     "body": {
-      "description": "The stop deployment parameters"
+      "description": "The stop deployment parameters",
+      "required": false
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/open_point_in_time.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/open_point_in_time.json
@@ -73,7 +73,8 @@
       }
     },
     "body": {
-      "description": "An index_filter specified with the Query DSL"
+      "description": "An index_filter specified with the Query DSL",
+      "required": false
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/render_search_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/render_search_template.json
@@ -39,7 +39,8 @@
       ]
     },
     "body": {
-      "description": "The search definition template and its params"
+      "description": "The search definition template and its params",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/scripts_painless_execute.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/scripts_painless_execute.json
@@ -27,7 +27,8 @@
     },
     "params": {},
     "body": {
-      "description": "The script to execute"
+      "description": "The script to execute",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/scroll.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/scroll.json
@@ -60,7 +60,8 @@
       }
     },
     "body": {
-      "description": "The scroll ID if not passed by URL or query parameter."
+      "description": "The scroll ID if not passed by URL or query parameter.",
+      "required": false
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
@@ -266,7 +266,8 @@
       }
     },
     "body": {
-      "description": "The search definition using the Query DSL"
+      "description": "The search definition using the Query DSL",
+      "required": false
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/slm.put_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/slm.put_lifecycle.json
@@ -43,7 +43,8 @@
       }
     },
     "body": {
-      "description": "The snapshot lifecycle policy definition to register"
+      "description": "The snapshot lifecycle policy definition to register",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/terms_enum.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/terms_enum.json
@@ -33,7 +33,8 @@
     },
     "params": {},
     "body": {
-      "description": "field name, string which is the prefix expected in matching terms, timeout and size for max number of results"
+      "description": "field name, string which is the prefix expected in matching terms, timeout and size for max number of results",
+      "required": true
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
@@ -192,7 +192,8 @@
       }
     },
     "body": {
-      "description": "The search definition using the Query DSL"
+      "description": "The search definition using the Query DSL",
+      "required": false
     }
   }
 }

--- a/rest-api-spec/src/main/resources/schema.json
+++ b/rest-api-spec/src/main/resources/schema.json
@@ -161,7 +161,8 @@
                 }
             },
             "required": [
-                "description"
+                "description",
+                "required"
             ],
             "title": "API request Body",
             "description": "The request body for the API. Does not detail the structure, only whether the API accepts a body and its format"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [rest-api-spec: Enforce body "required" field (#136356)](https://github.com/elastic/elasticsearch/pull/136356)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)