### PR TITLE
Fix testStopQueryInlineStats - don't expect specific result when aggregation is interrupted

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -567,9 +567,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.action.EsqlActionBreakerIT
   method: testTopNPushedToLuceneOnSortedIndex
   issue: https://github.com/elastic/elasticsearch/issues/135939
-- class: org.elasticsearch.xpack.esql.action.CrossClusterAsyncQueryStopIT
-  method: testStopQueryInlineStats
-  issue: https://github.com/elastic/elasticsearch/issues/135032
 - class: org.elasticsearch.xpack.ml.integration.RegressionIT
   method: testAliasFields
   issue: https://github.com/elastic/elasticsearch/issues/135996

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterAsyncQueryStopIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterAsyncQueryStopIT.java
@@ -318,7 +318,7 @@ public class CrossClusterAsyncQueryStopIT extends AbstractCrossClusterTestCase {
                     // The sum could be null, if the stats did not manage to compute anything before being stopped
                     // Or it could be 45L if it managed to add 0-9
                     if (v != null) {
-                        assertThat((long) v, equalTo(45L));
+                        assertThat((long) v, lessThanOrEqualTo(45L));
                     }
                     v = row.next();
                     if (v != null) {


### PR DESCRIPTION
Looks like we can't expect a specific number here.

Closes https://github.com/elastic/elasticsearch/issues/135032