### PR TITLE
Revert "Remove some uses of 8.0.0 transport version constant (#135715)"

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/GrokProcessorGetAction.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/GrokProcessorGetAction.java
@@ -8,6 +8,7 @@
  */
 package org.elasticsearch.ingest.common;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
@@ -59,7 +60,9 @@ public class GrokProcessorGetAction {
         Request(StreamInput in) throws IOException {
             super(in);
             this.sorted = in.readBoolean();
-            this.ecsCompatibility = in.readString();
+            this.ecsCompatibility = in.getTransportVersion().onOrAfter(TransportVersions.V_8_0_0)
+                ? in.readString()
+                : GrokProcessor.DEFAULT_ECS_COMPATIBILITY_MODE;
         }
 
         @Override
@@ -71,7 +74,9 @@ public class GrokProcessorGetAction {
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             out.writeBoolean(sorted);
-            out.writeString(ecsCompatibility);
+            if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_0_0)) {
+                out.writeString(ecsCompatibility);
+            }
         }
 
         public boolean sorted() {

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/stats/GeoIpStatsAction.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/stats/GeoIpStatsAction.java
@@ -174,7 +174,9 @@ public class GeoIpStatsAction {
             }
             databases = in.readCollectionAsImmutableSet(StreamInput::readString);
             filesInTemp = in.readCollectionAsImmutableSet(StreamInput::readString);
-            configDatabases = in.readCollectionAsImmutableSet(StreamInput::readString);
+            configDatabases = in.getTransportVersion().onOrAfter(TransportVersions.V_8_0_0)
+                ? in.readCollectionAsImmutableSet(StreamInput::readString)
+                : null;
         }
 
         protected NodeResponse(
@@ -224,7 +226,9 @@ public class GeoIpStatsAction {
             }
             out.writeStringCollection(databases);
             out.writeStringCollection(filesInTemp);
-            out.writeStringCollection(configDatabases);
+            if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_0_0)) {
+                out.writeStringCollection(configDatabases);
+            }
         }
 
         @Override

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQueryBuilder.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolateQueryBuilder.java
@@ -35,6 +35,7 @@ import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.InputStreamStreamInput;
@@ -205,7 +206,15 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
         super(in);
         field = in.readString();
         name = in.readOptionalString();
+        if (in.getTransportVersion().before(TransportVersions.V_8_0_0)) {
+            String documentType = in.readOptionalString();
+            assert documentType == null;
+        }
         indexedDocumentIndex = in.readOptionalString();
+        if (in.getTransportVersion().before(TransportVersions.V_8_0_0)) {
+            String indexedDocumentType = in.readOptionalString();
+            assert indexedDocumentType == null;
+        }
         indexedDocumentId = in.readOptionalString();
         indexedDocumentRouting = in.readOptionalString();
         indexedDocumentPreference = in.readOptionalString();
@@ -239,7 +248,15 @@ public class PercolateQueryBuilder extends AbstractQueryBuilder<PercolateQueryBu
         }
         out.writeString(field);
         out.writeOptionalString(name);
+        if (out.getTransportVersion().before(TransportVersions.V_8_0_0)) {
+            // In 7x, typeless percolate queries are represented by null documentType values
+            out.writeOptionalString(null);
+        }
         out.writeOptionalString(indexedDocumentIndex);
+        if (out.getTransportVersion().before(TransportVersions.V_8_0_0)) {
+            // In 7x, typeless percolate queries are represented by null indexedDocumentType values
+            out.writeOptionalString(null);
+        }
         out.writeOptionalString(indexedDocumentId);
         out.writeOptionalString(indexedDocumentRouting);
         out.writeOptionalString(indexedDocumentPreference);

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/system_indices/task/FeatureMigrationResults.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/system_indices/task/FeatureMigrationResults.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.system_indices.task;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.cluster.DiffableUtils;
 import org.elasticsearch.cluster.NamedDiff;
