### PR TITLE
ESQL: Support `StubRelation` with empty output in `PropagateEmptyRelation`

### DIFF
--- a/docs/changelog/136959.yaml
+++ b/docs/changelog/136959.yaml
@@ -1,0 +1,6 @@
+pr: 136959
+summary: "ESQL: Support `StubRelation` with empty output in `PropagateEmptyRelation`"
+area: ES|QL
+type: bug
+issues:
+  - 136851

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
@@ -70,7 +70,6 @@ public abstract class GenerativeRestTest extends ESRestTestCase implements Query
         "cannot be cast to class", // https://github.com/elastic/elasticsearch/issues/133992
         "can't find input for", // https://github.com/elastic/elasticsearch/issues/136596
         "unexpected byte", // https://github.com/elastic/elasticsearch/issues/136598
-        "Rule execution limit", // https://github.com/elastic/elasticsearch/issues/136599
         "Output has changed from", // https://github.com/elastic/elasticsearch/issues/136797
         "out of bounds for length", // https://github.com/elastic/elasticsearch/issues/136851
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/inlinestats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/inlinestats.csv-spec
@@ -4166,3 +4166,39 @@ from employees
 c:long
 1
 ;
+
+
+// https://github.com/elastic/elasticsearch/issues/136851
+propagateEmptyStubRelation
+required_capability: fix_propagate_empty_stub_relation
+required_capability: fork_v9
+
+from countries_bbox_web 
+| limit 307 
+| drop `id` 
+| drop name 
+| inline stats  `shape` = count(*), UKmoYKgHt = count(*), jEHxaMcLul = count(*), VRjIowfF = count(*) 
+| drop UKmoYKgHt, UKmoYKgH*, shape 
+| FORK  (where  NOT true) (where  NOT false) (where  NOT VRjIowfF >= 50) (where jEHxaMcLul > 50 AND true | where  NOT false AND jEHxaMcLul == 50  | where false OR false OR  NOT false AND  NOT false) (where false AND  NOT false) 
+| WHERE _fork == "fork3" 
+| DROP _fork 
+| stats  oYhFLywK = avg(VRjIowfF) + count(VRjIowfF) + max(VRjIowfF), sygFReMcRSnf = count(*), WmxejCVu = count(*), REnkUKYklmVO = absent(VRjIowfF + VRjIowfF)
+;
+
+oYhFLywK:double | sygFReMcRSnf:long | WmxejCVu:long | REnkUKYklmVO:boolean
+248.0           | 248               | 248           | false
+;
+
+
+propagateEmptyStubRelation2
+required_capability: fix_propagate_empty_stub_relation
+
+ROW a = 12 
+| drop a 
+| inline stats b = count(*)
+;
+
+b:long
+0
+;
+

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1542,6 +1542,11 @@ public class EsqlCapabilities {
          */
         ATTRIBUTE_EQUALS_RESPECTS_NAME_ID,
 
+        /**
+         * Support for PropagateEmptyRelation with StubRelation when output is empty
+         */
+        FIX_PROPAGATE_EMPTY_STUB_RELATION(INLINESTATS_V11.enabled),
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateEmptyRelation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateEmptyRelation.java
@@ -22,6 +22,7 @@ import org.elasticsearch.xpack.esql.optimizer.rules.logical.local.LocalPropagate
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.UnaryPlan;
+import org.elasticsearch.xpack.esql.plan.logical.join.StubRelation;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalSupplier;
 import org.elasticsearch.xpack.esql.planner.PlannerUtils;
@@ -41,7 +42,8 @@ public class PropagateEmptyRelation extends OptimizerRules.ParameterizedOptimize
     @Override
     protected LogicalPlan rule(UnaryPlan plan, LogicalOptimizerContext ctx) {
         LogicalPlan p = plan;
-        if (plan.child() instanceof LocalRelation local && local.hasEmptySupplier()) {
+        if (plan.child() instanceof LocalRelation local && local.hasEmptySupplier()
+            || plan.child() instanceof StubRelation stub && stub.output().isEmpty()) {
             // only care about non-grouped aggs might return something (count)
             if (plan instanceof Aggregate agg && agg.groupings().isEmpty()) {
                 List<Block> emptyBlocks = aggsFromEmpty(ctx.foldCtx(), agg.aggregates());


### PR DESCRIPTION
This PR extends the `PropagateEmptyRelation` optimizer rule to handle `StubRelation` nodes with empty output, in addition to the existing `LocalRelation` support. 

Previously, when using `INLINE STATS` after dropping all fields (such as `ROW a = 12 | drop a | inline stats b = count(*)`), the optimizer would create a `StubRelation` with empty output but fail to properly optimize aggregations over it. The `PropagateEmptyRelation` rule now checks for both `LocalRelation` with empty supplier and `StubRelation` with empty output, allowing correct optimization of aggregations in these scenarios. 

Closes #136851