### PR TITLE
[9.1] [ML] Future proof index names in REST tests (#136458)

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/custom_all_field.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/custom_all_field.yml
@@ -75,7 +75,7 @@ setup:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       indices.refresh:
-        index: [.ml-anomalies-shared]
+        index: [.ml-anomalies*]
 
 ---
 "Test querying custom all field":
@@ -148,7 +148,7 @@ setup:
 
   - do:
       search:
-        index: .ml-anomalies-shared
+        index: .ml-anomalies-custom-all-test-1,.ml-anomalies-custom-all-test-2
         expand_wildcards: all
         rest_total_hits_as_int: true
         body: { query: { bool: { must: [

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/jobs_get_stats.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/jobs_get_stats.yml
@@ -444,7 +444,7 @@ setup:
 
   # With the index closed the low level ML API reports a problem
   - do:
-      catch: /type=cluster_block_exception, reason=index \[.ml-anomalies-shared\] blocked by. \[FORBIDDEN\/.\/index closed\]/
+      catch: /type=cluster_block_exception, reason=index \[.ml-anomalies-shared.*?\] blocked by. \[FORBIDDEN\/.\/index closed\]/
       ml.get_job_stats: {}
 
   # But the high level X-Pack API returns what it can - we do this

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/upgrade_job_snapshot.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/upgrade_job_snapshot.yml
@@ -60,7 +60,7 @@ setup:
       headers:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
       indices.refresh:
-        index: [.ml-anomalies-shared,.ml-state-000001]
+        index: [.ml-anomalies*,.ml-state-000001]
 
 ---
 "Test with unknown job id":


### PR DESCRIPTION
Backports the following commits to 9.1:
 - [ML] Future proof index names in REST tests (#136458)