### PR TITLE
[8.19] Reindex-from-remote: Validate basic auth params (#136501)

### DIFF
--- a/docs/changelog/136501.yaml
+++ b/docs/changelog/136501.yaml
@@ -1,0 +1,6 @@
+pr: 136501
+summary: "Reindex-from-remote: Validate basic auth params"
+area: Indices APIs
+type: bug
+issues:
+ - 135925

--- a/server/src/main/java/org/elasticsearch/index/reindex/ReindexRequest.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/ReindexRequest.java
@@ -116,6 +116,12 @@ public class ReindexRequest extends AbstractBulkIndexByScrollRequest<ReindexRequ
             if (getSlices() == AbstractBulkByScrollRequest.AUTO_SLICES || getSlices() > 1) {
                 e = addValidationError("reindex from remote sources doesn't support slices > 1 but was [" + getSlices() + "]", e);
             }
+            if (getRemoteInfo().getUsername() != null && getRemoteInfo().getPassword() == null) {
+                e = addValidationError("reindex from remote source included username but not password", e);
+            }
+            if (getRemoteInfo().getPassword() != null && getRemoteInfo().getUsername() == null) {
+                e = addValidationError("reindex from remote source included password but not username", e);
+            }
         }
         return e;
     }

--- a/server/src/test/java/org/elasticsearch/index/reindex/ReindexRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/ReindexRequestTests.java
@@ -186,6 +186,46 @@ public class ReindexRequestTests extends AbstractBulkByScrollRequestTestCase<Rei
         );
     }
 
+    public void testReindexFromRemoteRejectsUsernameWithNoPassword() {
+        ReindexRequest reindex = newRequest();
+        reindex.setRemoteInfo(
+            new RemoteInfo(
+                randomAlphaOfLength(5),
+                randomAlphaOfLength(5),
+                between(1, Integer.MAX_VALUE),
+                null,
+                matchAll,
+                "user",
+                null,
+                emptyMap(),
+                RemoteInfo.DEFAULT_SOCKET_TIMEOUT,
+                RemoteInfo.DEFAULT_CONNECT_TIMEOUT
+            )
+        );
+        ActionRequestValidationException e = reindex.validate();
+        assertEquals("Validation Failed: 1: reindex from remote source included username but not password;", e.getMessage());
+    }
+
+    public void testReindexFromRemoteRejectsPasswordWithNoUsername() {
+        ReindexRequest reindex = newRequest();
+        reindex.setRemoteInfo(
+            new RemoteInfo(
+                randomAlphaOfLength(5),
+                randomAlphaOfLength(5),
+                between(1, Integer.MAX_VALUE),
+                null,
+                matchAll,
+                null,
+                new SecureString("password".toCharArray()),
+                emptyMap(),
+                RemoteInfo.DEFAULT_SOCKET_TIMEOUT,
+                RemoteInfo.DEFAULT_CONNECT_TIMEOUT
+            )
+        );
+        ActionRequestValidationException e = reindex.validate();
+        assertEquals("Validation Failed: 1: reindex from remote source included password but not username;", e.getMessage());
+    }
+
     public void testNoSliceBuilderSetWithSlicedRequest() {
         ReindexRequest reindex = newRequest();
         reindex.getSearchRequest().source().slice(new SliceBuilder(0, 4));


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Reindex-from-remote: Validate basic auth params (#136501)