### PR TITLE
[ML] Skip download check for non-packaged models

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutTrainedModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutTrainedModelAction.java
@@ -272,14 +272,18 @@ public class TransportPutTrainedModelAction extends TransportMasterNodeAction<Re
             }
         }, finalResponseListener::onFailure);
 
-        checkForExistingModelDownloadTask(
-            client,
-            trainedModelConfig.getModelId(),
-            request.isWaitForCompletion(),
-            finalResponseListener,
-            () -> handlePackageAndTagsListener.onResponse(null),
-            request.ackTimeout()
-        );
+        if (isPackageModel) {
+            checkForExistingModelDownloadTask(
+                client,
+                trainedModelConfig.getModelId(),
+                request.isWaitForCompletion(),
+                finalResponseListener,
+                () -> handlePackageAndTagsListener.onResponse(null),
+                request.ackTimeout()
+            );
+        } else {
+            handlePackageAndTagsListener.onResponse(null);
+        }
     }
 
     void verifyMlNodesAndModelArchitectures(


### PR DESCRIPTION
While investigating https://github.com/elastic/elasticsearch/issues/133603 I noticed that when creating a ML trained model the check for an existing download of the model always runs. Only pre-packaged models can be downloaded, the test can be skipped for models being uploaded to Elasticsearch
