### PR TITLE
Throw IllegalArgumentException when shape field is missing during fetch

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/AbstractGeometryQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/AbstractGeometryQueryBuilder.java
@@ -362,7 +362,7 @@ public abstract class AbstractGeometryQueryBuilder<QB extends AbstractGeometryQu
                             }
                         }
                     }
-                    throw new IllegalStateException("Shape with name [" + getRequest.id() + "] found but missing " + path + " field");
+                    throw new IllegalArgumentException("Shape with name [" + getRequest.id() + "] found but missing " + path + " field");
                 }
             } catch (Exception e) {
                 l.onFailure(e);

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityTests.java
@@ -601,10 +601,10 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
         final ShapeQueryBuilder shapeQuery2 = new ShapeQueryBuilder("field", "2").relation(ShapeRelation.WITHIN)
             .indexedShapeIndex("shape_index")
             .indexedShapePath("other");
-        IllegalStateException e;
+        IllegalArgumentException e;
         if (randomBoolean()) {
             e = expectThrows(
-                IllegalStateException.class,
+                IllegalArgumentException.class,
                 () -> client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user6", USERS_PASSWD)))
                     .prepareSearch("search_index")
                     .setQuery(QueryBuilders.matchAllQuery())
@@ -613,7 +613,7 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
             );
         } else {
             e = expectThrows(
-                IllegalStateException.class,
+                IllegalArgumentException.class,
                 () -> client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user6", USERS_PASSWD)))
                     .prepareSearch("search_index")
                     .setQuery(shapeQuery2)


### PR DESCRIPTION
geoshape queries support queries using [pre-indexed shapes](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-geo-shape-query#_pre_indexed_shape).  Currently if we provide an existing document with an incorrect field, we are throwing an IllegalStateException which translate into a 500 http error. 

This is not right as this is wrong input from the user so we should throw an  IllegalArgumentException which translates into a 400 error.