### PR TITLE
Stop reusing cluster for CrossClusterAsyncQueryStopIT and unmute

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -411,9 +411,6 @@ tests:
 - class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
   method: testCancelViaExpirationOnRemoteResultsWithMinimizeRoundtrips
   issue: https://github.com/elastic/elasticsearch/issues/127302
-- class: org.elasticsearch.xpack.esql.action.CrossClusterAsyncQueryStopIT
-  method: testStopQueryLocal
-  issue: https://github.com/elastic/elasticsearch/issues/133481
 - class: org.elasticsearch.xpack.esql.inference.rerank.RerankOperatorTests
   method: testSimpleCircuitBreaking
   issue: https://github.com/elastic/elasticsearch/issues/133619

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterAsyncQueryStopIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterAsyncQueryStopIT.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.action;
 
 import org.elasticsearch.Build;
+import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.core.Tuple;
@@ -16,6 +17,8 @@ import org.elasticsearch.logging.Logger;
 import org.elasticsearch.tasks.TaskInfo;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.async.AsyncStopRequest;
+import org.elasticsearch.xpack.core.async.DeleteAsyncResultRequest;
+import org.elasticsearch.xpack.core.async.TransportDeleteAsyncResultAction;
 import org.elasticsearch.xpack.esql.plugin.EsqlPlugin;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
@@ -28,7 +31,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.xpack.esql.action.AbstractEsqlIntegTestCase.randomIncludeCCSMetadata;
-import static org.elasticsearch.xpack.esql.action.EsqlAsyncTestUtils.deleteAsyncId;
 import static org.elasticsearch.xpack.esql.action.EsqlAsyncTestUtils.getAsyncResponse;
 import static org.elasticsearch.xpack.esql.action.EsqlAsyncTestUtils.startAsyncQuery;
 import static org.elasticsearch.xpack.esql.action.EsqlAsyncTestUtils.startAsyncQueryWithPragmas;
@@ -130,7 +132,7 @@ public class CrossClusterAsyncQueryStopIT extends AbstractCrossClusterTestCase {
         } finally {
             // Ensure proper cleanup if the test fails
             CountingPauseFieldPlugin.allowEmitting.countDown();
-            assertAcked(deleteAsyncId(client(), asyncExecutionId));
+            deleteAsyncId(client(), asyncExecutionId);
         }
     }
 
@@ -227,7 +229,7 @@ public class CrossClusterAsyncQueryStopIT extends AbstractCrossClusterTestCase {
             }
         } finally {
             SimplePauseFieldPlugin.allowEmitting.countDown();
-            assertAcked(deleteAsyncId(client, asyncExecutionId));
+            deleteAsyncId(client, asyncExecutionId);
         }
     }
 
@@ -270,7 +272,7 @@ public class CrossClusterAsyncQueryStopIT extends AbstractCrossClusterTestCase {
             }
         } finally {
             SimplePauseFieldPlugin.allowEmitting.countDown();
-            assertAcked(deleteAsyncId(client(), asyncExecutionId));
+            deleteAsyncId(client(), asyncExecutionId);
         }
     }
 
@@ -356,7 +358,16 @@ public class CrossClusterAsyncQueryStopIT extends AbstractCrossClusterTestCase {
         } finally {
             // Ensure proper cleanup if the test fails
             CountingPauseFieldPlugin.allowEmitting.countDown();
-            assertAcked(deleteAsyncId(client(), asyncExecutionId));
+            deleteAsyncId(client(), asyncExecutionId);
+        }
+    }
+
+    public void deleteAsyncId(Client client, String id) {
+        try {
+            DeleteAsyncResultRequest request = new DeleteAsyncResultRequest(id);
+            assertAcked(client.execute(TransportDeleteAsyncResultAction.TYPE, request).actionGet(30, TimeUnit.SECONDS));
+        } catch (ElasticsearchTimeoutException e) {
+            LOGGER.warn("timeout waiting for DELETE response: {}: {}", id, e);
         }
     }
 

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterAsyncQueryStopIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterAsyncQueryStopIT.java
@@ -43,6 +43,11 @@ public class CrossClusterAsyncQueryStopIT extends AbstractCrossClusterTestCase {
 
     private static final Logger LOGGER = LogManager.getLogger(CrossClusterAsyncQueryStopIT.class);
 
+    @Override
+    protected boolean reuseClusters() {
+        return false;
+    }
+
     public void testStopQuery() throws Exception {
         assumeTrue("Pragma does not work in release builds", Build.current().isSnapshot());
         Map<String, Object> testClusterInfo = setupClusters(3);


### PR DESCRIPTION
We got a lot of error contamination from other tests and DELETE timeouts. Let's see if not reusing clusters helps it. 

Closes https://github.com/elastic/elasticsearch/issues/133481