### PR TITLE
Precompute whether the role has all access to every index

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/IndicesPermission.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/IndicesPermission.java
@@ -72,6 +72,7 @@ public final class IndicesPermission {
     private final RestrictedIndices restrictedIndices;
     private final Group[] groups;
     private final boolean hasFieldOrDocumentLevelSecurity;
+    private final boolean hasAllIndicesPermissions;
 
     public static class Builder {
 
@@ -104,6 +105,7 @@ public final class IndicesPermission {
         this.groups = groups;
         this.hasFieldOrDocumentLevelSecurity = Arrays.stream(groups).noneMatch(Group::isTotal)
             && Arrays.stream(groups).anyMatch(g -> g.hasQuery() || g.fieldPermissions.hasFieldLevelSecurity());
+        this.hasAllIndicesPermissions = Arrays.stream(groups).anyMatch(Group::isTotal);
     }
 
     /**
@@ -146,6 +148,10 @@ public final class IndicesPermission {
 
     public boolean hasFieldOrDocumentLevelSecurity() {
         return hasFieldOrDocumentLevelSecurity;
+    }
+
+    public boolean hasAllIndicesPermissions() {
+        return hasAllIndicesPermissions;
     }
 
     private IsResourceAuthorizedPredicate buildIndexMatcherPredicateForAction(String action) {
@@ -584,10 +590,8 @@ public final class IndicesPermission {
         FieldPermissionsCache fieldPermissionsCache
     ) {
         // Short circuit if the indicesPermission allows all access to every index
-        for (Group group : groups) {
-            if (group.isTotal()) {
-                return IndicesAccessControl.allowAll();
-            }
+        if (hasAllIndicesPermissions()) {
+            return IndicesAccessControl.allowAll();
         }
 
         final Map<String, IndexResource> resources = Maps.newMapWithExpectedSize(requestedIndicesOrAliases.size());


### PR DESCRIPTION
The role's permissions do not change, so we precompute the result to avoid executing the for-loop check on each request.