### PR TITLE
[ML] Fix and expand test coverage for model alias validation

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutTrainedModelAliasAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutTrainedModelAliasAction.java
@@ -29,7 +29,7 @@ public class PutTrainedModelAliasAction extends ActionType<AcknowledgedResponse>
 
     // NOTE this is similar to our valid ID check. The difference here is that model_aliases cannot end in numbers
     // This is to protect our automatic model naming conventions from hitting weird model_alias conflicts
-    private static final Pattern VALID_MODEL_ALIAS_CHAR_PATTERN = Pattern.compile("[a-z0-9](?:[a-z0-9_\\-\\.]*[a-z])?");
+    private static final Pattern VALID_MODEL_ALIAS_CHAR_PATTERN = Pattern.compile("[a-z0-9](?:[a-z0-9_\\-.]*[a-z])?");
 
     public static final PutTrainedModelAliasAction INSTANCE = new PutTrainedModelAliasAction();
     public static final String NAME = "cluster:admin/xpack/ml/inference/model_aliases/put";

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
@@ -140,7 +140,7 @@ public final class Messages {
     public static final String INFERENCE_DEPLOYMENT_UPDATED_NUMBER_OF_ALLOCATIONS = "Updated number_of_allocations to [{0}]";
 
     public static final String INVALID_MODEL_ALIAS = "Invalid model_alias; ''{0}'' can contain lowercase alphanumeric (a-z and 0-9), "
-        + "hyphens or underscores; must start with alphanumeric and cannot end with numbers";
+        + "hyphens or underscores; must start with alphanumeric and cannot end with numbers, hyphens or underscores";
     public static final String TRAINED_MODEL_INPUTS_DIFFER_SIGNIFICANTLY =
         "The input fields for new model [{0}] and for old model [{1}] differ significantly, model results may change drastically.";
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PutTrainedModelAliasActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PutTrainedModelAliasActionRequestTests.java
@@ -10,29 +10,65 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.action.PutTrainedModelAliasAction.Request;
-import org.junit.Before;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
 public class PutTrainedModelAliasActionRequestTests extends AbstractWireSerializingTestCase<Request> {
 
-    private String modelAlias;
-
-    @Before
-    public void setupModelAlias() {
-        modelAlias = randomAlphaOfLength(10);
-    }
+    private static final Set<String> INVALID_CHARACTERS = Set.of(
+        "!",
+        "@",
+        "#",
+        "$",
+        "%",
+        "^",
+        "&",
+        "*",
+        "(",
+        ")",
+        "+",
+        "=",
+        "[",
+        "]",
+        "{",
+        "}",
+        "|",
+        ";",
+        ":",
+        "'",
+        "\"",
+        ",",
+        "<",
+        ">",
+        "/",
+        "?"
+    );
 
     @Override
     protected Request createTestInstance() {
-        return new Request(modelAlias, randomAlphaOfLength(10), randomBoolean());
+        return new Request(randomAlphaOfLength(10), randomAlphaOfLength(10), randomBoolean());
     }
 
     @Override
     protected Request mutateInstance(Request instance) {
-        return null;// TODO implement https://github.com/elastic/elasticsearch/issues/25929
+        String modelAlias = instance.getModelAlias();
+        String modelId = instance.getModelId();
+        boolean reassign = instance.isReassign();
+        int value = randomInt(2);
+        return switch (value) {
+            case 0 -> new Request(randomValueOtherThan(modelAlias, () -> randomAlphaOfLength(10)), modelId, reassign);
+            case 1 -> new Request(modelAlias, randomValueOtherThan(modelId, () -> randomAlphaOfLength(10)), reassign);
+            case 2 -> new Request(modelAlias, modelId, reassign == false);
+            default -> throw new IllegalStateException("Unexpected value " + value);
+        };
     }
 
     @Override
@@ -40,30 +76,82 @@ public class PutTrainedModelAliasActionRequestTests extends AbstractWireSerializ
         return Request::new;
     }
 
-    public void testCtor() {
+    public void testConstructor() {
         expectThrows(Exception.class, () -> new Request(null, randomAlphaOfLength(10), randomBoolean()));
         expectThrows(Exception.class, () -> new Request(randomAlphaOfLength(10), null, randomBoolean()));
     }
 
     public void testValidate() {
-
-        { // model_alias equal to model Id
-            ActionRequestValidationException ex = new Request("foo", "foo", randomBoolean()).validate();
-            assertThat(ex, not(nullValue()));
-            assertThat(ex.getMessage(), containsString("model_alias [foo] cannot equal model_id [foo]"));
-        }
-        { // model_alias cannot end in numbers
-            modelAlias = randomAlphaOfLength(10) + randomIntBetween(0, Integer.MAX_VALUE);
+        List<String> validAliases = List.of("a", "1", "2b", "c-3d", "e_4f", "g.5h");
+        for (String modelAlias : validAliases) {
             ActionRequestValidationException ex = new Request(modelAlias, "foo", randomBoolean()).validate();
-            assertThat(ex, not(nullValue()));
-            assertThat(
-                ex.getMessage(),
-                containsString(
-                    "can contain lowercase alphanumeric (a-z and 0-9), hyphens or underscores; "
-                        + "must start with alphanumeric and cannot end with numbers"
-                )
-            );
+            assertThat("For alias [" + modelAlias + "]", ex, nullValue());
         }
     }
 
+    public void testValidate_modelAliasEqualToModelId() {
+        ActionRequestValidationException ex = new Request("foo", "foo", randomBoolean()).validate();
+        assertThat(ex, not(nullValue()));
+        assertThat(ex.getMessage(), containsString("model_alias [foo] cannot equal model_id [foo]"));
+    }
+
+    public void testValidate_modelAliasEqualToModelIdWithInvalidCharacter() {
+        String modelAlias = "foo" + randomFrom(INVALID_CHARACTERS);
+        ActionRequestValidationException ex = new Request(modelAlias, modelAlias, randomBoolean()).validate();
+        assertThat("For alias [" + modelAlias + "]", ex, not(nullValue()));
+        assertThat(ex.validationErrors(), hasSize(2));
+        assertThat(ex.getMessage(), containsString("model_alias [" + modelAlias + "] cannot equal model_id [" + modelAlias + "]"));
+        assertThat(
+            ex.getMessage(),
+            containsString(
+                "can contain lowercase alphanumeric (a-z and 0-9), hyphens or underscores; "
+                    + "must start with alphanumeric and cannot end with numbers"
+            )
+        );
+    }
+
+    public void testValidate_modelAliasContainsUppercase() {
+        List<String> invalidAliases = List.of("Start", "midDle", "enD");
+        for (String invalidAlias : invalidAliases) {
+            assertInvalidAlias(invalidAlias);
+        }
+    }
+
+    public void testValidate_modelAliasEndsWithNumber() {
+        String modelAlias = (randomAlphaOfLength(10) + randomIntBetween(0, Integer.MAX_VALUE)).toLowerCase(Locale.ROOT);
+        assertInvalidAlias(modelAlias);
+    }
+
+    public void testValidate_modelAliasStartsWithInvalidCharacter() {
+        Set<String> invalidFirstCharacters = new HashSet<>(INVALID_CHARACTERS);
+        // '-', '_' and '.' are not valid as the first character
+        invalidFirstCharacters.addAll(Set.of("-", "_", "."));
+        String modelAlias = (randomFrom(invalidFirstCharacters) + randomAlphaOfLength(10)).toLowerCase(Locale.ROOT);
+        assertInvalidAlias(modelAlias);
+    }
+
+    public void testValidate_modelAliasContainsInvalidCharacter() {
+        String modelAlias = (randomAlphaOfLength(5) + randomFrom(INVALID_CHARACTERS) + randomAlphaOfLength(5)).toLowerCase(Locale.ROOT);
+        assertInvalidAlias(modelAlias);
+    }
+
+    public void testValidate_modelAliasEndsWithInvalidCharacter() {
+        Set<String> invalidLastCharacters = new HashSet<>(INVALID_CHARACTERS);
+        // '-', '_' and '.' are not valid as the last character
+        invalidLastCharacters.addAll(Set.of("-", "_", "."));
+        String modelAlias = (randomAlphaOfLength(10) + randomFrom(invalidLastCharacters)).toLowerCase(Locale.ROOT);
+        assertInvalidAlias(modelAlias);
+    }
+
+    private static void assertInvalidAlias(String modelAlias) {
+        ActionRequestValidationException ex = new Request(modelAlias, "foo", randomBoolean()).validate();
+        assertThat("For alias [" + modelAlias + "]", ex, not(nullValue()));
+        assertThat(
+            ex.getMessage(),
+            containsString(
+                "can contain lowercase alphanumeric (a-z and 0-9), hyphens or underscores; "
+                    + "must start with alphanumeric and cannot end with numbers"
+            )
+        );
+    }
 }


### PR DESCRIPTION
The existing test for the validate() method was not using lowercase for the model alias, leading to the test not testing the behaviour it was intending to.

- Expand coverage for PutTrainedModelAliasAction.validate()
- Reword invalid model alias message slightly to be more accurate
- Implement missing mutateInstance() method