### PR TITLE
[docs][esql] Include search and security pages in elasticsearch docs nav

### DIFF
--- a/docs/reference/query-languages/esql/esql-use-cases.md
+++ b/docs/reference/query-languages/esql/esql-use-cases.md
@@ -1,0 +1,13 @@
+---
+applies_to:
+  stack:
+  serverless:
+navigation_title: "Use cases"
+---
+
+# Use cases for {{esql}}
+
+These pages detail how to use {{esql}} for search and cybersecurity use cases:
+
+* [ES|QL for search](docs-content://solutions/search/esql-for-search.md): Learn how to use {{esql}} for search use cases using {{es}}.
+* [ES|QL for security](docs-content://solutions/security/esql-for-security.md): Learn how to use {{esql}} for cybersecurity use cases.

--- a/docs/reference/query-languages/esql/esql-use-cases.md
+++ b/docs/reference/query-languages/esql/esql-use-cases.md
@@ -9,5 +9,5 @@ navigation_title: "Use cases"
 
 These pages detail how to use {{esql}} for search and cybersecurity use cases:
 
-* [ES|QL for search](docs-content://solutions/search/esql-for-search.md): Learn how to use {{esql}} for search use cases using {{es}}.
-* [ES|QL for security](docs-content://solutions/security/esql-for-security.md): Learn how to use {{esql}} for cybersecurity use cases.
+- [ES|QL for search](docs-content://solutions/search/esql-for-search.md): Learn how to use {{esql}} for lexical (keyword) search, relevance scoring, semantic and hybrid search, semantic reranking, and more.
+- [ES|QL for security](docs-content://solutions/security/esql-for-security.md): Learn how to use {{esql}} for threat hunting, timeline investigation, detection rules, and migrating Splunk queries.

--- a/docs/reference/query-languages/toc.yml
+++ b/docs/reference/query-languages/toc.yml
@@ -161,7 +161,7 @@ toc:
       - file: esql/esql-examples.md
         children:
           - file: esql/esql-search-tutorial.md
-          - title: "ES|QL for threat hunting tutorial"
+          - title: "ES|QL for threat hunting"
             crosslink: docs-content://solutions/security/esql-for-security/esql-threat-hunting-tutorial.md
       - file: esql/esql-troubleshooting.md
         children:

--- a/docs/reference/query-languages/toc.yml
+++ b/docs/reference/query-languages/toc.yml
@@ -161,6 +161,8 @@ toc:
       - file: esql/esql-examples.md
         children:
           - file: esql/esql-search-tutorial.md
+          - title: "ES|QL for threat hunting tutorial"
+            crosslink: docs-content://solutions/security/esql-for-security/esql-threat-hunting-tutorial.md
       - file: esql/esql-troubleshooting.md
         children:
           - file: esql/esql-query-log.md

--- a/docs/reference/query-languages/toc.yml
+++ b/docs/reference/query-languages/toc.yml
@@ -87,6 +87,12 @@ toc:
   - file: esql.md
     children:
       - file: esql/esql-getting-started.md
+      - file: esql/esql-use-cases.md
+        children:
+          - title: "ES|QL for search"
+            crosslink: docs-content://solutions/search/esql-for-search.md
+          - title: "ES|QL for cybersecurity"
+            crosslink: docs-content://solutions/security/esql-for-security.md
       - file: esql/esql-rest.md
       - file: esql/esql-syntax-reference.md
         children:


### PR DESCRIPTION
Thanks to @theletterf (https://github.com/elastic/docs-builder/pull/1615) we can now include pages from other repos in nav, which helps fight scattered-ness and makes other ESQL pages equally prominent