### PR TITLE
Unmuting test #136388 fixed via #136367

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -636,9 +636,6 @@ tests:
 - class: org.elasticsearch.xpack.remotecluster.RemoteClusterSecurityBWCToRCS2ClusterRestIT
   method: testBwcCCSViaRCS1orRCS2
   issue: https://github.com/elastic/elasticsearch/issues/136368
-- class: org.elasticsearch.index.store.AsyncDirectIODirectoryTests
-  method: testIsLoaded
-  issue: https://github.com/elastic/elasticsearch/issues/136388
 
 # Examples:
 #


### PR DESCRIPTION
mute came in right when pr was about to be merged, or whatever. Basically, just need to unmute. Verified the PR fixed it.

closes: https://github.com/elastic/elasticsearch/issues/136388
related: https://github.com/elastic/elasticsearch/pull/136367