### PR TITLE
[8.19] rest-api-spec: Use more precise number types (#136378)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/_internal.update_desired_nodes.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/_internal.update_desired_nodes.json
@@ -27,7 +27,7 @@
               "description": "the history id"
             },
             "version": {
-              "type": "integer",
+              "type": "int",
               "description": "the version number"
             }
           }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/async_search.submit.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/async_search.submit.json
@@ -53,7 +53,7 @@
         "default": "5d"
       },
       "batched_reduce_size": {
-        "type": "number",
+        "type": "long",
         "description": "The number of shard results that should be reduced at once on the coordinating node. This value should be used as the granularity at which progress results will be made available.",
         "default": 5
       },
@@ -101,7 +101,7 @@
         "description": "A comma-separated list of fields to return as the docvalue representation of a field for each hit"
       },
       "from": {
-        "type": "number",
+        "type": "int",
         "description": "Starting offset (default: 0)"
       },
       "ignore_unavailable": {
@@ -158,7 +158,7 @@
         "description": "Search operation type"
       },
       "size": {
-        "type": "number",
+        "type": "int",
         "description": "Number of hits to return (default: 10)"
       },
       "sort": {
@@ -178,7 +178,7 @@
         "description": "A list of fields to extract and return from the _source field"
       },
       "terminate_after": {
-        "type": "number",
+        "type": "long",
         "description": "The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early."
       },
       "stats": {
@@ -200,7 +200,7 @@
         "description": "Specify suggest mode"
       },
       "suggest_size": {
-        "type": "number",
+        "type": "long",
         "description": "How many suggestions to return in response"
       },
       "suggest_text": {
@@ -237,7 +237,7 @@
         "description": "Specify whether to return sequence number and primary term of the last modification of each hit"
       },
       "max_concurrent_shard_requests": {
-        "type": "number",
+        "type": "int",
         "description": "The number of concurrent shard requests per node this search executes concurrently. This value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests",
         "default": 5
       }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.state.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.state.json
@@ -86,7 +86,7 @@
         "description": "Return settings in flat format (default: false)"
       },
       "wait_for_metadata_version": {
-        "type": "number",
+        "type": "long",
         "description": "Wait for the metadata version to be equal or greater than the specified metadata version"
       },
       "wait_for_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/count.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/count.json
@@ -67,7 +67,7 @@
         "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both."
       },
       "min_score": {
-        "type": "number",
+        "type": "double",
         "description": "Include only documents with a specific `_score` value in the result"
       },
       "preference": {
@@ -110,7 +110,7 @@
         "description": "Specify whether format-based query failures (such as providing text to a numeric field) should be ignored"
       },
       "terminate_after": {
-        "type": "number",
+        "type": "long",
         "description": "The maximum count for each shard, upon reaching which the query execution will terminate early"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/create.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/create.json
@@ -61,7 +61,7 @@
         "description": "Explicit operation timeout"
       },
       "version": {
-        "type": "number",
+        "type": "long",
         "description": "Explicit version number for concurrency control"
       },
       "version_type": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete.json
@@ -57,15 +57,15 @@
         "description": "Explicit operation timeout"
       },
       "if_seq_no": {
-        "type": "number",
+        "type": "long",
         "description": "only perform the delete operation if the last operation that has changed the document has the specified sequence number"
       },
       "if_primary_term": {
-        "type": "number",
+        "type": "long",
         "description": "only perform the delete operation if the last operation that has changed the document has the specified primary term"
       },
       "version": {
-        "type": "number",
+        "type": "long",
         "description": "Explicit version number for concurrency control"
       },
       "version_type": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
@@ -54,7 +54,7 @@
         "description": "The field to use as default where no field prefix is given in the query string"
       },
       "from": {
-        "type": "number",
+        "type": "long",
         "default": 0,
         "description": "Starting offset (default: 0)"
       },
@@ -123,7 +123,7 @@
         "description": "Explicit timeout for each search request. Defaults to no timeout."
       },
       "max_docs": {
-        "type": "number",
+        "type": "long",
         "description": "Maximum number of documents to process (default: all documents)"
       },
       "sort": {
@@ -131,7 +131,7 @@
         "description": "A comma-separated list of <field>:<direction> pairs"
       },
       "terminate_after": {
-        "type": "number",
+        "type": "long",
         "description": "The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early."
       },
       "stats": {
@@ -162,7 +162,7 @@
         "description": "Sets the number of shard copies that must be active before proceeding with the delete by query operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)"
       },
       "scroll_size": {
-        "type": "number",
+        "type": "long",
         "default": 1000,
         "description": "Size on the scroll request powering the delete by query"
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/exists.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/exists.json
@@ -67,7 +67,7 @@
         "description": "A list of fields to extract and return from the _source field"
       },
       "version": {
-        "type": "number",
+        "type": "long",
         "description": "Explicit version number for concurrency control"
       },
       "version_type": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/exists_source.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/exists_source.json
