### PR TITLE
ESQL: Rename SupportedVersion methods

### DIFF
--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
@@ -296,8 +296,12 @@ public enum DataType implements Writeable {
     // NOTE: If INDEX_SOURCE somehow gets backported to a version that doesn't actually support these types, we'll be missing validation for
     // mixed/multi clusters with remotes that don't support these types. This is low-ish risk because these types require specific
     // geo functions to turn up in the query, and those types aren't available before 9.2.0 either.
-    GEOHASH(builder().esType("geohash").typeName("GEOHASH").estimatedSize(Long.BYTES).supportedSince(DataTypesTransportVersions.INDEX_SOURCE)),
-    GEOTILE(builder().esType("geotile").typeName("GEOTILE").estimatedSize(Long.BYTES).supportedSince(DataTypesTransportVersions.INDEX_SOURCE)),
+    GEOHASH(
+        builder().esType("geohash").typeName("GEOHASH").estimatedSize(Long.BYTES).supportedSince(DataTypesTransportVersions.INDEX_SOURCE)
+    ),
+    GEOTILE(
+        builder().esType("geotile").typeName("GEOTILE").estimatedSize(Long.BYTES).supportedSince(DataTypesTransportVersions.INDEX_SOURCE)
+    ),
     GEOHEX(builder().esType("geohex").typeName("GEOHEX").estimatedSize(Long.BYTES).supportedSince(DataTypesTransportVersions.INDEX_SOURCE)),
 
     /**

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
@@ -121,7 +121,7 @@ import static java.util.stream.Collectors.toMap;
  *         Ensure the capabilities for this type are always enabled.</li>
  *     <li>
  *         Mark the type with a new transport version via
- *         {@link Builder#supportedOn(TransportVersion)}. This will enable the type on
+ *         {@link Builder#supportedSince(TransportVersion)}. This will enable the type on
  *         non-SNAPSHOT builds as long as all nodes in the cluster (and remote clusters)
  *         support it.</li>
  *     <li>
@@ -296,9 +296,9 @@ public enum DataType implements Writeable {
     // NOTE: If INDEX_SOURCE somehow gets backported to a version that doesn't actually support these types, we'll be missing validation for
     // mixed/multi clusters with remotes that don't support these types. This is low-ish risk because these types require specific
     // geo functions to turn up in the query, and those types aren't available before 9.2.0 either.
-    GEOHASH(builder().esType("geohash").typeName("GEOHASH").estimatedSize(Long.BYTES).supportedOn(DataTypesTransportVersions.INDEX_SOURCE)),
-    GEOTILE(builder().esType("geotile").typeName("GEOTILE").estimatedSize(Long.BYTES).supportedOn(DataTypesTransportVersions.INDEX_SOURCE)),
-    GEOHEX(builder().esType("geohex").typeName("GEOHEX").estimatedSize(Long.BYTES).supportedOn(DataTypesTransportVersions.INDEX_SOURCE)),
+    GEOHASH(builder().esType("geohash").typeName("GEOHASH").estimatedSize(Long.BYTES).supportedSince(DataTypesTransportVersions.INDEX_SOURCE)),
+    GEOTILE(builder().esType("geotile").typeName("GEOTILE").estimatedSize(Long.BYTES).supportedSince(DataTypesTransportVersions.INDEX_SOURCE)),
+    GEOHEX(builder().esType("geohex").typeName("GEOHEX").estimatedSize(Long.BYTES).supportedSince(DataTypesTransportVersions.INDEX_SOURCE)),
 
     /**
      * Fields with this type represent a Lucene doc id. This field is a bit magic in that:
@@ -322,7 +322,7 @@ public enum DataType implements Writeable {
     // mixed/multi clusters with remotes that don't support these types. This is low-ish risk because _tsid requires specifically being
     // used in `FROM idx METADATA _tsid` or in the `TS` command, which both weren't available before 9.2.0.
     TSID_DATA_TYPE(
-        builder().esType("_tsid").estimatedSize(Long.BYTES * 2).docValues().supportedOn(DataTypesTransportVersions.INDEX_SOURCE)
+        builder().esType("_tsid").estimatedSize(Long.BYTES * 2).docValues().supportedSince(DataTypesTransportVersions.INDEX_SOURCE)
     ),
     /**
      * Fields with this type are the partial result of running a non-time-series aggregation
@@ -333,13 +333,13 @@ public enum DataType implements Writeable {
     AGGREGATE_METRIC_DOUBLE(
         builder().esType("aggregate_metric_double")
             .estimatedSize(Double.BYTES * 3 + Integer.BYTES)
-            .supportedOn(DataTypesTransportVersions.ESQL_AGGREGATE_METRIC_DOUBLE_CREATED_VERSION)
+            .supportedSince(DataTypesTransportVersions.ESQL_AGGREGATE_METRIC_DOUBLE_CREATED_VERSION)
     ),
     /**
      * Fields with this type are dense vectors, represented as an array of float values.
      */
     DENSE_VECTOR(
-        builder().esType("dense_vector").estimatedSize(4096).supportedOn(DataTypesTransportVersions.ESQL_DENSE_VECTOR_CREATED_VERSION)
+        builder().esType("dense_vector").estimatedSize(4096).supportedSince(DataTypesTransportVersions.ESQL_DENSE_VECTOR_CREATED_VERSION)
     );
 
     public static final Set<DataType> UNDER_CONSTRUCTION = Arrays.stream(DataType.values())
@@ -744,7 +744,7 @@ public enum DataType implements Writeable {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        if (supportedVersion.supports(out.getTransportVersion()) == false) {
+        if (supportedVersion.supportedOn(out.getTransportVersion()) == false) {
             /*
              * TODO when we implement version aware planning flip this to an IllegalStateException
              * so we throw a 500 error. It'll be our bug then. Right now it's a sign that the user
@@ -955,8 +955,8 @@ public enum DataType implements Writeable {
          * <p>
          * Generally, we should add a dedicated transport version when a type is enabled on release builds.
          */
-        Builder supportedOn(TransportVersion supportedVersion) {
-            this.supportedVersion = SupportedVersion.supportedOn(supportedVersion);
+        Builder supportedSince(TransportVersion supportedVersion) {
+            this.supportedVersion = SupportedVersion.supportedSince(supportedVersion);
             return this;
         }
 

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/SupportedVersion.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/SupportedVersion.java
@@ -11,15 +11,15 @@ import org.elasticsearch.Build;
 import org.elasticsearch.TransportVersion;
 
 public interface SupportedVersion {
-    boolean supports(TransportVersion version);
+    boolean supportedOn(TransportVersion version);
 
     default boolean supportedLocally() {
-        return supports(TransportVersion.current());
+        return supportedOn(TransportVersion.current());
     }
 
     SupportedVersion SUPPORTED_ON_ALL_NODES = new SupportedVersion() {
         @Override
-        public boolean supports(TransportVersion version) {
+        public boolean supportedOn(TransportVersion version) {
             return true;
         }
 
@@ -56,7 +56,7 @@ public interface SupportedVersion {
     // Check usage of this constant to be sure.
     SupportedVersion UNDER_CONSTRUCTION = new SupportedVersion() {
         @Override
-        public boolean supports(TransportVersion version) {
+        public boolean supportedOn(TransportVersion version) {
             return Build.current().isSnapshot();
         }
 
@@ -73,10 +73,10 @@ public interface SupportedVersion {
      *     continue to work. Otherwise, we'd have to update bwc tests to skip older versions based
      *     on a capability check, which can be error-prone and risks turning off an unrelated bwc test.
      */
-    static SupportedVersion supportedOn(TransportVersion supportedVersion) {
+    static SupportedVersion supportedSince(TransportVersion supportedVersion) {
         return new SupportedVersion() {
             @Override
-            public boolean supports(TransportVersion version) {
+            public boolean supportedOn(TransportVersion version) {
                 return version.supports(supportedVersion) || Build.current().isSnapshot();
             }
 


### PR DESCRIPTION
`SupportedVersion#supports(TransportVersion version)` is confusing, because it works the opposite way than `TransportVersion#supports(TransportVersion otherVersion)`. Rename to `#supportedOn` instead, and use builder methods `supportedSince` instead of the current `supportedOn` to declare the first transport version when a data type was made available in release builds.