### PR TITLE
[Sampling] Adding additional yaml rest tests for get random sample stats api

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_sample_stats/20_with_sampling_config.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_sample_stats/20_with_sampling_config.yml
@@ -1,0 +1,215 @@
+---
+"Test get sample for basic sample config":
+  - requires:
+      cluster_features: [ "random_sampling" ]
+      reason: requires feature 'random_sampling' to get random samples
+
+  - do:
+      indices.create:
+        index: sample_test
+        body:
+          settings:
+            number_of_shards: 1
+
+  - do:
+      indices.put_sample_configuration:
+        index: sample_test
+        body:
+          rate: 1.0
+          max_samples: 100
+
+  - do:
+      indices.get_sample_stats:
+        index: sample_test
+        human: true
+  - match: { potential_samples: 0 }
+  - match: { samples_rejected_for_max_samples_exceeded: 0 }
+  - match: { samples_rejected_for_condition: 0 }
+  - match: { samples_rejected_for_rate: 0 }
+  - match: { samples_rejected_for_exception: 0 }
+  - match: { samples_rejected_for_size: 0 }
+  - match: { samples_accepted: 0 }
+  - match: { time_sampling_millis: 0 }
+  - match: { time_sampling: "0s" }
+  - match: { time_evaluating_condition_millis: 0 }
+  - match: { time_evaluating_condition: "0s" }
+  - match: { time_compiling_condition_millis: 0 }
+  - match: { time_compiling_condition: "0s" }
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "sample_test"}}'
+          - '{"animal": "dog", "foo": "bar"}'
+          - '{"index": {"_index": "sample_test"}}'
+          - '{"animal": "cat", "foo": "baz"}'
+
+  - do:
+      indices.get_sample_stats:
+        index: sample_test
+        human: true
+  - match: { potential_samples: 2 }
+  - match: { samples_rejected_for_max_samples_exceeded: 0 }
+  - match: { samples_rejected_for_condition: 0 }
+  - match: { samples_rejected_for_rate: 0 }
+  - match: { samples_rejected_for_exception: 0 }
+  - match: { samples_rejected_for_size: 0 }
+  - match: { samples_accepted: 2 }
+  - match: { time_evaluating_condition_millis: 0 }
+  - match: { time_evaluating_condition: "0s" }
+  - match: { time_compiling_condition_millis: 0 }
+  - match: { time_compiling_condition: "0s" }
+
+---
+"Test get sample for conditional sample config":
+  - requires:
+      cluster_features: [ "random_sampling" ]
+      reason: requires feature 'random_sampling' to get random samples
+
+  - do:
+      indices.create:
+        index: sample_test
+        body:
+          settings:
+            number_of_shards: 1
+
+  - do:
+      indices.put_sample_configuration:
+        index: sample_test
+        body:
+          rate: 1.0
+          max_samples: 100
+          if: "ctx?.animal == 'dog'"
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "sample_test"}}'
+          - '{"animal": "dog", "foo": "bar"}'
+          - '{"index": {"_index": "sample_test"}}'
+          - '{"animal": "cat", "foo": "baz"}'
+
+  - do:
+      indices.get_sample_stats:
+        index: sample_test
+        human: true
+  - match: { potential_samples: 2 }
+  - match: { samples_rejected_for_max_samples_exceeded: 0 }
+  - match: { samples_rejected_for_condition: 1 }
+  - match: { samples_rejected_for_rate: 0 }
+  - match: { samples_rejected_for_exception: 0 }
+  - match: { samples_rejected_for_size: 0 }
+  - match: { samples_accepted: 1 }
+
+---
+"Test that deleting sample config deletes sample stats":
+  - requires:
+      cluster_features: [ "random_sampling" ]
+      reason: requires feature 'random_sampling' to get random samples
+
+  - do:
+      indices.create:
+        index: sample_test
+        body:
+          settings:
+            number_of_shards: 1
+
+  - do:
+      indices.put_sample_configuration:
+        index: sample_test
+        body:
+          rate: 1.0
+          max_samples: 100
+
+  - do:
+      indices.get_sample_stats:
+        index: sample_test
+        human: true
+  - match: { potential_samples: 0 }
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "sample_test"}}'
+          - '{"animal": "dog", "foo": "bar"}'
+
+  - do:
+      indices.get_sample_stats:
+        index: sample_test
+        human: true
+  - match: { potential_samples: 1 }
+
+  - do:
+      indices.delete_sample_configuration:
+        index: sample_test
+
+  - do:
+      indices.get_sample_stats:
+        index: sample_test
+      catch: missing
+
+---
+"Test that deleting index deletes sample":
+  - requires:
+      cluster_features: [ "random_sampling" ]
+      reason: requires feature 'random_sampling' to get random samples
+
+  - do:
+      indices.create:
+        index: sample_test
+        body:
+          settings:
+            number_of_shards: 1
+
+  - do:
+      indices.put_sample_configuration:
+        index: sample_test
+        body:
+          rate: 1.0
+          max_samples: 100
+
+#  - do:
+#      indices.get_sample_stats:
+#        index: sample_test
+#        human: true
+#  - match: { potential_samples: 0 }
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "sample_test"}}'
+          - '{"animal": "dog", "foo": "bar"}'
+          - '{"index": {"_index": "sample_test"}}'
+          - '{"animal": "cat", "foo": "baz"}'
+
+#  - do:
+#      indices.get_sample_stats:
+#        index: sample_test
+#        human: true
+#  - match: { potential_samples: 2 }
+
+  - do:
+      indices.delete:
+        index: sample_test
+
+  - do:
+      indices.get_sample:
+        index: sample_test
+      catch: missing
+
+  - do:
+      indices.get_sample_stats:
+        index: sample_test
+      catch: missing
+
+---
+teardown:
+
+  - do:
+      indices.delete:
+        index: sample_test
+        ignore_unavailable: true

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_sample_stats/20_with_sampling_config.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_sample_stats/20_with_sampling_config.yml
@@ -171,11 +171,11 @@
           rate: 1.0
           max_samples: 100
 
