### PR TITLE
Lazy compute and cache `grantsAll` per privilege

### DIFF
--- a/docs/changelog/136679.yaml
+++ b/docs/changelog/136679.yaml
@@ -1,0 +1,5 @@
+pr: 136679
+summary: Lazy compute and cache `grantsAll` per privilege
+area: Authorization
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/ApplicationPermission.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/ApplicationPermission.java
@@ -197,7 +197,7 @@ public final class ApplicationPermission {
             if (this.application.test(other.getApplication()) == false) {
                 return false;
             }
-            if (Operations.isTotal(privilege.getAutomaton())) {
+            if (privilege.isGrantingAll()) {
                 return true;
             }
             return Operations.isEmpty(privilege.getAutomaton()) == false

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/Privilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/Privilege.java
@@ -7,6 +7,8 @@
 package org.elasticsearch.xpack.core.security.authz.privilege;
 
 import org.apache.lucene.util.automaton.Automaton;
+import org.apache.lucene.util.automaton.Operations;
+import org.elasticsearch.common.util.CachedSupplier;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.xpack.core.security.support.Automatons;
 
@@ -18,6 +20,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import static org.elasticsearch.xpack.core.security.support.Automatons.patterns;
 
@@ -29,6 +32,7 @@ public class Privilege {
     protected final Set<String> name;
     protected final Automaton automaton;
     protected final Predicate<String> predicate;
+    protected final Supplier<Boolean> grantsAll;
 
     public Privilege(String name, String... patterns) {
         this(Collections.singleton(name), patterns);
@@ -42,6 +46,7 @@ public class Privilege {
         this.name = name;
         this.automaton = automaton;
         this.predicate = Automatons.predicate(automaton);
+        this.grantsAll = CachedSupplier.wrap(() -> Operations.isTotal(automaton));
     }
 
     public Set<String> name() {
@@ -78,6 +83,13 @@ public class Privilege {
 
     public Automaton getAutomaton() {
         return automaton;
+    }
+
+    /**
+     * Returns true if this privilege grants all names.
+     */
+    public boolean isGrantingAll() {
+        return grantsAll.get();
     }
 
     /**


### PR DESCRIPTION
This change avoids calling expensive `Operations.isTotal` every 
time an application privilege is checked. This is done by caching 
the result per privilege. It avoids re-building privilege's automaton 
each time upstream `ApplicationPermission#grants` is called.
