### PR TITLE
[9.2] Avoid counting snapshot failures twice in SLM (#136759)

### DIFF
--- a/docs/changelog/136759.yaml
+++ b/docs/changelog/136759.yaml
@@ -1,0 +1,5 @@
+pr: 136759
+summary: Avoid counting snapshot failures twice in SLM
+area: ILM+SLM
+type: bug
+issues: []

--- a/x-pack/plugin/slm/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTaskTests.java
+++ b/x-pack/plugin/slm/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTaskTests.java
@@ -528,7 +528,8 @@ public class SnapshotLifecycleTaskTests extends ESTestCase {
                 inferredFailureSnapshot,
                 snapshotInfoSuccess.snapshotId(),
                 snapshotInfoFailure1.snapshotId(),
-                snapshotInfoFailure2.snapshotId()
+                snapshotInfoFailure2.snapshotId(),
+                initiatingSnapshot
             )
         );
         var inProgress = Map.of(policyId, List.of(stillRunning));


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Avoid counting snapshot failures twice in SLM (#136759)