@@ -63,7 +63,7 @@
         "description": "A list of fields to extract and return from the _source field"
       },
       "version": {
-        "type": "number",
+        "type": "long",
         "description": "Explicit version number for concurrency control"
       },
       "version_type": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/get.json
@@ -73,7 +73,7 @@
         "description": "A list of fields to extract and return from the _source field"
       },
       "version": {
-        "type": "number",
+        "type": "long",
         "description": "Explicit version number for concurrency control"
       },
       "version_type": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/get_source.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/get_source.json
@@ -63,7 +63,7 @@
         "description": "A list of fields to extract and return from the _source field"
       },
       "version": {
-        "type": "number",
+        "type": "long",
         "description": "Explicit version number for concurrency control"
       },
       "version_type": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/index.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/index.json
@@ -81,7 +81,7 @@
         "description": "Explicit operation timeout"
       },
       "version": {
-        "type": "number",
+        "type": "long",
         "description": "Explicit version number for concurrency control"
       },
       "version_type": {
@@ -94,11 +94,11 @@
         "description": "Specific version type"
       },
       "if_seq_no": {
-        "type": "number",
+        "type": "long",
         "description": "only perform the index operation if the last operation that has changed the document has the specified sequence number"
       },
       "if_primary_term": {
-        "type": "number",
+        "type": "long",
         "description": "only perform the index operation if the last operation that has changed the document has the specified primary term"
       },
       "pipeline": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.forcemerge.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.forcemerge.json
@@ -59,7 +59,7 @@
         "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both."
       },
       "max_num_segments": {
-        "type": "number",
+        "type": "long",
         "description": "The number of segments the index should be merged into (default: dynamic)"
       },
       "only_expunge_deletes": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_template.json
@@ -33,7 +33,7 @@
     },
     "params": {
       "order": {
-        "type": "number",
+        "type": "int",
         "description": "The order for this template when merging multiple matching ones (higher numbers are merged later, overriding the lower numbers)"
       },
       "create": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/msearch.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/msearch.json
@@ -48,7 +48,7 @@
         "description": "Search operation type"
       },
       "max_concurrent_searches": {
-        "type": "number",
+        "type": "int",
         "description": "Controls the maximum number of concurrent searches the multi search api will execute"
       },
       "typed_keys": {
@@ -56,11 +56,11 @@
         "description": "Specify whether aggregation and suggester names should be prefixed by their respective types in the response"
       },
       "pre_filter_shard_size": {
-        "type": "number",
+        "type": "long",
         "description": "A threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. This filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method ie. if date filters are mandatory to match but the shard bounds and the query are disjoint."
       },
       "max_concurrent_shard_requests": {
-        "type": "number",
+        "type": "int",
         "description": "The number of concurrent shard requests each sub search executes concurrently per node. This value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests",
         "default": 5
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/msearch_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/msearch_template.json
@@ -53,7 +53,7 @@
         "description": "Specify whether aggregation and suggester names should be prefixed by their respective types in the response"
       },
       "max_concurrent_searches": {
-        "type": "number",
+        "type": "long",
         "description": "Controls the maximum number of concurrent searches the multi search api will execute"
       },
       "rest_total_hits_as_int": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/mtermvectors.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/mtermvectors.json
@@ -86,7 +86,7 @@
         "description": "Specifies if requests are real-time as opposed to near-real-time (default: true)."
       },
       "version": {
-        "type": "number",
+        "type": "long",
         "description": "Explicit version number for concurrency control"
       },
       "version_type": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.hot_threads.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.hot_threads.json
@@ -40,12 +40,12 @@
         "description": "The interval for the second sampling of threads"
       },
       "snapshots": {
-        "type": "number",
+        "type": "long",
         "default": 10,
         "description": "Number of samples of thread stacktrace (default: 10)"
       },
       "threads": {
-        "type": "number",
+        "type": "long",
         "default": 3,
         "description": "Specify the number of threads to provide information for (default: 3)"
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/open_point_in_time.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/open_point_in_time.json
@@ -67,7 +67,7 @@
         "description": "Specify whether to tolerate shards missing when creating the point-in-time, or otherwise throw an exception. (default: false)"
       },
       "max_concurrent_shard_requests": {
-        "type": "number",
+        "type": "int",
         "description": "The number of concurrent shard requests per node executed concurrently when opening this point-in-time. This value should be used to limit the impact of opening the point-in-time on the cluster",
         "default": 5
       }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/reindex.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/reindex.json
