### PR TITLE
Remove trappy timeouts from `ClearInferenceEndpointCacheAction.Request`

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/registry/ClearInferenceEndpointCacheAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/registry/ClearInferenceEndpointCacheAction.java
@@ -134,7 +134,7 @@ public class ClearInferenceEndpointCacheAction extends AcknowledgedTransportMast
 
     public static class Request extends AcknowledgedRequest<ClearInferenceEndpointCacheAction.Request> {
         protected Request() {
-            super(TRAPPY_IMPLICIT_DEFAULT_MASTER_NODE_TIMEOUT, DEFAULT_ACK_TIMEOUT);
+            super(INFINITE_MASTER_NODE_TIMEOUT, TimeValue.ZERO);
         }
 
         protected Request(StreamInput in) throws IOException {


### PR DESCRIPTION
This is an internal fire-and-forget action, no sense in imposing any
timeout on the master-node action. It also doesn't care about
acknowledgements so it may as well use a zero ack timeout.