### PR TITLE
Move lifecycle deletion logic to metadata service

### DIFF
--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycle.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycle.java
@@ -141,7 +141,7 @@ public class IndexLifecycle extends Plugin implements ActionPlugin, HealthPlugin
     @Override
     public Collection<?> createComponents(PluginServices services) {
         final List<Object> components = new ArrayList<>();
-        PutLifecycleMetadataService putLifecycleMetadataService = new PutLifecycleMetadataService(
+        LifecycleMetadataService lifecycleMetadataService = new LifecycleMetadataService(
             services.clusterService(),
             services.xContentRegistry(),
             services.client(),
@@ -149,7 +149,7 @@ public class IndexLifecycle extends Plugin implements ActionPlugin, HealthPlugin
             services.threadPool(),
             services.projectResolver()
         );
-        components.add(putLifecycleMetadataService);
+        components.add(lifecycleMetadataService);
 
         ILMHistoryTemplateRegistry ilmTemplateRegistry = new ILMHistoryTemplateRegistry(
             settings,

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/LifecycleMetadataService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/LifecycleMetadataService.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.ilm;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.internal.Client;
@@ -25,6 +26,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.cluster.service.MasterServiceTaskQueue;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.reservedstate.ReservedClusterStateHandler;
@@ -37,6 +39,7 @@ import org.elasticsearch.xpack.core.ilm.LifecyclePolicyMetadata;
 import org.elasticsearch.xpack.core.ilm.Phase;
 import org.elasticsearch.xpack.core.ilm.SearchableSnapshotAction;
 import org.elasticsearch.xpack.core.ilm.WaitForSnapshotAction;
+import org.elasticsearch.xpack.core.ilm.action.DeleteLifecycleAction;
 import org.elasticsearch.xpack.core.ilm.action.PutLifecycleRequest;
 import org.elasticsearch.xpack.core.slm.SnapshotLifecycleMetadata;
 import org.elasticsearch.xpack.ilm.action.ReservedLifecycleAction;
@@ -61,7 +64,7 @@ public class LifecycleMetadataService {
     private final XPackLicenseState licenseState;
     private final ThreadPool threadPool;
     private final ProjectResolver projectResolver;
-    private final MasterServiceTaskQueue<UpdateLifecyclePolicyTask> taskQueue;
+    private final MasterServiceTaskQueue<AckedClusterStateUpdateTask> taskQueue;
 
     public LifecycleMetadataService(
         ClusterService clusterService,
@@ -76,7 +79,7 @@ public class LifecycleMetadataService {
         this.licenseState = licenseState;
         this.threadPool = threadPool;
         this.projectResolver = projectResolver;
-        this.taskQueue = clusterService.createTaskQueue("ilm-put-lifecycle-queue", Priority.NORMAL, new IlmLifecycleExecutor());
+        this.taskQueue = clusterService.createTaskQueue("ilm-lifecycle-queue", Priority.NORMAL, new IlmLifecycleExecutor());
     }
 
     public void addLifecycle(PutLifecycleRequest request, ClusterState state, ActionListener<AcknowledgedResponse> listener) {
@@ -305,9 +308,64 @@ public class LifecycleMetadataService {
         }
     }
 
-    private static class IlmLifecycleExecutor extends SimpleBatchedAckListenerTaskExecutor<UpdateLifecyclePolicyTask> {
+    public void deleteLifecycle(DeleteLifecycleAction.Request request, ActionListener<AcknowledgedResponse> listener) {
+        final var projectId = projectResolver.getProjectId();
+        DeleteLifecyclePolicyTask deleteTask = new DeleteLifecyclePolicyTask(
+            projectId,
+            request.getPolicyName(),
+            request.masterNodeTimeout(),
+            request.ackTimeout(),
+            listener
+        );
+        taskQueue.submitTask("delete-lifecycle-" + request.getPolicyName(), deleteTask, deleteTask.timeout());
+    }
+
+    public static class DeleteLifecyclePolicyTask extends AckedClusterStateUpdateTask {
+        private final ProjectId projectId;
+        private final String policyName;
+
+        public DeleteLifecyclePolicyTask(
+            ProjectId projectId,
+            String policyName,
+            TimeValue masterNodeTimeout,
+            TimeValue ackTimeout,
+            ActionListener<AcknowledgedResponse> listener
+        ) {
+            super(masterNodeTimeout, ackTimeout, listener);
+            this.projectId = projectId;
+            this.policyName = policyName;
+        }
+
         @Override
-        public Tuple<ClusterState, ClusterStateAckListener> executeTask(UpdateLifecyclePolicyTask task, ClusterState clusterState)
+        public ClusterState execute(ClusterState currentState) {
+            ProjectMetadata projectMetadata = currentState.metadata().getProject(projectId);
+            List<String> indicesUsingPolicy = projectMetadata.indices()
+                .values()
+                .stream()
+                .filter(idxMeta -> policyName.equals(idxMeta.getLifecyclePolicyName()))
+                .map(idxMeta -> idxMeta.getIndex().getName())
+                .toList();
+            if (indicesUsingPolicy.isEmpty() == false) {
+                throw new IllegalArgumentException(
+                    "Cannot delete policy [" + policyName + "]. It is in use by one or more indices: " + indicesUsingPolicy
+                );
+            }
+            IndexLifecycleMetadata currentMetadata = projectMetadata.custom(IndexLifecycleMetadata.TYPE);
+            if (currentMetadata == null || currentMetadata.getPolicyMetadatas().containsKey(policyName) == false) {
+                throw new ResourceNotFoundException("Lifecycle policy not found: {}", policyName);
+            }
+            SortedMap<String, LifecyclePolicyMetadata> newPolicies = new TreeMap<>(currentMetadata.getPolicyMetadatas());
+            newPolicies.remove(policyName);
+            IndexLifecycleMetadata newMetadata = new IndexLifecycleMetadata(newPolicies, currentILMMode(projectMetadata));
+            ProjectMetadata.Builder newProjectMetadata = ProjectMetadata.builder(projectMetadata)
+                .putCustom(IndexLifecycleMetadata.TYPE, newMetadata);
+            return ClusterState.builder(currentState).putProjectMetadata(newProjectMetadata).build();
+        }
+    }
+
+    private static class IlmLifecycleExecutor extends SimpleBatchedAckListenerTaskExecutor<AckedClusterStateUpdateTask> {
+        @Override
+        public Tuple<ClusterState, ClusterStateAckListener> executeTask(AckedClusterStateUpdateTask task, ClusterState clusterState)
             throws Exception {
             return Tuple.tuple(task.execute(clusterState), task);
         }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/LifecycleMetadataService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/LifecycleMetadataService.java
@@ -52,9 +52,9 @@ import static org.elasticsearch.xpack.core.ilm.LifecycleOperationMetadata.curren
 import static org.elasticsearch.xpack.core.ilm.PhaseCacheManagement.updateIndicesForPolicy;
 import static org.elasticsearch.xpack.core.searchablesnapshots.SearchableSnapshotsConstants.SEARCHABLE_SNAPSHOT_FEATURE;
 
-public class PutLifecycleMetadataService {
+public class LifecycleMetadataService {
 
-    private static final Logger logger = LogManager.getLogger(PutLifecycleMetadataService.class);
+    private static final Logger logger = LogManager.getLogger(LifecycleMetadataService.class);
 
     private final NamedXContentRegistry xContentRegistry;
     private final Client client;
@@ -63,7 +63,7 @@ public class PutLifecycleMetadataService {
     private final ProjectResolver projectResolver;
     private final MasterServiceTaskQueue<UpdateLifecyclePolicyTask> taskQueue;
 
-    public PutLifecycleMetadataService(
+    public LifecycleMetadataService(
         ClusterService clusterService,
         NamedXContentRegistry xContentRegistry,
         Client client,

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/PutLifecycleMetadataService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/PutLifecycleMetadataService.java
@@ -154,7 +154,7 @@ public class PutLifecycleMetadataService {
         for (Phase phase : phasesWithSearchableSnapshotActions) {
             SearchableSnapshotAction action = (SearchableSnapshotAction) phase.getActions().get(SearchableSnapshotAction.NAME);
             String repository = action.getSnapshotRepository();
-            if (RepositoriesMetadata.get(state.cluster()).repository(repository) == null) {
+            if (RepositoriesMetadata.get(state.metadata()).repository(repository) == null) {
                 throw new IllegalArgumentException(
                     "no such repository ["
                         + repository

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/PutLifecycleMetadataService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/PutLifecycleMetadataService.java
@@ -15,7 +15,6 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateAckListener;
-import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.ProjectState;
 import org.elasticsearch.cluster.SimpleBatchedAckListenerTaskExecutor;
 import org.elasticsearch.cluster.metadata.ProjectId;
@@ -26,7 +25,6 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.cluster.service.MasterServiceTaskQueue;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.core.Nullable;
-import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.reservedstate.ReservedClusterStateHandler;
@@ -58,7 +56,6 @@ public class PutLifecycleMetadataService {
 
     private static final Logger logger = LogManager.getLogger(PutLifecycleMetadataService.class);
 
-    private final ClusterService clusterService;
     private final NamedXContentRegistry xContentRegistry;
     private final Client client;
     private final XPackLicenseState licenseState;
@@ -74,18 +71,12 @@ public class PutLifecycleMetadataService {
         ThreadPool threadPool,
         ProjectResolver projectResolver
     ) {
-        this.clusterService = clusterService;
         this.xContentRegistry = xContentRegistry;
         this.client = client;
         this.licenseState = licenseState;
         this.threadPool = threadPool;
         this.projectResolver = projectResolver;
         this.taskQueue = clusterService.createTaskQueue("ilm-put-lifecycle-queue", Priority.NORMAL, new IlmLifecycleExecutor());
-    }
-
-    @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private void submitUnbatchedTask(@SuppressWarnings("SameParameterValue") String source, ClusterStateUpdateTask task) {
-        clusterService.submitUnbatchedStateUpdateTask(source, task);
     }
 
     public void addLifecycle(PutLifecycleRequest request, ClusterState state, ActionListener<AcknowledgedResponse> listener) {

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/ReservedLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/ReservedLifecycleAction.java
@@ -22,7 +22,7 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
 import org.elasticsearch.xpack.core.ilm.action.DeleteLifecycleAction;
 import org.elasticsearch.xpack.core.ilm.action.PutLifecycleRequest;
-import org.elasticsearch.xpack.ilm.PutLifecycleMetadataService;
+import org.elasticsearch.xpack.ilm.LifecycleMetadataService;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -87,7 +87,7 @@ public class ReservedLifecycleAction implements ReservedProjectStateHandler<List
         ClusterState state = prevState.state();
 
         for (var request : requests) {
-            PutLifecycleMetadataService.UpdateLifecyclePolicyTask task = new PutLifecycleMetadataService.UpdateLifecyclePolicyTask(
+            LifecycleMetadataService.UpdateLifecyclePolicyTask task = new LifecycleMetadataService.UpdateLifecyclePolicyTask(
                 state.metadata().getProject(projectId).id(),
                 request,
                 licenseState,

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/ReservedLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/ReservedLifecycleAction.java
@@ -20,7 +20,6 @@ import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
-import org.elasticsearch.xpack.core.ilm.action.DeleteLifecycleAction;
 import org.elasticsearch.xpack.core.ilm.action.PutLifecycleRequest;
 import org.elasticsearch.xpack.ilm.LifecycleMetadataService;
 
@@ -104,13 +103,11 @@ public class ReservedLifecycleAction implements ReservedProjectStateHandler<List
         toDelete.removeAll(entities);
 
         for (var policyToDelete : toDelete) {
-            TransportDeleteLifecycleAction.DeleteLifecyclePolicyTask task = new TransportDeleteLifecycleAction.DeleteLifecyclePolicyTask(
+            LifecycleMetadataService.DeleteLifecyclePolicyTask task = new LifecycleMetadataService.DeleteLifecyclePolicyTask(
                 state.metadata().getProject(projectId).id(),
-                new DeleteLifecycleAction.Request(
-                    RESERVED_CLUSTER_STATE_HANDLER_IGNORED_TIMEOUT,
-                    RESERVED_CLUSTER_STATE_HANDLER_IGNORED_TIMEOUT,
-                    policyToDelete
-                ),
+                policyToDelete,
+                RESERVED_CLUSTER_STATE_HANDLER_IGNORED_TIMEOUT,
+                RESERVED_CLUSTER_STATE_HANDLER_IGNORED_TIMEOUT,
                 ActionListener.noop()
             );
             state = task.execute(state);

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportDeleteLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportDeleteLifecycleAction.java
@@ -7,42 +7,29 @@
 
 package org.elasticsearch.xpack.ilm.action;
 
-import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
-import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
-import org.elasticsearch.cluster.metadata.ProjectId;
-import org.elasticsearch.cluster.metadata.ProjectMetadata;
-import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
-import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.xpack.core.ilm.IndexLifecycleMetadata;
-import org.elasticsearch.xpack.core.ilm.LifecyclePolicyMetadata;
 import org.elasticsearch.xpack.core.ilm.action.DeleteLifecycleAction;
 import org.elasticsearch.xpack.core.ilm.action.DeleteLifecycleAction.Request;
+import org.elasticsearch.xpack.ilm.LifecycleMetadataService;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
-
-import static org.elasticsearch.xpack.core.ilm.LifecycleOperationMetadata.currentILMMode;
 
 public class TransportDeleteLifecycleAction extends TransportMasterNodeAction<Request, AcknowledgedResponse> {
 
-    private final ProjectResolver projectResolver;
+    private final LifecycleMetadataService lifecycleMetadataService;
 
     @Inject
     public TransportDeleteLifecycleAction(
@@ -50,7 +37,7 @@ public class TransportDeleteLifecycleAction extends TransportMasterNodeAction<Re
         ClusterService clusterService,
         ThreadPool threadPool,
         ActionFilters actionFilters,
-        ProjectResolver projectResolver
+        LifecycleMetadataService lifecycleMetadataService
     ) {
         super(
             DeleteLifecycleAction.NAME,
@@ -62,56 +49,12 @@ public class TransportDeleteLifecycleAction extends TransportMasterNodeAction<Re
             AcknowledgedResponse::readFrom,
             EsExecutors.DIRECT_EXECUTOR_SERVICE
         );
-        this.projectResolver = projectResolver;
+        this.lifecycleMetadataService = lifecycleMetadataService;
     }
 
     @Override
     protected void masterOperation(Task task, Request request, ClusterState state, ActionListener<AcknowledgedResponse> listener) {
-        final var projectId = projectResolver.getProjectId();
-        submitUnbatchedTask("delete-lifecycle-" + request.getPolicyName(), new DeleteLifecyclePolicyTask(projectId, request, listener));
-    }
-
-    public static class DeleteLifecyclePolicyTask extends AckedClusterStateUpdateTask {
-        private final ProjectId projectId;
-        private final Request request;
-
-        public DeleteLifecyclePolicyTask(ProjectId projectId, Request request, ActionListener<AcknowledgedResponse> listener) {
-            super(request, listener);
-            this.projectId = projectId;
-            this.request = request;
-        }
-
-        @Override
-        public ClusterState execute(ClusterState currentState) {
-            String policyToDelete = request.getPolicyName();
-            ProjectMetadata projectMetadata = currentState.metadata().getProject(projectId);
-            List<String> indicesUsingPolicy = projectMetadata.indices()
-                .values()
-                .stream()
-                .filter(idxMeta -> policyToDelete.equals(idxMeta.getLifecyclePolicyName()))
-                .map(idxMeta -> idxMeta.getIndex().getName())
-                .toList();
-            if (indicesUsingPolicy.isEmpty() == false) {
-                throw new IllegalArgumentException(
-                    "Cannot delete policy [" + request.getPolicyName() + "]. It is in use by one or more indices: " + indicesUsingPolicy
-                );
-            }
-            IndexLifecycleMetadata currentMetadata = projectMetadata.custom(IndexLifecycleMetadata.TYPE);
-            if (currentMetadata == null || currentMetadata.getPolicyMetadatas().containsKey(request.getPolicyName()) == false) {
-                throw new ResourceNotFoundException("Lifecycle policy not found: {}", request.getPolicyName());
-            }
-            SortedMap<String, LifecyclePolicyMetadata> newPolicies = new TreeMap<>(currentMetadata.getPolicyMetadatas());
-            newPolicies.remove(request.getPolicyName());
-            IndexLifecycleMetadata newMetadata = new IndexLifecycleMetadata(newPolicies, currentILMMode(projectMetadata));
-            ProjectMetadata.Builder newProjectMetadata = ProjectMetadata.builder(projectMetadata)
-                .putCustom(IndexLifecycleMetadata.TYPE, newMetadata);
-            return ClusterState.builder(currentState).putProjectMetadata(newProjectMetadata).build();
-        }
-    }
-
-    @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private void submitUnbatchedTask(@SuppressWarnings("SameParameterValue") String source, ClusterStateUpdateTask task) {
-        clusterService.submitUnbatchedStateUpdateTask(source, task);
+        lifecycleMetadataService.deleteLifecycle(request, listener);
     }
 
     @Override

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportPutLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportPutLifecycleAction.java
@@ -23,7 +23,7 @@ import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleMetadata;
 import org.elasticsearch.xpack.core.ilm.action.ILMActions;
 import org.elasticsearch.xpack.core.ilm.action.PutLifecycleRequest;
-import org.elasticsearch.xpack.ilm.PutLifecycleMetadataService;
+import org.elasticsearch.xpack.ilm.LifecycleMetadataService;
 
 import java.util.Optional;
 import java.util.Set;
@@ -34,7 +34,7 @@ import java.util.Set;
  */
 public class TransportPutLifecycleAction extends TransportMasterNodeAction<PutLifecycleRequest, AcknowledgedResponse> {
 
-    private final PutLifecycleMetadataService putLifecycleMetadataService;
+    private final LifecycleMetadataService lifecycleMetadataService;
 
     @Inject
     public TransportPutLifecycleAction(
@@ -42,7 +42,7 @@ public class TransportPutLifecycleAction extends TransportMasterNodeAction<PutLi
         ClusterService clusterService,
         ThreadPool threadPool,
         ActionFilters actionFilters,
-        PutLifecycleMetadataService putLifecycleMetadataService
+        LifecycleMetadataService lifecycleMetadataService
     ) {
         super(
             ILMActions.PUT.name(),
@@ -54,7 +54,7 @@ public class TransportPutLifecycleAction extends TransportMasterNodeAction<PutLi
             AcknowledgedResponse::readFrom,
             EsExecutors.DIRECT_EXECUTOR_SERVICE
         );
-        this.putLifecycleMetadataService = putLifecycleMetadataService;
+        this.lifecycleMetadataService = lifecycleMetadataService;
     }
 
     @Override
@@ -64,7 +64,7 @@ public class TransportPutLifecycleAction extends TransportMasterNodeAction<PutLi
         ClusterState state,
         ActionListener<AcknowledgedResponse> listener
     ) {
-        putLifecycleMetadataService.addLifecycle(request, state, listener);
+        lifecycleMetadataService.addLifecycle(request, state, listener);
     }
 
     @Override

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/action/TransportDeleteLifecycleActionTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/action/TransportDeleteLifecycleActionTests.java
@@ -8,13 +8,13 @@
 package org.elasticsearch.xpack.ilm.action;
 
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ilm.action.DeleteLifecycleAction;
+import org.elasticsearch.xpack.ilm.LifecycleMetadataService;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.mockito.Mockito.mock;
@@ -28,7 +28,7 @@ public class TransportDeleteLifecycleActionTests extends ESTestCase {
             mock(ClusterService.class),
             threadPool,
             mock(ActionFilters.class),
-            mock(ProjectResolver.class)
+            mock(LifecycleMetadataService.class)
         );
         assertEquals(ReservedLifecycleAction.NAME, putAction.reservedStateHandlerName().get());
 

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/action/TransportPutLifecycleActionTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/action/TransportPutLifecycleActionTests.java
@@ -19,8 +19,8 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicyMetadata;
 import org.elasticsearch.xpack.core.ilm.action.PutLifecycleRequest;
-import org.elasticsearch.xpack.ilm.LifecyclePolicyTestsUtils;
 import org.elasticsearch.xpack.ilm.LifecycleMetadataService;
+import org.elasticsearch.xpack.ilm.LifecyclePolicyTestsUtils;
 
 import java.util.Map;
 

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/action/TransportPutLifecycleActionTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/action/TransportPutLifecycleActionTests.java
@@ -20,7 +20,7 @@ import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicyMetadata;
 import org.elasticsearch.xpack.core.ilm.action.PutLifecycleRequest;
 import org.elasticsearch.xpack.ilm.LifecyclePolicyTestsUtils;
-import org.elasticsearch.xpack.ilm.PutLifecycleMetadataService;
+import org.elasticsearch.xpack.ilm.LifecycleMetadataService;
 
 import java.util.Map;
 
@@ -37,10 +37,10 @@ public class TransportPutLifecycleActionTests extends ESTestCase {
 
         LifecyclePolicyMetadata existing = new LifecyclePolicyMetadata(policy1, headers1, randomNonNegativeLong(), randomNonNegativeLong());
 
-        assertTrue(PutLifecycleMetadataService.isNoopUpdate(existing, policy1, headers1));
-        assertFalse(PutLifecycleMetadataService.isNoopUpdate(existing, policy2, headers1));
-        assertFalse(PutLifecycleMetadataService.isNoopUpdate(existing, policy1, headers2));
-        assertFalse(PutLifecycleMetadataService.isNoopUpdate(null, policy1, headers1));
+        assertTrue(LifecycleMetadataService.isNoopUpdate(existing, policy1, headers1));
+        assertFalse(LifecycleMetadataService.isNoopUpdate(existing, policy2, headers1));
+        assertFalse(LifecycleMetadataService.isNoopUpdate(existing, policy1, headers2));
+        assertFalse(LifecycleMetadataService.isNoopUpdate(null, policy1, headers1));
     }
 
     public void testReservedStateHandler() throws Exception {
@@ -52,7 +52,7 @@ public class TransportPutLifecycleActionTests extends ESTestCase {
             mockClusterService,
             threadPool,
             mock(ActionFilters.class),
-            mock(PutLifecycleMetadataService.class)
+            mock(LifecycleMetadataService.class)
         );
         assertEquals(ReservedLifecycleAction.NAME, putAction.reservedStateHandlerName().get());
 


### PR DESCRIPTION
Moves the lifecycle deletion logic to the metadata service alongside the lifecycle creation logic.

This is to make implementing bulk lifecycle management easier. In #132658 the lifecycle creation logic was moved from the put lifecycle transport action into its own metadata service. This metadata service allows us to have a location to eventually implement bulk lifecycle creation. Eventually we will reuse this bulk logic in the reserved cluster state services. To do that we must support deletion logic alongside creating resources. By moving the lifecycle deletion logic to the metadata service, it allows us to combine the creation and deletion logic into one bulk resource operation and reuse it for reserved cluster state, plugin provided content installation, and bulk resource installation.

This refactor accomplishes the following:
* Renames the `PutLifecycleMetadataService` to `LifecycleMetadataService`.
* Removes some unused code from the service.
* Moves lifecycle deletion logic and task to the metadata service.
* Makes lifecycle deletion a batched cluster state operation alongside lifecycle creation.
* Fixes a deprecated method usage for retrieving repositories from project metadata instead of from cluster state.