### PR TITLE
fix for ignoring recording status of spans

### DIFF
--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/tracing/APMTracer.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/tracing/APMTracer.java
@@ -189,6 +189,17 @@ public class APMTracer extends AbstractLifecycleComponent implements org.elastic
                 spanBuilder.setStartTimestamp(startTime);
             }
             final Span span = spanBuilder.startSpan();
+            // If the agent decided not to record this span (e.g., due to transaction_max_spans), isRecording() will be false.
+            if (span.isRecording() == false) {
+                logger.warn("Elastic APM agent has reached the transaction_max_spans limit. Span [{}] [{}] will not be recorded.", spanId, spanName);
+                // It's good practice to end the no-op span immediately to release any resources.
+                span.end();
+                // Returning null from computeIfAbsent means no value will be inserted into the map.
+                return null;
+            }
+
+            // If we are here, the span is real and being recorded.
+            logger.trace("Successfully started tracing [{}] [{}]", spanId, spanName);
             final Context contextForNewSpan = Context.current().with(span);
 
             updateThreadContext(traceContext, services, contextForNewSpan);


### PR DESCRIPTION
1. APMTracer receives the parent task's trace context and sets that as the parent of a new span.
```
            final Context parentContext = getParentContext(traceContext);
                spanBuilder.setParent(parentContext);
```
2. APMTracer requests a new span, setting the start time to the same as the transaction start time
```
            Instant startTime = traceContext.getTransient(Task.TRACE_START_TIME);
                spanBuilder.setStartTimestamp(startTime);
            final Span span = spanBuilder.startSpan();
```
3. The span is created but is too many for the transaction because transaction_max_spans is exceeded for this span, so it is set as a non-recording span
4. APMTracer stores the Context containing the span in its spans map, ie this new span is now the next parent span so will be stored as the task's trace context
- this is incorrect because the span is a non-recording span, so should be discarded
- the result of the incorrect approach is that you can have a chain of descendent spans in a transaction which can be unlimited in size, and all with the same start time
