### PR TITLE
Fix reroute to target for logsdb and tsid routing

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexRouting.java
@@ -363,10 +363,9 @@ public abstract class IndexRouting {
                 if (routing == null) {
                     throw new IllegalStateException("Routing should be set by the coordinator");
                 }
-                return indexShard(indexRequest);
+                return hashToShardId(TimeSeriesRoutingHashFieldMapper.decode(indexRequest.routing()));
             } else if (addIdWithRoutingHash) {
-                // TODO: is this correct?
-                return hashToShardId(effectiveRoutingToHash(indexRequest.id()));
+                return hashToShardId(idToHash(indexRequest.id()));
             } else {
                 checkNoRouting(indexRequest.routing());
                 return indexShard(indexRequest);


### PR DESCRIPTION
These two features need tweaks in order to reroute correctly when they
are enabled. This commit fixes the routing calculation and adds unit
tests to ensure the documents end up in the correct place.