### PR TITLE
Fixed recent OutOfMemory errors in logsdb java rest tests

### DIFF
--- a/x-pack/plugin/logsdb/build.gradle
+++ b/x-pack/plugin/logsdb/build.gradle
@@ -33,6 +33,7 @@ dependencies {
   implementation project(':modules:mapper-extras')
   testImplementation project(':modules:data-streams')
   testImplementation(testArtifact(project(xpackModule('core'))))
+  javaRestTestImplementation("commons-io:commons-io:2.15.1")
   javaRestTestImplementation(testArtifact(project(xpackModule('spatial'))))
   internalClusterTestImplementation(testArtifact(project(xpackModule('core'))))
 }

--- a/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/qa/StandardVersusLogsIndexModeChallengeRestIT.java
+++ b/x-pack/plugin/logsdb/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/qa/StandardVersusLogsIndexModeChallengeRestIT.java
@@ -7,6 +7,10 @@
 
 package org.elasticsearch.xpack.logsdb.qa;
 
+import org.apache.commons.io.input.ReaderInputStream;
+import org.apache.http.HttpEntity;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.InputStreamEntity;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
@@ -33,6 +37,8 @@ import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.Charset;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -126,7 +132,7 @@ public abstract class StandardVersusLogsIndexModeChallengeRestIT extends Abstrac
     }
 
     public void testMatchAllQuery() throws IOException {
-        int numberOfDocuments = ESTestCase.randomIntBetween(20, 60);
+        int numberOfDocuments = ESTestCase.randomIntBetween(20, 80);
         final List<XContentBuilder> documents = generateDocuments(numberOfDocuments);
 
         indexDocuments(documents);
@@ -203,7 +209,7 @@ public abstract class StandardVersusLogsIndexModeChallengeRestIT extends Abstrac
     }
 
     public void testHistogramAggregation() throws IOException {
-        int numberOfDocuments = ESTestCase.randomIntBetween(20, 70);
+        int numberOfDocuments = ESTestCase.randomIntBetween(20, 80);
         final List<XContentBuilder> documents = generateDocuments(numberOfDocuments);
 
         indexDocuments(documents);
@@ -239,7 +245,7 @@ public abstract class StandardVersusLogsIndexModeChallengeRestIT extends Abstrac
     }
 
     public void testDateHistogramAggregation() throws IOException {
-        int numberOfDocuments = ESTestCase.randomIntBetween(20, 70);
+        int numberOfDocuments = ESTestCase.randomIntBetween(20, 80);
         final List<XContentBuilder> documents = generateDocuments(numberOfDocuments);
 
         indexDocuments(documents);
@@ -405,7 +411,7 @@ public abstract class StandardVersusLogsIndexModeChallengeRestIT extends Abstrac
 
     protected final Map<String, Object> performBulkRequest(String json, boolean isBaseline) throws IOException {
         var request = new Request("POST", "/" + (isBaseline ? getBaselineDataStreamName() : getContenderDataStreamName()) + "/_bulk");
-        request.setJsonEntity(json);
+        request.setEntity(getHttpEntity(json));
         request.addParameter("refresh", "true");
         var response = client.performRequest(request);
         assertOK(response);
@@ -416,5 +422,18 @@ public abstract class StandardVersusLogsIndexModeChallengeRestIT extends Abstrac
             equalTo(false)
         );
         return responseBody;
+    }
+
+    /**
+     * When our JSON string is extremely large, calling request.setJsonEntity() may result in an OutOfMemory exception. This happens because
+     * the entire JSON string is converted into a single contiguous bytes array. This is especially problematic when the JSON string
+     * contains non-ascii characters as they require additional space to be encoded.
+     *
+     * The code below overcomes that by streaming the bytes on demand as opposed to all at once.
+     */
+    private HttpEntity getHttpEntity(String json) {
+        if (json == null) return null;
+        Charset charset = ContentType.APPLICATION_JSON.getCharset();
+        return new InputStreamEntity(new ReaderInputStream(new StringReader(json), charset), -1, ContentType.APPLICATION_JSON);
     }
 }


### PR DESCRIPTION
This is related to https://github.com/elastic/elasticsearch/issues/136002, https://github.com/elastic/elasticsearch/issues/135820, and https://github.com/elastic/elasticsearch/issues/136699.

With this change, I've essentially reverted https://github.com/elastic/elasticsearch/pull/136579.

My in depth investigation can be found [here](https://github.com/elastic/elasticsearch/issues/136699). 

tldr: we [recently](https://github.com/elastic/elasticsearch/commit/6a64375f20c5a25db8c3d4f44fa395d3845959a8) added non-ascii characters to our randomized tests. With that, the encoded JSON string could explode in size because non-ascii characters require more bytes to be encoded. This explains the recent influx of OutOfMemory errors in tests. The solution is to forego the encoding all at  once and instead stream the JSON bytes on demand.

Tested with the previously failing commands:

```
./gradlew ":x-pack:plugin:logsdb:javaRestTest" --tests "org.elasticsearch.xpack.logsdb.qa.BulkDynamicMappingChallengeRestIT.testTermsAggregation" -Dtests.seed=1D45B6AF8DFC118 -Dtests.locale=lt-LT -Dtests.timezone=Australia/South -Druntime.java=25

./gradlew ":x-pack:plugin:logsdb:javaRestTest" --tests "org.elasticsearch.xpack.logsdb.qa.BulkDynamicMappingChallengeRestIT.testHistogramAggregation" -Dtests.seed=EE07E6FBFF95F687 -Dtests.locale=no-Latn-NO -Dtests.timezone=America/Phoenix -Druntime.java=25

./gradlew ":x-pack:plugin:logsdb:javaRestTest" --tests "org.elasticsearch.xpack.logsdb.qa.BulkDynamicMappingChallengeRestIT.testMatchAllQuery" -Dtests.seed=44C97E4C1DB9C64B -Dtests.locale=en-AT -Dtests.timezone=Atlantic/Reykjavik -Druntime.java=25
```

Also tested by changing the number of docs to the max amount of 80.