@@ -61,7 +61,7 @@
         "description": "The number of slices this task should be divided into. Defaults to 1, meaning the task isn't sliced into subtasks. Can be set to `auto`."
       },
       "max_docs": {
-        "type": "number",
+        "type": "int",
         "description": "Maximum number of documents to process (default: all documents)"
       },
       "require_alias": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
@@ -80,7 +80,7 @@
         "description": "A comma-separated list of fields to return as the docvalue representation of a field for each hit"
       },
       "from": {
-        "type": "number",
+        "type": "int",
         "default": 0,
         "description": "Starting offset (default: 0)"
       },
@@ -147,7 +147,7 @@
         "description": "Search operation type"
       },
       "size": {
-        "type": "number",
+        "type": "int",
         "default": 10,
         "description": "Number of hits to return (default: 10)"
       },
@@ -169,7 +169,7 @@
         "description": "A list of fields to extract and return from the _source field"
       },
       "terminate_after": {
-        "type": "number",
+        "type": "long",
         "default": 0,
         "description": "The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early."
       },
@@ -192,7 +192,7 @@
         "description": "Specify suggest mode"
       },
       "suggest_size": {
-        "type": "number",
+        "type": "long",
         "description": "How many suggestions to return in response"
       },
       "suggest_text": {
@@ -237,17 +237,17 @@
         "description": "Specify if request cache should be used for this request or not, defaults to index level setting"
       },
       "batched_reduce_size": {
-        "type": "number",
+        "type": "long",
         "description": "The number of shard results that should be reduced at once on the coordinating node. This value should be used as a protection mechanism to reduce the memory overhead per search request if the potential number of shards in the request can be large.",
         "default": 512
       },
       "max_concurrent_shard_requests": {
-        "type": "number",
+        "type": "int",
         "description": "The number of concurrent shard requests per node this search executes concurrently. This value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests",
         "default": 5
       },
       "pre_filter_shard_size": {
-        "type": "number",
+        "type": "long",
         "description": "A threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. This filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method ie. if date filters are mandatory to match but the shard bounds and the query are disjoint."
       },
       "rest_total_hits_as_int": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.update_user_profile_data.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.update_user_profile_data.json
@@ -33,11 +33,11 @@
     },
     "params": {
       "if_seq_no": {
-        "type": "number",
+        "type": "long",
         "description": "only perform the update operation if the last operation that has changed the document has the specified sequence number"
       },
       "if_primary_term": {
-        "type": "number",
+        "type": "long",
         "description": "only perform the update operation if the last operation that has changed the document has the specified primary term"
       },
       "refresh": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.get.json
@@ -72,7 +72,7 @@
         "description": "Allows setting a sort order for the result. Defaults to start_time"
       },
       "size": {
-        "type": "integer",
+        "type": "int",
         "default": 0,
         "description": "Maximum number of snapshots to return. Defaults to 0 which means return all that match without limit."
       },
