### PR TITLE
Bump DeprecationIndexingTemplate version to retroactively fix template upgrade

### DIFF
--- a/docs/changelog/136421.yaml
+++ b/docs/changelog/136421.yaml
@@ -1,0 +1,5 @@
+pr: 136421
+summary: Bump version to retroactively fix template upgrade
+area: Infra/Logging
+type: bug
+issues: []

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/DeprecationIndexingTemplateRegistry.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/DeprecationIndexingTemplateRegistry.java
@@ -33,7 +33,8 @@ import static org.elasticsearch.xpack.core.ClientHelper.DEPRECATION_ORIGIN;
 public class DeprecationIndexingTemplateRegistry extends IndexTemplateRegistry {
     // history (please add a comment why you increased the version here)
     // version 1: initial
-    public static final int INDEX_TEMPLATE_VERSION = 1;
+    // version 2: bump to fix https://github.com/elastic/sdh-elasticsearch/issues/9371
+    public static final int INDEX_TEMPLATE_VERSION = 2;
 
     public static final String DEPRECATION_INDEXING_TEMPLATE_VERSION_VARIABLE = "xpack.deprecation.indexing.template.version";
 


### PR DESCRIPTION
Bump version to `2` to retroactively fix template upgrade bug in `7.x`. Relevant to https://github.com/elastic/elasticsearch/pull/136417

More details in https://github.com/elastic/sdh-elasticsearch/issues/9371