### PR TITLE
Unmutes testNodeTriesToJoinClusterAndThenSameMasterIsElected

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -660,9 +660,6 @@ tests:
 - class: org.elasticsearch.xpack.restart.FullClusterRestartIT
   method: testRollupAfterRestart {cluster=UPGRADED}
   issue: https://github.com/elastic/elasticsearch/issues/136437
-- class: org.elasticsearch.cluster.coordination.NodeJoiningIT
-  method: testNodeTriesToJoinClusterAndThenSameMasterIsElected
-  issue: https://github.com/elastic/elasticsearch/issues/136332
 - class: org.elasticsearch.test.rest.yaml.RcsCcsCommonYamlTestSuiteIT
   method: test {p0=search.vectors/200_dense_vector_docvalue_fields/Enable docvalue_fields parameter for dense_vector fields}
   issue: https://github.com/elastic/elasticsearch/issues/136443

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/NodeJoiningIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/NodeJoiningIT.java
@@ -133,9 +133,11 @@ public class NodeJoiningIT extends ESIntegTestCase {
         In this scenario, node N attempts to join a cluster, there is an election and the original master is re-elected.
         Node N should join the cluster, but it should not be disconnected (#ES-11449)
      */
-    @TestLogging(reason = "test includes assertions about logging", value = "org.elasticsearch.cluster.coordination:INFO")
     @TestIssueLogging(
-        value = "org.elasticsearch.cluster.coordination.NodeJoiningIT:DEBUG",
+        value = "org.elasticsearch.cluster.coordination.NodeJoiningIT:DEBUG," +
+            "org.elasticsearch.cluster.coordination.Coordinator:DEBUG," +
+            "org.elasticsearch.cluster.service.MasterService:DEBUG," +
+            "org.elasticsearch.cluster.coordination.NodeJoinExecutor:DEBUG",
         issueUrl = "https://github.com/elastic/elasticsearch/issues/136332"
     )
     public void testNodeTriesToJoinClusterAndThenSameMasterIsElected() {

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/NodeJoiningIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/NodeJoiningIT.java
@@ -134,10 +134,10 @@ public class NodeJoiningIT extends ESIntegTestCase {
         Node N should join the cluster, but it should not be disconnected (#ES-11449)
      */
     @TestIssueLogging(
-        value = "org.elasticsearch.cluster.coordination.NodeJoiningIT:DEBUG," +
-            "org.elasticsearch.cluster.coordination.Coordinator:DEBUG," +
-            "org.elasticsearch.cluster.service.MasterService:DEBUG," +
-            "org.elasticsearch.cluster.coordination.NodeJoinExecutor:DEBUG",
+        value = "org.elasticsearch.cluster.coordination.NodeJoiningIT:DEBUG,"
+            + "org.elasticsearch.cluster.coordination.Coordinator:DEBUG,"
+            + "org.elasticsearch.cluster.service.MasterService:DEBUG,"
+            + "org.elasticsearch.cluster.coordination.NodeJoinExecutor:DEBUG",
         issueUrl = "https://github.com/elastic/elasticsearch/issues/136332"
     )
     public void testNodeTriesToJoinClusterAndThenSameMasterIsElected() {


### PR DESCRIPTION
Unmutes the failing test
testNodeTriesToJoinClusterAndThenSameMasterIsElected and adds test logging inside the Coordinator, MasterService and NodeJoinExecutor classes
