### PR TITLE
ES|QL: Add exclusion to Generative tests and unmute

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -552,9 +552,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.heap_attack.HeapAttackIT
   method: testLookupExplosionManyMatchesManyFields
   issue: https://github.com/elastic/elasticsearch/issues/136791
-- class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/136850
 
 # Examples:
 #

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
@@ -72,6 +72,7 @@ public abstract class GenerativeRestTest extends ESRestTestCase implements Query
         "unexpected byte", // https://github.com/elastic/elasticsearch/issues/136598
         "Rule execution limit", // https://github.com/elastic/elasticsearch/issues/136599
         "Output has changed from", // https://github.com/elastic/elasticsearch/issues/136797
+        "out of bounds for length", // https://github.com/elastic/elasticsearch/issues/136851
 
         // Awaiting fixes for correctness
         "Expecting at most \\[.*\\] columns, got \\[.*\\]", // https://github.com/elastic/elasticsearch/issues/129561


### PR DESCRIPTION
Adding an exclusion for https://github.com/elastic/elasticsearch/issues/136851

Fixes: https://github.com/elastic/elasticsearch/issues/136850