### PR TITLE
Trigger snapshot dra-workflow for 7.17 explicitly

### DIFF
--- a/.buildkite/scripts/dra-workflow.trigger.sh
+++ b/.buildkite/scripts/dra-workflow.trigger.sh
@@ -46,4 +46,18 @@ for BRANCH in "${BRANCHES[@]}"; do
         DRA_WORKFLOW: staging
         VERSION_QUALIFIER: ${VERSION_QUALIFIER:-}
 EOF
+
+  if [ "$BRANCH" = "7.17" ]; then
+    cat <<EOF
+  - trigger: elasticsearch-dra-workflow
+    label: Trigger DRA snapshot workflow for $BRANCH
+    async: true
+    build:
+      branch: "$BRANCH"
+      commit: "$LAST_GOOD_COMMIT"
+      env:
+        DRA_WORKFLOW: snapshot
+        VERSION_QUALIFIER: ${VERSION_QUALIFIER:-}
+EOF
+  fi
 done


### PR DESCRIPTION
We want to build staging and snapshot dra artifacts for 7.17 ones a week.
We have a dedicated scheduler for running 7.17 dra trigger ones a week but that
has only build the staging artifacts. Usually snapshot dra builds are triggered by
changes in the codebase.
Since 7.17 is only in support but not actively worked on we dont have regular changes there,
therefore we want at least trigger that pipeline ones a week to ensure we are still
capable to build those artifacts