### PR TITLE
EIS: rename inference endpoints

### DIFF
--- a/docs/changelog/136626.yaml
+++ b/docs/changelog/136626.yaml
@@ -1,0 +1,5 @@
+pr: 136626
+summary: "EIS: rename infernece endpoints"
+area: Machine Learning
+type: enhancement
+issues: []

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/MockElasticInferenceServiceAuthorizationServer.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/MockElasticInferenceServiceAuthorizationServer.java
@@ -39,7 +39,7 @@ public class MockElasticInferenceServiceAuthorizationServer implements TestRule 
                       "task_types": ["chat"]
                     },
                     {
-                      "model_name": "elser_model_2",
+                      "model_name": "elastic-elser-v2",
                       "task_types": ["embed/text/sparse"]
                     },
                     {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceService.java
@@ -109,12 +109,8 @@ public class ElasticInferenceService extends SenderService {
     private static final Integer DENSE_TEXT_EMBEDDINGS_MAX_BATCH_SIZE = 16;
 
     // rainbow-sprinkles
-    static final String LEGACY_DEFAULT_CHAT_COMPLETION_MODEL_ID_V1 = "rainbow-sprinkles";
-    static final String LEGACY_DEFAULT_CHAT_COMPLETION_ENDPOINT_ID_V1 = ".rainbow-sprinkles-elastic";
-
-    // gp-llm-v1
-    static final String DEFAULT_CHAT_COMPLETION_MODEL_ID_V1 = "gp-llm-v1";
-    static final String DEFAULT_CHAT_COMPLETION_ENDPOINT_ID_V1 = defaultEndpointId(DEFAULT_CHAT_COMPLETION_MODEL_ID_V1);
+    static final String DEFAULT_CHAT_COMPLETION_MODEL_ID_V1 = "rainbow-sprinkles";
+    static final String DEFAULT_CHAT_COMPLETION_ENDPOINT_ID_V1 = ".rainbow-sprinkles-elastic";
 
     // elastic-elser-v2
     static final String DEFAULT_ELSER_2_MODEL_ID = "elastic-elser-v2";
@@ -190,19 +186,6 @@ public class ElasticInferenceService extends SenderService {
         ElasticInferenceServiceComponents elasticInferenceServiceComponents
     ) {
         return Map.of(
-            LEGACY_DEFAULT_CHAT_COMPLETION_MODEL_ID_V1,
-            new DefaultModelConfig(
-                new ElasticInferenceServiceCompletionModel(
-                    LEGACY_DEFAULT_CHAT_COMPLETION_ENDPOINT_ID_V1,
-                    TaskType.CHAT_COMPLETION,
-                    NAME,
-                    new ElasticInferenceServiceCompletionServiceSettings(LEGACY_DEFAULT_CHAT_COMPLETION_MODEL_ID_V1),
-                    EmptyTaskSettings.INSTANCE,
-                    EmptySecretSettings.INSTANCE,
-                    elasticInferenceServiceComponents
-                ),
-                MinimalServiceSettings.chatCompletion(NAME)
-            ),
             DEFAULT_CHAT_COMPLETION_MODEL_ID_V1,
             new DefaultModelConfig(
                 new ElasticInferenceServiceCompletionModel(

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceService.java
@@ -109,19 +109,19 @@ public class ElasticInferenceService extends SenderService {
     private static final Integer DENSE_TEXT_EMBEDDINGS_MAX_BATCH_SIZE = 16;
 
     // rainbow-sprinkles
-    static final String DEFAULT_CHAT_COMPLETION_MODEL_ID_V1 = "rainbow-sprinkles";
+    static final String DEFAULT_CHAT_COMPLETION_MODEL_ID_V1 = "gp-llm-v1";
     static final String DEFAULT_CHAT_COMPLETION_ENDPOINT_ID_V1 = defaultEndpointId(DEFAULT_CHAT_COMPLETION_MODEL_ID_V1);
 
-    // elser-2
-    static final String DEFAULT_ELSER_2_MODEL_ID = "elser_model_2";
-    static final String DEFAULT_ELSER_ENDPOINT_ID_V2 = defaultEndpointId("elser-2");
+    // elastic-elser-v2
+    static final String DEFAULT_ELSER_2_MODEL_ID = "elastic-elser-v2";
+    static final String DEFAULT_ELSER_ENDPOINT_ID_V2 = defaultEndpointId(DEFAULT_ELSER_2_MODEL_ID);
 
-    // multilingual-text-embed
-    static final String DEFAULT_MULTILINGUAL_EMBED_MODEL_ID = "multilingual-embed-v1";
+    // jina-embeddings-v3
+    static final String DEFAULT_MULTILINGUAL_EMBED_MODEL_ID = "jina-embeddings-v3";
     static final String DEFAULT_MULTILINGUAL_EMBED_ENDPOINT_ID = defaultEndpointId(DEFAULT_MULTILINGUAL_EMBED_MODEL_ID);
 
-    // rerank-v1
-    static final String DEFAULT_RERANK_MODEL_ID_V1 = "rerank-v1";
+    // elastic-rerank-v1
+    static final String DEFAULT_RERANK_MODEL_ID_V1 = "elastic-rerank-v1";
     static final String DEFAULT_RERANK_ENDPOINT_ID_V1 = defaultEndpointId(DEFAULT_RERANK_MODEL_ID_V1);
 
     /**
@@ -134,7 +134,7 @@ public class ElasticInferenceService extends SenderService {
     );
 
     public static String defaultEndpointId(String modelId) {
-        return Strings.format(".%s-elastic", modelId);
+        return Strings.format(".%s", modelId);
     }
 
     private final ElasticInferenceServiceComponents elasticInferenceServiceComponents;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceService.java
@@ -109,6 +109,10 @@ public class ElasticInferenceService extends SenderService {
     private static final Integer DENSE_TEXT_EMBEDDINGS_MAX_BATCH_SIZE = 16;
 
     // rainbow-sprinkles
+    static final String LEGACY_DEFAULT_CHAT_COMPLETION_MODEL_ID_V1 = "rainbow-sprinkles";
+    static final String LEGACY_DEFAULT_CHAT_COMPLETION_ENDPOINT_ID_V1 = ".rainbow-sprinkles-elastic";
+
+    // gp-llm-v1
     static final String DEFAULT_CHAT_COMPLETION_MODEL_ID_V1 = "gp-llm-v1";
     static final String DEFAULT_CHAT_COMPLETION_ENDPOINT_ID_V1 = defaultEndpointId(DEFAULT_CHAT_COMPLETION_MODEL_ID_V1);
 
@@ -186,6 +190,19 @@ public class ElasticInferenceService extends SenderService {
         ElasticInferenceServiceComponents elasticInferenceServiceComponents
     ) {
         return Map.of(
+            LEGACY_DEFAULT_CHAT_COMPLETION_MODEL_ID_V1,
+            new DefaultModelConfig(
+                new ElasticInferenceServiceCompletionModel(
+                    LEGACY_DEFAULT_CHAT_COMPLETION_ENDPOINT_ID_V1,
+                    TaskType.CHAT_COMPLETION,
+                    NAME,
+                    new ElasticInferenceServiceCompletionServiceSettings(LEGACY_DEFAULT_CHAT_COMPLETION_MODEL_ID_V1),
+                    EmptyTaskSettings.INSTANCE,
+                    EmptySecretSettings.INSTANCE,
+                    elasticInferenceServiceComponents
+                ),
+                MinimalServiceSettings.chatCompletion(NAME)
+            ),
             DEFAULT_CHAT_COMPLETION_MODEL_ID_V1,
             new DefaultModelConfig(
                 new ElasticInferenceServiceCompletionModel(

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceService.java
@@ -113,16 +113,21 @@ public class ElasticInferenceService extends SenderService {
     static final String DEFAULT_CHAT_COMPLETION_ENDPOINT_ID_V1 = ".rainbow-sprinkles-elastic";
 
     // elastic-elser-v2
-    static final String DEFAULT_ELSER_2_MODEL_ID = "elastic-elser-v2";
-    static final String DEFAULT_ELSER_ENDPOINT_ID_V2 = defaultEndpointId(DEFAULT_ELSER_2_MODEL_ID);
-
-    // jina-embeddings-v3
-    static final String DEFAULT_MULTILINGUAL_EMBED_MODEL_ID = "jina-embeddings-v3";
-    static final String DEFAULT_MULTILINGUAL_EMBED_ENDPOINT_ID = defaultEndpointId(DEFAULT_MULTILINGUAL_EMBED_MODEL_ID);
+    static final String DEFAULT_ELSER_V2_MODEL_ID = "elastic-elser-v2";
+    static final String DEFAULT_ELSER_V2_ENDPOINT_ID = defaultEndpointId(DEFAULT_ELSER_V2_MODEL_ID);
 
     // elastic-rerank-v1
     static final String DEFAULT_RERANK_MODEL_ID_V1 = "elastic-rerank-v1";
     static final String DEFAULT_RERANK_ENDPOINT_ID_V1 = defaultEndpointId(DEFAULT_RERANK_MODEL_ID_V1);
+
+    // jina-embeddings-v3
+    static final String DEFAULT_JINA_EMBEDDINGS_V3_MODEL_ID = "jina-embeddings-v3";
+    static final String DEFAULT_JINA_EMBEDDINGS_V3_ENDPOINT_ID = defaultEndpointId(DEFAULT_JINA_EMBEDDINGS_V3_MODEL_ID);
+
+    // jina-reranker-v3
+    static final String DEFAULT_JINA_RERANKER_V3_MODEL_ID = "jina-reranker-v3";
+    static final String DEFAULT_JINA_RERANKER_V3_ENDPOINT_ID = defaultEndpointId(DEFAULT_KINA_RERANKER_V3_MODEL_ID);
+
 
     /**
      * The task types that the {@link InferenceAction.Request} can accept.
@@ -199,13 +204,13 @@ public class ElasticInferenceService extends SenderService {
                 ),
                 MinimalServiceSettings.chatCompletion(NAME)
             ),
-            DEFAULT_ELSER_2_MODEL_ID,
+            DEFAULT_ELSER_V2_MODEL_ID,
             new DefaultModelConfig(
                 new ElasticInferenceServiceSparseEmbeddingsModel(
-                    DEFAULT_ELSER_ENDPOINT_ID_V2,
+                    DEFAULT_ELSER_V2_ENDPOINT_ID,
                     TaskType.SPARSE_EMBEDDING,
                     NAME,
-                    new ElasticInferenceServiceSparseEmbeddingsServiceSettings(DEFAULT_ELSER_2_MODEL_ID, null),
+                    new ElasticInferenceServiceSparseEmbeddingsServiceSettings(DEFAULT_ELSER_V2_MODEL_ID, null),
                     EmptyTaskSettings.INSTANCE,
                     EmptySecretSettings.INSTANCE,
                     elasticInferenceServiceComponents,
@@ -213,14 +218,14 @@ public class ElasticInferenceService extends SenderService {
                 ),
                 MinimalServiceSettings.sparseEmbedding(NAME)
             ),
-            DEFAULT_MULTILINGUAL_EMBED_MODEL_ID,
+            DEFAULT_JINA_EMBEDDINGS_V3_MODEL_ID,
             new DefaultModelConfig(
                 new ElasticInferenceServiceDenseTextEmbeddingsModel(
-                    DEFAULT_MULTILINGUAL_EMBED_ENDPOINT_ID,
+                    DEFAULT_JINA_EMBEDDINGS_V3_ENDPOINT_ID,
                     TaskType.TEXT_EMBEDDING,
                     NAME,
                     new ElasticInferenceServiceDenseTextEmbeddingsServiceSettings(
-                        DEFAULT_MULTILINGUAL_EMBED_MODEL_ID,
+                        DEFAULT_JINA_EMBEDDINGS_V3_MODEL_ID,
                         defaultDenseTextEmbeddingsSimilarity(),
                         null,
                         null

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceService.java
@@ -109,16 +109,16 @@ public class ElasticInferenceService extends SenderService {
     private static final Integer DENSE_TEXT_EMBEDDINGS_MAX_BATCH_SIZE = 16;
 
     // rainbow-sprinkles
-    static final String DEFAULT_CHAT_COMPLETION_MODEL_ID_V1 = "rainbow-sprinkles";
-    static final String DEFAULT_CHAT_COMPLETION_ENDPOINT_ID_V1 = ".rainbow-sprinkles-elastic";
+    static final String DEFAULT_CHAT_COMPLETION_V1_MODEL_ID = "rainbow-sprinkles";
+    static final String DEFAULT_CHAT_COMPLETION_V1_ENDPOINT_ID = ".rainbow-sprinkles-elastic";
 
     // elastic-elser-v2
     static final String DEFAULT_ELSER_V2_MODEL_ID = "elastic-elser-v2";
     static final String DEFAULT_ELSER_V2_ENDPOINT_ID = defaultEndpointId(DEFAULT_ELSER_V2_MODEL_ID);
 
     // elastic-rerank-v1
-    static final String DEFAULT_RERANK_MODEL_ID_V1 = "elastic-rerank-v1";
-    static final String DEFAULT_RERANK_ENDPOINT_ID_V1 = defaultEndpointId(DEFAULT_RERANK_MODEL_ID_V1);
+    static final String DEFAULT_RERANK_V1_MODEL_ID = "elastic-rerank-v1";
+    static final String DEFAULT_RERANK_V1_ENDPOINT_ID = defaultEndpointId(DEFAULT_RERANK_V1_MODEL_ID);
 
     // jina-embeddings-v3
     static final String DEFAULT_JINA_EMBEDDINGS_V3_MODEL_ID = "jina-embeddings-v3";
@@ -191,13 +191,13 @@ public class ElasticInferenceService extends SenderService {
         ElasticInferenceServiceComponents elasticInferenceServiceComponents
     ) {
         return Map.of(
-            DEFAULT_CHAT_COMPLETION_MODEL_ID_V1,
+            DEFAULT_CHAT_COMPLETION_V1_MODEL_ID,
             new DefaultModelConfig(
                 new ElasticInferenceServiceCompletionModel(
-                    DEFAULT_CHAT_COMPLETION_ENDPOINT_ID_V1,
+                    DEFAULT_CHAT_COMPLETION_V1_ENDPOINT_ID,
                     TaskType.CHAT_COMPLETION,
                     NAME,
-                    new ElasticInferenceServiceCompletionServiceSettings(DEFAULT_CHAT_COMPLETION_MODEL_ID_V1),
+                    new ElasticInferenceServiceCompletionServiceSettings(DEFAULT_CHAT_COMPLETION_V1_MODEL_ID),
                     EmptyTaskSettings.INSTANCE,
                     EmptySecretSettings.INSTANCE,
                     elasticInferenceServiceComponents
@@ -217,6 +217,19 @@ public class ElasticInferenceService extends SenderService {
                     ChunkingSettingsBuilder.DEFAULT_SETTINGS
                 ),
                 MinimalServiceSettings.sparseEmbedding(NAME)
+            ),
+            DEFAULT_RERANK_V1_MODEL_ID,
+            new DefaultModelConfig(
+                new ElasticInferenceServiceRerankModel(
+                    DEFAULT_RERANK_V1_ENDPOINT_ID,
+                    TaskType.RERANK,
+                    NAME,
+                    new ElasticInferenceServiceRerankServiceSettings(DEFAULT_RERANK_V1_MODEL_ID),
+                    EmptyTaskSettings.INSTANCE,
+                    EmptySecretSettings.INSTANCE,
+                    elasticInferenceServiceComponents
+                ),
+                MinimalServiceSettings.rerank(NAME)
             ),
             DEFAULT_JINA_EMBEDDINGS_V3_MODEL_ID,
             new DefaultModelConfig(
@@ -242,19 +255,19 @@ public class ElasticInferenceService extends SenderService {
                     DenseVectorFieldMapper.ElementType.FLOAT
                 )
             ),
-            DEFAULT_RERANK_MODEL_ID_V1,
+            DEFAULT_JINA_RERANKER_V3_MODEL_ID,
             new DefaultModelConfig(
                 new ElasticInferenceServiceRerankModel(
-                    DEFAULT_RERANK_ENDPOINT_ID_V1,
+                    DEFAULT_JINA_RERANKER_V3_ENDPOINT_ID,
                     TaskType.RERANK,
                     NAME,
-                    new ElasticInferenceServiceRerankServiceSettings(DEFAULT_RERANK_MODEL_ID_V1),
+                    new ElasticInferenceServiceRerankServiceSettings(DEFAULT_JINA_RERANKER_V3_MODEL_ID),
                     EmptyTaskSettings.INSTANCE,
                     EmptySecretSettings.INSTANCE,
                     elasticInferenceServiceComponents
                 ),
                 MinimalServiceSettings.rerank(NAME)
-            )
+            ),
         );
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
@@ -1234,7 +1234,7 @@ public class ElasticInferenceServiceTests extends ESSingleNodeTestCase {
                       "task_types": ["chat"]
                     },
                     {
-                      "model_name": "elser_model_2",
+                      "model_name": "elastic-elser-v2",
                       "task_types": ["embed/text/sparse"]
                     },
                     {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceTests.java
@@ -406,7 +406,7 @@ public class ElasticsearchInternalServiceTests extends InferenceServiceTestCase 
                     elserServiceSettings,
                     null,
                     "The [elser] service is deprecated and will be removed in a future release. Use the [elasticsearch] service "
-                        + "instead, with [model_id] set to [.elser_model_2] in the [service_settings]",
+                        + "instead, with [model_id] set to [.elastic-elser-v2] in the [service_settings]",
                     false
                 )
             );
@@ -435,7 +435,7 @@ public class ElasticsearchInternalServiceTests extends InferenceServiceTestCase 
                     + " deprecated and will be removed in a future release. Please specify a model_id field.";
             String warnWarning =
                 "The [elser] service is deprecated and will be removed in a future release. Use the [elasticsearch] service "
-                    + "instead, with [model_id] set to [.elser_model_2] in the [service_settings]";
+                    + "instead, with [model_id] set to [.elastic-elser-v2] in the [service_settings]";
             service.parseRequestConfig(
                 randomInferenceEntityId,
                 TaskType.SPARSE_EMBEDDING,
@@ -509,7 +509,7 @@ public class ElasticsearchInternalServiceTests extends InferenceServiceTestCase 
                     elserServiceSettings,
                     null,
                     "The [elser] service is deprecated and will be removed in a future release. Use the [elasticsearch] service "
-                        + "instead, with [model_id] set to [.elser_model_2] in the [service_settings]",
+                        + "instead, with [model_id] set to [.elastic-elser-v2] in the [service_settings]",
                     true
                 )
             );
@@ -547,7 +547,7 @@ public class ElasticsearchInternalServiceTests extends InferenceServiceTestCase 
                     elserServiceSettings,
                     null,
                     "The [elser] service is deprecated and will be removed in a future release. Use the [elasticsearch] service "
-                        + "instead, with [model_id] set to [.elser_model_2] in the [service_settings]",
+                        + "instead, with [model_id] set to [.elastic-elser-v2] in the [service_settings]",
                     true
                 )
             );
@@ -756,7 +756,7 @@ public class ElasticsearchInternalServiceTests extends InferenceServiceTestCase 
                         ElasticsearchInternalServiceSettings.NUM_THREADS,
                         4,
                         "model_version",
-                        ".elser_model_2"
+                        ".elastic-elser-v2"
                     )
                 )
             );
@@ -764,7 +764,7 @@ public class ElasticsearchInternalServiceTests extends InferenceServiceTestCase 
             var model = service.parsePersistedConfig(randomInferenceEntityId, TaskType.TEXT_EMBEDDING, settings);
             assertThat(model, instanceOf(ElserInternalModel.class));
             ElserInternalModel elserInternalModel = (ElserInternalModel) model;
-            assertThat(elserInternalModel.getServiceSettings().modelId(), is(".elser_model_2"));
+            assertThat(elserInternalModel.getServiceSettings().modelId(), is(".elastic-elser-v2"));
         }
 
         // Null model variant


### PR DESCRIPTION
The model names in the Elastic Inference Service (EIS) are changing.

- Change ELSER name. We are still in tech preview, this is ok.
- Change reranker name. This was not released to production yet.
- Change dense embeddings name. This was not released to production yet.
- Add a new reranker name as currently it's undecided which one we will release. The ACL will control this.

### TODO
- [ ] Backport labels