### PR TITLE
[Transform] Associate legacy audit index

### DIFF
--- a/docs/changelog/136508.yaml
+++ b/docs/changelog/136508.yaml
@@ -1,0 +1,6 @@
+pr: 136508
+summary: Associate legacy audit index
+area: Transform
+type: bug
+issues:
+ - 121241

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -317,9 +317,6 @@ tests:
     issue: https://github.com/elastic/elasticsearch/issues/121117
   - class: org.elasticsearch.xpack.ml.integration.PyTorchModelIT
     issue: https://github.com/elastic/elasticsearch/issues/121165
-  - class: org.elasticsearch.xpack.transform.integration.TransformAuditorIT
-    method: testAuditorWritesAudits
-    issue: https://github.com/elastic/elasticsearch/issues/121241
   - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
     method: test {p0=nodes.stats/11_indices_metrics/indices mappings exact count test for indices level}
     issue: https://github.com/elastic/elasticsearch/issues/120950

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/Transform.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/Transform.java
@@ -128,6 +128,7 @@ import java.util.function.UnaryOperator;
 import static org.elasticsearch.xpack.core.ClientHelper.TRANSFORM_ORIGIN;
 import static org.elasticsearch.xpack.core.transform.TransformMessages.FAILED_TO_UNSET_RESET_MODE;
 import static org.elasticsearch.xpack.core.transform.transforms.persistence.TransformInternalIndexConstants.AUDIT_INDEX_PATTERN;
+import static org.elasticsearch.xpack.core.transform.transforms.persistence.TransformInternalIndexConstants.AUDIT_INDEX_PATTERN_DEPRECATED;
 import static org.elasticsearch.xpack.core.transform.transforms.persistence.TransformInternalIndexConstants.TRANSFORM_PREFIX;
 import static org.elasticsearch.xpack.core.transform.transforms.persistence.TransformInternalIndexConstants.TRANSFORM_PREFIX_DEPRECATED;
 
@@ -436,7 +437,10 @@ public class Transform extends Plugin implements SystemIndexPlugin, PersistentTa
 
     @Override
     public Collection<AssociatedIndexDescriptor> getAssociatedIndexDescriptors() {
-        return List.of(new AssociatedIndexDescriptor(AUDIT_INDEX_PATTERN, "Audit index"));
+        return List.of(
+            new AssociatedIndexDescriptor(AUDIT_INDEX_PATTERN, "Audit index"),
+            new AssociatedIndexDescriptor(AUDIT_INDEX_PATTERN_DEPRECATED, "Legacy audit index")
+        );
     }
 
     @Override


### PR DESCRIPTION
If a user manually creates the legacy audit index, TransformClusterStateListener will automatically add the non-legacy alias to forward messages to it. If the transform feature had never been accessed before (for example after the feature is reset), then the next time the auditor is called, it will associate with the existing legacy index rather than the notifications index.

We cannot cleanly block users from manually creating system or hidden indices (yet), but we can associate the legacy index with the transform feature so that a feature reset will delete the legacy index (like it does with the notifications index). The next time the transform feature is used, it will automatically create the notifications index rather than reusing the legacy index.

Resolve #121241

------------------

This is only reproducible after the legacy index is manually created in [testAliasCreatedforBWCIndexes](https://github.com/elastic/elasticsearch/blob/8.19/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformAuditorIT.java#L96), so we need to run the full suite until it runs the tests in the failing order (`testAliasCreatedforBWCIndexes` -> `testAuditorWritesAudits`)

This is not needed for 9.x because the code to alias the deprecated index had been removed in 9.0: https://github.com/elastic/elasticsearch/commit/d839205135774841bdad8a6604264e0256684830
