### PR TITLE
[9.2] Bugfix 136545 (#136556)

### DIFF
--- a/docs/changelog/136556.yaml
+++ b/docs/changelog/136556.yaml
@@ -1,0 +1,5 @@
+pr: 136556
+summary: Bugfix 136545
+area: Vector Search
+type: bug
+issues: []

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/240_source_synthetic_dense_vectors.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/240_source_synthetic_dense_vectors.yml
@@ -213,7 +213,6 @@ setup:
   - length:     { hits.hits.3._source.nested: 3 }
   - not_exists:   hits.hits.3._source.nested.0.vector
 
-
 ---
 "Bulk partial update with synthetic vectors":
   - do:
@@ -342,3 +341,52 @@ setup:
   - match: { hits.total.relation: eq }
   - match: { hits.hits.0._source.name: zoolander3.jpg }
   - match: { hits.hits.0._source.nested: $original_nested }
+
+---
+"Ensure both fields and docvalue_fields are supported":
+  - requires:
+      cluster_features: ["mapper.exclude_vectors_docvalue_bugfix"]
+      reason: "Bugfix for issue #136545"
+  - do:
+      headers:
+        Content-Type: application/json
+      indices.create:
+        index: just_vectors
+        body:
+          mappings:
+            properties:
+              vector1:
+                type: dense_vector
+                dims: 5
+                index: true
+                element_type: float
+                similarity: cosine
+              vector2:
+                type: dense_vector
+                dims: 5
+                element_type: float
+                index: false
+          settings:
+            index:
+              mapping:
+                exclude_source_vectors: true
+  - do:
+      headers:
+        Content-Type: application/json
+      index:
+        refresh: true
+        index: just_vectors
+        id: "1"
+        body:
+          vector1: [230.0, 300.33, -34.8988, 15.555, -200.0]
+          vector2: [230.0, 300.33, -34.8988, 15.555, -200.0]
+  # shouldn't throw
+  - do:
+      headers:
+        Content-Type: application/json
+      search:
+        index: just_vectors
+        body:
+          _source: false
+          fields: ["vector1"]
+          docvalue_fields: ["vector2"]

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -52,6 +52,7 @@ public class MapperFeatures implements FeatureSpecification {
     static final NodeFeature IGNORED_SOURCE_FIELDS_PER_ENTRY = new NodeFeature("mapper.ignored_source_fields_per_entry");
     public static final NodeFeature MULTI_FIELD_UNICODE_OPTIMISATION_FIX = new NodeFeature("mapper.multi_field.unicode_optimisation_fix");
     static final NodeFeature PATTERN_TEXT_RENAME = new NodeFeature("mapper.pattern_text_rename");
+    static final NodeFeature EXCLUDE_VECTORS_DOCVALUE_BUGFIX = new NodeFeature("mapper.exclude_vectors_docvalue_bugfix");
 
     @Override
     public Set<NodeFeature> getTestFeatures() {
@@ -89,7 +90,8 @@ public class MapperFeatures implements FeatureSpecification {
             IGNORED_SOURCE_FIELDS_PER_ENTRY,
             MULTI_FIELD_UNICODE_OPTIMISATION_FIX,
             MATCH_ONLY_TEXT_BLOCK_LOADER_FIX,
-            PATTERN_TEXT_RENAME
+            PATTERN_TEXT_RENAME,
+            EXCLUDE_VECTORS_DOCVALUE_BUGFIX
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceLoader.java
@@ -24,6 +24,7 @@ import org.elasticsearch.xcontent.json.JsonXContent;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -467,6 +468,10 @@ public interface SourceLoader {
      */
     static Source applySyntheticVectors(Source originalSource, List<SyntheticVectorPatch> patches) {
         Map<String, Object> newMap = originalSource.source();
+        // Make sure we have a mutable map, empty implies `Map.of()`
+        if (newMap.isEmpty()) {
+            newMap = new LinkedHashMap<>();
+        }
         applyPatches("", newMap, patches);
         return Source.fromMap(newMap, originalSource.sourceContentType());
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Bugfix 136545 (#136556)](https://github.com/elastic/elasticsearch/pull/136556)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)