### PR TITLE
[ES|QL] Adding precondition for planning tests including score

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -567,12 +567,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.FieldExtractorIT
   method: testTextFieldWithKeywordSubfield {STORED}
   issue: https://github.com/elastic/elasticsearch/issues/136918
-- class: org.elasticsearch.xpack.esql.optimizer.LogicalPlanOptimizerTests
-  method: testEvalWithScoreExplicitLimit
-  issue: https://github.com/elastic/elasticsearch/issues/136920
-- class: org.elasticsearch.xpack.esql.optimizer.LogicalPlanOptimizerTests
-  method: testEvalWithScoreImplicitLimit
-  issue: https://github.com/elastic/elasticsearch/issues/136921
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=ml/sparse_vector_search/Test sparse_vector search with query vector and pruning config}
   issue: https://github.com/elastic/elasticsearch/issues/136061

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -211,6 +211,10 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
     private static final LiteralsOnTheRight LITERALS_ON_THE_RIGHT = new LiteralsOnTheRight();
 
     public void testEvalWithScoreImplicitLimit() {
+        assumeTrue(
+            "[SCORE] function is only available in snapshot builds",
+            Build.current().isSnapshot() || false == EsqlFunctionRegistry.isSnapshotOnly(Score.NAME)
+        );
         var plan = plan("""
             FROM test
             | EVAL s = SCORE(MATCH(last_name, "high"))
@@ -224,6 +228,10 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
     }
 
     public void testEvalWithScoreExplicitLimit() {
+        assumeTrue(
+            "[SCORE] function is only available in snapshot builds",
+            Build.current().isSnapshot() || false == EsqlFunctionRegistry.isSnapshotOnly(Score.NAME)
+        );
         var plan = plan("""
             FROM test
             | EVAL s = SCORE(MATCH(last_name, "high"))

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -211,10 +211,8 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
     private static final LiteralsOnTheRight LITERALS_ON_THE_RIGHT = new LiteralsOnTheRight();
 
     public void testEvalWithScoreImplicitLimit() {
-        assumeTrue(
-            "[SCORE] function is only available in snapshot builds",
-            Build.current().isSnapshot() || false == EsqlFunctionRegistry.isSnapshotOnly(Score.NAME)
-        );
+        assumeTrue("[SCORE] function is only available in snapshot builds", EsqlCapabilities.Cap.SCORE_FUNCTION.isEnabled());
+
         var plan = plan("""
             FROM test
             | EVAL s = SCORE(MATCH(last_name, "high"))
@@ -228,10 +226,8 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
     }
 
     public void testEvalWithScoreExplicitLimit() {
-        assumeTrue(
-            "[SCORE] function is only available in snapshot builds",
-            Build.current().isSnapshot() || false == EsqlFunctionRegistry.isSnapshotOnly(Score.NAME)
-        );
+        assumeTrue("[SCORE] function is only available in snapshot builds", EsqlCapabilities.Cap.SCORE_FUNCTION.isEnabled());
+
         var plan = plan("""
             FROM test
             | EVAL s = SCORE(MATCH(last_name, "high"))

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
@@ -670,9 +670,13 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
      *              [[QueryBuilderAndTags{queryBuilder=[null], tags=[]}]]
     */
     public void testEvalWithScoreImplicitLimit() {
+        assumeTrue(
+            "[SCORE] function is only available in snapshot builds",
+            Build.current().isSnapshot() || false == EsqlFunctionRegistry.isSnapshotOnly(Score.NAME)
+        );
         var plan = physicalPlan("""
-            from test
-            | eval s = score(match(first_name, "foo"))
+            FROM test
+            | EVAL s = SCORE(MATCH(first_name, "foo"))
             """);
 
         var optimized = optimizedPlan(plan);
@@ -702,10 +706,14 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
      *              [[QueryBuilderAndTags{queryBuilder=[null], tags=[]}]]
      */
     public void testEvalWithScoreExplicitLimit() {
+        assumeTrue(
+            "[SCORE] function is only available in snapshot builds",
+            Build.current().isSnapshot() || false == EsqlFunctionRegistry.isSnapshotOnly(Score.NAME)
+        );
         var plan = physicalPlan("""
-            from test
-            | eval s = score(match(first_name, "foo"))
-            | limit 42
+            FROM test
+            | EVAL s = SCORE(MATCH(first_name, "foo"))
+            | LIMIT 42
             """);
 
         var optimized = optimizedPlan(plan);
@@ -743,6 +751,10 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
      * }], tags=[]}]]
      **/
     public void testEvalWithScoreAndFilterOnEval() {
+        assumeTrue(
+            "[SCORE] function is only available in snapshot builds",
+            Build.current().isSnapshot() || false == EsqlFunctionRegistry.isSnapshotOnly(Score.NAME)
+        );
         var plan = physicalPlan("""
             FROM test
             | EVAL s = SCORE(MATCH(first_name, "foo"))
@@ -796,6 +808,10 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
      * }], tags=[]}]]
      **/
     public void testEvalWithScoreAndGenericFilter() {
+        assumeTrue(
+            "[SCORE] function is only available in snapshot builds",
+            Build.current().isSnapshot() || false == EsqlFunctionRegistry.isSnapshotOnly(Score.NAME)
+        );
         var plan = physicalPlan("""
             FROM test
             | EVAL s = SCORE(MATCH(first_name, "foo"))
@@ -847,6 +863,10 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
      * }], tags=[]}]]
      */
     public void testEvalWithScoreForTopN() {
+        assumeTrue(
+            "[SCORE] function is only available in snapshot builds",
+            Build.current().isSnapshot() || false == EsqlFunctionRegistry.isSnapshotOnly(Score.NAME)
+        );
         var plan = physicalPlan("""
             FROM test
             | EVAL s = SCORE(MATCH(first_name, "foo"))

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
@@ -670,10 +670,8 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
      *              [[QueryBuilderAndTags{queryBuilder=[null], tags=[]}]]
     */
     public void testEvalWithScoreImplicitLimit() {
-        assumeTrue(
-            "[SCORE] function is only available in snapshot builds",
-            Build.current().isSnapshot() || false == EsqlFunctionRegistry.isSnapshotOnly(Score.NAME)
-        );
+        assumeTrue("[SCORE] function is only available in snapshot builds", EsqlCapabilities.Cap.SCORE_FUNCTION.isEnabled());
+
         var plan = physicalPlan("""
             FROM test
             | EVAL s = SCORE(MATCH(first_name, "foo"))
@@ -706,10 +704,8 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
      *              [[QueryBuilderAndTags{queryBuilder=[null], tags=[]}]]
      */
     public void testEvalWithScoreExplicitLimit() {
-        assumeTrue(
-            "[SCORE] function is only available in snapshot builds",
-            Build.current().isSnapshot() || false == EsqlFunctionRegistry.isSnapshotOnly(Score.NAME)
-        );
+        assumeTrue("[SCORE] function is only available in snapshot builds", EsqlCapabilities.Cap.SCORE_FUNCTION.isEnabled());
+
         var plan = physicalPlan("""
             FROM test
             | EVAL s = SCORE(MATCH(first_name, "foo"))
@@ -751,10 +747,8 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
      * }], tags=[]}]]
      **/
     public void testEvalWithScoreAndFilterOnEval() {
-        assumeTrue(
-            "[SCORE] function is only available in snapshot builds",
-            Build.current().isSnapshot() || false == EsqlFunctionRegistry.isSnapshotOnly(Score.NAME)
-        );
+        assumeTrue("[SCORE] function is only available in snapshot builds", EsqlCapabilities.Cap.SCORE_FUNCTION.isEnabled());
+
         var plan = physicalPlan("""
             FROM test
             | EVAL s = SCORE(MATCH(first_name, "foo"))
@@ -808,10 +802,8 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
      * }], tags=[]}]]
      **/
     public void testEvalWithScoreAndGenericFilter() {
-        assumeTrue(
-            "[SCORE] function is only available in snapshot builds",
-            Build.current().isSnapshot() || false == EsqlFunctionRegistry.isSnapshotOnly(Score.NAME)
-        );
+        assumeTrue("[SCORE] function is only available in snapshot builds", EsqlCapabilities.Cap.SCORE_FUNCTION.isEnabled());
+
         var plan = physicalPlan("""
             FROM test
             | EVAL s = SCORE(MATCH(first_name, "foo"))
@@ -863,10 +855,8 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
      * }], tags=[]}]]
      */
     public void testEvalWithScoreForTopN() {
-        assumeTrue(
-            "[SCORE] function is only available in snapshot builds",
-            Build.current().isSnapshot() || false == EsqlFunctionRegistry.isSnapshotOnly(Score.NAME)
-        );
+        assumeTrue("[SCORE] function is only available in snapshot builds", EsqlCapabilities.Cap.SCORE_FUNCTION.isEnabled());
+
         var plan = physicalPlan("""
             FROM test
             | EVAL s = SCORE(MATCH(first_name, "foo"))


### PR DESCRIPTION
Adding precondition for tests including `SCORE` to exclude non-snapshot builds, as the function is under `SNAPSHOT` atm. 

Closes https://github.com/elastic/elasticsearch/issues/136920 and https://github.com/elastic/elasticsearch/issues/136921