### PR TITLE
Disable cross-cluster functionality for `_fleet/_fleet_msearch`

### DIFF
--- a/docs/changelog/136703.yaml
+++ b/docs/changelog/136703.yaml
@@ -1,12 +1,18 @@
 pr: 136703
 summary: Disable cross-cluster functionality for `_fleet/_fleet_msearch`
-area: CCS
+area: Search
 type: breaking
 issues: []
 breaking:
   title: Disable cross-cluster functionality for `_fleet/_fleet_msearch`
-  area: CCS
-  details: Please describe the details of this change for the release notes. You can
-    use asciidoc.
-  impact: Please describe the impact of this change to users
+  area: Search
+  details: |-
+    This endpoint is largely used for local searches only and is not compatible with true cross-cluster searches where
+    arbitrary number of indices and remotes can be specified. Although it is meant to accept an index parameter that
+    denotes a single searchable target, such a limitation can be bypassed through various means.
+
+    Keeping in view this endpoint's stated intent and future scope, cross-cluster functionality is being explicitly disabled.
+  impact: |-
+    This endpoint will no longer accept remote indices. Should one be provided, a top-level error is returned with
+    an appropriate explanation.
   notable: false

--- a/docs/changelog/136703.yaml
+++ b/docs/changelog/136703.yaml
@@ -1,0 +1,12 @@
+pr: 136703
+summary: Disable cross-cluster functionality for `_fleet/_fleet_msearch`
+area: CCS
+type: breaking
+issues: []
+breaking:
+  title: Disable cross-cluster functionality for `_fleet/_fleet_msearch`
+  area: CCS
+  details: Please describe the details of this change for the release notes. You can
+    use asciidoc.
+  impact: Please describe the impact of this change to users
+  notable: false

--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/rest/RestFleetMultiSearchAction.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/rest/RestFleetMultiSearchAction.java
@@ -107,15 +107,14 @@ public class RestFleetMultiSearchAction extends BaseRestHandler {
                         "Fleet search API param wait_for_checkpoints is only supported with an index to search specified. "
                             + "No index specified."
                     );
+                } else if (indices.length > 1) {
+                    throw new IllegalArgumentException(
+                        "Fleet search API only supports searching a single index. Found: [" + Arrays.toString(indices) + "]."
+                    );
                 }
             }
-            if (indices.length > 1) {
-                throw new IllegalArgumentException(
-                    "Fleet search API only supports searching a single index. Found: [" + Arrays.toString(indices) + "]."
-                );
-            }
 
-            if (RemoteClusterService.isRemoteIndexName(indices[0])) {
+            if (indices.length == 1 && RemoteClusterService.isRemoteIndexName(indices[0])) {
                 throw new IllegalArgumentException("Fleet search API does not support remote indices. Found: [" + indices[0] + "].");
             }
             long[] checkpoints = searchRequest.getWaitForCheckpoints().get("*");

--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/rest/RestFleetMultiSearchAction.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/rest/RestFleetMultiSearchAction.java
@@ -22,6 +22,7 @@ import org.elasticsearch.rest.action.RestCancellableNodeClient;
 import org.elasticsearch.rest.action.RestRefCountedChunkedToXContentListener;
 import org.elasticsearch.rest.action.search.RestMultiSearchAction;
 import org.elasticsearch.rest.action.search.RestSearchAction;
+import org.elasticsearch.transport.RemoteClusterService;
 import org.elasticsearch.usage.SearchUsageHolder;
 
 import java.io.IOException;
@@ -106,11 +107,16 @@ public class RestFleetMultiSearchAction extends BaseRestHandler {
                         "Fleet search API param wait_for_checkpoints is only supported with an index to search specified. "
                             + "No index specified."
                     );
-                } else if (indices.length > 1) {
-                    throw new IllegalArgumentException(
-                        "Fleet search API only supports searching a single index. Found: [" + Arrays.toString(indices) + "]."
-                    );
                 }
+            }
+            if (indices.length > 1) {
+                throw new IllegalArgumentException(
+                    "Fleet search API only supports searching a single index. Found: [" + Arrays.toString(indices) + "]."
+                );
+            }
+
+            if (RemoteClusterService.isRemoteIndexName(indices[0])) {
+                throw new IllegalArgumentException("Fleet search API does not support remote indices. Found: [" + indices[0] + "].");
             }
             long[] checkpoints = searchRequest.getWaitForCheckpoints().get("*");
             if (checkpoints != null) {


### PR DESCRIPTION
As done here: https://github.com/elastic/elasticsearch/pull/136039, I'm also disabling cross-cluster functionality for the Fleet multisearch endpoint. This, too, is covered by the previously approved blanket-breaking change proposal.

Note: This endpoint prevents multiple indices only when checkpoints are specified. However, the docs don't seem to say any such thing:
```
index string Required
A single target to search. If the target is an index alias, it must resolve to a single index.
``` 

It also says:
```
However, similar to the Fleet search API, it supports the wait_for_checkpoints parameter.
```

But `_fleet/_fleet_search` does not depend on this param to prevent multiple indices. I'll recheck this point and update this PR with the changes and an explicit comment.