### PR TITLE
[9.0] test(TestInferenceService): prevent negative embedding values (#136806)

### DIFF
--- a/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestSparseInferenceServiceExtension.java
+++ b/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestSparseInferenceServiceExtension.java
@@ -191,7 +191,9 @@ public class TestSparseInferenceServiceExtension implements InferenceServiceExte
 
         private static float generateEmbedding(String input, int position) {
             // Ensure non-negative and non-zero values for features
-            return Math.abs(input.hashCode()) + 1 + position;
+            int hash = input.hashCode();
+            int absHash = (hash == Integer.MIN_VALUE) ? Integer.MAX_VALUE : Math.abs(hash);
+            return absHash + 1.0f + position;
         }
 
         public static class Configuration {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [test(TestInferenceService): prevent negative embedding values (#136806)](https://github.com/elastic/elasticsearch/pull/136806)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)