-#  - do:
-#      indices.get_sample_stats:
-#        index: sample_test
-#        human: true
-#  - match: { potential_samples: 0 }
+  - do:
+      indices.get_sample_stats:
+        index: sample_test
+        human: true
+  - match: { potential_samples: 0 }
 
   - do:
       bulk:
@@ -186,11 +186,11 @@
           - '{"index": {"_index": "sample_test"}}'
           - '{"animal": "cat", "foo": "baz"}'
 
-#  - do:
-#      indices.get_sample_stats:
-#        index: sample_test
-#        human: true
-#  - match: { potential_samples: 2 }
+  - do:
+      indices.get_sample_stats:
+        index: sample_test
+        human: true
+  - match: { potential_samples: 2 }
 
   - do:
       indices.delete:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_sample_stats/20_with_sampling_config.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_sample_stats/20_with_sampling_config.yml
@@ -1,5 +1,5 @@
 ---
-"Test get sample for basic sample config":
+"Test get sample stats for basic sample config":
   - requires:
       cluster_features: [ "random_sampling" ]
       reason: requires feature 'random_sampling' to get random samples
@@ -60,9 +60,10 @@
   - match: { time_evaluating_condition: "0s" }
   - match: { time_compiling_condition_millis: 0 }
   - match: { time_compiling_condition: "0s" }
+  - match: { last_exception: null }
 
 ---
-"Test get sample for conditional sample config":
+"Test get sample stats for conditional sample config":
   - requires:
       cluster_features: [ "random_sampling" ]
       reason: requires feature 'random_sampling' to get random samples
@@ -102,6 +103,7 @@
   - match: { samples_rejected_for_exception: 0 }
   - match: { samples_rejected_for_size: 0 }
   - match: { samples_accepted: 1 }
+  - match: { last_exception: null }
 
 ---
 "Test that deleting sample config deletes sample stats":
@@ -152,7 +154,7 @@
       catch: missing
 
 ---
-"Test that deleting index deletes sample":
+"Test that deleting index deletes sample stats":
   - requires:
       cluster_features: [ "random_sampling" ]
       reason: requires feature 'random_sampling' to get random samples
@@ -205,6 +207,100 @@
       indices.get_sample_stats:
         index: sample_test
       catch: missing
