### PR TITLE
Revert "Remove transport versions V_8_2_0 through V_8_5_0 (#136240)"

### DIFF
--- a/modules/aggregations/src/test/java/org/elasticsearch/aggregations/bucket/histogram/InternalAutoDateHistogramTests.java
+++ b/modules/aggregations/src/test/java/org/elasticsearch/aggregations/bucket/histogram/InternalAutoDateHistogramTests.java
@@ -9,10 +9,14 @@
 
 package org.elasticsearch.aggregations.bucket.histogram;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.aggregations.bucket.AggregationMultiBucketAggregationTestCase;
 import org.elasticsearch.aggregations.bucket.histogram.AutoDateHistogramAggregationBuilder.RoundingInfo;
 import org.elasticsearch.aggregations.bucket.histogram.InternalAutoDateHistogram.BucketInfo;
 import org.elasticsearch.common.Rounding;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.index.mapper.DateFieldMapper;
@@ -24,6 +28,7 @@ import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInter
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.test.InternalAggregationTestCase;
 
+import java.io.IOException;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -31,6 +36,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -449,5 +455,25 @@ public class InternalAutoDateHistogramTests extends AggregationMultiBucketAggreg
         assertThat(copy.getBucketInfo(), equalTo(orig.getBucketInfo()));
         assertThat(copy.getFormatter(), equalTo(orig.getFormatter()));
         assertThat(copy.getInterval(), equalTo(orig.getInterval()));
+    }
+
+    public void testReadFromPre830() throws IOException {
+        byte[] bytes = Base64.getDecoder()
+            .decode(
+                "BG5hbWUKAAYBCAFa6AcEAAAAAQAAAAUAAAAKAAAAHgFzBnNlY29uZAEHAVrg1AMEAAAAAQAAAAUAAAAKAAA"
+                    + "AHgFtBm1pbnV0ZQEGAVqA3dsBAwAAAAEAAAADAAAADAFoBGhvdXIBBQFagLiZKQIAAAABAAAABwFk"
+                    + "A2RheQEEAVqAkPvTCQIAAAABAAAAAwFNBW1vbnRoAQIBWoDYxL11BgAAAAEAAAAFAAAACgAAABQAA"
+                    + "AAyAAAAZAF5BHllYXIAAARib29sAQAAAAAAAAAKZAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+            );
+        try (StreamInput in = new NamedWriteableAwareStreamInput(new BytesArray(bytes).streamInput(), getNamedWriteableRegistry())) {
+            in.setTransportVersion(TransportVersions.V_8_2_0);
+            InternalAutoDateHistogram deserialized = new InternalAutoDateHistogram(in);
+            assertEquals("name", deserialized.getName());
+            assertEquals(1, deserialized.getBucketInnerInterval());
+            assertEquals(1, deserialized.getBuckets().size());
+            InternalAutoDateHistogram.Bucket bucket = deserialized.getBuckets().iterator().next();
+            assertEquals(10, bucket.key);
+            assertEquals(100, bucket.getDocCount());
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/Build.java
+++ b/server/src/main/java/org/elasticsearch/Build.java
@@ -205,7 +205,11 @@ public record Build(
 
     public static Build readBuild(StreamInput in) throws IOException {
         final String flavor;
-        flavor = in.readString();
+        if (in.getTransportVersion().before(TransportVersions.V_8_3_0) || in.getTransportVersion().onOrAfter(TransportVersions.V_8_10_X)) {
+            flavor = in.readString();
+        } else {
+            flavor = "default";
+        }
         // be lenient when reading on the wire, the enumeration values from other versions might be different than what we know
         final Type type = Type.fromDisplayName(in.readString(), false);
         String hash = in.readString();
@@ -247,7 +251,10 @@ public record Build(
     }
 
     public static void writeBuild(Build build, StreamOutput out) throws IOException {
-        out.writeString(build.flavor());
+        if (out.getTransportVersion().before(TransportVersions.V_8_3_0)
+            || out.getTransportVersion().onOrAfter(TransportVersions.V_8_10_X)) {
+            out.writeString(build.flavor());
+        }
         out.writeString(build.type().displayName());
         out.writeString(build.hash());
         out.writeString(build.date());

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -61,6 +61,10 @@ public class TransportVersions {
     public static final TransportVersion V_7_9_0 = def(7_09_00_99);
     public static final TransportVersion V_7_10_0 = def(7_10_00_99);
     public static final TransportVersion V_8_0_0 = def(8_00_00_99);
+    public static final TransportVersion V_8_2_0 = def(8_02_00_99);
+    public static final TransportVersion V_8_3_0 = def(8_03_00_99);
+    public static final TransportVersion V_8_4_0 = def(8_04_00_99);
+    public static final TransportVersion V_8_5_0 = def(8_05_00_99);
     public static final TransportVersion V_8_6_0 = def(8_06_00_99);
     public static final TransportVersion V_8_6_1 = def(8_06_01_99);
     public static final TransportVersion V_8_7_0 = def(8_07_00_99);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/desirednodes/UpdateDesiredNodesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/desirednodes/UpdateDesiredNodesResponse.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.action.admin.cluster.desirednodes;
 
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -19,6 +21,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 public class UpdateDesiredNodesResponse extends ActionResponse implements ToXContentObject {
+    private static final TransportVersion DRY_RUN_SUPPORTING_VERSION = TransportVersions.V_8_4_0;
 
     private final boolean replacedExistingHistoryId;
     private final boolean dryRun;
@@ -34,13 +37,15 @@ public class UpdateDesiredNodesResponse extends ActionResponse implements ToXCon
 
     public UpdateDesiredNodesResponse(StreamInput in) throws IOException {
         this.replacedExistingHistoryId = in.readBoolean();
-        dryRun = in.readBoolean();
+        dryRun = in.getTransportVersion().onOrAfter(DRY_RUN_SUPPORTING_VERSION) ? in.readBoolean() : false;
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeBoolean(replacedExistingHistoryId);
-        out.writeBoolean(dryRun);
+        if (out.getTransportVersion().onOrAfter(DRY_RUN_SUPPORTING_VERSION)) {
+            out.writeBoolean(dryRun);
+        }
     }
 
     public boolean hasReplacedExistingHistoryId() {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/PluginsAndModules.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/PluginsAndModules.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.action.admin.cluster.node.info;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.node.ReportingService;
@@ -41,7 +42,11 @@ public class PluginsAndModules implements ReportingService.Info {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeCollection(plugins);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_3_0)) {
+            out.writeCollection(plugins);
+        } else {
+            out.writeCollection(plugins.stream().map(PluginRuntimeInfo::descriptor).toList());
+        }
         out.writeCollection(modules);
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/ClusterGetSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/ClusterGetSettingsAction.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.action.admin.cluster.settings;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
@@ -50,6 +51,7 @@ public class ClusterGetSettingsAction extends ActionType<ClusterGetSettingsActio
         @UpdateForV10(owner = UpdateForV10.Owner.CORE_INFRA)
         public Request(StreamInput in) throws IOException {
             super(in);
+            assert in.getTransportVersion().onOrAfter(TransportVersions.V_8_3_0);
         }
 
         @Override
@@ -99,6 +101,7 @@ public class ClusterGetSettingsAction extends ActionType<ClusterGetSettingsActio
         @UpdateForV10(owner = UpdateForV10.Owner.CORE_INFRA)
         @Override
         public void writeTo(StreamOutput out) throws IOException {
+            assert out.getTransportVersion().onOrAfter(TransportVersions.V_8_3_0);
             persistentSettings.writeTo(out);
             transientSettings.writeTo(out);
             settings.writeTo(out);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequest.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.action.admin.cluster.snapshots.get;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.common.Strings;
@@ -40,6 +41,7 @@ public class GetSnapshotsRequest extends MasterNodeRequest<GetSnapshotsRequest> 
     public static final String NO_POLICY_PATTERN = "_none";
     public static final boolean DEFAULT_VERBOSE_MODE = true;
 
+    private static final TransportVersion INDICES_FLAG_VERSION = TransportVersions.V_8_3_0;
     private static final TransportVersion STATE_FLAG_VERSION = TransportVersion.fromName("state_param_get_snapshot");
 
     public static final int NO_LIMIT = -1;
@@ -119,7 +121,9 @@ public class GetSnapshotsRequest extends MasterNodeRequest<GetSnapshotsRequest> 
         offset = in.readVInt();
         policies = in.readStringArray();
         fromSortValue = in.readOptionalString();
-        includeIndexNames = in.readBoolean();
+        if (in.getTransportVersion().onOrAfter(INDICES_FLAG_VERSION)) {
+            includeIndexNames = in.readBoolean();
+        }
         if (in.getTransportVersion().supports(STATE_FLAG_VERSION)) {
             states = in.readEnumSet(SnapshotState.class);
         } else {
@@ -141,7 +145,9 @@ public class GetSnapshotsRequest extends MasterNodeRequest<GetSnapshotsRequest> 
         out.writeVInt(offset);
         out.writeStringArray(policies);
         out.writeOptionalString(fromSortValue);
-        out.writeBoolean(includeIndexNames);
+        if (out.getTransportVersion().onOrAfter(INDICES_FLAG_VERSION)) {
+            out.writeBoolean(includeIndexNames);
+        }
         if (out.getTransportVersion().supports(STATE_FLAG_VERSION)) {
             out.writeEnumSet(states);
         } else if (states.equals(EnumSet.allOf(SnapshotState.class)) == false) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.action.admin.cluster.snapshots.restore;
 
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
@@ -50,6 +52,7 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
     private boolean includeGlobalState = false;
     private boolean partial = false;
     private boolean includeAliases = true;
+    public static final TransportVersion VERSION_SUPPORTING_QUIET_PARAMETER = TransportVersions.V_8_4_0;
     private boolean quiet = false;
     private Settings indexSettings = Settings.EMPTY;
     private String[] ignoreIndexSettings = Strings.EMPTY_ARRAY;
@@ -89,7 +92,11 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
         includeGlobalState = in.readBoolean();
         partial = in.readBoolean();
         includeAliases = in.readBoolean();
-        quiet = in.readBoolean();
+        if (in.getTransportVersion().onOrAfter(VERSION_SUPPORTING_QUIET_PARAMETER)) {
+            quiet = in.readBoolean();
+        } else {
+            quiet = true;
+        }
         indexSettings = readSettingsFromStream(in);
         ignoreIndexSettings = in.readStringArray();
         snapshotUuid = in.readOptionalString();
@@ -109,7 +116,9 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
         out.writeBoolean(includeGlobalState);
         out.writeBoolean(partial);
         out.writeBoolean(includeAliases);
-        out.writeBoolean(quiet);
+        if (out.getTransportVersion().onOrAfter(VERSION_SUPPORTING_QUIET_PARAMETER)) {
+            out.writeBoolean(quiet);
+        }
         indexSettings.writeTo(out);
         out.writeStringArray(ignoreIndexSettings);
         out.writeOptionalString(snapshotUuid);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageStats.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.action.admin.indices.diskusage;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -189,7 +190,9 @@ public final class IndexDiskUsageStats implements ToXContentFragment, Writeable 
             pointsBytes = in.readVLong();
             normsBytes = in.readVLong();
             termVectorsBytes = in.readVLong();
-            knnVectorsBytes = in.readVLong();
+            if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+                knnVectorsBytes = in.readVLong();
+            }
         }
 
         @Override
@@ -200,7 +203,9 @@ public final class IndexDiskUsageStats implements ToXContentFragment, Writeable 
             out.writeVLong(pointsBytes);
             out.writeVLong(normsBytes);
             out.writeVLong(termVectorsBytes);
-            out.writeVLong(knnVectorsBytes);
+            if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+                out.writeVLong(knnVectorsBytes);
+            }
         }
 
         private void add(PerFieldDiskUsage other) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MaxPrimaryShardDocsCondition.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MaxPrimaryShardDocsCondition.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.action.admin.indices.rollover;
 
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -59,5 +61,10 @@ public class MaxPrimaryShardDocsCondition extends Condition<Long> {
         } else {
             throw new IllegalArgumentException("invalid token when parsing " + NAME + " condition: " + parser.currentToken());
         }
+    }
+
+    @Override
+    boolean includedInVersion(TransportVersion version) {
+        return version.onOrAfter(TransportVersions.V_8_2_0);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MinAgeCondition.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MinAgeCondition.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.action.admin.indices.rollover;
 
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.TimeValue;
@@ -61,5 +63,10 @@ public class MinAgeCondition extends Condition<TimeValue> {
         } else {
             throw new IllegalArgumentException("invalid token when parsing " + NAME + " condition: " + parser.currentToken());
         }
+    }
+
+    @Override
+    boolean includedInVersion(TransportVersion version) {
+        return version.onOrAfter(TransportVersions.V_8_4_0);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MinDocsCondition.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MinDocsCondition.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.action.admin.indices.rollover;
 
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -59,5 +61,10 @@ public class MinDocsCondition extends Condition<Long> {
         } else {
             throw new IllegalArgumentException("invalid token when parsing " + NAME + " condition: " + parser.currentToken());
         }
+    }
+
+    @Override
+    boolean includedInVersion(TransportVersion version) {
+        return version.onOrAfter(TransportVersions.V_8_4_0);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MinPrimaryShardDocsCondition.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MinPrimaryShardDocsCondition.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.action.admin.indices.rollover;
 
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -59,5 +61,10 @@ public class MinPrimaryShardDocsCondition extends Condition<Long> {
         } else {
             throw new IllegalArgumentException("invalid token when parsing " + NAME + " condition: " + parser.currentToken());
         }
+    }
+
+    @Override
+    boolean includedInVersion(TransportVersion version) {
+        return version.onOrAfter(TransportVersions.V_8_4_0);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MinPrimaryShardSizeCondition.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MinPrimaryShardSizeCondition.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.action.admin.indices.rollover;
 
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -60,5 +62,10 @@ public class MinPrimaryShardSizeCondition extends Condition<ByteSizeValue> {
         } else {
             throw new IllegalArgumentException("invalid token when parsing " + NAME + " condition: " + parser.currentToken());
         }
+    }
+
+    @Override
+    boolean includedInVersion(TransportVersion version) {
+        return version.onOrAfter(TransportVersions.V_8_4_0);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MinSizeCondition.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MinSizeCondition.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.action.admin.indices.rollover;
 
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -60,5 +62,10 @@ public class MinSizeCondition extends Condition<ByteSizeValue> {
         } else {
             throw new IllegalArgumentException("invalid token when parsing " + NAME + " condition: " + parser.currentToken());
         }
+    }
+
+    @Override
+    boolean includedInVersion(TransportVersion version) {
+        return version.onOrAfter(TransportVersions.V_8_4_0);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/OptimalShardCountCondition.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/OptimalShardCountCondition.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.action.admin.indices.rollover;
 
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -60,5 +62,10 @@ public class OptimalShardCountCondition extends Condition<Integer> {
         } else {
             throw new IllegalArgumentException("invalid token when parsing " + NAME + " condition: " + parser.currentToken());
         }
+    }
+
+    @Override
+    boolean includedInVersion(TransportVersion version) {
+        return version.onOrAfter(TransportVersions.V_8_14_0);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStats.java
@@ -49,6 +49,7 @@ import java.util.Objects;
 
 public class CommonStats implements Writeable, ToXContentFragment {
 
+    private static final TransportVersion VERSION_SUPPORTING_NODE_MAPPINGS = TransportVersions.V_8_5_0;
     private static final TransportVersion VERSION_SUPPORTING_DENSE_VECTOR_STATS = TransportVersions.V_8_10_X;
     private static final TransportVersion VERSION_SUPPORTING_SPARSE_VECTOR_STATS = TransportVersions.V_8_15_0;
 
@@ -218,7 +219,9 @@ public class CommonStats implements Writeable, ToXContentFragment {
         recoveryStats = in.readOptionalWriteable(RecoveryStats::new);
         bulk = in.readOptionalWriteable(BulkStats::new);
         shards = in.readOptionalWriteable(ShardCountStats::new);
-        nodeMappings = in.readOptionalWriteable(NodeMappingStats::new);
+        if (in.getTransportVersion().onOrAfter(VERSION_SUPPORTING_NODE_MAPPINGS)) {
+            nodeMappings = in.readOptionalWriteable(NodeMappingStats::new);
+        }
         if (in.getTransportVersion().onOrAfter(VERSION_SUPPORTING_DENSE_VECTOR_STATS)) {
             denseVectorStats = in.readOptionalWriteable(DenseVectorStats::new);
         }
@@ -247,7 +250,9 @@ public class CommonStats implements Writeable, ToXContentFragment {
         out.writeOptionalWriteable(recoveryStats);
         out.writeOptionalWriteable(bulk);
         out.writeOptionalWriteable(shards);
-        out.writeOptionalWriteable(nodeMappings);
+        if (out.getTransportVersion().onOrAfter(VERSION_SUPPORTING_NODE_MAPPINGS)) {
+            out.writeOptionalWriteable(nodeMappings);
+        }
         if (out.getTransportVersion().onOrAfter(VERSION_SUPPORTING_DENSE_VECTOR_STATS)) {
             out.writeOptionalWriteable(denseVectorStats);
         }

--- a/server/src/main/java/org/elasticsearch/action/datastreams/GetDataStreamAction.java
+++ b/server/src/main/java/org/elasticsearch/action/datastreams/GetDataStreamAction.java
@@ -343,7 +343,9 @@ public class GetDataStreamAction extends ActionType<GetDataStreamAction.Response
                 dataStreamStatus.writeTo(out);
                 out.writeOptionalString(indexTemplate);
                 out.writeOptionalString(ilmPolicyName);
-                out.writeOptionalWriteable(timeSeries);
+                if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_3_0)) {
+                    out.writeOptionalWriteable(timeSeries);
+                }
                 if (out.getTransportVersion().onOrAfter(V_8_11_X)) {
                     out.writeMap(indexSettingsValues);
                     out.writeBoolean(templatePreferIlmValue);

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeRequest.java
@@ -46,8 +46,13 @@ class FieldCapabilitiesNodeRequest extends LegacyActionRequest implements Indice
         super(in);
         shardIds = in.readCollectionAsList(ShardId::new);
         fields = in.readStringArray();
-        filters = in.readStringArray();
-        allowedTypes = in.readStringArray();
+        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_2_0)) {
+            filters = in.readStringArray();
+            allowedTypes = in.readStringArray();
+        } else {
+            filters = Strings.EMPTY_ARRAY;
+            allowedTypes = Strings.EMPTY_ARRAY;
+        }
         originalIndices = OriginalIndices.readOriginalIndices(in);
         indexFilter = in.readOptionalNamedWriteable(QueryBuilder.class);
         nowInMillis = in.readLong();
@@ -132,8 +137,10 @@ class FieldCapabilitiesNodeRequest extends LegacyActionRequest implements Indice
         super.writeTo(out);
         out.writeCollection(shardIds);
         out.writeStringArray(fields);
-        out.writeStringArray(filters);
-        out.writeStringArray(allowedTypes);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_2_0)) {
+            out.writeStringArray(filters);
+            out.writeStringArray(allowedTypes);
+        }
         OriginalIndices.writeOriginalIndices(originalIndices, out);
         out.writeOptionalNamedWriteable(indexFilter);
         out.writeLong(nowInMillis);

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesRequest.java
@@ -81,8 +81,10 @@ public final class FieldCapabilitiesRequest extends LegacyActionRequest implemen
         indexFilter = in.readOptionalNamedWriteable(QueryBuilder.class);
         nowInMillis = in.readOptionalLong();
         runtimeFields = in.readGenericMap();
-        filters = in.readStringArray();
-        types = in.readStringArray();
+        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_2_0)) {
+            filters = in.readStringArray();
+            types = in.readStringArray();
+        }
         if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_13_0)) {
             includeEmptyFields = in.readBoolean();
         }
