### PR TITLE
Drop project-id from threadcontext for CCS

### DIFF
--- a/docs/changelog/136664.yaml
+++ b/docs/changelog/136664.yaml
@@ -1,0 +1,5 @@
+pr: 136664
+summary: Drop project-id from threadcontext for CCS
+area: Authorization
+type: bug
+issues: []

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/CrossClusterAccessTransportInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/CrossClusterAccessTransportInterceptor.java
@@ -325,7 +325,12 @@ public class CrossClusterAccessTransportInterceptor implements RemoteClusterTran
                     threadContext.newRestorableContext(true),
                     handler
                 );
-                try (ThreadContext.StoredContext ignored = threadContext.stashContextPreservingRequestHeaders(AuditUtil.AUDIT_REQUEST_ID)) {
+                try (
+                    ThreadContext.StoredContext ignored = threadContext.stashContextPreservingRequestHeaders(
+                        ThreadContext.HeadersFor.REMOTE_CLUSTER,
+                        AuditUtil.AUDIT_REQUEST_ID
+                    )
+                ) {
                     if (connection.getTransportVersion().supports(ADD_CROSS_CLUSTER_API_KEY_SIGNATURE)) {
                         crossClusterAccessHeaders.writeToContext(threadContext, signer);
                     } else {


### PR DESCRIPTION
When making a request to a remote cluster, we don't want to include the current project-id ("X-Elastic-Project-Id") header in the thread context that we send to the remote cluster because the current project-id is not relevant to the thread context for the remote execution.
