### PR TITLE
[8.19] Fixed geo point block loader slowness (#136147)

### DIFF
--- a/docs/changelog/136147.yaml
+++ b/docs/changelog/136147.yaml
@@ -1,0 +1,5 @@
+pr: 136147
+summary: Fixed geo point block loader slowness
+area: Mapping
+type: bug
+issues: []

--- a/server/src/test/java/org/elasticsearch/index/mapper/blockloader/GeoPointFieldBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/blockloader/GeoPointFieldBlockLoaderTests.java
@@ -41,19 +41,15 @@ public class GeoPointFieldBlockLoaderTests extends BlockLoaderTestCase {
             throw new IllegalStateException("Unexpected null_value format");
         }
 
-        if (params.preference() == MappedFieldType.FieldExtractPreference.DOC_VALUES && hasDocValues(fieldMapping, true)) {
-            if (values instanceof List<?> == false) {
-                var point = convert(values, nullValue, testContext.isMultifield());
-                return point != null ? point.getEncoded() : null;
+        // read from doc_values
+        boolean preferToLoadFromDocValues = params.preference() == MappedFieldType.FieldExtractPreference.DOC_VALUES;
+        boolean noPreference = params.preference() == MappedFieldType.FieldExtractPreference.NONE;
+        if (hasDocValues(fieldMapping, true)) {
+            if (preferToLoadFromDocValues) {
+                return longValues(values, nullValue, testContext.isMultifield());
+            } else if (noPreference && params.syntheticSource()) {
+                return bytesRefWkbValues(values, nullValue, testContext.isMultifield());
             }
-
-            var resultList = ((List<Object>) values).stream()
-                .map(v -> convert(v, nullValue, testContext.isMultifield()))
-                .filter(Objects::nonNull)
-                .map(GeoPoint::getEncoded)
-                .sorted()
-                .toList();
-            return maybeFoldList(resultList);
         }
 
         // stored source is used
@@ -79,21 +75,48 @@ public class GeoPointFieldBlockLoaderTests extends BlockLoaderTestCase {
 
         // synthetic source and doc_values are present
         if (hasDocValues(fieldMapping, true)) {
-            if (values instanceof List<?> == false) {
-                return toWKB(normalize(convert(values, nullValue, false)));
-            }
-
-            var resultList = ((List<Object>) values).stream()
-                .map(v -> convert(v, nullValue, false))
-                .filter(Objects::nonNull)
-                .sorted(Comparator.comparingLong(GeoPoint::getEncoded))
-                .map(p -> toWKB(normalize(p)))
-                .toList();
-            return maybeFoldList(resultList);
+            return bytesRefWkbValues(values, nullValue, false);
         }
 
-        // synthetic source but no doc_values so using fallback synthetic source
+        // synthetic source is enabled, but no doc_values are present, so fallback to ignored source
         return exactValuesFromSource(values, nullValue, false);
+    }
+
+    /**
+     * Use when values are stored as points encoded as longs.
+     */
+    @SuppressWarnings("unchecked")
+    private Object longValues(Object values, GeoPoint nullValue, boolean needsMultifieldAdjustment) {
+        if (values instanceof List<?> == false) {
+            var point = convert(values, nullValue, needsMultifieldAdjustment);
+            return point != null ? point.getEncoded() : null;
+        }
+
+        var resultList = ((List<Object>) values).stream()
+            .map(v -> convert(v, nullValue, needsMultifieldAdjustment))
+            .filter(Objects::nonNull)
+            .map(GeoPoint::getEncoded)
+            .sorted()
+            .toList();
+        return maybeFoldList(resultList);
+    }
+
+    /**
+     * Use when values are stored as WKB encoded points.
+     */
+    @SuppressWarnings("unchecked")
+    private Object bytesRefWkbValues(Object values, GeoPoint nullValue, boolean needsMultifieldAdjustment) {
+        if (values instanceof List<?> == false) {
+            return toWKB(normalize(convert(values, nullValue, needsMultifieldAdjustment)));
+        }
+
+        var resultList = ((List<Object>) values).stream()
+            .map(v -> convert(v, nullValue, needsMultifieldAdjustment))
+            .filter(Objects::nonNull)
+            .sorted(Comparator.comparingLong(GeoPoint::getEncoded))
+            .map(p -> toWKB(normalize(p)))
+            .toList();
+        return maybeFoldList(resultList);
     }
 
     @SuppressWarnings("unchecked")
@@ -155,6 +178,12 @@ public class GeoPointFieldBlockLoaderTests extends BlockLoaderTestCase {
         return point;
     }
 
+    /**
+     * Normalizes the given point by forcing it to be encoded and then decoded, similarly to how actual block loaders work when they read
+     * values. During encoding/decoding, some precision may be lost, so the lat/lon coordinates may change. Without this, the point returned
+     * by the block loader will be ever so slightly different from the original point. This will cause the tests to fail. This method
+     * exists to essentially mimic what happens to the point when it gets stored and then later loaded back.
+     */
     private GeoPoint normalize(GeoPoint point) {
         if (point == null) {
             return null;
@@ -169,4 +198,5 @@ public class GeoPointFieldBlockLoaderTests extends BlockLoaderTestCase {
 
         return new BytesRef(WellKnownBinary.toWKB(new Point(point.getX(), point.getY()), ByteOrder.LITTLE_ENDIAN));
     }
+
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fixed geo point block loader slowness (#136147)](https://github.com/elastic/elasticsearch/pull/136147)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)