### PR TITLE
Fix duplicate entry in Elasticsearch reference TOC

### DIFF
--- a/docs/reference/elasticsearch/toc.yml
+++ b/docs/reference/elasticsearch/toc.yml
@@ -64,7 +64,6 @@ toc:
         - file: index-settings/path.md
   - file: index-lifecycle-actions/index.md
     children:
-        - file: index-lifecycle-actions/index.md
         - file: index-lifecycle-actions/ilm-allocate.md
         - file: index-lifecycle-actions/ilm-delete.md
         - file: index-lifecycle-actions/ilm-forcemerge.md


### PR DESCRIPTION
Removed duplicate entry for index-lifecycle-actions/index.md in the table of contents.

cc @colleenmcginnis
