### PR TITLE
[9.2] Register action named writeables with indices (#136218)

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -1081,7 +1081,7 @@ public class ActionModule extends AbstractModule {
         return reservedClusterStateService;
     }
 
-    public List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+    public static List<NamedWriteableRegistry.Entry> getNamedWriteables() {
         return List.of(
             new NamedWriteableRegistry.Entry(
                 ExtendedSearchUsageMetric.class,

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterModule.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterModule.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.cluster;
 
+import org.elasticsearch.action.ActionModule;
 import org.elasticsearch.action.admin.indices.rollover.MetadataRolloverService;
 import org.elasticsearch.action.admin.indices.sampling.SamplingMetadata;
 import org.elasticsearch.cluster.action.index.MappingUpdatedAction;
@@ -320,6 +321,9 @@ public class ClusterModule extends AbstractModule {
 
         // Streams
         registerProjectCustom(entries, StreamsMetadata.TYPE, StreamsMetadata::new, StreamsMetadata::readDiffFrom);
+
+        // Actions
+        entries.addAll(ActionModule.getNamedWriteables());
 
         return entries;
     }

--- a/x-pack/plugin/inference/qa/multi-node/build.gradle
+++ b/x-pack/plugin/inference/qa/multi-node/build.gradle
@@ -1,0 +1,12 @@
+import org.elasticsearch.gradle.util.GradleUtils
+
+apply plugin: 'elasticsearch.internal-yaml-rest-test'
+
+dependencies {
+  clusterPlugins project(':x-pack:plugin:inference:qa:test-service-plugin')
+}
+
+tasks.named('yamlRestTest') {
+  usesDefaultDistribution("to be triaged")
+  maxParallelForks = 1
+}

--- a/x-pack/plugin/inference/qa/multi-node/src/yamlRestTest/java/org/elasticsearch/xpack/inference/InferenceRestMultiNodeIT.java
+++ b/x-pack/plugin/inference/qa/multi-node/src/yamlRestTest/java/org/elasticsearch/xpack/inference/InferenceRestMultiNodeIT.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference;
+
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.elasticsearch.client.Request;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
+import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
+import org.junit.After;
+import org.junit.ClassRule;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class InferenceRestMultiNodeIT extends ESClientYamlSuiteTestCase {
+
+    public InferenceRestMultiNodeIT(final ClientYamlTestCandidate testCandidate) {
+        super(testCandidate);
+    }
+
+    @ClassRule
+    public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .systemProperty("tests.seed", System.getProperty("tests.seed"))
+        .setting("xpack.security.enabled", "false")
+        .setting("xpack.security.http.ssl.enabled", "false")
+        .setting("xpack.license.self_generated.type", "trial")
+        .plugin("inference-service-test")
+        .nodes(3)
+        .distribution(DistributionType.DEFAULT)
+        .build();
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
+
+    @ParametersFactory
+    public static Iterable<Object[]> parameters() throws Exception {
+        return ESClientYamlSuiteTestCase.createParameters();
+    }
+
+    @After
+    public void cleanup() throws Exception {
+        for (var model : getAllModels()) {
+            var inferenceId = model.get("inference_id");
+            try {
+                var endpoint = Strings.format("_inference/%s?force", inferenceId);
+                adminClient().performRequest(new Request("DELETE", endpoint));
+            } catch (Exception ex) {
+                logger.warn(() -> "failed to delete inference endpoint " + inferenceId, ex);
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    static List<Map<String, Object>> getAllModels() throws IOException {
+        var request = new Request("GET", "_inference/_all");
+        var response = client().performRequest(request);
+        return (List<Map<String, Object>>) entityAsMap(response).get("endpoints");
+    }
+}

--- a/x-pack/plugin/inference/qa/multi-node/src/yamlRestTest/resources/rest-api-spec/test/inference/10_retriever_extended_telemetry.yml
+++ b/x-pack/plugin/inference/qa/multi-node/src/yamlRestTest/resources/rest-api-spec/test/inference/10_retriever_extended_telemetry.yml
@@ -1,0 +1,120 @@
+setup:
+  - requires:
+      cluster_features: "search.usage.extended_data"
+      reason: extended search usage data introduced in 9.2.0
+
+  - do:
+      inference.put:
+        task_type: rerank
+        inference_id: my-rerank-model
+        body: >
+          {
+            "service": "test_reranking_service",
+            "service_settings": {
+              "model_id": "my_model",
+              "api_key": "abc64"
+            },
+            "task_settings": {
+            }
+          }
+
+  - do:
+      inference.put:
+        task_type: sparse_embedding
+        inference_id: sparse-inference-id
+        body: >
+          {
+            "service": "test_service",
+            "service_settings": {
+              "model": "my_model",
+              "api_key": "abc64"
+            },
+            "task_settings": {
+            }
+          }
+
+  - do:
+      indices.create:
+        index: test-index
+        body:
+          mappings:
+            properties:
+              text:
+                type: text
+                copy_to: semantic_text_field
+              topic:
+                type: keyword
+              subtopic:
+                type: keyword
+              inference_text_field:
+                type: text
+              semantic_text_field:
+                type: semantic_text
+                inference_id: sparse-inference-id
+                chunking_settings:
+                  strategy: word
+                  max_chunk_size: 10
+                  overlap: 1
+
+  - do:
+      index:
+        index: test-index
+        id: doc_2
+        body:
+          text: "The phases of the Moon come from the position of the Moon relative to the Earth and Sun."
+          topic: [ "science" ]
+          subtopic: [ "astronomy" ]
+          inference_text_field: "0"
+        refresh: true
+
+  - do:
+      index:
+        index: test-index
+        id: doc_3
+        body:
+          text: "Sun Moon Lake is a lake in Nantou County, Taiwan. It is the largest lake in Taiwan."
+          topic: [ "geography" ]
+          inference_text_field: "1"
+        refresh: true
+
+  - do:
+      index:
+        index: test-index
+        id: doc_1
+        body:
+          text: "As seen from Earth, a solar eclipse happens when the Moon is directly between the Earth and the Sun."
+          topic: [ "science" ]
+          subtopic: [ "technology" ]
+          inference_text_field: "-1"
+        refresh: true
+
+---
+"Reranking based on rescore_chunks is reflected in extended search usage stats":
+
+  - do:
+      search:
+        index: test-index
+        body:
+          track_total_hits: true
+          fields: [ "text", "semantic_text_field", "topic" ]
+          retriever:
+            text_similarity_reranker:
+              retriever:
+                standard:
+                  query:
+                    match:
+                      topic:
+                        query: "science"
+              rank_window_size: 10
+              inference_id: my-rerank-model
+              inference_text: "how often does the moon hide the sun?"
+              field: semantic_text_field
+              chunk_rescorer: {}
+          size: 10
+
+  - do:
+      cluster.stats: {}
+
+  - not_exists: _nodes.failures
+  - exists: indices.search.extended.retrievers.text_similarity_reranker.chunk_rescorer
+

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceFeatures.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceFeatures.java
@@ -52,6 +52,7 @@ public class InferenceFeatures implements FeatureSpecification {
     private static final NodeFeature SEMANTIC_TEXT_FIELDS_CHUNKS_FORMAT = new NodeFeature("semantic_text.fields_chunks_format");
 
     public static final NodeFeature INFERENCE_ENDPOINT_CACHE = new NodeFeature("inference.endpoint.cache");
+    public static final NodeFeature SEARCH_USAGE_EXTENDED_DATA = new NodeFeature("search.usage.extended_data");
 
     @Override
     public Set<NodeFeature> getFeatures() {
@@ -96,7 +97,8 @@ public class InferenceFeatures implements FeatureSpecification {
                 SemanticQueryBuilder.SEMANTIC_QUERY_FILTER_FIELD_CAPS_FIX,
                 InterceptedInferenceQueryBuilder.NEW_SEMANTIC_QUERY_INTERCEPTORS,
                 TEXT_SIMILARITY_RERANKER_SNIPPETS,
-                ModelStats.SEMANTIC_TEXT_USAGE
+                ModelStats.SEMANTIC_TEXT_USAGE,
+                SEARCH_USAGE_EXTENDED_DATA
             )
         );
         testFeatures.addAll(getFeatures());


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Register action named writeables with indices (#136218)