### PR TITLE
[9.1] Fix ignore_unmapped setting when using geo_shape query with a pre-indexed shape (#136961)

### DIFF
--- a/docs/changelog/136961.yaml
+++ b/docs/changelog/136961.yaml
@@ -1,0 +1,7 @@
+pr: 136961
+summary: Fix `ignore_unmapped` setting when using `geo_shape` query with a pre-indexed
+  shape
+area: Geo
+type: bug
+issues:
+ - 136954

--- a/test/framework/src/main/java/org/elasticsearch/search/geo/GeoShapeQueryBuilderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/geo/GeoShapeQueryBuilderTestCase.java
@@ -169,7 +169,9 @@ public abstract class GeoShapeQueryBuilderTestCase extends AbstractQueryTestCase
         );
         assertEquals("query must be rewritten first", e.getMessage());
         QueryBuilder rewrite = rewriteAndFetch(query, createSearchExecutionContext());
-        GeoShapeQueryBuilder geoShapeQueryBuilder = new GeoShapeQueryBuilder(query.fieldName(), indexedShapeToReturn);
+        GeoShapeQueryBuilder geoShapeQueryBuilder = new GeoShapeQueryBuilder(query.fieldName(), indexedShapeToReturn).ignoreUnmapped(
+            query.ignoreUnmapped()
+        );
         geoShapeQueryBuilder.strategy(query.strategy());
         geoShapeQueryBuilder.relation(query.relation());
         assertEquals(geoShapeQueryBuilder, rewrite);
@@ -180,7 +182,9 @@ public abstract class GeoShapeQueryBuilderTestCase extends AbstractQueryTestCase
         QueryBuilder builder = new BoolQueryBuilder().should(shape).should(shape);
 
         builder = rewriteAndFetch(builder, createSearchExecutionContext());
-        GeoShapeQueryBuilder expectedShape = new GeoShapeQueryBuilder(shape.fieldName(), indexedShapeToReturn);
+        GeoShapeQueryBuilder expectedShape = new GeoShapeQueryBuilder(shape.fieldName(), indexedShapeToReturn).ignoreUnmapped(
+            shape.ignoreUnmapped()
+        );
         expectedShape.strategy(shape.strategy());
         expectedShape.relation(shape.relation());
         QueryBuilder expected = new BoolQueryBuilder().should(expectedShape).should(expectedShape);

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryBuilderTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryBuilderTests.java
@@ -182,7 +182,9 @@ public abstract class ShapeQueryBuilderTests extends AbstractQueryTestCase<Shape
         );
         assertEquals("query must be rewritten first", e.getMessage());
         QueryBuilder rewrite = rewriteAndFetch(query, createSearchExecutionContext());
-        ShapeQueryBuilder geoShapeQueryBuilder = new ShapeQueryBuilder(fieldName(), indexedShapeToReturn);
+        ShapeQueryBuilder geoShapeQueryBuilder = new ShapeQueryBuilder(fieldName(), indexedShapeToReturn).ignoreUnmapped(
+            query.ignoreUnmapped()
+        );
         geoShapeQueryBuilder.relation(query.relation());
         assertEquals(geoShapeQueryBuilder, rewrite);
     }
@@ -193,7 +195,7 @@ public abstract class ShapeQueryBuilderTests extends AbstractQueryTestCase<Shape
 
         builder = rewriteAndFetch(builder, createSearchExecutionContext());
 
-        ShapeQueryBuilder expectedShape = new ShapeQueryBuilder(fieldName(), indexedShapeToReturn);
+        ShapeQueryBuilder expectedShape = new ShapeQueryBuilder(fieldName(), indexedShapeToReturn).ignoreUnmapped(shape.ignoreUnmapped());
         expectedShape.relation(shape.relation());
         QueryBuilder expected = new BoolQueryBuilder().should(expectedShape).should(expectedShape);
         assertEquals(expected, builder);


### PR DESCRIPTION
Backports the following commits to 9.1:
 - Fix ignore_unmapped setting when using geo_shape query with a pre-indexed shape (#136961)