### PR TITLE
Fix AsyncSearchErrorTraceIT_ testAsyncSearchFailingQueryErrorTraceFalse

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -354,9 +354,6 @@ tests:
 - class: org.elasticsearch.search.CCSDuelIT
   method: testTermsAggsWithProfile
   issue: https://github.com/elastic/elasticsearch/issues/132880
-- class: org.elasticsearch.xpack.search.AsyncSearchErrorTraceIT
-  method: testAsyncSearchFailingQueryErrorTraceDefault
-  issue: https://github.com/elastic/elasticsearch/issues/133010
 - class: org.elasticsearch.xpack.security.authc.AuthenticationServiceTests
   method: testInvalidToken
   issue: https://github.com/elastic/elasticsearch/issues/133328

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchErrorTraceIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchErrorTraceIT.java
@@ -76,7 +76,7 @@ public class AsyncSearchErrorTraceIT extends ESIntegTestCase {
         createAsyncRequest.addParameter("keep_on_completion", "true");
         createAsyncRequest.addParameter("wait_for_completion_timeout", "0ms");
         Map<String, Object> createAsyncResponseEntity = performRequestAndGetResponseEntity(createAsyncRequest);
-        if (createAsyncResponseEntity.get("is_running").equals("true")) {
+        if (Boolean.TRUE.equals(createAsyncResponseEntity.get("is_running"))) {
             String asyncExecutionId = (String) createAsyncResponseEntity.get("id");
             Request getAsyncRequest = new Request("GET", "/_async_search/" + asyncExecutionId);
             awaitAsyncRequestDoneRunning(getAsyncRequest);
@@ -103,7 +103,7 @@ public class AsyncSearchErrorTraceIT extends ESIntegTestCase {
         createAsyncRequest.addParameter("keep_on_completion", "true");
         createAsyncRequest.addParameter("wait_for_completion_timeout", "0ms");
         Map<String, Object> createAsyncResponseEntity = performRequestAndGetResponseEntity(createAsyncRequest);
-        if (createAsyncResponseEntity.get("is_running").equals("true")) {
+        if (Boolean.TRUE.equals(createAsyncResponseEntity.get("is_running"))) {
             String asyncExecutionId = (String) createAsyncResponseEntity.get("id");
             Request getAsyncRequest = new Request("GET", "/_async_search/" + asyncExecutionId);
             getAsyncRequest.addParameter("error_trace", "true");
@@ -131,7 +131,7 @@ public class AsyncSearchErrorTraceIT extends ESIntegTestCase {
         createAsyncRequest.addParameter("keep_on_completion", "true");
         createAsyncRequest.addParameter("wait_for_completion_timeout", "0ms");
         Map<String, Object> createAsyncResponseEntity = performRequestAndGetResponseEntity(createAsyncRequest);
-        if (createAsyncResponseEntity.get("is_running").equals("true")) {
+        if (Boolean.TRUE.equals(createAsyncResponseEntity.get("is_running"))) {
             String asyncExecutionId = (String) createAsyncResponseEntity.get("id");
             Request getAsyncRequest = new Request("GET", "/_async_search/" + asyncExecutionId);
             getAsyncRequest.addParameter("error_trace", "false");
@@ -172,7 +172,7 @@ public class AsyncSearchErrorTraceIT extends ESIntegTestCase {
         try (var mockLog = MockLog.capture(SearchService.class)) {
             ErrorTraceHelper.addSeenLoggingExpectations(numShards, mockLog, errorTriggeringIndex);
             Map<String, Object> createAsyncResponseEntity = performRequestAndGetResponseEntity(createAsyncRequest);
-            if (createAsyncResponseEntity.get("is_running").equals("true")) {
+            if (Boolean.TRUE.equals(createAsyncResponseEntity.get("is_running"))) {
                 String asyncExecutionId = (String) createAsyncResponseEntity.get("id");
                 Request getAsyncRequest = new Request("GET", "/_async_search/" + asyncExecutionId);
                 // Use the same value of error_trace as the search request
@@ -206,7 +206,7 @@ public class AsyncSearchErrorTraceIT extends ESIntegTestCase {
         createAsyncSearchRequest.addParameter("keep_on_completion", "true");
         createAsyncSearchRequest.addParameter("wait_for_completion_timeout", "0ms");
         Map<String, Object> createAsyncResponseEntity = performRequestAndGetResponseEntity(createAsyncSearchRequest);
-        if (createAsyncResponseEntity.get("is_running").equals("true")) {
+        if (Boolean.TRUE.equals(createAsyncResponseEntity.get("is_running"))) {
             String asyncExecutionId = (String) createAsyncResponseEntity.get("id");
             Request getAsyncRequest = new Request("GET", "/_async_search/" + asyncExecutionId);
             getAsyncRequest.addParameter("error_trace", "true");
@@ -234,7 +234,7 @@ public class AsyncSearchErrorTraceIT extends ESIntegTestCase {
         createAsyncSearchRequest.addParameter("keep_on_completion", "true");
         createAsyncSearchRequest.addParameter("wait_for_completion_timeout", "0ms");
         Map<String, Object> createAsyncResponseEntity = performRequestAndGetResponseEntity(createAsyncSearchRequest);
-        if (createAsyncResponseEntity.get("is_running").equals("true")) {
+        if (Boolean.TRUE.equals(createAsyncResponseEntity.get("is_running"))) {
             String asyncExecutionId = (String) createAsyncResponseEntity.get("id");
             Request getAsyncRequest = new Request("GET", "/_async_search/" + asyncExecutionId);
             getAsyncRequest.addParameter("error_trace", "false");


### PR DESCRIPTION
The exception is thrown while attempting to acquire a shard lock. The key stack frames show that it occurs during the after-test checks (assertAfterTest), when ESIntegTestCase runs its “assert after test” cleanup. At that point, it’s trying to lock shard 0 of the .async-search index, but the shard is still in the starting state because the async task hasn’t fully finished. As a result, the lock attempt times out after 5 seconds.

```
Caused by: org.elasticsearch.env.ShardLockObtainFailedException: [.async-search][0]: obtaining shard lock for [InternalTestCluster assert after test] timed out after [5000ms]; this shard lock is still held by a different instance of the shard and has been in state [starting shard] for [5.3s/5310ms] |  
  | at org.elasticsearch.env.NodeEnvironment.shardLock(NodeEnvironment.java:895) |  
  | at org.elasticsearch.test.InternalTestCluster.assertAfterTest(InternalTestCluster.java:2617) |  
  | at org.elasticsearch.test.ESIntegTestCase.afterInternal(ESIntegTestCase.java:612) |  
  | at org.elasticsearch.test.ESIntegTestCase.cleanUpCluster(ESIntegTestCase.java:2620) |  
  | at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104) |  
  | at java.lang.reflect.Method.invoke(Method.java:565) |  
  | at com.carrotsearch.randomizedtesting.RandomizedRunner.invoke(RandomizedRunner.java:1763) |  
  | at com.carrotsearch.randomizedtesting.RandomizedRunner$10.evaluate(RandomizedRunner.java:1004) |  
  | at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36) |  
  | at org.junit.rules.RunRules.evaluate(RunRules.java:20) |  
  | at org.apache.lucene.tests.util.TestRuleSetupTeardownChained$1.evaluate(TestRuleSetupTeardownChained.java:48) |  
  | at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43) |  
  | at org.apache.lucene.tests.util.TestRuleThreadAndTestName$1.evaluate(TestRuleThreadAndTestName.java:45) |  
  | at org.apache.lucene.tests.util.TestRuleIgnoreAfterMaxFailures$1.evaluate(TestRuleIgnoreAfterMaxFailures.java:60) |  
  | at org.apache.lucene.tests.util.TestRuleMarkFailure$1.evaluate(TestRuleMarkFailure.java:44)
...
```

The REST response returns is_running as a Boolean, but the code reads it as a String and evaluates true.equals("true"), which is always false. As a result, the wait/poll step is skipped, and the test executes the assertion immediately. This creates a race condition where the async search has not yet finished propagating results between the data and coordinating nodes, causing ErrorTraceHelper.assertStackTraceCleared(..) to occasionally run too early and fail.

```
 if (createAsyncResponseEntity.get("is_running").equals("true")) 
```

Closes #136986 #136691 