### PR TITLE
Remove explicit inference model information for Fleet `.integration_knowledge`

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/fleet-integration-knowledge.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/fleet-integration-knowledge.json
@@ -16,12 +16,7 @@
           "type": "keyword"
         },
         "content": {
-          "type": "semantic_text",
-          "inference_id": ".elser-2-elasticsearch",
-          "model_settings": {
-            "service": "elasticsearch",
-            "task_type": "sparse_embedding"
-          }
+          "type": "semantic_text"
         },
         "version": {
           "type": "version"


### PR DESCRIPTION
Relates to https://github.com/elastic/kibana/issues/239796

Follow up to https://github.com/elastic/elasticsearch/pull/132506/files#r2285096764.

With https://github.com/elastic/elasticsearch/issues/133171 fixed, we should no longer have to set the explicit inference ID for this `semantic_text` field.

Ideally this will also let us take advantage of EIS becoming the default inference endpoint for Cloud (whenever that happens), while defaulting to `.elser-2-elasticsearch` for on-prem.

This is being treated as a blocker for 9.2.0 as part of https://github.com/elastic/kibana/issues/239796. We don't want users to have this index installed with explicit IDs before EIS becomes the default.