### PR TITLE
[TEST] Fix PutSynonymsActionRequestSerializingTests equality tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/synonyms/PutSynonymsActionRequestSerializingTests.java
+++ b/server/src/test/java/org/elasticsearch/action/synonyms/PutSynonymsActionRequestSerializingTests.java
@@ -14,6 +14,8 @@ import org.elasticsearch.synonyms.SynonymRule;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.elasticsearch.action.synonyms.SynonymsTestUtils.randomSynonymsSet;
 
@@ -32,14 +34,14 @@ public class PutSynonymsActionRequestSerializingTests extends AbstractWireSerial
     @Override
     protected PutSynonymsAction.Request mutateInstance(PutSynonymsAction.Request instance) throws IOException {
         String synonymsSetId = instance.synonymsSetId();
-        SynonymRule[] synonymRules = instance.synonymRules();
+        List<SynonymRule> synonymRules = Arrays.asList(instance.synonymRules());
         boolean refresh = instance.refresh();
         switch (between(0, 2)) {
             case 0 -> synonymsSetId = randomValueOtherThan(synonymsSetId, () -> randomIdentifier());
-            case 1 -> synonymRules = randomValueOtherThan(synonymRules, () -> randomSynonymsSet());
+            case 1 -> synonymRules = randomValueOtherThan(synonymRules, () -> Arrays.asList(randomSynonymsSet()));
             case 2 -> refresh = refresh == false;
             default -> throw new AssertionError("Illegal randomisation branch");
         }
-        return new PutSynonymsAction.Request(synonymsSetId, synonymRules, refresh);
+        return new PutSynonymsAction.Request(synonymsSetId, synonymRules.toArray(new SynonymRule[0]), refresh);
     }
 }


### PR DESCRIPTION
Relates #136414

`randomValueOtherThan` does not handle arrays. Fixing this by mutating `synonymRules` as a list before converting back to array.

Closes #136652
