### PR TITLE
[9.2] Fix log formatting in `SnapshotLifecycleTask` (#136709)

### DIFF
--- a/docs/changelog/136709.yaml
+++ b/docs/changelog/136709.yaml
@@ -1,0 +1,5 @@
+pr: 136709
+summary: Fix log formatting in `SnapshotLifecycleTask`
+area: ILM+SLM
+type: bug
+issues: []

--- a/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTask.java
+++ b/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTask.java
@@ -265,8 +265,9 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
                 @Override
                 public void onFailure(Exception e) {
                     SnapshotHistoryStore.logErrorOrWarning(
+                        logger,
                         clusterService.state(),
-                        () -> format("failed to create snapshot for snapshot lifecycle policy [{}]", policyMetadata.getPolicy().getId()),
+                        () -> format("failed to create snapshot for snapshot lifecycle policy [%s]", policyMetadata.getPolicy().getId()),
                         e
                     );
                     final long timestamp = Instant.now().toEpochMilli();

--- a/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/history/SnapshotHistoryStore.java
+++ b/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/history/SnapshotHistoryStore.java
@@ -88,6 +88,7 @@ public class SnapshotHistoryStore {
                 );
             },
                 exception -> logErrorOrWarning(
+                    logger,
                     clusterService.state(),
                     () -> format("failed to index snapshot history item in data stream [%s]: [%s]", SLM_HISTORY_DATA_STREAM, item),
                     exception
@@ -95,6 +96,7 @@ public class SnapshotHistoryStore {
             ));
         } catch (IOException exception) {
             logErrorOrWarning(
+                logger,
                 clusterService.state(),
                 () -> format("failed to index snapshot history item in data stream [%s]: [%s]", SLM_HISTORY_DATA_STREAM, item),
                 exception
@@ -103,7 +105,7 @@ public class SnapshotHistoryStore {
     }
 
     // On node shutdown, some operations are expected to fail, we log a warning instead of error during node shutdown for those exceptions
-    public static void logErrorOrWarning(ClusterState clusterState, Supplier<?> failureMsgSupplier, Exception exception) {
+    public static void logErrorOrWarning(Logger logger, ClusterState clusterState, Supplier<?> failureMsgSupplier, Exception exception) {
         if (PluginShutdownService.isLocalNodeShutdown(clusterState)) {
             logger.warn(failureMsgSupplier, exception);
         } else {


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Fix log formatting in `SnapshotLifecycleTask` (#136709)