### PR TITLE
[9.2] Replace remote Enrich hack with proper handling of remote Enrich (#134967)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
@@ -582,6 +582,20 @@ public final class EsqlTestUtils {
         return limit;
     }
 
+    public static Limit asLimit(Object node, Integer limitLiteral, Boolean duplicated, Boolean local) {
+        Limit limit = as(node, Limit.class);
+        if (limitLiteral != null) {
+            assertEquals(as(limit.limit(), Literal.class).value(), limitLiteral);
+        }
+        if (duplicated != null) {
+            assertEquals(limit.duplicated(), duplicated);
+        }
+        if (local != null) {
+            assertEquals(limit.local(), local);
+        }
+        return limit;
+    }
+
     public static Map<String, EsField> loadMapping(String name) {
         return LoadMapping.loadMapping(name);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/capabilities/PostOptimizationVerificationAware.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/capabilities/PostOptimizationVerificationAware.java
@@ -16,6 +16,11 @@ import org.elasticsearch.xpack.esql.common.Failures;
 public interface PostOptimizationVerificationAware {
 
     /**
+     * Marker interface for verifiers that should only be run on Coordinator
+     */
+    interface CoordinatorOnly extends PostOptimizationVerificationAware {}
+
+    /**
      * Validates the implementing expression - discovered failures are reported to the given
      * {@link Failures} class.
      *

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizer.java
@@ -9,13 +9,11 @@ package org.elasticsearch.xpack.esql.optimizer;
 
 import org.elasticsearch.xpack.esql.VerificationException;
 import org.elasticsearch.xpack.esql.common.Failures;
-import org.elasticsearch.xpack.esql.optimizer.rules.logical.PropagateEmptyRelation;
-import org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceStatsFilteredAggWithEval;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.OptimizerRules;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceStringCasingWithInsensitiveRegexMatch;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.local.IgnoreNullMetrics;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.local.InferIsNotNull;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.local.InferNonNullAggConstraint;
-import org.elasticsearch.xpack.esql.optimizer.rules.logical.local.LocalPropagateEmptyRelation;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.local.ReplaceDateTruncBucketWithRoundTo;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.local.ReplaceFieldWithConstantOrNull;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.local.ReplaceTopNWithLimitAndSort;
@@ -24,6 +22,7 @@ import org.elasticsearch.xpack.esql.rule.ParameterizedRuleExecutor;
 import org.elasticsearch.xpack.esql.rule.Rule;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.elasticsearch.common.util.CollectionUtils.arrayAsArrayList;
@@ -34,12 +33,12 @@ import static org.elasticsearch.xpack.esql.optimizer.LogicalPlanOptimizer.operat
  * This class is part of the planner. Data node level logical optimizations.  At this point we have access to
  * {@link org.elasticsearch.xpack.esql.stats.SearchStats} which provides access to metadata about the index.
  *
- * <p>NB: This class also reapplies all the rules from {@link LogicalPlanOptimizer#operators(boolean)}
+ * <p>NB: This class also reapplies all the rules from {@link LogicalPlanOptimizer#operators()}
  * and {@link LogicalPlanOptimizer#cleanup()}
  */
 public class LocalLogicalPlanOptimizer extends ParameterizedRuleExecutor<LogicalPlan, LocalLogicalOptimizerContext> {
 
-    private final LogicalVerifier verifier = LogicalVerifier.INSTANCE;
+    private final LogicalVerifier verifier = LogicalVerifier.LOCAL_INSTANCE;
 
     private static final List<Batch<LogicalPlan>> RULES = arrayAsArrayList(
         new Batch<>(
@@ -53,7 +52,7 @@ public class LocalLogicalPlanOptimizer extends ParameterizedRuleExecutor<Logical
             new ReplaceDateTruncBucketWithRoundTo()
         ),
         localOperators(),
-        cleanup()
+        localCleanup()
     );
 
     public LocalLogicalPlanOptimizer(LocalLogicalOptimizerContext localLogicalOptimizerContext) {
@@ -67,30 +66,38 @@ public class LocalLogicalPlanOptimizer extends ParameterizedRuleExecutor<Logical
 
     @SuppressWarnings("unchecked")
     private static Batch<LogicalPlan> localOperators() {
-        var operators = operators(true);
-        var rules = operators.rules();
-        List<Rule<?, LogicalPlan>> newRules = new ArrayList<>(rules.length);
+        return localBatch(operators(), new ReplaceStringCasingWithInsensitiveRegexMatch());
+    }
 
-        // apply updates to existing rules that have different applicability locally
-        for (var r : rules) {
-            switch (r) {
-                case PropagateEmptyRelation ignoredPropagate -> newRules.add(new LocalPropagateEmptyRelation());
-                // skip it: once a fragment contains an Agg, this can no longer be pruned, which the rule can do
-                case ReplaceStatsFilteredAggWithEval ignoredReplace -> {
+    @SuppressWarnings("unchecked")
+    private static Batch<LogicalPlan> localCleanup() {
+        return localBatch(cleanup());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Batch<LogicalPlan> localBatch(Batch<LogicalPlan> batch, Rule<?, LogicalPlan>... additionalRules) {
+        Rule<?, LogicalPlan>[] rules = batch.rules();
+
+        List<Rule<?, LogicalPlan>> newRules = new ArrayList<>(rules.length);
+        for (Rule<?, LogicalPlan> r : rules) {
+            if (r instanceof OptimizerRules.LocalAware<?> localAware) {
+                Rule<?, LogicalPlan> local = localAware.local();
+                if (local != null) {
+                    newRules.add(local);
                 }
-                default -> newRules.add(r);
+            } else {
+                newRules.add(r);
             }
         }
 
-        // add rule that should only apply locally
-        newRules.add(new ReplaceStringCasingWithInsensitiveRegexMatch());
+        newRules.addAll(Arrays.asList(additionalRules));
 
-        return operators.with(newRules.toArray(Rule[]::new));
+        return batch.with(newRules.toArray(Rule[]::new));
     }
 
     public LogicalPlan localOptimize(LogicalPlan plan) {
         LogicalPlan optimized = execute(plan);
-        Failures failures = verifier.verify(optimized, true, plan.output());
+        Failures failures = verifier.verify(optimized, plan.output());
         if (failures.hasFailures()) {
             throw new VerificationException(failures);
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
@@ -36,7 +36,7 @@ public class LocalPhysicalPlanOptimizer extends ParameterizedRuleExecutor<Physic
 
     private static final List<Batch<PhysicalPlan>> RULES = rules(true);
 
-    private final PhysicalVerifier verifier = PhysicalVerifier.INSTANCE;
+    private final PhysicalVerifier verifier = PhysicalVerifier.LOCAL_INSTANCE;
 
     public LocalPhysicalPlanOptimizer(LocalPhysicalOptimizerContext context) {
         super(context);
@@ -47,7 +47,7 @@ public class LocalPhysicalPlanOptimizer extends ParameterizedRuleExecutor<Physic
     }
 
     PhysicalPlan verify(PhysicalPlan optimizedPlan, List<Attribute> expectedOutputAttributes) {
-        Failures failures = verifier.verify(optimizedPlan, true, expectedOutputAttributes);
+        Failures failures = verifier.verify(optimizedPlan, expectedOutputAttributes);
         if (failures.hasFailures()) {
             throw new VerificationException(failures);
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
@@ -16,10 +16,13 @@ import org.elasticsearch.xpack.esql.optimizer.rules.logical.BooleanSimplificatio
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.CombineBinaryComparisons;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.CombineDisjunctions;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.CombineEvals;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.CombineLimitTopN;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.CombineProjections;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.ConstantFolding;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.ExtractAggregateCommonFilter;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.FoldNull;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.HoistRemoteEnrichLimit;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.HoistRemoteEnrichTopN;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.LiteralsOnTheRight;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.PartiallyFoldCase;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.PropagateEmptyRelation;
@@ -85,7 +88,7 @@ import java.util.List;
  *     <li>The {@link LogicalPlanOptimizer#substitutions()} phase rewrites things to expand out shorthand in the syntax.  For example,
  *     a nested expression embedded in a stats gets replaced with an eval followed by a stats, followed by another eval.  This phase
  *     also applies surrogates, such as replacing an average with a sum divided by a count.</li>
- *     <li>{@link LogicalPlanOptimizer#operators(boolean)} (NB: The word "operator" is extremely overloaded and referrers to many different
+ *     <li>{@link LogicalPlanOptimizer#operators()} (NB: The word "operator" is extremely overloaded and referrers to many different
  *     things.) transform the tree in various different ways.  This includes folding (i.e. computing constant expressions at parse
  *     time), combining expressions, dropping redundant clauses, and some normalization such as putting literals on the right whenever
  *     possible.  These rules are run in a loop until none of the rules make any changes to the plan (there is also a safety shut off
@@ -93,14 +96,14 @@ import java.util.List;
  *     <li>{@link LogicalPlanOptimizer#cleanup()}  Which can replace sorts+limit with a TopN</li>
  * </ul>
  *
- * <p>Note that the {@link LogicalPlanOptimizer#operators(boolean)} and {@link LogicalPlanOptimizer#cleanup()} steps are reapplied at the
- * {@link LocalLogicalPlanOptimizer} layer.</p>
+ * <p>Note that the {@link LogicalPlanOptimizer#operators()} and {@link LogicalPlanOptimizer#cleanup()} steps are reapplied
+ * at the {@link LocalLogicalPlanOptimizer} layer.</p>
  */
 public class LogicalPlanOptimizer extends ParameterizedRuleExecutor<LogicalPlan, LogicalOptimizerContext> {
 
     private static final List<RuleExecutor.Batch<LogicalPlan>> RULES = List.of(
         substitutions(),
-        operators(false),
+        operators(),
         new Batch<>("Skip Compute", new SkipQueryOnLimitZero()),
         cleanup(),
         new Batch<>("Set as Optimized", Limiter.ONCE, new SetAsOptimized())
@@ -115,7 +118,7 @@ public class LogicalPlanOptimizer extends ParameterizedRuleExecutor<LogicalPlan,
     public LogicalPlan optimize(LogicalPlan verified) {
         var optimized = execute(verified);
 
-        Failures failures = verifier.verify(optimized, false, verified.output());
+        Failures failures = verifier.verify(optimized, verified.output());
         if (failures.hasFailures()) {
             throw new VerificationException(failures);
         }
@@ -163,10 +166,11 @@ public class LogicalPlanOptimizer extends ParameterizedRuleExecutor<LogicalPlan,
         );
     }
 
-    protected static Batch<LogicalPlan> operators(boolean local) {
+    protected static Batch<LogicalPlan> operators() {
         return new Batch<>(
             "Operator Optimization",
-            new CombineProjections(local),
+            new HoistRemoteEnrichLimit(),
+            new CombineProjections(),
             new CombineEvals(),
             new PruneEmptyPlans(),
             new PropagateEmptyRelation(),
@@ -212,6 +216,13 @@ public class LogicalPlanOptimizer extends ParameterizedRuleExecutor<LogicalPlan,
     }
 
     protected static Batch<LogicalPlan> cleanup() {
-        return new Batch<>("Clean Up", new ReplaceLimitAndSortAsTopN(), new ReplaceRowAsLocalRelation(), new PropgateUnmappedFields());
+        return new Batch<>(
+            "Clean Up",
+            new ReplaceLimitAndSortAsTopN(),
+            new HoistRemoteEnrichTopN(),
+            new ReplaceRowAsLocalRelation(),
+            new PropgateUnmappedFields(),
+            new CombineLimitTopN()
+        );
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalVerifier.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalVerifier.java
@@ -11,7 +11,6 @@ import org.elasticsearch.xpack.esql.capabilities.PostOptimizationPlanVerificatio
 import org.elasticsearch.xpack.esql.capabilities.PostOptimizationVerificationAware;
 import org.elasticsearch.xpack.esql.common.Failures;
 import org.elasticsearch.xpack.esql.optimizer.rules.PlanConsistencyChecker;
-import org.elasticsearch.xpack.esql.plan.logical.Enrich;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 
 import java.util.ArrayList;
@@ -19,21 +18,11 @@ import java.util.List;
 import java.util.function.BiConsumer;
 
 public final class LogicalVerifier extends PostOptimizationPhasePlanVerifier<LogicalPlan> {
+    public static final LogicalVerifier LOCAL_INSTANCE = new LogicalVerifier(true);
+    public static final LogicalVerifier INSTANCE = new LogicalVerifier(false);
 
-    public static final LogicalVerifier INSTANCE = new LogicalVerifier();
-
-    private LogicalVerifier() {}
-
-    @Override
-    boolean skipVerification(LogicalPlan optimizedPlan, boolean skipRemoteEnrichVerification) {
-        if (skipRemoteEnrichVerification) {
-            // AwaitsFix https://github.com/elastic/elasticsearch/issues/118531
-            var enriches = optimizedPlan.collectFirstChildren(Enrich.class::isInstance);
-            if (enriches.isEmpty() == false && ((Enrich) enriches.get(0)).mode() == Enrich.Mode.REMOTE) {
-                return true;
-            }
-        }
-        return false;
+    private LogicalVerifier(boolean isLocal) {
+        super(isLocal);
     }
 
     @Override
@@ -44,14 +33,16 @@ public final class LogicalVerifier extends PostOptimizationPhasePlanVerifier<Log
             PlanConsistencyChecker.checkPlan(p, depFailures);
 
             if (failures.hasFailures() == false) {
-                if (p instanceof PostOptimizationVerificationAware pova) {
+                if (p instanceof PostOptimizationVerificationAware pova
+                    && (pova instanceof PostOptimizationVerificationAware.CoordinatorOnly && isLocal) == false) {
                     pova.postOptimizationVerification(failures);
                 }
                 if (p instanceof PostOptimizationPlanVerificationAware popva) {
                     checkers.add(popva.postOptimizationPlanVerification());
                 }
                 p.forEachExpression(ex -> {
-                    if (ex instanceof PostOptimizationVerificationAware va) {
+                    if (ex instanceof PostOptimizationVerificationAware va
+                        && (va instanceof PostOptimizationVerificationAware.CoordinatorOnly && isLocal) == false) {
                         va.postOptimizationVerification(failures);
                     }
                 });

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizer.java
@@ -39,7 +39,7 @@ public class PhysicalPlanOptimizer extends ParameterizedRuleExecutor<PhysicalPla
     }
 
     PhysicalPlan verify(PhysicalPlan optimizedPlan, List<Attribute> expectedOutputAttributes) {
-        Failures failures = verifier.verify(optimizedPlan, false, expectedOutputAttributes);
+        Failures failures = verifier.verify(optimizedPlan, expectedOutputAttributes);
         if (failures.hasFailures()) {
             throw new VerificationException(failures);
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/PhysicalVerifier.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/PhysicalVerifier.java
@@ -12,8 +12,7 @@ import org.elasticsearch.xpack.esql.common.Failures;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.optimizer.rules.PlanConsistencyChecker;
-import org.elasticsearch.xpack.esql.plan.logical.Enrich;
-import org.elasticsearch.xpack.esql.plan.physical.EnrichExec;
+import org.elasticsearch.xpack.esql.plan.logical.ExecutesOn;
 import org.elasticsearch.xpack.esql.plan.physical.FieldExtractExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
 
@@ -21,21 +20,11 @@ import static org.elasticsearch.xpack.esql.common.Failure.fail;
 
 /** Physical plan verifier. */
 public final class PhysicalVerifier extends PostOptimizationPhasePlanVerifier<PhysicalPlan> {
+    public static final PhysicalVerifier LOCAL_INSTANCE = new PhysicalVerifier(true);
+    public static final PhysicalVerifier INSTANCE = new PhysicalVerifier(false);
 
-    public static final PhysicalVerifier INSTANCE = new PhysicalVerifier();
-
-    private PhysicalVerifier() {}
-
-    @Override
-    boolean skipVerification(PhysicalPlan optimizedPlan, boolean skipRemoteEnrichVerification) {
-        if (skipRemoteEnrichVerification) {
-            // AwaitsFix https://github.com/elastic/elasticsearch/issues/118531
-            var enriches = optimizedPlan.collectFirstChildren(EnrichExec.class::isInstance);
-            if (enriches.isEmpty() == false && ((EnrichExec) enriches.get(0)).mode() == Enrich.Mode.REMOTE) {
-                return true;
-            }
-        }
-        return false;
+    private PhysicalVerifier(boolean isLocal) {
+        super(isLocal);
     }
 
     @Override
@@ -54,6 +43,19 @@ public final class PhysicalVerifier extends PostOptimizationPhasePlanVerifier<Ph
                     );
                 }
             }
+
+            // This check applies only for coordinator physical plans (isLocal == false)
+            if (isLocal == false && p instanceof ExecutesOn ex && ex.executesOn() == ExecutesOn.ExecuteLocation.REMOTE) {
+                failures.add(
+                    fail(
+                        p,
+                        "Physical plan contains remote executing operation [{}] in local part. "
+                            + "This usually means this command is incompatible with some of the preceding commands.",
+                        p.nodeName()
+                    )
+                );
+            }
+
             PlanConsistencyChecker.checkPlan(p, depFailures);
 
             if (failures.hasFailures() == false) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/PostOptimizationPhasePlanVerifier.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/PostOptimizationPhasePlanVerifier.java
@@ -32,13 +32,17 @@ import static org.elasticsearch.xpack.esql.core.expression.Attribute.dataTypeEqu
  */
 public abstract class PostOptimizationPhasePlanVerifier<P extends QueryPlan<P>> {
 
+    // Are we verifying the global plan (coordinator) or a local plan (data node)?
+    protected final boolean isLocal;
+
+    protected PostOptimizationPhasePlanVerifier(boolean isLocal) {
+        this.isLocal = isLocal;
+    }
+
     /** Verifies the optimized plan */
-    public Failures verify(P optimizedPlan, boolean skipRemoteEnrichVerification, List<Attribute> expectedOutputAttributes) {
+    public Failures verify(P optimizedPlan, List<Attribute> expectedOutputAttributes) {
         Failures failures = new Failures();
         Failures depFailures = new Failures();
-        if (skipVerification(optimizedPlan, skipRemoteEnrichVerification)) {
-            return failures;
-        }
 
         checkPlanConsistency(optimizedPlan, failures, depFailures);
 
@@ -50,8 +54,6 @@ public abstract class PostOptimizationPhasePlanVerifier<P extends QueryPlan<P>> 
 
         return failures;
     }
-
-    abstract boolean skipVerification(P optimizedPlan, boolean skipRemoteEnrichVerification);
 
     abstract void checkPlanConsistency(P optimizedPlan, Failures failures, Failures depFailures);
 
@@ -71,7 +73,7 @@ public abstract class PostOptimizationPhasePlanVerifier<P extends QueryPlan<P>> 
                 .stream()
                 .anyMatch(x -> x.name().equals(ProjectAwayColumns.ALL_FIELDS_PROJECTED));
             // LookupJoinExec represents the lookup index with EsSourceExec and this is turned into EsQueryExec by
-            // ReplaceSourceAttributes. Because InsertFieldExtractions doesn't apply to lookup indices, the
+            // ReplaceSourceAttributes. Because InsertFieldExtraction doesn't apply to lookup indices, the
             // right hand side will only have the EsQueryExec providing the _doc attribute and nothing else.
             // We perform an optimizer run on every fragment. LookupJoinExec also contains such a fragment,
             // and currently it only contains an EsQueryExec after optimization.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/CombineLimitTopN.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/CombineLimitTopN.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer.rules.logical;
+
+import org.elasticsearch.xpack.esql.expression.Foldables;
+import org.elasticsearch.xpack.esql.plan.logical.Limit;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.Project;
+import org.elasticsearch.xpack.esql.plan.logical.TopN;
+
+/**
+ * Combines a Limit immediately followed by a TopN into a single TopN.
+ * This is needed because {@link HoistRemoteEnrichTopN} can create new TopN nodes that are not covered by the previous rules.
+ */
+public final class CombineLimitTopN extends OptimizerRules.OptimizerRule<Limit> {
+
+    public CombineLimitTopN() {
+        super(OptimizerRules.TransformDirection.DOWN);
+    }
+
+    @Override
+    public LogicalPlan rule(Limit limit) {
+        if (limit.child() instanceof TopN topn) {
+            int thisLimitValue = Foldables.limitValue(limit.limit(), limit.sourceText());
+            int topNValue = Foldables.limitValue(topn.limit(), topn.sourceText());
+            if (topNValue <= thisLimitValue) {
+                return topn;
+            } else {
+                return new TopN(topn.source(), topn.child(), topn.order(), limit.limit(), topn.local());
+            }
+        }
+        if (limit.child() instanceof Project proj) {
+            // It is possible that Project is sitting on top on TopN. Swap limit and project then.
+            return proj.replaceChild(limit.replaceChild(proj.child()));
+        }
+        return limit;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/CombineProjections.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/CombineProjections.java
@@ -22,6 +22,7 @@ import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
 import org.elasticsearch.xpack.esql.plan.logical.UnaryPlan;
+import org.elasticsearch.xpack.esql.rule.Rule;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -29,9 +30,13 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-public final class CombineProjections extends OptimizerRules.OptimizerRule<UnaryPlan> {
+public final class CombineProjections extends OptimizerRules.OptimizerRule<UnaryPlan> implements OptimizerRules.LocalAware<UnaryPlan> {
     // don't drop groupings from a local plan, as the layout has already been agreed upon
     private final boolean local;
+
+    public CombineProjections() {
+        this(false);
+    }
 
     public CombineProjections(boolean local) {
         super(OptimizerRules.TransformDirection.UP);
@@ -256,5 +261,10 @@ public final class CombineProjections extends OptimizerRules.OptimizerRule<Unary
 
     private static Expression trimAliases(Expression e) {
         return e.transformDown(Alias.class, Alias::child);
+    }
+
+    @Override
+    public Rule<UnaryPlan, LogicalPlan> local() {
+        return new CombineProjections(true);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/HoistRemoteEnrichLimit.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/HoistRemoteEnrichLimit.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer.rules.logical;
+
+import org.elasticsearch.xpack.esql.optimizer.LogicalOptimizerContext;
+import org.elasticsearch.xpack.esql.plan.logical.CardinalityPreserving;
+import org.elasticsearch.xpack.esql.plan.logical.Enrich;
+import org.elasticsearch.xpack.esql.plan.logical.ExecutesOn;
+import org.elasticsearch.xpack.esql.plan.logical.Limit;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.PipelineBreaker;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.IdentityHashMap;
+import java.util.Set;
+
+/**
+ * Locate any LIMIT that is "visible" under remote ENRICH, and make a copy of it above the ENRICH. The original limit is marked as local.
+ * This allows the correct semantics of the remote application of limit. Enrich itself does not change the cardinality,
+ * but the limit needs to be taken twice, locally on the node and again on the coordinator.
+ * This runs only on LogicalPlanOptimizer not on local one.
+ */
+public final class HoistRemoteEnrichLimit extends OptimizerRules.ParameterizedOptimizerRule<Enrich, LogicalOptimizerContext>
+    implements
+        OptimizerRules.CoordinatorOnly {
+
+    public HoistRemoteEnrichLimit() {
+        super(OptimizerRules.TransformDirection.UP);
+    }
+
+    @Override
+    protected LogicalPlan rule(Enrich en, LogicalOptimizerContext ctx) {
+        if (en.mode() == Enrich.Mode.REMOTE) {
+            // Since limits are combinable, we will just assemble the set of candidates and create one combined lowest limit above the
+            // Enrich.
+            Set<Limit> seenLimits = Collections.newSetFromMap(new IdentityHashMap<>());
+            en.child().forEachDownMayReturnEarly((p, stop) -> {
+                if (p instanceof Limit l && l.local() == false) {
+                    // Local limits can be ignored here as they are always duplicates that have another limit upstairs
+                    seenLimits.add(l);
+                    return;
+                }
+                if ((p instanceof CardinalityPreserving) == false // can change the number of rows, so we can't just pull a limit from
+                                                                  // under it
+                    // this will fail the verifier anyway, so no need to continue
+                    || (p instanceof ExecutesOn ex && ex.executesOn() == ExecutesOn.ExecuteLocation.COORDINATOR)
+                // This is essentially another remote enrich - let it take care of its own limits
+                    || (p instanceof Enrich e && e.mode() == Enrich.Mode.REMOTE)
+                // If it's a pipeline breaker, this part will be on the coordinator anyway, which likely will fail the verifier
+                // In any case, duplicating anything below there is pointless.
+                    || p instanceof PipelineBreaker) {
+                    stop.set(true);
+                }
+            });
+
+            if (seenLimits.isEmpty()) {
+                return en;
+            }
+            // Mark original limits as local
+            LogicalPlan transformLimits = en.transformDown(Limit.class, l -> seenLimits.contains(l) ? l.withLocal(true) : l);
+            // Shouldn't actually throw because we checked seenLimits is not empty
+            Limit lowestLimit = seenLimits.stream().min(Comparator.comparing(l -> (int) l.limit().fold(ctx.foldCtx()))).orElseThrow();
+            // Insert new lowest limit on top of the Enrich, and mark it as duplicated since we don't want it to be pushed down
+            return new Limit(lowestLimit.source(), lowestLimit.limit(), transformLimits, true, false);
+        }
+        return en;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/HoistRemoteEnrichTopN.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/HoistRemoteEnrichTopN.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer.rules.logical;
+
+import org.elasticsearch.xpack.esql.core.expression.Alias;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.AttributeMap;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Expressions;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.util.Holder;
+import org.elasticsearch.xpack.esql.expression.Order;
+import org.elasticsearch.xpack.esql.plan.logical.CardinalityPreserving;
+import org.elasticsearch.xpack.esql.plan.logical.Enrich;
+import org.elasticsearch.xpack.esql.plan.logical.Eval;
+import org.elasticsearch.xpack.esql.plan.logical.ExecutesOn;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.PipelineBreaker;
+import org.elasticsearch.xpack.esql.plan.logical.Project;
+import org.elasticsearch.xpack.esql.plan.logical.TopN;
+import org.elasticsearch.xpack.esql.plan.logical.UnaryPlan;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Locate any TopN that is "visible" under remote ENRICH, and make a copy of it above the ENRICH,
+ * while making a copy of the original fields. Mark the original TopN as local.
+ * This is the same idea as {@link HoistRemoteEnrichLimit} but for TopN instead of Limit.
+ * This must happen after {@link ReplaceLimitAndSortAsTopN}.
+ * This also has handling for the case where Enrich overrides the field(s) TopN is using. In this case,
+ * we need to create aliases for the fields used by TopN, and then use those aliases in the copy TopN.
+ * Then we need to add Project to remove the alias fields. Fortunately, PushDownUtils has the logic to do that.
+ */
+public final class HoistRemoteEnrichTopN extends OptimizerRules.OptimizerRule<Enrich> implements OptimizerRules.CoordinatorOnly {
+    public HoistRemoteEnrichTopN() {
+        super(OptimizerRules.TransformDirection.UP);
+    }
+
+    @Override
+    protected LogicalPlan rule(Enrich en) {
+        if (en.mode() == Enrich.Mode.REMOTE) {
+            LogicalPlan plan = en.child();
+            List<Attribute> outputs = en.output();
+            // This loop only takes care of one TopN. Repeated TopNs may be a problem, we can't handle them here.
+            while (true) {
+                if (plan instanceof TopN topN && topN.local() == false) {
+                    Set<Attribute> missingAttributes = checkOrderInOutputs(topN.order(), outputs);
+
+                    // Do we need to do any aliasing because some of the fields were overridden by Enrich or other generating plans?
+                    if (missingAttributes.isEmpty()) {
+                        // No need for aliasing - then it's simple, just copy the TopN on top of Enrich and mark the original as local
+                        LogicalPlan transformedEnrich = en.transformDown(TopN.class, t -> t == topN ? topN.withLocal(true) : t);
+                        return new TopN(topN.source(), transformedEnrich, topN.order(), topN.limit(), false);
+                    } else {
+                        Set<String> missingNames = new HashSet<>(Expressions.names(missingAttributes));
+                        AttributeMap.Builder<Alias> aliasesForReplacedAttributesBuilder = AttributeMap.builder();
+                        List<Expression> rewrittenExpressions = new ArrayList<>();
+
+                        // Replace the missing attributes in order expressions with their aliases
+                        for (Order expr : topN.order()) {
+                            rewrittenExpressions.add(expr.transformUp(Attribute.class, attr -> {
+                                if (missingNames.contains(attr.name())) {
+                                    Alias renamedAttribute = aliasesForReplacedAttributesBuilder.computeIfAbsent(attr, a -> {
+                                        String tempName = TemporaryNameUtils.locallyUniqueTemporaryName(a.name());
+                                        return new Alias(a.source(), tempName, a, null, true);
+                                    });
+                                    return renamedAttribute.toAttribute();
+                                }
+
+                                return attr;
+                            }));
+                        }
+                        var replacedAttributes = aliasesForReplacedAttributesBuilder.build();
+                        // We need to create a copy of attributes used by TopN, because Enrich or some command on the way overwrites them.
+                        // Shadowed structure is going to look like this:
+                        /*
+                         Project[[_meta_field{f}#16, first_name{f}#11, gender{f}#12, hire_date{f}#17, job{f}#18, job.raw{f}#19,...]]
+                         \_TopN[[Order[$$emp_no$temp_name$26{r$}#27,ASC,LAST]],10[INTEGER],false]
+                          \_Enrich[REMOTE,languages_remote[KEYWORD],id{r}#4,{"match":{"indices":[],"match_field":"id",
+                         "enrich_fields":["language_code","language_name"]}},{=languages_idx},[language_code{r}#24, language_name{r}#25]]
+                            \_Eval[[emp_no{f}#10 + 1[INTEGER] AS emp_no#8]]
+                             \_Eval[[emp_no{f}#10 AS $$emp_no$temp_name$26#27]]
+                               \_TopN[[Order[emp_no{f}#10,ASC,LAST]],10[INTEGER],true]
+                                \_Eval[[emp_no{f}#10 AS id#4]]
+                                 \_EsRelation[test][_meta_field{f}#16, emp_no{f}#10, first_name{f}#11, ..]
+                         */
+                        // Put Eval which renames the affected fields above the original TopN, and mark that one as local
+                        Eval replacementTop = new Eval(topN.source(), topN.withLocal(true), new ArrayList<>(replacedAttributes.values()));
+                        Holder<Boolean> stop = new Holder<>(false);
+                        LogicalPlan transformedEnrich = en.transformDown(p -> switch (p) {
+                            case TopN t when stop.get() == false && t == topN -> {
+                                stop.set(true);
+                                yield replacementTop;
+                            }
+                            // We only need to take care of Project because Drop can't possibly drop our newly created fields
+                            case Project pr when stop.get() == false -> {
+                                List<NamedExpression> allFields = new LinkedList<>(pr.projections());
+                                allFields.addAll(replacementTop.fields());
+                                yield pr.withProjections(allFields);
+                            }
+                            default -> p;
+                        });
+                        @SuppressWarnings("unchecked")
+                        List<Order> newOrder = (List<Order>) (List<?>) rewrittenExpressions;
+
+                        // Verify that the outputs of transformed Enrich contain all the fields TopN needs
+                        // This can happen if there's a node that removes fields like Project and we didn't catch it above
+                        var missing = checkOrderInOutputs(newOrder, transformedEnrich.output());
+                        if (missing.isEmpty() == false) {
+                            throw new IllegalStateException(
+                                "Attribute ["
+                                    + Expressions.names(missing)
+                                    + "] required by TopN but is not in the outputs of Enrich ["
+                                    + Expressions.names(transformedEnrich.output())
+                                    + "]"
+                            );
+                        }
+
+                        // Create a copy of TopN with the rewritten attributes on top on Enrich
+                        var copyTop = new TopN(topN.source(), transformedEnrich, newOrder, topN.limit(), false);
+                        // And use the Project to remove the fields that we don't need anymore
+                        return new Project(en.source(), copyTop, outputs);
+                    }
+                }
+                if ((plan instanceof CardinalityPreserving) == false // can change the number of rows, so we can't just pull a TopN from
+                                                                     // under it
+                    // this will fail the verifier anyway, so no need to continue
+                    || (plan instanceof ExecutesOn ex && ex.executesOn() == ExecutesOn.ExecuteLocation.COORDINATOR)
+                    // This is another remote Enrich, it can handle its own limits
+                    || (plan instanceof Enrich e && e.mode() == Enrich.Mode.REMOTE)
+                    || plan instanceof PipelineBreaker) {
+                    break;
+                }
+                if (plan instanceof UnaryPlan u) {
+                    plan = u.child();
+                } else {
+                    // The only non-unary plans right now are Join and Fork, and they are not cardinality preserving,
+                    // so really there's nothing to do here. But if we had binary plan that is cardinality preserving,
+                    // we would need to add it here.
+                    break;
+                }
+            }
+        }
+        return en;
+    }
+
+    /**
+     * Checks if all attributes used in the order expressions are present in outputs.
+     * Returns the set of missing attributes.
+     */
+    private Set<Attribute> checkOrderInOutputs(List<Order> orderList, List<Attribute> outputs) {
+        var outputsSet = outputs.stream().map(Attribute::id).collect(Collectors.toSet());
+        Set<Attribute> missingAttributes = new HashSet<>();
+        for (Order o : orderList) {
+            o.child().forEachDown(Attribute.class, a -> {
+                if (outputsSet.contains(a.id()) == false) {
+                    missingAttributes.add(a);
+                }
+            });
+        }
+        return missingAttributes;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/OptimizerRules.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/OptimizerRules.java
@@ -109,4 +109,23 @@ public final class OptimizerRules {
 
         protected abstract LogicalPlan rule(SubPlan plan, P context);
     }
+
+    /**
+     * Rule that has a different implementation when applied to a local plan.
+     */
+    public interface LocalAware<SubPlan extends LogicalPlan> {
+        /**
+         * the local version of the rule. {@code null} if the rule should not be applied locally.
+         */
+        Rule<SubPlan, LogicalPlan> local();
+    }
+
+    /**
+     * This rule should only be applied on the coordinator plan, not for a local plan.
+     */
+    public interface CoordinatorOnly extends LocalAware<LogicalPlan> {
+        default Rule<LogicalPlan, LogicalPlan> local() {
+            return null;
+        }
+    }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateEmptyRelation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateEmptyRelation.java
@@ -17,18 +17,22 @@ import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
 import org.elasticsearch.xpack.esql.optimizer.LogicalOptimizerContext;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.local.LocalPropagateEmptyRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.UnaryPlan;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalSupplier;
 import org.elasticsearch.xpack.esql.planner.PlannerUtils;
+import org.elasticsearch.xpack.esql.rule.Rule;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @SuppressWarnings("removal")
-public class PropagateEmptyRelation extends OptimizerRules.ParameterizedOptimizerRule<UnaryPlan, LogicalOptimizerContext> {
+public class PropagateEmptyRelation extends OptimizerRules.ParameterizedOptimizerRule<UnaryPlan, LogicalOptimizerContext>
+    implements
+        OptimizerRules.LocalAware<UnaryPlan> {
     public PropagateEmptyRelation() {
         super(OptimizerRules.TransformDirection.DOWN);
     }
@@ -82,5 +86,10 @@ public class PropagateEmptyRelation extends OptimizerRules.ParameterizedOptimize
 
     private static LogicalPlan replacePlanByRelation(UnaryPlan plan, LocalSupplier supplier) {
         return new LocalRelation(plan.source(), plan.output(), supplier);
+    }
+
+    @Override
+    public Rule<UnaryPlan, LogicalPlan> local() {
+        return new LocalPropagateEmptyRelation();
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineLimits.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineLimits.java
@@ -7,6 +7,10 @@
 
 package org.elasticsearch.xpack.esql.optimizer.rules.logical;
 
+import org.elasticsearch.xpack.esql.core.expression.Alias;
+import org.elasticsearch.xpack.esql.core.expression.FoldContext;
+import org.elasticsearch.xpack.esql.core.util.Holder;
+import org.elasticsearch.xpack.esql.expression.function.fulltext.Score;
 import org.elasticsearch.xpack.esql.optimizer.LogicalOptimizerContext;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.Enrich;
@@ -21,11 +25,14 @@ import org.elasticsearch.xpack.esql.plan.logical.inference.InferencePlan;
 import org.elasticsearch.xpack.esql.plan.logical.join.InlineJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.Join;
 import org.elasticsearch.xpack.esql.plan.logical.join.JoinTypes;
+import org.elasticsearch.xpack.esql.rule.Rule;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public final class PushDownAndCombineLimits extends OptimizerRules.ParameterizedOptimizerRule<Limit, LogicalOptimizerContext> {
+public final class PushDownAndCombineLimits extends OptimizerRules.ParameterizedOptimizerRule<Limit, LogicalOptimizerContext>
+    implements
+        OptimizerRules.LocalAware<Limit> {
 
     public PushDownAndCombineLimits() {
         super(OptimizerRules.TransformDirection.DOWN);
@@ -34,23 +41,25 @@ public final class PushDownAndCombineLimits extends OptimizerRules.Parameterized
     @Override
     public LogicalPlan rule(Limit limit, LogicalOptimizerContext ctx) {
         if (limit.child() instanceof Limit childLimit) {
-            var limitSource = limit.limit();
-            var parentLimitValue = (int) limitSource.fold(ctx.foldCtx());
-            var childLimitValue = (int) childLimit.limit().fold(ctx.foldCtx());
-            // We want to preserve the duplicated() value of the smaller limit, so we'll use replaceChild.
-            return parentLimitValue < childLimitValue ? limit.replaceChild(childLimit.child()) : childLimit;
+            return combineLimits(limit, childLimit, ctx.foldCtx());
         } else if (limit.child() instanceof UnaryPlan unary) {
             if (unary instanceof Eval
                 || unary instanceof Project
                 || unary instanceof RegexExtract
-                || unary instanceof Enrich
                 || unary instanceof InferencePlan<?>) {
                 return unary.replaceChild(limit.replaceChild(unary.child()));
             } else if (unary instanceof MvExpand) {
                 // MV_EXPAND can increase the number of rows, so we cannot just push the limit down
                 // (we also have to preserve the LIMIT afterwards)
                 // To avoid repeating this infinitely, we have to set duplicated = true.
-                return duplicateLimitAsFirstGrandchild(limit);
+                return duplicateLimitAsFirstGrandchild(limit, false);
+            } else if (unary instanceof Enrich enrich) {
+                if (enrich.mode() == Enrich.Mode.REMOTE) {
+                    return duplicateLimitAsFirstGrandchild(limit, true);
+                } else {
+                    // We can push past local enrich because it does not increase the number of rows
+                    return enrich.replaceChild(limit.replaceChild(enrich.child()));
+                }
             }
             // check if there's a 'visible' descendant limit lower than the current one
             // and if so, align the current limit since it adds no value
@@ -71,9 +80,24 @@ public final class PushDownAndCombineLimits extends OptimizerRules.Parameterized
             // The InlineJoin is currently excluded, as its right-hand side uses as data source a StubRelation that points to the entire
             // left-hand side, so adding a limit in there would lead to the right-hand side work on incomplete data.
             // To avoid repeating this infinitely, we have to set duplicated = true.
-            return duplicateLimitAsFirstGrandchild(limit);
+            // We use withLocal = false because if we have a remote join it will be forced into the fragment by the mapper anyway,
+            // And the verifier checks that there are no non-synthetic limits before the join.
+            // TODO: However, this means that the non-remote join will be always forced on the coordinator. We may want to revisit this.
+            return duplicateLimitAsFirstGrandchild(limit, false);
         }
         return limit;
+    }
+
+    private static Limit combineLimits(Limit upper, Limit lower, FoldContext ctx) {
+        // Keep the smallest limit
+        var upperLimitValue = (int) upper.limit().fold(ctx);
+        var lowerLimitValue = (int) lower.limit().fold(ctx);
+        // We want to preserve the duplicated() value of the smaller limit.
+        if (lowerLimitValue <= upperLimitValue) {
+            return lower.withLocal(lower.local());
+        } else {
+            return new Limit(upper.source(), upper.limit(), lower.child(), upper.duplicated(), upper.local());
+        }
     }
 
     /**
@@ -104,14 +128,15 @@ public final class PushDownAndCombineLimits extends OptimizerRules.Parameterized
      * Duplicate the limit past its child if it wasn't duplicated yet. The duplicate is placed on top of its leftmost grandchild.
      * Idempotent. (Sets {@link Limit#duplicated()} to {@code true} on the limit that remains at the top.)
      */
-    private static Limit duplicateLimitAsFirstGrandchild(Limit limit) {
+    private static Limit duplicateLimitAsFirstGrandchild(Limit limit, boolean withLocal) {
         if (limit.duplicated()) {
             return limit;
         }
 
         List<LogicalPlan> grandChildren = limit.child().children();
         LogicalPlan firstGrandChild = grandChildren.getFirst();
-        LogicalPlan newFirstGrandChild = limit.replaceChild(firstGrandChild);
+        // Use the local limit under the original node, so it won't break the pipeline
+        LogicalPlan newFirstGrandChild = (withLocal ? limit.withLocal(withLocal) : limit).replaceChild(firstGrandChild);
 
         List<LogicalPlan> newGrandChildren = new ArrayList<>();
         newGrandChildren.add(newFirstGrandChild);
@@ -121,5 +146,10 @@ public final class PushDownAndCombineLimits extends OptimizerRules.Parameterized
 
         LogicalPlan newChild = limit.child().replaceChildren(newGrandChildren);
         return limit.replaceChild(newChild).withDuplicated(true);
+    }
+
+    @Override
+    public Rule<Limit, LogicalPlan> local() {
+        return new PushDownAndCombineLimits(true);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineLimits.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineLimits.java
@@ -7,10 +7,7 @@
 
 package org.elasticsearch.xpack.esql.optimizer.rules.logical;
 
-import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
-import org.elasticsearch.xpack.esql.core.util.Holder;
-import org.elasticsearch.xpack.esql.expression.function.fulltext.Score;
 import org.elasticsearch.xpack.esql.optimizer.LogicalOptimizerContext;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.Enrich;
@@ -25,14 +22,11 @@ import org.elasticsearch.xpack.esql.plan.logical.inference.InferencePlan;
 import org.elasticsearch.xpack.esql.plan.logical.join.InlineJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.Join;
 import org.elasticsearch.xpack.esql.plan.logical.join.JoinTypes;
-import org.elasticsearch.xpack.esql.rule.Rule;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public final class PushDownAndCombineLimits extends OptimizerRules.ParameterizedOptimizerRule<Limit, LogicalOptimizerContext>
-    implements
-        OptimizerRules.LocalAware<Limit> {
+public final class PushDownAndCombineLimits extends OptimizerRules.ParameterizedOptimizerRule<Limit, LogicalOptimizerContext> {
 
     public PushDownAndCombineLimits() {
         super(OptimizerRules.TransformDirection.DOWN);
@@ -43,10 +37,7 @@ public final class PushDownAndCombineLimits extends OptimizerRules.Parameterized
         if (limit.child() instanceof Limit childLimit) {
             return combineLimits(limit, childLimit, ctx.foldCtx());
         } else if (limit.child() instanceof UnaryPlan unary) {
-            if (unary instanceof Eval
-                || unary instanceof Project
-                || unary instanceof RegexExtract
-                || unary instanceof InferencePlan<?>) {
+            if (unary instanceof Eval || unary instanceof Project || unary instanceof RegexExtract || unary instanceof InferencePlan<?>) {
                 return unary.replaceChild(limit.replaceChild(unary.child()));
             } else if (unary instanceof MvExpand) {
                 // MV_EXPAND can increase the number of rows, so we cannot just push the limit down
@@ -146,10 +137,5 @@ public final class PushDownAndCombineLimits extends OptimizerRules.Parameterized
 
         LogicalPlan newChild = limit.child().replaceChildren(newGrandChildren);
         return limit.replaceChild(newChild).withDuplicated(true);
-    }
-
-    @Override
-    public Rule<Limit, LogicalPlan> local() {
-        return new PushDownAndCombineLimits(true);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceLimitAndSortAsTopN.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceLimitAndSortAsTopN.java
@@ -18,7 +18,7 @@ public final class ReplaceLimitAndSortAsTopN extends OptimizerRules.OptimizerRul
     protected LogicalPlan rule(Limit plan) {
         LogicalPlan p = plan;
         if (plan.child() instanceof OrderBy o) {
-            p = new TopN(o.source(), o.child(), o.order(), plan.limit());
+            p = new TopN(o.source(), o.child(), o.order(), plan.limit(), false);
         }
         return p;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceStatsFilteredAggWithEval.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceStatsFilteredAggWithEval.java
@@ -41,8 +41,9 @@ import java.util.List;
  * This rule is applied to both STATS' {@link Aggregate} and {@link InlineJoin} right-hand side {@link Aggregate} plans.
  * The logic is common for both, but the handling of the {@link InlineJoin} is slightly different when it comes to pruning
  * its right-hand side {@link Aggregate}.
+ * Skipped in local optimizer: once a fragment contains an Agg, this can no longer be pruned, which the rule can do
  */
-public class ReplaceStatsFilteredAggWithEval extends OptimizerRules.OptimizerRule<LogicalPlan> {
+public class ReplaceStatsFilteredAggWithEval extends OptimizerRules.OptimizerRule<LogicalPlan> implements OptimizerRules.CoordinatorOnly {
     @Override
     protected LogicalPlan rule(LogicalPlan plan) {
         Aggregate aggregate;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/CardinalityPreserving.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/CardinalityPreserving.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.logical;
+
+/**
+ * This interface marks a command which does not add or remove rows, and is neutral towards limit aggregation.
+ * This means that this sequence:
+ *  ```
+ *  ... LIMIT X | MY_COMMAND
+ *  ```
+ *  is safe to replace with this sequence:
+ *  ```
+ *  ... local LIMIT X | MY_COMMAND | LIMIT X
+ *  Where the local limit is applied only on the node.
+ *  ```
+ *  It is not true, for example, for WHERE:
+ *  ```
+ *  ... LIMIT X | WHERE side="dark"
+ *  ```
+ *  If the first X rows do not contain any "dark" rows, the result is empty, however if we switch:
+ *  ```
+ *  ... local LIMIT X | WHERE side="dark" | LIMIT X
+ *  ```
+ *  and we have N nodes, then the first N*X rows may contain "dark" rows, and the final result is not empty in this case.
+ * <br>
+ * This property is important for processing Limit and TopN with remote operations such as remote ENRICH, since it allows
+ * us to localize the limits without changing the semantics.
+ */
+public interface CardinalityPreserving {}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Drop.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Drop.java
@@ -17,7 +17,7 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import java.util.List;
 import java.util.Objects;
 
-public class Drop extends UnaryPlan implements TelemetryAware, SortAgnostic {
+public class Drop extends UnaryPlan implements TelemetryAware, CardinalityPreserving, SortAgnostic {
     private final List<NamedExpression> removals;
 
     public Drop(Source source, LogicalPlan child, List<NamedExpression> removals) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Enrich.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Enrich.java
@@ -48,9 +48,10 @@ import static org.elasticsearch.xpack.esql.expression.NamedExpressions.mergeOutp
 public class Enrich extends UnaryPlan
     implements
         GeneratingPlan<Enrich>,
-        PostOptimizationVerificationAware,
+        PostOptimizationVerificationAware.CoordinatorOnly,
         PostAnalysisVerificationAware,
         TelemetryAware,
+        CardinalityPreserving,
         SortAgnostic,
         ExecutesOn {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
@@ -71,12 +72,11 @@ public class Enrich extends UnaryPlan
 
     @Override
     public ExecuteLocation executesOn() {
-        if (mode == Mode.REMOTE) {
-            return ExecuteLocation.REMOTE;
-        } else if (mode == Mode.COORDINATOR) {
-            return ExecuteLocation.COORDINATOR;
-        }
-        return ExecuteLocation.ANY;
+        return switch (mode) {
+            case REMOTE -> ExecuteLocation.REMOTE;
+            case COORDINATOR -> ExecuteLocation.COORDINATOR;
+            default -> ExecuteLocation.ANY;
+        };
     }
 
     public enum Mode {
@@ -277,13 +277,21 @@ public class Enrich extends UnaryPlan
     private void checkForPlansForbiddenBeforeRemoteEnrich(Failures failures) {
         Set<Source> fails = new HashSet<>();
 
-        this.forEachUp(LogicalPlan.class, u -> {
+        this.forEachDown(LogicalPlan.class, u -> {
             if (u instanceof ExecutesOn ex && ex.executesOn() == ExecuteLocation.COORDINATOR) {
-                fails.add(u.source());
+                failures.add(
+                    fail(this, "ENRICH with remote policy can't be executed after [" + u.source().text() + "]" + u.source().source())
+                );
             }
         });
+    }
 
-        fails.forEach(f -> failures.add(fail(this, "ENRICH with remote policy can't be executed after [" + f.text() + "]" + f.source())));
+    @Override
+    public void postAnalysisVerification(Failures failures) {
+        if (this.mode == Mode.REMOTE) {
+            checkMvExpandAfterLimit(failures);
+        }
+
     }
 
     /**
@@ -305,14 +313,6 @@ public class Enrich extends UnaryPlan
                 }
             });
         });
-
-    }
-
-    @Override
-    public void postAnalysisVerification(Failures failures) {
-        if (this.mode == Mode.REMOTE) {
-            checkMvExpandAfterLimit(failures);
-        }
 
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Eval.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Eval.java
@@ -36,7 +36,13 @@ import static org.elasticsearch.xpack.esql.common.Failure.fail;
 import static org.elasticsearch.xpack.esql.core.expression.Expressions.asAttributes;
 import static org.elasticsearch.xpack.esql.expression.NamedExpressions.mergeOutputAttributes;
 
-public class Eval extends UnaryPlan implements GeneratingPlan<Eval>, PostAnalysisVerificationAware, TelemetryAware, SortAgnostic {
+public class Eval extends UnaryPlan
+    implements
+        GeneratingPlan<Eval>,
+        PostAnalysisVerificationAware,
+        TelemetryAware,
+        CardinalityPreserving,
+        SortAgnostic {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(LogicalPlan.class, "Eval", Eval::new);
 
     private final List<Alias> fields;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Insist.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Insist.java
@@ -18,7 +18,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
-public class Insist extends UnaryPlan implements SurrogateLogicalPlan {
+public class Insist extends UnaryPlan implements SurrogateLogicalPlan, CardinalityPreserving {
     private final List<? extends Attribute> insistedAttributes;
     private @Nullable List<Attribute> lazyOutput = null;
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Keep.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Keep.java
@@ -15,7 +15,7 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import java.util.List;
 import java.util.Objects;
 
-public class Keep extends Project implements TelemetryAware, SortAgnostic {
+public class Keep extends Project implements TelemetryAware, CardinalityPreserving, SortAgnostic {
 
     public Keep(Source source, LogicalPlan child, List<? extends NamedExpression> projections) {
         super(source, child, projections);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Limit.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Limit.java
@@ -18,7 +18,7 @@ import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 import java.io.IOException;
 import java.util.Objects;
 
-public class Limit extends UnaryPlan implements TelemetryAware, PipelineBreaker {
+public class Limit extends UnaryPlan implements TelemetryAware, PipelineBreaker, ExecutesOn {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(LogicalPlan.class, "Limit", Limit::new);
 
     private final Expression limit;
@@ -29,19 +29,25 @@ public class Limit extends UnaryPlan implements TelemetryAware, PipelineBreaker 
      * infinite loops from adding a duplicate of the limit past the child over and over again.
      */
     private final transient boolean duplicated;
+    /**
+     * Local limit is not a pipeline breaker, and is applied only to the local node's data.
+     * It should always end up inside a fragment.
+     */
+    private final transient boolean local;
 
     /**
-     * Default way to create a new instance. Do not use this to copy an existing instance, as this sets {@link Limit#duplicated} to
-     * {@code false}.
+     * Default way to create a new instance. Do not use this to copy an existing instance, as this sets {@link Limit#duplicated}
+     * and {@link Limit#local} to {@code false}.
      */
     public Limit(Source source, Expression limit, LogicalPlan child) {
-        this(source, limit, child, false);
+        this(source, limit, child, false, false);
     }
 
-    public Limit(Source source, Expression limit, LogicalPlan child, boolean duplicated) {
+    public Limit(Source source, Expression limit, LogicalPlan child, boolean duplicated, boolean local) {
         super(source, child);
         this.limit = limit;
         this.duplicated = duplicated;
+        this.local = local;
     }
 
     /**
@@ -52,6 +58,7 @@ public class Limit extends UnaryPlan implements TelemetryAware, PipelineBreaker 
             Source.readFrom((PlanStreamInput) in),
             in.readNamedWriteable(Expression.class),
             in.readNamedWriteable(LogicalPlan.class),
+            false,
             false
         );
     }
@@ -75,12 +82,12 @@ public class Limit extends UnaryPlan implements TelemetryAware, PipelineBreaker 
 
     @Override
     protected NodeInfo<Limit> info() {
-        return NodeInfo.create(this, Limit::new, limit, child(), duplicated);
+        return NodeInfo.create(this, Limit::new, limit, child(), duplicated, local);
     }
 
     @Override
     public Limit replaceChild(LogicalPlan newChild) {
-        return new Limit(source(), limit, newChild, duplicated);
+        return new Limit(source(), limit, newChild, duplicated, local);
     }
 
     public Expression limit() {
@@ -88,15 +95,23 @@ public class Limit extends UnaryPlan implements TelemetryAware, PipelineBreaker 
     }
 
     public Limit withLimit(Expression limit) {
-        return new Limit(source(), limit, child(), duplicated);
+        return new Limit(source(), limit, child(), duplicated, local);
     }
 
     public boolean duplicated() {
         return duplicated;
     }
 
+    public boolean local() {
+        return local;
+    }
+
     public Limit withDuplicated(boolean duplicated) {
-        return new Limit(source(), limit, child(), duplicated);
+        return new Limit(source(), limit, child(), duplicated, local);
+    }
+
+    public Limit withLocal(boolean newLocal) {
+        return new Limit(source(), limit, child(), duplicated, newLocal);
     }
 
     @Override
@@ -106,7 +121,7 @@ public class Limit extends UnaryPlan implements TelemetryAware, PipelineBreaker 
 
     @Override
     public int hashCode() {
-        return Objects.hash(limit, child(), duplicated);
+        return Objects.hash(limit, child(), duplicated, local);
     }
 
     @Override
@@ -120,6 +135,15 @@ public class Limit extends UnaryPlan implements TelemetryAware, PipelineBreaker 
 
         Limit other = (Limit) obj;
 
-        return Objects.equals(limit, other.limit) && Objects.equals(child(), other.child()) && (duplicated == other.duplicated);
+        return Objects.equals(limit, other.limit)
+            && Objects.equals(child(), other.child())
+            && (duplicated == other.duplicated)
+            && (local == other.local);
+    }
+
+    @Override
+    public ExecuteLocation executesOn() {
+        // Global limit always needs to be on the coordinator
+        return local ? ExecuteLocation.ANY : ExecuteLocation.COORDINATOR;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Project.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Project.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 /**
  * A {@code Project} is a {@code Plan} with one child. In {@code FROM idx | KEEP x, y}, the {@code KEEP} statement is a Project.
  */
-public class Project extends UnaryPlan implements SortAgnostic {
+public class Project extends UnaryPlan implements CardinalityPreserving, SortAgnostic {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(LogicalPlan.class, "Project", Project::new);
 
     private final List<? extends NamedExpression> projections;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/RegexExtract.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/RegexExtract.java
@@ -24,7 +24,12 @@ import java.util.Objects;
 import static org.elasticsearch.xpack.esql.common.Failure.fail;
 import static org.elasticsearch.xpack.esql.expression.NamedExpressions.mergeOutputAttributes;
 
-public abstract class RegexExtract extends UnaryPlan implements GeneratingPlan<RegexExtract>, PostAnalysisVerificationAware, SortAgnostic {
+public abstract class RegexExtract extends UnaryPlan
+    implements
+        GeneratingPlan<RegexExtract>,
+        PostAnalysisVerificationAware,
+        CardinalityPreserving,
+        SortAgnostic {
     protected final Expression input;
     protected final List<Attribute> extractedFields;
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Rename.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Rename.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-public class Rename extends UnaryPlan implements TelemetryAware, SortAgnostic {
+public class Rename extends UnaryPlan implements TelemetryAware, CardinalityPreserving, SortAgnostic {
 
     private final List<Alias> renamings;
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/TopN.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/TopN.java
@@ -21,16 +21,22 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
-public class TopN extends UnaryPlan implements PipelineBreaker {
+public class TopN extends UnaryPlan implements PipelineBreaker, ExecutesOn {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(LogicalPlan.class, "TopN", TopN::new);
 
     private final List<Order> order;
     private final Expression limit;
+    /**
+     * Local topn is not a pipeline breaker, and is applied only to the local node's data.
+     * It should always end up inside a fragment.
+     */
+    private final transient boolean local;
 
-    public TopN(Source source, LogicalPlan child, List<Order> order, Expression limit) {
+    public TopN(Source source, LogicalPlan child, List<Order> order, Expression limit, boolean local) {
         super(source, child);
         this.order = order;
         this.limit = limit;
+        this.local = local;
     }
 
     private TopN(StreamInput in) throws IOException {
@@ -38,7 +44,8 @@ public class TopN extends UnaryPlan implements PipelineBreaker {
             Source.readFrom((PlanStreamInput) in),
             in.readNamedWriteable(LogicalPlan.class),
             in.readCollectionAsList(Order::new),
-            in.readNamedWriteable(Expression.class)
+            in.readNamedWriteable(Expression.class),
+            false
         );
     }
 
@@ -62,12 +69,20 @@ public class TopN extends UnaryPlan implements PipelineBreaker {
 
     @Override
     protected NodeInfo<TopN> info() {
-        return NodeInfo.create(this, TopN::new, child(), order, limit);
+        return NodeInfo.create(this, TopN::new, child(), order, limit, local);
     }
 
     @Override
     public TopN replaceChild(LogicalPlan newChild) {
-        return new TopN(source(), newChild, order, limit);
+        return new TopN(source(), newChild, order, limit, local);
+    }
+
+    public TopN withLocal(boolean local) {
+        return new TopN(source(), child(), order, limit, local);
+    }
+
+    public boolean local() {
+        return local;
     }
 
     public Expression limit() {
@@ -80,15 +95,20 @@ public class TopN extends UnaryPlan implements PipelineBreaker {
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), order, limit);
+        return Objects.hash(super.hashCode(), order, limit, local);
     }
 
     @Override
     public boolean equals(Object obj) {
         if (super.equals(obj)) {
             var other = (TopN) obj;
-            return Objects.equals(order, other.order) && Objects.equals(limit, other.limit);
+            return Objects.equals(order, other.order) && Objects.equals(limit, other.limit) && local == other.local;
         }
         return false;
+    }
+
+    @Override
+    public ExecuteLocation executesOn() {
+        return local ? ExecuteLocation.ANY : ExecuteLocation.COORDINATOR;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/inference/InferencePlan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/inference/InferencePlan.java
@@ -13,6 +13,7 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.UnresolvedAttribute;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.plan.GeneratingPlan;
+import org.elasticsearch.xpack.esql.plan.logical.CardinalityPreserving;
 import org.elasticsearch.xpack.esql.plan.logical.ExecutesOn;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.SortAgnostic;
@@ -24,6 +25,7 @@ import java.util.Objects;
 
 public abstract class InferencePlan<PlanType extends InferencePlan<PlanType>> extends UnaryPlan
     implements
+        CardinalityPreserving,
         SortAgnostic,
         GeneratingPlan<InferencePlan<PlanType>>,
         ExecutesOn.Coordinator {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EnrichExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EnrichExec.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 import org.elasticsearch.xpack.esql.plan.logical.Enrich;
+import org.elasticsearch.xpack.esql.plan.logical.ExecutesOn;
 
 import java.io.IOException;
 import java.util.List;
@@ -24,7 +25,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.xpack.esql.expression.NamedExpressions.mergeOutputAttributes;
 
-public class EnrichExec extends UnaryExec implements EstimatesRowSize {
+public class EnrichExec extends UnaryExec implements EstimatesRowSize, ExecutesOn {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
         PhysicalPlan.class,
         "EnrichExec",
@@ -190,5 +191,14 @@ public class EnrichExec extends UnaryExec implements EstimatesRowSize {
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), mode, matchType, matchField, policyName, policyMatchField, concreteIndices, enrichFields);
+    }
+
+    @Override
+    public ExecuteLocation executesOn() {
+        return switch (mode) {
+            case REMOTE -> ExecuteLocation.REMOTE;
+            case COORDINATOR -> ExecuteLocation.COORDINATOR;
+            default -> ExecuteLocation.ANY;
+        };
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTestUtils.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTestUtils.java
@@ -195,6 +195,15 @@ public final class AnalyzerTestUtils {
             "languages_idx",
             "mapping-languages.json"
         );
+        loadEnrichPolicyResolution(
+            enrichResolution,
+            Enrich.Mode.REMOTE,
+            MATCH_TYPE,
+            "languages_remote",
+            "language_code",
+            "languages_idx",
+            "mapping-languages.json"
+        );
         return enrichResolution;
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/AbstractLogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/AbstractLogicalPlanOptimizerTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.TransportVersion;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.EsqlTestUtils;
+import org.elasticsearch.xpack.esql.VerificationException;
 import org.elasticsearch.xpack.esql.analysis.Analyzer;
 import org.elasticsearch.xpack.esql.analysis.AnalyzerTestUtils;
 import org.elasticsearch.xpack.esql.analysis.EnrichResolution;
@@ -19,6 +20,7 @@ import org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry;
 import org.elasticsearch.xpack.esql.index.EsIndex;
 import org.elasticsearch.xpack.esql.index.IndexResolution;
 import org.elasticsearch.xpack.esql.parser.EsqlParser;
+import org.elasticsearch.xpack.esql.plan.logical.Enrich;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.junit.BeforeClass;
 
@@ -27,6 +29,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static java.util.Collections.emptyMap;
+import static org.elasticsearch.xpack.core.enrich.EnrichPolicy.MATCH_TYPE;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_VERIFIER;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.emptyInferenceResolution;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.loadMapping;
@@ -36,6 +39,7 @@ import static org.elasticsearch.xpack.esql.EsqlTestUtils.withDefaultLimitWarning
 import static org.elasticsearch.xpack.esql.analysis.AnalyzerTestUtils.defaultInferenceResolution;
 import static org.elasticsearch.xpack.esql.analysis.AnalyzerTestUtils.defaultLookupResolution;
 import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
+import static org.hamcrest.Matchers.containsString;
 
 public abstract class AbstractLogicalPlanOptimizerTests extends ESTestCase {
     protected static EsqlParser parser;
@@ -82,6 +86,24 @@ public abstract class AbstractLogicalPlanOptimizerTests extends ESTestCase {
         );
         enrichResolution = new EnrichResolution();
         AnalyzerTestUtils.loadEnrichPolicyResolution(enrichResolution, "languages_idx", "id", "languages_idx", "mapping-languages.json");
+        AnalyzerTestUtils.loadEnrichPolicyResolution(
+            enrichResolution,
+            Enrich.Mode.REMOTE,
+            MATCH_TYPE,
+            "languages_remote",
+            "id",
+            "languages_idx",
+            "mapping-languages.json"
+        );
+        AnalyzerTestUtils.loadEnrichPolicyResolution(
+            enrichResolution,
+            Enrich.Mode.COORDINATOR,
+            MATCH_TYPE,
+            "languages_coordinator",
+            "id",
+            "languages_idx",
+            "mapping-languages.json"
+        );
 
         // Most tests used data from the test index, so we load it here, and use it in the plan() function.
         mapping = loadMapping("mapping-basic.json");
@@ -247,4 +269,14 @@ public abstract class AbstractLogicalPlanOptimizerTests extends ESTestCase {
     protected List<String> filteredWarnings() {
         return withDefaultLimitWarning(super.filteredWarnings());
     }
+
+    protected <T extends Throwable> void failPlan(String esql, Class<T> exceptionClass, String reason) {
+        var e = expectThrows(exceptionClass, () -> plan(esql));
+        assertThat(e.getMessage(), containsString(reason));
+    }
+
+    protected void failPlan(String esql, String reason) {
+        failPlan(esql, VerificationException.class, reason);
+    }
+
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -1053,8 +1053,8 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
         var optimizedPlan = rule.apply(limit, logicalOptimizerCtx);
 
         var expectedPlan = join instanceof InlineJoin
-            ? new Limit(limit.source(), limit.limit(), join, false)
-            : new Limit(limit.source(), limit.limit(), join.replaceChildren(limit.replaceChild(join.left()), join.right()), true);
+            ? new Limit(limit.source(), limit.limit(), join, false, false)
+            : new Limit(limit.source(), limit.limit(), join.replaceChildren(limit.replaceChild(join.left()), join.right()), true, false);
 
         assertEquals(expectedPlan, optimizedPlan);
 
@@ -5597,7 +5597,7 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
             List<Attribute> initialGeneratedExprs = ((GeneratingPlan) initialPlan).generatedAttributes();
             LogicalPlan optimizedPlan = testCase.rule.apply(initialPlan);
 
-            Failures inconsistencies = LogicalVerifier.INSTANCE.verify(optimizedPlan, false, initialPlan.output());
+            Failures inconsistencies = LogicalVerifier.INSTANCE.verify(optimizedPlan, initialPlan.output());
             assertFalse(inconsistencies.hasFailures());
 
             Project project = as(optimizedPlan, Project.class);
@@ -5652,7 +5652,7 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
             List<Attribute> initialGeneratedExprs = ((GeneratingPlan) initialPlan).generatedAttributes();
             LogicalPlan optimizedPlan = testCase.rule.apply(initialPlan);
 
-            Failures inconsistencies = LogicalVerifier.INSTANCE.verify(optimizedPlan, false, initialPlan.output());
+            Failures inconsistencies = LogicalVerifier.INSTANCE.verify(optimizedPlan, initialPlan.output());
             assertFalse(inconsistencies.hasFailures());
 
             Project project = as(optimizedPlan, Project.class);
@@ -5712,7 +5712,7 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
 
             // This ensures that our generating plan doesn't use invalid references, resp. that any rename from the Project has
             // been propagated into the generating plan.
-            Failures inconsistencies = LogicalVerifier.INSTANCE.verify(optimizedPlan, false, initialPlan.output());
+            Failures inconsistencies = LogicalVerifier.INSTANCE.verify(optimizedPlan, initialPlan.output());
             assertFalse(inconsistencies.hasFailures());
 
             Project project = as(optimizedPlan, Project.class);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/HoistRemoteEnrichLimitTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/HoistRemoteEnrichLimitTests.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer.rules.logical;
+
+import org.elasticsearch.xpack.esql.expression.Foldables;
+import org.elasticsearch.xpack.esql.optimizer.AbstractLogicalPlanOptimizerTests;
+import org.elasticsearch.xpack.esql.plan.logical.Dissect;
+import org.elasticsearch.xpack.esql.plan.logical.Enrich;
+import org.elasticsearch.xpack.esql.plan.logical.Eval;
+import org.elasticsearch.xpack.esql.plan.logical.Limit;
+import org.elasticsearch.xpack.esql.plan.logical.Project;
+
+import java.util.Locale;
+
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+public class HoistRemoteEnrichLimitTests extends AbstractLogicalPlanOptimizerTests {
+
+    /**
+     * <pre>
+     * Limit[10[INTEGER],true,false]
+     * \_Enrich[REMOTE,languages_remote[KEYWORD],id{r}#4,{"match":{"indices":[],"match_field":"id",
+     * "enrich_fields":["language_code","language_name"]}},{=languages_idx},[language_code{r}#20, language_name{r}#21]]
+     *   \_Eval[[emp_no{f}#6 AS id#4]]
+     *     \_Limit[10[INTEGER],false,true]
+     *       \_EsRelation[test][_meta_field{f}#12, emp_no{f}#6, first_name{f}#7, ...]
+     * </pre>
+     */
+    public void testLimitWithinRemoteEnrich() {
+        var plan = plan(randomFrom("""
+            from test
+            | EVAL id = emp_no
+            | LIMIT 10
+            | ENRICH _remote:languages_remote
+            """, """
+            from test
+            | LIMIT 10
+            | EVAL id = emp_no
+            | ENRICH _remote:languages_remote
+            """)); // it should be the same in any order
+
+        var limit = as(plan, Limit.class);
+        assertTrue(limit.duplicated());
+        assertFalse(limit.local());
+        var enrich = as(limit.child(), Enrich.class);
+        assertThat(enrich.mode(), is(Enrich.Mode.REMOTE));
+        var eval = as(enrich.child(), Eval.class);
+        var innerLimit = as(eval.child(), Limit.class);
+        assertFalse(innerLimit.duplicated());
+        assertTrue(innerLimit.local());
+    }
+
+    /**
+     * <pre>
+     * Limit[10[INTEGER],true,false]
+     * \_Enrich[REMOTE,languages_remote[KEYWORD],id{r}#4,{"match":{"indices":[],"match_field":"id","enrich_fields":["language_cod
+     * e","language_name"]}},{=languages_idx},[language_code{r}#20, language_name{r}#21]]
+     *   \_Eval[[emp_no{f}#6 AS id#4]]
+     *     \_Limit[10[INTEGER],false,true]
+     *       \_EsRelation[test][_meta_field{f}#12, emp_no{f}#6, first_name{f}#7, ge..]
+     * </pre>
+     */
+    public void testLimitWithinRemoteEnrichAndAfter() {
+        var plan = plan("""
+            from test
+            | LIMIT 20
+            | EVAL id = emp_no
+            | ENRICH _remote:languages_remote
+            | LIMIT 10
+            """); // it should be the same in any order
+
+        var limit = as(plan, Limit.class);
+        assertTrue(limit.duplicated());
+        assertFalse(limit.local());
+        var enrich = as(limit.child(), Enrich.class);
+        assertThat(enrich.mode(), is(Enrich.Mode.REMOTE));
+        var eval = as(enrich.child(), Eval.class);
+        var innerLimit = as(eval.child(), Limit.class);
+        assertFalse(innerLimit.duplicated());
+        assertTrue(innerLimit.local());
+    }
+
+    // Same as above but limits are reversed
+    public void testLimitWithinRemoteEnrichAndAfterHigher() {
+        var plan = plan("""
+            from test
+            | LIMIT 10
+            | EVAL id = emp_no
+            | ENRICH _remote:languages_remote
+            | LIMIT 20
+            """); // it should be the same in any order
+
+        var limit = as(plan, Limit.class);
+        assertTrue(limit.duplicated());
+        assertFalse(limit.local());
+        var enrich = as(limit.child(), Enrich.class);
+        assertThat(enrich.mode(), is(Enrich.Mode.REMOTE));
+        var eval = as(enrich.child(), Eval.class);
+        var innerLimit = as(eval.child(), Limit.class);
+        assertFalse(innerLimit.duplicated());
+        assertTrue(innerLimit.local());
+    }
+
+    /**
+     * <pre>
+     * Project[[salary{f}#19 AS wage#10, emp_no{f}#14 AS id#4, first_name{r}#11, language_code{r}#28, language_name{r}#29]]
+     * \_Limit[5[INTEGER],true,false]
+     *   \_Enrich[REMOTE,languages_remote[KEYWORD],emp_no{f}#14,{"match":{"indices":[],"match_field":"id","enrich_fields":["languag
+     * e_code","language_name"]}},{=languages_idx},[language_code{r}#28, language_name{r}#29]]
+     *     \_Dissect[first_name{f}#15,Parser[pattern=%{first_name}s, appendSeparator=, parser=org.elasticsearch.dissect.DissectParse
+     * r@7d5c7931],[first_name{r}#11]]
+     *       \_Limit[5[INTEGER],false,true]
+     *         \_EsRelation[test][_meta_field{f}#20, emp_no{f}#14, first_name{f}#15, ..]
+     * </pre>
+     */
+    public void testManyLimitsWithinRemoteEnrich() {
+        var plan = plan("""
+            from test
+            | LIMIT 10
+            | EVAL id = emp_no
+            | KEEP first_name, salary, id
+            | RENAME salary AS wage
+            | DISSECT first_name "%{first_name}s"
+            | LIMIT 5
+            | ENRICH _remote:languages_remote
+            """);
+
+        var project = as(plan, Project.class);
+        var limit = as(project.child(), Limit.class);
+        assertTrue(limit.duplicated());
+        assertFalse(limit.local());
+        assertThat(Foldables.limitValue(limit.limit(), limit.sourceText()), equalTo(5));
+        var enrich = as(limit.child(), Enrich.class);
+        assertThat(enrich.mode(), is(Enrich.Mode.REMOTE));
+        var dissect = as(enrich.child(), Dissect.class);
+        var innerLimit = as(dissect.child(), Limit.class);
+        assertFalse(innerLimit.duplicated());
+        assertTrue(innerLimit.local());
+        assertThat(Foldables.limitValue(innerLimit.limit(), innerLimit.sourceText()), equalTo(5));
+    }
+
+    /**
+     * Project[[first_name{f}#14, salary{f}#18 AS wage#11, emp_no{f}#13 AS id#4, language_code{r}#32, language_name{r}#33]]
+     * \_Limit[5[INTEGER],true,false]
+     *   \_Enrich[REMOTE,languages_remote[KEYWORD],emp_no{f}#13,{"match":{"indices":[],"match_field":"id","enrich_fields":["languag
+     * e_code","language_name"]}},{=languages_idx},[language_code{r}#32, language_name{r}#33]]
+     *     \_Limit[5[INTEGER],true,true]
+     *       \_Enrich[REMOTE,languages_remote[KEYWORD],emp_no{f}#13,{"match":{"indices":[],"match_field":"id","enrich_fields":["languag
+     * e_code","language_name"]}},{=languages_idx},[language_code{r}#27, language_name{r}#28]]
+     *         \_Limit[5[INTEGER],false,true]
+     *           \_EsRelation[test][_meta_field{f}#19, emp_no{f}#13, first_name{f}#14, ..]
+     */
+    public void testLimitsWithinRemoteEnrichTwice() {
+        var plan = plan("""
+            from test
+            | LIMIT 10
+            | EVAL id = emp_no
+            | KEEP first_name, salary, id
+            | ENRICH _remote:languages_remote
+            | RENAME salary AS wage
+            | LIMIT 5
+            | ENRICH _remote:languages_remote
+            """);
+        var project = as(plan, Project.class);
+        var limit = as(project.child(), Limit.class);
+        assertTrue(limit.duplicated());
+        assertFalse(limit.local());
+        assertThat(Foldables.limitValue(limit.limit(), limit.sourceText()), equalTo(5));
+        var enrich = as(limit.child(), Enrich.class);
+        assertThat(enrich.mode(), is(Enrich.Mode.REMOTE));
+        var innerLimit = as(enrich.child(), Limit.class);
+        assertTrue(innerLimit.duplicated());
+        assertTrue(innerLimit.local());
+        assertThat(Foldables.limitValue(innerLimit.limit(), innerLimit.sourceText()), equalTo(5));
+        var secondEnrich = as(innerLimit.child(), Enrich.class);
+        assertThat(secondEnrich.mode(), is(Enrich.Mode.REMOTE));
+        var innermostLimit = as(secondEnrich.child(), Limit.class);
+        assertFalse(innermostLimit.duplicated());
+        assertTrue(innermostLimit.local());
+        assertThat(Foldables.limitValue(innermostLimit.limit(), innermostLimit.sourceText()), equalTo(5));
+    }
+
+    // These cases do not get hoisting, and it's ok
+    public void testLimitWithinOtherEnrich() {
+        String enrichPolicy = randomFrom("languages_idx", "_any:languages_idx", "_coordinator:languages_coordinator");
+        var plan = plan(String.format(Locale.ROOT, """
+            from test
+            | EVAL id = emp_no
+            | LIMIT 10
+            | ENRICH %s
+            """, enrichPolicy));
+        // Here ENRICH is on top - no hoisting happens
+        var enrich = as(plan, Enrich.class);
+        assertThat(enrich.mode(), not(is(Enrich.Mode.REMOTE)));
+    }
+
+    // Non-cardinality preserving commands after limit
+    public void testFilterLimitThenEnrich() {
+        // Hoisting does not happen, so the verifier fails since LIMIT is before remote ENRICH
+        failPlan("""
+            from test
+            | EVAL id = emp_no
+            | LIMIT 10
+            | WHERE first_name != "john"
+            | ENRICH _remote:languages_remote
+            """, "ENRICH with remote policy can't be executed after [LIMIT 10]");
+    }
+
+    public void testMvExpandLimitThenEnrich() {
+        // Hoisting does not happen, so the verifier fails since LIMIT is before remote ENRICH
+        failPlan("""
+            from test
+            | EVAL id = emp_no
+            | LIMIT 10
+            | MV_EXPAND languages
+            | ENRICH _remote:languages_remote
+            """, "MV_EXPAND after LIMIT is incompatible with remote ENRICH");
+    }
+
+    // Other cases where hoisting does not happen:
+    // - ExecutesOn.COORDINATOR - this fails the verifier
+    // - PipelineBreaker - all relevant ones are also ExecutesOn.COORDINATOR
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/HoistRemoteEnrichTopNTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/HoistRemoteEnrichTopNTests.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer.rules.logical;
+
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.xpack.esql.EsqlTestUtils;
+import org.elasticsearch.xpack.esql.analysis.Analyzer;
+import org.elasticsearch.xpack.esql.analysis.AnalyzerTestUtils;
+import org.elasticsearch.xpack.esql.analysis.EnrichResolution;
+import org.elasticsearch.xpack.esql.core.expression.Alias;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.expression.Order;
+import org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry;
+import org.elasticsearch.xpack.esql.index.EsIndex;
+import org.elasticsearch.xpack.esql.index.IndexResolution;
+import org.elasticsearch.xpack.esql.optimizer.AbstractLogicalPlanOptimizerTests;
+import org.elasticsearch.xpack.esql.plan.logical.Enrich;
+import org.elasticsearch.xpack.esql.plan.logical.Eval;
+import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.Project;
+import org.elasticsearch.xpack.esql.plan.logical.TopN;
+
+import java.util.Map;
+
+import static org.elasticsearch.xpack.core.enrich.EnrichPolicy.MATCH_TYPE;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_VERIFIER;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.emptyInferenceResolution;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.loadMapping;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.testAnalyzerContext;
+import static org.elasticsearch.xpack.esql.analysis.AnalyzerTestUtils.defaultLookupResolution;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+
+// @TestLogging(reason = "debug", value = "org.elasticsearch.xpack.esql.optimizer:TRACE")
+public class HoistRemoteEnrichTopNTests extends AbstractLogicalPlanOptimizerTests {
+
+    /**
+     * <pre>
+     * TopN[[Order[emp_no{f}#7,ASC,LAST]],10[INTEGER],false]
+     * \_Enrich[REMOTE,languages_remote[KEYWORD],id{r}#4,{"match":{"indices":[],"match_field":"id","enrich_fields":["language_cod
+     * e","language_name"]}},{=languages_idx},[language_code{r}#21, language_name{r}#22]]
+     *   \_TopN[[Order[emp_no{f}#7,ASC,LAST]],10[INTEGER],true]
+     *     \_Eval[[emp_no{f}#7 AS id#4]]
+     *       \_EsRelation[test][_meta_field{f}#13, emp_no{f}#7, first_name{f}#8, ge..]
+     * </pre>
+     */
+    public void testLimitWithinRemoteEnrich() {
+        var plan = plan("""
+            from test
+            | EVAL id = emp_no
+            | SORT emp_no
+            | LIMIT 10
+            | ENRICH _remote:languages_remote
+            """);
+
+        var topn = as(plan, TopN.class);
+        assertFalse(topn.local());
+        var enrich = as(topn.child(), Enrich.class);
+        assertThat(enrich.mode(), is(Enrich.Mode.REMOTE));
+        var innerTopN = as(enrich.child(), TopN.class);
+        assertTrue(innerTopN.local());
+        as(innerTopN.child(), Eval.class);
+    }
+
+    /** <pre>
+     * Project[[_meta_field{f}#16, first_name{f}#11, gender{f}#12, hire_date{f}#17, job{f}#18, job.raw{f}#19, languages{f}#13
+     * , last_name{f}#14, long_noidx{f}#20, salary{f}#15, id{r}#4, emp_no{r}#8, language_code{r}#24, language_name{r}#25]]
+     * \_TopN[[Order[$$emp_no$temp_name$26{r$}#27,ASC,LAST]],10[INTEGER],false]
+     *   \_Enrich[REMOTE,languages_remote[KEYWORD],id{r}#4,{"match":{"indices":[],"match_field":"id","enrich_fields":["language_cod
+     * e","language_name"]}},{=languages_idx},[language_code{r}#24, language_name{r}#25]]
+     *     \_Eval[[emp_no{f}#10 + 1[INTEGER] AS emp_no#8]]
+     *       \_Eval[[emp_no{f}#10 AS $$emp_no$temp_name$26#27]]
+     *         \_TopN[[Order[emp_no{f}#10,ASC,LAST]],10[INTEGER],true]
+     *           \_Eval[[emp_no{f}#10 AS id#4]]
+     *             \_EsRelation[test][_meta_field{f}#16, emp_no{f}#10, first_name{f}#11, ..]
+     * </pre>
+     */
+    public void testLimitWithinRemoteEnrichShadow() {
+        var plan = plan("""
+            from test
+            | EVAL id = emp_no
+            | SORT emp_no
+            | LIMIT 10
+            | EVAL emp_no = emp_no + 1
+            | ENRICH _remote:languages_remote
+            """);
+
+        var proj = as(plan, Project.class);
+        var topn = as(proj.child(), TopN.class);
+        assertFalse(topn.local());
+        Order topNOrder = topn.order().getFirst();
+        NamedExpression expr = as(topNOrder.child(), NamedExpression.class);
+        assertThat(expr.name(), startsWith("$$emp_no$temp_name$"));
+        var enrich = as(topn.child(), Enrich.class);
+        assertThat(enrich.mode(), is(Enrich.Mode.REMOTE));
+        // EVAL emp_no = emp_no + 1
+        var eval1 = as(enrich.child(), Eval.class);
+        var evalAlias = as(eval1.expressions().getFirst(), Alias.class);
+        assertThat(evalAlias.name(), equalTo("emp_no"));
+        // Generated aliasing Eval
+        var eval2 = as(eval1.child(), Eval.class);
+        var evalAlias2 = as(eval2.expressions().getFirst(), Alias.class);
+        var evalName2 = as(evalAlias2.child(), NamedExpression.class);
+        assertThat(evalName2.name(), equalTo("emp_no"));
+        var innerTopN = as(eval2.child(), TopN.class);
+        assertTrue(innerTopN.local());
+    }
+
+    private LogicalPlan planWithPolicyOverride(String query) {
+        // Set up index and enrich policy with overlapping fields
+        var enrichResolution = new EnrichResolution();
+        AnalyzerTestUtils.loadEnrichPolicyResolution(
+            enrichResolution,
+            Enrich.Mode.REMOTE,
+            MATCH_TYPE,
+            "hosts",
+            "host",
+            "hosts",
+            "mapping-hosts.json"
+        );
+        var mapping = loadMapping("mapping-host_inventory.json");
+        EsIndex inventory = new EsIndex("host_inventory", mapping, Map.of("host_inventory", IndexMode.STANDARD));
+        IndexResolution resolution = IndexResolution.valid(inventory);
+        var analyzer = new Analyzer(
+            testAnalyzerContext(
+                EsqlTestUtils.TEST_CFG,
+                new EsqlFunctionRegistry(),
+                resolution,
+                defaultLookupResolution(),
+                enrichResolution,
+                emptyInferenceResolution()
+            ),
+            TEST_VERIFIER
+        );
+
+        var analyzed = analyzer.analyze(parser.createStatement(query));
+        return logicalOptimizer.optimize(analyzed);
+    }
+
+    /**
+     * Test case for aliasing within TopN + Enrich. This happens when Enrich had a field that overrides an existing field,
+     * so we need to alias it.
+     * <pre>
+     *     Project[[host.name{f}#10, host.os{f}#11, host.version{f}#12, host.name{f}#10 AS host#5, host_group{r}#21, description{
+     * r}#22, card{r}#23, ip0{r}#24, ip1{r}#25]]
+     * \_Project[[host.name{f}#10, host.os{f}#11, host.version{f}#12, host_group{r}#21, description{r}#22, card{r}#23, ip0{r}#2
+     * 4, ip1{r}#25]]
+     *   \_TopN[[Order[$$description$temp_name$27{r$}#28,ASC,LAST]],10[INTEGER],false]
+     *     \_Enrich[REMOTE,hosts[KEYWORD],host.name{f}#10,{"match":{"indices":[],"match_field":"host","enrich_fields":["host_group","
+     * description","card","ip0","ip1"]}},{=hosts},[host_group{r}#21, description{r}#22, card{r}#23, ip0{r}#24, ip1{r}#
+     * 25]]
+     *       \_Eval[[description{f}#13 AS $$description$temp_name$27#28]]
+     *         \_TopN[[Order[description{f}#13,ASC,LAST]],10[INTEGER],true]
+     *           \_EsRelation[host_inventory][description{f}#13, host.name{f}#10, host.os{f}#11, ..]
+     * </pre>
+     * TODO: probably makes sense to remove double project, but this can be done later
+     */
+    public void testTopNWithinRemoteEnrichAliasing() {
+        var query = ("""
+            from host_inventory
+            | SORT description
+            | LIMIT 10
+            | EVAL host = host.name
+            | KEEP host*, description
+            | ENRICH _remote:hosts
+            """);
+        LogicalPlan plan = planWithPolicyOverride(query);
+
+        var proj1 = as(plan, Project.class);
+        var proj2 = as(proj1.child(), Project.class);
+        var topn = as(proj2.child(), TopN.class);
+        assertFalse(topn.local());
+        Order topNOrder = topn.order().getFirst();
+        NamedExpression expr = as(topNOrder.child(), NamedExpression.class);
+        assertThat(expr.name(), startsWith("$$description$temp_name$"));
+        var enrich = as(topn.child(), Enrich.class);
+        assertThat(enrich.mode(), is(Enrich.Mode.REMOTE));
+        var eval = as(enrich.child(), Eval.class);
+        var evalAlias = as(eval.expressions().getFirst(), Alias.class);
+        var evalName = as(evalAlias.child(), NamedExpression.class);
+        assertThat(evalName.name(), equalTo("description"));
+        var innerTopN = as(eval.child(), TopN.class);
+        assertTrue(innerTopN.local());
+    }
+
+    public void testTopNSortFieldsWithinRemoteEnrichAliasing() {
+        // Now let's try sort which has more than one field
+        var query = ("""
+            from host_inventory
+            | SORT host.name, description
+            | LIMIT 10
+            | EVAL host = host.name
+            | KEEP host*, description
+            | ENRICH _remote:hosts
+            """);
+        LogicalPlan plan = planWithPolicyOverride(query);
+
+        var proj1 = as(plan, Project.class);
+        var proj2 = as(proj1.child(), Project.class);
+        var topn = as(proj2.child(), TopN.class);
+        assertFalse(topn.local());
+        Order topNOrder = topn.order().get(1);
+        NamedExpression expr = as(topNOrder.child(), NamedExpression.class);
+        assertThat(expr.name(), startsWith("$$description$temp_name$"));
+        var enrich = as(topn.child(), Enrich.class);
+        assertThat(enrich.mode(), is(Enrich.Mode.REMOTE));
+        var eval = as(enrich.child(), Eval.class);
+        var evalAlias = as(eval.expressions().getFirst(), Alias.class);
+        var evalName = as(evalAlias.child(), NamedExpression.class);
+        assertThat(evalName.name(), equalTo("description"));
+        var innerTopN = as(eval.child(), TopN.class);
+        assertTrue(innerTopN.local());
+    }
+
+    /**
+     * Plan with functions in sort:
+     * <pre>
+     * Project[[host.name{f}#13, host.os{f}#14, host.version{f}#15, host.name{f}#13 AS host#8, host_group{r}#24, description{
+     * r}#25, card{r}#26, ip0{r}#27, ip1{r}#28]]
+     * \_TopN[[Order[host.version{f}#15,ASC,LAST], Order[$$order_by$1$0{r}#30,ASC,LAST], Order[$$order_by$2$1{r}#31,ASC,LAST
+     * ], Order[host.os{f}#14,ASC,LAST]],10[INTEGER],false]
+     *   \_Enrich[REMOTE,hosts[KEYWORD],host.name{f}#13,{"match":{"indices":[],"match_field":"host","enrich_fields":["host_group","
+     * description","card","ip0","ip1"]}},{=hosts},[host_group{r}#24, description{r}#25, card{r}#26, ip0{r}#27, ip1{r}#
+     * 28]]
+     *     \_TopN[[Order[host.version{f}#15,ASC,LAST], Order[$$order_by$1$0{r}#30,ASC,LAST], Order[$$order_by$2$1{r}#31,ASC,LAST
+     * ], Order[host.os{f}#14,ASC,LAST]],10[INTEGER],true]
+     *       \_Eval[[LENGTH(description{f}#16) AS $$order_by$1$0#30, TOLOWER(description{f}#16) AS $$order_by$2$1#31]]
+     *         \_EsRelation[host_inventory][description{f}#16, host.name{f}#13, host.os{f}#14, ..]
+     *  </pre>
+     */
+    public void testTopNSortExpressionWithinRemoteEnrichAliasing() {
+        // Now let's try sort which has more than one field
+        var query = ("""
+            from host_inventory
+            | SORT host.version, LENGTH(description), to_lower(description), host.os
+            | LIMIT 10
+            | EVAL host = host.name
+            | KEEP host*, description
+            | ENRICH _remote:hosts
+            """);
+        LogicalPlan plan = planWithPolicyOverride(query);
+
+        var proj1 = as(plan, Project.class);
+        var topn = as(proj1.child(), TopN.class);
+        assertFalse(topn.local());
+        Order topNOrder = topn.order().get(1);
+        NamedExpression expr = as(topNOrder.child(), NamedExpression.class);
+        assertThat(expr.name(), startsWith("$$order_by$1$0"));
+        var enrich = as(topn.child(), Enrich.class);
+        assertThat(enrich.mode(), is(Enrich.Mode.REMOTE));
+        var innerTopN = as(enrich.child(), TopN.class);
+        assertTrue(innerTopN.local());
+    }
+
+    public void testFilterLimitThenEnrich() {
+        // Hoisting does not happen, so the verifier fails since TopN is before remote ENRICH
+        failPlan("""
+            from test
+            | EVAL id = emp_no
+            | SORT emp_no
+            | LIMIT 10
+            | WHERE first_name != "john"
+            | ENRICH _remote:languages_remote
+            """, "ENRICH with remote policy can't be executed after [SORT emp_no]");
+    }
+
+    public void testMvExpandLimitThenEnrich() {
+        failPlan("""
+            from test
+            | EVAL id = emp_no
+            | SORT emp_no
+            | LIMIT 10
+            | MV_EXPAND languages
+            | ENRICH _remote:languages_remote
+            """, "MV_EXPAND after LIMIT is incompatible with remote ENRICH");
+    }
+
+    public void testTwoSortsWithinRemoteEnrich() {
+        failPlan("""
+            from test
+            | EVAL id = emp_no
+            | SORT emp_no
+            | LIMIT 10
+            | SORT id
+            | LIMIT 5
+            | ENRICH _remote:languages_remote
+            """, "ENRICH with remote policy can't be executed after [SORT emp_no]");
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineLimitsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownAndCombineLimitsTests.java
@@ -16,17 +16,23 @@ import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.expression.Order;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToInteger;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
+import org.elasticsearch.xpack.esql.plan.logical.Enrich;
 import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.Filter;
 import org.elasticsearch.xpack.esql.plan.logical.Limit;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.plan.logical.MvExpand;
 import org.elasticsearch.xpack.esql.plan.logical.OrderBy;
 import org.elasticsearch.xpack.esql.plan.logical.UnaryPlan;
 import org.elasticsearch.xpack.esql.plan.logical.inference.Completion;
 import org.elasticsearch.xpack.esql.plan.logical.inference.Rerank;
+import org.elasticsearch.xpack.esql.plan.logical.join.Join;
+import org.elasticsearch.xpack.esql.plan.logical.join.JoinConfig;
+import org.elasticsearch.xpack.esql.plan.logical.join.JoinTypes;
 
 import java.util.List;
+import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 
@@ -42,7 +48,7 @@ import static org.elasticsearch.xpack.esql.optimizer.LocalLogicalPlanOptimizerTe
 
 public class PushDownAndCombineLimitsTests extends ESTestCase {
 
-    private static class PushDownLimitTestCase<PlanType extends UnaryPlan> {
+    private static class PushDownLimitTestCase<PlanType extends LogicalPlan> {
         private final Class<PlanType> clazz;
         private final BiFunction<LogicalPlan, Attribute, PlanType> planBuilder;
         private final BiConsumer<PlanType, PlanType> planChecker;
@@ -101,6 +107,25 @@ public class PushDownAndCombineLimitsTests extends ESTestCase {
                 assertEquals(basePlan.queryText(), optimizedPlan.queryText());
                 assertEquals(basePlan.rerankFields(), optimizedPlan.rerankFields());
                 assertEquals(basePlan.scoreAttribute(), optimizedPlan.scoreAttribute());
+            }
+        ),
+        new PushDownLimitTestCase<>(
+            Enrich.class,
+            (plan, attr) -> new Enrich(
+                EMPTY,
+                plan,
+                randomFrom(Enrich.Mode.ANY, Enrich.Mode.COORDINATOR),
+                randomLiteral(KEYWORD),
+                attr,
+                null,
+                Map.of(),
+                List.of()
+            ),
+            (basePlan, optimizedPlan) -> {
+                assertEquals(basePlan.source(), optimizedPlan.source());
+                assertEquals(basePlan.mode(), optimizedPlan.mode());
+                assertEquals(basePlan.policyName(), optimizedPlan.policyName());
+                assertEquals(basePlan.matchField(), optimizedPlan.matchField());
             }
         )
     );
@@ -171,6 +196,58 @@ public class PushDownAndCombineLimitsTests extends ESTestCase {
                 )
             );
             assertEquals(as(optimizedPlan.child(), UnaryPlan.class).child(), nonPushableLimitTestPlan.child());
+        }
+    }
+
+    private static final List<PushDownLimitTestCase<? extends LogicalPlan>> DUPLICATING_TEST_CASES = List.of(
+        new PushDownLimitTestCase<>(
+            Enrich.class,
+            (plan, attr) -> new Enrich(EMPTY, plan, Enrich.Mode.REMOTE, randomLiteral(KEYWORD), attr, null, Map.of(), List.of()),
+            (basePlan, optimizedPlan) -> {
+                assertEquals(basePlan.source(), optimizedPlan.source());
+                assertEquals(basePlan.mode(), optimizedPlan.mode());
+                assertEquals(basePlan.policyName(), optimizedPlan.policyName());
+                assertEquals(basePlan.matchField(), optimizedPlan.matchField());
+                var limit = as(optimizedPlan.child(), Limit.class);
+                assertTrue(limit.local());
+                assertFalse(limit.duplicated());
+            }
+        ),
+        new PushDownLimitTestCase<>(MvExpand.class, (plan, attr) -> new MvExpand(EMPTY, plan, attr, attr), (basePlan, optimizedPlan) -> {
+            assertEquals(basePlan.source(), optimizedPlan.source());
+            assertEquals(basePlan.expanded(), optimizedPlan.expanded());
+            var limit = as(optimizedPlan.child(), Limit.class);
+            assertFalse(limit.local());
+            assertFalse(limit.duplicated());
+        }),
+        new PushDownLimitTestCase<>(
+            Join.class,
+            (plan, attr) -> new Join(EMPTY, plan, plan, new JoinConfig(JoinTypes.LEFT, List.of(), List.of(), attr)),
+            (basePlan, optimizedPlan) -> {
+                assertEquals(basePlan.source(), optimizedPlan.source());
+                var limit = as(optimizedPlan.left(), Limit.class);
+                assertFalse(limit.local());
+                assertFalse(limit.duplicated());
+            }
+        )
+
+    );
+
+    public void testPushableLimitDuplicate() {
+        FieldAttribute a = getFieldAttribute("a");
+        FieldAttribute b = getFieldAttribute("b");
+        EsRelation relation = relation().withAttributes(List.of(a, b));
+
+        for (PushDownLimitTestCase<? extends LogicalPlan> duplicatingTestCase : DUPLICATING_TEST_CASES) {
+            int precedingLimitValue = randomIntBetween(1, 10_000);
+            Limit precedingLimit = new Limit(EMPTY, new Literal(EMPTY, precedingLimitValue, INTEGER), relation);
+            LogicalPlan duplicatingLimitTestPlan = duplicatingTestCase.buildPlan(precedingLimit, a);
+            int upperLimitValue = randomIntBetween(1, precedingLimitValue);
+            Limit upperLimit = new Limit(EMPTY, new Literal(EMPTY, upperLimitValue, INTEGER), duplicatingLimitTestPlan);
+            Limit optimizedPlan = as(optimizePlan(upperLimit), Limit.class);
+            duplicatingTestCase.checkOptimizedPlan(duplicatingLimitTestPlan, optimizedPlan.child());
+            assertTrue(optimizedPlan.duplicated());
+            assertFalse(optimizedPlan.local());
         }
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Replace remote Enrich hack with proper handling of remote Enrich (#134967)](https://github.com/elastic/elasticsearch/pull/134967)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)