### PR TITLE
[9.2] Always use NORMAL ReadAdvice with cfs files (#135831)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/store/FsDirectoryFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/store/FsDirectoryFactory.java
@@ -147,6 +147,9 @@ public class FsDirectoryFactory implements IndexStorePlugin.DirectoryFactory {
             if (context.hints().contains(StandardIOBehaviorHint.INSTANCE)) {
                 return Optional.of(ReadAdvice.NORMAL);
             }
+            if (name.endsWith(".cfs")) {
+                return Optional.of(ReadAdvice.NORMAL);
+            }
             return MMapDirectory.ADVISE_BY_CONTEXT.apply(name, context);
         };
     }


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Always use NORMAL ReadAdvice with cfs files (#135831)