### PR TITLE
Revert "allowCrossProject for _search"

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -163,11 +163,6 @@ public class SearchRequest extends LegacyActionRequest implements IndicesRequest
         return true;
     }
 
-    @Override
-    public boolean allowsCrossProject() {
-        return true;
-    }
-
     /**
      * Creates a new sub-search request starting from the original search request that is provided.
      * For internal use only, allows to fork a search request into multiple search requests that will be executed independently.


### PR DESCRIPTION
Was set in place for a demo, reverting for the time being
Reverts elastic/elasticsearch#136397