### PR TITLE
[ES-12994] Pass JDK major and identifier to JDK benchmark

### DIFF
--- a/.buildkite/scripts/trigger-if-java-ea-new-build.sh
+++ b/.buildkite/scripts/trigger-if-java-ea-new-build.sh
@@ -80,13 +80,13 @@ echo "SHOULD_TRIGGER: $SHOULD_TRIGGER"
 
 if [[ "$SHOULD_TRIGGER" == "true" ]]; then
   EFFECTIVE_START_DATE=$(date -u -d "@$BUILD_TIME" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -r "$BUILD_TIME" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "")
-  
+
   # Use "master" branch for elasticsearch-performance-esbench-jdk when BUILDKITE_BRANCH is "main"
   TRIGGER_BRANCH="$BUILDKITE_BRANCH"
   if [[ "$BUILDKITE_BRANCH" == "main" ]]; then
     TRIGGER_BRANCH="master"
   fi
-  
+
   echo "Triggering performance-esbench-jdk for new jdk build $JDK_IDENTIFIER"
   cat << EOF | buildkite-agent pipeline upload
 steps:
@@ -98,7 +98,7 @@ steps:
     env:
       EFFECTIVE_START_DATE: "$EFFECTIVE_START_DATE"
       EXECUTION_MODE: "start-run"
-      JDK_MAJOR: "$TARGET_JDK"
+      JDK_VERSION: "$TARGET_JDK"
       JDK_IDENTIFIER: "$JDK_IDENTIFIER"
 EOF
 fi

--- a/.buildkite/scripts/trigger-if-java-ea-new-build.sh
+++ b/.buildkite/scripts/trigger-if-java-ea-new-build.sh
@@ -13,7 +13,7 @@
 RECENT_TIME_WINDOW=${RECENT_TIME_WINDOW:-24}
 
 # Extract current JDK major version from bundled_jdk in version.properties
-CURRENT_JDK=$(grep "^bundled_jdk =" build-tools-internal/version.properties | cut -d'=' -f2 | tr -d ' ' | cut -d'.' -f1)
+CURRENT_JDK=$(grep "^bundled_jdk =" build-tools-internal/version.properties | cut -d'=' -f2 | tr -d ' ' | cut -d'+' -f1)
 TARGET_JDK=$((CURRENT_JDK + 1))
 
 echo "Current JDK major version: $CURRENT_JDK"
@@ -98,5 +98,7 @@ steps:
     env:
       EFFECTIVE_START_DATE: "$EFFECTIVE_START_DATE"
       EXECUTION_MODE: "start-run"
+      JDK_MAJOR: "$TARGET_JDK"
+      JDK_IDENTIFIER: "$JDK_IDENTIFIER"
 EOF
 fi


### PR DESCRIPTION
Fixes and extends https://buildkite.com/elastic/elasticsearch-java-ea-check-new-build pipeline.