### PR TITLE
Add docs for chunk_rescorer in text_similarity_reranker

### DIFF
--- a/docs/reference/elasticsearch/rest-apis/retrievers/retrievers-examples.md
+++ b/docs/reference/elasticsearch/rest-apis/retrievers/retrievers-examples.md
@@ -440,7 +440,7 @@ GET /retrievers_example/_search
             "query": "artificial intelligence"
         }
     }
-}     
+}
 ```
 
 This returns the following response based on the final rrf score for each result.
@@ -497,7 +497,7 @@ GET /retrievers_example/_search
             "fields": ["text", "text_semantic"]
         }
     }
-}     
+}
 ```
 
 ::::{note}
@@ -570,7 +570,7 @@ GET /retrievers_example/_search
             "normalizer": "minmax"
         }
     }
-}     
+}
 ```
 
 This returns the following response based on the normalized score for each result:
@@ -1503,6 +1503,7 @@ PUT _inference/rerank/my-rerank-model
 ```
 
 Let’s start by reranking the results of the `rrf` retriever in our previous example.
+We'll also apply a `chunk_rescorer` to ensure that we only consider the best scoring chunks when sending information to the reranker.
 
 ```console
 GET retrievers_example/_search
@@ -1541,7 +1542,15 @@ GET retrievers_example/_search
             },
             "field": "text",
             "inference_id": "my-rerank-model",
-            "inference_text": "What are the state of the art applications of AI in information retrieval?"
+            "inference_text": "What are the state of the art applications of AI in information retrieval?",
+            "chunk_rescorer": {
+                "size": 1,
+                "chunking_settings": {
+                    "strategy": "sentence",
+                    "max_chunk_size": 300,
+                    "sentence_overlap": 0
+                }
+            },
         }
     },
     "_source": false

--- a/docs/reference/elasticsearch/rest-apis/retrievers/text-similarity-reranker-retriever.md
+++ b/docs/reference/elasticsearch/rest-apis/retrievers/text-similarity-reranker-retriever.md
@@ -101,7 +101,7 @@ score = ln(score), if score < 0
     `chunking_settings`
     :   (Optional, `object`)
 
-    Settings for chunking text into smaller passages for scoring and reranking. Defaults to the optimal chunk size for the Elastic Reranker. Note that if chunking settings are specified that chunk content into larger chunks than the reranker's token limit, it may result in truncation and negatively impact relevance.
+    Settings for chunking text into smaller passages for scoring and reranking. Defaults to the optimal chunking settings for the Elastic Reranker. Refer to the Inference API for valid values for `chunking_settings`. Warning: if chunking settings are specified that chunk content into larger chunks than the reranker's token limit, it may result in truncation and negatively impact relevance.
 
 
 ## Example: Elastic Rerank [text-similarity-reranker-retriever-example-elastic-rerank]

--- a/docs/reference/elasticsearch/rest-apis/retrievers/text-similarity-reranker-retriever.md
+++ b/docs/reference/elasticsearch/rest-apis/retrievers/text-similarity-reranker-retriever.md
@@ -101,7 +101,10 @@ score = ln(score), if score < 0
     `chunking_settings`
     :   (Optional, `object`)
 
-    Settings for chunking text into smaller passages for scoring and reranking. Defaults to the optimal chunking settings for the Elastic Reranker. Refer to the Inference API for valid values for `chunking_settings`. Warning: if chunking settings are specified that chunk content into larger chunks than the reranker's token limit, it may result in truncation and negatively impact relevance.
+    Settings for chunking text into smaller passages for scoring and reranking. Defaults to the optimal chunking settings for [Elastic Rerank](docs-content:///explore-analyze/machine-learning/nlp/ml-nlp-rerank.md). Refer to the [Inference API documentation](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-inference-put#operation-inference-put-body-application-json-chunking_settings) for valid values for `chunking_settings`. 
+    :::{warning} 
+    If you configure chunks larger than the reranker's token limit, the results may be truncated. This can degrade relevance significantly.
+    :::
 
 
 ## Example: Elastic Rerank [text-similarity-reranker-retriever-example-elastic-rerank]

--- a/docs/reference/elasticsearch/rest-apis/retrievers/text-similarity-reranker-retriever.md
+++ b/docs/reference/elasticsearch/rest-apis/retrievers/text-similarity-reranker-retriever.md
@@ -86,6 +86,22 @@ score = ln(score), if score < 0
 
     Applies the specified [boolean query filter](/reference/query-languages/query-dsl/query-dsl-bool-query.md) to the child  `retriever`. If the child retriever already specifies any filters, then this top-level filter is applied in conjuction with the filter defined in the child retriever.
 
+`chunk_rescorer` {applies_to}`stack: beta 9.2`
+:   (Optional, `object`)
+
+    When specified, chunks and scores documents based on configured chunking settings, and only sends the best scoring chunks to the reranking model as input. This helps improve relevance when reranking long documents that would otherwise be truncated by the reranking model's token limit.
+
+    Parameters for `chunk_rescorer`:
+
+    `size`
+    :   (Optional, `int`)
+
+    The number of chunks to pass to the reranker for consideration. Defaults to `1`.
+
+    `chunking_settings`
+    :   (Optional, `object`)
+
+    Settings for chunking text into smaller passages for scoring and reranking. Defaults to the optimal chunk size for the Elastic Reranker. Note that if chunking settings are specified that chunk content into larger chunks than the reranker's token limit, it may result in truncation and negatively impact relevance.
 
 
 ## Example: Elastic Rerank [text-similarity-reranker-retriever-example-elastic-rerank]

--- a/docs/reference/elasticsearch/rest-apis/retrievers/text-similarity-reranker-retriever.md
+++ b/docs/reference/elasticsearch/rest-apis/retrievers/text-similarity-reranker-retriever.md
@@ -89,7 +89,7 @@ score = ln(score), if score < 0
 `chunk_rescorer` {applies_to}`stack: beta 9.2`
 :   (Optional, `object`)
 
-    When specified, chunks and scores documents based on configured chunking settings, and only sends the best scoring chunks to the reranking model as input. This helps improve relevance when reranking long documents that would otherwise be truncated by the reranking model's token limit.
+    Chunks and scores documents based on configured chunking settings, and only sends the best scoring chunks to the reranking model as input. This helps improve relevance when reranking long documents that would otherwise be truncated by the reranking model's token limit.
 
     Parameters for `chunk_rescorer`:
 

--- a/docs/reference/elasticsearch/rest-apis/retrievers/text-similarity-reranker-retriever.md
+++ b/docs/reference/elasticsearch/rest-apis/retrievers/text-similarity-reranker-retriever.md
@@ -96,7 +96,7 @@ score = ln(score), if score < 0
     `size`
     :   (Optional, `int`)
 
-    The number of chunks to pass to the reranker for consideration. Defaults to `1`.
+    The number of chunks to pass to the reranker. Defaults to `1`.
 
     `chunking_settings`
     :   (Optional, `object`)


### PR DESCRIPTION
Adds documentation for the `chunk_rescorer` introduced in https://github.com/elastic/elasticsearch/pull/133576
<img width="955" height="531" alt="Screenshot 2025-10-10 at 3 23 34 PM" src="https://github.com/user-attachments/assets/863446dd-923c-4082-8c8b-b2bb5b34cc10" />
<img width="948" height="1115" alt="Screenshot 2025-10-10 at 3 16 00 PM" src="https://github.com/user-attachments/assets/ce5bb6c1-8eeb-4438-a09b-fc9e2c2ddbb3" />

