### PR TITLE
Make exponential histogram aggregation tests check feature flag

### DIFF
--- a/x-pack/plugin/mapper-exponential-histogram/src/test/java/org/elasticsearch/xpack/exponentialhistogram/aggregations/metrics/ExponentialHistogramAggregatorTestCase.java
+++ b/x-pack/plugin/mapper-exponential-histogram/src/test/java/org/elasticsearch/xpack/exponentialhistogram/aggregations/metrics/ExponentialHistogramAggregatorTestCase.java
@@ -30,10 +30,7 @@ public abstract class ExponentialHistogramAggregatorTestCase extends AggregatorT
 
     @Before
     public void setup() {
-        assumeTrue(
-            "Only when exponential_histogram feature flag is enabled",
-            EXPONENTIAL_HISTOGRAM_FEATURE.isEnabled()
-        );
+        assumeTrue("Only when exponential_histogram feature flag is enabled", EXPONENTIAL_HISTOGRAM_FEATURE.isEnabled());
     }
 
     @Override

--- a/x-pack/plugin/mapper-exponential-histogram/src/test/java/org/elasticsearch/xpack/exponentialhistogram/aggregations/metrics/ExponentialHistogramAggregatorTestCase.java
+++ b/x-pack/plugin/mapper-exponential-histogram/src/test/java/org/elasticsearch/xpack/exponentialhistogram/aggregations/metrics/ExponentialHistogramAggregatorTestCase.java
@@ -16,6 +16,7 @@ import org.elasticsearch.search.aggregations.AggregatorTestCase;
 import org.elasticsearch.xpack.exponentialhistogram.ExponentialHistogramFieldMapper;
 import org.elasticsearch.xpack.exponentialhistogram.ExponentialHistogramMapperPlugin;
 import org.elasticsearch.xpack.exponentialhistogram.IndexWithCount;
+import org.junit.Before;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -23,7 +24,17 @@ import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import static org.elasticsearch.xpack.exponentialhistogram.ExponentialHistogramFieldMapper.EXPONENTIAL_HISTOGRAM_FEATURE;
+
 public abstract class ExponentialHistogramAggregatorTestCase extends AggregatorTestCase {
+
+    @Before
+    public void setup() {
+        assumeTrue(
+            "Only when exponential_histogram feature flag is enabled",
+            EXPONENTIAL_HISTOGRAM_FEATURE.isEnabled()
+        );
+    }
 
     @Override
     protected List<SearchPlugin> getSearchPlugins() {


### PR DESCRIPTION
In #136163 I forgot to make the tests only execute if the feature flag is present, causing failures in release tests.
Fixes #136630, #136628, #136631, #136629.
