### PR TITLE
[9.2] [ML] Clean up inference indices on failed endpoint creation (#136577)

### DIFF
--- a/docs/changelog/136577.yaml
+++ b/docs/changelog/136577.yaml
@@ -1,0 +1,6 @@
+pr: 136577
+summary: Clean up inference indices on failed endpoint creation
+area: Machine Learning
+type: bug
+issues:
+ - 123726


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[ML] Clean up inference indices on failed endpoint creation (#136577)](https://github.com/elastic/elasticsearch/pull/136577)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)