### PR TITLE
[9.2] Remove explicit inference model information for Fleet `.integration_knowledge` (#136837)

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/fleet-integration-knowledge.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/fleet-integration-knowledge.json
@@ -16,12 +16,7 @@
           "type": "keyword"
         },
         "content": {
-          "type": "semantic_text",
-          "inference_id": ".elser-2-elasticsearch",
-          "model_settings": {
-            "service": "elasticsearch",
-            "task_type": "sparse_embedding"
-          }
+          "type": "semantic_text"
         },
         "version": {
           "type": "version"


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Remove explicit inference model information for Fleet `.integration_knowledge` (#136837)