@@ -133,8 +135,10 @@ public final class FieldCapabilitiesRequest extends LegacyActionRequest implemen
         out.writeOptionalNamedWriteable(indexFilter);
         out.writeOptionalLong(nowInMillis);
         out.writeGenericMap(runtimeFields);
-        out.writeStringArray(filters);
-        out.writeStringArray(types);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_2_0)) {
+            out.writeStringArray(filters);
+            out.writeStringArray(types);
+        }
         if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_13_0)) {
             out.writeBoolean(includeEmptyFields);
         }

--- a/server/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/get/MultiGetRequest.java
@@ -260,7 +260,11 @@ public class MultiGetRequest extends LegacyActionRequest
         refresh = in.readBoolean();
         realtime = in.readBoolean();
         items = in.readCollectionAsList(Item::new);
-        forceSyntheticSource = in.readBoolean();
+        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+            forceSyntheticSource = in.readBoolean();
+        } else {
+            forceSyntheticSource = false;
+        }
     }
 
     @Override
@@ -270,7 +274,13 @@ public class MultiGetRequest extends LegacyActionRequest
         out.writeBoolean(refresh);
         out.writeBoolean(realtime);
         out.writeCollection(items);
-        out.writeBoolean(forceSyntheticSource);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+            out.writeBoolean(forceSyntheticSource);
+        } else {
+            if (forceSyntheticSource) {
+                throw new IllegalArgumentException("force_synthetic_source is not supported before 8.4.0");
+            }
+        }
     }
 
     public List<Item> getItems() {

--- a/server/src/main/java/org/elasticsearch/action/get/MultiGetShardRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/get/MultiGetShardRequest.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.action.get;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.single.shard.SingleShardRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -83,7 +84,11 @@ public class MultiGetShardRequest extends SingleShardRequest<MultiGetShardReques
         preference = in.readOptionalString();
         refresh = in.readBoolean();
         realtime = in.readBoolean();
-        forceSyntheticSource = in.readBoolean();
+        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+            forceSyntheticSource = in.readBoolean();
+        } else {
+            forceSyntheticSource = false;
+        }
     }
 
     @Override
@@ -99,7 +104,13 @@ public class MultiGetShardRequest extends SingleShardRequest<MultiGetShardReques
         out.writeOptionalString(preference);
         out.writeBoolean(refresh);
         out.writeBoolean(realtime);
-        out.writeBoolean(forceSyntheticSource);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+            out.writeBoolean(forceSyntheticSource);
+        } else {
+            if (forceSyntheticSource) {
+                throw new IllegalArgumentException("force_synthetic_source is not supported before 8.4.0");
+            }
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -273,7 +273,11 @@ public class SearchRequest extends LegacyActionRequest implements IndicesRequest
         }
         waitForCheckpoints = in.readMap(StreamInput::readLongArray);
         waitForCheckpointsTimeout = in.readTimeValue();
-        forceSyntheticSource = in.readBoolean();
+        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+            forceSyntheticSource = in.readBoolean();
+        } else {
+            forceSyntheticSource = false;
+        }
     }
 
     @Override
@@ -313,7 +317,13 @@ public class SearchRequest extends LegacyActionRequest implements IndicesRequest
         }
         out.writeMap(waitForCheckpoints, StreamOutput::writeLongArray);
         out.writeTimeValue(waitForCheckpointsTimeout);
-        out.writeBoolean(forceSyntheticSource);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+            out.writeBoolean(forceSyntheticSource);
+        } else {
+            if (forceSyntheticSource) {
+                throw new IllegalArgumentException("force_synthetic_source is not supported before 8.4.0");
+            }
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -342,8 +342,13 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
         return TransportVersion.minimumCompatible();
     }
 
+    private static final TransportVersion DIFFABLE_VERSION = TransportVersions.V_8_5_0;
+
     public static NamedDiff<Custom> readDiffFrom(StreamInput in) throws IOException {
-        return new SnapshotInProgressDiff(in);
+        if (in.getTransportVersion().onOrAfter(DIFFABLE_VERSION)) {
+            return new SnapshotInProgressDiff(in);
+        }
+        return readDiffFrom(Custom.class, TYPE, in);
     }
 
     @Override
