### PR TITLE
[GPU] Cache GPUSupport.isSupported value

### DIFF
--- a/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/GPUPlugin.java
+++ b/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/GPUPlugin.java
@@ -32,6 +32,8 @@ public class GPUPlugin extends Plugin implements InternalVectorFormatProviderPlu
         AUTO
     }
 
+    private final boolean isGpuSupported = GPUSupport.isSupported(true);
+
     /**
      * Setting to control whether to use GPU for vectors indexing.
      * Currently only applicable for index_options.type: hnsw.
@@ -69,14 +71,14 @@ public class GPUPlugin extends Plugin implements InternalVectorFormatProviderPlu
                             "[index.vectors.indexing.use_gpu] doesn't support [index_options.type] of [" + indexOptions.getType() + "]."
                         );
                     }
-                    if (GPUSupport.isSupported(true) == false) {
+                    if (isGpuSupported == false) {
                         throw new IllegalArgumentException(
                             "[index.vectors.indexing.use_gpu] was set to [true], but GPU resources are not accessible on the node."
                         );
                     }
                     return getVectorsFormat(indexOptions);
                 }
-                if (gpuMode == GpuMode.AUTO && vectorIndexTypeSupported(indexOptions.getType()) && GPUSupport.isSupported(false)) {
+                if (gpuMode == GpuMode.AUTO && vectorIndexTypeSupported(indexOptions.getType()) && isGpuSupported) {
                     return getVectorsFormat(indexOptions);
                 }
             }


### PR DESCRIPTION
No need to call this repeatedly, and log support/non-support every time