@@ -34,6 +35,7 @@ import java.util.TreeMap;
  */
 public class FeatureMigrationResults implements Metadata.ProjectCustom {
     public static final String TYPE = "system_index_migration";
+    public static final TransportVersion MIGRATION_ADDED_VERSION = TransportVersions.V_8_0_0;
 
     static final ParseField RESULTS_FIELD = new ParseField("results");
 
@@ -92,7 +94,7 @@ public class FeatureMigrationResults implements Metadata.ProjectCustom {
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {
-        return TransportVersion.minimumCompatible();
+        return MIGRATION_ADDED_VERSION;
     }
 
     @Override
@@ -162,7 +164,7 @@ public class FeatureMigrationResults implements Metadata.ProjectCustom {
 
         @Override
         public TransportVersion getMinimalSupportedVersion() {
-            return TransportVersion.minimumCompatible();
+            return MIGRATION_ADDED_VERSION;
         }
 
     }

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/system_indices/task/SystemIndexMigrationTaskParams.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/system_indices/task/SystemIndexMigrationTaskParams.java
@@ -17,6 +17,8 @@ import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 
+import static org.elasticsearch.system_indices.task.FeatureMigrationResults.MIGRATION_ADDED_VERSION;
+
 /**
  * The params used to initialize {@link SystemIndexMigrator} when it's initially kicked off.
  *
@@ -66,7 +68,7 @@ public class SystemIndexMigrationTaskParams implements PersistentTaskParams {
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {
-        return TransportVersion.minimumCompatible();
+        return MIGRATION_ADDED_VERSION;
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlScalingReason.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlScalingReason.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.ml.autoscaling;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
@@ -48,7 +49,11 @@ public class MlScalingReason implements AutoscalingDeciderResult.Reason {
         this.waitingAnalyticsJobs = in.readStringCollectionAsList();
         this.waitingAnomalyJobs = in.readStringCollectionAsList();
         this.waitingSnapshotUpgrades = in.readStringCollectionAsList();
-        this.waitingModels = in.readStringCollectionAsList();
+        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_0_0)) {
+            this.waitingModels = in.readStringCollectionAsList();
+        } else {
+            this.waitingModels = List.of();
+        }
         this.passedConfiguration = Settings.readSettingsFromStream(in);
         this.currentMlCapacity = new AutoscalingCapacity(in);
         this.requiredCapacity = in.readOptionalWriteable(AutoscalingCapacity::new);
@@ -131,7 +136,9 @@ public class MlScalingReason implements AutoscalingDeciderResult.Reason {
         out.writeStringCollection(this.waitingAnalyticsJobs);
         out.writeStringCollection(this.waitingAnomalyJobs);
         out.writeStringCollection(this.waitingSnapshotUpgrades);
-        out.writeStringCollection(this.waitingModels);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_0_0)) {
+            out.writeStringCollection(this.waitingModels);
+        }
         this.passedConfiguration.writeTo(out);
         this.currentMlCapacity.writeTo(out);
         out.writeOptionalWriteable(this.requiredCapacity);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedConfigAutoUpdater.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedConfigAutoUpdater.java
@@ -14,6 +14,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.ClusterState;
@@ -46,7 +47,7 @@ public class DatafeedConfigAutoUpdater implements MlAutoUpdateService.UpdateActi
 
     @Override
     public boolean isMinTransportVersionSupported(TransportVersion minNodeVersion) {
-        return true;
+        return minNodeVersion.onOrAfter(TransportVersions.V_8_0_0);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/heuristic/PValueScoreTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/heuristic/PValueScoreTests.java
@@ -9,12 +9,12 @@ package org.elasticsearch.xpack.ml.aggs.heuristic;
 
 import org.apache.commons.math3.util.FastMath;
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.search.aggregations.bucket.AbstractNXYSignificanceHeuristicTestCase;
 import org.elasticsearch.search.aggregations.bucket.terms.heuristic.SignificanceHeuristic;
-import org.elasticsearch.test.TransportVersionUtils;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.ml.MachineLearning;
 import org.elasticsearch.xpack.ml.MachineLearningTests;
@@ -34,7 +34,7 @@ public class PValueScoreTests extends AbstractNXYSignificanceHeuristicTestCase {
 
     @Override
     protected TransportVersion randomVersion() {
-        return TransportVersionUtils.randomCompatibleVersion(random());
+        return randomFrom(TransportVersions.V_8_0_0);
     }
 
     @Override

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/DataStreamsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/DataStreamsUpgradeIT.java
@@ -8,12 +8,15 @@ package org.elasticsearch.upgrades;
 
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.Build;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Node;
 import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
+import org.elasticsearch.client.WarningsHandler;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.DataStreamTestHelper;
 import org.elasticsearch.common.settings.SecureString;
@@ -538,6 +541,25 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
             indexTemplate.replace("$TEMPLATE", templateWithNoTimestamp).replace("$PATTERN", dataStreamFromNonDataStreamIndices + "-*")
         );
         String indexName = dataStreamFromNonDataStreamIndices + "-01";
+        if (minimumTransportVersion().before(TransportVersions.V_8_0_0)) {
+            /*
+             * It is not possible to create a 7.x index template with a type. And you can't create an empty index with a type. But you can
+             * create the index with a type by posting a document to an index with a type. We do that here so that we test that the type is
+             * removed when we reindex into 8.x.
+             */
+            String typeName = "test-type";
+            Request createIndexRequest = new Request("POST", indexName + "/" + typeName);
+            createIndexRequest.setJsonEntity("""
+                {
+                  "@timestamp": "2099-11-15T13:12:00",
+                  "message": "GET /search HTTP/1.1 200 1070000",
+                  "user": {
+                    "id": "kimchy"
+                  }
+                }""");
+            createIndexRequest.setOptions(RequestOptions.DEFAULT.toBuilder().setWarningsHandler(WarningsHandler.PERMISSIVE).build());
+            assertOK(client().performRequest(createIndexRequest));
+        }
         assertOK(client().performRequest(putIndexTemplateRequest));
         bulkLoadDataMissingTimestamp(indexName);
         /*


### PR DESCRIPTION
This reverts commit c58a727242c5e1aca47e186477eecab1378962f4.

https://github.com/elastic/elasticsearch-serverless/issues/4688