### PR TITLE
[Sampling] Checking that a sampling configuration exists before attempting to delete it when its index has been deleted

### DIFF
--- a/server/src/main/java/org/elasticsearch/ingest/SamplingService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/SamplingService.java
@@ -510,8 +510,14 @@ public class SamplingService extends AbstractLifecycleComponent implements Clust
                 IndexMetadata current = currentProject.index(index.getIndex());
                 if (current == null) {
                     String indexName = index.getIndex().getName();
-                    logger.debug("Deleting sample configuration for {} because the index has been deleted", indexName);
-                    deleteSampleConfiguration(projectId, indexName);
+                    SamplingConfiguration samplingConfiguration = getSamplingConfiguration(
+                        event.state().projectState(projectId).metadata(),
+                        indexName
+                    );
+                    if (samplingConfiguration != null) {
+                        logger.debug("Deleting sample configuration for {} because the index has been deleted", indexName);
+                        deleteSampleConfiguration(projectId, indexName);
+                    }
                 }
             }
         }


### PR DESCRIPTION
This fixes a minor bug introduced in #136653. When an index is deleted, we need to make sure that it has a sampling configuration before attempting to delete its sampling configuration. Otherwise, it writes something like this to the log:
```
[2025-10-22T13:06:07,115][WARN ][o.e.i.SamplingService    ] [runTask-0] Failed to delete sample configuration for logs org.elasticsearch.ResourceNotFoundException: provided index [logs] has no sampling configuration
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.ingest.SamplingService$DeleteSampleConfigurationExecutor.validateConfigExists(SamplingService.java:1275)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.ingest.SamplingService$DeleteSampleConfigurationExecutor.executeTask(SamplingService.java:1245)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.ingest.SamplingService$DeleteSampleConfigurationExecutor.executeTask(SamplingService.java:1231)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.cluster.SimpleBatchedAckListenerTaskExecutor.execute(SimpleBatchedAckListenerTaskExecutor.java:64)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.cluster.service.MasterService.innerExecuteTasks(MasterService.java:1100)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.cluster.service.MasterService.executeTasks(MasterService.java:1063)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.cluster.service.MasterService.executeAndPublishBatch(MasterService.java:246)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.cluster.service.MasterService$BatchingTaskQueue$Processor.lambda$run$2(MasterService.java:1710)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.action.ActionListener.run(ActionListener.java:465)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.cluster.service.MasterService$BatchingTaskQueue$Processor.run(MasterService.java:1707)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.cluster.service.MasterService$5.lambda$doRun$0(MasterService.java:1308)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.action.ActionListener.run(ActionListener.java:465)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.cluster.service.MasterService$5.doRun(MasterService.java:1287)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:1076)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:27)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
        at java.base/java.lang.Thread.run(Thread.java:1474)
```