### PR TITLE
[9.2] Handle indices with zero/missing uptime correctly in write-load calculation (#136929)

### DIFF
--- a/docs/changelog/136929.yaml
+++ b/docs/changelog/136929.yaml
@@ -1,0 +1,5 @@
+pr: 136929
+summary: Handle indices with zero/missing uptime correctly in write-load calculation
+area: Allocation
+type: bug
+issues: []

--- a/x-pack/plugin/write-load-forecaster/src/main/java/org/elasticsearch/xpack/writeloadforecaster/LicensedWriteLoadForecaster.java
+++ b/x-pack/plugin/write-load-forecaster/src/main/java/org/elasticsearch/xpack/writeloadforecaster/LicensedWriteLoadForecaster.java
@@ -160,6 +160,10 @@ class LicensedWriteLoadForecaster implements WriteLoadForecaster {
                     maxShardUptimeInMillis = Math.max(maxShardUptimeInMillis, shardUptimeInMillis);
                 }
             }
+            // An index only contributes to the weighted average proportionally to its uptime
+            if (totalShardUptimeInMillis == 0) {
+                continue;
+            }
             double weightedAverageShardWriteLoad = totalShardWriteLoad / totalShardUptimeInMillis;
             double totalIndexWriteLoad = weightedAverageShardWriteLoad * writeLoad.numberOfShards();
             // We need to weight the contribution from each index somehow, but we only know
@@ -171,6 +175,8 @@ class LicensedWriteLoadForecaster implements WriteLoadForecaster {
             // that index. It should be safe to extrapolate our weighted average out to the
             // maximum uptime observed, based on the assumption that write-load is roughly
             // evenly distributed across shards of a datastream index.
+            assert Double.isFinite(totalIndexWriteLoad) : "Invalid total index write load: " + totalIndexWriteLoad;
+            assert maxShardUptimeInMillis > 0 : "Invalid max shard uptime in millis: " + maxShardUptimeInMillis;
             allIndicesWriteLoad += totalIndexWriteLoad * maxShardUptimeInMillis;
             allIndicesUptime += maxShardUptimeInMillis;
         }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Handle indices with zero/missing uptime correctly in write-load calculation (#136929)](https://github.com/elastic/elasticsearch/pull/136929)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)