### PR TITLE
[ES|QL] fixing bug when handling 1d literal vectors

### DIFF
--- a/docs/changelog/136891.yaml
+++ b/docs/changelog/136891.yaml
@@ -1,0 +1,6 @@
+pr: 136891
+summary: Fixing bug when handling 1d literal vectors
+area: ES|QL
+type: bug
+issues:
+ - 136364

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/vector/VectorSimilarityFunctionsIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/vector/VectorSimilarityFunctionsIT.java
@@ -142,6 +142,27 @@ public class VectorSimilarityFunctionsIT extends AbstractEsqlIntegTestCase {
         }
     }
 
+    @SuppressWarnings("unchecked")
+    public void testSimilarityWithOneDimVector() {
+        final float oneDimFloat = randomFloat();
+        final float[] randomVector = randomVectorArray(1);
+        var query = String.format(Locale.ROOT, """
+                ROW left_vector = to_dense_vector(%s)
+                | EVAL similarity = %s(left_vector, %f)
+                | KEEP left_vector, similarity
+            """, Arrays.toString(randomVector), functionName, oneDimFloat);
+        try (var resp = run(query)) {
+            List<List<Object>> valuesList = EsqlTestUtils.getValuesList(resp);
+            valuesList.forEach(values -> {
+                float[] left = new float[] { (float) values.get(0) };
+                Double similarity = (Double) values.get(1);
+                assertNotNull(similarity);
+                float expectedSimilarity = similarityFunction.calculateSimilarity(left, new float[] { oneDimFloat });
+                assertEquals(expectedSimilarity, similarity, 0.0001);
+            });
+        }
+    }
+
     public void testDifferentDimensions() {
         var randomVector = randomVectorArray(randomValueOtherThan(numDims, () -> randomIntBetween(32, 64) * 2));
         var query = String.format(Locale.ROOT, """

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/VectorSimilarityFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/VectorSimilarityFunction.java
@@ -100,7 +100,13 @@ public abstract class VectorSimilarityFunction extends BinaryScalarFunction impl
         EvaluatorMapper.ToEvaluator toEvaluator
     ) {
         if (expression instanceof Literal) {
-            return new ConstantVectorProvider.Factory((ArrayList<Float>) ((Literal) expression).value());
+            ArrayList<Float> constantVector;
+            if (((Literal) expression).value() instanceof Float) {
+                constantVector = new ArrayList<>(List.of((Float) ((Literal) expression).value()));
+            } else {
+                constantVector = (ArrayList<Float>) ((Literal) expression).value();
+            }
+            return new ConstantVectorProvider.Factory(constantVector);
         } else {
             return new ExpressionVectorProvider.Factory(toEvaluator.apply(expression));
         }


### PR DESCRIPTION
Simple fix to account for constant 1-d vectors after the refactoring in https://github.com/elastic/elasticsearch/pull/135602. E.g.:

```sql
ROW left_vector = to_dense_vector([1.5])
| EVAL similarity = v_cosine(left_vector, 2.3)
| KEEP left_vector, similarity
```

Closes https://github.com/elastic/elasticsearch/issues/136364