### PR TITLE
Introduce ESTestCase.randomArrayOtherThan() methods

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/indices/sampling/DeleteSampleConfigurationActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/sampling/DeleteSampleConfigurationActionTests.java
@@ -47,7 +47,7 @@ public class DeleteSampleConfigurationActionTests extends AbstractWireSerializin
                     instance.masterNodeTimeout(),
                     instance.ackTimeout()
                 );
-                String[] newIndices = randomValueOtherThanArray(instance.indices(), () -> new String[] { randomAlphaOfLength(10) });
+                String[] newIndices = randomArrayOtherThan(instance.indices(), () -> new String[] { randomAlphaOfLength(10) });
                 mutated.indices(newIndices);
                 yield mutated;
             }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/sampling/DeleteSampleConfigurationActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/sampling/DeleteSampleConfigurationActionTests.java
@@ -47,7 +47,7 @@ public class DeleteSampleConfigurationActionTests extends AbstractWireSerializin
                     instance.masterNodeTimeout(),
                     instance.ackTimeout()
                 );
-                String[] newIndices = randomValueOtherThan(instance.indices(), () -> new String[] { randomAlphaOfLength(10) });
+                String[] newIndices = randomValueOtherThanArray(instance.indices(), () -> new String[] { randomAlphaOfLength(10) });
                 mutated.indices(newIndices);
                 yield mutated;
             }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/sampling/PutSampleConfigurationActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/sampling/PutSampleConfigurationActionTests.java
@@ -55,7 +55,7 @@ public class PutSampleConfigurationActionTests extends AbstractWireSerializingTe
                     instance.masterNodeTimeout(),
                     instance.ackTimeout()
                 );
-                mutated.indices(randomValueOtherThan(instance.indices(), () -> new String[] { randomAlphaOfLengthBetween(1, 10) }));
+                mutated.indices(randomValueOtherThanArray(instance.indices(), () -> new String[] { randomAlphaOfLengthBetween(1, 10) }));
                 yield mutated;
             }
             default -> throw new IllegalStateException("Invalid mutation case");

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/sampling/PutSampleConfigurationActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/sampling/PutSampleConfigurationActionTests.java
@@ -55,7 +55,7 @@ public class PutSampleConfigurationActionTests extends AbstractWireSerializingTe
                     instance.masterNodeTimeout(),
                     instance.ackTimeout()
                 );
-                mutated.indices(randomValueOtherThanArray(instance.indices(), () -> new String[] { randomAlphaOfLengthBetween(1, 10) }));
+                mutated.indices(randomArrayOtherThan(instance.indices(), () -> new String[] { randomAlphaOfLengthBetween(1, 10) }));
                 yield mutated;
             }
             default -> throw new IllegalStateException("Invalid mutation case");

--- a/server/src/test/java/org/elasticsearch/action/synonyms/PutSynonymsActionRequestSerializingTests.java
+++ b/server/src/test/java/org/elasticsearch/action/synonyms/PutSynonymsActionRequestSerializingTests.java
@@ -36,7 +36,7 @@ public class PutSynonymsActionRequestSerializingTests extends AbstractWireSerial
         boolean refresh = instance.refresh();
         switch (between(0, 2)) {
             case 0 -> synonymsSetId = randomValueOtherThan(synonymsSetId, () -> randomIdentifier());
-            case 1 -> synonymRules = randomValueOtherThanArray(synonymRules, () -> randomSynonymsSet());
+            case 1 -> synonymRules = randomArrayOtherThan(synonymRules, () -> randomSynonymsSet());
             case 2 -> refresh = refresh == false;
             default -> throw new AssertionError("Illegal randomisation branch");
         }

--- a/server/src/test/java/org/elasticsearch/action/synonyms/PutSynonymsActionRequestSerializingTests.java
+++ b/server/src/test/java/org/elasticsearch/action/synonyms/PutSynonymsActionRequestSerializingTests.java
@@ -14,8 +14,6 @@ import org.elasticsearch.synonyms.SynonymRule;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
 
 import static org.elasticsearch.action.synonyms.SynonymsTestUtils.randomSynonymsSet;
 
