### PR TITLE
Bugfix 136545

### DIFF
--- a/docs/changelog/136556.yaml
+++ b/docs/changelog/136556.yaml
@@ -1,0 +1,5 @@
+pr: 136556
+summary: Bugfix 136545
+area: Vector Search
+type: bug
+issues: []

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/240_source_synthetic_dense_vectors.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/240_source_synthetic_dense_vectors.yml
@@ -21,7 +21,10 @@ setup:
                 type: dense_vector
                 dims: 3
                 similarity: l2_norm
-
+              vector2:
+                type: dense_vector
+                dims: 3
+                similarity: l2_norm
               nested:
                 type: nested
                 properties:
@@ -39,6 +42,7 @@ setup:
         body:
           name: cow.jpg
           vector: [1, 2, 3]
+          vector2: [1, 2, 3]
 
   - do:
       index:
@@ -213,7 +217,6 @@ setup:
   - length:     { hits.hits.3._source.nested: 3 }
   - not_exists:   hits.hits.3._source.nested.0.vector
 
-
 ---
 "Bulk partial update with synthetic vectors":
   - do:
@@ -342,3 +345,52 @@ setup:
   - match: { hits.total.relation: eq }
   - match: { hits.hits.0._source.name: zoolander3.jpg }
   - match: { hits.hits.0._source.nested: $original_nested }
+
+---
+"Ensure both fields and docvalue_fields are supported":
+  - requires:
+      cluster_features: ["mapper.exclude_vectors_docvalue_bugfix"]
+      reason: "Bugfix for issue #136545"
+  - do:
+      headers:
+        Content-Type: application/json
+      indices.create:
+        index: just_vectors
+        body:
+          mappings:
+            properties:
+              vector1:
+                type: dense_vector
+                dims: 5
+                index: true
+                element_type: float
+                similarity: cosine
+              vector2:
+                type: dense_vector
+                dims: 5
+                element_type: float
+                index: false
+          settings:
+            index:
+              mapping:
+                exclude_source_vectors: true
+  - do:
+      headers:
+        Content-Type: application/json
+      index:
+        refresh: true
+        index: just_vectors
+        id: "1"
+        body:
+          vector1: [230.0, 300.33, -34.8988, 15.555, -200.0]
+          vector2: [230.0, 300.33, -34.8988, 15.555, -200.0]
+  # shouldn't throw
+  - do:
+      headers:
+        Content-Type: application/json
+      search:
+        index: just_vectors
+        body:
+          _source: false
+          fields: ["vector1"]
+          docvalue_fields: ["vector2"]

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/240_source_synthetic_dense_vectors.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/240_source_synthetic_dense_vectors.yml
@@ -21,10 +21,7 @@ setup:
                 type: dense_vector
                 dims: 3
                 similarity: l2_norm
-              vector2:
-                type: dense_vector
-                dims: 3
-                similarity: l2_norm
+
               nested:
                 type: nested
                 properties:
@@ -42,7 +39,6 @@ setup:
         body:
           name: cow.jpg
           vector: [1, 2, 3]
-          vector2: [1, 2, 3]
 
   - do:
       index:

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -57,6 +57,7 @@ public class MapperFeatures implements FeatureSpecification {
     static final NodeFeature INDEX_MAPPING_IGNORE_DYNAMIC_BEYOND_FIELD_NAME_LIMIT = new NodeFeature(
         "mapper.ignore_dynamic_field_names_beyond_limit"
     );
+    static final NodeFeature EXCLUDE_VECTORS_DOCVALUE_BUGFIX = new NodeFeature("mapper.exclude_vectors_docvalue_bugfix");
 
     @Override
     public Set<NodeFeature> getTestFeatures() {
@@ -97,7 +98,8 @@ public class MapperFeatures implements FeatureSpecification {
             PATTERN_TEXT_RENAME,
             DISKBBQ_ON_DISK_RESCORING,
             PROVIDE_INDEX_SORT_SETTING_DEFAULTS,
-            INDEX_MAPPING_IGNORE_DYNAMIC_BEYOND_FIELD_NAME_LIMIT
+            INDEX_MAPPING_IGNORE_DYNAMIC_BEYOND_FIELD_NAME_LIMIT,
+            EXCLUDE_VECTORS_DOCVALUE_BUGFIX
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceLoader.java
@@ -24,6 +24,7 @@ import org.elasticsearch.xcontent.json.JsonXContent;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -467,6 +468,10 @@ public interface SourceLoader {
      */
     static Source applySyntheticVectors(Source originalSource, List<SyntheticVectorPatch> patches) {
         Map<String, Object> newMap = originalSource.source();
+        // Make sure we have a mutable map, empty implies `Map.of()`
+        if (newMap.isEmpty()) {
+            newMap = new LinkedHashMap<>();
+        }
         applyPatches("", newMap, patches);
         return Source.fromMap(newMap, originalSource.sourceContentType());
     }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
@@ -187,11 +187,6 @@ public abstract class MapperServiceTestCase extends FieldTypeTestCase {
         return createMapperService(getVersion(), settings, () -> true, mappings);
     }
 
-    public final MapperService createSyntheticVectorsSourceMapperService(XContentBuilder mappings) throws IOException {
-        var settings = Settings.builder().put("index.mapping.exclude_source_vectors", "true").build();
-        return createMapperService(getVersion(), settings, () -> true, mappings);
-    }
-
     protected IndexVersion getVersion() {
         return IndexVersion.current();
     }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
@@ -187,6 +187,11 @@ public abstract class MapperServiceTestCase extends FieldTypeTestCase {
         return createMapperService(getVersion(), settings, () -> true, mappings);
     }
 
+    public final MapperService createSyntheticVectorsSourceMapperService(XContentBuilder mappings) throws IOException {
+        var settings = Settings.builder().put("index.mapping.exclude_source_vectors", "true").build();
+        return createMapperService(getVersion(), settings, () -> true, mappings);
+    }
+
     protected IndexVersion getVersion() {
         return IndexVersion.current();
     }


### PR DESCRIPTION
Sometimes, when the _source is empty, the underlying code will return `Map.of()` which is immutable. We don't really have an `isImmutable()` flag for Java objects (I mean...why not??), so I defaulted to assuming `isEmpty()` implies immutable and we create a new ordered map.


closes: https://github.com/elastic/elasticsearch/issues/136545