@@ -1871,20 +1876,24 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             assert after != null : "should only write instances that were diffed from this node's state";
-            if (out.getTransportVersion().supports(PROJECT_ID_IN_SNAPSHOT) == false) {
-                DiffableUtils.jdkMapDiffWithUpdatedKeys(mapDiff, projectRepo -> {
-                    if (ProjectId.DEFAULT.equals(projectRepo.projectId()) == false) {
-                        final var message = "Cannot write instance with non-default project id "
-                            + projectRepo.projectId()
-                            + " to version before "
-                            + PROJECT_ID_IN_SNAPSHOT;
-                        assert false : message;
-                        throw new IllegalArgumentException(message);
-                    }
-                    return projectRepo.name();
-                }, DiffableUtils.getStringKeySerializer()).writeTo(out);
+            if (out.getTransportVersion().onOrAfter(DIFFABLE_VERSION)) {
+                if (out.getTransportVersion().supports(PROJECT_ID_IN_SNAPSHOT) == false) {
+                    DiffableUtils.jdkMapDiffWithUpdatedKeys(mapDiff, projectRepo -> {
+                        if (ProjectId.DEFAULT.equals(projectRepo.projectId()) == false) {
+                            final var message = "Cannot write instance with non-default project id "
+                                + projectRepo.projectId()
+                                + " to version before "
+                                + PROJECT_ID_IN_SNAPSHOT;
+                            assert false : message;
+                            throw new IllegalArgumentException(message);
+                        }
+                        return projectRepo.name();
+                    }, DiffableUtils.getStringKeySerializer()).writeTo(out);
+                } else {
+                    mapDiff.writeTo(out);
+                }
             } else {
-                mapDiff.writeTo(out);
+                new SimpleDiffable.CompleteDiff<>(after).writeTo(out);
             }
             if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_13_0)) {
                 out.writeStringCollection(nodeIdsForRemoval);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DesiredNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DesiredNode.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.cluster.metadata;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -40,6 +41,7 @@ import static org.elasticsearch.node.NodeRoleSettings.NODE_ROLES_SETTING;
 
 public final class DesiredNode implements Writeable, ToXContentObject, Comparable<DesiredNode> {
 
+    public static final TransportVersion RANGE_FLOAT_PROCESSORS_SUPPORT_TRANSPORT_VERSION = TransportVersions.V_8_3_0;
     private static final TransportVersion REMOVE_DESIRED_NODE_VERSION = TransportVersion.fromName("remove_desired_node_version");
 
     private static final ParseField SETTINGS_FIELD = new ParseField("settings");
@@ -151,8 +153,13 @@ public final class DesiredNode implements Writeable, ToXContentObject, Comparabl
         final var settings = Settings.readSettingsFromStream(in);
         final Processors processors;
         final ProcessorsRange processorsRange;
-        processors = in.readOptionalWriteable(Processors::readFrom);
-        processorsRange = in.readOptionalWriteable(ProcessorsRange::readFrom);
+        if (in.getTransportVersion().onOrAfter(RANGE_FLOAT_PROCESSORS_SUPPORT_TRANSPORT_VERSION)) {
+            processors = in.readOptionalWriteable(Processors::readFrom);
+            processorsRange = in.readOptionalWriteable(ProcessorsRange::readFrom);
+        } else {
+            processors = Processors.readFrom(in);
+            processorsRange = null;
+        }
         final var memory = ByteSizeValue.readFrom(in);
         final var storage = ByteSizeValue.readFrom(in);
         if (in.getTransportVersion().supports(REMOVE_DESIRED_NODE_VERSION) == false) {
@@ -164,8 +171,14 @@ public final class DesiredNode implements Writeable, ToXContentObject, Comparabl
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         settings.writeTo(out);
-        out.writeOptionalWriteable(processors);
-        out.writeOptionalWriteable(processorsRange);
+        if (out.getTransportVersion().onOrAfter(RANGE_FLOAT_PROCESSORS_SUPPORT_TRANSPORT_VERSION)) {
+            out.writeOptionalWriteable(processors);
+            out.writeOptionalWriteable(processorsRange);
+        } else {
+            assert processorsRange == null;
+            assert processors != null;
+            processors.writeTo(out);
+        }
         memory.writeTo(out);
         storage.writeTo(out);
         if (out.getTransportVersion().supports(REMOVE_DESIRED_NODE_VERSION) == false) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DesiredNodeWithStatus.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DesiredNodeWithStatus.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.cluster.metadata;
 
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -30,6 +32,7 @@ public record DesiredNodeWithStatus(DesiredNode desiredNode, Status status)
         ToXContentObject,
         Comparable<DesiredNodeWithStatus> {
 
+    private static final TransportVersion STATUS_TRACKING_SUPPORT_VERSION = TransportVersions.V_8_4_0;
     private static final ParseField STATUS_FIELD = new ParseField("status");
 
     public static final ConstructingObjectParser<DesiredNodeWithStatus, Void> PARSER = new ConstructingObjectParser<>(
@@ -75,14 +78,25 @@ public record DesiredNodeWithStatus(DesiredNode desiredNode, Status status)
     public static DesiredNodeWithStatus readFrom(StreamInput in) throws IOException {
         final var desiredNode = DesiredNode.readFrom(in);
         final Status status;
-        status = Status.fromValue(in.readShort());
+        if (in.getTransportVersion().onOrAfter(STATUS_TRACKING_SUPPORT_VERSION)) {
+            status = Status.fromValue(in.readShort());
+        } else {
+            // During upgrades, we consider all desired nodes as PENDING
+            // since it's impossible to know if a node that was supposed to
+            // join the cluster, it joined. The status will be updated
+            // once the master node is upgraded to a version >= STATUS_TRACKING_SUPPORT_VERSION
+            // in NodeJoinExecutor or when the desired nodes are upgraded to a new version.
+            status = Status.PENDING;
+        }
         return new DesiredNodeWithStatus(desiredNode, status);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         desiredNode.writeTo(out);
-        out.writeShort(status.value);
+        if (out.getTransportVersion().onOrAfter(STATUS_TRACKING_SUPPORT_VERSION)) {
+            out.writeShort(status.value);
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -1599,6 +1599,8 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         return builder;
     }
 
+    private static final TransportVersion SETTING_DIFF_VERSION = TransportVersions.V_8_5_0;
+
     private static class IndexMetadataDiff implements Diff<IndexMetadata> {
 
         private final String index;
@@ -1694,8 +1696,13 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             settingsVersion = in.readVLong();
             aliasesVersion = in.readVLong();
             state = State.fromId(in.readByte());
-            settings = null;
-            settingsDiff = Settings.readSettingsDiffFromStream(in);
+            if (in.getTransportVersion().onOrAfter(SETTING_DIFF_VERSION)) {
+                settings = null;
+                settingsDiff = Settings.readSettingsDiffFromStream(in);
+            } else {
+                settings = Settings.readSettingsFromStream(in);
+                settingsDiff = null;
+            }
             primaryTerms = in.readVLongArray();
             mappings = DiffableUtils.readImmutableOpenMapDiff(in, DiffableUtils.getStringKeySerializer(), MAPPING_DIFF_VALUE_READER);
             if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_14_0)) {
@@ -1758,7 +1765,11 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             out.writeByte(state.id);
             assert settings != null
                 : "settings should always be non-null since this instance is not expected to have been read from another node";
-            settingsDiff.writeTo(out);
+            if (out.getTransportVersion().onOrAfter(SETTING_DIFF_VERSION)) {
+                settingsDiff.writeTo(out);
+            } else {
+                settings.writeTo(out);
+            }
             out.writeVLongArray(primaryTerms);
             mappings.writeTo(out);
             if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_14_0)) {

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.cluster.node;
 
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
@@ -59,6 +61,7 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
     }
 
     static final String COORDINATING_ONLY = "coordinating_only";
+    public static final TransportVersion EXTERNAL_ID_VERSION = TransportVersions.V_8_3_0;
     public static final Comparator<DiscoveryNode> DISCOVERY_NODE_COMPARATOR = Comparator.comparing(DiscoveryNode::getName)
         .thenComparing(DiscoveryNode::getId);
 
@@ -328,7 +331,11 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
         minReadOnlyIndexVersion = IndexVersion.readVersion(in);
         IndexVersion maxIndexVersion = IndexVersion.readVersion(in);
         versionInfo = new VersionInformation(version, minIndexVersion, minReadOnlyIndexVersion, maxIndexVersion);
-        this.externalId = readStringLiteral.read(in);
+        if (in.getTransportVersion().onOrAfter(EXTERNAL_ID_VERSION)) {
+            this.externalId = readStringLiteral.read(in);
+        } else {
+            this.externalId = nodeName;
+        }
         this.roleNames = Set.of(roleNames);
     }
 
@@ -360,7 +367,9 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
         IndexVersion.writeVersion(versionInfo.minIndexVersion(), out);
         IndexVersion.writeVersion(versionInfo.minReadOnlyIndexVersion(), out);
         IndexVersion.writeVersion(versionInfo.maxIndexVersion(), out);
-        out.writeString(externalId);
+        if (out.getTransportVersion().onOrAfter(EXTERNAL_ID_VERSION)) {
+            out.writeString(externalId);
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java
@@ -42,6 +42,7 @@ public final class ShardRouting implements Writeable, ToXContentObject {
      * Used if shard size is not available
      */
     public static final long UNAVAILABLE_EXPECTED_SHARD_SIZE = -1;
+    private static final TransportVersion EXPECTED_SHARD_SIZE_FOR_STARTED_VERSION = TransportVersions.V_8_5_0;
     private static final TransportVersion RELOCATION_FAILURE_INFO_VERSION = TransportVersions.V_8_6_0;
 
     private final ShardId shardId;
@@ -348,7 +349,9 @@ public final class ShardRouting implements Writeable, ToXContentObject {
             relocationFailureInfo = RelocationFailureInfo.NO_FAILURES;
         }
         allocationId = in.readOptionalWriteable(AllocationId::new);
-        if (state == ShardRoutingState.RELOCATING || state == ShardRoutingState.INITIALIZING || state == ShardRoutingState.STARTED) {
+        if (state == ShardRoutingState.RELOCATING
+            || state == ShardRoutingState.INITIALIZING
+            || (state == ShardRoutingState.STARTED && in.getTransportVersion().onOrAfter(EXPECTED_SHARD_SIZE_FOR_STARTED_VERSION))) {
             expectedShardSize = in.readLong();
         } else {
             expectedShardSize = UNAVAILABLE_EXPECTED_SHARD_SIZE;
@@ -384,7 +387,9 @@ public final class ShardRouting implements Writeable, ToXContentObject {
             relocationFailureInfo.writeTo(out);
         }
         out.writeOptionalWriteable(allocationId);
-        if (state == ShardRoutingState.RELOCATING || state == ShardRoutingState.INITIALIZING || state == ShardRoutingState.STARTED) {
+        if (state == ShardRoutingState.RELOCATING
+            || state == ShardRoutingState.INITIALIZING
+            || (state == ShardRoutingState.STARTED && out.getTransportVersion().onOrAfter(EXPECTED_SHARD_SIZE_FOR_STARTED_VERSION))) {
             out.writeLong(expectedShardSize);
         }
 

--- a/server/src/main/java/org/elasticsearch/common/unit/Processors.java
+++ b/server/src/main/java/org/elasticsearch/common/unit/Processors.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.common.unit;
 
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -29,6 +31,8 @@ public class Processors implements Writeable, Comparable<Processors>, ToXContent
     public static final Processors ZERO = new Processors(0.0);
     public static final Processors MAX_PROCESSORS = new Processors(Double.MAX_VALUE);
 
+    public static final TransportVersion FLOAT_PROCESSORS_SUPPORT_TRANSPORT_VERSION = TransportVersions.V_8_3_0;
+    public static final TransportVersion DOUBLE_PROCESSORS_SUPPORT_TRANSPORT_VERSION = TransportVersions.V_8_5_0;
     static final int NUMBER_OF_DECIMAL_PLACES = 5;
     private static final double MIN_REPRESENTABLE_PROCESSORS = 1E-5;
 
@@ -61,13 +65,26 @@ public class Processors implements Writeable, Comparable<Processors>, ToXContent
 
     public static Processors readFrom(StreamInput in) throws IOException {
         final double processorCount;
-        processorCount = in.readDouble();
+        if (in.getTransportVersion().before(FLOAT_PROCESSORS_SUPPORT_TRANSPORT_VERSION)) {
+            processorCount = in.readInt();
+        } else if (in.getTransportVersion().before(DOUBLE_PROCESSORS_SUPPORT_TRANSPORT_VERSION)) {
+            processorCount = in.readFloat();
+        } else {
+            processorCount = in.readDouble();
+        }
         return new Processors(processorCount);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeDouble(count);
+        if (out.getTransportVersion().before(FLOAT_PROCESSORS_SUPPORT_TRANSPORT_VERSION)) {
+            assert hasDecimals() == false;
+            out.writeInt((int) count);
+        } else if (out.getTransportVersion().before(DOUBLE_PROCESSORS_SUPPORT_TRANSPORT_VERSION)) {
+            out.writeFloat((float) count);
+        } else {
+            out.writeDouble(count);
+        }
     }
 
     @Nullable

--- a/server/src/main/java/org/elasticsearch/health/node/selection/HealthNodeTaskParams.java
+++ b/server/src/main/java/org/elasticsearch/health/node/selection/HealthNodeTaskParams.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.health.node.selection;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.persistent.PersistentTaskParams;
@@ -48,7 +49,7 @@ public class HealthNodeTaskParams implements PersistentTaskParams {
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {
-        return TransportVersion.minimumCompatible();
+        return TransportVersions.V_8_5_0;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/engine/Segment.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Segment.java
@@ -253,9 +253,17 @@ public class Segment implements Writeable {
                 o.writeBoolean(((SortedNumericSortField) field).getSelector() == SortedNumericSelector.Type.MAX);
                 o.writeBoolean(field.getReverse());
             } else if (field.getType().equals(SortField.Type.STRING)) {
-                o.writeByte(SORT_STRING_SINGLE);
-                o.writeOptionalBoolean(field.getMissingValue() == null ? null : field.getMissingValue() == SortField.STRING_FIRST);
-                o.writeBoolean(field.getReverse());
+                if (o.getTransportVersion().before(TransportVersions.V_8_5_0)) {
+                    // The closest supported version before 8.5.0 was SortedSet fields, so we mimic that
+                    o.writeByte(SORT_STRING_SET);
+                    o.writeOptionalBoolean(field.getMissingValue() == null ? null : field.getMissingValue() == SortField.STRING_FIRST);
+                    o.writeBoolean(true);
+                    o.writeBoolean(field.getReverse());
+                } else {
+                    o.writeByte(SORT_STRING_SINGLE);
+                    o.writeOptionalBoolean(field.getMissingValue() == null ? null : field.getMissingValue() == SortField.STRING_FIRST);
+                    o.writeBoolean(field.getReverse());
+                }
             } else {
                 throw new IOException("invalid index sort field:" + field);
             }

--- a/server/src/main/java/org/elasticsearch/index/reindex/RemoteInfo.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/RemoteInfo.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.index.reindex;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -101,7 +102,11 @@ public class RemoteInfo implements Writeable, ToXContentObject, Closeable {
         port = in.readVInt();
         query = in.readBytesReference();
         username = in.readOptionalString();
-        password = in.readOptionalSecureString();
+        if (in.getTransportVersion().before(TransportVersions.V_8_2_0)) {
+            password = new SecureString(in.readOptionalString().toCharArray());
+        } else {
+            password = in.readOptionalSecureString();
+        }
         int headersLength = in.readVInt();
         Map<String, String> headers = Maps.newMapWithExpectedSize(headersLength);
         for (int i = 0; i < headersLength; i++) {
@@ -120,7 +125,11 @@ public class RemoteInfo implements Writeable, ToXContentObject, Closeable {
         out.writeVInt(port);
         out.writeBytesReference(query);
         out.writeOptionalString(username);
-        out.writeOptionalSecureString(password);
+        if (out.getTransportVersion().before(TransportVersions.V_8_2_0)) {
+            out.writeOptionalString(password.toString());
+        } else {
+            out.writeOptionalSecureString(password);
+        }
         out.writeVInt(headers.size());
         for (Map.Entry<String, String> header : headers.entrySet()) {
             out.writeString(header.getKey());

--- a/server/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
+++ b/server/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.indices;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.NodeStatsLevel;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.indices.stats.CommonStats;
@@ -63,6 +64,7 @@ import static java.util.Objects.requireNonNull;
  */
 public class NodeIndicesStats implements Writeable, ChunkedToXContent {
 
+    private static final TransportVersion VERSION_SUPPORTING_STATS_BY_INDEX = TransportVersions.V_8_5_0;
     private static final TransportVersion NODES_STATS_SUPPORTS_MULTI_PROJECT = TransportVersion.fromName(
         "nodes_stats_supports_multi_project"
     );
@@ -88,7 +90,11 @@ public class NodeIndicesStats implements Writeable, ChunkedToXContent {
             statsByShard.put(index, indexShardStats);
         }
 
-        statsByIndex = in.readMap(Index::new, CommonStats::new);
+        if (in.getTransportVersion().onOrAfter(VERSION_SUPPORTING_STATS_BY_INDEX)) {
+            statsByIndex = in.readMap(Index::new, CommonStats::new);
+        } else {
+            statsByIndex = new HashMap<>();
+        }
 
         if (in.getTransportVersion().supports(NODES_STATS_SUPPORTS_MULTI_PROJECT)) {
             projectsByIndex = in.readMap(Index::new, ProjectId::readFrom);
@@ -237,7 +243,9 @@ public class NodeIndicesStats implements Writeable, ChunkedToXContent {
     public void writeTo(StreamOutput out) throws IOException {
         stats.writeTo(out);
         out.writeMap(statsByShard, StreamOutput::writeWriteable, StreamOutput::writeCollection);
-        out.writeMap(statsByIndex);
+        if (out.getTransportVersion().onOrAfter(VERSION_SUPPORTING_STATS_BY_INDEX)) {
+            out.writeMap(statsByIndex);
+        }
         if (out.getTransportVersion().supports(NODES_STATS_SUPPORTS_MULTI_PROJECT)) {
             out.writeMap(projectsByIndex);
         }

--- a/server/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetadata.java
+++ b/server/src/main/java/org/elasticsearch/indices/store/TransportNodesListShardStoreMetadata.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.IndexNotFoundException;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.support.ActionFilters;
@@ -204,6 +205,9 @@ public class TransportNodesListShardStoreMetadata extends TransportNodesAction<
         public static final StoreFilesMetadata EMPTY = new StoreFilesMetadata(Store.MetadataSnapshot.EMPTY, emptyList());
 
         public static StoreFilesMetadata readFrom(StreamInput in) throws IOException {
+            if (in.getTransportVersion().before(TransportVersions.V_8_2_0)) {
+                new ShardId(in);
+            }
             final var metadataSnapshot = Store.MetadataSnapshot.readFrom(in);
             final var peerRecoveryRetentionLeases = in.readCollectionAsImmutableList(RetentionLease::new);
             if (metadataSnapshot == Store.MetadataSnapshot.EMPTY && peerRecoveryRetentionLeases.isEmpty()) {
@@ -215,6 +219,10 @@ public class TransportNodesListShardStoreMetadata extends TransportNodesAction<
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
+            if (out.getTransportVersion().before(TransportVersions.V_8_2_0)) {
+                // no compatible version cares about the shard ID, we can just make one up
+                FAKE_SHARD_ID.writeTo(out);
+            }
             metadataSnapshot.writeTo(out);
             out.writeCollection(peerRecoveryRetentionLeases);
         }

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.monitor.jvm;
 
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -275,6 +276,10 @@ public class JvmInfo implements ReportingService.Info {
         vmName = in.readString();
         vmVersion = in.readString();
         vmVendor = in.readString();
+        if (in.getTransportVersion().before(TransportVersions.V_8_3_0)) {
+            // Before 8.0 the no-jdk distributions could have bundledJdk false, this is always true now.
+            in.readBoolean();
+        }
         usingBundledJdk = in.readOptionalBoolean();
         startTime = in.readLong();
         inputArguments = new String[in.readInt()];
@@ -305,6 +310,9 @@ public class JvmInfo implements ReportingService.Info {
         out.writeString(vmName);
         out.writeString(vmVersion);
         out.writeString(vmVendor);
+        if (out.getTransportVersion().before(TransportVersions.V_8_3_0)) {
+            out.writeBoolean(true);
+        }
         out.writeOptionalBoolean(usingBundledJdk);
         out.writeLong(startTime);
         out.writeInt(inputArguments.length);

--- a/server/src/main/java/org/elasticsearch/monitor/os/OsInfo.java
+++ b/server/src/main/java/org/elasticsearch/monitor/os/OsInfo.java
@@ -9,6 +9,8 @@
 
 package org.elasticsearch.monitor.os;
 
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.Processors;
@@ -19,6 +21,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import java.io.IOException;
 
 public class OsInfo implements ReportingService.Info {
+    private static final TransportVersion DOUBLE_PRECISION_ALLOCATED_PROCESSORS_SUPPORT = TransportVersions.V_8_5_0;
 
     private final long refreshInterval;
     private final int availableProcessors;
@@ -49,7 +52,11 @@ public class OsInfo implements ReportingService.Info {
     public OsInfo(StreamInput in) throws IOException {
         this.refreshInterval = in.readLong();
         this.availableProcessors = in.readInt();
-        this.allocatedProcessors = Processors.readFrom(in);
+        if (in.getTransportVersion().onOrAfter(DOUBLE_PRECISION_ALLOCATED_PROCESSORS_SUPPORT)) {
+            this.allocatedProcessors = Processors.readFrom(in);
+        } else {
+            this.allocatedProcessors = Processors.of((double) in.readInt());
+        }
         this.name = in.readOptionalString();
         this.prettyName = in.readOptionalString();
         this.arch = in.readOptionalString();
@@ -60,7 +67,11 @@ public class OsInfo implements ReportingService.Info {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeLong(refreshInterval);
         out.writeInt(availableProcessors);
-        allocatedProcessors.writeTo(out);
+        if (out.getTransportVersion().onOrAfter(DOUBLE_PRECISION_ALLOCATED_PROCESSORS_SUPPORT)) {
+            allocatedProcessors.writeTo(out);
+        } else {
+            out.writeInt(getAllocatedProcessors());
+        }
         out.writeOptionalString(name);
         out.writeOptionalString(prettyName);
         out.writeOptionalString(arch);

--- a/server/src/main/java/org/elasticsearch/plugins/PluginDescriptor.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginDescriptor.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.plugins;
 
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Strings;
@@ -44,6 +45,9 @@ public class PluginDescriptor implements Writeable, ToXContentObject {
     public static final String INTERNAL_DESCRIPTOR_FILENAME = "plugin-descriptor.properties";
     public static final String STABLE_DESCRIPTOR_FILENAME = "stable-plugin-descriptor.properties";
     public static final String NAMED_COMPONENTS_FILENAME = "named_components.json";
+
+    private static final TransportVersion MODULE_NAME_SUPPORT = TransportVersions.V_8_3_0;
+    private static final TransportVersion BOOTSTRAP_SUPPORT_REMOVED = TransportVersions.V_8_4_0;
 
     private final String name;
     private final String description;
@@ -125,14 +129,27 @@ public class PluginDescriptor implements Writeable, ToXContentObject {
         } else {
             this.classname = in.readString();
         }
-        this.moduleName = in.readOptionalString();
+        if (in.getTransportVersion().onOrAfter(MODULE_NAME_SUPPORT)) {
+            this.moduleName = in.readOptionalString();
+        } else {
+            this.moduleName = null;
+        }
         extendedPlugins = in.readStringCollectionAsList();
         hasNativeController = in.readBoolean();
 
+        if (in.getTransportVersion().before(BOOTSTRAP_SUPPORT_REMOVED)) {
+            in.readString(); // plugin type
+            in.readOptionalString(); // java opts
+        }
         isLicensed = in.readBoolean();
 
-        isModular = in.readBoolean();
-        isStable = in.readBoolean();
+        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+            isModular = in.readBoolean();
+            isStable = in.readBoolean();
+        } else {
+            isModular = moduleName != null;
+            isStable = false;
+        }
 
         ensureCorrectArgumentsForPluginType();
     }
@@ -153,12 +170,21 @@ public class PluginDescriptor implements Writeable, ToXContentObject {
         } else {
             out.writeString(classname);
         }
-        out.writeOptionalString(moduleName);
+        if (out.getTransportVersion().onOrAfter(MODULE_NAME_SUPPORT)) {
+            out.writeOptionalString(moduleName);
+        }
         out.writeStringCollection(extendedPlugins);
         out.writeBoolean(hasNativeController);
+
+        if (out.getTransportVersion().before(BOOTSTRAP_SUPPORT_REMOVED)) {
+            out.writeString("ISOLATED");
+            out.writeOptionalString(null);
+        }
         out.writeBoolean(isLicensed);
-        out.writeBoolean(isModular);
-        out.writeBoolean(isStable);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+            out.writeBoolean(isModular);
+            out.writeBoolean(isStable);
+        }
     }
 
     private void ensureCorrectArgumentsForPluginType() {

--- a/server/src/main/java/org/elasticsearch/plugins/PluginRuntimeInfo.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginRuntimeInfo.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.plugins;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -40,11 +41,19 @@ public record PluginRuntimeInfo(PluginDescriptor descriptor, @Nullable Boolean i
     }
 
     private static Boolean readIsOfficial(StreamInput in) throws IOException {
-        return in.readBoolean();
+        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_3_0)) {
+            return in.readBoolean();
+        } else {
+            return null;
+        }
     }
 
     private static PluginApiInfo readApiInfo(StreamInput in) throws IOException {
-        return in.readOptionalWriteable(PluginApiInfo::new);
+        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_3_0)) {
+            return in.readOptionalWriteable(PluginApiInfo::new);
+        } else {
+            return null;
+        }
     }
 
     @Override
@@ -64,7 +73,9 @@ public record PluginRuntimeInfo(PluginDescriptor descriptor, @Nullable Boolean i
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         descriptor.writeTo(out);
-        out.writeBoolean(isOfficial);
-        out.writeOptionalWriteable(pluginApiInfo);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_3_0)) {
+            out.writeBoolean(isOfficial);
+            out.writeOptionalWriteable(pluginApiInfo);
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/random/RandomSamplerAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/random/RandomSamplerAggregationBuilder.java
@@ -41,7 +41,6 @@ public class RandomSamplerAggregationBuilder extends AbstractAggregationBuilder<
         RandomSamplerAggregationBuilder.NAME,
         RandomSamplerAggregationBuilder::new
     );
-
     static {
         PARSER.declareInt(RandomSamplerAggregationBuilder::setSeed, SEED);
         PARSER.declareInt(RandomSamplerAggregationBuilder::setShardSeed, SHARD_SEED);
@@ -177,7 +176,7 @@ public class RandomSamplerAggregationBuilder extends AbstractAggregationBuilder<
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {
-        return TransportVersion.minimumCompatible();
+        return TransportVersions.V_8_2_0;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregationBuilder.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
@@ -92,7 +93,9 @@ public final class CardinalityAggregationBuilder extends ValuesSourceAggregation
         if (in.readBoolean()) {
             precisionThreshold = in.readLong();
         }
-        executionHint = in.readOptionalString();
+        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+            executionHint = in.readOptionalString();
+        }
     }
 
     @Override
@@ -107,7 +110,9 @@ public final class CardinalityAggregationBuilder extends ValuesSourceAggregation
         if (hasPrecisionThreshold) {
             out.writeLong(precisionThreshold);
         }
-        out.writeOptionalString(executionHint);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+            out.writeOptionalString(executionHint);
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/dfs/DfsSearchResult.java
+++ b/server/src/main/java/org/elasticsearch/search/dfs/DfsSearchResult.java
@@ -54,11 +54,13 @@ public final class DfsSearchResult extends SearchPhaseResult {
 
         maxDoc = in.readVInt();
         setShardSearchRequest(in.readOptionalWriteable(ShardSearchRequest::new));
-        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_7_0)) {
-            knnResults = in.readOptionalCollectionAsList(DfsKnnResults::new);
-        } else {
-            DfsKnnResults results = in.readOptionalWriteable(DfsKnnResults::new);
-            knnResults = results != null ? List.of(results) : List.of();
+        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+            if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_7_0)) {
+                knnResults = in.readOptionalCollectionAsList(DfsKnnResults::new);
+            } else {
+                DfsKnnResults results = in.readOptionalWriteable(DfsKnnResults::new);
+                knnResults = results != null ? List.of(results) : List.of();
+            }
         }
         if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_6_0)) {
             searchProfileDfsPhaseResult = in.readOptionalWriteable(SearchProfileDfsPhaseResult::new);
@@ -132,19 +134,21 @@ public final class DfsSearchResult extends SearchPhaseResult {
         writeFieldStats(out, fieldStatistics);
         out.writeVInt(maxDoc);
         out.writeOptionalWriteable(getShardSearchRequest());
-        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_7_0)) {
-            out.writeOptionalCollection(knnResults);
-        } else {
-            if (knnResults != null && knnResults.size() > 1) {
-                throw new IllegalArgumentException(
-                    "Cannot serialize multiple KNN results to nodes using previous transport version ["
-                        + out.getTransportVersion().toReleaseVersion()
-                        + "], minimum required transport version is ["
-                        + TransportVersions.V_8_7_0.toReleaseVersion()
-                        + "]"
-                );
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+            if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_7_0)) {
+                out.writeOptionalCollection(knnResults);
+            } else {
+                if (knnResults != null && knnResults.size() > 1) {
+                    throw new IllegalArgumentException(
+                        "Cannot serialize multiple KNN results to nodes using previous transport version ["
+                            + out.getTransportVersion().toReleaseVersion()
+                            + "], minimum required transport version is ["
+                            + TransportVersions.V_8_7_0.toReleaseVersion()
+                            + "]"
+                    );
+                }
+                out.writeOptionalWriteable(knnResults == null || knnResults.isEmpty() ? null : knnResults.get(0));
             }
-            out.writeOptionalWriteable(knnResults == null || knnResults.isEmpty() ? null : knnResults.get(0));
         }
         if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_6_0)) {
             out.writeOptionalWriteable(searchProfileDfsPhaseResult);

--- a/server/src/main/java/org/elasticsearch/search/vectors/KnnScoreDocQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/KnnScoreDocQueryBuilder.java
@@ -231,6 +231,6 @@ public class KnnScoreDocQueryBuilder extends AbstractQueryBuilder<KnnScoreDocQue
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {
-        return TransportVersion.minimumCompatible();
+        return TransportVersions.V_8_4_0;
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/vectors/KnnVectorQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/KnnVectorQueryBuilder.java
@@ -284,7 +284,9 @@ public class KnnVectorQueryBuilder extends AbstractQueryBuilder<KnnVectorQueryBu
                 in.readBoolean(); // used for byteQueryVector, which was always null
             }
         }
-        this.filterQueries.addAll(readQueries(in));
+        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_2_0)) {
+            this.filterQueries.addAll(readQueries(in));
+        }
         if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_8_0)) {
             this.vectorSimilarity = in.readOptionalFloat();
         } else {
@@ -389,7 +391,9 @@ public class KnnVectorQueryBuilder extends AbstractQueryBuilder<KnnVectorQueryBu
                 out.writeBoolean(false); // used for byteQueryVector, which was always null
             }
         }
-        writeQueries(out, filterQueries);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_2_0)) {
+            writeQueries(out, filterQueries);
+        }
         if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_8_0)) {
             out.writeOptionalFloat(vectorSimilarity);
         }

--- a/server/src/test/java/org/elasticsearch/TransportVersionTests.java
+++ b/server/src/test/java/org/elasticsearch/TransportVersionTests.java
@@ -34,31 +34,27 @@ import static org.hamcrest.Matchers.sameInstance;
 public class TransportVersionTests extends ESTestCase {
 
     public void testVersionComparison() {
-        TransportVersion older = TransportVersionUtils.randomVersionBetween(
-            random(),
-            TransportVersion.minimumCompatible(),
-            TransportVersionUtils.getPreviousVersion(TransportVersion.current())
-        );
-        TransportVersion newer = TransportVersionUtils.randomVersionBetween(random(), older, TransportVersion.current());
-        assertThat(older.before(newer), is(true));
-        assertThat(older.before(older), is(false));
-        assertThat(newer.before(older), is(false));
+        TransportVersion V_8_2_0 = TransportVersions.V_8_2_0;
+        TransportVersion V_8_16_0 = TransportVersions.V_8_16_0;
+        assertThat(V_8_2_0.before(V_8_16_0), is(true));
+        assertThat(V_8_2_0.before(V_8_2_0), is(false));
+        assertThat(V_8_16_0.before(V_8_2_0), is(false));
 
-        assertThat(older.onOrBefore(newer), is(true));
-        assertThat(older.onOrBefore(older), is(true));
-        assertThat(newer.onOrBefore(older), is(false));
+        assertThat(V_8_2_0.onOrBefore(V_8_16_0), is(true));
+        assertThat(V_8_2_0.onOrBefore(V_8_2_0), is(true));
+        assertThat(V_8_16_0.onOrBefore(V_8_2_0), is(false));
 
-        assertThat(older.after(newer), is(false));
-        assertThat(older.after(older), is(false));
-        assertThat(newer.after(older), is(true));
+        assertThat(V_8_2_0.after(V_8_16_0), is(false));
+        assertThat(V_8_2_0.after(V_8_2_0), is(false));
+        assertThat(V_8_16_0.after(V_8_2_0), is(true));
 
-        assertThat(older.onOrAfter(newer), is(false));
-        assertThat(older.onOrAfter(older), is(true));
-        assertThat(newer.onOrAfter(older), is(true));
+        assertThat(V_8_2_0.onOrAfter(V_8_16_0), is(false));
+        assertThat(V_8_2_0.onOrAfter(V_8_2_0), is(true));
+        assertThat(V_8_16_0.onOrAfter(V_8_2_0), is(true));
 
-        assertThat(older, is(lessThan(newer)));
-        assertThat(older.compareTo(older), is(0));
-        assertThat(newer, is(greaterThan(older)));
+        assertThat(V_8_2_0, is(lessThan(V_8_16_0)));
+        assertThat(V_8_2_0.compareTo(V_8_2_0), is(0));
+        assertThat(V_8_16_0, is(greaterThan(V_8_2_0)));
     }
 
     public static class CorrectFakeVersion {

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeResponseTests.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.action.fieldcaps;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -113,7 +114,7 @@ public class FieldCapabilitiesNodeResponseTests extends AbstractWireSerializingT
         FieldCapabilitiesNodeResponse inNode = randomNodeResponse(indexResponses);
         final TransportVersion version = TransportVersionUtils.randomVersionBetween(
             random(),
-            TransportVersion.minimumCompatible(),
+            TransportVersions.V_8_2_0,
             TransportVersion.current()
         );
         final FieldCapabilitiesNodeResponse outNode = copyInstance(inNode, version);

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponseTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.action.fieldcaps;
 
 import org.elasticsearch.ElasticsearchExceptionTests;
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -166,7 +167,7 @@ public class FieldCapabilitiesResponseTests extends AbstractWireSerializingTestC
         FieldCapabilitiesResponse inResponse = randomCCSResponse(indexResponses);
         final TransportVersion version = TransportVersionUtils.randomVersionBetween(
             random(),
-            TransportVersion.minimumCompatible(),
+            TransportVersions.V_8_2_0,
             TransportVersion.current()
         );
         final FieldCapabilitiesResponse outResponse = copyInstance(inResponse, version);

--- a/server/src/test/java/org/elasticsearch/action/get/GetRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/get/GetRequestTests.java
@@ -8,7 +8,10 @@
  */
 package org.elasticsearch.action.get;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.test.ESTestCase;
 
 import static org.hamcrest.CoreMatchers.hasItems;
@@ -33,5 +36,14 @@ public class GetRequestTests extends ESTestCase {
             assertEquals(1, validate.validationErrors().size());
             assertThat(validate.validationErrors(), hasItems("id is missing"));
         }
+    }
+
+    public void testForceSyntheticUnsupported() {
+        GetRequest request = new GetRequest("index", "id");
+        request.setForceSyntheticSource(true);
+        StreamOutput out = new BytesStreamOutput();
+        out.setTransportVersion(TransportVersions.V_8_3_0);
+        Exception e = expectThrows(IllegalArgumentException.class, () -> request.writeTo(out));
+        assertEquals(e.getMessage(), "force_synthetic_source is not supported before 8.4.0");
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/get/MultiGetRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/get/MultiGetRequestTests.java
@@ -9,8 +9,11 @@
 
 package org.elasticsearch.action.get;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import org.elasticsearch.test.ESTestCase;
@@ -117,6 +120,15 @@ public class MultiGetRequestTests extends ESTestCase {
                 }
             }
         }
+    }
+
+    public void testForceSyntheticUnsupported() {
+        MultiGetRequest request = createTestInstance();
+        request.setForceSyntheticSource(true);
+        StreamOutput out = new BytesStreamOutput();
+        out.setTransportVersion(TransportVersions.V_8_3_0);
+        Exception e = expectThrows(IllegalArgumentException.class, () -> request.writeTo(out));
+        assertEquals(e.getMessage(), "force_synthetic_source is not supported before 8.4.0");
     }
 
     private MultiGetRequest createTestInstance() {

--- a/server/src/test/java/org/elasticsearch/action/get/MultiGetShardRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/get/MultiGetShardRequestTests.java
@@ -9,6 +9,9 @@
 
 package org.elasticsearch.action.get;
 
+import org.elasticsearch.TransportVersions;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
@@ -95,6 +98,14 @@ public class MultiGetShardRequestTests extends AbstractWireSerializingTestCase<M
             }
             default -> throw new IllegalStateException("Unexpected mutation branch value: " + mutationBranch);
         }
