### PR TITLE
[9.1] ES|QL: Make ResolveUnionTypes rule stateless (#136492)

### DIFF
--- a/docs/changelog/136492.yaml
+++ b/docs/changelog/136492.yaml
@@ -1,0 +1,5 @@
+pr: 136492
+summary: Make `ResolveUnionTypes` rule stateless
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -1646,15 +1646,13 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
 
         record TypeResolutionKey(String fieldName, DataType fieldType) {}
 
-        private List<FieldAttribute> unionFieldAttributes;
-
         @Override
         public LogicalPlan apply(LogicalPlan plan) {
-            unionFieldAttributes = new ArrayList<>();
-            return plan.transformUp(LogicalPlan.class, p -> p.childrenResolved() == false ? p : doRule(p));
+            List<FieldAttribute> unionFieldAttributes = new ArrayList<>();
+            return plan.transformUp(LogicalPlan.class, p -> p.childrenResolved() == false ? p : doRule(p, unionFieldAttributes));
         }
 
-        private LogicalPlan doRule(LogicalPlan plan) {
+        private LogicalPlan doRule(LogicalPlan plan, List<FieldAttribute> unionFieldAttributes) {
             Holder<Integer> alreadyAddedUnionFieldAttributes = new Holder<>(unionFieldAttributes.size());
             // Collect field attributes from previous runs
             if (plan instanceof EsRelation rel) {


### PR DESCRIPTION
Backports the following commits to 9.1:
 - ES|QL: Make ResolveUnionTypes rule stateless (#136492)