### PR TITLE
Added a Builder for KeywordFieldType, removed redundant constructors

### DIFF
--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldTypeTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldTypeTests.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.index.mapper.extras;
 
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queries.intervals.Intervals;
 import org.apache.lucene.queries.intervals.IntervalsSource;
@@ -44,6 +43,7 @@ import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
 import org.elasticsearch.index.mapper.FieldTypeTestCase;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.MapperBuilderContext;
 import org.elasticsearch.index.mapper.MappingParserContext;
 import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.mapper.TextSearchInfo;
@@ -249,12 +249,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
 
     public void testBlockLoaderUsesSyntheticSourceDelegateWhenIgnoreAboveIsNotSet() {
         // given
-        KeywordFieldMapper.KeywordFieldType syntheticSourceDelegate = new KeywordFieldMapper.KeywordFieldType(
-            "child",
-            true,
-            true,
-            Collections.emptyMap()
-        );
+        KeywordFieldMapper.KeywordFieldType syntheticSourceDelegate = KeywordFieldMapper.KeywordFieldType.builder().name("child").build();
 
         MatchOnlyTextFieldMapper.MatchOnlyTextFieldType ft = new MatchOnlyTextFieldMapper.MatchOnlyTextFieldType(
             "parent",
@@ -291,16 +286,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
 
         KeywordFieldMapper.Builder builder = new KeywordFieldMapper.Builder("child", mappingParserContext);
         builder.ignoreAbove(123);
-
-        KeywordFieldMapper.KeywordFieldType syntheticSourceDelegate = new KeywordFieldMapper.KeywordFieldType(
-            "child",
-            mock(FieldType.class),
-            mock(NamedAnalyzer.class),
-            mock(NamedAnalyzer.class),
-            mock(NamedAnalyzer.class),
-            builder,
-            true
-        );
+        KeywordFieldMapper.KeywordFieldType syntheticSourceDelegate = builder.build(MapperBuilderContext.root(true, false)).fieldType();
 
         MatchOnlyTextFieldMapper.MatchOnlyTextFieldType ft = new MatchOnlyTextFieldMapper.MatchOnlyTextFieldType(
             "parent",
@@ -340,16 +326,7 @@ public class MatchOnlyTextFieldTypeTests extends FieldTypeTestCase {
         doReturn(mock(ScriptCompiler.class)).when(mappingParserContext).scriptCompiler();
 
         KeywordFieldMapper.Builder builder = new KeywordFieldMapper.Builder("child", mappingParserContext);
-
-        KeywordFieldMapper.KeywordFieldType syntheticSourceDelegate = new KeywordFieldMapper.KeywordFieldType(
-            "child",
-            mock(FieldType.class),
-            mock(NamedAnalyzer.class),
-            mock(NamedAnalyzer.class),
-            mock(NamedAnalyzer.class),
-            builder,
-            true
-        );
+        KeywordFieldMapper.KeywordFieldType syntheticSourceDelegate = builder.build(MapperBuilderContext.root(true, false)).fieldType();
 
         MatchOnlyTextFieldMapper.MatchOnlyTextFieldType ft = new MatchOnlyTextFieldMapper.MatchOnlyTextFieldType(
             "parent",

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/aggregations/ParentToChildrenAggregatorTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/aggregations/ParentToChildrenAggregatorTests.java
@@ -118,7 +118,7 @@ public class ParentToChildrenAggregatorTests extends AggregatorTestCase {
     }
 
     public void testParentChildAsSubAgg() throws IOException {
-        MappedFieldType kwd = new KeywordFieldMapper.KeywordFieldType("kwd", randomBoolean(), true, Collections.emptyMap());
+        MappedFieldType kwd = KeywordFieldMapper.KeywordFieldType.builder().name("kwd").isIndexed(randomBoolean()).build();
         try (Directory directory = newDirectory()) {
             RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory);
 
@@ -192,7 +192,7 @@ public class ParentToChildrenAggregatorTests extends AggregatorTestCase {
                     aggregationBuilder.subAggregation(termsAggregationBuilder);
 
                     var fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.LONG);
-                    var fieldType2 = new KeywordFieldMapper.KeywordFieldType("string_field", false, true, Map.of());
+                    var fieldType2 = KeywordFieldMapper.KeywordFieldType.builder().name("string_field").isIndexed(false).build();
                     var e = expectThrows(RuntimeException.class, () -> {
                         searchAndReduce(
                             indexReader,
@@ -223,7 +223,7 @@ public class ParentToChildrenAggregatorTests extends AggregatorTestCase {
                     aggregationBuilder.subAggregation(termsAggregationBuilder);
 
                     var fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.LONG);
-                    var fieldType2 = new KeywordFieldMapper.KeywordFieldType("string_field", false, true, Map.of());
+                    var fieldType2 = KeywordFieldMapper.KeywordFieldType.builder().name("string_field").isIndexed(false).build();
                     InternalChildren result = searchAndReduce(
                         indexReader,
                         new AggTestConfig(aggregationBuilder, withJoinFields(fieldType, fieldType2)).withQuery(

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryBuilderStoreTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/QueryBuilderStoreTests.java
@@ -92,7 +92,7 @@ public class QueryBuilderStoreTests extends ESTestCase {
             );
             when(searchExecutionContext.getFieldType(Mockito.anyString())).thenAnswer(invocation -> {
                 final String fieldName = (String) invocation.getArguments()[0];
-                return new KeywordFieldMapper.KeywordFieldType(fieldName);
+                return KeywordFieldMapper.KeywordFieldType.builder().name(fieldName).build();
             });
             PercolateQuery.QueryStore queryStore = PercolateQueryBuilder.createStore(fieldMapper.fieldType(), searchExecutionContext);
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fieldcaps/FieldCapabilitiesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fieldcaps/FieldCapabilitiesIT.java
@@ -1024,7 +1024,7 @@ public class FieldCapabilitiesIT extends ESIntegTestCase {
         private static final String FIELD_NAME = "_test";
 
         protected TestMetadataMapper() {
-            super(new KeywordFieldMapper.KeywordFieldType(FIELD_NAME));
+            super(KeywordFieldMapper.KeywordFieldType.builder().name(FIELD_NAME).build());
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -827,7 +827,7 @@ public final class FlattenedFieldMapper extends FieldMapper {
         }
 
         public MappedFieldType getKeyedFieldType() {
-            return new KeywordFieldMapper.KeywordFieldType(name() + KEYED_FIELD_SUFFIX);
+            return KeywordFieldMapper.KeywordFieldType.builder().name(name() + KEYED_FIELD_SUFFIX).build();
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/index/IndexSortSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexSortSettingsTests.java
@@ -164,7 +164,7 @@ public class IndexSortSettingsTests extends ESTestCase {
 
     public void testSortingAgainstAliases() {
         IndexSettings indexSettings = indexSettings(Settings.builder().put("index.sort.field", "field").build());
-        MappedFieldType aliased = new KeywordFieldMapper.KeywordFieldType("aliased");
+        MappedFieldType aliased = KeywordFieldMapper.KeywordFieldType.builder().name("aliased").build();
         Exception e = expectThrows(IllegalArgumentException.class, () -> buildIndexSort(indexSettings, Map.of("field", aliased)));
         assertEquals("Cannot use alias [field] as an index sort field", e.getMessage());
     }
@@ -173,7 +173,7 @@ public class IndexSortSettingsTests extends ESTestCase {
         IndexSettings indexSettings = indexSettings(
             Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersions.V_7_12_0).put("index.sort.field", "field").build()
         );
-        MappedFieldType aliased = new KeywordFieldMapper.KeywordFieldType("aliased");
+        MappedFieldType aliased = KeywordFieldMapper.KeywordFieldType.builder().name("aliased").build();
         Sort sort = buildIndexSort(indexSettings, Map.of("field", aliased));
         assertThat(sort.getSort(), arrayWithSize(1));
         assertThat(sort.getSort()[0].getField(), equalTo("aliased"));

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
@@ -3284,7 +3284,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
             private static final String FIELD_NAME = "_mock_metadata";
 
             protected MockMetadataMapper() {
-                super(new KeywordFieldMapper.KeywordFieldType(FIELD_NAME));
+                super(KeywordFieldMapper.KeywordFieldType.builder().name(FIELD_NAME).build());
             }
 
             @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldTypeTests.java
@@ -28,7 +28,7 @@ public class FieldNamesFieldTypeTests extends ESTestCase {
 
     public void testTermQuery() {
         FieldNamesFieldMapper.FieldNamesFieldType fieldNamesFieldType = FieldNamesFieldMapper.FieldNamesFieldType.get(true);
-        KeywordFieldMapper.KeywordFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("field_name");
+        KeywordFieldMapper.KeywordFieldType fieldType = KeywordFieldMapper.KeywordFieldType.builder().name("field_name").build();
 
         Settings settings = settings(IndexVersion.current()).build();
         IndexSettings indexSettings = new IndexSettings(

--- a/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
@@ -203,7 +203,7 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
         private final DummyEnumType restrictedEnumField;
 
         protected TestMapper(String simpleName, String fullName, BuilderParams builderParams, ParametrizedMapperTests.Builder builder) {
-            super(simpleName, new KeywordFieldMapper.KeywordFieldType(fullName), builderParams);
+            super(simpleName, KeywordFieldMapper.KeywordFieldType.builder().name(fullName).build(), builderParams);
             this.fixed = builder.fixed.getValue();
             this.fixed2 = builder.fixed2.getValue();
             this.variable = builder.variable.getValue();

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldTypeTests.java
@@ -8,7 +8,6 @@
  */
 package org.elasticsearch.index.mapper;
 
-import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queries.intervals.Intervals;
 import org.apache.lucene.queries.intervals.IntervalsSource;
@@ -41,7 +40,6 @@ import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
-import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.mapper.TextFieldMapper.TextFieldType;
 import org.elasticsearch.script.ScriptCompiler;
 
@@ -304,12 +302,7 @@ public class TextFieldTypeTests extends FieldTypeTestCase {
 
     public void testBlockLoaderUsesSyntheticSourceDelegateWhenIgnoreAboveIsNotSet() {
         // given
-        KeywordFieldMapper.KeywordFieldType syntheticSourceDelegate = new KeywordFieldMapper.KeywordFieldType(
-            "child",
-            true,
-            true,
-            Collections.emptyMap()
-        );
+        KeywordFieldMapper.KeywordFieldType syntheticSourceDelegate = KeywordFieldMapper.KeywordFieldType.builder().name("child").build();
 
         TextFieldType ft = new TextFieldType(
             "parent",
@@ -350,16 +343,7 @@ public class TextFieldTypeTests extends FieldTypeTestCase {
 
         KeywordFieldMapper.Builder builder = new KeywordFieldMapper.Builder("child", mappingParserContext);
         builder.ignoreAbove(123);
-
-        KeywordFieldMapper.KeywordFieldType syntheticSourceDelegate = new KeywordFieldMapper.KeywordFieldType(
-            "child",
-            mock(FieldType.class),
-            mock(NamedAnalyzer.class),
-            mock(NamedAnalyzer.class),
-            mock(NamedAnalyzer.class),
-            builder,
-            true
-        );
+        KeywordFieldMapper.KeywordFieldType syntheticSourceDelegate = builder.build(MapperBuilderContext.root(true, false)).fieldType();
 
         TextFieldType ft = new TextFieldType(
             "parent",
@@ -401,16 +385,7 @@ public class TextFieldTypeTests extends FieldTypeTestCase {
         doReturn(true).when(mappingParserContext).isWithinMultiField();
 
         KeywordFieldMapper.Builder builder = new KeywordFieldMapper.Builder("child", mappingParserContext);
-
-        KeywordFieldMapper.KeywordFieldType syntheticSourceDelegate = new KeywordFieldMapper.KeywordFieldType(
-            "child",
-            mock(FieldType.class),
-            mock(NamedAnalyzer.class),
-            mock(NamedAnalyzer.class),
-            mock(NamedAnalyzer.class),
-            builder,
-            true
-        );
+        KeywordFieldMapper.KeywordFieldType syntheticSourceDelegate = builder.build(MapperBuilderContext.root(true, false)).fieldType();
 
         TextFieldType ft = new TextFieldType(
             "parent",

--- a/server/src/test/java/org/elasticsearch/index/query/functionscore/ScoreFunctionBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/functionscore/ScoreFunctionBuilderTests.java
@@ -63,7 +63,8 @@ public class ScoreFunctionBuilderTests extends ESTestCase {
         Mockito.when(context.index()).thenReturn(settings.getIndex());
         Mockito.when(context.getShardId()).thenReturn(0);
         Mockito.when(context.getIndexSettings()).thenReturn(settings);
-        Mockito.when(context.getFieldType(IdFieldMapper.NAME)).thenReturn(new KeywordFieldMapper.KeywordFieldType(IdFieldMapper.NAME));
+        Mockito.when(context.getFieldType(IdFieldMapper.NAME))
+            .thenReturn(KeywordFieldMapper.KeywordFieldType.builder().name(IdFieldMapper.NAME).build());
         Mockito.when(context.isFieldMapped(IdFieldMapper.NAME)).thenReturn(true);
         builder.toFunction(context);
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregatorTests.java
@@ -136,12 +136,12 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
     public void setUp() throws Exception {
         super.setUp();
         FIELD_TYPES = new MappedFieldType[9];
-        FIELD_TYPES[0] = new KeywordFieldMapper.KeywordFieldType("keyword");
+        FIELD_TYPES[0] = KeywordFieldMapper.KeywordFieldType.builder().name("keyword").build();
         FIELD_TYPES[1] = new NumberFieldMapper.NumberFieldType("long", NumberFieldMapper.NumberType.LONG);
         FIELD_TYPES[2] = new NumberFieldMapper.NumberFieldType("double", NumberFieldMapper.NumberType.DOUBLE);
         FIELD_TYPES[3] = new DateFieldMapper.DateFieldType("date", DateFormatter.forPattern("yyyy-MM-dd||epoch_millis"));
         FIELD_TYPES[4] = new NumberFieldMapper.NumberFieldType("price", NumberFieldMapper.NumberType.INTEGER);
-        FIELD_TYPES[5] = new KeywordFieldMapper.KeywordFieldType("terms");
+        FIELD_TYPES[5] = KeywordFieldMapper.KeywordFieldType.builder().name("terms").build();
         FIELD_TYPES[6] = new IpFieldMapper.IpFieldType("ip");
         FIELD_TYPES[7] = new GeoPointFieldMapper.GeoPointFieldType("geo_point");
         FIELD_TYPES[8] = TimeSeriesIdFieldMapper.FIELD_TYPE;
@@ -824,7 +824,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
         },
             new AggTestConfig(
                 builder,
-                new KeywordFieldMapper.KeywordFieldType(nestedPath + "." + leafNameField),
+                KeywordFieldMapper.KeywordFieldType.builder().name(nestedPath + "." + leafNameField).build(),
                 new NumberFieldMapper.NumberFieldType("price", NumberFieldMapper.NumberType.LONG)
             ).withLogDocMergePolicy()
         );
@@ -879,7 +879,7 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
         },
             new AggTestConfig(
                 builder,
-                new KeywordFieldMapper.KeywordFieldType(nestedPath + "." + leafNameField),
+                KeywordFieldMapper.KeywordFieldType.builder().name(nestedPath + "." + leafNameField).build(),
                 new NumberFieldMapper.NumberFieldType("price", NumberFieldMapper.NumberType.LONG)
             ).withLogDocMergePolicy()
         );
@@ -3289,8 +3289,8 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             "name",
             List.of(new TermsValuesSourceBuilder("leading").field("keyword").missingBucket(true))
         ).size(2);
-        final MappedFieldType keywordMapping = new KeywordFieldMapper.KeywordFieldType("keyword");
-        final MappedFieldType fooMapping = new KeywordFieldMapper.KeywordFieldType("foo");
+        final MappedFieldType keywordMapping = KeywordFieldMapper.KeywordFieldType.builder().name("keyword").build();
+        final MappedFieldType fooMapping = KeywordFieldMapper.KeywordFieldType.builder().name("foo").build();
 
         CheckedConsumer<RandomIndexWriter, IOException> buildIndex = iw -> {
             for (int i = 1; i <= 100; i++) {
@@ -3329,8 +3329,8 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             "name",
             List.of(new TermsValuesSourceBuilder("leading").field("keyword").missingBucket(true))
         ).size(13); // We need a size that is more than 1/8 of the total count.
-        final MappedFieldType keywordMapping = new KeywordFieldMapper.KeywordFieldType("keyword");
-        final MappedFieldType fooMapping = new KeywordFieldMapper.KeywordFieldType("foo");
+        final MappedFieldType keywordMapping = KeywordFieldMapper.KeywordFieldType.builder().name("keyword").build();
+        final MappedFieldType fooMapping = KeywordFieldMapper.KeywordFieldType.builder().name("foo").build();
 
         CheckedConsumer<RandomIndexWriter, IOException> buildIndex = iw -> {
             for (int i = 1; i <= 100; i++) {
@@ -3364,8 +3364,8 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             "name",
             List.of(new TermsValuesSourceBuilder("leading").field("keyword"))
         ).size(2);
-        final MappedFieldType keywordMapping = new KeywordFieldMapper.KeywordFieldType("keyword");
-        final MappedFieldType fooMapping = new KeywordFieldMapper.KeywordFieldType("foo");
+        final MappedFieldType keywordMapping = KeywordFieldMapper.KeywordFieldType.builder().name("keyword").build();
+        final MappedFieldType fooMapping = KeywordFieldMapper.KeywordFieldType.builder().name("foo").build();
 
         CheckedConsumer<RandomIndexWriter, IOException> buildIndex = iw -> {
             for (int i = 1; i <= 100; i++) {
@@ -3432,8 +3432,8 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
             "name",
             List.of(new TermsValuesSourceBuilder("leading").field("keyword").order(SortOrder.DESC))
         ).size(2);
-        final MappedFieldType keywordMapping = new KeywordFieldMapper.KeywordFieldType("keyword");
-        final MappedFieldType fooMapping = new KeywordFieldMapper.KeywordFieldType("foo");
+        final MappedFieldType keywordMapping = KeywordFieldMapper.KeywordFieldType.builder().name("keyword").build();
+        final MappedFieldType fooMapping = KeywordFieldMapper.KeywordFieldType.builder().name("foo").build();
 
         CheckedConsumer<RandomIndexWriter, IOException> buildIndex = iw -> {
             for (int i = 1; i <= 100; i++) {
@@ -3504,9 +3504,9 @@ public class CompositeAggregatorTests extends AggregatorTestCase {
                 new TermsValuesSourceBuilder("secondary_keyword").field("secondary_keyword")
             )
         ).size(2);
-        final MappedFieldType leadingKeywordMapping = new KeywordFieldMapper.KeywordFieldType("leading_keyword");
-        final MappedFieldType secondaryKeywordMapping = new KeywordFieldMapper.KeywordFieldType("secondary_keyword");
-        final MappedFieldType fooMapping = new KeywordFieldMapper.KeywordFieldType("foo");
+        final MappedFieldType leadingKeywordMapping = KeywordFieldMapper.KeywordFieldType.builder().name("leading_keyword").build();
+        final MappedFieldType secondaryKeywordMapping = KeywordFieldMapper.KeywordFieldType.builder().name("secondary_keyword").build();
+        final MappedFieldType fooMapping = KeywordFieldMapper.KeywordFieldType.builder().name("foo").build();
 
         CheckedConsumer<RandomIndexWriter, IOException> buildIndex = iw -> {
             for (int i = 1; i <= 100; i++) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeValuesCollectorQueueTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeValuesCollectorQueueTests.java
@@ -390,7 +390,7 @@ public class CompositeValuesCollectorQueueTests extends AggregatorTestCase {
     }
 
     private static MappedFieldType createKeyword(String name) {
-        return new KeywordFieldMapper.KeywordFieldType(name);
+        return KeywordFieldMapper.KeywordFieldType.builder().name(name).build();
     }
 
     private static int compareKey(CompositeKey key1, CompositeKey key2) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/SingleDimensionValuesSourceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/SingleDimensionValuesSourceTests.java
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.when;
 
 public class SingleDimensionValuesSourceTests extends ESTestCase {
     public void testBinarySorted() {
-        MappedFieldType keyword = new KeywordFieldMapper.KeywordFieldType("keyword");
+        MappedFieldType keyword = KeywordFieldMapper.KeywordFieldType.builder().name("keyword").build();
         BinaryValuesSource source = new BinaryValuesSource(
             BigArrays.NON_RECYCLING_INSTANCE,
             (b) -> {},
@@ -94,7 +94,7 @@ public class SingleDimensionValuesSourceTests extends ESTestCase {
     }
 
     public void testGlobalOrdinalsSorted() {
-        final MappedFieldType keyword = new KeywordFieldMapper.KeywordFieldType("keyword");
+        final MappedFieldType keyword = KeywordFieldMapper.KeywordFieldType.builder().name("keyword").build();
         GlobalOrdinalValuesSource source = new GlobalOrdinalValuesSource(
             BigArrays.NON_RECYCLING_INSTANCE,
             keyword,

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorTests.java
@@ -413,7 +413,7 @@ public class NestedAggregatorTests extends AggregatorTestCase {
             }
             try (DirectoryReader indexReader = wrapInMockESDirectoryReader(DirectoryReader.open(directory))) {
                 MappedFieldType fieldType1 = new NumberFieldMapper.NumberFieldType("num_pages", NumberFieldMapper.NumberType.LONG);
-                MappedFieldType fieldType2 = new KeywordFieldMapper.KeywordFieldType("author");
+                MappedFieldType fieldType2 = KeywordFieldMapper.KeywordFieldType.builder().name("author").build();
 
                 TermsAggregationBuilder termsBuilder = new TermsAggregationBuilder("authors").userValueTypeHint(ValueType.STRING)
                     .field("author")
@@ -547,7 +547,7 @@ public class NestedAggregatorTests extends AggregatorTestCase {
             });
             try (DirectoryReader indexReader = wrapInMockESDirectoryReader(DirectoryReader.open(directory))) {
                 MappedFieldType fieldType1 = new NumberFieldMapper.NumberFieldType("num_pages", NumberFieldMapper.NumberType.LONG);
-                MappedFieldType fieldType2 = new KeywordFieldMapper.KeywordFieldType("author");
+                MappedFieldType fieldType2 = KeywordFieldMapper.KeywordFieldType.builder().name("author").build();
 
                 TermsAggregationBuilder termsBuilder = new TermsAggregationBuilder("authors").userValueTypeHint(ValueType.STRING)
                     .size(books.size())
@@ -651,8 +651,8 @@ public class NestedAggregatorTests extends AggregatorTestCase {
                 FilterAggregationBuilder filterAggregationBuilder = new FilterAggregationBuilder("filterAgg", new MatchAllQueryBuilder());
                 filterAggregationBuilder.subAggregation(nestedBuilder);
 
-                MappedFieldType fieldType1 = new KeywordFieldMapper.KeywordFieldType("key");
-                MappedFieldType fieldType2 = new KeywordFieldMapper.KeywordFieldType("value");
+                MappedFieldType fieldType1 = KeywordFieldMapper.KeywordFieldType.builder().name("key").build();
+                MappedFieldType fieldType2 = KeywordFieldMapper.KeywordFieldType.builder().name("value").build();
 
                 SingleBucketAggregation filter = searchAndReduce(
                     indexReader,

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/DateRangeAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/DateRangeAggregatorTests.java
@@ -332,7 +332,7 @@ public class DateRangeAggregatorTests extends AggregatorTestCase {
         DateRangeAggregationBuilder aggregationBuilder = new DateRangeAggregationBuilder("date_range").field("not_a_number")
             .addRange("2015-11-13", "2015-11-14");
 
-        MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("not_a_number");
+        MappedFieldType fieldType = KeywordFieldMapper.KeywordFieldType.builder().name("not_a_number").build();
 
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregatorTests.java
@@ -482,7 +482,7 @@ public class RangeAggregatorTests extends AggregatorTestCase {
     public void testUnsupportedType() {
         RangeAggregationBuilder aggregationBuilder = new RangeAggregationBuilder("range").field("not_a_number").addRange(-2d, 5d);
 
-        MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("not_a_number");
+        MappedFieldType fieldType = KeywordFieldMapper.KeywordFieldType.builder().name("not_a_number").build();
 
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> testCase(iw -> {
             iw.addDocument(singleton(new SortedSetDocValuesField("string", new BytesRef("foo"))));

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedSamplerTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedSamplerTests.java
@@ -93,7 +93,7 @@ public class DiversifiedSamplerTests extends AggregatorTestCase {
         IndexWriterConfig iwc = LuceneTestCase.newIndexWriterConfig(random(), new MockAnalyzer(random()));
         iwc.setMergePolicy(new LogDocMergePolicy());
         RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory, iwc);
-        MappedFieldType genreFieldType = new KeywordFieldMapper.KeywordFieldType("genre");
+        MappedFieldType genreFieldType = KeywordFieldMapper.KeywordFieldType.builder().name("genre").build();
         writeBooks(indexWriter);
         indexWriter.close();
         DirectoryReader indexReader = DirectoryReader.open(directory);
@@ -111,7 +111,7 @@ public class DiversifiedSamplerTests extends AggregatorTestCase {
         testCase(indexReader, genreFieldType, null, verify);
 
         // wrong field:
-        genreFieldType = new KeywordFieldMapper.KeywordFieldType("wrong_field");
+        genreFieldType = KeywordFieldMapper.KeywordFieldType.builder().name("wrong_field").build();
         testCase(indexReader, genreFieldType, null, result -> {
             Terms terms = result.getAggregations().get("terms");
             assertEquals(1, terms.getBuckets().size());
@@ -129,7 +129,7 @@ public class DiversifiedSamplerTests extends AggregatorTestCase {
         indexWriter.close();
         DirectoryReader indexReader = DirectoryReader.open(directory);
 
-        MappedFieldType genreFieldType = new KeywordFieldMapper.KeywordFieldType("genre");
+        MappedFieldType genreFieldType = KeywordFieldMapper.KeywordFieldType.builder().name("genre").build();
         Consumer<InternalSampler> verify = result -> {
             Terms terms = result.getAggregations().get("terms");
             assertThat(terms.getBuckets().size(), greaterThan(0));
@@ -164,7 +164,7 @@ public class DiversifiedSamplerTests extends AggregatorTestCase {
         int shardSize,
         int maxDocsPerValue
     ) throws IOException {
-        MappedFieldType idFieldType = new KeywordFieldMapper.KeywordFieldType("id");
+        MappedFieldType idFieldType = KeywordFieldMapper.KeywordFieldType.builder().name("id").build();
 
         SortedDoublesIndexFieldData fieldData = new SortedDoublesIndexFieldData(
             "price",
@@ -194,9 +194,9 @@ public class DiversifiedSamplerTests extends AggregatorTestCase {
         indexWriter.close();
         IndexReader indexReader = DirectoryReader.open(directory);
 
-        MappedFieldType idFieldType = new KeywordFieldMapper.KeywordFieldType("id");
+        MappedFieldType idFieldType = KeywordFieldMapper.KeywordFieldType.builder().name("id").build();
 
-        MappedFieldType genreFieldType = new KeywordFieldMapper.KeywordFieldType("genre");
+        MappedFieldType genreFieldType = KeywordFieldMapper.KeywordFieldType.builder().name("genre").build();
 
         DiversifiedAggregationBuilder builder = new DiversifiedAggregationBuilder("_name").field(genreFieldType.name())
             .subAggregation(new TermsAggregationBuilder("terms").field("id"));

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/KeywordTermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/KeywordTermsAggregatorTests.java
@@ -26,7 +26,6 @@ import org.elasticsearch.search.aggregations.support.ValueType;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -98,7 +97,7 @@ public class KeywordTermsAggregatorTests extends AggregatorTestCase {
         ValueType valueType
     ) throws IOException {
         boolean indexed = randomBoolean();
-        MappedFieldType keywordFieldType = new KeywordFieldMapper.KeywordFieldType(KEYWORD_FIELD, indexed, true, Collections.emptyMap());
+        MappedFieldType keywordFieldType = KeywordFieldMapper.KeywordFieldType.builder().name(KEYWORD_FIELD).isIndexed(indexed).build();
         FieldType luceneFieldType = new FieldType(KeywordFieldMapper.Defaults.FIELD_TYPE);
         if (indexed == false) {
             luceneFieldType.setIndexOptions(IndexOptions.NONE);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregatorTests.java
@@ -233,7 +233,7 @@ public class RareTermsAggregatorTests extends AggregatorTestCase {
                 document.add(new SortedDocValuesField("string", new BytesRef("a")));
                 document.add(new NumericDocValuesField("long", 0L));
                 indexWriter.addDocument(document);
-                MappedFieldType fieldType1 = new KeywordFieldMapper.KeywordFieldType("another_string");
+                MappedFieldType fieldType1 = KeywordFieldMapper.KeywordFieldType.builder().name("another_string").build();
                 MappedFieldType fieldType2 = new NumberFieldMapper.NumberFieldType("another_long", NumberFieldMapper.NumberType.LONG);
 
                 try (DirectoryReader indexReader = maybeWrapReaderEs(indexWriter.getReader())) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregatorTests.java
@@ -674,7 +674,7 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
     }
 
     public void testMatchNoDocsQuery() throws Exception {
-        MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("string", randomBoolean(), true, Collections.emptyMap());
+        MappedFieldType fieldType = KeywordFieldMapper.KeywordFieldType.builder().name("string").isIndexed(randomBoolean()).build();
         SignificantTermsAggregationBuilder aggregationBuilder = new SignificantTermsAggregationBuilder("_name").field("string");
         CheckedConsumer<RandomIndexWriter, IOException> createIndex = iw -> {
             iw.addDocument(doc(fieldType, "a", "b"));

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorTests.java
@@ -224,7 +224,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
         indexWriter.close();
         DirectoryReader indexReader = DirectoryReader.open(directory);
         // We do not use LuceneTestCase.newSearcher because we need a DirectoryReader
-        MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("string");
+        MappedFieldType fieldType = KeywordFieldType.builder().name("string").build();
 
         try (AggregationContext context = createAggregationContext(indexReader, new MatchAllDocsQuery(), fieldType)) {
             TermsAggregationBuilder aggregationBuilder = new TermsAggregationBuilder("_name").userValueTypeHint(ValueType.STRING)
@@ -269,7 +269,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
     }
 
     public void testSimple() throws Exception {
-        MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("string", randomBoolean(), true, Collections.emptyMap());
+        MappedFieldType fieldType = KeywordFieldType.builder().name("string").isIndexed(randomBoolean()).build();
         TermsAggregationBuilder aggregationBuilder = new TermsAggregationBuilder("_name").executionHint(
             randomFrom(TermsAggregatorFactory.ExecutionMode.values()).toString()
         ).field("string").order(BucketOrder.key(true));
@@ -302,7 +302,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
     }
 
     private void testMatchNoDocsQuery(TermsAggregatorFactory.ExecutionMode hint) throws Exception {
-        MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("string", randomBoolean(), true, Collections.emptyMap());
+        MappedFieldType fieldType = KeywordFieldType.builder().name("string").isIndexed(randomBoolean()).build();
         TermsAggregationBuilder aggregationBuilder = new TermsAggregationBuilder("_name").field("string");
         if (hint != null) {
             aggregationBuilder.executionHint(hint.toString());
@@ -322,7 +322,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
     }
 
     public void testStringShardMinDocCount() throws IOException {
-        MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("string", true, true, Collections.emptyMap());
+        MappedFieldType fieldType = KeywordFieldType.builder().name("string").build();
         for (TermsAggregatorFactory.ExecutionMode executionMode : TermsAggregatorFactory.ExecutionMode.values()) {
             TermsAggregationBuilder aggregationBuilder = new TermsAggregationBuilder("_name").field("string")
                 .executionHint(executionMode.toString())
@@ -347,7 +347,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
     }
 
     public void testStringShardZeroMinDocCount() throws IOException {
-        MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("string", true, true, Collections.emptyMap());
+        MappedFieldType fieldType = KeywordFieldType.builder().name("string").build();
         for (TermsAggregatorFactory.ExecutionMode executionMode : TermsAggregatorFactory.ExecutionMode.values()) {
             TermsAggregationBuilder aggregationBuilder = new TermsAggregationBuilder("_name").field("string")
                 .executionHint(executionMode.toString())
@@ -417,7 +417,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
      * via ordinals.
      */
     public void testStringZeroMinDocCountMatchNone() throws IOException {
-        MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("string", true, true, Collections.emptyMap());
+        MappedFieldType fieldType = KeywordFieldType.builder().name("string").build();
         for (TermsAggregatorFactory.ExecutionMode executionMode : TermsAggregatorFactory.ExecutionMode.values()) {
             TermsAggregationBuilder aggregationBuilder = new TermsAggregationBuilder("_name").field("string")
                 .executionHint(executionMode.toString())
@@ -481,7 +481,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
     }
 
     public void testManyTerms() throws Exception {
-        MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("string", randomBoolean(), true, Collections.emptyMap());
+        MappedFieldType fieldType = KeywordFieldType.builder().name("string").isIndexed(randomBoolean()).build();
         TermsAggregationBuilder aggregationBuilder = new TermsAggregationBuilder("_name").executionHint(randomHint()).field("string");
         /*
          * index all of the fields into a single segment so our
@@ -514,7 +514,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
     }
 
     public void testManyTermsOrderBySubAgg() throws Exception {
-        MappedFieldType kft = new KeywordFieldMapper.KeywordFieldType("string", randomBoolean(), true, Collections.emptyMap());
+        MappedFieldType kft = KeywordFieldType.builder().name("string").isIndexed(randomBoolean()).build();
         MappedFieldType lft = new NumberFieldType("long", NumberType.LONG);
 
         TermsAggregationBuilder aggregationBuilder = new TermsAggregationBuilder("_name").executionHint(randomHint())
@@ -553,8 +553,8 @@ public class TermsAggregatorTests extends AggregatorTestCase {
      * a {@link TooManyBucketsException} if we built the sub-aggs eagerly.
      */
     public void testDelaysSubAggs() throws Exception {
-        MappedFieldType s1ft = new KeywordFieldMapper.KeywordFieldType("string1", randomBoolean(), true, Collections.emptyMap());
-        MappedFieldType s2ft = new KeywordFieldMapper.KeywordFieldType("string2", randomBoolean(), true, Collections.emptyMap());
+        MappedFieldType s1ft = KeywordFieldType.builder().name("string1").isIndexed(randomBoolean()).build();
+        MappedFieldType s2ft = KeywordFieldType.builder().name("string2").isIndexed(randomBoolean()).build();
         TermsAggregationBuilder aggregationBuilder = new TermsAggregationBuilder("_name").executionHint(randomHint())
             .field("string1")
             .shardSize(1000)
@@ -602,8 +602,8 @@ public class TermsAggregatorTests extends AggregatorTestCase {
     }
 
     public void testStringIncludeExclude() throws Exception {
-        MappedFieldType ft1 = new KeywordFieldMapper.KeywordFieldType("mv_field", randomBoolean(), true, Collections.emptyMap());
-        MappedFieldType ft2 = new KeywordFieldMapper.KeywordFieldType("sv_field", randomBoolean(), true, Collections.emptyMap());
+        MappedFieldType ft1 = KeywordFieldType.builder().name("mv_field").isIndexed(randomBoolean()).build();
+        MappedFieldType ft2 = KeywordFieldType.builder().name("sv_field").isIndexed(randomBoolean()).build();
         CheckedConsumer<RandomIndexWriter, IOException> buildIndex = iw -> {
             iw.addDocument(doc(ft1, ft2, "val000", "val001", "val001"));
             iw.addDocument(doc(ft1, ft2, "val002", "val003", "val003"));
@@ -939,7 +939,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
     }
 
     public void testStringTermsAggregator() throws Exception {
-        MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("field", randomBoolean(), true, Collections.emptyMap());
+        MappedFieldType fieldType = KeywordFieldType.builder().name("field").isIndexed(randomBoolean()).build();
         BiFunction<String, Boolean, List<IndexableField>> luceneFieldFactory = (val, mv) -> {
             List<IndexableField> result = new ArrayList<>(2);
             if (mv) {
@@ -1106,7 +1106,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                     }
 
                     if (multiValued == false) {
-                        MappedFieldType filterFieldType = new KeywordFieldMapper.KeywordFieldType("include");
+                        MappedFieldType filterFieldType = KeywordFieldType.builder().name("include").build();
                         aggregationBuilder = new FilterAggregationBuilder("_name1", QueryBuilders.termQuery("include", "yes"));
                         aggregationBuilder.subAggregation(
                             new TermsAggregationBuilder("_name2").userValueTypeHint(valueType)
@@ -1207,7 +1207,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
     public void testEmpty() throws Exception {
         try (Directory directory = newDirectory()) {
             try (RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory)) {
-                MappedFieldType fieldType1 = new KeywordFieldMapper.KeywordFieldType("string");
+                MappedFieldType fieldType1 = KeywordFieldType.builder().name("string").build();
                 MappedFieldType fieldType2 = new NumberFieldMapper.NumberFieldType("long", NumberFieldMapper.NumberType.LONG);
                 MappedFieldType fieldType3 = new NumberFieldMapper.NumberFieldType("double", NumberFieldMapper.NumberType.DOUBLE);
                 try (DirectoryReader indexReader = maybeWrapReaderEs(indexWriter.getReader())) {
@@ -1260,7 +1260,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
 
                 try (DirectoryReader indexReader = maybeWrapReaderEs(indexWriter.getReader())) {
 
-                    MappedFieldType fieldType1 = new KeywordFieldMapper.KeywordFieldType("unrelated_value");
+                    MappedFieldType fieldType1 = KeywordFieldType.builder().name("unrelated_value").build();
 
                     ValueType[] valueTypes = new ValueType[] { ValueType.STRING, ValueType.LONG, ValueType.DOUBLE };
                     String[] fieldNames = new String[] { "string", "long", "double" };
@@ -1354,8 +1354,8 @@ public class TermsAggregatorTests extends AggregatorTestCase {
     }
 
     public void testNestedTermsAgg() throws Exception {
-        MappedFieldType fieldType1 = new KeywordFieldMapper.KeywordFieldType("field1", randomBoolean(), true, Collections.emptyMap());
-        MappedFieldType fieldType2 = new KeywordFieldMapper.KeywordFieldType("field2", randomBoolean(), true, Collections.emptyMap());
+        MappedFieldType fieldType1 = KeywordFieldType.builder().name("field1").isIndexed(randomBoolean()).build();
+        MappedFieldType fieldType2 = KeywordFieldType.builder().name("field2").isIndexed(randomBoolean()).build();
         try (Directory directory = newDirectory()) {
             try (RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory)) {
                 List<IndexableField> document = new ArrayList<>();
@@ -1516,7 +1516,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
 
     public void testHeisenpig() throws IOException {
         MappedFieldType nestedFieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.LONG);
-        KeywordFieldType animalFieldType = new KeywordFieldType("str", randomBoolean(), true, Collections.emptyMap());
+        KeywordFieldType animalFieldType = KeywordFieldType.builder().name("str").isIndexed(randomBoolean()).build();
         try (Directory directory = newDirectory()) {
             try (RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory)) {
                 String[] tags = new String[] { "danger", "fluffiness" };
@@ -1592,7 +1592,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
 
     public void testManySegmentsStillSingleton() throws IOException {
         NumberFieldType nFt = new NumberFieldType("n", NumberFieldMapper.NumberType.LONG);
-        KeywordFieldType strFt = new KeywordFieldType("str", true, true, Collections.emptyMap());
+        KeywordFieldType strFt = KeywordFieldType.builder().name("str").build();
         AggregationBuilder builder = new TermsAggregationBuilder("n").field("n")
             .subAggregation(new TermsAggregationBuilder("str").field("str"));
         withNonMergingIndex(iw -> {
@@ -1636,7 +1636,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
         Function<MapMatcher, MapMatcher> extraMatcher
     ) throws IOException {
         randomizeAggregatorImpl = false;
-        KeywordFieldType strFt = new KeywordFieldType("str", false, true, Collections.emptyMap());
+        KeywordFieldType strFt = KeywordFieldType.builder().name("str").isIndexed(false).build();
         AggregationBuilder builder = new TermsAggregationBuilder("str").field("str").includeExclude(includeExclude);
         CheckedConsumer<RandomIndexWriter, IOException> buildIndex = iw -> {
             for (int i = 0; i < count; i++) {
@@ -1731,9 +1731,9 @@ public class TermsAggregatorTests extends AggregatorTestCase {
     }
 
     private void threeLayerStringTestCase(String executionHint) throws IOException {
-        MappedFieldType ift = new KeywordFieldType("i", randomBoolean(), true, Collections.emptyMap());
-        MappedFieldType jft = new KeywordFieldType("j", randomBoolean(), true, Collections.emptyMap());
-        MappedFieldType kft = new KeywordFieldType("k", randomBoolean(), true, Collections.emptyMap());
+        MappedFieldType ift = KeywordFieldType.builder().name("i").isIndexed(randomBoolean()).build();
+        MappedFieldType jft = KeywordFieldType.builder().name("j").isIndexed(randomBoolean()).build();
+        MappedFieldType kft = KeywordFieldType.builder().name("k").isIndexed(randomBoolean()).build();
 
         try (Directory dir = newDirectory()) {
             try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
@@ -1841,7 +1841,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                         .order(BucketOrder.aggregation("script", true))
                         .subAggregation(bucketScriptAgg);
 
-                    MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("field");
+                    MappedFieldType fieldType = KeywordFieldType.builder().name("field").build();
 
                     AggregationExecutionException.InvalidPath e = expectThrows(
                         AggregationExecutionException.InvalidPath.class,
@@ -1936,7 +1936,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                 AggTestConfig aggTestConfig = new AggTestConfig(
                     aggregationBuilder,
                     new NumberFieldType("a", NumberType.INTEGER),
-                    bIsString ? new KeywordFieldType("b") : new NumberFieldType("b", NumberType.INTEGER)
+                    bIsString ? KeywordFieldType.builder().name("b").build() : new NumberFieldType("b", NumberType.INTEGER)
                 ).withSplitLeavesIntoSeperateAggregators(false).withMaxBuckets(Integer.MAX_VALUE);
                 LongTerms terms = searchAndReduce(indexReader, aggTestConfig);
                 assertThat(
@@ -1953,7 +1953,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
 
     public void testAsSubAgg() throws IOException {
         DateFieldType dft = new DateFieldType("d");
-        KeywordFieldType kft = new KeywordFieldType("k", false, true, Collections.emptyMap());
+        KeywordFieldType kft = KeywordFieldType.builder().name("k").isIndexed(false).build();
         AggregationBuilder builder = new DateHistogramAggregationBuilder("dh").field("d")
             .calendarInterval(DateHistogramInterval.YEAR)
             .subAggregation(new TermsAggregationBuilder("k").field("k"));
@@ -2013,7 +2013,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
     }
 
     public void testWithFilterAndPreciseSize() throws IOException {
-        KeywordFieldType kft = new KeywordFieldType("k", true, true, Collections.emptyMap());
+        KeywordFieldType kft = KeywordFieldType.builder().name("k").build();
         CheckedConsumer<RandomIndexWriter, IOException> buildIndex = iw -> {
             iw.addDocument(List.of(new Field("k", new BytesRef("a"), KeywordFieldMapper.Defaults.FIELD_TYPE)));
             iw.addDocument(List.of(new Field("k", new BytesRef("b"), KeywordFieldMapper.Defaults.FIELD_TYPE)));
@@ -2115,7 +2115,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
                         .entry("collection_strategy", either(equalTo("remap using single bucket ords")).or(equalTo("dense")))
                 )
             );
-        }, new KeywordFieldType("k", true, true, Collections.emptyMap()));
+        }, KeywordFieldType.builder().name("k").build());
     }
 
     /**
@@ -2138,7 +2138,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
             }
         };
         BytesRef[] values = new BytesRef[] { new BytesRef("stuff"), new BytesRef("more_stuff"), new BytesRef("other_stuff"), };
-        MappedFieldType keywordFt = new KeywordFieldType("k", true, true, Collections.emptyMap());
+        MappedFieldType keywordFt = KeywordFieldType.builder().name("k").build();
         MappedFieldType dummyFt = new KeywordScriptFieldType("dummy", scriptFactory, new Script("test"), Map.of(), OnScriptError.FAIL);
         debugTestCase(new TermsAggregationBuilder("t").field("dummy"), new MatchAllDocsQuery(), iw -> {
             for (int d = 0; d < totalDocs; d++) {
@@ -2174,7 +2174,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
         long totalDocs = 500;
         long[] totalCount = new long[] { 0 };
         BytesRef value = new BytesRef("stuff");
-        MappedFieldType keywordFt = new KeywordFieldType("k", true, true, Collections.emptyMap());
+        MappedFieldType keywordFt = KeywordFieldType.builder().name("k").build();
         debugTestCase(new TermsAggregationBuilder("t").field("k"), new MatchAllDocsQuery(), iw -> {
             for (int d = 0; d < totalDocs; d++) {
                 List<IndexableField> doc = new ArrayList<>();
@@ -2213,7 +2213,7 @@ public class TermsAggregatorTests extends AggregatorTestCase {
         long totalDocs = 500;
         long[] totalCounts = new long[] { 0, 0, 0 };
         BytesRef[] values = new BytesRef[] { new BytesRef("a"), new BytesRef("b"), new BytesRef("c") };
-        MappedFieldType keywordFt = new KeywordFieldType("k", true, true, Collections.emptyMap());
+        MappedFieldType keywordFt = KeywordFieldType.builder().name("k").build();
         debugTestCase(new TermsAggregationBuilder("t").field("k").order(BucketOrder.key(true)), new MatchAllDocsQuery(), iw -> {
             for (int d = 0; d < totalDocs; d++) {
                 BytesRef value = values[d % values.length];

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorTests.java
@@ -274,7 +274,7 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
 
     public void testSingleValuedString() throws IOException {
         final CardinalityAggregationBuilder aggregationBuilder = new CardinalityAggregationBuilder("name").field("str_value");
-        final MappedFieldType mappedFieldTypes = new KeywordFieldMapper.KeywordFieldType("str_value");
+        final MappedFieldType mappedFieldTypes = KeywordFieldMapper.KeywordFieldType.builder().name("str_value").build();
 
         testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
             iw.addDocument(singleton(new SortedDocValuesField("str_value", new BytesRef("one"))));
@@ -290,7 +290,7 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
     public void testIndexedSingleValuedString() throws IOException {
         // Indexing enables dynamic pruning optimizations
         final CardinalityAggregationBuilder aggregationBuilder = new CardinalityAggregationBuilder("name").field("str_value");
-        final MappedFieldType mappedFieldTypes = new KeywordFieldMapper.KeywordFieldType("str_value");
+        final MappedFieldType mappedFieldTypes = KeywordFieldMapper.KeywordFieldType.builder().name("str_value").build();
 
         CheckedConsumer<RandomIndexWriter, IOException> buildIndex = iw -> {
             iw.addDocument(
@@ -352,7 +352,7 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
         // aggregation with minimum precision so we don't need to generate too many distinct values
         final CardinalityAggregationBuilder aggregationBuilder = new CardinalityAggregationBuilder("name").field("str_value")
             .precisionThreshold(1);
-        final MappedFieldType mappedFieldTypes = new KeywordFieldMapper.KeywordFieldType("str_value");
+        final MappedFieldType mappedFieldTypes = KeywordFieldMapper.KeywordFieldType.builder().name("str_value").build();
 
         // range big enough that will force force promotion to HHL the time to time
         final BytesRef[] differentValues = new BytesRef[randomIntBetween(10, 30)];
@@ -434,7 +434,7 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
     public void testSingleValuedStringValueScript() throws IOException {
         final CardinalityAggregationBuilder aggregationBuilder = new CardinalityAggregationBuilder("name").field("str_value")
             .script(new Script(ScriptType.INLINE, MockScriptEngine.NAME, "_value", emptyMap()));
-        final MappedFieldType mappedFieldTypes = new KeywordFieldMapper.KeywordFieldType("str_value");
+        final MappedFieldType mappedFieldTypes = KeywordFieldMapper.KeywordFieldType.builder().name("str_value").build();
 
         testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
             iw.addDocument(singleton(new SortedDocValuesField("str_value", new BytesRef("one"))));
@@ -451,7 +451,7 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
         final CardinalityAggregationBuilder aggregationBuilder = new CardinalityAggregationBuilder("name").script(
             new Script(ScriptType.INLINE, MockScriptEngine.NAME, "doc['str_value'].value", emptyMap())
         );
-        final MappedFieldType mappedFieldTypes = new KeywordFieldMapper.KeywordFieldType("str_value");
+        final MappedFieldType mappedFieldTypes = KeywordFieldMapper.KeywordFieldType.builder().name("str_value").build();
 
         testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
             iw.addDocument(singleton(new SortedDocValuesField("str_value", new BytesRef("one"))));
@@ -468,7 +468,7 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
         final CardinalityAggregationBuilder aggregationBuilder = new CardinalityAggregationBuilder("name").script(
             new Script(ScriptType.INLINE, MockScriptEngine.NAME, "doc['str_values']", emptyMap())
         );
-        final MappedFieldType mappedFieldTypes = new KeywordFieldMapper.KeywordFieldType("str_values");
+        final MappedFieldType mappedFieldTypes = KeywordFieldMapper.KeywordFieldType.builder().name("str_values").build();
 
         testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
             iw.addDocument(
@@ -510,7 +510,7 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
     public void testMultiValuedStringValueScript() throws IOException {
         final CardinalityAggregationBuilder aggregationBuilder = new CardinalityAggregationBuilder("name").field("str_values")
             .script(new Script(ScriptType.INLINE, MockScriptEngine.NAME, "_value", emptyMap()));
-        final MappedFieldType mappedFieldTypes = new KeywordFieldMapper.KeywordFieldType("str_values");
+        final MappedFieldType mappedFieldTypes = KeywordFieldMapper.KeywordFieldType.builder().name("str_values").build();
 
         testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
             iw.addDocument(
@@ -551,7 +551,7 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
 
     public void testMultiValuedString() throws IOException {
         final CardinalityAggregationBuilder aggregationBuilder = new CardinalityAggregationBuilder("name").field("str_values");
-        final MappedFieldType mappedFieldTypes = new KeywordFieldMapper.KeywordFieldType("str_values");
+        final MappedFieldType mappedFieldTypes = KeywordFieldMapper.KeywordFieldType.builder().name("str_values").build();
 
         testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
             iw.addDocument(
@@ -593,7 +593,7 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
     public void testIndexedMultiValuedString() throws IOException {
         // Indexing enables dynamic pruning optimizations
         final CardinalityAggregationBuilder aggregationBuilder = new CardinalityAggregationBuilder("name").field("str_values");
-        final MappedFieldType mappedFieldTypes = new KeywordFieldMapper.KeywordFieldType("str_values");
+        final MappedFieldType mappedFieldTypes = KeywordFieldMapper.KeywordFieldType.builder().name("str_values").build();
 
         CheckedConsumer<RandomIndexWriter, IOException> buildIndex = iw -> {
             iw.addDocument(
@@ -670,7 +670,7 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
     public void testIndexedAllDifferentValues() throws IOException {
         // Indexing enables testing of ordinal values
         final CardinalityAggregationBuilder aggregationBuilder = new CardinalityAggregationBuilder("name").field("str_values");
-        final MappedFieldType mappedFieldTypes = new KeywordFieldMapper.KeywordFieldType("str_values");
+        final MappedFieldType mappedFieldTypes = KeywordFieldMapper.KeywordFieldType.builder().name("str_values").build();
         int docs = randomIntBetween(50, 100);
         CheckedConsumer<RandomIndexWriter, IOException> buildIndex = iw -> {
 
@@ -852,7 +852,7 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
 
     public void testAsSubAggregation() throws IOException {
         final MappedFieldType mappedFieldTypes[] = {
-            new KeywordFieldMapper.KeywordFieldType("str_value"),
+            KeywordFieldMapper.KeywordFieldType.builder().name("str_value").build(),
             new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.LONG) };
 
         final AggregationBuilder aggregationBuilder = new TermsAggregationBuilder("terms").field("str_value")
@@ -895,7 +895,7 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
     public void testIndexedWithMissingValues() throws IOException {
         // Indexing enables dynamic pruning optimizations
         final CardinalityAggregationBuilder aggregationBuilder = new CardinalityAggregationBuilder("name").field("str_value");
-        final MappedFieldType mappedFieldTypes = new KeywordFieldMapper.KeywordFieldType("str_value");
+        final MappedFieldType mappedFieldTypes = KeywordFieldMapper.KeywordFieldType.builder().name("str_value").build();
 
         testAggregation(aggregationBuilder, new MatchAllDocsQuery(), iw -> {
             iw.addDocument(Collections.emptySet());
@@ -940,7 +940,7 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
         // Indexing enables dynamic pruning optimizations
         // Fields with more than 128 unique values exercise slightly different code paths
         final CardinalityAggregationBuilder aggregationBuilder = new CardinalityAggregationBuilder("name").field("str_value");
-        final MappedFieldType mappedFieldTypes = new KeywordFieldMapper.KeywordFieldType("str_value");
+        final MappedFieldType mappedFieldTypes = KeywordFieldMapper.KeywordFieldType.builder().name("str_value").build();
 
         CheckedConsumer<RandomIndexWriter, IOException> buildIndex = iw -> {
             for (int i = 0; i < 200; ++i) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/HDRPercentilesAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/HDRPercentilesAggregatorTests.java
@@ -67,7 +67,7 @@ public class HDRPercentilesAggregatorTests extends AggregatorTestCase {
      */
     public void testStringField() throws IOException {
         final String fieldName = "string";
-        MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType(fieldName);
+        MappedFieldType fieldType = KeywordFieldMapper.KeywordFieldType.builder().name(fieldName).build();
         expectThrows(IllegalArgumentException.class, () -> testCase(new FieldExistsQuery(fieldName), iw -> {
             iw.addDocument(singleton(new SortedSetDocValuesField("string", new BytesRef("bogus"))));
             iw.addDocument(singleton(new SortedSetDocValuesField("string", new BytesRef("zwomp"))));

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/MinAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/MinAggregatorTests.java
@@ -261,7 +261,7 @@ public class MinAggregatorTests extends AggregatorTestCase {
     public void testUnsupportedType() {
         MinAggregationBuilder aggregationBuilder = new MinAggregationBuilder("min").field("not_a_number");
 
-        MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("not_a_number");
+        MappedFieldType fieldType = KeywordFieldMapper.KeywordFieldType.builder().name("not_a_number").build();
 
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> testCase(iw -> {
             iw.addDocument(singleton(new SortedSetDocValuesField("string", new BytesRef("foo"))));

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregatorTests.java
@@ -114,7 +114,7 @@ public class TopHitsAggregatorTests extends AggregatorTestCase {
         assertTrue(AggregationInspectionHelper.hasValue(((InternalTopHits) terms.getBucketByKey("d").getAggregations().get("top"))));
     }
 
-    private static final MappedFieldType STRING_FIELD_TYPE = new KeywordFieldMapper.KeywordFieldType("string");
+    private static final MappedFieldType STRING_FIELD_TYPE = KeywordFieldMapper.KeywordFieldType.builder().name("string").build();
 
     private Aggregation testCase(Query query, AggregationBuilder builder) throws IOException {
         Directory directory = newDirectory();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregatorTests.java
@@ -396,7 +396,7 @@ public class ValueCountAggregatorTests extends AggregatorTestCase {
     private static MappedFieldType createMappedFieldType(String name, ValueType valueType) {
         return switch (valueType) {
             case BOOLEAN -> new BooleanFieldMapper.BooleanFieldType(name);
-            case STRING -> new KeywordFieldMapper.KeywordFieldType(name);
+            case STRING -> KeywordFieldMapper.KeywordFieldType.builder().name(name).build();
             case DOUBLE -> new NumberFieldMapper.NumberFieldType(name, NumberFieldMapper.NumberType.DOUBLE);
             case NUMBER, NUMERIC, LONG -> new NumberFieldMapper.NumberFieldType(name, NumberFieldMapper.NumberType.LONG);
             case DATE -> new DateFieldMapper.DateFieldType(name);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptAggregatorTests.java
@@ -70,7 +70,7 @@ public class BucketScriptAggregatorTests extends AggregatorTestCase {
 
     public void testScript() throws IOException {
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number_field", NumberFieldMapper.NumberType.INTEGER);
-        MappedFieldType fieldType1 = new KeywordFieldMapper.KeywordFieldType("the_field");
+        MappedFieldType fieldType1 = KeywordFieldMapper.KeywordFieldType.builder().name("the_field").build();
 
         FiltersAggregationBuilder filters = new FiltersAggregationBuilder("placeholder", new MatchAllQueryBuilder()).subAggregation(
             new TermsAggregationBuilder("the_terms").userValueTypeHint(ValueType.STRING)
@@ -106,7 +106,7 @@ public class BucketScriptAggregatorTests extends AggregatorTestCase {
 
     public void testNonMultiBucketParent() {
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number_field", NumberFieldMapper.NumberType.INTEGER);
-        MappedFieldType fieldType1 = new KeywordFieldMapper.KeywordFieldType("the_field");
+        MappedFieldType fieldType1 = KeywordFieldMapper.KeywordFieldType.builder().name("the_field").build();
 
         FilterAggregationBuilder filter = new FilterAggregationBuilder("placeholder", new MatchAllQueryBuilder()).subAggregation(
             new TermsAggregationBuilder("the_terms").userValueTypeHint(ValueType.STRING)

--- a/server/src/test/java/org/elasticsearch/search/collapse/CollapseBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/collapse/CollapseBuilderTests.java
@@ -182,18 +182,18 @@ public class CollapseBuilderTests extends AbstractXContentSerializingTestCase<Co
                 "cannot expand `inner_hits` for collapse field `field`, only indexed field can retrieve `inner_hits`"
             );
 
-            MappedFieldType keywordFieldType = new KeywordFieldMapper.KeywordFieldType("field");
+            MappedFieldType keywordFieldType = KeywordFieldMapper.KeywordFieldType.builder().name("field").build();
             when(searchExecutionContext.getFieldType("field")).thenReturn(keywordFieldType);
             CollapseBuilder kbuilder = new CollapseBuilder("field");
             collapseContext = kbuilder.build(searchExecutionContext);
             assertEquals(collapseContext.getFieldType(), keywordFieldType);
 
-            keywordFieldType = new KeywordFieldMapper.KeywordFieldType("field", true, false, Collections.emptyMap());
+            keywordFieldType = KeywordFieldMapper.KeywordFieldType.builder().name("field").hasDocValues(false).build();
             when(searchExecutionContext.getFieldType("field")).thenReturn(keywordFieldType);
             exc = expectThrows(IllegalArgumentException.class, () -> kbuilder.build(searchExecutionContext));
             assertEquals(exc.getMessage(), "cannot collapse on field `field` without `doc_values`");
 
-            keywordFieldType = new KeywordFieldMapper.KeywordFieldType("field", false, true, Collections.emptyMap());
+            keywordFieldType = KeywordFieldMapper.KeywordFieldType.builder().name("field").isIndexed(false).build();
             when(searchExecutionContext.getFieldType("field")).thenReturn(keywordFieldType);
             kbuilder.setInnerHits(new InnerHitBuilder().setName("field"));
             exc = expectThrows(IllegalArgumentException.class, () -> builder.build(searchExecutionContext));

--- a/server/src/test/java/org/elasticsearch/search/sort/FieldSortBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/FieldSortBuilderTests.java
@@ -343,11 +343,11 @@ public class FieldSortBuilderTests extends AbstractSortTestCase<FieldSortBuilder
     @Override
     protected MappedFieldType provideMappedFieldType(String name) {
         if (name.equals(MAPPED_STRING_FIELDNAME)) {
-            return new KeywordFieldMapper.KeywordFieldType(name);
+            return KeywordFieldMapper.KeywordFieldType.builder().name(name).build();
         } else if (name.startsWith("custom-")) {
             final MappedFieldType fieldType;
             if (name.startsWith("custom-keyword")) {
-                fieldType = new KeywordFieldMapper.KeywordFieldType(name);
+                fieldType = KeywordFieldMapper.KeywordFieldType.builder().name(name).build();
             } else if (name.startsWith("custom-date")) {
                 fieldType = new DateFieldMapper.DateFieldType(name);
             } else {

--- a/server/src/test/java/org/elasticsearch/search/suggest/completion/CategoryContextMappingTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/completion/CategoryContextMappingTests.java
@@ -795,7 +795,7 @@ public class CategoryContextMappingTests extends MapperServiceTestCase {
         CategoryContextMapping mapping = ContextBuilder.category("cat").field("category").build();
         LuceneDocument document = new LuceneDocument();
 
-        KeywordFieldMapper.KeywordFieldType keyword = new KeywordFieldMapper.KeywordFieldType("category");
+        KeywordFieldMapper.KeywordFieldType keyword = KeywordFieldMapper.KeywordFieldType.builder().name("category").build();
         document.add(
             new KeywordFieldMapper.KeywordField(keyword.name(), new BytesRef("category1"), KeywordFieldMapper.Defaults.FIELD_TYPE)
         );

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -1465,7 +1465,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
      * Make a {@linkplain DateFieldMapper.DateFieldType} for a {@code date}.
      */
     protected KeywordFieldMapper.KeywordFieldType keywordField(String name) {
-        return new KeywordFieldMapper.KeywordFieldType(name);
+        return KeywordFieldMapper.KeywordFieldType.builder().name(name).build();
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/bucket/DateHistogramAggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/bucket/DateHistogramAggregatorTestCase.java
@@ -90,8 +90,8 @@ public abstract class DateHistogramAggregatorTestCase extends AggregatorTestCase
         CheckedBiConsumer<RandomIndexWriter, DateFieldMapper.DateFieldType, IOException> buildIndex,
         Consumer<R> verify
     ) throws IOException {
-        KeywordFieldMapper.KeywordFieldType k1ft = new KeywordFieldMapper.KeywordFieldType("k1");
-        KeywordFieldMapper.KeywordFieldType k2ft = new KeywordFieldMapper.KeywordFieldType("k2");
+        KeywordFieldMapper.KeywordFieldType k1ft = KeywordFieldMapper.KeywordFieldType.builder().name("k1").build();
+        KeywordFieldMapper.KeywordFieldType k2ft = KeywordFieldMapper.KeywordFieldType.builder().name("k2").build();
         NumberFieldMapper.NumberFieldType nft = new NumberFieldMapper.NumberFieldType("n", NumberType.LONG);
         DateFieldMapper.DateFieldType dft = aggregableDateFieldType(false, randomBoolean());
         testCase(iw -> buildIndex.accept(iw, dft), verify, new AggTestConfig(builder, k1ft, k2ft, nft, dft));

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/boxplot/BoxplotAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/boxplot/BoxplotAggregatorTests.java
@@ -213,7 +213,7 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
     public void testUnsupportedType() {
         BoxplotAggregationBuilder aggregationBuilder = new BoxplotAggregationBuilder("boxplot").field("not_a_number");
 
-        MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("not_a_number");
+        MappedFieldType fieldType = KeywordFieldMapper.KeywordFieldType.builder().name("not_a_number").build();
 
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> testCase(iw -> {
             iw.addDocument(singleton(new SortedSetDocValuesField("string", new BytesRef("foo"))));

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/multiterms/MultiTermsAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/multiterms/MultiTermsAggregatorTests.java
@@ -659,7 +659,7 @@ public class MultiTermsAggregatorTests extends AggregatorTestCase {
         MappedFieldType dateType = dateFieldType(DATE_FIELD);
         MappedFieldType intType = new NumberFieldMapper.NumberFieldType(INT_FIELD, NumberFieldMapper.NumberType.INTEGER);
         MappedFieldType floatType = new NumberFieldMapper.NumberFieldType(FLOAT_FIELD, NumberFieldMapper.NumberType.FLOAT);
-        MappedFieldType keywordType = new KeywordFieldMapper.KeywordFieldType(KEYWORD_FIELD);
+        MappedFieldType keywordType = KeywordFieldMapper.KeywordFieldType.builder().name(KEYWORD_FIELD).build();
         MultiTermsAggregationBuilder builder = new MultiTermsAggregationBuilder("my_terms");
         builder.terms(terms);
         if (builderSetup != null) {

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/normalize/NormalizeAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/normalize/NormalizeAggregatorTests.java
@@ -35,7 +35,6 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuil
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -157,7 +156,7 @@ public class NormalizeAggregatorTests extends AggregatorTestCase {
             // setup mapping
             DateFieldMapper.DateFieldType dateFieldType = new DateFieldMapper.DateFieldType(DATE_FIELD);
             MappedFieldType valueFieldType = new NumberFieldMapper.NumberFieldType(VALUE_FIELD, NumberFieldMapper.NumberType.LONG);
-            MappedFieldType termFieldType = new KeywordFieldMapper.KeywordFieldType(TERM_FIELD, false, true, Collections.emptyMap());
+            MappedFieldType termFieldType = KeywordFieldMapper.KeywordFieldType.builder().name(TERM_FIELD).isIndexed(false).build();
 
             try (DirectoryReader indexReader = DirectoryReader.open(directory)) {
                 InternalAggregation internalAggregation = searchAndReduce(

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/rate/RateAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/rate/RateAggregatorTests.java
@@ -364,7 +364,7 @@ public class RateAggregatorTests extends AggregatorTestCase {
     public void testKeywordSandwich() throws IOException {
         MappedFieldType numType = new NumberFieldMapper.NumberFieldType("val", NumberFieldMapper.NumberType.INTEGER);
         MappedFieldType dateType = dateFieldType(DATE_FIELD);
-        MappedFieldType keywordType = new KeywordFieldMapper.KeywordFieldType("term");
+        MappedFieldType keywordType = KeywordFieldMapper.KeywordFieldType.builder().name("term").build();
         RateAggregationBuilder rateAggregationBuilder = new RateAggregationBuilder("my_rate").rateUnit("month").field("val");
         if (randomBoolean()) {
             rateAggregationBuilder.rateMode("sum");
@@ -424,7 +424,7 @@ public class RateAggregatorTests extends AggregatorTestCase {
     public void testWithComposite() throws IOException {
         MappedFieldType numType = new NumberFieldMapper.NumberFieldType("val", NumberFieldMapper.NumberType.INTEGER);
         MappedFieldType dateType = dateFieldType(DATE_FIELD);
-        MappedFieldType keywordType = new KeywordFieldMapper.KeywordFieldType("term");
+        MappedFieldType keywordType = KeywordFieldMapper.KeywordFieldType.builder().name("term").build();
         RateAggregationBuilder rateAggregationBuilder = new RateAggregationBuilder("my_rate").rateUnit("month").field("val");
         if (randomBoolean()) {
             rateAggregationBuilder.rateMode("sum");
@@ -507,7 +507,7 @@ public class RateAggregatorTests extends AggregatorTestCase {
 
         MappedFieldType numType = new NumberFieldMapper.NumberFieldType("val", NumberFieldMapper.NumberType.INTEGER);
         MappedFieldType dateType = dateFieldType(DATE_FIELD);
-        MappedFieldType keywordType = new KeywordFieldMapper.KeywordFieldType("term");
+        MappedFieldType keywordType = KeywordFieldMapper.KeywordFieldType.builder().name("term").build();
         RateAggregationBuilder rateAggregationBuilder = new RateAggregationBuilder("my_rate").rateUnit(rate).field("val");
         if (randomBoolean()) {
             rateAggregationBuilder.rateMode("sum");
@@ -579,7 +579,7 @@ public class RateAggregatorTests extends AggregatorTestCase {
     public void testKeywordSandwichWithSorting() throws IOException {
         MappedFieldType numType = new NumberFieldMapper.NumberFieldType("val", NumberFieldMapper.NumberType.INTEGER);
         MappedFieldType dateType = dateFieldType(DATE_FIELD);
-        MappedFieldType keywordType = new KeywordFieldMapper.KeywordFieldType("term");
+        MappedFieldType keywordType = KeywordFieldMapper.KeywordFieldType.builder().name("term").build();
         RateAggregationBuilder rateAggregationBuilder = new RateAggregationBuilder("my_rate").rateUnit("week").field("val");
         boolean useSum = randomBoolean();
         if (useSum) {
@@ -673,7 +673,7 @@ public class RateAggregatorTests extends AggregatorTestCase {
     public void testFilter() throws IOException {
         MappedFieldType numType = new NumberFieldMapper.NumberFieldType("val", NumberFieldMapper.NumberType.INTEGER);
         MappedFieldType dateType = dateFieldType(DATE_FIELD);
-        MappedFieldType keywordType = new KeywordFieldMapper.KeywordFieldType("term");
+        MappedFieldType keywordType = KeywordFieldMapper.KeywordFieldType.builder().name("term").build();
         RateAggregationBuilder rateAggregationBuilder = new RateAggregationBuilder("my_rate").rateUnit("month").field("val");
         if (randomBoolean()) {
             rateAggregationBuilder.rateMode("sum");
@@ -815,7 +815,7 @@ public class RateAggregatorTests extends AggregatorTestCase {
     public void testFilterWithHistogramField() throws IOException {
         MappedFieldType histType = new HistogramFieldMapper.HistogramFieldType("val", Collections.emptyMap());
         MappedFieldType dateType = dateFieldType(DATE_FIELD);
-        MappedFieldType keywordType = new KeywordFieldMapper.KeywordFieldType("term");
+        MappedFieldType keywordType = KeywordFieldMapper.KeywordFieldType.builder().name("term").build();
         RateAggregationBuilder rateAggregationBuilder = new RateAggregationBuilder("my_rate").rateUnit("month").field("val");
 
         AbstractAggregationBuilder<?> dateHistogramAggregationBuilder = randomValidMultiBucketAggBuilder(

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/ttest/TTestAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/ttest/TTestAggregatorTests.java
@@ -304,13 +304,13 @@ public class TTestAggregatorTests extends AggregatorTestCase {
         boolean wrongB = wrongA == false || randomBoolean(); // at least one of the fields should have unsupported type
         MappedFieldType fieldType1;
         if (wrongA) {
-            fieldType1 = new KeywordFieldMapper.KeywordFieldType("a");
+            fieldType1 = KeywordFieldMapper.KeywordFieldType.builder().name("a").build();
         } else {
             fieldType1 = new NumberFieldMapper.NumberFieldType("a", NumberFieldMapper.NumberType.INTEGER);
         }
         MappedFieldType fieldType2;
         if (wrongB) {
-            fieldType2 = new KeywordFieldMapper.KeywordFieldType("b");
+            fieldType2 = KeywordFieldMapper.KeywordFieldType.builder().name("b").build();
         } else {
             fieldType2 = new NumberFieldMapper.NumberFieldType("b", NumberFieldMapper.NumberType.INTEGER);
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCacheTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCacheTests.java
@@ -629,9 +629,9 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
         List<FieldMapper> types = new ArrayList<>();
         for (int i = 0; i < 11; i++) { // the tests use fields 1 to 10.
             // This field has a value.
-            types.add(new MockFieldMapper(new KeywordFieldMapper.KeywordFieldType("field-" + i)));
+            types.add(new MockFieldMapper(KeywordFieldMapper.KeywordFieldType.builder().name("field-" + i).build()));
             // This field never has a value
-            types.add(new MockFieldMapper(new KeywordFieldMapper.KeywordFieldType("dne-" + i)));
+            types.add(new MockFieldMapper(KeywordFieldMapper.KeywordFieldType.builder().name("dne-" + i).build()));
         }
 
         MappingLookup mappingLookup = MappingLookup.fromMappers(Mapping.EMPTY, types, List.of());

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapperIntegrationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/SecurityIndexReaderWrapperIntegrationTests.java
@@ -79,7 +79,7 @@ public class SecurityIndexReaderWrapperIntegrationTests extends AbstractBuilderT
 
     public void testDLS() throws Exception {
         ShardId shardId = new ShardId("_index", "_na_", 0);
-        MappingLookup mappingLookup = createMappingLookup(List.of(new KeywordFieldType("field")));
+        MappingLookup mappingLookup = createMappingLookup(List.of(KeywordFieldType.builder().name("field").build()));
         ScriptService scriptService = mock(ScriptService.class);
 
         final ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
@@ -212,7 +212,11 @@ public class SecurityIndexReaderWrapperIntegrationTests extends AbstractBuilderT
     public void testDLSWithLimitedPermissions() throws Exception {
         ShardId shardId = new ShardId("_index", "_na_", 0);
         MappingLookup mappingLookup = createMappingLookup(
-            List.of(new KeywordFieldType("field"), new KeywordFieldType("f1"), new KeywordFieldType("f2"))
+            List.of(
+                KeywordFieldType.builder().name("field").build(),
+                KeywordFieldType.builder().name("f1").build(),
+                KeywordFieldType.builder().name("f2").build()
+            )
         );
         ScriptService scriptService = mock(ScriptService.class);
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/read/SingletonOrdinalsBuilderTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/read/SingletonOrdinalsBuilderTests.java
@@ -70,7 +70,7 @@ public class SingletonOrdinalsBuilderTests extends ComputeTestCase {
                 }
             }
             Map<String, Integer> counts = new HashMap<>();
-            var keywordField = new KeywordFieldMapper.KeywordFieldType("f");
+            var keywordField = KeywordFieldMapper.KeywordFieldType.builder().name("f").build();
             var blockLoader = keywordField.blockLoader(ValuesSourceReaderOperatorTests.blContext());
             var blockFactory = new ComputeBlockLoaderFactory(factory);
             try (IndexReader reader = indexWriter.getReader()) {
@@ -220,7 +220,7 @@ public class SingletonOrdinalsBuilderTests extends ComputeTestCase {
             for (int i = 0; i < values.length; i++) {
                 starts[i + 1] = starts[i] + counts[i];
             }
-            var keywordField = new KeywordFieldMapper.KeywordFieldType("f");
+            var keywordField = KeywordFieldMapper.KeywordFieldType.builder().name("f").build();
             var blockLoader = keywordField.blockLoader(ValuesSourceReaderOperatorTests.blContext());
             var blockFactory = new ComputeBlockLoaderFactory(blockFactory());
             try (IndexReader reader = DirectoryReader.open(indexWriter)) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/read/ValueSourceReaderTypeConversionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/read/ValueSourceReaderTypeConversionTests.java
@@ -494,7 +494,7 @@ public class ValueSourceReaderTypeConversionTests extends AnyOperatorTestCase {
         List<Operator> operators = new ArrayList<>();
         Checks checks = new Checks(Block.MvOrdering.DEDUPLICATED_AND_SORTED_ASCENDING, Block.MvOrdering.DEDUPLICATED_AND_SORTED_ASCENDING);
         FieldCase testCase = new FieldCase(
-            new KeywordFieldMapper.KeywordFieldType("kwd"),
+            KeywordFieldMapper.KeywordFieldType.builder().name("kwd").build(),
             ElementType.BYTES_REF,
             checks::tags,
             StatusChecks::keywordsFromDocValues
@@ -1301,7 +1301,7 @@ public class ValueSourceReaderTypeConversionTests extends AnyOperatorTestCase {
         MappedFieldType intFt = mapperService(indexKey).fieldType("i");
         MappedFieldType longFt = mapperService(indexKey).fieldType("j");
         MappedFieldType doubleFt = mapperService(indexKey).fieldType("d");
-        MappedFieldType kwFt = new KeywordFieldMapper.KeywordFieldType("kw");
+        MappedFieldType kwFt = KeywordFieldMapper.KeywordFieldType.builder().name("kw").build();
 
         NumericDocValuesField intField = new NumericDocValuesField(intFt.name(), 0);
         NumericDocValuesField longField = new NumericDocValuesField(longFt.name(), 0);

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/read/ValuesSourceReaderOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/read/ValuesSourceReaderOperatorTests.java
@@ -490,7 +490,7 @@ public class ValuesSourceReaderOperatorTests extends OperatorTestCase {
         List<Operator> operators = new ArrayList<>();
         Checks checks = new Checks(Block.MvOrdering.DEDUPLICATED_AND_SORTED_ASCENDING, Block.MvOrdering.DEDUPLICATED_AND_SORTED_ASCENDING);
         FieldCase testCase = new FieldCase(
-            new KeywordFieldMapper.KeywordFieldType("kwd"),
+            KeywordFieldMapper.KeywordFieldType.builder().name("kwd").build(),
             ElementType.BYTES_REF,
             checks::tags,
             StatusChecks::keywordsFromDocValues
@@ -877,7 +877,7 @@ public class ValuesSourceReaderOperatorTests extends OperatorTestCase {
         );
         r.add(
             new FieldCase(
-                textFieldWithDelegate("text_with_delegate", new KeywordFieldMapper.KeywordFieldType("kwd")),
+                textFieldWithDelegate("text_with_delegate", KeywordFieldMapper.KeywordFieldType.builder().name("kwd").build()),
                 ElementType.BYTES_REF,
                 checks::tags,
                 StatusChecks::textWithDelegate
@@ -885,7 +885,7 @@ public class ValuesSourceReaderOperatorTests extends OperatorTestCase {
         );
         r.add(
             new FieldCase(
-                textFieldWithDelegate("mv_text_with_delegate", new KeywordFieldMapper.KeywordFieldType("mv_kwd")),
+                textFieldWithDelegate("mv_text_with_delegate", KeywordFieldMapper.KeywordFieldType.builder().name("mv_kwd").build()),
                 ElementType.BYTES_REF,
                 checks::mvStringsFromDocValues,
                 StatusChecks::mvTextWithDelegate
@@ -893,7 +893,10 @@ public class ValuesSourceReaderOperatorTests extends OperatorTestCase {
         );
         r.add(
             new FieldCase(
-                textFieldWithDelegate("missing_text_with_delegate", new KeywordFieldMapper.KeywordFieldType("missing_kwd")),
+                textFieldWithDelegate(
+                    "missing_text_with_delegate",
+                    KeywordFieldMapper.KeywordFieldType.builder().name("missing_kwd").build()
+                ),
                 ElementType.BYTES_REF,
                 checks::constantNulls,
                 StatusChecks::constantNullTextWithDelegate
@@ -1480,7 +1483,7 @@ public class ValuesSourceReaderOperatorTests extends OperatorTestCase {
         MappedFieldType intFt = mapperService.fieldType("i");
         MappedFieldType longFt = mapperService.fieldType("j");
         MappedFieldType doubleFt = mapperService.fieldType("d");
-        MappedFieldType kwFt = new KeywordFieldMapper.KeywordFieldType("kw");
+        MappedFieldType kwFt = KeywordFieldMapper.KeywordFieldType.builder().name("kw").build();
 
         NumericDocValuesField intField = new NumericDocValuesField(intFt.name(), 0);
         NumericDocValuesField longField = new NumericDocValuesField(longFt.name(), 0);

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/lookup/EnrichQuerySourceOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/lookup/EnrichQuerySourceOperatorTests.java
@@ -85,7 +85,7 @@ public class EnrichQuerySourceOperatorTests extends ESTestCase {
             );
             var inputTerms = makeTermsBlock(List.of(List.of("b2"), List.of("c1", "a2"), List.of("z2"), List.of(), List.of("a3"), List.of()))
         ) {
-            MappedFieldType uidField = new KeywordFieldMapper.KeywordFieldType("uid");
+            MappedFieldType uidField = KeywordFieldMapper.KeywordFieldType.builder().name("uid").build();
             QueryList queryList = QueryList.rawTermQueryList(uidField, directoryData.searchExecutionContext, AliasFilter.EMPTY, inputTerms);
             assertThat(queryList.getPositionCount(), equalTo(6));
             assertThat(queryList.getQuery(0), equalTo(new TermQuery(new Term("uid", new BytesRef("b2")))));
@@ -278,7 +278,7 @@ public class EnrichQuerySourceOperatorTests extends ESTestCase {
             var directoryReader = DirectoryReader.open(writer);
             var indexSearcher = newSearcher(directoryReader);
             var searchExecutionContext = mock(SearchExecutionContext.class);
-            var field = new KeywordFieldMapper.KeywordFieldType("uid");
+            var field = KeywordFieldMapper.KeywordFieldType.builder().name("uid").build();
             var fieldDataContext = FieldDataContext.noRuntimeFields("test");
             var indexFieldData = field.fielddataBuilder(fieldDataContext)
                 .build(new IndexFieldDataCache.None(), new NoneCircuitBreakerService());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProvidersTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProvidersTests.java
@@ -173,7 +173,7 @@ public class EsPhysicalOperationProvidersTests extends ESTestCase {
             @Override
             public MappedFieldType getFieldType(String name) {
                 return randomFrom(
-                    new KeywordFieldMapper.KeywordFieldType(name),
+                    KeywordFieldMapper.KeywordFieldType.builder().name(name).build(),
                     new NumberFieldMapper.NumberFieldType(name, randomFrom(NumberFieldMapper.NumberType.values()))
                 );
             }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/FrequentItemSetsAggregatorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/FrequentItemSetsAggregatorTests.java
@@ -110,7 +110,7 @@ public class FrequentItemSetsAggregatorTests extends AggregatorTestCase {
         int minimumSetSize = randomIntBetween(2, 5);
         int size = randomIntBetween(1, 100);
         Query query = new MatchAllDocsQuery();
-        MappedFieldType keywordType = new KeywordFieldMapper.KeywordFieldType(KEYWORD_FIELD1);
+        MappedFieldType keywordType = KeywordFieldMapper.KeywordFieldType.builder().name(KEYWORD_FIELD1).build();
 
         List<FrequentItemSet> expectedResults = List.of(
             new FrequentItemSet(Map.of(KEYWORD_FIELD1, List.of("item-1", "item-3")), 7, 0.7),
@@ -289,9 +289,9 @@ public class FrequentItemSetsAggregatorTests extends AggregatorTestCase {
         int size = randomIntBetween(1, 100);
 
         Query query = new MatchAllDocsQuery();
-        MappedFieldType keywordType1 = new KeywordFieldMapper.KeywordFieldType(KEYWORD_FIELD1);
-        MappedFieldType keywordType2 = new KeywordFieldMapper.KeywordFieldType(KEYWORD_FIELD2);
-        MappedFieldType keywordType3 = new KeywordFieldMapper.KeywordFieldType(KEYWORD_FIELD3);
+        MappedFieldType keywordType1 = KeywordFieldMapper.KeywordFieldType.builder().name(KEYWORD_FIELD1).build();
+        MappedFieldType keywordType2 = KeywordFieldMapper.KeywordFieldType.builder().name(KEYWORD_FIELD2).build();
+        MappedFieldType keywordType3 = KeywordFieldMapper.KeywordFieldType.builder().name(KEYWORD_FIELD3).build();
         MappedFieldType intType = new NumberFieldMapper.NumberFieldType(INT_FIELD, NumberFieldMapper.NumberType.INTEGER);
         MappedFieldType floatType = new NumberFieldMapper.NumberFieldType(FLOAT_FIELD, NumberFieldMapper.NumberType.FLOAT);
         MappedFieldType ipType = new IpFieldMapper.IpFieldType(IP_FIELD);
@@ -482,9 +482,9 @@ public class FrequentItemSetsAggregatorTests extends AggregatorTestCase {
         int size = randomIntBetween(1, 100);
 
         Query query = new MatchAllDocsQuery();
-        MappedFieldType keywordType1 = new KeywordFieldMapper.KeywordFieldType(KEYWORD_FIELD1);
-        MappedFieldType keywordType2 = new KeywordFieldMapper.KeywordFieldType(KEYWORD_FIELD2);
-        MappedFieldType keywordType3 = new KeywordFieldMapper.KeywordFieldType(KEYWORD_FIELD3);
+        MappedFieldType keywordType1 = KeywordFieldMapper.KeywordFieldType.builder().name(KEYWORD_FIELD1).build();
+        MappedFieldType keywordType2 = KeywordFieldMapper.KeywordFieldType.builder().name(KEYWORD_FIELD2).build();
+        MappedFieldType keywordType3 = KeywordFieldMapper.KeywordFieldType.builder().name(KEYWORD_FIELD3).build();
         MappedFieldType dateType = dateFieldType(DATE_FIELD);
 
         // mix in an ip field, which we do not analyze

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/RollupResponseTranslationTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/RollupResponseTranslationTests.java
@@ -516,7 +516,7 @@ public class RollupResponseTranslationTests extends AggregatorTestCase {
 
     public void testUnsupportedMultiBucket() throws IOException {
 
-        MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("foo");
+        MappedFieldType fieldType = KeywordFieldMapper.KeywordFieldType.builder().name("foo").build();
         QueryBuilder filter = QueryBuilders.boolQuery()
             .must(QueryBuilders.termQuery("field", "foo"))
             .should(QueryBuilders.termQuery("field", "bar"));
@@ -724,8 +724,8 @@ public class RollupResponseTranslationTests extends AggregatorTestCase {
             NumberFieldMapper.NumberType.LONG
         );
 
-        KeywordFieldMapper.KeywordFieldType nrKeywordFT = new KeywordFieldMapper.KeywordFieldType("partition");
-        KeywordFieldMapper.KeywordFieldType rKeywordFT = new KeywordFieldMapper.KeywordFieldType("partition");
+        KeywordFieldMapper.KeywordFieldType nrKeywordFT = KeywordFieldMapper.KeywordFieldType.builder().name("partition").build();
+        KeywordFieldMapper.KeywordFieldType rKeywordFT = KeywordFieldMapper.KeywordFieldType.builder().name("partition").build();
 
         // Note: term query for "a"
         List<InternalAggregation> results = new ArrayList<>(2);
@@ -1089,9 +1089,9 @@ public class RollupResponseTranslationTests extends AggregatorTestCase {
                 new SumAggregationBuilder("terms." + RollupField.COUNT_FIELD).field("stringfield.terms." + RollupField.COUNT_FIELD)
             );
 
-        KeywordFieldMapper.KeywordFieldType nrFTterm = new KeywordFieldMapper.KeywordFieldType(nonRollupTerms.field());
+        KeywordFieldMapper.KeywordFieldType nrFTterm = KeywordFieldMapper.KeywordFieldType.builder().name(nonRollupTerms.field()).build();
 
-        KeywordFieldMapper.KeywordFieldType rFTterm = new KeywordFieldMapper.KeywordFieldType(rollupTerms.field());
+        KeywordFieldMapper.KeywordFieldType rFTterm = KeywordFieldMapper.KeywordFieldType.builder().name(rollupTerms.field()).build();
 
         MappedFieldType rFTvalue = new NumberFieldMapper.NumberFieldType(
             "stringfield.terms." + RollupField.COUNT_FIELD,
@@ -1125,8 +1125,8 @@ public class RollupResponseTranslationTests extends AggregatorTestCase {
                 new SumAggregationBuilder("terms." + RollupField.COUNT_FIELD).field("stringfield.terms." + RollupField.COUNT_FIELD)
             );
 
-        KeywordFieldMapper.KeywordFieldType nrFTterm = new KeywordFieldMapper.KeywordFieldType(nonRollupTerms.field());
-        KeywordFieldMapper.KeywordFieldType rFTterm = new KeywordFieldMapper.KeywordFieldType(rollupTerms.field());
+        KeywordFieldMapper.KeywordFieldType nrFTterm = KeywordFieldMapper.KeywordFieldType.builder().name(nonRollupTerms.field()).build();
+        KeywordFieldMapper.KeywordFieldType rFTterm = KeywordFieldMapper.KeywordFieldType.builder().name(rollupTerms.field()).build();
 
         MappedFieldType rFTvalue = new NumberFieldMapper.NumberFieldType(
             "stringfield.terms." + RollupField.COUNT_FIELD,


### PR DESCRIPTION
This is a follow up for https://github.com/elastic/elasticsearch/pull/132962, where one of the [feedbacks](https://github.com/elastic/elasticsearch/pull/132962#discussion_r2380597835) I got was to clean up `KeywordFieldType`'s constructors.

I agree with this feedback. The constructors are very long and nearly identical. This makes them quite error prone and difficult to extend.

This PR addresses that by removing all but one constructor and replacing them with a `Builder`.

Note, I left behind one of the constructors as it was too messy to remove. The two classes that rely on it ([ValuesSourceReaderBenchmark](https://github.com/elastic/elasticsearch/blob/0b014507220973c1cb28b05bddf5c773072a51f0/benchmarks/src/main/java/org/elasticsearch/benchmark/_nightly/esql/ValuesSourceReaderBenchmark.java#L220) and [EsPhysicalOperationProviders](https://github.com/elastic/elasticsearch/blob/0b014507220973c1cb28b05bddf5c773072a51f0/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java#L236)) can be reworked, but the end result is quite messy. Frankly, this mess is a consequence of how we're using the constructor in the first place. That being, we're creating a "builder" and bypassing the actual building in favor of using the builder as a data carrier, and then overriding a bunch of things that builder would've done for us. The workaround is to actually call `builder.build()`, but there are so nuances with needing to create a `MapperBuilderContext` for the builder to use, which I don't think is a good idea given that this is production and non-test code.