### PR TITLE
[ML] Release cluster state (#136769)

### DIFF
--- a/docs/changelog/136769.yaml
+++ b/docs/changelog/136769.yaml
@@ -1,0 +1,6 @@
+pr: 136769
+summary: Release cluster state
+area: Machine Learning
+type: bug
+issues:
+ - 123243

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/NodeLoadDetector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/NodeLoadDetector.java
@@ -87,7 +87,24 @@ public class NodeLoadDetector {
         int maxMachineMemoryPercent,
         boolean useAutoMachineMemoryCalculation
     ) {
-        PersistentTasksCustomMetadata persistentTasks = clusterState.getMetadata().custom(PersistentTasksCustomMetadata.TYPE);
+        return detectNodeLoad(
+            clusterState.getMetadata().custom(PersistentTasksCustomMetadata.TYPE),
+            assignmentMetadata,
+            node,
+            maxNumberOfOpenJobs,
+            maxMachineMemoryPercent,
+            useAutoMachineMemoryCalculation
+        );
+    }
+
+    public NodeLoad detectNodeLoad(
+        PersistentTasksCustomMetadata persistentTasks,
+        TrainedModelAssignmentMetadata assignmentMetadata,
+        DiscoveryNode node,
+        int maxNumberOfOpenJobs,
+        int maxMachineMemoryPercent,
+        boolean useAutoMachineMemoryCalculation
+    ) {
         Map<String, String> nodeAttributes = node.getAttributes();
         List<String> errors = new ArrayList<>();
         OptionalLong maxMlMemory = NativeMemoryCalculator.allowedBytesForMl(node, maxMachineMemoryPercent, useAutoMachineMemoryCalculation);


### PR DESCRIPTION
Backporting #136769

This is not a clean backport. `ProjectMetadata.Custom` had not replaced `Metadata.Custom` until 9.0, so we have to remove the Project-specific code for accessing custom metadata.