### PR TITLE
ESQL: Temporarily forbid LIMIT before INLINE STATS commands (#136752)

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/commands/layout/inlinestats-by.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/inlinestats-by.md
@@ -103,5 +103,5 @@ The following example shows how to filter which rows are used for each aggregati
 **Limitations**
 
 - The [`CATEGORIZE`](/reference/query-languages/esql/functions-operators/grouping-functions.md#esql-categorize) grouping function is not currently supported.
-- `INLINE STATS` cannot yet have an unbounded [`SORT`](/reference/query-languages/esql/commands/sort.md) before it.
-You must either move the SORT after it, or add a [`LIMIT`](/reference/query-languages/esql/commands/limit.md) before the [`SORT`](/reference/query-languages/esql/commands/sort.md).
+- You cannot currently use [`LIMIT`](/reference/query-languages/esql/commands/limit.md) (explicit or implicit) before `INLINE STATS`, because this can lead to unexpected results.
+- You cannot currently use [`FORK`](/reference/query-languages/esql/commands/fork.md) before `INLINE STATS`, because `FORK` adds an implicit [`LIMIT`](/reference/query-languages/esql/commands/limit.md) to each branch, which can lead to unexpected results.

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/tree/Node.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/tree/Node.java
@@ -37,7 +37,7 @@ import static java.util.Collections.emptyList;
  */
 public abstract class Node<T extends Node<T>> implements NamedWriteable {
     private static final int TO_STRING_MAX_PROP = 10;
-    private static final int TO_STRING_MAX_WIDTH = 110;
+    public static final int TO_STRING_MAX_WIDTH = 110;
 
     private final Source source;
     private final List<T> children;

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
@@ -58,6 +58,7 @@ public abstract class GenerativeRestTest extends ESRestTestCase implements Query
         "Unbounded SORT not supported yet",
         "The field names are too complex to process", // field_caps problem
         "must be \\[any type except counter types\\]", // TODO refine the generation of count()
+        "INLINE STATS cannot be used after an explicit or implicit LIMIT command",
 
         // Awaiting fixes for query failure
         "Unknown column \\[<all-fields-projected>\\]", // https://github.com/elastic/elasticsearch/issues/121741,

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/fork.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/fork.csv-spec
@@ -688,7 +688,8 @@ emp_no:integer | job_positions:keyword | _fork:keyword
 10087          | Junior Developer      | fork2
 ;
 
-forkBeforeInlineStats
+forkBeforeInlineStats-Ignore
+// temporarily forbid LIMIT before INLINE STATS
 required_capability: fork_v9
 required_capability: inline_stats
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/inlinestats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/inlinestats.csv-spec
@@ -345,7 +345,8 @@ emp_no:integer |avg_worked_seconds:long|avg_avg_worked_seconds:double|languages:
 10023          |330870342              |3.181719481E8                |null             |5                    |F
 ;
 
-three
+three-Ignore
+// temporarily forbid LIMIT before INLINE STATS
 required_capability: inline_stats
 
 FROM employees
@@ -369,6 +370,33 @@ emp_no:integer |avg_worked_seconds:long|avg_avg_worked_seconds:double|languages:
 10019          |342855721              |2.94833632E8                 |1                |5                    |1                     |5                     |null           
 10020          |373309605              |3.181719481E8                |null             |5                    |null                  |null                  |M              
 10023          |330870342              |3.181719481E8                |null             |5                    |3                     |5                     |F
+;
+
+threeTopNAtEnd
+required_capability: inline_stats
+// same as above but with the final INLINE STATS after before the LIMIT
+
+FROM employees
+| KEEP emp_no, languages, avg_worked_seconds, gender
+| INLINE STATS avg_avg_worked_seconds = AVG(avg_worked_seconds) BY languages
+| WHERE avg_worked_seconds > avg_avg_worked_seconds
+| INLINE STATS max_languages = MAX(languages) BY gender
+| INLINE STATS min(languages), max(languages) by gender
+| SORT emp_no ASC
+| LIMIT 10
+;
+
+emp_no:integer |avg_worked_seconds:long|avg_avg_worked_seconds:double|languages:integer|max_languages:integer|min(languages):integer|max(languages):integer|gender:keyword
+10002          |328922887              |3.133013149047619E8          |5                |5                    |1                     |5                     |F              
+10006          |372957040              |2.978159518235294E8          |3                |5                    |1                     |5                     |F              
+10007          |393084805              |2.863684210555556E8          |4                |5                    |1                     |5                     |F              
+10010          |315236372              |2.863684210555556E8          |4                |5                    |1                     |5                     |null           
+10012          |365510850              |3.133013149047619E8          |5                |5                    |1                     |5                     |null           
+10015          |390266432              |3.133013149047619E8          |5                |5                    |1                     |5                     |null           
+10018          |309604079              |3.0318626831578946E8         |2                |5                    |1                     |5                     |null           
+10019          |342855721              |2.94833632E8                 |1                |5                    |1                     |5                     |null           
+10020          |373309605              |3.181719481E8                |null             |5                    |1                     |5                     |M              
+10023          |330870342              |3.181719481E8                |null             |5                    |1                     |5                     |F
 ;
 
 // TODO: INLINE STATS unit test needed for this one
@@ -2567,7 +2595,8 @@ emp_no:integer | gender:keyword | languages:integer | greater_than:double | less
 10010          | null           | 4                 | 6.94921             | 7.12723          | 27921.22074   | 10
 ;
 
-twoConsecutiveInlinestatsWithFalseFilters
+twoConsecutiveInlinestatsWithFalseFilters-Ignore
+// temporarily forbid LIMIT before INLINE STATS
 required_capability: inline_stats
 from employees
 | keep emp_no
@@ -2582,6 +2611,25 @@ from employees
 10002          |0              |0              
 10003          |0              |0              
 ;
+
+twoConsecutiveInlinestatsWithFalseFilters_LimitAfterInlineStats
+// same as above but with LIMIT after INLINE STATS
+required_capability: inline_stats
+from employees
+| keep emp_no
+| inline stats count = count(*) where false
+| inline stats cc = count_distinct(emp_no) where false
+| sort emp_no
+| limit 3
+;
+
+    emp_no:i   |     count:l   |      cc:l       
+10001          |0              |0              
+10002          |0              |0              
+10003          |0              |0              
+;
+
+
 
 ////////////////////////////////
 // Union types tests
@@ -2946,7 +2994,8 @@ mc:l           | count:l       | event_duration:l
 6              |2              |3450233
 ;
 
-multiIndexIpStringInlinestats_Inline4
+multiIndexIpStringInlinestats_Inline4-Ignore
+// temporarily forbid LIMIT before INLINE STATS 
 required_capability: inline_stats
 
 FROM sample_data, sample_data_str
@@ -2965,6 +3014,26 @@ mc:l           | count:l       | event_duration:l
 5              |2              |2764889        
 5              |2              |3450233        
 5              |2              |3450233        
+;
+
+multiIndexIpStringInlinestats_Inline4_LimitAfterInlineStats
+// same as above but with LIMIT after INLINE STATS 
+required_capability: inline_stats
+
+FROM sample_data, sample_data_str
+| INLINE STATS count=count(*) BY client_ip::ip
+| INLINE STATS mc=count(count) BY count
+| SORT mc DESC, count ASC, event_duration
+| LIMIT 5
+| KEEP mc, count, event_duration
+;
+
+mc:l           | count:l       | event_duration:l 
+8              |8              |725448         
+8              |8              |725448         
+8              |8              |1756467        
+8              |8              |1756467        
+8              |8              |5033755        
 ;
 
 multiIndexWhereIpStringInlinestats 
@@ -4105,14 +4174,35 @@ null             | null                            | null            | null     
 ;
 
 
-inlineStatsAfterPruningAggregate8
+inlineStatsAfterPruningAggregate8-Ignore
 // https://github.com/elastic/elasticsearch/issues/135679
+// temporarily forbid LIMIT before INLINE STATS
 required_capability: inline_stats_double_release_fix
 
 from dense_vector,airport_city_boundaries
 | eval  kMvNZVQSH = -4048759096317256968, GzAYNHaHuIS = 4262770411405329967, EwPpQFmOPoB = "lkdgnbTrBT", `abbrev` = "LiXI" 
 | keep `city`, `kMvNZVQSH`, GzAYNHaHuIS, city_boundary, EwPpQFmOPoB, `city_boundary`, `id`, kMvNZVQSH, id, airport 
 | limit 6888 
+| keep `kMvNZVQSH`, EwPpQFmOPoB, city, `id`, kMvNZVQSH 
+| stats  `EwPpQFmOPoB2` = min(id), `EwPpQFmOPoB3` = count(*), kZiJPhNZ = count(id), ErGhdKhdv = count_distinct(city), EwPpQFmOPoB = min(id) 
+| eval  ErGhdKhdv = null, fHSyxniFCS = -710891486, ErGhdKhdv = -1104488048, zdxdQdVIyFh = -1579062572, `kZiJPhNZ` = null, SzmOySyUh = null, eWVVRiwP = 1092261898855405071, nUxVhGhcpkiV = true, RvqGioBAAzYs = 169356242 
+| eval  `kZiJPhNZ` = "gWJHDTcDMjRVSnlzSX", lxLgaagX = 4700531997851493340, `kZiJPhNZ` = false 
+| keep `zdxdQdVIyFh` 
+| inline stats  `zdxdQdVIyFh` = count(*), WbWVJnYJ = count(*), zdxdQdVIyFh2 = max(zdxdQdVIyFh), uKjfeKTfaH = max(zdxdQdVIyFh), QpovVxjMWSjh = min(zdxdQdVIyFh)
+;
+
+zdxdQdVIyFh:long | WbWVJnYJ:long | zdxdQdVIyFh2:integer | uKjfeKTfaH:integer | QpovVxjMWSjh:integer
+1                | 1             | -1579062572          | -1579062572        | -1579062572
+;
+
+inlineStatsAfterPruningAggregate8_NoLimit
+// https://github.com/elastic/elasticsearch/issues/135679
+// same as above but without LIMIT before INLINE STATS
+required_capability: inline_stats_double_release_fix
+
+from dense_vector,airport_city_boundaries
+| eval  kMvNZVQSH = -4048759096317256968, GzAYNHaHuIS = 4262770411405329967, EwPpQFmOPoB = "lkdgnbTrBT", `abbrev` = "LiXI" 
+| keep `city`, `kMvNZVQSH`, GzAYNHaHuIS, city_boundary, EwPpQFmOPoB, `city_boundary`, `id`, kMvNZVQSH, id, airport 
 | keep `kMvNZVQSH`, EwPpQFmOPoB, city, `id`, kMvNZVQSH 
 | stats  `EwPpQFmOPoB2` = min(id), `EwPpQFmOPoB3` = count(*), kZiJPhNZ = count(id), ErGhdKhdv = count_distinct(city), EwPpQFmOPoB = min(id) 
 | eval  ErGhdKhdv = null, fHSyxniFCS = -710891486, ErGhdKhdv = -1104488048, zdxdQdVIyFh = -1579062572, `kZiJPhNZ` = null, SzmOySyUh = null, eWVVRiwP = 1092261898855405071, nUxVhGhcpkiV = true, RvqGioBAAzYs = 169356242 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1625,6 +1625,10 @@ public class EsqlCapabilities {
          */
         ATTRIBUTE_EQUALS_RESPECTS_NAME_ID,
 
+        /**
+         * Temporarily forbid the use of an explicit or implicit LIMIT before INLINE STATS.
+         */
+        FORBID_LIMIT_BEFORE_INLINE_STATS(INLINE_STATS.enabled),
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Verifier.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Verifier.java
@@ -22,6 +22,7 @@ import org.elasticsearch.xpack.esql.core.expression.predicate.BinaryOperator;
 import org.elasticsearch.xpack.esql.core.expression.predicate.operator.comparison.BinaryComparison;
 import org.elasticsearch.xpack.esql.core.tree.Node;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.util.Holder;
 import org.elasticsearch.xpack.esql.expression.function.UnsupportedAttribute;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Neg;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
@@ -29,7 +30,9 @@ import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Esq
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.NotEquals;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
+import org.elasticsearch.xpack.esql.plan.logical.InlineStats;
 import org.elasticsearch.xpack.esql.plan.logical.Insist;
+import org.elasticsearch.xpack.esql.plan.logical.Limit;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Lookup;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
@@ -108,6 +111,7 @@ public class Verifier {
             checkOperationsOnUnsignedLong(p, failures);
             checkBinaryComparison(p, failures);
             checkInsist(p, failures);
+            checkLimitBeforeInlineStats(p, failures);
         });
 
         if (failures.hasFailures() == false) {
@@ -252,6 +256,44 @@ public class Verifier {
             LogicalPlan child = i.child();
             if ((child instanceof EsRelation || child instanceof Insist) == false) {
                 failures.add(fail(i, "[insist] can only be used after [from] or [insist] commands, but was [{}]", child.sourceText()));
+            }
+        }
+    }
+
+    /*
+     * This is a rudimentary check to prevent INLINE STATS after LIMIT. A LIMIT command can be added by other commands by default,
+     * the best example being FORK. A more robust solution would be to track the commands that add LIMIT and prevent them from doing so
+     * if INLINE STATS is present in the plan. However, this would require authors of new such commands to be aware of this limitation and
+     * implement the necessary checks, which is error-prone.
+     */
+    private static void checkLimitBeforeInlineStats(LogicalPlan plan, Failures failures) {
+        if (plan instanceof InlineStats is) {
+            Holder<Limit> inlineStatsDescendantLimit = new Holder<>();
+            is.forEachDownMayReturnEarly((p, breakEarly) -> {
+                if (p instanceof Limit l) {
+                    inlineStatsDescendantLimit.set(l);
+                    breakEarly.set(true);
+                    return;
+                }
+            });
+
+            var firstLimit = inlineStatsDescendantLimit.get();
+            if (firstLimit != null) {
+                var isString = is.sourceText().length() > Node.TO_STRING_MAX_WIDTH
+                    ? is.sourceText().substring(0, Node.TO_STRING_MAX_WIDTH) + "..."
+                    : is.sourceText();
+                var limitString = firstLimit.sourceText().length() > Node.TO_STRING_MAX_WIDTH
+                    ? firstLimit.sourceText().substring(0, Node.TO_STRING_MAX_WIDTH) + "..."
+                    : firstLimit.sourceText();
+                failures.add(
+                    fail(
+                        is,
+                        "INLINE STATS cannot be used after an explicit or implicit LIMIT command, but was [{}] after [{}] [{}]",
+                        isString,
+                        limitString,
+                        firstLimit.source().source().toString()
+                    )
+                );
             }
         }
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -63,6 +63,7 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
 import static org.elasticsearch.xpack.esql.core.type.DataType.LONG;
 import static org.elasticsearch.xpack.esql.core.type.DataType.UNSIGNED_LONG;
 import static org.elasticsearch.xpack.esql.core.type.DataType.VERSION;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -2809,6 +2810,139 @@ public class VerifierTests extends ESTestCase {
         assertThat(error("TS test | INLINE STATS max(network.connections) | STATS max(network.connections) by host", tsdb), equalTo("""
             1:11: INLINE STATS [INLINE STATS max(network.connections)] \
             can only be used after STATS when used with TS command"""));
+    }
+
+    public void testLimitBeforeInlineStats_WithTS() {
+        assumeTrue("LIMIT before INLINE STATS limitation check", EsqlCapabilities.Cap.FORBID_LIMIT_BEFORE_INLINE_STATS.isEnabled());
+        assertThat(
+            error("TS test | STATS m=max(languages) BY s=salary/10000 | LIMIT 5 | INLINE STATS max(s) BY m"),
+            containsString(
+                "1:64: INLINE STATS cannot be used after an explicit or implicit LIMIT command, "
+                    + "but was [INLINE STATS max(s) BY m] after [LIMIT 5] [@1:54]"
+            )
+        );
+    }
+
+    public void testLimitBeforeInlineStats_WithFork() {
+        assumeTrue("LIMIT before INLINE STATS limitation check", EsqlCapabilities.Cap.FORBID_LIMIT_BEFORE_INLINE_STATS.isEnabled());
+        assertThat(
+            error(
+                "FROM test\n"
+                    + "| WHERE emp_no == 10048 OR emp_no == 10081\n"
+                    + "| FORK (EVAL a = CONCAT(first_name, \" \", emp_no::keyword, \" \", last_name)\n"
+                    + "        | GROK a \"%{WORD:x} %{WORD:y} %{WORD:z}\" )\n"
+                    + "       (EVAL b = CONCAT(last_name, \" \", emp_no::keyword, \" \", first_name)\n"
+                    + "        | GROK b \"%{WORD:x} %{WORD:y} %{WORD:z}\" )\n"
+                    + "| SORT _fork, emp_no"
+                    + "| INLINE STATS max_lang = MAX(languages) BY gender"
+            ),
+            containsString(
+                "7:23: INLINE STATS cannot be used after an explicit or implicit LIMIT command, "
+                    + "but was [INLINE STATS max_lang = MAX(languages) BY gender] "
+                    + "after [(EVAL a = CONCAT(first_name, \" \", emp_no::keyword, \" \", last_name)\n"
+                    + "        | GROK a \"%{WORD:x} %{WORD:y} %{WOR...] [@3:8]"
+            )
+        );
+
+        assertThat(
+            error(
+                "FROM employees\n"
+                    + "| KEEP emp_no, languages, gender\n"
+                    + "| FORK (WHERE emp_no == 10048 OR emp_no == 10081)\n"
+                    + "       (WHERE emp_no == 10081 OR emp_no == 10087)\n"
+                    + "| LIMIT 5"
+                    + "| INLINE STATS max_lang = MAX(languages) BY gender \n"
+                    + "| SORT emp_no, gender, _fork\n"
+            ),
+            containsString(
+                "5:12: INLINE STATS cannot be used after an explicit or implicit LIMIT command, "
+                    + "but was [INLINE STATS max_lang = MAX(languages) BY gender] after [LIMIT 5] [@5:3]"
+            )
+        );
+
+        assertThat(
+            error(
+                "FROM employees\n"
+                    + "| KEEP emp_no, languages, gender\n"
+                    + "| FORK (WHERE emp_no == 10048 OR emp_no == 10081)\n"
+                    + "       (WHERE emp_no == 10081 OR emp_no == 10087)\n"
+                    + "| INLINE STATS max_lang = MAX(languages) BY gender \n"
+                    + "| SORT emp_no, gender, _fork\n"
+                    + "| LIMIT 5"
+            ),
+            containsString(
+                "5:3: INLINE STATS cannot be used after an explicit or implicit LIMIT command, "
+                    + "but was [INLINE STATS max_lang = MAX(languages) BY gender] "
+                    + "after [(WHERE emp_no == 10048 OR emp_no == 10081)\n"
+                    + "       (WHERE emp_no == 10081 OR emp_no == 10087)] [@3:8]"
+            )
+        );
+    }
+
+    public void testLimitBeforeInlineStats_WithFrom_And_Row() {
+        assumeTrue("LIMIT before INLINE STATS limitation check", EsqlCapabilities.Cap.FORBID_LIMIT_BEFORE_INLINE_STATS.isEnabled());
+        var sourceCommands = new String[] { "FROM test | ", "ROW salary=1,gender=\"M\",languages=1 | " };
+
+        assertThat(
+            error(randomFrom(sourceCommands) + "LIMIT 5 | INLINE STATS max(salary) BY gender"),
+            containsString(
+                "INLINE STATS cannot be used after an explicit or implicit LIMIT command, "
+                    + "but was [INLINE STATS max(salary) BY gender] after [LIMIT 5] [@"
+            )
+        );
+
+        assertThat(
+            error(randomFrom(sourceCommands) + "SORT languages | LIMIT 5 | INLINE STATS max(salary) BY gender"),
+            containsString(
+                "INLINE STATS cannot be used after an explicit or implicit LIMIT command, "
+                    + "but was [INLINE STATS max(salary) BY gender] after [LIMIT 5] [@"
+            )
+        );
+
+        assertThat(
+            error(randomFrom(sourceCommands) + "INLINE STATS avg(salary) | LIMIT 5 | INLINE STATS max(salary) BY gender"),
+            containsString(
+                "INLINE STATS cannot be used after an explicit or implicit LIMIT command, "
+                    + "but was [INLINE STATS max(salary) BY gender] after [LIMIT 5] [@"
+            )
+        );
+
+        assertThat(
+            error(
+                randomFrom(sourceCommands) + "LIMIT 1 | LIMIT 2 | INLINE STATS avg(salary) | LIMIT 5 | INLINE STATS max(salary) BY gender"
+            ),
+            allOf(
+                containsString(
+                    "INLINE STATS cannot be used after an explicit or implicit LIMIT command, "
+                        + "but was [INLINE STATS max(salary) BY gender] after [LIMIT 5] [@"
+                ),
+                containsString(
+                    "INLINE STATS cannot be used after an explicit or implicit LIMIT command, "
+                        + "but was [INLINE STATS avg(salary)] after [LIMIT 2] [@"
+                )
+            )
+        );
+
+        assertThat(
+            error(randomFrom(sourceCommands) + """
+                EVAL x = 1
+                | LIMIT 1
+                | INLINE STATS avg(salary)
+                | STATS m=max(languages) BY s=salary/10000
+                | LIMIT 5
+                | INLINE STATS max(s) BY m
+                """),
+            allOf(
+                containsString(
+                    "INLINE STATS cannot be used after an explicit or implicit LIMIT command, "
+                        + "but was [INLINE STATS max(s) BY m] after [LIMIT 5] [@"
+                ),
+                containsString(
+                    "INLINE STATS cannot be used after an explicit or implicit LIMIT command, "
+                        + "but was [INLINE STATS avg(salary)] after [LIMIT 1] [@"
+                )
+            )
+        );
     }
 
     private void checkVectorFunctionsNullArgs(String functionInvocation) throws Exception {


### PR DESCRIPTION
(cherry picked from commit e2eb70925c7ad0d218ae375550bcfe9ff7053189)

Backports https://github.com/elastic/elasticsearch/pull/136752