### PR TITLE
[Spacetime] Batch and report all YAML REST test assertion failures together

### DIFF
--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java
@@ -502,16 +502,16 @@ public abstract class ESClientYamlSuiteTestCase extends ESRestTestCase {
         try {
             List<ExecutableSection> sections = testCandidate.getTestSection().getExecutableSections();
             List<AssertionError> allAssertionErrors = new ArrayList<>();
-            
+
             int i = 0;
             while (i < sections.size()) {
                 ExecutableSection section = sections.get(i);
-                
+
                 // Execute non-assertion sections normally
                 if (!(section instanceof Assertion)) {
                     executeSection(section);
                     i++;
-                    
+
                     // After a "do" section, batch any following assertions
                     if (section instanceof DoSection) {
                         // Execute all consecutive assertions, collecting errors
@@ -527,7 +527,7 @@ public abstract class ESClientYamlSuiteTestCase extends ESRestTestCase {
                     i++;
                 }
             }
-            
+
             // After executing all sections, throw if any assertions failed
             if (!allAssertionErrors.isEmpty()) {
                 throw combineAssertionErrors(allAssertionErrors);
@@ -583,7 +583,7 @@ public abstract class ESClientYamlSuiteTestCase extends ESRestTestCase {
 
     /**
      * Combine multiple assertion errors into a single AssertionError with a detailed message.
-     * 
+     *
      * @param errors list of assertion errors to combine
      * @return a single AssertionError containing all failure information
      */
@@ -591,21 +591,21 @@ public abstract class ESClientYamlSuiteTestCase extends ESRestTestCase {
         if (errors.size() == 1) {
             return errors.get(0);
         }
-        
+
         StringBuilder message = new StringBuilder();
         message.append("Multiple assertion failures (").append(errors.size()).append("):\n");
-        
+
         for (int i = 0; i < errors.size(); i++) {
             message.append("  ").append(i + 1).append(") ").append(errors.get(i).getMessage()).append("\n");
         }
-        
+
         AssertionError combinedError = new AssertionError(message.toString());
-        
+
         // Add all errors as suppressed exceptions to preserve stack traces
         for (AssertionError error : errors) {
             combinedError.addSuppressed(error);
         }
-        
+
         return combinedError;
     }
 

--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/Assertion.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/Assertion.java
@@ -12,6 +12,7 @@ import org.elasticsearch.test.rest.yaml.ClientYamlTestExecutionContext;
 import org.elasticsearch.xcontent.XContentLocation;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -66,6 +67,21 @@ public abstract class Assertion implements ExecutableSection {
     @Override
     public final void execute(ClientYamlTestExecutionContext executionContext) throws IOException {
         doAssert(getActualValue(executionContext), resolveExpectedValue(executionContext));
+    }
+
+    /**
+     * Execute the assertion softly, collecting any errors instead of throwing immediately.
+     * This allows multiple assertions to be executed and all failures reported together.
+     * 
+     * @param executionContext the execution context
+     * @param errors list to collect any assertion errors
+     */
+    public final void executeSoftly(ClientYamlTestExecutionContext executionContext, List<AssertionError> errors) throws IOException {
+        try {
+            execute(executionContext);
+        } catch (AssertionError e) {
+            errors.add(e);
+        }
     }
 
     /**

--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/Assertion.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/Assertion.java
@@ -72,7 +72,7 @@ public abstract class Assertion implements ExecutableSection {
     /**
      * Execute the assertion softly, collecting any errors instead of throwing immediately.
      * This allows multiple assertions to be executed and all failures reported together.
-     * 
+     *
      * @param executionContext the execution context
      * @param errors list to collect any assertion errors
      */


### PR DESCRIPTION
## Summary

Improves YAML REST test failure reporting by batching assertions after each [do](cci:1://file:///Users/mrids/git_tree/elasticsearch/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/Assertion.java:86:4-89:79) section and collecting all assertion failures before reporting them together. This eliminates the current "whack-a-mole" workflow where developers must fix one assertion, re-run the test, discover the next failure, and repeat.

## Changes

- **Added `Assertion.executeSoftly()`**: New method that executes an assertion and collects any [AssertionError](cci:1://file:///Users/mrids/git_tree/elasticsearch/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java:583:4-609:5) instead of throwing immediately
- **Modified test execution flow in [ESClientYamlSuiteTestCase](cci:2://file:///Users/mrids/git_tree/elasticsearch/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java:67:0-634:1)**: After each [do](cci:1://file:///Users/mrids/git_tree/elasticsearch/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/Assertion.java:86:4-89:79) section, all consecutive assertions are executed using soft execution, errors are collected, and a single combined [AssertionError](cci:1://file:///Users/mrids/git_tree/elasticsearch/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java:583:4-609:5) is thrown at the end with all failure messages and stack traces preserved

## Behavior

**Before:**
```yaml
do: some_api_call
- assertion1  ✓
- assertion2  ✗  # Test stops here
- assertion3      # Never executed
- assertion4      # Never executed
```

**After:**
```yaml
do: some_api_call
- assertion1  ✓
- assertion2  ✗  # Collected
- assertion3  ✗  # Collected  
- assertion4  ✓

# Single error thrown with all failures:
Multiple assertion failures (2):
  1) <assertion2 failure message>
  2) <assertion3 failure message>
  ```
  
 ## Related

Fixes #134356