### PR TITLE
[WIP] ESQL docs: clarify duration aliases (minute vs month), case-insensitive, optional whitespace

### DIFF
--- a/docs/changelog/136426.yaml
+++ b/docs/changelog/136426.yaml
@@ -1,0 +1,6 @@
+summary: "Docs: clarify ESQL time span alias rules (month m/mm vs minute min/mi/n), note case-insensitive matching and optional whitespace, and add unambiguous examples."
+area: ES|QL
+type: docs
+issues:
+  - 135552
+pr: 136426

--- a/docs/reference/query-languages/esql/esql-time-spans.md
+++ b/docs/reference/query-languages/esql/esql-time-spans.md
@@ -110,17 +110,30 @@ POST /_query
 ```
 
 
+### Duration units and matching rules
+
+Duration literals can be written with or without a space between the number and the unit
+(for example, `1m` is equivalent to `1 m`). Matching is **case-insensitive**.
+
 ## Supported temporal units [esql-time-spans-table]
 
 | Temporal Units | Valid Abbreviations |
 | --- | --- |
 | year | y, yr, years |
 | quarter | q, quarters |
-| month | mo, months |
+| month | m, mm, month, months |
 | week | w, weeks |
 | day | d, days |
 | hour | h, hours |
-| minute | min, minutes |
+| minute | min, mi, n, minute, minutes |
 | second | s, sec, seconds |
 | millisecond | ms, milliseconds |
 
+**Examples**
+
+```esql
+FROM t | WHERE date_col > NOW() - 1m     // month (same as: 1 m)
+FROM t | WHERE ts > NOW() - 1mi          // minute
+FROM t | WHERE ts > NOW() - 1n           // minute
+FROM t | WHERE ts > NOW() - 500ms        // millisecond
+```


### PR DESCRIPTION
This is a docs-only change clarifying duration aliases in ESQL.

- month: `m`/`mm`; minute: `min`/`mi`/`n`; millisecond: `ms`
- matching is case-insensitive
- whitespace between number and unit is optional (`1m == 1 m`)
- examples included

Rationale: adding `m` as an alias for minute would be ambiguous with `m` for month
(case-insensitive matching + optional whitespace). Therefore we clarify the docs
and keep the current aliasing scheme.

Relates: elastic/elasticsearch#135552

Credit to @Wentao14614 for the initial observation.

