### PR TITLE
ESQL: Unmute AllSupportedFieldsIT#testFetchDenseVector

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -462,9 +462,6 @@ tests:
 - class: org.elasticsearch.indices.recovery.IndexRecoveryIT
   method: testUsesFileBasedRecoveryIfOperationsBasedRecoveryWouldBeUnreasonable
   issue: https://github.com/elastic/elasticsearch/issues/135737
-- class: org.elasticsearch.xpack.esql.ccq.AllSupportedFieldsIT
-  method: testFetchDenseVector {pref=null mode=time_series}
-  issue: https://github.com/elastic/elasticsearch/issues/135762
 - class: org.elasticsearch.xpack.esql.action.CrossClusterQueryWithPartialResultsIT
   method: testOneRemoteClusterPartial
   issue: https://github.com/elastic/elasticsearch/issues/124055


### PR DESCRIPTION
Fix https://github.com/elastic/elasticsearch/issues/135762

There have been changes since the test was muted, and the tests may have been affected by the then-ongoing transport version migration. Can't reproduce the failures as of now.