+
+---
+"Test get sample stats for exceeds size":
+  - requires:
+      cluster_features: [ "random_sampling" ]
+      reason: requires feature 'random_sampling' to get random samples
+
+  - do:
+      indices.create:
+        index: sample_test
+        body:
+          settings:
+            number_of_shards: 1
+
+  - do:
+      indices.put_sample_configuration:
+        index: sample_test
+        body:
+          rate: 1.0
+          max_samples: 1
+
+  - do:
+      indices.get_sample_stats:
+        index: sample_test
+        human: true
+  - match: { potential_samples: 0 }
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "sample_test"}}'
+          - '{"animal": "dog", "foo": "bar"}'
+          - '{"index": {"_index": "sample_test"}}'
+          - '{"animal": "cat", "foo": "baz"}'
+
+  - do:
+      indices.get_sample_stats:
+        index: sample_test
+        human: true
+  - match: { potential_samples: 2 }
+  - match: { samples_rejected_for_max_samples_exceeded: 1 }
+  - match: { samples_rejected_for_condition: 0 }
+  - match: { samples_rejected_for_rate: 0 }
+  - match: { samples_rejected_for_exception: 0 }
+  - match: { samples_rejected_for_size: 0 }
+  - match: { samples_accepted: 1 }
+  - match: { time_evaluating_condition_millis: 0 }
+  - match: { time_evaluating_condition: "0s" }
+  - match: { time_compiling_condition_millis: 0 }
+  - match: { time_compiling_condition: "0s" }
+
+---
+"Test get sample stats for conditional with exception":
+  - requires:
+      cluster_features: [ "random_sampling" ]
+      reason: requires feature 'random_sampling' to get random samples
+
+  - do:
+      indices.create:
+        index: sample_test
+        body:
+          settings:
+            number_of_shards: 1
+
+  - do:
+      indices.put_sample_configuration:
+        index: sample_test
+        body:
+          rate: 1.0
+          max_samples: 100
+          if: "ctx?.animal > 0"
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "sample_test"}}'
+          - '{"animal": "dog", "foo": "bar"}'
+          - '{"index": {"_index": "sample_test"}}'
+          - '{"animal": "cat", "foo": "baz"}'
+
+  - do:
+      indices.get_sample_stats:
+        index: sample_test
+        human: true
+  - match: { potential_samples: 2 }
+  - match: { samples_rejected_for_max_samples_exceeded: 0 }
+  - match: { samples_rejected_for_condition: 0 }
+  - match: { samples_rejected_for_rate: 0 }
+  - match: { samples_rejected_for_exception: 2 }
+  - match: { samples_rejected_for_size: 0 }
+  - match: { samples_accepted: 0 }
+  - match: { last_exception.type: "script_exception" }
 
 ---
 teardown:

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/sampling/TransportGetSampleStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/sampling/TransportGetSampleStatsAction.java
@@ -13,6 +13,7 @@ import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.nodes.TransportNodesAction;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -34,6 +35,7 @@ import static org.elasticsearch.action.admin.indices.sampling.GetSampleStatsActi
 public class TransportGetSampleStatsAction extends TransportNodesAction<Request, Response, NodeRequest, NodeResponse, Void> {
     private final SamplingService samplingService;
     private final ProjectResolver projectResolver;
+    private final IndexNameExpressionResolver indexNameExpressionResolver;
 
     @Inject
     public TransportGetSampleStatsAction(
@@ -42,7 +44,8 @@ public class TransportGetSampleStatsAction extends TransportNodesAction<Request,
         ThreadPool threadPool,
         ActionFilters actionFilters,
         SamplingService samplingService,
-        ProjectResolver projectResolver
+        ProjectResolver projectResolver,
+        IndexNameExpressionResolver indexNameExpressionResolver
     ) {
         super(
             GetSampleStatsAction.NAME,
@@ -54,6 +57,7 @@ public class TransportGetSampleStatsAction extends TransportNodesAction<Request,
         );
         this.samplingService = samplingService;
         this.projectResolver = projectResolver;
+        this.indexNameExpressionResolver = indexNameExpressionResolver;
     }
 
     @Override
@@ -71,6 +75,7 @@ public class TransportGetSampleStatsAction extends TransportNodesAction<Request,
 
     @Override
     protected Response newResponse(Request request, List<NodeResponse> nodeResponses, List<FailedNodeException> failures) {
+        indexNameExpressionResolver.concreteIndexNames(clusterService.state(), request);
         SamplingConfiguration samplingConfiguration = samplingService.getSamplingConfiguration(
             projectResolver.getProjectMetadata(clusterService.state()),
             request.indices()[0]


### PR DESCRIPTION
This adds additional yaml rest tests for the get random sample stats API, testing various sampling configurations, sampling configuration deletion, and index deletion.
Also, the `Test that deleting index deletes sample stats` test exposed a bug, so I've fixed it by making get sample stats behave more like get sample.