### PR TITLE
Suggest ./gradlew instead of ./gradle

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/ValidateTransportVersionReferencesTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/ValidateTransportVersionReferencesTask.java
@@ -59,7 +59,7 @@ public abstract class ValidateTransportVersionReferencesTask extends PrecommitTa
                         + "\") was used at "
                         + tvReference.location()
                         + ", but lacks a transport version definition. "
-                        + "If this is a new transport version, run './gradle generateTransportVersion'."
+                        + "If this is a new transport version, run './gradlew generateTransportVersion'."
                 );
             }
         }

--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -257,7 +257,7 @@ public record TransportVersion(String name, int id, TransportVersion nextPatchVe
                 message.append(names);
                 message.append("?");
             }
-            message.append(" If this is a new transport version, run './gradle generateTransportVersion'.");
+            message.append(" If this is a new transport version, run './gradlew generateTransportVersion'.");
             throw new IllegalStateException(message.toString());
         }
         return known;

--- a/server/src/test/java/org/elasticsearch/TransportVersionTests.java
+++ b/server/src/test/java/org/elasticsearch/TransportVersionTests.java
@@ -400,7 +400,7 @@ public class TransportVersionTests extends ESTestCase {
             is(
                 "Unknown transport version [to_child_lock_join_query]. "
                     + "Did you mean [to_child_block_join_query]? "
-                    + "If this is a new transport version, run './gradle generateTransportVersion'."
+                    + "If this is a new transport version, run './gradlew generateTransportVersion'."
             )
         );
 
@@ -409,7 +409,7 @@ public class TransportVersionTests extends ESTestCase {
             ise.getMessage(),
             is(
                 "Unknown transport version [brand_new_version_unrelated_to_others]. "
-                    + "If this is a new transport version, run './gradle generateTransportVersion'."
+                    + "If this is a new transport version, run './gradlew generateTransportVersion'."
             )
         );
     }


### PR DESCRIPTION
In some of our error messages, we recommend running `./gradle`, which generally doesn't work.