+    }
+
+    public void testForceSyntheticUnsupported() {
+        MultiGetShardRequest request = createTestInstance(true);
+        StreamOutput out = new BytesStreamOutput();
+        out.setTransportVersion(TransportVersions.V_8_3_0);
+        Exception e = expectThrows(IllegalArgumentException.class, () -> request.writeTo(out));
+        assertEquals(e.getMessage(), "force_synthetic_source is not supported before 8.4.0");
     }
 
     static MultiGetShardRequest createTestInstance(boolean forceSyntheticSource) {

--- a/server/src/test/java/org/elasticsearch/action/search/SearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchRequestTests.java
@@ -15,6 +15,8 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.ArrayUtils;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -100,6 +102,72 @@ public class SearchRequestTests extends AbstractSearchTestCase {
         assertNotSame(deserializedRequest, searchRequest);
     }
 
+    public void testSerializationMultiKNN() throws Exception {
+        SearchRequest searchRequest = createSearchRequest();
+        if (searchRequest.source() == null) {
+            searchRequest.source(new SearchSourceBuilder());
+        } else {
+            // tests version prior to 8.8 so remove possible rank builder
+            searchRequest.source().rankBuilder(null);
+            // tests version prior to 8_500_999 so remove possible multiple queries
+            searchRequest.source().subSearches(new ArrayList<>());
+        }
+        searchRequest.source()
+            .knnSearch(
+                List.of(
+                    new KnnSearchBuilder(
+                        randomAlphaOfLength(10),
+                        new float[] { 1, 2 },
+                        5,
+                        10,
+                        10f,
+                        randomRescoreVectorBuilder(),
+                        randomBoolean() ? null : randomFloat()
+                    ),
+                    new KnnSearchBuilder(
+                        randomAlphaOfLength(10),
+                        new float[] { 4, 12, 41 },
+                        3,
+                        5,
+                        10f,
+                        randomRescoreVectorBuilder(),
+                        randomBoolean() ? null : randomFloat()
+                    )
+                )
+            );
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> copyWriteable(
+                searchRequest,
+                namedWriteableRegistry,
+                SearchRequest::new,
+                TransportVersionUtils.randomVersionBetween(random(), TransportVersions.V_8_4_0, TransportVersions.V_8_6_0)
+            )
+        );
+
+        searchRequest.source()
+            .knnSearch(
+                List.of(
+                    new KnnSearchBuilder(
+                        randomAlphaOfLength(10),
+                        new float[] { 1, 2 },
+                        5,
+                        10,
+                        10f,
+                        randomRescoreVectorBuilder(),
+                        randomBoolean() ? null : randomFloat()
+                    )
+                )
+            );
+        // Shouldn't throw because its just one KNN request
+        copyWriteable(
+            searchRequest,
+            namedWriteableRegistry,
+            SearchRequest::new,
+            TransportVersionUtils.randomVersionBetween(random(), TransportVersions.V_8_4_0, TransportVersions.V_8_6_0)
+        );
+    }
+
     private static RescoreVectorBuilder randomRescoreVectorBuilder() {
         return randomBoolean() ? null : new RescoreVectorBuilder(randomFloatBetween(1.0f, 10.0f, false));
     }
