### PR TITLE
[9.2] Looks like we can't expect a specific number here (#136431)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -627,9 +627,6 @@ tests:
 - class: org.elasticsearch.datastreams.DataStreamIndexSettingsProviderTests
   method: testGetAdditionalIndexSettingsMappingsMerging
   issue: https://github.com/elastic/elasticsearch/issues/135884
-- class: org.elasticsearch.xpack.esql.action.CrossClusterAsyncQueryStopIT
-  method: testStopQueryInlineStats
-  issue: https://github.com/elastic/elasticsearch/issues/135032
 - class: org.elasticsearch.datastreams.DataStreamIndexSettingsProviderTests
   method: testGetAdditionalIndexSettings
   issue: https://github.com/elastic/elasticsearch/issues/135972

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterAsyncQueryStopIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterAsyncQueryStopIT.java
@@ -318,7 +318,7 @@ public class CrossClusterAsyncQueryStopIT extends AbstractCrossClusterTestCase {
                     // The sum could be null, if the stats did not manage to compute anything before being stopped
                     // Or it could be 45L if it managed to add 0-9
                     if (v != null) {
-                        assertThat((long) v, equalTo(45L));
+                        assertThat((long) v, lessThanOrEqualTo(45L));
                     }
                     v = row.next();
                     if (v != null) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Looks like we can&#x27;t expect a specific number here (#136431)](https://github.com/elastic/elasticsearch/pull/136431)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)