### PR TITLE
[CI] Fix FC config issue for old versions RCS 2.0 BWC tests

### DIFF
--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/AbstractRemoteClusterSecurityTestCase.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/AbstractRemoteClusterSecurityTestCase.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.remotecluster;
 
 import io.netty.handler.codec.http.HttpMethod;
+
 import org.apache.http.HttpHost;
 import org.apache.http.client.methods.HttpPost;
 import org.elasticsearch.client.Request;

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/AbstractRemoteClusterSecurityTestCase.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/AbstractRemoteClusterSecurityTestCase.java
@@ -84,6 +84,7 @@ public abstract class AbstractRemoteClusterSecurityTestCase extends ESRestTestCa
         .configFile("remote-cluster-client.key", Resource.fromClasspath("ssl/remote-cluster-client.key"))
         .configFile("remote-cluster-client.crt", Resource.fromClasspath("ssl/remote-cluster-client.crt"))
         .configFile("remote-cluster-client-ca.crt", Resource.fromClasspath("ssl/remote-cluster-client-ca.crt"))
+        .configFile("signing.crt", Resource.fromClasspath("signing/signing.crt"))
         .module("reindex") // Needed for the role metadata migration
         .user(USER, PASS.toString());
 

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityBWCToRCS2ClusterRestIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityBWCToRCS2ClusterRestIT.java
@@ -40,7 +40,6 @@ public class RemoteClusterSecurityBWCToRCS2ClusterRestIT extends AbstractRemoteC
             .setting("xpack.ml.enabled", "false")
             .setting("remote_cluster_server.enabled", "true")
             .setting("remote_cluster.port", "0")
-            .setting("cluster.remote.signing.certificate_authorities", "signing.crt")
             .configFile("signing.crt", Resource.fromClasspath("signing/signing.crt"))
             .setting("xpack.security.remote_cluster_server.ssl.enabled", "true")
             .setting("xpack.security.remote_cluster_server.ssl.key", "remote-cluster.key")

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityBWCToRCS2ClusterRestIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityBWCToRCS2ClusterRestIT.java
@@ -40,7 +40,6 @@ public class RemoteClusterSecurityBWCToRCS2ClusterRestIT extends AbstractRemoteC
             .setting("xpack.ml.enabled", "false")
             .setting("remote_cluster_server.enabled", "true")
             .setting("remote_cluster.port", "0")
-            .configFile("signing.crt", Resource.fromClasspath("signing/signing.crt"))
             .setting("xpack.security.remote_cluster_server.ssl.enabled", "true")
             .setting("xpack.security.remote_cluster_server.ssl.key", "remote-cluster.key")
             .setting("xpack.security.remote_cluster_server.ssl.certificate", "remote-cluster.crt")

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityReloadCredentialsRestIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityReloadCredentialsRestIT.java
@@ -197,7 +197,7 @@ public class RemoteClusterSecurityReloadCredentialsRestIT extends AbstractRemote
         final boolean configureSettingsFirst = randomBoolean();
         // it's valid to first configure remote cluster, then credentials
         if (configureSettingsFirst) {
-            putRemoteClusterSettings("my_remote_cluster", fulfillingCluster, false, isProxyMode, randomBoolean());
+            putQueryClusterSettings("my_remote_cluster", fulfillingCluster, false, isProxyMode, randomBoolean());
         }
 
         configureRemoteClusterCredentials("my_remote_cluster", remoteClusterCredentials, keystoreSettings);


### PR DESCRIPTION
This changes the test to only configure CA to trust for signature verification if we're on a cluster that supports that setting by checking the node features before updating the setting. 

Resolves: https://github.com/elastic/elasticsearch/issues/136498