### PR TITLE
[Sampling] Fixing SamplingServiceTests.testClusterChanged()

### DIFF
--- a/server/src/test/java/org/elasticsearch/ingest/SamplingServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/SamplingServiceTests.java
@@ -259,6 +259,7 @@ public class SamplingServiceTests extends ESTestCase {
     }
 
     public void testClusterChanged() {
+        assumeTrue("Requires sampling feature flag", RANDOM_SAMPLING_FEATURE_FLAG);
         String indexName = randomIdentifier();
         SamplingService samplingService = getTestSamplingService();
         Map<String, Object> inputRawDocSource = randomMap(1, 100, () -> Tuple.tuple(randomAlphaOfLength(10), randomAlphaOfLength(10)));
@@ -274,7 +275,7 @@ public class SamplingServiceTests extends ESTestCase {
                         new SamplingConfiguration(
                             1.0,
                             randomIntBetween(1, 1000),
-                            ByteSizeValue.ofBytes(randomLongBetween(100, 1000000)),
+                            ByteSizeValue.ofBytes(randomLongBetween(indexRequest.source().length(), 1_000_000)),
                             TimeValue.timeValueDays(randomIntBetween(1, 10)),
                             null
                         )
@@ -314,7 +315,7 @@ public class SamplingServiceTests extends ESTestCase {
                         new SamplingConfiguration(
                             1.0,
                             1001,
-                            ByteSizeValue.ofBytes(randomLongBetween(100, 1000000)),
+                            ByteSizeValue.ofBytes(randomLongBetween(indexRequest.source().length(), 1_000_000)),
                             TimeValue.timeValueDays(randomIntBetween(1, 10)),
                             null
                         )


### PR DESCRIPTION
This makes two fixes to SamplingServiceTests.testClusterChanged():

1. It prevents the test from running when the random sampling feature is not present
2. It avoids an edge case where the index request is larger than the maximum size of the entire sample

Closes #136450