### PR TITLE
otel-data: change timestamp to date_nanos

### DIFF
--- a/x-pack/plugin/otel-data/src/main/resources/component-templates/metrics-otel@mappings.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/component-templates/metrics-otel@mappings.yaml
@@ -8,6 +8,10 @@ template:
     index.mapping.total_fields.limit: 10000
   mappings:
     properties:
+      # In general, we use date_nanos in OTel, but for metrics, the very high frequency
+      # could destroy the high efficiency of the delta of delta encoding resulting in increased storage.
+      "@timestamp":
+        type: date
       start_timestamp:
         type: date
       metrics:

--- a/x-pack/plugin/otel-data/src/main/resources/component-templates/otel@mappings.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/component-templates/otel@mappings.yaml
@@ -9,8 +9,7 @@ template:
     dynamic: false
     properties:
       "@timestamp":
-#Ultimeately we aim to use date_nanos. Waiting for https://github.com/elastic/elasticsearch/issues/109352
-        type: date
+        type: date_nanos
       data_stream.type:
         type: constant_keyword
       data_stream.dataset:

--- a/x-pack/plugin/otel-data/src/yamlRestTest/resources/rest-api-spec/test/20_logs_tests.yml
+++ b/x-pack/plugin/otel-data/src/yamlRestTest/resources/rest-api-spec/test/20_logs_tests.yml
@@ -228,3 +228,21 @@ host.name pass-through:
   - match: { hits.hits.0.fields.kubernetes\.node\.uid : ["myNodeUid"] }
   - match: { hits.hits.0.fields.kubernetes\.node\.hostname : ["myNodeHostname"] }
   - match: { hits.hits.0.fields.orchestrator\.cluster\.name : ["myClusterName"] }
+---
+"@timestamp field should have type date_nanos":
+  - do:
+      bulk:
+        index: logs-generic.otel-default
+        refresh: true
+        body:
+          - create: {}
+          - '{"@timestamp":"2024-10-22T12:00:00.123456789Z","data_stream":{"dataset":"generic.otel","namespace":"default"},"body":{"text":"test log message"}}'
+  - is_false: errors
+  - do:
+      indices.get_data_stream:
+        name: logs-generic.otel-default
+  - set: { data_streams.0.indices.0.index_name: timestamp_index }
+  - do:
+      indices.get_mapping:
+        index: $timestamp_index
+  - match: { .$timestamp_index.mappings.properties.@timestamp.type: "date_nanos" }

--- a/x-pack/plugin/otel-data/src/yamlRestTest/resources/rest-api-spec/test/20_metrics_tests.yml
+++ b/x-pack/plugin/otel-data/src/yamlRestTest/resources/rest-api-spec/test/20_metrics_tests.yml
@@ -375,3 +375,21 @@ data stream settings ilm:
             number_of_shards: 2
   - match: { data_streams.0.name: metrics-generic.otel-default }
   - match: { data_streams.0.applied_to_data_stream: true }
+---
+"@timestamp field should have type date (and not date_nanos as other signals)":
+  - do:
+      bulk:
+        index: metrics-generic.otel-default
+        refresh: true
+        body:
+          - create: {}
+          - '{"@timestamp":"2024-07-18T14:48:33.467654000Z","attributes":{"processor.pid": 17}}'
+  - is_false: errors
+  - do:
+      indices.get_data_stream:
+        name: metrics-generic.otel-default
+  - set: { data_streams.0.indices.0.index_name: timestamp_index }
+  - do:
+      indices.get_mapping:
+        index: $timestamp_index
+  - match: { .$timestamp_index.mappings.properties.@timestamp.type: "date" }

--- a/x-pack/plugin/otel-data/src/yamlRestTest/resources/rest-api-spec/test/20_traces_tests.yml
+++ b/x-pack/plugin/otel-data/src/yamlRestTest/resources/rest-api-spec/test/20_traces_tests.yml
@@ -158,3 +158,21 @@ traces@lifecycle:
       indices.get_mapping:
         index: $idx0name
   - match: { .$idx0name.mappings.properties.attributes.properties.elastic\.profiler_stack_trace_ids.type: 'counted_keyword' }
+---
+"@timestamp field should have type date_nanos":
+  - do:
+      bulk:
+        index: traces-generic.otel-default
+        refresh: true
+        body:
+          - create: {}
+          - '{"@timestamp":"2024-10-22T12:00:00.123456789Z","data_stream":{"dataset":"generic.otel","namespace":"default"},"span_id":"1"}'
+  - is_false: errors
+  - do:
+      indices.get_data_stream:
+        name: traces-generic.otel-default
+  - set: { data_streams.0.indices.0.index_name: timestamp_index }
+  - do:
+      indices.get_mapping:
+        index: $timestamp_index
+  - match: { .$timestamp_index.mappings.properties.@timestamp.type: "date_nanos" }


### PR DESCRIPTION
Prior to this PR, in the otel mappings we used `date` data type for `@timestamp`. The main reason we went with that was that at the time there was no ES|QL support for date_nanos. This is now unblocked, so this PR moves to `date_nanos`.

This will also better match the [OTel spec](https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-timestamp)


For metrics, we keep it as `date` for better storage efficiency.