@@ -107,6 +175,10 @@ public class SearchRequestTests extends AbstractSearchTestCase {
     public void testRandomVersionSerialization() throws IOException {
         SearchRequest searchRequest = createSearchRequest();
         TransportVersion version = TransportVersionUtils.randomVersion(random());
+        if (version.before(TransportVersions.V_8_4_0)) {
+            // Versions before 8.4.0 don't support force_synthetic_source
+            searchRequest.setForceSyntheticSource(false);
+        }
         if (version.before(TransportVersions.V_8_7_0) && searchRequest.hasKnnSearch() && searchRequest.source().knnSearch().size() > 1) {
             // Versions before 8.7.0 don't support more than one KNN clause
             searchRequest.source().knnSearch(List.of(searchRequest.source().knnSearch().get(0)));
@@ -606,5 +678,14 @@ public class SearchRequestTests extends AbstractSearchTestCase {
 
     private String toDescription(SearchRequest request) {
         return request.createTask(0, "test", TransportSearchAction.TYPE.name(), TaskId.EMPTY_TASK_ID, emptyMap()).getDescription();
+    }
+
+    public void testForceSyntheticUnsupported() {
+        SearchRequest request = new SearchRequest();
+        request.setForceSyntheticSource(true);
+        StreamOutput out = new BytesStreamOutput();
+        out.setTransportVersion(TransportVersions.V_8_3_0);
+        Exception e = expectThrows(IllegalArgumentException.class, () -> request.writeTo(out));
+        assertEquals(e.getMessage(), "force_synthetic_source is not supported before 8.4.0");
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/MappingParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MappingParserTests.java
@@ -10,17 +10,20 @@
 package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.cluster.project.TestProjectResolvers;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
 import org.elasticsearch.index.similarity.SimilarityService;
 import org.elasticsearch.indices.IndicesModule;
 import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.test.index.IndexVersionUtils;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.hamcrest.CoreMatchers;
 
@@ -322,6 +325,33 @@ public class MappingParserTests extends MapperServiceTestCase {
                 () -> createMappingParser(Settings.EMPTY).parse("_doc", new CompressedXContent(BytesReference.bytes(builder)))
             );
             assertEquals("field name cannot contain only whitespaces", iae.getMessage());
+        }
+    }
+
+    public void testBlankFieldNameBefore8_6_0() throws Exception {
+        IndexVersion version = IndexVersionUtils.randomVersionBetween(
+            random(),
+            IndexVersions.MINIMUM_READONLY_COMPATIBLE,
+            IndexVersions.V_8_5_0
+        );
+        TransportVersion transportVersion = TransportVersions.V_8_5_0;
+        {
+            XContentBuilder builder = mapping(b -> b.startObject(" ").field("type", randomFieldType()).endObject());
+            MappingParser mappingParser = createMappingParser(Settings.EMPTY, version, transportVersion);
+            Mapping mapping = mappingParser.parse("_doc", new CompressedXContent(BytesReference.bytes(builder)));
+            assertNotNull(mapping.getRoot().getMapper(" "));
+        }
+        {
+            XContentBuilder builder = mapping(b -> b.startObject("top. .foo").field("type", randomFieldType()).endObject());
+            MappingParser mappingParser = createMappingParser(Settings.EMPTY, version, transportVersion);
+            Mapping mapping = mappingParser.parse("_doc", new CompressedXContent(BytesReference.bytes(builder)));
+            assertNotNull(((ObjectMapper) mapping.getRoot().getMapper("top")).getMapper(" "));
+        }
+        {
+            XContentBuilder builder = mappingNoSubobjects(b -> b.startObject(" ").field("type", "keyword").endObject());
+            MappingParser mappingParser = createMappingParser(Settings.EMPTY, version, transportVersion);
+            Mapping mapping = mappingParser.parse("_doc", new CompressedXContent(BytesReference.bytes(builder)));
+            assertNotNull(mapping.getRoot().getMapper(" "));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/search/internal/ShardSearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/search/internal/ShardSearchRequestTests.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.search.internal;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
@@ -19,6 +20,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.compress.CompressorFactory;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Nullable;
@@ -31,6 +33,7 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.InvalidAliasNameException;
 import org.elasticsearch.search.AbstractSearchTestCase;
 import org.elasticsearch.search.SearchSortValuesAndFormatsTests;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.test.TransportVersionUtils;
 import org.elasticsearch.xcontent.DeprecationHandler;
 import org.elasticsearch.xcontent.ToXContent;
@@ -40,6 +43,9 @@ import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.elasticsearch.index.query.AbstractQueryBuilder.parseTopLevelQuery;
@@ -223,6 +229,18 @@ public class ShardSearchRequestTests extends AbstractSearchTestCase {
         // New version
         for (int i = 0; i < iterations; i++) {
             TransportVersion version = TransportVersionUtils.randomCompatibleVersion(random());
+            if (request.isForceSyntheticSource()) {
+                version = TransportVersionUtils.randomVersionBetween(random(), TransportVersions.V_8_4_0, TransportVersion.current());
+            }
+            if (Optional.ofNullable(request.source()).map(SearchSourceBuilder::knnSearch).map(List::size).orElse(0) > 1) {
+                version = TransportVersionUtils.randomVersionBetween(random(), TransportVersions.V_8_7_0, TransportVersion.current());
+            }
+            if (request.source() != null && request.source().rankBuilder() != null) {
+                version = TransportVersionUtils.randomVersionBetween(random(), TransportVersions.V_8_8_0, TransportVersion.current());
+            }
+            if (request.source() != null && request.source().subSearches().size() >= 2) {
+                version = TransportVersionUtils.randomVersionBetween(random(), TransportVersions.V_8_9_X, TransportVersion.current());
+            }
             request = copyWriteable(request, namedWriteableRegistry, ShardSearchRequest::new, version);
             channelVersion = TransportVersion.min(channelVersion, version);
             assertThat(request.getChannelVersion(), equalTo(channelVersion));
@@ -241,5 +259,21 @@ public class ShardSearchRequestTests extends AbstractSearchTestCase {
         };
         shardSearchRequest.cacheKey(differentiator);
         assertThat(invoked.get(), is(true));
+    }
+
+    public void testForceSyntheticUnsupported() throws IOException {
+        SearchRequest request = createSearchRequest();
+        if (request.source() != null) {
+            request.source().rankBuilder(null);
+            if (request.source().subSearches().size() >= 2) {
+                request.source().subSearches(new ArrayList<>());
+            }
+        }
+        request.setForceSyntheticSource(true);
+        ShardSearchRequest shardRequest = createShardSearchReqest(request);
+        StreamOutput out = new BytesStreamOutput();
+        out.setTransportVersion(TransportVersions.V_8_3_0);
+        Exception e = expectThrows(IllegalArgumentException.class, () -> shardRequest.writeTo(out));
+        assertEquals(e.getMessage(), "force_synthetic_source is not supported before 8.4.0");
     }
 }

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCapacity.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCapacity.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.autoscaling.capacity;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -45,7 +46,11 @@ public class AutoscalingCapacity implements ToXContentObject, Writeable {
         public AutoscalingResources(StreamInput in) throws IOException {
             this.storage = in.readOptionalWriteable(ByteSizeValue::readFrom);
             this.memory = in.readOptionalWriteable(ByteSizeValue::readFrom);
-            this.processors = in.readOptionalWriteable(Processors::readFrom);
+            if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+                this.processors = in.readOptionalWriteable(Processors::readFrom);
+            } else {
+                this.processors = null;
+            }
         }
 
         @Nullable
@@ -83,7 +88,9 @@ public class AutoscalingCapacity implements ToXContentObject, Writeable {
         public void writeTo(StreamOutput out) throws IOException {
             out.writeOptionalWriteable(storage);
             out.writeOptionalWriteable(memory);
-            out.writeOptionalWriteable(processors);
+            if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+                out.writeOptionalWriteable(processors);
+            }
         }
 
         public static AutoscalingResources max(AutoscalingResources sm1, AutoscalingResources sm2) {

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/FixedAutoscalingDeciderService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/FixedAutoscalingDeciderService.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.autoscaling.capacity;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -118,7 +119,11 @@ public class FixedAutoscalingDeciderService implements AutoscalingDeciderService
             this.storage = in.readOptionalWriteable(ByteSizeValue::readFrom);
             this.memory = in.readOptionalWriteable(ByteSizeValue::readFrom);
             this.nodes = in.readInt();
-            this.processors = in.readOptionalWriteable(Processors::readFrom);
+            if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+                this.processors = in.readOptionalWriteable(Processors::readFrom);
+            } else {
+                this.processors = null;
+            }
         }
 
         @Override
@@ -144,7 +149,9 @@ public class FixedAutoscalingDeciderService implements AutoscalingDeciderService
             out.writeOptionalWriteable(storage);
             out.writeOptionalWriteable(memory);
             out.writeInt(nodes);
-            out.writeOptionalWriteable(processors);
+            if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+                out.writeOptionalWriteable(processors);
+            }
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/archive/ArchiveFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/archive/ArchiveFeatureSetUsage.java
@@ -8,8 +8,10 @@
 package org.elasticsearch.xpack.core.archive;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.XPackFeatureUsage;
 import org.elasticsearch.xpack.core.XPackField;
@@ -28,7 +30,7 @@ public class ArchiveFeatureSetUsage extends XPackFeatureUsage {
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {
-        return TransportVersion.minimumCompatible();
+        return TransportVersions.V_8_3_0;
     }
 
     @Override
@@ -47,7 +49,7 @@ public class ArchiveFeatureSetUsage extends XPackFeatureUsage {
     }
 
     @Override
-    protected void innerXContent(XContentBuilder builder, Params params) throws IOException {
+    protected void innerXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
         super.innerXContent(builder, params);
         builder.field("indices_count", numberOfArchiveIndices);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/PutFollowAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/PutFollowAction.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.core.ccr.action;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
@@ -196,7 +197,9 @@ public final class PutFollowAction extends ActionType<PutFollowAction.Response> 
             this.settings = Settings.readSettingsFromStream(in);
             this.parameters = new FollowParameters(in);
             waitForActiveShards(ActiveShardCount.readFrom(in));
-            this.dataStreamName = in.readOptionalString();
+            if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+                this.dataStreamName = in.readOptionalString();
+            }
         }
 
         @Override
@@ -208,7 +211,9 @@ public final class PutFollowAction extends ActionType<PutFollowAction.Response> 
             settings.writeTo(out);
             parameters.writeTo(out);
             waitForActiveShards.writeTo(out);
-            out.writeOptionalString(this.dataStreamName);
+            if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+                out.writeOptionalString(this.dataStreamName);
+            }
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleFeatureSetUsage.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.core.ilm;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.admin.indices.rollover.RolloverConditions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -426,12 +427,24 @@ public class IndexLifecycleFeatureSetUsage extends XPackFeatureUsage {
             this.setPriorityPriority = in.readOptionalVInt();
             this.shrinkMaxPrimaryShardSize = in.readOptionalWriteable(ByteSizeValue::readFrom);
             this.shrinkNumberOfShards = in.readOptionalVInt();
-            this.rolloverMaxPrimaryShardDocs = in.readOptionalVLong();
-            this.rolloverMinAge = in.readOptionalTimeValue();
-            this.rolloverMinDocs = in.readOptionalVLong();
-            this.rolloverMinPrimaryShardSize = in.readOptionalWriteable(ByteSizeValue::readFrom);
-            this.rolloverMinSize = in.readOptionalWriteable(ByteSizeValue::readFrom);
-            this.rolloverMinPrimaryShardDocs = in.readOptionalVLong();
+            if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_2_0)) {
+                this.rolloverMaxPrimaryShardDocs = in.readOptionalVLong();
+            } else {
+                this.rolloverMaxPrimaryShardDocs = null;
+            }
+            if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+                this.rolloverMinAge = in.readOptionalTimeValue();
+                this.rolloverMinDocs = in.readOptionalVLong();
+                this.rolloverMinPrimaryShardSize = in.readOptionalWriteable(ByteSizeValue::readFrom);
+                this.rolloverMinSize = in.readOptionalWriteable(ByteSizeValue::readFrom);
+                this.rolloverMinPrimaryShardDocs = in.readOptionalVLong();
+            } else {
+                this.rolloverMinAge = null;
+                this.rolloverMinDocs = null;
+                this.rolloverMinPrimaryShardSize = null;
+                this.rolloverMinSize = null;
+                this.rolloverMinPrimaryShardDocs = null;
+            }
         }
 
         @Override
@@ -445,12 +458,16 @@ public class IndexLifecycleFeatureSetUsage extends XPackFeatureUsage {
             out.writeOptionalVInt(setPriorityPriority);
             out.writeOptionalWriteable(shrinkMaxPrimaryShardSize);
             out.writeOptionalVInt(shrinkNumberOfShards);
-            out.writeOptionalVLong(rolloverMaxPrimaryShardDocs);
-            out.writeOptionalTimeValue(rolloverMinAge);
-            out.writeOptionalVLong(rolloverMinDocs);
-            out.writeOptionalWriteable(rolloverMinPrimaryShardSize);
-            out.writeOptionalWriteable(rolloverMinSize);
-            out.writeOptionalVLong(rolloverMinPrimaryShardDocs);
+            if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_2_0)) {
+                out.writeOptionalVLong(rolloverMaxPrimaryShardDocs);
+            }
+            if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+                out.writeOptionalTimeValue(rolloverMinAge);
+                out.writeOptionalVLong(rolloverMinDocs);
+                out.writeOptionalWriteable(rolloverMinPrimaryShardSize);
+                out.writeOptionalWriteable(rolloverMinSize);
+                out.writeOptionalVLong(rolloverMinPrimaryShardDocs);
+            }
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferModelAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferModelAction.java
@@ -174,7 +174,11 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
             this.objectsToInfer = in.readCollectionAsImmutableList(StreamInput::readGenericMap);
             this.update = in.readNamedWriteable(InferenceConfigUpdate.class);
             this.previouslyLicensed = in.readBoolean();
-            this.inferenceTimeout = in.readTimeValue();
+            if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_3_0)) {
+                this.inferenceTimeout = in.readTimeValue();
+            } else {
+                this.inferenceTimeout = TimeValue.MAX_VALUE;
+            }
             if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_7_0)) {
                 textInput = in.readOptionalStringCollectionAsList();
             } else {
@@ -263,7 +267,9 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
             out.writeCollection(objectsToInfer, StreamOutput::writeGenericMap);
             out.writeNamedWriteable(update);
             out.writeBoolean(previouslyLicensed);
-            out.writeTimeValue(inferenceTimeout);
+            if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_3_0)) {
+                out.writeTimeValue(inferenceTimeout);
+            }
             if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_7_0)) {
                 out.writeOptionalStringCollection(textInput);
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentAction.java
@@ -125,7 +125,9 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
             docs = in.readCollectionAsImmutableList(StreamInput::readGenericMap);
             update = in.readOptionalNamedWriteable(InferenceConfigUpdate.class);
             inferenceTimeout = in.readOptionalTimeValue();
-            highPriority = in.readBoolean();
+            if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_3_0)) {
+                highPriority = in.readBoolean();
+            }
             if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_7_0)) {
                 textInput = in.readOptionalStringCollectionAsList();
             } else {
@@ -221,7 +223,9 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
             out.writeCollection(docs, StreamOutput::writeGenericMap);
             out.writeOptionalNamedWriteable(update);
             out.writeOptionalTimeValue(inferenceTimeout);
-            out.writeBoolean(highPriority);
+            if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_3_0)) {
+                out.writeBoolean(highPriority);
+            }
             if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_7_0)) {
                 out.writeOptionalStringCollection(textInput);
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PreviewDatafeedAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PreviewDatafeedAction.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
@@ -85,8 +86,13 @@ public class PreviewDatafeedAction extends ActionType<PreviewDatafeedAction.Resp
             datafeedId = in.readString();
             datafeedConfig = in.readOptionalWriteable(DatafeedConfig::new);
             jobConfig = in.readOptionalWriteable(Job.Builder::new);
-            this.startTime = in.readOptionalLong();
-            this.endTime = in.readOptionalLong();
+            if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_3_0)) {
+                this.startTime = in.readOptionalLong();
+                this.endTime = in.readOptionalLong();
+            } else {
+                this.startTime = null;
+                this.endTime = null;
+            }
         }
 
         public Request(String datafeedId, String start, String end) {
@@ -158,8 +164,10 @@ public class PreviewDatafeedAction extends ActionType<PreviewDatafeedAction.Resp
             out.writeString(datafeedId);
             out.writeOptionalWriteable(datafeedConfig);
             out.writeOptionalWriteable(jobConfig);
-            out.writeOptionalLong(startTime);
-            out.writeOptionalLong(endTime);
+            if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_3_0)) {
+                out.writeOptionalLong(startTime);
+                out.writeOptionalLong(endTime);
+            }
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutTrainedModelVocabularyAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutTrainedModelVocabularyAction.java
@@ -82,7 +82,11 @@ public class PutTrainedModelVocabularyAction extends ActionType<AcknowledgedResp
             super(in);
             this.modelId = in.readString();
             this.vocabulary = in.readStringCollectionAsList();
-            this.merges = in.readStringCollectionAsList();
+            if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_2_0)) {
+                this.merges = in.readStringCollectionAsList();
+            } else {
+                this.merges = List.of();
+            }
             if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_9_X)) {
                 this.scores = in.readCollectionAsList(StreamInput::readDouble);
             } else {
@@ -130,7 +134,9 @@ public class PutTrainedModelVocabularyAction extends ActionType<AcknowledgedResp
             super.writeTo(out);
             out.writeString(modelId);
             out.writeStringCollection(vocabulary);
-            out.writeStringCollection(merges);
+            if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_2_0)) {
+                out.writeStringCollection(merges);
+            }
             if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_9_X)) {
                 out.writeCollection(scores, StreamOutput::writeDouble);
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java
@@ -175,7 +175,9 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
             }
             threadsPerAllocation = in.readVInt();
             queueCapacity = in.readVInt();
-            this.cacheSize = in.readOptionalWriteable(ByteSizeValue::readFrom);
+            if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+                this.cacheSize = in.readOptionalWriteable(ByteSizeValue::readFrom);
+            }
             if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_6_0)) {
                 this.priority = in.readEnum(Priority.class);
             } else {
@@ -301,7 +303,9 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
             }
             out.writeVInt(threadsPerAllocation);
             out.writeVInt(queueCapacity);
-            out.writeOptionalWriteable(cacheSize);
+            if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+                out.writeOptionalWriteable(cacheSize);
+            }
             if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_6_0)) {
                 out.writeEnum(priority);
             }
@@ -573,7 +577,11 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
             this.threadsPerAllocation = in.readVInt();
             this.numberOfAllocations = in.readVInt();
             this.queueCapacity = in.readVInt();
-            this.cacheSize = in.readOptionalWriteable(ByteSizeValue::readFrom);
+            if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+                this.cacheSize = in.readOptionalWriteable(ByteSizeValue::readFrom);
+            } else {
+                this.cacheSize = null;
+            }
             if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_6_0)) {
                 this.priority = in.readEnum(Priority.class);
             } else {
@@ -637,7 +645,9 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
             out.writeVInt(threadsPerAllocation);
             out.writeVInt(numberOfAllocations);
             out.writeVInt(queueCapacity);
-            out.writeOptionalWriteable(cacheSize);
+            if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+                out.writeOptionalWriteable(cacheSize);
+            }
             if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_6_0)) {
                 out.writeEnum(priority);
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/AssignmentStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/AssignmentStats.java
@@ -168,12 +168,27 @@ public class AssignmentStats implements ToXContentObject, Writeable {
             this.errorCount = in.readVInt();
             this.rejectedExecutionCount = in.readVInt();
             this.timeoutCount = in.readVInt();
-            this.peakThroughput = in.readVLong();
-            this.throughputLastPeriod = in.readVLong();
-            this.avgInferenceTimeLastPeriod = in.readOptionalDouble();
-            this.cacheHitCount = in.readOptionalVLong();
-            this.cacheHitCountLastPeriod = in.readOptionalVLong();
-            this.avgInferenceTimeExcludingCacheHit = in.readOptionalDouble();
+            if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_2_0)) {
+                this.peakThroughput = in.readVLong();
+                this.throughputLastPeriod = in.readVLong();
+                this.avgInferenceTimeLastPeriod = in.readOptionalDouble();
+            } else {
+                this.peakThroughput = 0;
+                this.throughputLastPeriod = 0;
+                this.avgInferenceTimeLastPeriod = null;
+            }
+            if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+                this.cacheHitCount = in.readOptionalVLong();
+                this.cacheHitCountLastPeriod = in.readOptionalVLong();
+            } else {
+                this.cacheHitCount = null;
+                this.cacheHitCountLastPeriod = null;
+            }
+            if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_5_0)) {
+                this.avgInferenceTimeExcludingCacheHit = in.readOptionalDouble();
+            } else {
+                this.avgInferenceTimeExcludingCacheHit = null;
+            }
 
         }
 
@@ -324,12 +339,18 @@ public class AssignmentStats implements ToXContentObject, Writeable {
             out.writeVInt(errorCount);
             out.writeVInt(rejectedExecutionCount);
             out.writeVInt(timeoutCount);
-            out.writeVLong(peakThroughput);
-            out.writeVLong(throughputLastPeriod);
-            out.writeOptionalDouble(avgInferenceTimeLastPeriod);
-            out.writeOptionalVLong(cacheHitCount);
-            out.writeOptionalVLong(cacheHitCountLastPeriod);
-            out.writeOptionalDouble(avgInferenceTimeExcludingCacheHit);
+            if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_2_0)) {
+                out.writeVLong(peakThroughput);
+                out.writeVLong(throughputLastPeriod);
+                out.writeOptionalDouble(avgInferenceTimeLastPeriod);
+            }
+            if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+                out.writeOptionalVLong(cacheHitCount);
+                out.writeOptionalVLong(cacheHitCountLastPeriod);
+            }
+            if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_5_0)) {
+                out.writeOptionalDouble(avgInferenceTimeExcludingCacheHit);
+            }
         }
 
         @Override
