### PR TITLE
ES|QL: more selective mute in generative tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -657,12 +657,6 @@ tests:
 - class: org.elasticsearch.index.codec.vectors.es93.ES93HnswBinaryQuantizedBFloat16VectorsFormatTests
   method: testFloatVectorScorerIteration
   issue: https://github.com/elastic/elasticsearch/issues/136566
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/136584
-- class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/136584
 
 # Examples:
 #

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
@@ -68,6 +68,10 @@ public abstract class GenerativeRestTest extends ESRestTestCase implements Query
         "optimized incorrectly due to missing references", // https://github.com/elastic/elasticsearch/issues/131509
         "long overflow", // https://github.com/elastic/elasticsearch/issues/135759
         "can't build page out of released blocks", // https://github.com/elastic/elasticsearch/issues/135679
+        "cannot be cast to class", // https://github.com/elastic/elasticsearch/issues/133992
+        "can't find input for", // https://github.com/elastic/elasticsearch/issues/136596
+        "unexpected byte", // https://github.com/elastic/elasticsearch/issues/136598
+        "Rule execution limit", // https://github.com/elastic/elasticsearch/issues/136599
 
         // Awaiting fixes for correctness
         "Expecting at most \\[.*\\] columns, got \\[.*\\]", // https://github.com/elastic/elasticsearch/issues/129561


### PR DESCRIPTION
Unmute generative tests and add allowed exceptions for 

- https://github.com/elastic/elasticsearch/issues/133992
- https://github.com/elastic/elasticsearch/issues/136596
- https://github.com/elastic/elasticsearch/issues/136598
- https://github.com/elastic/elasticsearch/issues/136599

Fixes: https://github.com/elastic/elasticsearch/issues/136584