### PR TITLE
Bugfix/disable matches highlight knn

### DIFF
--- a/docs/changelog/136563.yaml
+++ b/docs/changelog/136563.yaml
@@ -1,0 +1,5 @@
+pr: 136563
+summary: Bugfix/disable matches highlight knn
+area: Vector Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/lucene/search/uhighlight/CustomUnifiedHighlighter.java
+++ b/server/src/main/java/org/elasticsearch/lucene/search/uhighlight/CustomUnifiedHighlighter.java
@@ -64,14 +64,17 @@ import static org.elasticsearch.search.fetch.subphase.highlight.AbstractHighligh
  */
 public final class CustomUnifiedHighlighter extends UnifiedHighlighter {
     private static boolean isKnnQuery(Query q) {
+        // TODO: bug https://github.com/elastic/elasticsearch/issues/136427
+        // AbstractKnnVectorQuery is not public, so we need to list concrete classes
+        // currently there is a bug in Lucene that causes things that use
+        // AbstractKnnVectorQuery to throw NPEs in weight matches highlighting
         return q instanceof KnnScoreDocQuery
             || q instanceof RescoreKnnVectorQuery
             || q instanceof VectorSimilarityQuery
             || q instanceof ESKnnFloatVectorQuery
             || q instanceof ESKnnByteVectorQuery
             || q instanceof ESDiversifyingChildrenByteKnnVectorQuery
-            || q instanceof ESDiversifyingChildrenFloatKnnVectorQuery
-            || q instanceof IVFKnnFloatVectorQuery;
+            || q instanceof ESDiversifyingChildrenFloatKnnVectorQuery;
     }
 
     public static final char MULTIVAL_SEP_CHAR = (char) 0;

--- a/server/src/main/java/org/elasticsearch/lucene/search/uhighlight/CustomUnifiedHighlighter.java
+++ b/server/src/main/java/org/elasticsearch/lucene/search/uhighlight/CustomUnifiedHighlighter.java
@@ -39,7 +39,6 @@ import org.elasticsearch.search.vectors.ESDiversifyingChildrenByteKnnVectorQuery
 import org.elasticsearch.search.vectors.ESDiversifyingChildrenFloatKnnVectorQuery;
 import org.elasticsearch.search.vectors.ESKnnByteVectorQuery;
 import org.elasticsearch.search.vectors.ESKnnFloatVectorQuery;
-import org.elasticsearch.search.vectors.IVFKnnFloatVectorQuery;
 import org.elasticsearch.search.vectors.KnnScoreDocQuery;
 import org.elasticsearch.search.vectors.RescoreKnnVectorQuery;
 import org.elasticsearch.search.vectors.VectorSimilarityQuery;


### PR DESCRIPTION
There is currently a bug in Lucene where kNN will throw an NPE when utilizing matches mode.

In the future, we can likely go back to the traditional check of just the KnnDoc query. But until then, let's just stop hard failing with an NPE and simply skip weight matches for now.


closes: https://github.com/elastic/elasticsearch/issues/136427