@@ -449,11 +470,15 @@ public class AssignmentStats implements ToXContentObject, Writeable {
         numberOfAllocations = in.readOptionalVInt();
         queueCapacity = in.readOptionalVInt();
         startTime = in.readInstant();
-        nodeStats = in.readCollectionAsList(NodeStats::new);
+        nodeStats = in.readCollectionAsList(AssignmentStats.NodeStats::new);
         state = in.readOptionalEnum(AssignmentState.class);
         reason = in.readOptionalString();
         allocationStatus = in.readOptionalWriteable(AllocationStatus::new);
-        cacheSize = in.readOptionalWriteable(ByteSizeValue::readFrom);
+        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+            cacheSize = in.readOptionalWriteable(ByteSizeValue::readFrom);
+        } else {
+            cacheSize = null;
+        }
         if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_6_0)) {
             priority = in.readEnum(Priority.class);
         } else {
@@ -637,10 +662,16 @@ public class AssignmentStats implements ToXContentObject, Writeable {
         out.writeOptionalVInt(queueCapacity);
         out.writeInstant(startTime);
         out.writeCollection(nodeStats);
-        out.writeOptionalEnum(state);
+        if (AssignmentState.FAILED.equals(state) && out.getTransportVersion().before(TransportVersions.V_8_4_0)) {
+            out.writeOptionalEnum(AssignmentState.STARTING);
+        } else {
+            out.writeOptionalEnum(state);
+        }
         out.writeOptionalString(reason);
         out.writeOptionalWriteable(allocationStatus);
-        out.writeOptionalWriteable(cacheSize);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+            out.writeOptionalWriteable(cacheSize);
+        }
         if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_6_0)) {
             out.writeEnum(priority);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/RoutingInfo.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/RoutingInfo.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.core.ml.inference.assignment;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -74,8 +75,13 @@ public class RoutingInfo implements ToXContentObject, Writeable {
     }
 
     public RoutingInfo(StreamInput in) throws IOException {
-        this.currentAllocations = in.readVInt();
-        this.targetAllocations = in.readVInt();
+        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+            this.currentAllocations = in.readVInt();
+            this.targetAllocations = in.readVInt();
+        } else {
+            this.currentAllocations = 0;
+            this.targetAllocations = 0;
+        }
         this.state = in.readEnum(RoutingState.class);
         this.reason = in.readOptionalString();
     }
@@ -114,8 +120,10 @@ public class RoutingInfo implements ToXContentObject, Writeable {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeVInt(currentAllocations);
-        out.writeVInt(targetAllocations);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+            out.writeVInt(currentAllocations);
+            out.writeVInt(targetAllocations);
+        }
         out.writeEnum(state);
         out.writeOptionalString(reason);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/RoutingInfoUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/RoutingInfoUpdate.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.core.ml.inference.assignment;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -34,14 +35,24 @@ public class RoutingInfoUpdate implements Writeable {
     }
 
     public RoutingInfoUpdate(StreamInput in) throws IOException {
-        numberOfAllocations = Optional.ofNullable(in.readOptionalVInt());
-        stateAndReason = Optional.ofNullable(in.readOptionalWriteable(RoutingStateAndReason::new));
+        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+            numberOfAllocations = Optional.ofNullable(in.readOptionalVInt());
+            stateAndReason = Optional.ofNullable(in.readOptionalWriteable(RoutingStateAndReason::new));
+        } else {
+            numberOfAllocations = Optional.empty();
+            stateAndReason = Optional.of(new RoutingStateAndReason(in));
+        }
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeOptionalVInt(numberOfAllocations.orElse(null));
-        out.writeOptionalWriteable(stateAndReason.orElse(null));
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+            out.writeOptionalVInt(numberOfAllocations.orElse(null));
+            out.writeOptionalWriteable(stateAndReason.orElse(null));
+        } else {
+            assert stateAndReason.isPresent() : "updating routing info while nodes prior to 8.4.0 should only contain state and reason";
+            stateAndReason.get().writeTo(out);
+        }
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignment.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignment.java
@@ -168,7 +168,11 @@ public final class TrainedModelAssignment implements SimpleDiffable<TrainedModel
         this.assignmentState = in.readEnum(AssignmentState.class);
         this.reason = in.readOptionalString();
         this.startTime = in.readInstant();
-        this.maxAssignedAllocations = in.readVInt();
+        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+            this.maxAssignedAllocations = in.readVInt();
+        } else {
+            this.maxAssignedAllocations = totalCurrentAllocations();
+        }
         if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_16_0)) {
             this.adaptiveAllocationsSettings = in.readOptionalWriteable(AdaptiveAllocationsSettings::new);
         } else {
@@ -370,7 +374,9 @@ public final class TrainedModelAssignment implements SimpleDiffable<TrainedModel
         out.writeEnum(assignmentState);
         out.writeOptionalString(reason);
         out.writeInstant(startTime);
-        out.writeVInt(maxAssignedAllocations);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+            out.writeVInt(maxAssignedAllocations);
+        }
         if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_16_0)) {
             out.writeOptionalWriteable(adaptiveAllocationsSettings);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/AbstractTokenizationUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/AbstractTokenizationUpdate.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
@@ -33,7 +34,11 @@ public abstract class AbstractTokenizationUpdate implements TokenizationUpdate {
 
     public AbstractTokenizationUpdate(StreamInput in) throws IOException {
         this.truncate = in.readOptionalEnum(Tokenization.Truncate.class);
-        this.span = in.readOptionalInt();
+        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_2_0)) {
+            this.span = in.readOptionalInt();
+        } else {
+            this.span = null;
+        }
     }
 
     @Override
@@ -57,7 +62,9 @@ public abstract class AbstractTokenizationUpdate implements TokenizationUpdate {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeOptionalEnum(truncate);
-        out.writeOptionalInt(span);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_2_0)) {
+            out.writeOptionalInt(span);
+        }
     }
 
     public Integer getSpan() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/QuestionAnsweringConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/QuestionAnsweringConfig.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
