### PR TITLE
[PoC] Push vector similarity functions using BlockDocValuesReader

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/BlockDocValuesReader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BlockDocValuesReader.java
@@ -521,13 +521,13 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
         private final String fieldName;
         private final int dimensions;
         private final DenseVectorFieldMapper.DenseVectorFieldType fieldType;
-        private final DenseVectorFieldMapper.DenseVectorBlockValueLoader blockValueLoader;
+        private final DenseVectorFieldMapper.DenseVectorBlockLoaderValueFunction blockValueLoader;
 
         public DenseVectorValueBlockLoader(
             String fieldName,
             int dimensions,
             DenseVectorFieldMapper.DenseVectorFieldType fieldType,
-            DenseVectorFieldMapper.DenseVectorBlockValueLoader blockValueLoader
+            DenseVectorFieldMapper.DenseVectorBlockLoaderValueFunction blockValueLoader
         ) {
             this.fieldName = fieldName;
             this.dimensions = dimensions;
@@ -546,7 +546,7 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
                 case FLOAT -> {
                     FloatVectorValues floatVectorValues = context.reader().getFloatVectorValues(fieldName);
                     if (floatVectorValues != null) {
-                        DenseVectorFieldMapper.DenseVectorBlockValueLoader valueLoader = blockValueLoader;
+                        DenseVectorFieldMapper.DenseVectorBlockLoaderValueFunction valueLoader = blockValueLoader;
                         if (fieldType.isNormalized()) {
                             // Wrap in a normalizing loader
                             NumericDocValues magnitudeDocValues = context.reader()
@@ -574,10 +574,10 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
         protected final T vectorValues;
         protected final KnnVectorValues.DocIndexIterator iterator;
         protected final int dimensions;
-        protected final DenseVectorFieldMapper.DenseVectorBlockValueLoader blockValueLoader;
+        protected final DenseVectorFieldMapper.DenseVectorBlockLoaderValueFunction blockValueLoader;
 
         DenseVectorValueBlockReader(T vectorValues, int dimensions,
-                                    DenseVectorFieldMapper.DenseVectorBlockValueLoader blockValueLoader) {
+                                    DenseVectorFieldMapper.DenseVectorBlockLoaderValueFunction blockValueLoader) {
             this.vectorValues = vectorValues;
             iterator = vectorValues.iterator();
             this.dimensions = dimensions;
@@ -633,14 +633,14 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
     private static class FloatDenseVectorValueBlockReader extends DenseVectorValueBlockReader<FloatVectorValues, float[]> {
 
         FloatDenseVectorValueBlockReader(FloatVectorValues vectorValues, int dimensions,
-                                         DenseVectorFieldMapper.DenseVectorBlockValueLoader blockValueLoader) {
+                                         DenseVectorFieldMapper.DenseVectorBlockLoaderValueFunction blockValueLoader) {
             super(vectorValues, dimensions, blockValueLoader);
         }
 
         @Override
         protected void readValue(DoubleBuilder builder) throws IOException {
             float[] floats = vectorValues.vectorValue(iterator.index());
-            blockValueLoader.addValue(floats, builder);
+            blockValueLoader.applyAndAdd(floats, builder);
         }
 
         @Override
@@ -654,7 +654,7 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
         private final NumericDocValues magnitudeDocValues;
 
         FloatNormalizedBlockValueLoader(FloatVectorValues vectorValues, int dimensions,
-                                        DenseVectorFieldMapper.DenseVectorBlockValueLoader blockValueLoader,
+                                        DenseVectorFieldMapper.DenseVectorBlockLoaderValueFunction blockValueLoader,
                                                NumericDocValues magnitudeDocValues) {
             super(vectorValues, dimensions, blockValueLoader);
             this.magnitudeDocValues = magnitudeDocValues;
@@ -671,21 +671,21 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
                     floats[i] *= magnitude;
                 }
             }
-            blockValueLoader.addValue(floats, builder);
+            blockValueLoader.applyAndAdd(floats, builder);
         }
     }
 
     private static class ByteDenseVectorValueBlockReader extends DenseVectorValueBlockReader<ByteVectorValues, byte[]> {
 
         ByteDenseVectorValueBlockReader(ByteVectorValues vectorValues, int dimensions,
-                                        DenseVectorFieldMapper.DenseVectorBlockValueLoader blockValueLoader) {
+                                        DenseVectorFieldMapper.DenseVectorBlockLoaderValueFunction blockValueLoader) {
             super(vectorValues, dimensions, blockValueLoader);
         }
 
         @Override
         protected void readValue(DoubleBuilder builder) throws IOException {
             byte[] bytes = vectorValues.vectorValue(iterator.index());
-            blockValueLoader.addValue(bytes, builder);
+            blockValueLoader.applyAndAdd(bytes, builder);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/BlockDocValuesReader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BlockDocValuesReader.java
@@ -815,8 +815,8 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
     }
 
     private static class ByteDenseVectorValuesBlockReader extends DenseVectorValuesBlockReader<ByteVectorValues> {
-        ByteDenseVectorValuesBlockReader(ByteVectorValues floatVectorValues, int dimensions) {
-            super(floatVectorValues, dimensions);
+        ByteDenseVectorValuesBlockReader(ByteVectorValues byteVectorValues, int dimensions) {
+            super(byteVectorValues, dimensions);
         }
 
         protected void appendDoc(BlockLoader.FloatBuilder builder) throws IOException {

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -703,6 +703,10 @@ public abstract class MappedFieldType {
          * The {@code _field_names} field mapper, mostly used to check if it is enabled.
          */
         FieldNamesFieldMapper.FieldNamesFieldType fieldNames();
+
+        default Function<?, ?> valueTransformation() {
+            return null;
+        }
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -661,6 +661,10 @@ public abstract class MappedFieldType {
          * method to load the field if it needs to.
          */
         STORED,
+        /**
+         * A {@link BlockLoaderValueFunction} needs to be applied for extracting the field value.
+         * The function will be used to transform the field value after loading it, and returning a potentially different type
+         */
         FUNCTION;
     }
 
@@ -711,10 +715,22 @@ public abstract class MappedFieldType {
         }
     }
 
+    /**
+     * Function that can be used to transform values loaded by a {@link BlockLoader}. Will be part of the {@link BlockLoaderContext} when
+     * the fieldExtractPreference is {@link FieldExtractPreference#FUNCTION}.
+     * @param <T> the type of the value loaded by the BlockLoader before being transformed
+     * @param <B> the type of BlockLoader.Builder used to store the transformed values
+     */
     public interface BlockLoaderValueFunction<T, B extends BlockLoader.Builder> {
+        /**
+         * Creates a builder for the BlockLoader that will load the values transformed by this function.
+         */
         B builder(BlockLoader.BlockFactory factory, int expectedCount);
 
-        void applyAndAdd(T value, B builder) throws IOException;
+        /**
+         * Applies the function to the value passed as parameter, and adds it to the builder that was returned by {@link #builder(BlockLoader.BlockFactory, int)}.
+         */
+        void applyFunctionAndAdd(T value, B builder) throws IOException;
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -660,7 +660,8 @@ public abstract class MappedFieldType {
          * loading many fields. The {@link MappedFieldType} can chose a different
          * method to load the field if it needs to.
          */
-        STORED;
+        STORED,
+        FUNCTION;
     }
 
     /**
@@ -705,15 +706,15 @@ public abstract class MappedFieldType {
         FieldNamesFieldMapper.FieldNamesFieldType fieldNames();
 
         @Nullable
-        default BlockValueLoader<?, ?> valueLoader() {
-            return null;
+        default BlockLoaderValueFunction<?, ?> blockLoaderValueFunction() {
+            throw new UnsupportedOperationException("blockLoaderValueFunction is not supported");
         }
     }
 
-    public interface BlockValueLoader<T, B extends BlockLoader.Builder> {
+    public interface BlockLoaderValueFunction<T, B extends BlockLoader.Builder> {
         B builder(BlockLoader.BlockFactory factory, int expectedCount);
 
-        void addValue(T value, B builder) throws IOException;
+        void applyAndAdd(T value, B builder) throws IOException;
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -704,9 +704,16 @@ public abstract class MappedFieldType {
          */
         FieldNamesFieldMapper.FieldNamesFieldType fieldNames();
 
-        default Function<?, ?> valueTransformation() {
+        @Nullable
+        default BlockValueLoader<?, ?> valueLoader() {
             return null;
         }
+    }
+
+    public interface BlockValueLoader<T, B extends BlockLoader.Builder> {
+        B builder(BlockLoader.BlockFactory factory, int expectedCount);
+
+        void addValue(T value, B builder) throws IOException;
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -2691,7 +2691,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
                         name(),
                         dims,
                         this,
-                        (BlockValueLoader<float[], ?>) blContext.valueLoader()
+                        (BlockValueLoader<float[], BlockLoader.DoubleBuilder>) blContext.valueLoader()
                     );
                 }
                 return new BlockDocValuesReader.DenseVectorBlockLoader(name(), dims, this);

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -2691,7 +2691,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
                         name(),
                         dims,
                         this,
-                        (BlockValueLoader<float[], BlockLoader.DoubleBuilder>) blContext.valueLoader()
+                        (DenseVectorBlockValueLoader) blContext.valueLoader()
                     );
                 }
                 return new BlockDocValuesReader.DenseVectorBlockLoader(name(), dims, this);

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -3138,10 +3138,17 @@ public class DenseVectorFieldMapper extends FieldMapper {
 
     public interface SimilarityFunction {
         float calculateSimilarity(float[] v1, float[] v2);
+
         float calculateSimilarity(byte[] v1, byte[] v2);
     }
 
-    public static class DenseVectorBlockLoaderValueFunction implements MappedFieldType.BlockLoaderValueFunction<float[], BlockLoader.DoubleBuilder> {
+    /**
+     * A specialized BlockLoaderValueFunction that calculates similarity between an indexed vector and the query vector. As
+     * vectors can be indexed either as float[] or byte[] we need to handle both cases to route similarity correctly
+     */
+    public static class DenseVectorBlockLoaderValueFunction
+        implements
+            MappedFieldType.BlockLoaderValueFunction<float[], BlockLoader.DoubleBuilder> {
 
         private final SimilarityFunction similarityFunction;
         private final float[] vector;
@@ -3156,11 +3163,11 @@ public class DenseVectorFieldMapper extends FieldMapper {
             return factory.doubles(expectedCount);
         }
 
-        public void applyAndAdd(float[] value, BlockLoader.DoubleBuilder builder) throws IOException {
+        public void applyFunctionAndAdd(float[] value, BlockLoader.DoubleBuilder builder) throws IOException {
             builder.appendDouble(similarityFunction.calculateSimilarity(value, vector));
         }
 
-        public void applyAndAdd(byte[] value, BlockLoader.DoubleBuilder builder) throws IOException {
+        public void applyFunctionAndAdd(byte[] value, BlockLoader.DoubleBuilder builder) throws IOException {
             if (vectorAsBytes == null) {
                 vectorAsBytes = new byte[vector.length];
                 for (int i = 0; i < vector.length; i++) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -107,7 +107,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
@@ -2687,12 +2686,12 @@ public class DenseVectorFieldMapper extends FieldMapper {
             }
 
             if (indexed) {
-                if (blContext.valueTransformation() != null) {
-                    return new BlockDocValuesReader.DenseVectorFunctionBlockLoader(
+                if (blContext.valueLoader() != null) {
+                    return new BlockDocValuesReader.DenseVectorValueBlockLoader(
                         name(),
                         dims,
                         this,
-                        (Function<float[], Double>) blContext.valueTransformation()
+                        (BlockValueLoader<float[], ?>) blContext.valueLoader()
                     );
                 }
                 return new BlockDocValuesReader.DenseVectorBlockLoader(name(), dims, this);

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -107,6 +107,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
@@ -2678,6 +2679,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
         }
 
         @Override
+        @SuppressWarnings("unchecked")
         public BlockLoader blockLoader(MappedFieldType.BlockLoaderContext blContext) {
             if (dims == null) {
                 // No data has been indexed yet
@@ -2685,6 +2687,14 @@ public class DenseVectorFieldMapper extends FieldMapper {
             }
 
             if (indexed) {
+                if (blContext.valueTransformation() != null) {
+                    return new BlockDocValuesReader.DenseVectorFunctionBlockLoader(
+                        name(),
+                        dims,
+                        this,
+                        (Function<float[], Double>) blContext.valueTransformation()
+                    );
+                }
                 return new BlockDocValuesReader.DenseVectorBlockLoader(name(), dims, this);
             }
 

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/FieldFunctionAttribute.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/FieldFunctionAttribute.java
@@ -11,7 +11,12 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 
 import java.util.concurrent.atomic.AtomicLong;
 
-
+/**
+ * A field attribute that has a function applied to it for value extraction.
+ * This is used to replace a field attribute with a function that can extract
+ * the value in a way that is more efficient than loading the raw field value
+ * and applying the function to it.
+ */
 public class FieldFunctionAttribute extends FieldAttribute {
 
     private static final AtomicLong COUNTER = new AtomicLong();
@@ -32,6 +37,9 @@ public class FieldFunctionAttribute extends FieldAttribute {
         this.dataType = dataType;
     }
 
+    /**
+     * Returns the function that will be used to load the value of the field and transform it
+     */
     public MappedFieldType.BlockLoaderValueFunction<?, ?> getBlockLoaderValueFunction() {
         return blockLoaderValueFunction;
     }

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/FieldFunctionAttribute.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/FieldFunctionAttribute.java
@@ -6,35 +6,34 @@
  */
 package org.elasticsearch.xpack.esql.core.expression;
 
-import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 
 import java.util.concurrent.atomic.AtomicLong;
 
 
-public class FieldTransformationAttribute<T, B extends BlockLoader.Builder>  extends FieldAttribute {
+public class FieldFunctionAttribute extends FieldAttribute {
 
     private static final AtomicLong COUNTER = new AtomicLong();
 
-    private final MappedFieldType.BlockValueLoader<?, ?> blockValueLoader;
+    private final MappedFieldType.BlockLoaderValueFunction<?, ?> blockLoaderValueFunction;
     private final DataType dataType;
     private final FieldName fieldName;
 
-    public FieldTransformationAttribute(
+    public FieldFunctionAttribute(
         FieldAttribute fieldAttribute,
-        MappedFieldType.BlockValueLoader<?, ?> blockValueLoader,
+        MappedFieldType.BlockLoaderValueFunction<?, ?> blockLoaderValueFunction,
         DataType dataType
     ) {
         super(fieldAttribute.source(), fieldAttribute.parentName(), fieldAttribute.qualifier(),
             fieldAttribute.name() + "_replaced_" + COUNTER.incrementAndGet(), fieldAttribute.field(), fieldAttribute.synthetic());
         this.fieldName = fieldAttribute.fieldName();
-        this.blockValueLoader = blockValueLoader;
+        this.blockLoaderValueFunction = blockLoaderValueFunction;
         this.dataType = dataType;
     }
 
-    public MappedFieldType.BlockValueLoader<?, ?> getBlockValueLoader() {
-        return blockValueLoader;
+    public MappedFieldType.BlockLoaderValueFunction<?, ?> getBlockLoaderValueFunction() {
+        return blockLoaderValueFunction;
     }
 
     @Override

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/FieldFunctionAttribute.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/FieldFunctionAttribute.java
@@ -30,8 +30,14 @@ public class FieldFunctionAttribute extends FieldAttribute {
         MappedFieldType.BlockLoaderValueFunction<?, ?> blockLoaderValueFunction,
         DataType dataType
     ) {
-        super(fieldAttribute.source(), fieldAttribute.parentName(), fieldAttribute.qualifier(),
-            fieldAttribute.name() + "_replaced_" + COUNTER.incrementAndGet(), fieldAttribute.field(), fieldAttribute.synthetic());
+        super(
+            fieldAttribute.source(),
+            fieldAttribute.parentName(),
+            fieldAttribute.qualifier(),
+            fieldAttribute.name() + "_replaced_" + COUNTER.incrementAndGet(),
+            fieldAttribute.field(),
+            fieldAttribute.synthetic()
+        );
         this.fieldName = fieldAttribute.fieldName();
         this.blockLoaderValueFunction = blockLoaderValueFunction;
         this.dataType = dataType;

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/FieldTransformationAttribute.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/FieldTransformationAttribute.java
@@ -6,34 +6,35 @@
  */
 package org.elasticsearch.xpack.esql.core.expression;
 
+import org.elasticsearch.index.mapper.BlockLoader;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Function;
 
 
-public class FieldTransformationAttribute<T, U>  extends FieldAttribute {
+public class FieldTransformationAttribute<T, B extends BlockLoader.Builder>  extends FieldAttribute {
 
     private static final AtomicLong COUNTER = new AtomicLong();
 
-    private final Function<T, U> fieldValueTransformation;
+    private final MappedFieldType.BlockValueLoader<?, ?> blockValueLoader;
     private final DataType dataType;
     private final FieldName fieldName;
 
     public FieldTransformationAttribute(
         FieldAttribute fieldAttribute,
-        Function<T, U> fieldValueTransformation,
+        MappedFieldType.BlockValueLoader<?, ?> blockValueLoader,
         DataType dataType
     ) {
         super(fieldAttribute.source(), fieldAttribute.parentName(), fieldAttribute.qualifier(),
             fieldAttribute.name() + "_replaced_" + COUNTER.incrementAndGet(), fieldAttribute.field(), fieldAttribute.synthetic());
         this.fieldName = fieldAttribute.fieldName();
-        this.fieldValueTransformation = fieldValueTransformation;
+        this.blockValueLoader = blockValueLoader;
         this.dataType = dataType;
     }
 
-    public Function<T, U> getFieldValueTransformation() {
-        return fieldValueTransformation;
+    public MappedFieldType.BlockValueLoader<?, ?> getBlockValueLoader() {
+        return blockValueLoader;
     }
 
     @Override

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/FieldTransformationAttribute.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/FieldTransformationAttribute.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.esql.core.expression;
+
+import org.elasticsearch.xpack.esql.core.type.DataType;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+
+
+public class FieldTransformationAttribute<T, U>  extends FieldAttribute {
+
+    private static final AtomicLong COUNTER = new AtomicLong();
+
+    private final Function<T, U> fieldValueTransformation;
+    private final DataType dataType;
+    private final FieldName fieldName;
+
+    public FieldTransformationAttribute(
+        FieldAttribute fieldAttribute,
+        Function<T, U> fieldValueTransformation,
+        DataType dataType
+    ) {
+        super(fieldAttribute.source(), fieldAttribute.parentName(), fieldAttribute.qualifier(),
+            fieldAttribute.name() + "_replaced_" + COUNTER.incrementAndGet(), fieldAttribute.field(), fieldAttribute.synthetic());
+        this.fieldName = fieldAttribute.fieldName();
+        this.fieldValueTransformation = fieldValueTransformation;
+        this.dataType = dataType;
+    }
+
+    public Function<T, U> getFieldValueTransformation() {
+        return fieldValueTransformation;
+    }
+
+    @Override
+    public FieldName fieldName() {
+        return fieldName;
+    }
+
+    @Override
+    public DataType dataType() {
+        return dataType;
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/ShardContext.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/ShardContext.java
@@ -19,6 +19,7 @@ import org.elasticsearch.search.sort.SortBuilder;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 
 /**
  * Context of each shard we're operating against.
@@ -53,7 +54,12 @@ public interface ShardContext extends RefCounted {
     /**
      * Returns something to load values from this field into a {@link Block}.
      */
-    BlockLoader blockLoader(String name, boolean asUnsupportedSource, MappedFieldType.FieldExtractPreference fieldExtractPreference);
+    BlockLoader blockLoader(
+        String name,
+        boolean asUnsupportedSource,
+        MappedFieldType.FieldExtractPreference fieldExtractPreference,
+        Function<?, ?> valueTransformation
+    );
 
     /**
      * Returns the {@link MappedFieldType} for the given field name.

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/ShardContext.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/ShardContext.java
@@ -57,7 +57,7 @@ public interface ShardContext extends RefCounted {
         String name,
         boolean asUnsupportedSource,
         MappedFieldType.FieldExtractPreference fieldExtractPreference,
-        MappedFieldType.BlockValueLoader<?, ?> blockValueLoader
+        MappedFieldType.BlockLoaderValueFunction<?, ?> blockLoaderValueFunction
     );
 
     /**

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/ShardContext.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/ShardContext.java
@@ -19,7 +19,6 @@ import org.elasticsearch.search.sort.SortBuilder;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Function;
 
 /**
  * Context of each shard we're operating against.
@@ -58,7 +57,7 @@ public interface ShardContext extends RefCounted {
         String name,
         boolean asUnsupportedSource,
         MappedFieldType.FieldExtractPreference fieldExtractPreference,
-        Function<?, ?> valueTransformation
+        MappedFieldType.BlockValueLoader<?, ?> blockValueLoader
     );
 
     /**

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneSourceOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneSourceOperatorTests.java
@@ -464,7 +464,8 @@ public class LuceneSourceOperatorTests extends SourceOperatorTestCase {
         public BlockLoader blockLoader(
             String name,
             boolean asUnsupportedSource,
-            MappedFieldType.FieldExtractPreference fieldExtractPreference
+            MappedFieldType.FieldExtractPreference fieldExtractPreference,
+            Function<?, ?> valueTransformation
         ) {
             throw new UnsupportedOperationException();
         }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/DenseVectorFieldTypeIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/DenseVectorFieldTypeIT.java
@@ -217,7 +217,7 @@ public class DenseVectorFieldTypeIT extends AbstractEsqlIntegTestCase {
                 for (int j = 0; j < numDims; j++) {
                     switch (elementType) {
                         case FLOAT -> vector.add(randomFloatBetween(0F, 1F, true));
-                        case BYTE, BIT -> vector.add((byte) (randomFloatBetween(0F, 1F, true) * 127.0f));
+                        case BYTE, BIT -> vector.add((byte) randomIntBetween(-128, 127));
                         default -> throw new IllegalArgumentException("Unexpected element type: " + elementType);
                     }
                 }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/vector/VectorSimilarityFunctionsIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/vector/VectorSimilarityFunctionsIT.java
@@ -65,7 +65,7 @@ public class VectorSimilarityFunctionsIT extends AbstractEsqlIntegTestCase {
                 params.add(new Object[] { "v_l2_norm", L2Norm.SIMILARITY_FUNCTION, elementType });
             }
             if (EsqlCapabilities.Cap.HAMMING_VECTOR_SIMILARITY_FUNCTION.isEnabled() && elementType != ElementType.FLOAT) {
-                params.add(new Object[]{"v_hamming", Hamming.EVALUATOR_SIMILARITY_FUNCTION, elementType });
+                params.add(new Object[] { "v_hamming", Hamming.EVALUATOR_SIMILARITY_FUNCTION, elementType });
             }
         }
 
@@ -169,7 +169,6 @@ public class VectorSimilarityFunctionsIT extends AbstractEsqlIntegTestCase {
         return result;
     }
 
-
     @SuppressWarnings("unchecked")
     public void testTopNSimilarityBetweenConstantVectorAndField() {
         var randomVector = randomVector();
@@ -211,8 +210,11 @@ public class VectorSimilarityFunctionsIT extends AbstractEsqlIntegTestCase {
         }
     }
 
-    private Double calculateSimilarity(DenseVectorFieldMapper.SimilarityFunction similarityFunction, List<Number> randomVector,
-                                             List<Number> vector) {
+    private Double calculateSimilarity(
+        DenseVectorFieldMapper.SimilarityFunction similarityFunction,
+        List<Number> randomVector,
+        List<Number> vector
+    ) {
         if (randomVector == null || vector == null) {
             return null;
         }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/vector/VectorSimilarityFunctionsIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/vector/VectorSimilarityFunctionsIT.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.esql.vector;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
-import org.apache.lucene.index.VectorSimilarityFunction;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
@@ -18,13 +17,15 @@ import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.compute.operator.exchange.ExchangeService;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xpack.esql.EsqlClientException;
 import org.elasticsearch.xpack.esql.EsqlTestUtils;
 import org.elasticsearch.xpack.esql.action.AbstractEsqlIntegTestCase;
 import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
-import org.elasticsearch.xpack.esql.expression.function.vector.Hamming;
+import org.elasticsearch.xpack.esql.expression.function.vector.CosineSimilarity;
+import org.elasticsearch.xpack.esql.expression.function.vector.DotProduct;
 import org.elasticsearch.xpack.esql.expression.function.vector.L1Norm;
 import org.elasticsearch.xpack.esql.expression.function.vector.L2Norm;
 import org.elasticsearch.xpack.esql.expression.function.vector.VectorSimilarityFunction.SimilarityEvaluatorFunction;
@@ -39,27 +40,30 @@ import java.util.Locale;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 
+@TestLogging(value = "org.elasticsearch.xpack.esql:TRACE", reason = "debug")
 public class VectorSimilarityFunctionsIT extends AbstractEsqlIntegTestCase {
+
+    private List<List<Number>> leftVectors;
 
     @ParametersFactory
     public static Iterable<Object[]> parameters() throws Exception {
         List<Object[]> params = new ArrayList<>();
 
         if (EsqlCapabilities.Cap.COSINE_VECTOR_SIMILARITY_FUNCTION.isEnabled()) {
-            params.add(new Object[] { "v_cosine", (SimilarityEvaluatorFunction) VectorSimilarityFunction.COSINE::compare });
+            params.add(new Object[] { "v_cosine", CosineSimilarity.SIMILARITY_FUNCTION });
         }
         if (EsqlCapabilities.Cap.DOT_PRODUCT_VECTOR_SIMILARITY_FUNCTION.isEnabled()) {
-            params.add(new Object[] { "v_dot_product", (SimilarityEvaluatorFunction) VectorSimilarityFunction.DOT_PRODUCT::compare });
+            params.add(new Object[] { "v_dot_product", DotProduct.SIMILARITY_FUNCTION });
         }
         if (EsqlCapabilities.Cap.L1_NORM_VECTOR_SIMILARITY_FUNCTION.isEnabled()) {
-            params.add(new Object[] { "v_l1_norm", (SimilarityEvaluatorFunction) L1Norm::calculateSimilarity });
+            params.add(new Object[] { "v_l1_norm", L1Norm.SIMILARITY_FUNCTION });
         }
         if (EsqlCapabilities.Cap.L2_NORM_VECTOR_SIMILARITY_FUNCTION.isEnabled()) {
-            params.add(new Object[] { "v_l2_norm", (SimilarityEvaluatorFunction) L2Norm::calculateSimilarity });
+            params.add(new Object[] { "v_l2_norm", L2Norm.SIMILARITY_FUNCTION });
         }
-        if (EsqlCapabilities.Cap.HAMMING_VECTOR_SIMILARITY_FUNCTION.isEnabled()) {
-            params.add(new Object[] { "v_hamming", (SimilarityEvaluatorFunction) Hamming::calculateSimilarity });
-        }
+        // if (EsqlCapabilities.Cap.HAMMING_VECTOR_SIMILARITY_FUNCTION.isEnabled()) {
+        // params.add(new Object[] { "v_hamming", Hamming.SIMILARITY_FUNCTION});
+        // }
 
         return params;
     }
@@ -103,14 +107,14 @@ public class VectorSimilarityFunctionsIT extends AbstractEsqlIntegTestCase {
         try (var resp = run(query)) {
             List<List<Object>> valuesList = EsqlTestUtils.getValuesList(resp);
             valuesList.forEach(values -> {
-                float[] left = readVector((List<Float>) values.get(0));
-                float[] right = readVector((List<Float>) values.get(1));
+                float[] left = readVector((List<Number>) values.get(0));
+                float[] right = readVector((List<Number>) values.get(1));
                 Double similarity = (Double) values.get(2);
                 if (left == null || right == null) {
                     assertNull(similarity);
                 } else {
                     assertNotNull(similarity);
-                    float expectedSimilarity = similarityFunction.calculateSimilarity(left, right);
+                    double expectedSimilarity = similarityFunction.calculateSimilarity(left, right);
                     assertEquals(expectedSimilarity, similarity, 0.0001);
                 }
             });
@@ -129,17 +133,70 @@ public class VectorSimilarityFunctionsIT extends AbstractEsqlIntegTestCase {
         try (var resp = run(query)) {
             List<List<Object>> valuesList = EsqlTestUtils.getValuesList(resp);
             valuesList.forEach(values -> {
-                float[] left = readVector((List<Float>) values.get(0));
+                float[] left = readVector((List<Number>) values.get(0));
                 Double similarity = (Double) values.get(1);
                 if (left == null || randomVector == null) {
                     assertNull(similarity);
                 } else {
                     assertNotNull(similarity);
-                    float expectedSimilarity = similarityFunction.calculateSimilarity(left, randomVector);
+                    double expectedSimilarity = similarityFunction.calculateSimilarity(left, randomVector);
                     assertEquals(expectedSimilarity, similarity, 0.0001);
                 }
             });
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testTopNSimilarityBetweenConstantVectorAndField() {
+        var randomVector = randomVectorArray();
+        var query = String.format(Locale.ROOT, """
+                FROM test
+                | EVAL similarity = %s(left_vector, %s)
+                | SORT similarity DESC NULLS LAST
+                | LIMIT 10
+                | KEEP similarity
+            """, functionName, Arrays.toString(randomVector));
+
+        try (var resp = run(query)) {
+            List<List<Object>> valuesList = EsqlTestUtils.getValuesList(resp);
+            // for (List<Number> leftVector : leftVectors) {
+            // System.out.println("Original stored: " + leftVector + "converted: " +
+            // calculateSimilarityFloats(similarityFunction, randomVector, leftVector));
+            // }
+
+            List<Double> orderedSimilarity = leftVectors.stream()
+                .map(v -> calculateSimilarityFloats(similarityFunction, randomVector, v))
+                .sorted((d1, d2) -> {
+                    if (d1 == null && d2 == null) {
+                        return 0;
+                    }
+                    if (d1 == null) {
+                        return 1;
+                    }
+                    if (d2 == null) {
+                        return -1;
+                    }
+                    return -Double.compare(d1, d2);
+                })
+                .limit(10)
+                .toList();
+            for (int i = 0; i < valuesList.size(); i++) {
+                Double similarity = (Double) valuesList.get(i).get(0);
+                Double expectedSimilarity = orderedSimilarity.get(i);
+                if (similarity == null) {
+                    assertNull("Expected " + orderedSimilarity + " but got " + valuesList, expectedSimilarity);
+                } else {
+                    assertEquals("Expected " + orderedSimilarity + " but got " + valuesList, expectedSimilarity, similarity, 0.0001);
+                }
+            }
+        }
+    }
+
+    private Double calculateSimilarityFloats(SimilarityEvaluatorFunction similarityFunction, float[] randomVector, List<Number> vector) {
+        if (randomVector == null || vector == null) {
+            return null;
+        }
+        return similarityFunction.calculateSimilarity(randomVector, readVector(vector));
     }
 
     public void testDifferentDimensions() {
@@ -173,19 +230,19 @@ public class VectorSimilarityFunctionsIT extends AbstractEsqlIntegTestCase {
                 assertNull(similarity);
             } else {
                 assertNotNull(similarity);
-                float expectedSimilarity = similarityFunction.calculateSimilarity(vectorLeft, vectorRight);
+                double expectedSimilarity = similarityFunction.calculateSimilarity(vectorLeft, vectorRight);
                 assertEquals(expectedSimilarity, similarity, 0.0001);
             }
         }
     }
 
-    private static float[] readVector(List<Float> leftVector) {
+    private static float[] readVector(List<Number> leftVector) {
         if (leftVector == null) {
             return null;
         }
         float[] leftScratch = new float[leftVector.size()];
         for (int i = 0; i < leftVector.size(); i++) {
-            leftScratch[i] = leftVector.get(i);
+            leftScratch[i] = leftVector.get(i).floatValue();
         }
         return leftScratch;
     }
@@ -196,23 +253,25 @@ public class VectorSimilarityFunctionsIT extends AbstractEsqlIntegTestCase {
 
         numDims = randomIntBetween(32, 64) * 2; // min 64, even number
         int numDocs = randomIntBetween(10, 100);
+        this.leftVectors = new ArrayList<>();
         IndexRequestBuilder[] docs = new IndexRequestBuilder[numDocs];
         for (int i = 0; i < numDocs; i++) {
-            List<Float> leftVector = randomVector();
-            List<Float> rightVector = randomVector();
+            List<Number> leftVector = randomVector();
+            List<Number> rightVector = randomVector();
             docs[i] = prepareIndex("test").setId("" + i)
                 .setSource("id", String.valueOf(i), "left_vector", leftVector, "right_vector", rightVector);
+            leftVectors.add(leftVector);
         }
 
         indexRandom(true, docs);
     }
 
-    private List<Float> randomVector() {
+    private List<Number> randomVector() {
         assert numDims != 0 : "numDims must be set before calling randomVector()";
         if (rarely()) {
             return null;
         }
-        List<Float> vector = new ArrayList<>(numDims);
+        List<Number> vector = new ArrayList<>(numDims);
         for (int j = 0; j < numDims; j++) {
             vector.add(randomFloat());
         }
@@ -255,7 +314,7 @@ public class VectorSimilarityFunctionsIT extends AbstractEsqlIntegTestCase {
     }
 
     private void createDenseVectorField(XContentBuilder mapping, String fieldName) throws IOException {
-        mapping.startObject(fieldName).field("type", "dense_vector").field("similarity", "cosine");
+        mapping.startObject(fieldName).field("type", "dense_vector").field("similarity", "l2_norm");
         mapping.endObject();
     }
 }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/vector/VectorSimilarityFunctionsIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/vector/VectorSimilarityFunctionsIT.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.compute.operator.exchange.ExchangeService;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -28,7 +29,6 @@ import org.elasticsearch.xpack.esql.expression.function.vector.CosineSimilarity;
 import org.elasticsearch.xpack.esql.expression.function.vector.DotProduct;
 import org.elasticsearch.xpack.esql.expression.function.vector.L1Norm;
 import org.elasticsearch.xpack.esql.expression.function.vector.L2Norm;
-import org.elasticsearch.xpack.esql.expression.function.vector.VectorSimilarityFunction.SimilarityEvaluatorFunction;
 import org.junit.Before;
 
 import java.io.IOException;
@@ -85,12 +85,12 @@ public class VectorSimilarityFunctionsIT extends AbstractEsqlIntegTestCase {
     }
 
     private final String functionName;
-    private final SimilarityEvaluatorFunction similarityFunction;
+    private final DenseVectorFieldMapper.SimilarityFunction similarityFunction;
     private int numDims;
 
     public VectorSimilarityFunctionsIT(
         @Name("functionName") String functionName,
-        @Name("similarityFunction") SimilarityEvaluatorFunction similarityFunction
+        @Name("similarityFunction") DenseVectorFieldMapper.SimilarityFunction similarityFunction
     ) {
         this.functionName = functionName;
         this.similarityFunction = similarityFunction;
@@ -192,11 +192,12 @@ public class VectorSimilarityFunctionsIT extends AbstractEsqlIntegTestCase {
         }
     }
 
-    private Double calculateSimilarityFloats(SimilarityEvaluatorFunction similarityFunction, float[] randomVector, List<Number> vector) {
+    private Double calculateSimilarityFloats(DenseVectorFieldMapper.SimilarityFunction similarityFunction, float[] randomVector,
+                                             List<Number> vector) {
         if (randomVector == null || vector == null) {
             return null;
         }
-        return similarityFunction.calculateSimilarity(randomVector, readVector(vector));
+        return (double) similarityFunction.calculateSimilarity(randomVector, readVector(vector));
     }
 
     public void testDifferentDimensions() {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/AbstractLookupService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/AbstractLookupService.java
@@ -429,7 +429,8 @@ public abstract class AbstractLookupService<R extends AbstractLookupService.Requ
             BlockLoader loader = shardContext.blockLoader(
                 fieldName,
                 extractField.dataType() == DataType.UNSUPPORTED,
-                MappedFieldType.FieldExtractPreference.NONE
+                MappedFieldType.FieldExtractPreference.NONE,
+                null
             );
             fields.add(
                 new ValuesSourceReaderOperator.FieldInfo(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SpatialCentroid.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SpatialCentroid.java
@@ -109,10 +109,12 @@ public class SpatialCentroid extends SpatialAggregateFunction implements ToAggre
             case DataType.GEO_POINT -> switch (fieldExtractPreference) {
                 case DOC_VALUES -> new SpatialCentroidGeoPointDocValuesAggregatorFunctionSupplier();
                 case NONE, EXTRACT_SPATIAL_BOUNDS, STORED -> new SpatialCentroidGeoPointSourceValuesAggregatorFunctionSupplier();
+                case FUNCTION -> throw new EsqlIllegalArgumentException("Illegal field extract preference: " + fieldExtractPreference);
             };
             case DataType.CARTESIAN_POINT -> switch (fieldExtractPreference) {
                 case DOC_VALUES -> new SpatialCentroidCartesianPointDocValuesAggregatorFunctionSupplier();
                 case NONE, EXTRACT_SPATIAL_BOUNDS, STORED -> new SpatialCentroidCartesianPointSourceValuesAggregatorFunctionSupplier();
+                case FUNCTION -> throw new EsqlIllegalArgumentException("Illegal field extract preference: " + fieldExtractPreference);
             };
             default -> throw EsqlIllegalArgumentException.illegalDataType(type);
         };

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SpatialExtent.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SpatialExtent.java
@@ -123,12 +123,16 @@ public final class SpatialExtent extends SpatialAggregateFunction implements ToA
             case DataType.GEO_SHAPE -> switch (fieldExtractPreference) {
                 case EXTRACT_SPATIAL_BOUNDS -> new SpatialExtentGeoShapeDocValuesAggregatorFunctionSupplier();
                 case NONE, STORED -> new SpatialExtentGeoShapeSourceValuesAggregatorFunctionSupplier();
-                case DOC_VALUES, FUNCTION -> throw new EsqlIllegalArgumentException("Illegal field extract preference: " + fieldExtractPreference);
+                case DOC_VALUES, FUNCTION -> throw new EsqlIllegalArgumentException(
+                    "Illegal field extract preference: " + fieldExtractPreference
+                );
             };
             case DataType.CARTESIAN_SHAPE -> switch (fieldExtractPreference) {
                 case EXTRACT_SPATIAL_BOUNDS -> new SpatialExtentCartesianShapeDocValuesAggregatorFunctionSupplier();
                 case NONE, STORED -> new SpatialExtentCartesianShapeSourceValuesAggregatorFunctionSupplier();
-                case DOC_VALUES, FUNCTION -> throw new EsqlIllegalArgumentException("Illegal field extract preference: " + fieldExtractPreference);
+                case DOC_VALUES, FUNCTION -> throw new EsqlIllegalArgumentException(
+                    "Illegal field extract preference: " + fieldExtractPreference
+                );
             };
             default -> throw EsqlIllegalArgumentException.illegalDataType(type);
         };

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SpatialExtent.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/SpatialExtent.java
@@ -113,20 +113,22 @@ public final class SpatialExtent extends SpatialAggregateFunction implements ToA
             case DataType.GEO_POINT -> switch (fieldExtractPreference) {
                 case DOC_VALUES -> new SpatialExtentGeoPointDocValuesAggregatorFunctionSupplier();
                 case NONE, EXTRACT_SPATIAL_BOUNDS, STORED -> new SpatialExtentGeoPointSourceValuesAggregatorFunctionSupplier();
+                case FUNCTION -> throw new EsqlIllegalArgumentException("Illegal field extract preference: " + fieldExtractPreference);
             };
             case DataType.CARTESIAN_POINT -> switch (fieldExtractPreference) {
                 case DOC_VALUES -> new SpatialExtentCartesianPointDocValuesAggregatorFunctionSupplier();
                 case NONE, EXTRACT_SPATIAL_BOUNDS, STORED -> new SpatialExtentCartesianPointSourceValuesAggregatorFunctionSupplier();
+                case FUNCTION -> throw new EsqlIllegalArgumentException("Illegal field extract preference: " + fieldExtractPreference);
             };
             case DataType.GEO_SHAPE -> switch (fieldExtractPreference) {
                 case EXTRACT_SPATIAL_BOUNDS -> new SpatialExtentGeoShapeDocValuesAggregatorFunctionSupplier();
                 case NONE, STORED -> new SpatialExtentGeoShapeSourceValuesAggregatorFunctionSupplier();
-                case DOC_VALUES -> throw new EsqlIllegalArgumentException("Illegal field extract preference: " + fieldExtractPreference);
+                case DOC_VALUES, FUNCTION -> throw new EsqlIllegalArgumentException("Illegal field extract preference: " + fieldExtractPreference);
             };
             case DataType.CARTESIAN_SHAPE -> switch (fieldExtractPreference) {
                 case EXTRACT_SPATIAL_BOUNDS -> new SpatialExtentCartesianShapeDocValuesAggregatorFunctionSupplier();
                 case NONE, STORED -> new SpatialExtentCartesianShapeSourceValuesAggregatorFunctionSupplier();
-                case DOC_VALUES -> throw new EsqlIllegalArgumentException("Illegal field extract preference: " + fieldExtractPreference);
+                case DOC_VALUES, FUNCTION -> throw new EsqlIllegalArgumentException("Illegal field extract preference: " + fieldExtractPreference);
             };
             default -> throw EsqlIllegalArgumentException.illegalDataType(type);
         };

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/CosineSimilarity.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/CosineSimilarity.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.expression.function.vector;
 import org.apache.lucene.util.VectorUtil;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.function.scalar.BinaryScalarFunction;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
@@ -29,14 +30,14 @@ public class CosineSimilarity extends VectorSimilarityFunction {
         "CosineSimilarity",
         CosineSimilarity::new
     );
-    public static final BlockLoaderSimilarityEvaluatorFunction SIMILARITY_FUNCTION = new BlockLoaderSimilarityEvaluatorFunction() {
+    public static final DenseVectorFieldMapper.SimilarityFunction SIMILARITY_FUNCTION = new DenseVectorFieldMapper.SimilarityFunction() {
         @Override
-        public double calculateSimilarity(byte[] leftScratch, byte[] rightScratch) {
+        public float calculateSimilarity(byte[] leftScratch, byte[] rightScratch) {
             return VectorUtil.cosine(leftScratch, rightScratch);
         }
 
         @Override
-        public double calculateSimilarity(float[] leftScratch, float[] rightScratch) {
+        public float calculateSimilarity(float[] leftScratch, float[] rightScratch) {
             return VectorUtil.cosine(leftScratch, rightScratch);
         }
     };
@@ -65,7 +66,7 @@ public class CosineSimilarity extends VectorSimilarityFunction {
     }
 
     @Override
-    public BlockLoaderSimilarityEvaluatorFunction getSimilarityFunction() {
+    public DenseVectorFieldMapper.SimilarityFunction getSimilarityFunction() {
         return SIMILARITY_FUNCTION;
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/DotProduct.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/DotProduct.java
@@ -31,7 +31,7 @@ public class DotProduct extends VectorSimilarityFunction {
         DotProduct::new
     );
 
-    public static final DenseVectorFieldMapper.SimilarityFunction SIMILARITY_FUNCTION = new DenseVectorFieldMapper.SimilarityFunction () {
+    public static final DenseVectorFieldMapper.SimilarityFunction SIMILARITY_FUNCTION = new DenseVectorFieldMapper.SimilarityFunction() {
         @Override
         public float calculateSimilarity(byte[] leftScratch, byte[] rightScratch) {
             return VectorUtil.dotProduct(leftScratch, rightScratch);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/DotProduct.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/DotProduct.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.expression.function.vector;
 
+import org.apache.lucene.util.VectorUtil;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
@@ -21,8 +22,6 @@ import org.elasticsearch.xpack.esql.expression.function.Param;
 
 import java.io.IOException;
 
-import static org.apache.lucene.index.VectorSimilarityFunction.DOT_PRODUCT;
-
 public class DotProduct extends VectorSimilarityFunction {
 
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
@@ -30,7 +29,18 @@ public class DotProduct extends VectorSimilarityFunction {
         "DotProduct",
         DotProduct::new
     );
-    static final SimilarityEvaluatorFunction SIMILARITY_FUNCTION = DOT_PRODUCT::compare;
+
+    public static final BlockLoaderSimilarityEvaluatorFunction SIMILARITY_FUNCTION = new BlockLoaderSimilarityEvaluatorFunction() {
+        @Override
+        public double calculateSimilarity(byte[] leftScratch, byte[] rightScratch) {
+            return VectorUtil.dotProduct(leftScratch, rightScratch);
+        }
+
+        @Override
+        public double calculateSimilarity(float[] leftScratch, float[] rightScratch) {
+            return VectorUtil.dotProduct(leftScratch, rightScratch);
+        }
+    };
 
     @FunctionInfo(
         returnType = "double",
@@ -65,7 +75,7 @@ public class DotProduct extends VectorSimilarityFunction {
     }
 
     @Override
-    protected SimilarityEvaluatorFunction getSimilarityFunction() {
+    public BlockLoaderSimilarityEvaluatorFunction getSimilarityFunction() {
         return SIMILARITY_FUNCTION;
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/DotProduct.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/DotProduct.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.expression.function.vector;
 import org.apache.lucene.util.VectorUtil;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.function.scalar.BinaryScalarFunction;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
@@ -30,14 +31,14 @@ public class DotProduct extends VectorSimilarityFunction {
         DotProduct::new
     );
 
-    public static final BlockLoaderSimilarityEvaluatorFunction SIMILARITY_FUNCTION = new BlockLoaderSimilarityEvaluatorFunction() {
+    public static final DenseVectorFieldMapper.SimilarityFunction SIMILARITY_FUNCTION = new DenseVectorFieldMapper.SimilarityFunction () {
         @Override
-        public double calculateSimilarity(byte[] leftScratch, byte[] rightScratch) {
+        public float calculateSimilarity(byte[] leftScratch, byte[] rightScratch) {
             return VectorUtil.dotProduct(leftScratch, rightScratch);
         }
 
         @Override
-        public double calculateSimilarity(float[] leftScratch, float[] rightScratch) {
+        public float calculateSimilarity(float[] leftScratch, float[] rightScratch) {
             return VectorUtil.dotProduct(leftScratch, rightScratch);
         }
     };
@@ -75,7 +76,7 @@ public class DotProduct extends VectorSimilarityFunction {
     }
 
     @Override
-    public BlockLoaderSimilarityEvaluatorFunction getSimilarityFunction() {
+    public DenseVectorFieldMapper.SimilarityFunction getSimilarityFunction() {
         return SIMILARITY_FUNCTION;
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/Hamming.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/Hamming.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.expression.function.vector;
 import org.apache.lucene.util.VectorUtil;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.function.scalar.BinaryScalarFunction;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
@@ -25,14 +26,14 @@ import java.io.IOException;
 public class Hamming extends VectorSimilarityFunction {
 
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "Hamming", Hamming::new);
-    public static final BlockLoaderSimilarityEvaluatorFunction SIMILARITY_FUNCTION = new BlockLoaderSimilarityEvaluatorFunction() {
+    public static final DenseVectorFieldMapper.SimilarityFunction SIMILARITY_FUNCTION = new DenseVectorFieldMapper.SimilarityFunction () {
         @Override
-        public double calculateSimilarity(byte[] leftScratch, byte[] rightScratch) {
+        public float calculateSimilarity(byte[] leftScratch, byte[] rightScratch) {
             return Hamming.calculateSimilarity(leftScratch, rightScratch);
         }
 
         @Override
-        public double calculateSimilarity(float[] leftScratch, float[] rightScratch) {
+        public float calculateSimilarity(float[] leftScratch, float[] rightScratch) {
             throw new UnsupportedOperationException("Hamming distance is not supported for float vectors");
         }
     };
@@ -65,7 +66,7 @@ public class Hamming extends VectorSimilarityFunction {
     }
 
     @Override
-    public BlockLoaderSimilarityEvaluatorFunction getSimilarityFunction() {
+    public DenseVectorFieldMapper.SimilarityFunction  getSimilarityFunction() {
         return SIMILARITY_FUNCTION;
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/Hamming.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/Hamming.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 public class Hamming extends VectorSimilarityFunction {
 
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "Hamming", Hamming::new);
-    public static final DenseVectorFieldMapper.SimilarityFunction SIMILARITY_FUNCTION = new DenseVectorFieldMapper.SimilarityFunction () {
+    public static final DenseVectorFieldMapper.SimilarityFunction SIMILARITY_FUNCTION = new DenseVectorFieldMapper.SimilarityFunction() {
         @Override
         public float calculateSimilarity(byte[] leftScratch, byte[] rightScratch) {
             return Hamming.calculateSimilarity(leftScratch, rightScratch);
@@ -37,25 +37,26 @@ public class Hamming extends VectorSimilarityFunction {
             throw new UnsupportedOperationException("Hamming distance is not supported for float vectors");
         }
     };
-    public static final DenseVectorFieldMapper.SimilarityFunction EVALUATOR_SIMILARITY_FUNCTION = new DenseVectorFieldMapper.SimilarityFunction () {
-        @Override
-        public float calculateSimilarity(byte[] leftScratch, byte[] rightScratch) {
-            return Hamming.calculateSimilarity(leftScratch, rightScratch);
-        }
+    public static final DenseVectorFieldMapper.SimilarityFunction EVALUATOR_SIMILARITY_FUNCTION =
+        new DenseVectorFieldMapper.SimilarityFunction() {
+            @Override
+            public float calculateSimilarity(byte[] leftScratch, byte[] rightScratch) {
+                return Hamming.calculateSimilarity(leftScratch, rightScratch);
+            }
 
-        @Override
-        public float calculateSimilarity(float[] leftScratch, float[] rightScratch) {
-            byte[] a = new byte[leftScratch.length];
-            byte[] b = new byte[rightScratch.length];
-            for (int i = 0; i < leftScratch.length; i++) {
-                a[i] = (byte) leftScratch[i];
+            @Override
+            public float calculateSimilarity(float[] leftScratch, float[] rightScratch) {
+                byte[] a = new byte[leftScratch.length];
+                byte[] b = new byte[rightScratch.length];
+                for (int i = 0; i < leftScratch.length; i++) {
+                    a[i] = (byte) leftScratch[i];
+                }
+                for (int i = 0; i < leftScratch.length; i++) {
+                    b[i] = (byte) rightScratch[i];
+                }
+                return Hamming.calculateSimilarity(a, b);
             }
-            for (int i = 0; i < leftScratch.length; i++) {
-                b[i] = (byte) rightScratch[i];
-            }
-            return Hamming.calculateSimilarity(a, b);
-        }
-    };
+        };
 
     @FunctionInfo(
         returnType = "double",
@@ -85,7 +86,7 @@ public class Hamming extends VectorSimilarityFunction {
     }
 
     @Override
-    public DenseVectorFieldMapper.SimilarityFunction  getSimilarityFunction() {
+    public DenseVectorFieldMapper.SimilarityFunction getSimilarityFunction() {
         return SIMILARITY_FUNCTION;
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/Hamming.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/Hamming.java
@@ -37,6 +37,25 @@ public class Hamming extends VectorSimilarityFunction {
             throw new UnsupportedOperationException("Hamming distance is not supported for float vectors");
         }
     };
+    public static final DenseVectorFieldMapper.SimilarityFunction EVALUATOR_SIMILARITY_FUNCTION = new DenseVectorFieldMapper.SimilarityFunction () {
+        @Override
+        public float calculateSimilarity(byte[] leftScratch, byte[] rightScratch) {
+            return Hamming.calculateSimilarity(leftScratch, rightScratch);
+        }
+
+        @Override
+        public float calculateSimilarity(float[] leftScratch, float[] rightScratch) {
+            byte[] a = new byte[leftScratch.length];
+            byte[] b = new byte[rightScratch.length];
+            for (int i = 0; i < leftScratch.length; i++) {
+                a[i] = (byte) leftScratch[i];
+            }
+            for (int i = 0; i < leftScratch.length; i++) {
+                b[i] = (byte) rightScratch[i];
+            }
+            return Hamming.calculateSimilarity(a, b);
+        }
+    };
 
     @FunctionInfo(
         returnType = "double",
@@ -68,6 +87,10 @@ public class Hamming extends VectorSimilarityFunction {
     @Override
     public DenseVectorFieldMapper.SimilarityFunction  getSimilarityFunction() {
         return SIMILARITY_FUNCTION;
+    }
+
+    public DenseVectorFieldMapper.SimilarityFunction getEvaluatorSimilarityFunction() {
+        return EVALUATOR_SIMILARITY_FUNCTION;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/Hamming.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/Hamming.java
@@ -25,7 +25,17 @@ import java.io.IOException;
 public class Hamming extends VectorSimilarityFunction {
 
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "Hamming", Hamming::new);
-    static final SimilarityEvaluatorFunction SIMILARITY_FUNCTION = Hamming::calculateSimilarity;
+    public static final BlockLoaderSimilarityEvaluatorFunction SIMILARITY_FUNCTION = new BlockLoaderSimilarityEvaluatorFunction() {
+        @Override
+        public double calculateSimilarity(byte[] leftScratch, byte[] rightScratch) {
+            return Hamming.calculateSimilarity(leftScratch, rightScratch);
+        }
+
+        @Override
+        public double calculateSimilarity(float[] leftScratch, float[] rightScratch) {
+            throw new UnsupportedOperationException("Hamming distance is not supported for float vectors");
+        }
+    };
 
     @FunctionInfo(
         returnType = "double",
@@ -55,7 +65,7 @@ public class Hamming extends VectorSimilarityFunction {
     }
 
     @Override
-    protected SimilarityEvaluatorFunction getSimilarityFunction() {
+    public BlockLoaderSimilarityEvaluatorFunction getSimilarityFunction() {
         return SIMILARITY_FUNCTION;
     }
 
@@ -74,15 +84,7 @@ public class Hamming extends VectorSimilarityFunction {
         return ENTRY.name;
     }
 
-    public static float calculateSimilarity(float[] leftScratch, float[] rightScratch) {
-        byte[] a = new byte[leftScratch.length];
-        byte[] b = new byte[rightScratch.length];
-        for (int i = 0; i < leftScratch.length; i++) {
-            a[i] = (byte) leftScratch[i];
-        }
-        for (int i = 0; i < leftScratch.length; i++) {
-            b[i] = (byte) rightScratch[i];
-        }
-        return VectorUtil.xorBitCount(a, b);
+    public static float calculateSimilarity(byte[] leftScratch, byte[] rightScratch) {
+        return VectorUtil.xorBitCount(leftScratch, rightScratch);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/L1Norm.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/L1Norm.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.expression.function.vector;
 
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.function.scalar.BinaryScalarFunction;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
@@ -24,9 +25,9 @@ import java.io.IOException;
 public class L1Norm extends VectorSimilarityFunction {
 
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "L1Norm", L1Norm::new);
-    public static final BlockLoaderSimilarityEvaluatorFunction SIMILARITY_FUNCTION = new BlockLoaderSimilarityEvaluatorFunction() {
+    public static final DenseVectorFieldMapper.SimilarityFunction SIMILARITY_FUNCTION = new DenseVectorFieldMapper.SimilarityFunction() {
         @Override
-        public double calculateSimilarity(byte[] leftScratch, byte[] rightScratch) {
+        public float calculateSimilarity(byte[] leftScratch, byte[] rightScratch) {
             float result = 0f;
             for (int i = 0; i < leftScratch.length; i++) {
                 result += Math.absExact(leftScratch[i] - rightScratch[i]);
@@ -35,7 +36,7 @@ public class L1Norm extends VectorSimilarityFunction {
         }
 
         @Override
-        public double calculateSimilarity(float[] leftScratch, float[] rightScratch) {
+        public float calculateSimilarity(float[] leftScratch, float[] rightScratch) {
             float result = 0f;
             for (int i = 0; i < leftScratch.length; i++) {
                 result += Math.abs(leftScratch[i] - rightScratch[i]);
@@ -77,7 +78,7 @@ public class L1Norm extends VectorSimilarityFunction {
     }
 
     @Override
-    public BlockLoaderSimilarityEvaluatorFunction getSimilarityFunction() {
+    public DenseVectorFieldMapper.SimilarityFunction getSimilarityFunction() {
         return SIMILARITY_FUNCTION;
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/L1Norm.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/L1Norm.java
@@ -24,7 +24,25 @@ import java.io.IOException;
 public class L1Norm extends VectorSimilarityFunction {
 
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "L1Norm", L1Norm::new);
-    static final SimilarityEvaluatorFunction SIMILARITY_FUNCTION = L1Norm::calculateSimilarity;
+    public static final BlockLoaderSimilarityEvaluatorFunction SIMILARITY_FUNCTION = new BlockLoaderSimilarityEvaluatorFunction() {
+        @Override
+        public double calculateSimilarity(byte[] leftScratch, byte[] rightScratch) {
+            float result = 0f;
+            for (int i = 0; i < leftScratch.length; i++) {
+                result += Math.absExact(leftScratch[i] - rightScratch[i]);
+            }
+            return result;
+        }
+
+        @Override
+        public double calculateSimilarity(float[] leftScratch, float[] rightScratch) {
+            float result = 0f;
+            for (int i = 0; i < leftScratch.length; i++) {
+                result += Math.abs(leftScratch[i] - rightScratch[i]);
+            }
+            return result;
+        }
+    };
 
     @FunctionInfo(
         returnType = "double",
@@ -59,7 +77,7 @@ public class L1Norm extends VectorSimilarityFunction {
     }
 
     @Override
-    protected SimilarityEvaluatorFunction getSimilarityFunction() {
+    public BlockLoaderSimilarityEvaluatorFunction getSimilarityFunction() {
         return SIMILARITY_FUNCTION;
     }
 
@@ -71,14 +89,6 @@ public class L1Norm extends VectorSimilarityFunction {
     @Override
     public String getWriteableName() {
         return ENTRY.name;
-    }
-
-    public static float calculateSimilarity(float[] leftScratch, float[] rightScratch) {
-        float result = 0f;
-        for (int i = 0; i < leftScratch.length; i++) {
-            result += Math.abs(leftScratch[i] - rightScratch[i]);
-        }
-        return result;
     }
 
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/L2Norm.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/L2Norm.java
@@ -25,7 +25,18 @@ import java.io.IOException;
 public class L2Norm extends VectorSimilarityFunction {
 
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "L2Norm", L2Norm::new);
-    static final SimilarityEvaluatorFunction SIMILARITY_FUNCTION = L2Norm::calculateSimilarity;
+
+    public static final BlockLoaderSimilarityEvaluatorFunction SIMILARITY_FUNCTION = new BlockLoaderSimilarityEvaluatorFunction() {
+        @Override
+        public double calculateSimilarity(byte[] leftScratch, byte[] rightScratch) {
+            return (float) Math.sqrt(VectorUtil.squareDistance(leftScratch, rightScratch));
+        }
+
+        @Override
+        public double calculateSimilarity(float[] leftScratch, float[] rightScratch) {
+            return (float) Math.sqrt(VectorUtil.squareDistance(leftScratch, rightScratch));
+        }
+    };
 
     @FunctionInfo(
         returnType = "double",
@@ -60,7 +71,7 @@ public class L2Norm extends VectorSimilarityFunction {
     }
 
     @Override
-    protected SimilarityEvaluatorFunction getSimilarityFunction() {
+    public BlockLoaderSimilarityEvaluatorFunction getSimilarityFunction() {
         return SIMILARITY_FUNCTION;
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/L2Norm.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/L2Norm.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.expression.function.vector;
 import org.apache.lucene.util.VectorUtil;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.function.scalar.BinaryScalarFunction;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
@@ -26,14 +27,14 @@ public class L2Norm extends VectorSimilarityFunction {
 
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "L2Norm", L2Norm::new);
 
-    public static final BlockLoaderSimilarityEvaluatorFunction SIMILARITY_FUNCTION = new BlockLoaderSimilarityEvaluatorFunction() {
+    public static final DenseVectorFieldMapper.SimilarityFunction SIMILARITY_FUNCTION = new DenseVectorFieldMapper.SimilarityFunction() {
         @Override
-        public double calculateSimilarity(byte[] leftScratch, byte[] rightScratch) {
+        public float calculateSimilarity(byte[] leftScratch, byte[] rightScratch) {
             return (float) Math.sqrt(VectorUtil.squareDistance(leftScratch, rightScratch));
         }
 
         @Override
-        public double calculateSimilarity(float[] leftScratch, float[] rightScratch) {
+        public float calculateSimilarity(float[] leftScratch, float[] rightScratch) {
             return (float) Math.sqrt(VectorUtil.squareDistance(leftScratch, rightScratch));
         }
     };
@@ -71,7 +72,7 @@ public class L2Norm extends VectorSimilarityFunction {
     }
 
     @Override
-    public BlockLoaderSimilarityEvaluatorFunction getSimilarityFunction() {
+    public DenseVectorFieldMapper.SimilarityFunction getSimilarityFunction() {
         return SIMILARITY_FUNCTION;
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/VectorSimilarityFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/VectorSimilarityFunction.java
@@ -82,7 +82,7 @@ public abstract class VectorSimilarityFunction extends BinaryScalarFunction impl
         return new SimilarityEvaluatorFactory(
             leftVectorProviderFactory,
             rightVectorProviderFactory,
-            getSimilarityFunction(),
+            getEvaluatorSimilarityFunction(),
             getClass().getSimpleName() + "Evaluator"
         );
     }
@@ -103,6 +103,10 @@ public abstract class VectorSimilarityFunction extends BinaryScalarFunction impl
      * Returns the similarity function to be used for evaluating the similarity between two vectors.
      */
     public abstract DenseVectorFieldMapper.SimilarityFunction getSimilarityFunction();
+
+    public DenseVectorFieldMapper.SimilarityFunction getEvaluatorSimilarityFunction() {
+        return getSimilarityFunction();
+    }
 
     private record SimilarityEvaluatorFactory(
         VectorValueProviderFactory leftVectorProviderFactory,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/VectorSimilarityFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/VectorSimilarityFunction.java
@@ -111,7 +111,7 @@ public abstract class VectorSimilarityFunction extends BinaryScalarFunction impl
     private record SimilarityEvaluatorFactory(
         VectorValueProviderFactory leftVectorProviderFactory,
         VectorValueProviderFactory rightVectorProviderFactory,
-        DenseVectorFieldMapper.SimilarityFunction  similarityFunction,
+        DenseVectorFieldMapper.SimilarityFunction similarityFunction,
         String evaluatorName
     ) implements EvalOperator.ExpressionEvaluator.Factory {
 
@@ -136,7 +136,7 @@ public abstract class VectorSimilarityFunction extends BinaryScalarFunction impl
     private record SimilarityEvaluator(
         VectorValueProvider left,
         VectorValueProvider right,
-        DenseVectorFieldMapper.SimilarityFunction  similarityFunction,
+        DenseVectorFieldMapper.SimilarityFunction similarityFunction,
         String evaluatorName,
         BlockFactory blockFactory
     ) implements EvalOperator.ExpressionEvaluator {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/VectorSimilarityFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/VectorSimilarityFunction.java
@@ -74,7 +74,11 @@ public abstract class VectorSimilarityFunction extends BinaryScalarFunction impl
      */
     @FunctionalInterface
     public interface SimilarityEvaluatorFunction {
-        float calculateSimilarity(float[] leftScratch, float[] rightScratch);
+        double calculateSimilarity(float[] leftScratch, float[] rightScratch);
+    }
+
+    public interface BlockLoaderSimilarityEvaluatorFunction extends SimilarityEvaluatorFunction {
+        double calculateSimilarity(byte[] leftScratch, byte[] rightScratch);
     }
 
     @Override
@@ -109,7 +113,7 @@ public abstract class VectorSimilarityFunction extends BinaryScalarFunction impl
     /**
      * Returns the similarity function to be used for evaluating the similarity between two vectors.
      */
-    protected abstract SimilarityEvaluatorFunction getSimilarityFunction();
+    public abstract BlockLoaderSimilarityEvaluatorFunction getSimilarityFunction();
 
     private record SimilarityEvaluatorFactory(
         VectorValueProviderFactory leftVectorProviderFactory,
@@ -177,7 +181,7 @@ public abstract class VectorSimilarityFunction extends BinaryScalarFunction impl
                                 dimsRight
                             );
                         }
-                        float result = similarityFunction.calculateSimilarity(leftVector, rightVector);
+                        double result = similarityFunction.calculateSimilarity(leftVector, rightVector);
                         builder.appendDouble(result);
                     }
                     return builder.build();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
@@ -21,6 +21,7 @@ import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.ReplaceRoundT
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.ReplaceSourceAttributes;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.SpatialDocValuesExtraction;
 import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.SpatialShapeBoundsExtraction;
+import org.elasticsearch.xpack.esql.optimizer.rules.physical.local.VectorSimilarityFunctionsPushdown;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
 import org.elasticsearch.xpack.esql.rule.ParameterizedRuleExecutor;
 import org.elasticsearch.xpack.esql.rule.Rule;
@@ -87,7 +88,8 @@ public class LocalPhysicalPlanOptimizer extends ParameterizedRuleExecutor<Physic
             Limiter.ONCE,
             new InsertFieldExtraction(),
             new SpatialDocValuesExtraction(),
-            new SpatialShapeBoundsExtraction()
+            new SpatialShapeBoundsExtraction(),
+            new VectorSimilarityFunctionsPushdown()
         );
         return optimizeForEsSource ? List.of(pushdown, substitutionRules, fieldExtraction) : List.of(pushdown, fieldExtraction);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/VectorSimilarityFunctionsPushdown.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/VectorSimilarityFunctionsPushdown.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
+
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.FieldTransformationAttribute;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.expression.function.vector.VectorSimilarityFunction;
+import org.elasticsearch.xpack.esql.optimizer.PhysicalOptimizerRules;
+import org.elasticsearch.xpack.esql.plan.physical.EvalExec;
+import org.elasticsearch.xpack.esql.plan.physical.FieldExtractExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+public class VectorSimilarityFunctionsPushdown extends PhysicalOptimizerRules.OptimizerRule<EvalExec> {
+
+    // TODO We could replace on filters as well
+
+    @Override
+    protected PhysicalPlan rule(EvalExec eval) {
+        return replaceSimilarityFunctionsForFieldTransformations(eval);
+    }
+
+    @SuppressWarnings("unchecked")
+    private EvalExec replaceSimilarityFunctionsForFieldTransformations(EvalExec eval) {
+        Map<Attribute, Attribute> replacements = new HashMap<>();
+        EvalExec resultEval = (EvalExec) eval.transformExpressionsDown(VectorSimilarityFunction.class, similarityFunction -> {
+            if (similarityFunction.left() instanceof Literal ^ similarityFunction.right() instanceof Literal) {
+                return replaceFieldsForFieldTransformations(similarityFunction, replacements);
+            }
+            return similarityFunction;
+        });
+
+        if (replacements.isEmpty()) {
+            return eval;
+        }
+
+        resultEval = (EvalExec) resultEval.transformDown(FieldExtractExec.class, fieldEx -> {
+            List<Attribute> attrs = fieldEx.attributesToExtract();
+            assert attrs.stream().anyMatch(replacements::containsKey) : "Expected at least one attribute to be replaced";
+            List<Attribute> replaceAttrs = attrs.stream().map(a -> replacements.getOrDefault(a, a)).toList();
+
+            return fieldEx.withAttributesToExtract(replaceAttrs);
+        });
+
+        return resultEval;
+    }
+
+    private static Expression replaceFieldsForFieldTransformations(
+        VectorSimilarityFunction similarityFunction,
+        Map<Attribute, Attribute> replacements
+    ) {
+        // Only replace if exactly one side is a literal and the other a field attribute
+        if ((similarityFunction.left() instanceof Literal ^ similarityFunction.right() instanceof Literal) == false) {
+            return similarityFunction;
+        }
+
+        Literal literal = (Literal) (similarityFunction.left() instanceof Literal ? similarityFunction.left() : similarityFunction.right());
+        FieldAttribute fieldAttribute = null;
+        if (similarityFunction.left() instanceof FieldAttribute fa) {
+            fieldAttribute = fa;
+        } else if (similarityFunction.right() instanceof FieldAttribute fa) {
+            fieldAttribute = fa;
+        }
+        if (fieldAttribute == null) {
+            return similarityFunction;
+        }
+        @SuppressWarnings("unchecked")
+        List<Number> vectorList = (List<Number>) literal.value();
+        float[] vectorArray = new float[vectorList.size()];
+        for (int i = 0; i < vectorList.size(); i++) {
+            vectorArray[i] = vectorList.get(i).floatValue();
+        }
+
+        // Create a transformation function that computes similarity between each value and the literal value
+        Function<float[], Double> transformFunction = v -> similarityFunction.getSimilarityFunction().calculateSimilarity(v, vectorArray);
+
+        // Change the similarity function to a reference of a transformation on the field
+        var fieldTransformationAttribute = new FieldTransformationAttribute<>(fieldAttribute, transformFunction, DataType.DOUBLE);
+        replacements.put(fieldAttribute, fieldTransformationAttribute);
+        return fieldTransformationAttribute;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/FieldExtractExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/FieldExtractExec.java
@@ -80,7 +80,8 @@ public class FieldExtractExec extends UnaryExec implements EstimatesRowSize {
         List<Attribute> attributesToExtract,
         MappedFieldType.FieldExtractPreference defaultPreference,
         Set<Attribute> docValuesAttributes,
-        Set<Attribute> boundsAttributes, Set<Attribute> fieldFunctionAttributes
+        Set<Attribute> boundsAttributes,
+        Set<Attribute> fieldFunctionAttributes
     ) {
         super(source, child);
         this.attributesToExtract = attributesToExtract;
@@ -137,28 +138,63 @@ public class FieldExtractExec extends UnaryExec implements EstimatesRowSize {
 
     @Override
     public UnaryExec replaceChild(PhysicalPlan newChild) {
-        return new FieldExtractExec(source(), newChild, attributesToExtract,
-            defaultPreference, docValuesAttributes, boundsAttributes, fieldFunctionAttributes);
+        return new FieldExtractExec(
+            source(),
+            newChild,
+            attributesToExtract,
+            defaultPreference,
+            docValuesAttributes,
+            boundsAttributes,
+            fieldFunctionAttributes
+        );
     }
 
     public FieldExtractExec withDocValuesAttributes(Set<Attribute> docValuesAttributes) {
-        return new FieldExtractExec(source(), child(), attributesToExtract, defaultPreference,
-            docValuesAttributes, boundsAttributes, fieldFunctionAttributes);
+        return new FieldExtractExec(
+            source(),
+            child(),
+            attributesToExtract,
+            defaultPreference,
+            docValuesAttributes,
+            boundsAttributes,
+            fieldFunctionAttributes
+        );
     }
 
     public FieldExtractExec withBoundsAttributes(Set<Attribute> boundsAttributes) {
-        return new FieldExtractExec(source(), child(), attributesToExtract, defaultPreference,
-            docValuesAttributes, boundsAttributes, fieldFunctionAttributes);
+        return new FieldExtractExec(
+            source(),
+            child(),
+            attributesToExtract,
+            defaultPreference,
+            docValuesAttributes,
+            boundsAttributes,
+            fieldFunctionAttributes
+        );
     }
 
     public FieldExtractExec withAttributesToExtract(List<Attribute> attributesToExtract) {
-        return new FieldExtractExec(source(), child(), attributesToExtract, defaultPreference,
-            docValuesAttributes, boundsAttributes, fieldFunctionAttributes);
+        return new FieldExtractExec(
+            source(),
+            child(),
+            attributesToExtract,
+            defaultPreference,
+            docValuesAttributes,
+            boundsAttributes,
+            fieldFunctionAttributes
+        );
     }
 
     public FieldExtractExec withFieldFunctionAttributes(Set<Attribute> fieldFunctionAttributes) {
-        return new FieldExtractExec(source(), child(), attributesToExtract, defaultPreference,
-            docValuesAttributes, boundsAttributes, fieldFunctionAttributes);
+        return new FieldExtractExec(
+            source(),
+            child(),
+            attributesToExtract,
+            defaultPreference,
+            docValuesAttributes,
+            boundsAttributes,
+            fieldFunctionAttributes
+        );
     }
 
     public List<Attribute> attributesToExtract() {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/FieldExtractExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/FieldExtractExec.java
@@ -145,6 +145,10 @@ public class FieldExtractExec extends UnaryExec implements EstimatesRowSize {
         return new FieldExtractExec(source(), child(), attributesToExtract, defaultPreference, docValuesAttributes, boundsAttributes);
     }
 
+    public FieldExtractExec withAttributesToExtract(List<Attribute> attributesToExtract) {
+        return new FieldExtractExec(source(), child(), attributesToExtract, defaultPreference, docValuesAttributes, boundsAttributes);
+    }
+
     public List<Attribute> attributesToExtract() {
         return attributesToExtract;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
@@ -193,12 +193,12 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
             shardContext = new DefaultShardContextForUnmappedField(shardContext, kf);
         }
 
-        Function<?, ?> valueTransformation = attr instanceof FieldTransformationAttribute<?, ?>
-            ? ((FieldTransformationAttribute<?, ?>) attr).getFieldValueTransformation()
-            : Function.identity();
+        MappedFieldType.BlockValueLoader<?, ?> blockValueLoader = attr instanceof FieldTransformationAttribute<?, ?>
+            ? ((FieldTransformationAttribute<?, ?>) attr).getBlockValueLoader()
+            : null;
         boolean isUnsupported = attr.dataType() == DataType.UNSUPPORTED;
         String fieldName = getFieldName(attr);
-        BlockLoader blockLoader = shardContext.blockLoader(fieldName, isUnsupported, fieldExtractPreference, valueTransformation);
+        BlockLoader blockLoader = shardContext.blockLoader(fieldName, isUnsupported, fieldExtractPreference, blockValueLoader);
         MultiTypeEsField unionTypes = findUnionTypes(attr);
         if (unionTypes != null) {
             // Use the fully qualified name `cluster:index-name` because multiple types are resolved on coordinator with the cluster prefix
@@ -484,7 +484,7 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
             String name,
             boolean asUnsupportedSource,
             MappedFieldType.FieldExtractPreference fieldExtractPreference,
-            Function<?, ?> valueTransformation
+            MappedFieldType.BlockValueLoader<?, ?> blockValueLoader
         ) {
             if (asUnsupportedSource) {
                 return BlockLoader.CONSTANT_NULLS;
@@ -531,8 +531,8 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
                 }
 
                 @Override
-                public Function<?, ?> valueTransformation() {
-                    return valueTransformation;
+                public MappedFieldType.BlockValueLoader<?, ?> valueLoader() {
+                    return blockValueLoader;
                 }
             });
             if (loader == null) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/vector/AbstractVectorSimilarityFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/vector/AbstractVectorSimilarityFunctionTestCase.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.expression.function.vector;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 
 import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
@@ -43,7 +44,7 @@ public abstract class AbstractVectorSimilarityFunctionTestCase extends AbstractV
 
     protected static Iterable<Object[]> similarityParameters(
         String className,
-        VectorSimilarityFunction.SimilarityEvaluatorFunction similarityFunction
+        DenseVectorFieldMapper.SimilarityFunction similarityFunction
     ) {
 
         final String evaluatorName = className


### PR DESCRIPTION
Pushes down vector similarity functions, and applies them when loading vectors via `BlockDocValuesReader`.

This avoids the overhead of loading vectors into blocks, and calculate the functions afterwards in the compute engine. This directly calculates the similarity functions when loading the field, and loads the results directly into a block.

This approach consists on:
- A new `FieldExtractPreference`:  `FUNCTION`. This signals that the field must be extracted using a function.
- A `BlockLoaderValueFunction` interface, that is available on the `BlockLoaderContext` for fields that are extracted via `FUNCTION`. This interface defines both the Builder that will be used as a result of the transformation, and the transformation itself.
- This function is applied via a `DenseVectorValueBlockLoader`, that is used when a `FUNCTION` is used to extract a dense vector. It applies the transformation and loads the results.
- A `FieldFunctionAttribute` that is used to extract a `FieldAttribute` with a function.
- A `VectorSimilarityFunctionsPushdown` local physical optimization rule, that replaces a vector similarity function applied to a field with a `FieldFunctionAttribute` that will be used to extract the function result at field loading.

Work still pending:
- [ ] `VectorSimilarityFunctionsPushdown` needs to take into account that the field may still need to be extracted as it may be a reference in other places of the query
- [ ] Replace the current dense vector loading so it reuses the `DenseVectorValueBlockLoader` - vector loading could be done using a `BlockLoaderValueFunction` that just adds the vectors to the block. This will reduce code duplication and use a single code path for loading a field.
- [ ] Testing