### PR TITLE
[9.2] Fix Sporadic SemanticTextInferenceFieldsIT Failures (#136840)

### DIFF
--- a/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/SemanticTextInferenceFieldsIT.java
+++ b/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/SemanticTextInferenceFieldsIT.java
@@ -60,7 +60,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 
-@ESIntegTestCase.ClusterScope(minNumDataNodes = 3, maxNumDataNodes = 5)
+@ESIntegTestCase.ClusterScope(numDataNodes = 3, numClientNodes = 0, supportsDedicatedMasters = false)
 public class SemanticTextInferenceFieldsIT extends ESIntegTestCase {
     private final String indexName = randomIdentifier();
     private final Map<String, TaskType> inferenceIds = new HashMap<>();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Fix Sporadic SemanticTextInferenceFieldsIT Failures (#136840)](https://github.com/elastic/elasticsearch/pull/136840)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)