@@ -34,14 +32,14 @@ public class PutSynonymsActionRequestSerializingTests extends AbstractWireSerial
     @Override
     protected PutSynonymsAction.Request mutateInstance(PutSynonymsAction.Request instance) throws IOException {
         String synonymsSetId = instance.synonymsSetId();
-        List<SynonymRule> synonymRules = Arrays.asList(instance.synonymRules());
+        SynonymRule[] synonymRules = instance.synonymRules();
         boolean refresh = instance.refresh();
         switch (between(0, 2)) {
             case 0 -> synonymsSetId = randomValueOtherThan(synonymsSetId, () -> randomIdentifier());
-            case 1 -> synonymRules = randomValueOtherThan(synonymRules, () -> Arrays.asList(randomSynonymsSet()));
+            case 1 -> synonymRules = randomValueOtherThanArray(synonymRules, () -> randomSynonymsSet());
             case 2 -> refresh = refresh == false;
             default -> throw new AssertionError("Illegal randomisation branch");
         }
-        return new PutSynonymsAction.Request(synonymsSetId, synonymRules.toArray(new SynonymRule[0]), refresh);
+        return new PutSynonymsAction.Request(synonymsSetId, synonymRules, refresh);
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/vectors/KnnSearchBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/KnnSearchBuilderTests.java
@@ -126,7 +126,7 @@ public class KnnSearchBuilderTests extends AbstractXContentSerializingTestCase<K
                 ).boost(instance.boost);
             }
             case 1 -> {
-                float[] newVector = randomValueOtherThanArray(instance.queryVector.asFloatVector(), () -> randomVector(5));
+                float[] newVector = randomArrayOtherThan(instance.queryVector.asFloatVector(), () -> randomVector(5));
                 yield new KnnSearchBuilder(
                     instance.field,
                     newVector,

--- a/server/src/test/java/org/elasticsearch/search/vectors/KnnSearchBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/KnnSearchBuilderTests.java
@@ -126,7 +126,7 @@ public class KnnSearchBuilderTests extends AbstractXContentSerializingTestCase<K
                 ).boost(instance.boost);
             }
             case 1 -> {
-                float[] newVector = randomValueOtherThan(instance.queryVector.asFloatVector(), () -> randomVector(5));
+                float[] newVector = randomValueOtherThanArray(instance.queryVector.asFloatVector(), () -> randomVector(5));
                 yield new KnnSearchBuilder(
                     instance.field,
                     newVector,

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -1501,7 +1501,72 @@ public abstract class ESTestCase extends LuceneTestCase {
      * helper to get a random value in a certain range that's different from the input
      */
     public static <T> T randomValueOtherThan(T input, Supplier<T> randomSupplier) {
+        assert input == null || input.getClass().isArray() == false
+            : "randomValueOtherThan() does not work as expected with arrays, use randomValueOtherThanArray() instead";
         return randomValueOtherThanMany(v -> Objects.equals(input, v), randomSupplier);
+    }
+
+    /**
+     * helper to get a random value in a certain range that's different from the input, for object arrays
+     */
+    public static <T> T[] randomValueOtherThanArray(T[] input, Supplier<T[]> randomSupplier) {
+        return randomValueOtherThanMany(v -> Arrays.equals(input, v), randomSupplier);
+    }
+
+    /**
+     * helper to get a random value in a certain range that's different from the input, for boolean arrays
+     */
+    public static boolean[] randomValueOtherThanArray(boolean[] input, Supplier<boolean[]> randomSupplier) {
+        return randomValueOtherThanMany(v -> Arrays.equals(input, v), randomSupplier);
+    }
+
+    /**
+     * helper to get a random value in a certain range that's different from the input, for byte arrays
+     */
+    public static byte[] randomValueOtherThanArray(byte[] input, Supplier<byte[]> randomSupplier) {
+        return randomValueOtherThanMany(v -> Arrays.equals(input, v), randomSupplier);
+    }
+
+    /**
+     * helper to get a random value in a certain range that's different from the input, for char arrays
+     */
+    public static char[] randomValueOtherThanArray(char[] input, Supplier<char[]> randomSupplier) {
+        return randomValueOtherThanMany(v -> Arrays.equals(input, v), randomSupplier);
+    }
+
+    /**
+     * helper to get a random value in a certain range that's different from the input, for short arrays
+     */
+    public static short[] randomValueOtherThanArray(short[] input, Supplier<short[]> randomSupplier) {
+        return randomValueOtherThanMany(v -> Arrays.equals(input, v), randomSupplier);
+    }
+
+    /**
+     * helper to get a random value in a certain range that's different from the input, for int arrays
+     */
+    public static int[] randomValueOtherThanArray(int[] input, Supplier<int[]> randomSupplier) {
+        return randomValueOtherThanMany(v -> Arrays.equals(input, v), randomSupplier);
+    }
+
+    /**
+     * helper to get a random value in a certain range that's different from the input, for long arrays
+     */
+    public static long[] randomValueOtherThanArray(long[] input, Supplier<long[]> randomSupplier) {
+        return randomValueOtherThanMany(v -> Arrays.equals(input, v), randomSupplier);
+    }
+
+    /**
+     * helper to get a random value in a certain range that's different from the input, for float arrays
+     */
+    public static float[] randomValueOtherThanArray(float[] input, Supplier<float[]> randomSupplier) {
+        return randomValueOtherThanMany(v -> Arrays.equals(input, v), randomSupplier);
+    }
+
+    /**
+     * helper to get a random value in a certain range that's different from the input, for double arrays
+     */
+    public static double[] randomValueOtherThanArray(double[] input, Supplier<double[]> randomSupplier) {
+        return randomValueOtherThanMany(v -> Arrays.equals(input, v), randomSupplier);
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -1502,70 +1502,70 @@ public abstract class ESTestCase extends LuceneTestCase {
      */
     public static <T> T randomValueOtherThan(T input, Supplier<T> randomSupplier) {
         assert input == null || input.getClass().isArray() == false
-            : "randomValueOtherThan() does not work as expected with arrays, use randomValueOtherThanArray() instead";
+            : "randomValueOtherThan() does not work as expected with arrays, use randomArrayOtherThan() instead";
         return randomValueOtherThanMany(v -> Objects.equals(input, v), randomSupplier);
     }
 
     /**
      * helper to get a random value in a certain range that's different from the input, for object arrays
      */
-    public static <T> T[] randomValueOtherThanArray(T[] input, Supplier<T[]> randomSupplier) {
+    public static <T> T[] randomArrayOtherThan(T[] input, Supplier<T[]> randomSupplier) {
         return randomValueOtherThanMany(v -> Arrays.equals(input, v), randomSupplier);
     }
 
     /**
      * helper to get a random value in a certain range that's different from the input, for boolean arrays
      */
-    public static boolean[] randomValueOtherThanArray(boolean[] input, Supplier<boolean[]> randomSupplier) {
+    public static boolean[] randomArrayOtherThan(boolean[] input, Supplier<boolean[]> randomSupplier) {
         return randomValueOtherThanMany(v -> Arrays.equals(input, v), randomSupplier);
     }
 
     /**
      * helper to get a random value in a certain range that's different from the input, for byte arrays
      */
-    public static byte[] randomValueOtherThanArray(byte[] input, Supplier<byte[]> randomSupplier) {
+    public static byte[] randomArrayOtherThan(byte[] input, Supplier<byte[]> randomSupplier) {
         return randomValueOtherThanMany(v -> Arrays.equals(input, v), randomSupplier);
     }
 
     /**
      * helper to get a random value in a certain range that's different from the input, for char arrays
      */
-    public static char[] randomValueOtherThanArray(char[] input, Supplier<char[]> randomSupplier) {
+    public static char[] randomArrayOtherThan(char[] input, Supplier<char[]> randomSupplier) {
         return randomValueOtherThanMany(v -> Arrays.equals(input, v), randomSupplier);
     }
 
     /**
      * helper to get a random value in a certain range that's different from the input, for short arrays
      */
-    public static short[] randomValueOtherThanArray(short[] input, Supplier<short[]> randomSupplier) {
+    public static short[] randomArrayOtherThan(short[] input, Supplier<short[]> randomSupplier) {
         return randomValueOtherThanMany(v -> Arrays.equals(input, v), randomSupplier);
     }
 
     /**
      * helper to get a random value in a certain range that's different from the input, for int arrays
      */
-    public static int[] randomValueOtherThanArray(int[] input, Supplier<int[]> randomSupplier) {
+    public static int[] randomArrayOtherThan(int[] input, Supplier<int[]> randomSupplier) {
         return randomValueOtherThanMany(v -> Arrays.equals(input, v), randomSupplier);
     }
 
     /**
      * helper to get a random value in a certain range that's different from the input, for long arrays
      */
-    public static long[] randomValueOtherThanArray(long[] input, Supplier<long[]> randomSupplier) {
+    public static long[] randomArrayOtherThan(long[] input, Supplier<long[]> randomSupplier) {
         return randomValueOtherThanMany(v -> Arrays.equals(input, v), randomSupplier);
     }
 
     /**
      * helper to get a random value in a certain range that's different from the input, for float arrays
      */
-    public static float[] randomValueOtherThanArray(float[] input, Supplier<float[]> randomSupplier) {
+    public static float[] randomArrayOtherThan(float[] input, Supplier<float[]> randomSupplier) {
         return randomValueOtherThanMany(v -> Arrays.equals(input, v), randomSupplier);
     }
 
     /**
      * helper to get a random value in a certain range that's different from the input, for double arrays
      */
-    public static double[] randomValueOtherThanArray(double[] input, Supplier<double[]> randomSupplier) {
+    public static double[] randomArrayOtherThan(double[] input, Supplier<double[]> randomSupplier) {
         return randomValueOtherThanMany(v -> Arrays.equals(input, v), randomSupplier);
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ClusterRequestTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ClusterRequestTests.java
@@ -121,7 +121,7 @@ public class ClusterRequestTests extends AbstractWireSerializingTestCase<Cluster
                     in.configuration(),
                     new RemoteClusterPlan(
                         plan.plan(),
-                        randomValueOtherThan(plan.targetIndices(), () -> generateRandomStringArray(10, 10, false, false)),
+                        randomValueOtherThanArray(plan.targetIndices(), () -> generateRandomStringArray(10, 10, false, false)),
                         plan.originalIndices()
                     )
                 );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ClusterRequestTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ClusterRequestTests.java
@@ -121,7 +121,7 @@ public class ClusterRequestTests extends AbstractWireSerializingTestCase<Cluster
                     in.configuration(),
                     new RemoteClusterPlan(
                         plan.plan(),
-                        randomValueOtherThanArray(plan.targetIndices(), () -> generateRandomStringArray(10, 10, false, false)),
+                        randomArrayOtherThan(plan.targetIndices(), () -> generateRandomStringArray(10, 10, false, false)),
                         plan.originalIndices()
                     )
                 );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/DataNodeRequestSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/DataNodeRequestSerializationTests.java
@@ -243,7 +243,7 @@ public class DataNodeRequestSerializationTests extends AbstractWireSerializingTe
                 yield request;
             }
             case 7 -> {
-                var indices = randomValueOtherThan(in.indices(), () -> generateRandomStringArray(10, 10, false, false));
+                var indices = randomValueOtherThanArray(in.indices(), () -> generateRandomStringArray(10, 10, false, false));
                 var request = new DataNodeRequest(
                     in.sessionId(),
                     in.configuration(),

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/DataNodeRequestSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/DataNodeRequestSerializationTests.java
@@ -243,7 +243,7 @@ public class DataNodeRequestSerializationTests extends AbstractWireSerializingTe
                 yield request;
             }
             case 7 -> {
-                var indices = randomValueOtherThanArray(in.indices(), () -> generateRandomStringArray(10, 10, false, false));
+                var indices = randomArrayOtherThan(in.indices(), () -> generateRandomStringArray(10, 10, false, false));
                 var request = new DataNodeRequest(
                     in.sessionId(),
                     in.configuration(),


### PR DESCRIPTION
The existing randomValueOtherThan() method uses Objects.equals() to determine if a randomly generated object is equal to the provided argument. This approach does not work as expected for arrays, however, since two arrays with identical contents will not be considered equal by Objects.equals(). See #136652

This commit introduces randomArrayOtherThan() methods for Object arrays and primitive arrays and converts all places in the code that were previously passing arrays into randomValueOtherThan() to use the new array-specific methods