### PR TITLE
Fix Sporadic SemanticTextInferenceFieldsIT Failures

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -534,12 +534,6 @@ tests:
 - class: org.elasticsearch.test.rest.yaml.RcsCcsCommonYamlTestSuiteIT
   method: test {p0=search.vectors/200_dense_vector_docvalue_fields/Enable docvalue_fields parameter for dense_vector fields}
   issue: https://github.com/elastic/elasticsearch/issues/136443
-- class: org.elasticsearch.xpack.inference.integration.SemanticTextInferenceFieldsIT
-  method: testExcludeInferenceFieldsFromSource
-  issue: https://github.com/elastic/elasticsearch/issues/136451
-- class: org.elasticsearch.xpack.inference.integration.SemanticTextInferenceFieldsIT
-  method: testExcludeInferenceFieldsFromSourceOldIndexVersions
-  issue: https://github.com/elastic/elasticsearch/issues/136452
 - class: org.elasticsearch.xpack.remotecluster.CrossClusterEsqlRCS2UnavailableRemotesIT
   method: testEsqlRcs2UnavailableRemoteScenarios
   issue: https://github.com/elastic/elasticsearch/issues/136493

--- a/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/SemanticTextInferenceFieldsIT.java
+++ b/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/SemanticTextInferenceFieldsIT.java
@@ -60,7 +60,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 
-@ESIntegTestCase.ClusterScope(minNumDataNodes = 3, maxNumDataNodes = 5)
+@ESIntegTestCase.ClusterScope(numDataNodes = 3, numClientNodes = 0, supportsDedicatedMasters = false)
 public class SemanticTextInferenceFieldsIT extends ESIntegTestCase {
     private final String indexName = randomIdentifier();
     private final Map<String, TaskType> inferenceIds = new HashMap<>();


### PR DESCRIPTION
Fixes sporadic `SemanticTextInferenceFieldsIT` failures by limiting the number of nodes used by the integration test. In the test failures observed, the test suite attempted to create 7 nodes:

- 5 dedicated data nodes
- 1 dedicated master node
- 1 dedicated client (i.e. coordinating) node

This consumed a lot of resources, leading to occasional failures in CI.

The only requirement for this integration test is multiple data nodes, to force serialization of search results. Thus, hard-coding the number of data nodes to 3 with no dedicated master or client nodes is fine.

Fixes #136451
Fixes #136452