@@ -94,7 +94,7 @@
         "description": "Offset identifier to start pagination from as returned by the 'next' field in the response body."
       },
       "offset": {
-        "type": "integer",
+        "type": "int",
         "default": 0,
         "description": "Numeric offset to start pagination based on the snapshots matching the request. Defaults to 0"
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.repository_analyze.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.repository_analyze.json
@@ -29,36 +29,36 @@
     },
     "params": {
       "blob_count": {
-        "type": "number",
+        "type": "int",
         "default": 100,
         "description": "Number of blobs to create during the test. Defaults to 100."
       },
       "concurrency": {
-        "type": "number",
+        "type": "int",
         "default": 10,
         "description": "Number of operations to run concurrently during the test. Defaults to 10."
       },
       "register_operation_count": {
-        "type": "number",
+        "type": "int",
         "default": 10,
         "description": "The minimum number of linearizable register operations to perform in total. Defaults to 10."
       },
       "read_node_count": {
-        "type": "number",
+        "type": "int",
         "default": 10,
         "description": "Number of nodes on which to read a blob after writing. Defaults to 10."
       },
       "early_read_node_count": {
-        "type": "number",
+        "type": "int",
         "default": 2,
         "description": "Number of nodes on which to perform an early read on a blob, i.e. before writing has completed. Early reads are rare actions so the 'rare_action_probability' parameter is also relevant. Defaults to 2."
       },
       "seed": {
-        "type": "number",
+        "type": "int",
         "description": "Seed for the random number generator used to create the test workload. Defaults to a random value."
       },
       "rare_action_probability": {
-        "type": "number",
+        "type": "double",
         "default": 0,
         "description": "Probability of taking a rare action such as an early read or an overwrite. Defaults to 0.02."
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.repository_verify_integrity.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/snapshot.repository_verify_integrity.json
@@ -29,32 +29,32 @@
     },
     "params": {
       "meta_thread_pool_concurrency": {
-        "type": "number",
+        "type": "int",
         "default": 0,
         "description": "Number of threads to use for reading metadata"
       },
       "blob_thread_pool_concurrency": {
-        "type": "number",
+        "type": "int",
         "default": 1,
         "description": "Number of threads to use for reading blob contents"
       },
       "snapshot_verification_concurrency": {
-        "type": "number",
+        "type": "int",
         "default": 0,
         "description": "Number of snapshots to verify concurrently"
       },
       "index_verification_concurrency": {
-        "type": "number",
+        "type": "int",
         "default": 0,
         "description": "Number of indices to verify concurrently"
       },
       "index_snapshot_verification_concurrency": {
-        "type": "number",
+        "type": "int",
         "default": 1,
         "description": "Number of snapshots to verify concurrently within each index"
       },
       "max_failed_shard_snapshots": {
-        "type": "number",
+        "type": "int",
         "default": 10000,
         "description": "Maximum permitted number of failed shard snapshots"
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/termvectors.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/termvectors.json
@@ -92,7 +92,7 @@
         "description": "Specifies if request is real-time as opposed to near-real-time (default: true)."
       },
       "version": {
-        "type": "number",
+        "type": "long",
         "description": "Explicit version number for concurrency control"
       },
       "version_type": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.get_transform_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.get_transform_stats.json
@@ -29,12 +29,12 @@
     },
     "params": {
       "from": {
-        "type": "number",
+        "type": "long",
         "default": 0,
         "description": "skips a number of transform stats, defaults to 0"
       },
       "size": {
-        "type": "number",
+        "type": "long",
         "default": 100,
         "description": "specifies a max number of transform stats to get, defaults to 100"
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update.json
@@ -69,7 +69,7 @@
         "description": "If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes."
       },
       "retry_on_conflict": {
-        "type": "number",
+        "type": "int",
         "default": 0,
         "description": "Specify how many times should the operation be retried when a conflict occurs (default: 0)"
       },
@@ -83,11 +83,11 @@
         "description": "Explicit operation timeout"
       },
       "if_seq_no": {
-        "type": "number",
+        "type": "long",
         "description": "only perform the update operation if the last operation that has changed the document has the specified sequence number"
       },
       "if_primary_term": {
-        "type": "number",
+        "type": "long",
         "description": "only perform the update operation if the last operation that has changed the document has the specified primary term"
       },
       "require_alias": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
@@ -54,7 +54,7 @@
         "description": "The field to use as default where no field prefix is given in the query string"
       },
       "from": {
-        "type": "number",
+        "type": "long",
         "default": 0,
         "description": "Starting offset (default: 0)"
       },
@@ -128,7 +128,7 @@
         "description": "Explicit timeout for each search request. Defaults to no timeout."
       },
       "max_docs": {
-        "type": "number",
+        "type": "long",
         "description": "Maximum number of documents to process (default: all documents)"
       },
       "sort": {
@@ -136,7 +136,7 @@
         "description": "A comma-separated list of <field>:<direction> pairs"
       },
       "terminate_after": {
-        "type": "number",
+        "type": "long",
         "description": "The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early."
       },
       "stats": {
@@ -171,7 +171,7 @@
         "description": "Sets the number of shard copies that must be active before proceeding with the update by query operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)"
       },
       "scroll_size": {
-        "type": "number",
+        "type": "long",
         "default": 1000,
         "description": "Size on the scroll request powering the update by query"
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/watcher.put_watch.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/watcher.put_watch.json
@@ -38,15 +38,15 @@
         "description": "Specify whether the watch is in/active by default"
       },
       "version": {
-        "type": "number",
+        "type": "long",
         "description": "Explicit version number for concurrency control"
       },
       "if_seq_no": {
-        "type": "number",
+        "type": "long",
         "description": "only update the watch if the last operation that has changed the watch has the specified sequence number"
       },
       "if_primary_term": {
-        "type": "number",
+        "type": "long",
         "description": "only update the watch if the last operation that has changed the watch has the specified primary term"
       }
     },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [rest-api-spec: Use more precise number types (#136378)](https://github.com/elastic/elasticsearch/pull/136378)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)