### PR TITLE
[8.19] streams: fix stability/documentation (#136642)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/streams.logs_disable.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/streams.logs_disable.json
@@ -1,10 +1,10 @@
 {
   "streams.logs_disable": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/streams-logs-disable.html",
+      "url": "https://www.elastic.co/docs/api/doc/elasticsearch#TODO",
       "description": "Disable the Logs Streams feature for this cluster"
     },
-    "stability": "stable",
+    "stability": "experimental",
     "visibility": "feature_flag",
     "feature_flag": "logs_stream",
     "headers": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/streams.logs_enable.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/streams.logs_enable.json
@@ -1,10 +1,10 @@
 {
   "streams.logs_enable": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/streams-logs-enable.html",
+      "url": "https://www.elastic.co/docs/api/doc/elasticsearch#TODO",
       "description": "Enable the Logs Streams feature for this cluster"
     },
-    "stability": "stable",
+    "stability": "experimental",
     "visibility": "feature_flag",
     "feature_flag": "logs_stream",
     "headers": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/streams.status.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/streams.status.json
@@ -1,10 +1,10 @@
 {
   "streams.status": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/streams-status.html",
+      "url": "https://www.elastic.co/docs/api/doc/elasticsearch#TODO",
       "description": "Return the current status of the streams feature for each streams type"
     },
-    "stability": "stable",
+    "stability": "experimental",
     "visibility": "feature_flag",
     "feature_flag": "logs_stream",
     "headers": {


### PR DESCRIPTION
Backports the following commits to 8.19:
 - streams: fix stability/documentation (#136642)