### PR TITLE
SQL: do not attempt to canonicalize InnerAggregate

### DIFF
--- a/docs/changelog/136854.yaml
+++ b/docs/changelog/136854.yaml
@@ -1,0 +1,5 @@
+pr: 136854
+summary: Do not attempt to canonicalize `InnerAggregate`
+area: SQL
+type: bug
+issues: []

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/aggregate/InnerAggregate.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/aggregate/InnerAggregate.java
@@ -51,6 +51,12 @@ public class InnerAggregate extends AggregateFunction {
         throw new UnsupportedOperationException("can't be rewritten");
     }
 
+    @Override
+    protected Expression canonicalize() {
+        // we can't replace children (see above), so we can't canonicalize either.
+        return this;
+    }
+
     public AggregateFunction inner() {
         return inner;
     }


### PR DESCRIPTION
`InnerAggregate` does not support `replaceChildren()`, so we should not try to canonicalize it either.

It's a very corner case, but it could happen (ref. ES-12727)

```
java.lang.UnsupportedOperationException: can't be rewritten at org.elasticsearch.xpack.ql.expression.function.aggregate.InnerAggregate.replaceChildren(InnerAggregate.java:51)
at org.elasticsearch.xpack.ql.expression.function.aggregate.InnerAggregate.replaceChildren(InnerAggregate.java:18)
at org.elasticsearch.xpack.ql.tree.Node.replaceChildrenSameSize(Node.java:231)
at org.elasticsearch.xpack.ql.expression.Expression.canonicalize(Expression.java:165)
at org.elasticsearch.xpack.ql.expression.Expression.canonical(Expression.java:151)
at org.elasticsearch.xpack.ql.expression.Expression.semanticHash(Expression.java:173)
at org.elasticsearch.xpack.ql.expression.predicate.BinaryOperator.canonicalize(BinaryOperator.java:55)
at org.elasticsearch.xpack.ql.expression.Expression.canonical(Expression.java:151)
at org.elasticsearch.xpack.ql.expression.Expression.semanticEquals(Expression.java:169)
at org.elasticsearch.xpack.sql.expression.predicate.conditional.NullIf.foldable(NullIf.java:57)
```

Unfortunately I don't have a reproducer (@bpintea probably you know this better than me, if you have ideas about this, I'll be happy to add a query to the tests)