### PR TITLE
[Sampling] Improving random sampling performance very slightly

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportAbstractBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportAbstractBulkAction.java
@@ -312,7 +312,7 @@ public abstract class TransportAbstractBulkAction extends HandledTransportAction
                 }
             });
             return true;
-        } else if (haveRunIngestService == false && samplingService != null && samplingService.atLeastOneSampleConfigured()) {
+        } else if (haveRunIngestService == false && samplingService != null && samplingService.atLeastOneSampleConfigured(project)) {
             /*
              * Else ample only if this request has not passed through IngestService::executeBulkRequest. Otherwise, some request within the
              * bulk had pipelines and we sampled in IngestService already.

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -1385,7 +1385,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         IngestDocument ingestDocument,
         Metadata originalDocumentMetadata
     ) {
-        if (samplingService != null && samplingService.atLeastOneSampleConfigured()) {
+        if (samplingService != null && samplingService.atLeastOneSampleConfigured(projectMetadata)) {
             /*
              * We need both the original document and the fully updated document for sampling, so we make a copy of the original
              * before overwriting it here. We can discard it after sampling.

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -728,7 +728,7 @@ class NodeConstruction {
 
         FeatureService featureService = new FeatureService(pluginsService.loadServiceProviders(FeatureSpecification.class));
 
-        SamplingService samplingService = SamplingService.create(scriptService, clusterService, projectResolver, settings);
+        SamplingService samplingService = SamplingService.create(scriptService, clusterService, settings);
         modules.bindToInstance(SamplingService.class, samplingService);
         clusterService.addListener(samplingService);
 

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionIngestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionIngestTests.java
@@ -180,7 +180,7 @@ public class TransportBulkActionIngestTests extends ESTestCase {
 
         private static SamplingService initializeSamplingService() {
             SamplingService samplingService = mock(SamplingService.class);
-            when(samplingService.atLeastOneSampleConfigured()).thenReturn(true);
+            when(samplingService.atLeastOneSampleConfigured(any())).thenReturn(true);
             return samplingService;
         }
 

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
@@ -163,7 +163,7 @@ public class TransportBulkActionTests extends ESTestCase {
 
         private static SamplingService initializeSamplingService() {
             SamplingService samplingService = mock(SamplingService.class);
-            when(samplingService.atLeastOneSampleConfigured()).thenReturn(true);
+            when(samplingService.atLeastOneSampleConfigured(any())).thenReturn(true);
             return samplingService;
         }
 

--- a/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
@@ -3357,7 +3357,7 @@ public class IngestServiceTests extends ESTestCase {
             Predicates.never(),
             samplingService
         );
-        when(samplingService.atLeastOneSampleConfigured()).thenReturn(true);
+        when(samplingService.atLeastOneSampleConfigured(any())).thenReturn(true);
         PutPipelineRequest putRequest = putJsonPipelineRequest("_id", "{\"processors\": [{\"mock\" : {}}]}");
         var projectId = randomProjectIdOrDefault();
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)

--- a/server/src/test/java/org/elasticsearch/ingest/SamplingServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/SamplingServiceTests.java
@@ -16,7 +16,6 @@ import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.metadata.ProjectMetadata;
-import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.project.TestProjectResolvers;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
@@ -352,8 +351,6 @@ public class SamplingServiceTests extends ESTestCase {
             TestProjectResolvers.singleProject(randomProjectIdOrDefault())
         );
         ClusterService clusterService = ClusterServiceUtils.createClusterService(new DeterministicTaskQueue().getThreadPool());
-        final ProjectId projectId = ProjectId.DEFAULT;
-        final ProjectResolver projectResolver = TestProjectResolvers.singleProject(projectId);
-        return SamplingService.create(scriptService, clusterService, projectResolver, Settings.EMPTY);
+        return SamplingService.create(scriptService, clusterService, Settings.EMPTY);
     }
 }


### PR DESCRIPTION
In doing some profiling of random sampling, I realized that we are unnecessarily constructing a ProjectMetadata object inside of `SamplingService.atLeastOneSampleConfigured()`. That method is called frequently enough during heavng bulk loading that it registers in the profiler. There is no need for this, since all callers already have a ProjectMetadata.