@@ -220,7 +221,7 @@ public class QuestionAnsweringConfig implements NlpConfig {
 
     @Override
     public TransportVersion getMinimalSupportedTransportVersion() {
-        return TransportVersion.minimumCompatible();
+        return TransportVersions.V_8_3_0;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/QuestionAnsweringConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/QuestionAnsweringConfigUpdate.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
@@ -51,7 +52,10 @@ public class QuestionAnsweringConfigUpdate extends NlpConfigUpdate implements Na
     }
 
     @SuppressWarnings({ "unchecked" })
-    private static final ObjectParser<Builder, Void> STRICT_PARSER = new ObjectParser<>(NAME, Builder::new);
+    private static final ObjectParser<QuestionAnsweringConfigUpdate.Builder, Void> STRICT_PARSER = new ObjectParser<>(
+        NAME,
+        QuestionAnsweringConfigUpdate.Builder::new
+    );
 
     static {
         STRICT_PARSER.declareString(Builder::setQuestion, QUESTION);
@@ -175,7 +179,9 @@ public class QuestionAnsweringConfigUpdate extends NlpConfigUpdate implements Na
         return question;
     }
 
-    public static class Builder implements InferenceConfigUpdate.Builder<Builder, QuestionAnsweringConfigUpdate> {
+    public static class Builder
+        implements
+            InferenceConfigUpdate.Builder<QuestionAnsweringConfigUpdate.Builder, QuestionAnsweringConfigUpdate> {
         private Integer numTopClasses;
         private Integer maxAnswerLength;
         private String resultsField;
@@ -183,7 +189,7 @@ public class QuestionAnsweringConfigUpdate extends NlpConfigUpdate implements Na
         private String question;
 
         @Override
-        public Builder setResultsField(String resultsField) {
+        public QuestionAnsweringConfigUpdate.Builder setResultsField(String resultsField) {
             this.resultsField = resultsField;
             return this;
         }
@@ -216,6 +222,6 @@ public class QuestionAnsweringConfigUpdate extends NlpConfigUpdate implements Na
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {
-        return TransportVersion.minimumCompatible();
+        return TransportVersions.V_8_3_0;
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextSimilarityConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextSimilarityConfig.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
@@ -173,7 +174,7 @@ public class TextSimilarityConfig implements NlpConfig {
 
     @Override
     public TransportVersion getMinimalSupportedTransportVersion() {
-        return TransportVersion.minimumCompatible();
+        return TransportVersions.V_8_5_0;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextSimilarityConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextSimilarityConfigUpdate.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
@@ -48,7 +49,10 @@ public class TextSimilarityConfigUpdate extends NlpConfigUpdate implements Named
         return new TextSimilarityConfigUpdate(text, resultsField, tokenizationUpdate, spanScoreFunction);
     }
 
-    private static final ObjectParser<Builder, Void> STRICT_PARSER = new ObjectParser<>(NAME, Builder::new);
+    private static final ObjectParser<TextSimilarityConfigUpdate.Builder, Void> STRICT_PARSER = new ObjectParser<>(
+        NAME,
+        TextSimilarityConfigUpdate.Builder::new
+    );
 
     static {
         STRICT_PARSER.declareString(Builder::setText, TEXT);
@@ -162,14 +166,14 @@ public class TextSimilarityConfigUpdate extends NlpConfigUpdate implements Named
         return text;
     }
 
-    public static class Builder implements InferenceConfigUpdate.Builder<Builder, TextSimilarityConfigUpdate> {
+    public static class Builder implements InferenceConfigUpdate.Builder<TextSimilarityConfigUpdate.Builder, TextSimilarityConfigUpdate> {
         private String resultsField;
         private String spanScoreFunction;
         private TokenizationUpdate tokenizationUpdate;
         private String text;
 
         @Override
-        public Builder setResultsField(String resultsField) {
+        public TextSimilarityConfigUpdate.Builder setResultsField(String resultsField) {
             this.resultsField = resultsField;
             return this;
         }
@@ -197,6 +201,6 @@ public class TextSimilarityConfigUpdate extends NlpConfigUpdate implements Named
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {
-        return TransportVersion.minimumCompatible();
+        return TransportVersions.V_8_5_0;
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/Tokenization.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/Tokenization.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
 import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -133,7 +134,11 @@ public abstract class Tokenization implements NamedXContentObject, NamedWriteabl
         this.withSpecialTokens = in.readBoolean();
         this.maxSequenceLength = in.readVInt();
         this.truncate = in.readEnum(Truncate.class);
-        this.span = in.readInt();
+        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_2_0)) {
+            this.span = in.readInt();
+        } else {
+            this.span = UNSET_SPAN_VALUE;
+        }
     }
 
     /**
@@ -172,7 +177,9 @@ public abstract class Tokenization implements NamedXContentObject, NamedWriteabl
         out.writeBoolean(withSpecialTokens);
         out.writeVInt(maxSequenceLength);
         out.writeEnum(truncate);
-        out.writeInt(span);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_2_0)) {
+            out.writeInt(span);
+        }
     }
 
     public abstract String getMaskToken();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/SecurityFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/SecurityFeatureSetUsage.java
@@ -63,8 +63,12 @@ public class SecurityFeatureSetUsage extends XPackFeatureUsage {
         roleMappingStoreUsage = in.readGenericMap();
         fips140Usage = in.readGenericMap();
         operatorPrivilegesUsage = in.readGenericMap();
-        domainsUsage = in.readGenericMap();
-        userProfileUsage = in.readGenericMap();
+        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_2_0)) {
+            domainsUsage = in.readGenericMap();
+        }
+        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_5_0)) {
+            userProfileUsage = in.readGenericMap();
+        }
         if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_8_0)) {
             remoteClusterServerUsage = in.readGenericMap();
         }
@@ -123,8 +127,12 @@ public class SecurityFeatureSetUsage extends XPackFeatureUsage {
         out.writeGenericMap(roleMappingStoreUsage);
         out.writeGenericMap(fips140Usage);
         out.writeGenericMap(operatorPrivilegesUsage);
-        out.writeGenericMap(domainsUsage);
-        out.writeGenericMap(userProfileUsage);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_2_0)) {
+            out.writeGenericMap(domainsUsage);
+        }
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_5_0)) {
+            out.writeGenericMap(userProfileUsage);
+        }
         if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_8_0)) {
             out.writeGenericMap(remoteClusterServerUsage);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/Grant.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/Grant.java
@@ -57,7 +57,11 @@ public class Grant implements Writeable {
         this.username = in.readOptionalString();
         this.password = in.readOptionalSecureString();
         this.accessToken = in.readOptionalSecureString();
-        this.runAsUsername = in.readOptionalString();
+        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+            this.runAsUsername = in.readOptionalString();
+        } else {
+            this.runAsUsername = null;
+        }
         if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_12_0)) {
             this.clientAuthentication = in.readOptionalWriteable(ClientAuthentication::new);
         } else {
@@ -70,7 +74,9 @@ public class Grant implements Writeable {
         out.writeOptionalString(username);
         out.writeOptionalSecureString(password);
         out.writeOptionalSecureString(accessToken);
-        out.writeOptionalString(runAsUsername);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+            out.writeOptionalString(runAsUsername);
+        }
         if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_12_0)) {
             out.writeOptionalWriteable(clientAuthentication);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/AuthenticateRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/AuthenticateRequest.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.core.security.action.user;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -19,6 +20,10 @@ public class AuthenticateRequest extends LegacyActionRequest {
 
     public AuthenticateRequest(StreamInput in) throws IOException {
         super(in);
+        if (in.getTransportVersion().before(TransportVersions.V_8_5_0)) {
+            // Older versions included the username as a field
+            in.readString();
+        }
     }
 
     private AuthenticateRequest() {}
@@ -32,5 +37,8 @@ public class AuthenticateRequest extends LegacyActionRequest {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
+        if (out.getTransportVersion().before(TransportVersions.V_8_5_0)) {
+            throw new IllegalStateException("cannot send authenticate request to a node of earlier version");
+        }
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/GetUsersRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/GetUsersRequest.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.core.security.action.user;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.Strings;
@@ -27,7 +28,11 @@ public class GetUsersRequest extends LegacyActionRequest implements UserRequest 
     public GetUsersRequest(StreamInput in) throws IOException {
         super(in);
         usernames = in.readStringArray();
-        withProfileUid = in.readBoolean();
+        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_5_0)) {
+            withProfileUid = in.readBoolean();
+        } else {
+            withProfileUid = false;
+        }
     }
 
     public GetUsersRequest() {
@@ -72,7 +77,9 @@ public class GetUsersRequest extends LegacyActionRequest implements UserRequest 
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeStringArray(usernames);
-        out.writeBoolean(withProfileUid);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_5_0)) {
+            out.writeBoolean(withProfileUid);
+        }
     }
 
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/GetUsersResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/GetUsersResponse.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.core.security.action.user;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
@@ -56,11 +57,13 @@ public class GetUsersResponse extends ActionResponse implements ToXContentObject
                 Authentication.AuthenticationSerializationHelper.writeUserTo(user, out);
             }
         }
-        if (profileUidLookup != null) {
-            out.writeBoolean(true);
-            out.writeMap(profileUidLookup, StreamOutput::writeString);
-        } else {
-            out.writeBoolean(false);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_5_0)) {
+            if (profileUidLookup != null) {
+                out.writeBoolean(true);
+                out.writeMap(profileUidLookup, StreamOutput::writeString);
+            } else {
+                out.writeBoolean(false);
+            }
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecyclePolicyMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecyclePolicyMetadata.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.core.slm;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.cluster.SimpleDiffable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -116,7 +117,7 @@ public class SnapshotLifecyclePolicyMetadata implements SimpleDiffable<SnapshotL
         this.modifiedDate = in.readVLong();
         this.lastSuccess = in.readOptionalWriteable(SnapshotInvocationRecord::new);
         this.lastFailure = in.readOptionalWriteable(SnapshotInvocationRecord::new);
-        this.invocationsSinceLastSuccess = in.readVLong();
+        this.invocationsSinceLastSuccess = in.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0) ? in.readVLong() : 0L;
     }
 
     @Override
@@ -127,7 +128,9 @@ public class SnapshotLifecyclePolicyMetadata implements SimpleDiffable<SnapshotL
         out.writeVLong(this.modifiedDate);
         out.writeOptionalWriteable(this.lastSuccess);
         out.writeOptionalWriteable(this.lastFailure);
-        out.writeVLong(this.invocationsSinceLastSuccess);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+            out.writeVLong(this.invocationsSinceLastSuccess);
+        }
     }
 
     public static Builder builder() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/cert/CertificateInfo.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/cert/CertificateInfo.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.core.ssl.cert;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -62,7 +63,11 @@ public class CertificateInfo implements ToXContentObject, Writeable, Comparable<
         this.serialNumber = in.readString();
         this.hasPrivateKey = in.readBoolean();
         this.expiry = Instant.ofEpochMilli(in.readLong()).atZone(ZoneOffset.UTC);
-        this.issuer = in.readString();
+        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+            this.issuer = in.readString();
+        } else {
+            this.issuer = "";
+        }
     }
 
     @Override
@@ -74,7 +79,9 @@ public class CertificateInfo implements ToXContentObject, Writeable, Comparable<
         out.writeString(serialNumber);
         out.writeBoolean(hasPrivateKey);
         out.writeLong(expiry.toInstant().toEpochMilli());
-        out.writeString(issuer);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+            out.writeString(issuer);
+        }
     }
 
     @Nullable

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/NodeTermsEnumResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/NodeTermsEnumResponse.java
@@ -7,12 +7,15 @@
 package org.elasticsearch.xpack.core.termsenum.action;
 
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.transport.TransportResponse;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Internal response of a terms enum request executed directly against a specific shard.
@@ -27,7 +30,15 @@ class NodeTermsEnumResponse extends TransportResponse {
     private final String nodeId;
 
     NodeTermsEnumResponse(StreamInput in) throws IOException {
-        terms = in.readStringCollectionAsList();
+        if (in.getTransportVersion().before(TransportVersions.V_8_2_0)) {
+            terms = in.readCollectionAsList(r -> {
+                String term = r.readString();
+                in.readLong(); // obsolete docCount field
+                return term;
+            });
+        } else {
+            terms = in.readStringCollectionAsList();
+        }
         error = in.readOptionalString();
         complete = in.readBoolean();
         nodeId = in.readString();
@@ -58,7 +69,14 @@ class NodeTermsEnumResponse extends TransportResponse {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeStringCollection(terms);
+        if (out.getTransportVersion().before(TransportVersions.V_8_2_0)) {
+            out.writeCollection(terms.stream().map(term -> (Writeable) out1 -> {
+                out1.writeString(term);
+                out1.writeLong(1); // obsolete docCount field
+            }).collect(Collectors.toList()));
+        } else {
+            out.writeStringCollection(terms);
+        }
         out.writeOptionalString(error);
         out.writeBoolean(complete);
         out.writeString(nodeId);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/action/AbstractFindStructureRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/action/AbstractFindStructureRequest.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.core.textstructure.action;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -80,7 +81,11 @@ public abstract class AbstractFindStructureRequest extends LegacyActionRequest {
         quote = in.readBoolean() ? (char) in.readVInt() : null;
         shouldTrimFields = in.readOptionalBoolean();
         grokPattern = in.readOptionalString();
-        ecsCompatibility = in.readOptionalString();
+        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_5_0)) {
+            ecsCompatibility = in.readOptionalString();
+        } else {
+            ecsCompatibility = null;
+        }
         timestampFormat = in.readOptionalString();
         timestampField = in.readOptionalString();
     }
@@ -322,7 +327,9 @@ public abstract class AbstractFindStructureRequest extends LegacyActionRequest {
         }
         out.writeOptionalBoolean(shouldTrimFields);
         out.writeOptionalString(grokPattern);
-        out.writeOptionalString(ecsCompatibility);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_5_0)) {
+            out.writeOptionalString(ecsCompatibility);
+        }
         out.writeOptionalString(timestampFormat);
         out.writeOptionalString(timestampField);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/structurefinder/TextStructure.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/structurefinder/TextStructure.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.core.textstructure.structurefinder;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -225,7 +226,11 @@ public class TextStructure implements ToXContentObject, Writeable {
         quote = in.readBoolean() ? (char) in.readVInt() : null;
         shouldTrimFields = in.readOptionalBoolean();
         grokPattern = in.readOptionalString();
-        ecsCompatibility = getNonNullEcsCompatibilityString(in.readString());
+        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_5_0)) {
+            ecsCompatibility = getNonNullEcsCompatibilityString(in.readString());
+        } else {
+            ecsCompatibility = getNonNullEcsCompatibilityString(null);
+        }
         jodaTimestampFormats = in.readBoolean() ? in.readCollectionAsImmutableList(StreamInput::readString) : null;
         javaTimestampFormats = in.readBoolean() ? in.readCollectionAsImmutableList(StreamInput::readString) : null;
         timestampField = in.readOptionalString();
@@ -267,7 +272,9 @@ public class TextStructure implements ToXContentObject, Writeable {
         }
         out.writeOptionalBoolean(shouldTrimFields);
         out.writeOptionalString(grokPattern);
-        out.writeString(ecsCompatibility);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_5_0)) {
+            out.writeString(ecsCompatibility);
+        }
         if (jodaTimestampFormats == null) {
             out.writeBoolean(false);
         } else {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/SettingsConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/SettingsConfig.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.core.transform.transforms;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -162,8 +163,16 @@ public class SettingsConfig implements Writeable, ToXContentObject {
         this.usePit = in.readOptionalInt();
 
         deduceMappings = in.readOptionalInt();
-        numFailureRetries = in.readOptionalInt();
-        unattended = in.readOptionalInt();
+        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+            numFailureRetries = in.readOptionalInt();
+        } else {
+            numFailureRetries = null;
+        }
+        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_5_0)) {
+            unattended = in.readOptionalInt();
+        } else {
+            unattended = DEFAULT_UNATTENDED;
+        }
     }
 
     public Integer getMaxPageSearchSize() {
@@ -266,8 +275,12 @@ public class SettingsConfig implements Writeable, ToXContentObject {
         out.writeOptionalInt(usePit);
 
         out.writeOptionalInt(deduceMappings);
-        out.writeOptionalInt(numFailureRetries);
-        out.writeOptionalInt(unattended);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
+            out.writeOptionalInt(numFailureRetries);
+        }
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_5_0)) {
+            out.writeOptionalInt(unattended);
+        }
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InferModelActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InferModelActionRequestTests.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.TimeValue;
@@ -209,6 +210,62 @@ public class InferModelActionRequestTests extends AbstractBWCWireSerializationTe
     @Override
     protected Request mutateInstanceForVersion(Request instance, TransportVersion version) {
         InferenceConfigUpdate adjustedUpdate = mutateInferenceConfigUpdate(instance.getUpdate(), version);
+
+        if (version.before(TransportVersions.V_8_3_0)) {
+            return new Request(
+                instance.getId(),
+                adjustedUpdate,
+                instance.getObjectsToInfer(),
+                null,
+                TimeValue.MAX_VALUE,
+                instance.isPreviouslyLicensed()
+            );
+        } else if (version.before(TransportVersions.V_8_7_0)) {
+            return new Request(
+                instance.getId(),
+                adjustedUpdate,
+                instance.getObjectsToInfer(),
+                null,
+                instance.getInferenceTimeout(),
+                instance.isPreviouslyLicensed()
+            );
+        } else if (version.before(TransportVersions.V_8_8_0)) {
+            var r = new Request(
+                instance.getId(),
+                adjustedUpdate,
+                instance.getObjectsToInfer(),
+                instance.getTextInput(),
+                instance.getInferenceTimeout(),
+                instance.isPreviouslyLicensed()
+            );
+            r.setHighPriority(false);
+            return r;
+        } else if (version.before(TransportVersions.V_8_12_0)) {
+            var r = new Request(
+                instance.getId(),
+                adjustedUpdate,
+                instance.getObjectsToInfer(),
+                instance.getTextInput(),
+                instance.getInferenceTimeout(),
+                instance.isPreviouslyLicensed()
+            );
+            r.setHighPriority(instance.isHighPriority());
+            r.setPrefixType(TrainedModelPrefixStrings.PrefixType.NONE);
+            return r;
+        } else if (version.before(TransportVersions.V_8_15_0)) {
+            var r = new Request(
+                instance.getId(),
+                adjustedUpdate,
+                instance.getObjectsToInfer(),
+                instance.getTextInput(),
+                instance.getInferenceTimeout(),
+                instance.isPreviouslyLicensed()
+            );
+            r.setHighPriority(instance.isHighPriority());
+            r.setPrefixType(instance.getPrefixType());
+            r.setChunked(false);  // r.setChunked(instance.isChunked()); for the next version
+            return r;
+        }
 
         return instance;
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/BertJapaneseTokenizationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/BertJapaneseTokenizationTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractBWCSerializationTestCase;
 import org.elasticsearch.xcontent.XContentParser;
@@ -20,6 +21,15 @@ public class BertJapaneseTokenizationTests extends AbstractBWCSerializationTestC
     private boolean lenient;
 
     public static BertJapaneseTokenization mutateForVersion(BertJapaneseTokenization instance, TransportVersion version) {
+        if (version.before(TransportVersions.V_8_2_0)) {
+            return new BertJapaneseTokenization(
+                instance.doLowerCase,
+                instance.withSpecialTokens,
+                instance.maxSequenceLength,
+                instance.truncate,
+                null
+            );
+        }
         return instance;
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/BertJapaneseTokenizationUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/BertJapaneseTokenizationUpdateTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCase;
 
@@ -74,6 +75,9 @@ public class BertJapaneseTokenizationUpdateTests extends AbstractBWCWireSerializ
 
     @Override
     protected BertJapaneseTokenizationUpdate mutateInstanceForVersion(BertJapaneseTokenizationUpdate instance, TransportVersion version) {
+        if (version.before(TransportVersions.V_8_2_0)) {
+            return new BertJapaneseTokenizationUpdate(instance.getTruncate(), null);
+        }
 
         return instance;
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/BertTokenizationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/BertTokenizationTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractBWCSerializationTestCase;
 import org.elasticsearch.xcontent.XContentParser;
@@ -22,6 +23,15 @@ public class BertTokenizationTests extends AbstractBWCSerializationTestCase<Bert
     private boolean lenient;
 
     public static BertTokenization mutateForVersion(BertTokenization instance, TransportVersion version) {
+        if (version.before(TransportVersions.V_8_2_0)) {
+            return new BertTokenization(
+                instance.doLowerCase,
+                instance.withSpecialTokens,
+                instance.maxSequenceLength,
+                instance.truncate,
+                null
+            );
+        }
         return instance;
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/BertTokenizationUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/BertTokenizationUpdateTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCase;
 
@@ -74,6 +75,9 @@ public class BertTokenizationUpdateTests extends AbstractBWCWireSerializationTes
 
     @Override
     protected BertTokenizationUpdate mutateInstanceForVersion(BertTokenizationUpdate instance, TransportVersion version) {
+        if (version.before(TransportVersions.V_8_2_0)) {
+            return new BertTokenizationUpdate(instance.getTruncate(), null);
+        }
 
         return instance;
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/MPNetTokenizationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/MPNetTokenizationTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractBWCSerializationTestCase;
 import org.elasticsearch.xcontent.XContentParser;
@@ -20,6 +21,15 @@ public class MPNetTokenizationTests extends AbstractBWCSerializationTestCase<MPN
     private boolean lenient;
 
     static MPNetTokenization mutateForVersion(MPNetTokenization instance, TransportVersion version) {
+        if (version.before(TransportVersions.V_8_2_0)) {
+            return new MPNetTokenization(
+                instance.doLowerCase,
+                instance.withSpecialTokens,
+                instance.maxSequenceLength,
+                instance.truncate,
+                null
+            );
+        }
         return instance;
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/MPNetTokenizationUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/MPNetTokenizationUpdateTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCase;
 
@@ -67,6 +68,9 @@ public class MPNetTokenizationUpdateTests extends AbstractBWCWireSerializationTe
 
     @Override
     protected MPNetTokenizationUpdate mutateInstanceForVersion(MPNetTokenizationUpdate instance, TransportVersion version) {
+        if (version.before(TransportVersions.V_8_2_0)) {
+            return new MPNetTokenizationUpdate(instance.getTruncate(), null);
+        }
 
         return instance;
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/RobertaTokenizationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/RobertaTokenizationTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractBWCSerializationTestCase;
 import org.elasticsearch.xcontent.XContentParser;
@@ -20,6 +21,15 @@ public class RobertaTokenizationTests extends AbstractBWCSerializationTestCase<R
     private boolean lenient;
 
     public static RobertaTokenization mutateForVersion(RobertaTokenization instance, TransportVersion version) {
+        if (version.before(TransportVersions.V_8_2_0)) {
+            return new RobertaTokenization(
+                instance.withSpecialTokens,
+                instance.isAddPrefixSpace(),
+                instance.maxSequenceLength,
+                instance.truncate,
+                null
+            );
+        }
         return instance;
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/RobertaTokenizationUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/RobertaTokenizationUpdateTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCase;
 
@@ -67,6 +68,9 @@ public class RobertaTokenizationUpdateTests extends AbstractBWCWireSerialization
 
     @Override
     protected RobertaTokenizationUpdate mutateInstanceForVersion(RobertaTokenizationUpdate instance, TransportVersion version) {
+        if (version.before(TransportVersions.V_8_2_0)) {
+            return new RobertaTokenizationUpdate(instance.getTruncate(), null);
+        }
 
         return instance;
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/XLMRobertaTokenizationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/XLMRobertaTokenizationTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractBWCSerializationTestCase;
 import org.elasticsearch.xcontent.XContentParser;
@@ -20,6 +21,9 @@ public class XLMRobertaTokenizationTests extends AbstractBWCSerializationTestCas
     private boolean lenient;
 
     public static XLMRobertaTokenization mutateForVersion(XLMRobertaTokenization instance, TransportVersion version) {
+        if (version.before(TransportVersions.V_8_2_0)) {
+            return new XLMRobertaTokenization(instance.withSpecialTokens, instance.maxSequenceLength, instance.truncate, null);
+        }
         return instance;
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/XLMRobertaTokenizationUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/XLMRobertaTokenizationUpdateTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCase;
 
@@ -67,6 +68,9 @@ public class XLMRobertaTokenizationUpdateTests extends AbstractBWCWireSerializat
 
     @Override
     protected XLMRobertaTokenizationUpdate mutateInstanceForVersion(XLMRobertaTokenizationUpdate instance, TransportVersion version) {
+        if (version.before(TransportVersions.V_8_2_0)) {
+            return new XLMRobertaTokenizationUpdate(instance.getTruncate(), null);
+        }
 
         return instance;
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ssl/cert/CertificateInfoTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ssl/cert/CertificateInfoTests.java
@@ -6,10 +6,19 @@
  */
 package org.elasticsearch.xpack.core.ssl.cert;
 
+import org.elasticsearch.TransportVersions;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.InputStreamStreamInput;
+import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xpack.core.ssl.CertParsingUtils;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
@@ -18,7 +27,9 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 
 public class CertificateInfoTests extends ESTestCase {
 
@@ -75,6 +86,24 @@ public class CertificateInfoTests extends ESTestCase {
         );
         assertNotEquals(certificate.getSubjectX500Principal().toString(), certificateInfo.issuer());
         assertEquals("CN=root-ca, OU=test, O=elasticsearch, C=US", certificateInfo.issuer());
+    }
+
+    public void testMissingIssuer() throws Exception {
+        // only possible in mixed versions if object is serialized from an old version
+        final CertificateInfo certInfo = new CertificateInfo("/path/to/cert", "jks", "a", true, readSampleCertificate(selfSignedCertPath));
+        // send from old
+        ByteArrayOutputStream outBuffer = new ByteArrayOutputStream();
+        OutputStreamStreamOutput out = new OutputStreamStreamOutput(outBuffer);
+        out.setTransportVersion(TransportVersions.V_8_3_0);
+        certInfo.writeTo(out);
+        // receive from old
+        ByteArrayInputStream inBuffer = new ByteArrayInputStream(outBuffer.toByteArray());
+        StreamInput in = new InputStreamStreamInput(inBuffer);
+        in.setTransportVersion(TransportVersions.V_8_3_0);
+        CertificateInfo certInfoFromOld = new CertificateInfo(in);
+        // convert to a JSON string
+        String toXContentString = Strings.toString(certInfoFromOld.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS));
+        assertThat(toXContentString, not(containsString("issuer")));
     }
 
     private X509Certificate readSampleCertificate(String dataPath) throws CertificateException, IOException {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/CategorizeTextAggregationBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/CategorizeTextAggregationBuilder.java
@@ -7,9 +7,12 @@
 
 package org.elasticsearch.xpack.ml.aggs.categorization;
 
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
@@ -40,6 +43,15 @@ public class CategorizeTextAggregationBuilder extends AbstractAggregationBuilder
         new TermsAggregator.ConstantBucketCountThresholds(1, 0, 10, -1);
 
     public static final String NAME = "categorize_text";
+
+    // In 8.3 the algorithm used by this aggregation was completely changed.
+    // Prior to 8.3 the Drain algorithm was used. From 8.3 the same algorithm
+    // we use in our C++ categorization code was used. As a result of this
+    // the aggregation will not perform well in mixed version clusters where
+    // some nodes are pre-8.3 and others are newer, so we throw an error in
+    // this situation. The aggregation was experimental at the time this change
+    // was made, so this is acceptable.
+    public static final TransportVersion ALGORITHM_CHANGED_VERSION = TransportVersions.V_8_3_0;
 
     static final ParseField FIELD_NAME = new ParseField("field");
     static final ParseField SIMILARITY_THRESHOLD = new ParseField("similarity_threshold");
@@ -106,6 +118,16 @@ public class CategorizeTextAggregationBuilder extends AbstractAggregationBuilder
     public CategorizeTextAggregationBuilder(StreamInput in) throws IOException {
         super(in);
         // Disallow this aggregation in mixed version clusters that cross the algorithm change boundary.
+        if (in.getTransportVersion().before(ALGORITHM_CHANGED_VERSION)) {
+            throw new ElasticsearchStatusException(
+                "["
+                    + NAME
+                    + "] aggregation cannot be used in a cluster where some nodes have version ["
+                    + ALGORITHM_CHANGED_VERSION.toReleaseVersion()
+                    + "] or higher and others have a version before this",
+                RestStatus.BAD_REQUEST
+            );
+        }
         this.bucketCountThresholds = new TermsAggregator.BucketCountThresholds(in);
         this.fieldName = in.readString();
         this.similarityThreshold = in.readVInt();
@@ -253,6 +275,16 @@ public class CategorizeTextAggregationBuilder extends AbstractAggregationBuilder
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
         // Disallow this aggregation in mixed version clusters that cross the algorithm change boundary.
+        if (out.getTransportVersion().before(ALGORITHM_CHANGED_VERSION)) {
+            throw new ElasticsearchStatusException(
+                "["
+                    + NAME
+                    + "] aggregation cannot be used in a cluster where some nodes have version ["
+                    + ALGORITHM_CHANGED_VERSION.toReleaseVersion()
+                    + "] or higher and others have a version before this",
+                RestStatus.BAD_REQUEST
+            );
+        }
         bucketCountThresholds.writeTo(out);
         out.writeString(fieldName);
         out.writeVInt(similarityThreshold);
@@ -308,6 +340,10 @@ public class CategorizeTextAggregationBuilder extends AbstractAggregationBuilder
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {
-        return TransportVersion.minimumCompatible();
+        // This isn't strictly true, as the categorize_text aggregation has existed since 7.16.
+        // However, the implementation completely changed in 8.3, so it's best that if the
+        // coordinating node is on 8.3 or above then it should refuse to use this aggregation
+        // until the older nodes are upgraded.
+        return ALGORITHM_CHANGED_VERSION;
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/InternalCategorizationAggregation.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/InternalCategorizationAggregation.java
@@ -8,9 +8,11 @@
 package org.elasticsearch.xpack.ml.aggs.categorization;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.BytesRefHash;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.AggregatorReducer;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -107,6 +109,16 @@ public class InternalCategorizationAggregation extends InternalMultiBucketAggreg
 
         public Bucket(StreamInput in) throws IOException {
             // Disallow this aggregation in mixed version clusters that cross the algorithm change boundary.
+            if (in.getTransportVersion().before(CategorizeTextAggregationBuilder.ALGORITHM_CHANGED_VERSION)) {
+                throw new ElasticsearchStatusException(
+                    "["
+                        + CategorizeTextAggregationBuilder.NAME
+                        + "] aggregation cannot be used in a cluster where some nodes have version ["
+                        + CategorizeTextAggregationBuilder.ALGORITHM_CHANGED_VERSION.toReleaseVersion()
+                        + "] or higher and others have a version before this",
+                    RestStatus.BAD_REQUEST
+                );
+            }
             serializableCategory = new SerializableTokenListCategory(in);
             key = new BucketKey(serializableCategory);
             bucketOrd = -1;
@@ -116,6 +128,16 @@ public class InternalCategorizationAggregation extends InternalMultiBucketAggreg
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             // Disallow this aggregation in mixed version clusters that cross the algorithm change boundary.
+            if (out.getTransportVersion().before(CategorizeTextAggregationBuilder.ALGORITHM_CHANGED_VERSION)) {
+                throw new ElasticsearchStatusException(
+                    "["
+                        + CategorizeTextAggregationBuilder.NAME
+                        + "] aggregation cannot be used in a cluster where some nodes have version ["
+                        + CategorizeTextAggregationBuilder.ALGORITHM_CHANGED_VERSION.toReleaseVersion()
+                        + "] or higher and others have a version before this",
+                    RestStatus.BAD_REQUEST
+                );
+            }
             serializableCategory.writeTo(out);
             aggregations.writeTo(out);
         }
@@ -217,6 +239,16 @@ public class InternalCategorizationAggregation extends InternalMultiBucketAggreg
     public InternalCategorizationAggregation(StreamInput in) throws IOException {
         super(in);
         // Disallow this aggregation in mixed version clusters that cross the algorithm change boundary.
+        if (in.getTransportVersion().before(CategorizeTextAggregationBuilder.ALGORITHM_CHANGED_VERSION)) {
+            throw new ElasticsearchStatusException(
+                "["
+                    + CategorizeTextAggregationBuilder.NAME
+                    + "] aggregation cannot be used in a cluster where some nodes have version ["
+                    + CategorizeTextAggregationBuilder.ALGORITHM_CHANGED_VERSION.toReleaseVersion()
+                    + "] or higher and others have a version before this",
+                RestStatus.BAD_REQUEST
+            );
+        }
         this.similarityThreshold = in.readVInt();
         this.buckets = in.readCollectionAsList(Bucket::new);
         this.requiredSize = readSize(in);
@@ -226,6 +258,16 @@ public class InternalCategorizationAggregation extends InternalMultiBucketAggreg
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
         // Disallow this aggregation in mixed version clusters that cross the algorithm change boundary.
+        if (out.getTransportVersion().before(CategorizeTextAggregationBuilder.ALGORITHM_CHANGED_VERSION)) {
+            throw new ElasticsearchStatusException(
+                "["
+                    + CategorizeTextAggregationBuilder.NAME
+                    + "] aggregation cannot be used in a cluster where some nodes have version ["
+                    + CategorizeTextAggregationBuilder.ALGORITHM_CHANGED_VERSION.toReleaseVersion()
+                    + "] or higher and others have a version before this",
+                RestStatus.BAD_REQUEST
+            );
+        }
         out.writeVInt(similarityThreshold);
         out.writeCollection(buckets);
         writeSize(requiredSize, out);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/changepoint/ChangePointAggregationBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/changepoint/ChangePointAggregationBuilder.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.ml.aggs.changepoint;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.aggregations.pipeline.BucketHelpers;
@@ -59,7 +60,7 @@ public class ChangePointAggregationBuilder extends BucketMetricsPipelineAggregat
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {
-        return TransportVersion.minimumCompatible();
+        return TransportVersions.V_8_2_0;
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/FrequentItemSetsAggregationBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/FrequentItemSetsAggregationBuilder.java
@@ -262,7 +262,7 @@ public final class FrequentItemSetsAggregationBuilder extends AbstractAggregatio
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {
-        return TransportVersion.minimumCompatible();
+        return TransportVersions.V_8_4_0;
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/Vocabulary.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/Vocabulary.java
@@ -64,7 +64,11 @@ public class Vocabulary implements Writeable, ToXContentObject {
     public Vocabulary(StreamInput in) throws IOException {
         vocab = in.readStringCollectionAsList();
         modelId = in.readString();
-        merges = in.readStringCollectionAsList();
+        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_2_0)) {
+            merges = in.readStringCollectionAsList();
+        } else {
+            merges = List.of();
+        }
         if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_9_X)) {
             scores = in.readCollectionAsList(StreamInput::readDouble);
         } else {
@@ -88,7 +92,9 @@ public class Vocabulary implements Writeable, ToXContentObject {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeStringCollection(vocab);
         out.writeString(modelId);
-        out.writeStringCollection(merges);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_2_0)) {
+            out.writeStringCollection(merges);
+        }
         if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_9_X)) {
             out.writeCollection(scores, StreamOutput::writeDouble);
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
@@ -197,8 +197,11 @@ public class TokenService {
     // UUIDs are 16 bytes encoded base64 without padding, therefore the length is (16 / 3) * 4 + ((16 % 3) * 8 + 5) / 6 chars
     private static final int TOKEN_LENGTH = 22;
     private static final String TOKEN_DOC_ID_PREFIX = TOKEN_DOC_TYPE + "_";
+    static final int LEGACY_MINIMUM_BYTES = VERSION_BYTES + SALT_BYTES + IV_BYTES + 1;
     static final int MINIMUM_BYTES = VERSION_BYTES + TOKEN_LENGTH + 1;
+    static final int LEGACY_MINIMUM_BASE64_BYTES = Double.valueOf(Math.ceil((4 * LEGACY_MINIMUM_BYTES) / 3)).intValue();
     public static final int MINIMUM_BASE64_BYTES = Double.valueOf(Math.ceil((4 * MINIMUM_BYTES) / 3)).intValue();
+    static final TransportVersion VERSION_CLIENT_AUTH_FOR_REFRESH = TransportVersions.V_8_2_0;
     static final TransportVersion VERSION_GET_TOKEN_DOC_FOR_REFRESH = TransportVersions.V_8_10_X;
 
     private static final Logger logger = LogManager.getLogger(TokenService.class);
@@ -1802,10 +1805,18 @@ public class TokenService {
                     .field("refreshed", false)
                     .startObject("client")
                     .field("type", "unassociated_client");
-                builder.field(
-                    "authentication",
-                    originatingClientAuth.maybeRewriteForOlderVersion(userToken.getTransportVersion()).encode()
-                );
+                if (userToken.getTransportVersion().onOrAfter(VERSION_CLIENT_AUTH_FOR_REFRESH)) {
+                    builder.field(
+                        "authentication",
+                        originatingClientAuth.maybeRewriteForOlderVersion(userToken.getTransportVersion()).encode()
+                    );
+                } else {
+                    builder.field("user", originatingClientAuth.getEffectiveSubject().getUser().principal())
+                        .field("realm", originatingClientAuth.getAuthenticatingSubject().getRealm().getName());
+                    if (originatingClientAuth.getAuthenticatingSubject().getRealm().getDomain() != null) {
+                        builder.field("realm_domain", originatingClientAuth.getAuthenticatingSubject().getRealm().getDomain());
+                    }
+                }
                 builder.endObject().endObject();
             }
             final Authentication.RealmRef userTokenEffectiveRealm = userToken.getAuthentication().getEffectiveSubject().getRealm();
@@ -2477,6 +2488,7 @@ public class TokenService {
             String iv,
             String salt
         ) {
+            assert associatedAuthentication.getEffectiveSubject().getTransportVersion().onOrAfter(VERSION_CLIENT_AUTH_FOR_REFRESH);
             this.invalidated = invalidated;
             // not used, filled-in for consistency's sake
             this.associatedUser = associatedAuthentication.getEffectiveSubject().getUser().principal();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
@@ -119,6 +119,7 @@ import static org.elasticsearch.test.TestMatchers.throwableWithMessage;
 import static org.elasticsearch.xpack.security.authc.TokenService.RAW_TOKEN_BYTES_LENGTH;
 import static org.elasticsearch.xpack.security.authc.TokenService.RAW_TOKEN_BYTES_TOTAL_LENGTH;
 import static org.elasticsearch.xpack.security.authc.TokenService.RAW_TOKEN_DOC_ID_BYTES_LENGTH;
+import static org.elasticsearch.xpack.security.authc.TokenService.VERSION_CLIENT_AUTH_FOR_REFRESH;
 import static org.elasticsearch.xpack.security.authc.TokenService.VERSION_GET_TOKEN_DOC_FOR_REFRESH;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.contains;
@@ -405,7 +406,20 @@ public class TokenServiceTests extends ESTestCase {
         String iv,
         String salt
     ) {
-        return new RefreshTokenStatus(invalidated, authentication, refreshed, refreshInstant, supersedingTokens, iv, salt);
+        if (authentication.getEffectiveSubject().getTransportVersion().onOrAfter(VERSION_CLIENT_AUTH_FOR_REFRESH)) {
+            return new RefreshTokenStatus(invalidated, authentication, refreshed, refreshInstant, supersedingTokens, iv, salt);
+        } else {
+            return new RefreshTokenStatus(
+                invalidated,
+                authentication.getEffectiveSubject().getUser().principal(),
+                authentication.getAuthenticatingSubject().getRealm().getName(),
+                refreshed,
+                refreshInstant,
+                supersedingTokens,
+                iv,
+                salt
+            );
+        }
     }
 
     private void storeTokenHeader(ThreadContext requestContext, String tokenString) {

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/query/GeoGridQueryBuilder.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/query/GeoGridQueryBuilder.java
@@ -14,6 +14,7 @@ import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -42,17 +43,14 @@ import java.util.Objects;
 /**
  * Creates a Lucene query that will filter for all documents that intersects the specified
  * bin of a grid.
- * <p>
+ *
  * It supports geohash and geotile grids for both GeoShape and GeoPoint and the geohex grid
  * only for GeoPoint.
- *
- */
+ * */
 public class GeoGridQueryBuilder extends AbstractQueryBuilder<GeoGridQueryBuilder> {
     public static final String NAME = "geo_grid";
 
-    /**
-     * Grids supported by this query
-     */
+    /** Grids supported by this query */
     public enum Grid {
         GEOHASH {
 
@@ -205,9 +203,7 @@ public class GeoGridQueryBuilder extends AbstractQueryBuilder<GeoGridQueryBuilde
     private static final boolean DEFAULT_IGNORE_UNMAPPED = false;
     private static final ParseField IGNORE_UNMAPPED_FIELD = new ParseField("ignore_unmapped");
 
-    /**
-     * Name of field holding geo coordinates to compute the bounding box on.
-     */
+    /** Name of field holding geo coordinates to compute the bounding box on.*/
     private final String fieldName;
     private Grid grid;
     private String gridId;
@@ -215,10 +211,8 @@ public class GeoGridQueryBuilder extends AbstractQueryBuilder<GeoGridQueryBuilde
 
     /**
      * Create new grid query.
-     *
      * @param fieldName name of index field containing geo coordinates to operate on.
-     *
-     */
+     * */
     public GeoGridQueryBuilder(String fieldName) {
         if (fieldName == null) {
             throw new IllegalArgumentException("Field name must not be empty.");
@@ -247,8 +241,7 @@ public class GeoGridQueryBuilder extends AbstractQueryBuilder<GeoGridQueryBuilde
 
     /**
      * Adds the grid and the gridId
-     *
-     * @param grid   The type of grid
+     * @param grid The type of grid
      * @param gridId The grid bin identifier
      */
     public GeoGridQueryBuilder setGridId(Grid grid, String gridId) {
@@ -258,9 +251,7 @@ public class GeoGridQueryBuilder extends AbstractQueryBuilder<GeoGridQueryBuilde
         return this;
     }
 
-    /**
-     * Returns the name of the field to base the grid computation on.
-     */
+    /** Returns the name of the field to base the grid computation on. */
     public String fieldName() {
         return this.fieldName;
     }
@@ -409,6 +400,6 @@ public class GeoGridQueryBuilder extends AbstractQueryBuilder<GeoGridQueryBuilde
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {
-        return TransportVersion.minimumCompatible();
+        return TransportVersions.V_8_3_0;
     }
 }

--- a/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlQueryRequest.java
+++ b/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlQueryRequest.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.sql.action;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -162,7 +163,7 @@ public class SqlQueryRequest extends AbstractSqlQueryRequest {
         this.waitForCompletionTimeout = in.readOptionalTimeValue();
         this.keepOnCompletion = in.readBoolean();
         this.keepAlive = in.readOptionalTimeValue();
-        allowPartialSearchResults = in.readBoolean();
+        allowPartialSearchResults = in.getTransportVersion().onOrAfter(TransportVersions.V_8_3_0) && in.readBoolean();
     }
 
     /**
@@ -294,7 +295,9 @@ public class SqlQueryRequest extends AbstractSqlQueryRequest {
         out.writeOptionalTimeValue(waitForCompletionTimeout);
         out.writeBoolean(keepOnCompletion);
         out.writeOptionalTimeValue(keepAlive);
-        out.writeBoolean(allowPartialSearchResults);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_3_0)) {
+            out.writeBoolean(allowPartialSearchResults);
+        }
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/SearchHitCursor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/SearchHitCursor.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.sql.execution.search;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
@@ -68,7 +69,7 @@ public class SearchHitCursor implements Cursor {
         extractors = in.readNamedWriteableCollectionAsList(HitExtractor.class);
         mask = BitSet.valueOf(in.readByteArray());
         includeFrozen = in.readBoolean();
-        allowPartialSearchResults = in.readBoolean();
+        allowPartialSearchResults = in.getTransportVersion().onOrAfter(TransportVersions.V_8_3_0) && in.readBoolean();
     }
 
     @Override
@@ -79,7 +80,9 @@ public class SearchHitCursor implements Cursor {
         out.writeNamedWriteableCollection(extractors);
         out.writeByteArray(mask.toByteArray());
         out.writeBoolean(includeFrozen);
-        out.writeBoolean(allowPartialSearchResults);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_3_0)) {
+            out.writeBoolean(allowPartialSearchResults);
+        }
     }
 
     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/index/VersionCompatibilityChecks.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/index/VersionCompatibilityChecks.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.sql.index;
 
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.sql.proto.SqlVersion;
@@ -19,6 +21,8 @@ import static org.elasticsearch.xpack.sql.proto.VersionCompatibility.supportsUns
 import static org.elasticsearch.xpack.sql.proto.VersionCompatibility.supportsVersionType;
 
 public final class VersionCompatibilityChecks {
+
+    public static final TransportVersion INTRODUCING_UNSIGNED_LONG_TRANSPORT = TransportVersions.V_8_2_0;
 
     private VersionCompatibilityChecks() {}
 

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/checkpoint/TransformGetCheckpointTests.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/checkpoint/TransformGetCheckpointTests.java
@@ -7,7 +7,7 @@
 
 package org.elasticsearch.xpack.transform.checkpoint;
 
-import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.LatchedActionListener;
@@ -133,7 +133,7 @@ public class TransformGetCheckpointTests extends ESSingleNodeTestCase {
         testIndices = testIndicesList.toArray(new String[0]);
 
         clusterStateWithIndex = ClusterState.builder(ClusterStateCreationUtils.state(numberOfNodes, testIndices, numberOfShards))
-            .putCompatibilityVersions("node01", TransportVersion.minimumCompatible(), Map.of())
+            .putCompatibilityVersions("node01", TransportVersions.V_8_5_0, Map.of())
             .build();
 
         client = mock(Client.class);

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetCheckpointAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetCheckpointAction.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.transform.action;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.action.NoShardAvailableActionException;
@@ -37,6 +38,7 @@ import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.transport.ActionNotFoundTransportException;
 import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TransportService;
@@ -164,6 +166,9 @@ public class TransportGetCheckpointAction extends HandledTransportAction<Request
             }
             if (shard.assignedToNode() && nodes.get(shard.currentNodeId()) != null) {
                 // special case: The minimum TransportVersion in the cluster is on an old version
+                if (clusterState.getMinTransportVersion().before(TransportVersions.V_8_2_0)) {
+                    throw new ActionNotFoundTransportException(GetCheckpointNodeAction.NAME);
+                }
 
                 String nodeId = shard.currentNodeId();
                 nodesAndShards.computeIfAbsent(nodeId, k -> new HashSet<>()).add(shard.shardId());


### PR DESCRIPTION
This reverts commit d117362515c343bf250a0152c48033905f2e300f.

https://github.com/elastic/elasticsearch-serverless/issues/4688