### PR TITLE
Unmuting test related to #136402 #136403

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -636,12 +636,6 @@ tests:
 - class: org.elasticsearch.xpack.restart.FullClusterRestartIT
   method: testSlmPolicyAndStats {cluster=UPGRADED}
   issue: https://github.com/elastic/elasticsearch/issues/136399
-- class: org.elasticsearch.test.rest.yaml.RcsCcsCommonYamlTestSuiteIT
-  method: test {p0=search.vectors/160_knn_query_missing_params/kNN query in a bool clause - missing num_candidates}
-  issue: https://github.com/elastic/elasticsearch/issues/136402
-- class: org.elasticsearch.test.rest.yaml.CcsCommonYamlTestSuiteIT
-  method: test {p0=search.vectors/220_dense_vector_node_index_stats/index node stats non-quantized}
-  issue: https://github.com/elastic/elasticsearch/issues/136403
 - class: org.elasticsearch.TransportVersionTests
   method: testVersionComparison
   issue: https://github.com/elastic/elasticsearch/issues/136410


### PR DESCRIPTION
seems like an innocuous timeout due to encryption at rest. 

https://github.com/elastic/elasticsearch/issues/136402
https://github.com/elastic/elasticsearch/issues/136403