### PR TITLE
Remove subscription link for preview feature

### DIFF
--- a/docs/reference/elasticsearch/mapping-reference/mapping-source-field.md
+++ b/docs/reference/elasticsearch/mapping-reference/mapping-source-field.md
@@ -18,7 +18,7 @@ If disk usage is important to you, then consider the following options:
 ## Synthetic `_source` [synthetic-source]
 
 :::{note}
-This feature requires a [subscription](https://www.elastic.co/subscriptions).
+This feature requires an Enterprise subscription.
 :::
 
 Though very handy to have around, the source field takes up a significant amount of space on disk. Instead of storing source documents on disk exactly as you send them, Elasticsearch can reconstruct source content on the fly upon retrieval. To enable this feature, use the value `synthetic` for the index setting `index.mapping.source.mode`:

--- a/docs/reference/elasticsearch/mapping-reference/mapping-source-field.md
+++ b/docs/reference/elasticsearch/mapping-reference/mapping-source-field.md
@@ -18,7 +18,7 @@ If disk usage is important to you, then consider the following options:
 ## Synthetic `_source` [synthetic-source]
 
 :::{note}
-This feature requires an Enterprise subscription.
+This feature requires a [subscription](https://www.elastic.co/subscriptions).
 :::
 
 Though very handy to have around, the source field takes up a significant amount of space on disk. Instead of storing source documents on disk exactly as you send them, Elasticsearch can reconstruct source content on the fly upon retrieval. To enable this feature, use the value `synthetic` for the index setting `index.mapping.source.mode`:

--- a/docs/reference/elasticsearch/mapping-reference/pattern-text.md
+++ b/docs/reference/elasticsearch/mapping-reference/pattern-text.md
@@ -10,7 +10,7 @@ serverless: preview
 stack: preview 9.2
 ```
 :::{note}
-This feature requires a [subscription](https://www.elastic.co/subscriptions).
+This feature requires an Enterprise subscription.
 :::
 
 The `pattern_text` field type is a variant of [`text`](/reference/elasticsearch/mapping-reference/text.md) with improved space efficiency for log data.


### PR DESCRIPTION
Since pattern_text is still in technical preview, it should not link to the subscriptions page.