### PR TITLE
[9.2] Start readiness service after http is started (#136729)

### DIFF
--- a/docs/changelog/136729.yaml
+++ b/docs/changelog/136729.yaml
@@ -1,0 +1,5 @@
+pr: 136729
+summary: Start readiness service after http is started
+area: Infra/Node Lifecycle
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -277,9 +277,6 @@ public class Node implements Closeable {
         logger.info("starting ...");
         pluginLifecycleComponents.forEach(LifecycleComponent::start);
 
-        if (ReadinessService.enabled(environment)) {
-            injector.getInstance(ReadinessService.class).start();
-        }
         injector.getInstance(MappingUpdatedAction.class).setClient(client);
         injector.getInstance(IndicesService.class).start();
         injector.getInstance(IndicesClusterStateService.class).start();
@@ -408,6 +405,9 @@ public class Node implements Closeable {
         }
 
         injector.getInstance(HttpServerTransport.class).start();
+        if (ReadinessService.enabled(environment)) {
+            injector.getInstance(ReadinessService.class).start();
+        }
 
         if (WRITE_PORTS_FILE_SETTING.get(settings())) {
             TransportService transport = injector.getInstance(TransportService.class);


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Start readiness service after http is started (#136729)