### PR TITLE
[ML] Fix MlAssignmentPlannerUpgradeIT.estMlAssignmentPlannerUpgrade() 

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlAssignmentPlannerUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlAssignmentPlannerUpgradeIT.java
@@ -67,7 +67,6 @@ public class MlAssignmentPlannerUpgradeIT extends AbstractUpgradeTestCase {
         RAW_MODEL_SIZE = Base64.getDecoder().decode(BASE_64_ENCODED_MODEL).length;
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/101926")
     public void testMlAssignmentPlannerUpgrade() throws Exception {
         assumeFalse("This test deploys multiple models which cannot be accommodated on a single processor", IS_SINGLE_PROCESSOR_TEST);
 

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlAssignmentPlannerUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlAssignmentPlannerUpgradeIT.java
@@ -187,12 +187,12 @@ public class MlAssignmentPlannerUpgradeIT extends AbstractUpgradeTestCase {
         createTrainedModel("old_memory_format", 0, 0);
         putModelDefinition("old_memory_format");
         putVocabulary(List.of("these", "are", "my", "words"), "old_memory_format");
-        startDeployment("old_memory_format");
+        startDeployment("old_memory_format", "started", "low");
 
         createTrainedModel("new_memory_format", ByteSizeValue.ofMb(300).getBytes(), ByteSizeValue.ofMb(10).getBytes());
         putModelDefinition("new_memory_format");
         putVocabulary(List.of("these", "are", "my", "words"), "new_memory_format");
-        startDeployment("new_memory_format");
+        startDeployment("new_memory_format", "started", "low");
     }
 
     private void cleanupDeployments() throws IOException {
@@ -248,10 +248,14 @@ public class MlAssignmentPlannerUpgradeIT extends AbstractUpgradeTestCase {
     }
 
     private Response startDeployment(String modelId) throws IOException {
-        return startDeployment(modelId, "started");
+        return startDeployment(modelId, "started", "normal");
     }
 
     private Response startDeployment(String modelId, String waitForState) throws IOException {
+        return startDeployment(modelId, waitForState, "normal");
+    }
+
+    private Response startDeployment(String modelId, String waitForState, String priority) throws IOException {
         String inferenceThreadParamName = "threads_per_allocation";
         String modelThreadParamName = "number_of_allocations";
         String compatibleHeader = null;
@@ -271,7 +275,8 @@ public class MlAssignmentPlannerUpgradeIT extends AbstractUpgradeTestCase {
                 + inferenceThreadParamName
                 + "=1&"
                 + modelThreadParamName
-                + "=1"
+                + "=1&priority="
+                + priority
         );
         if (compatibleHeader != null) {
             request.setOptions(request.getOptions().toBuilder().addHeader("Accept", compatibleHeader).build());


### PR DESCRIPTION
As suggested [here](https://github.com/elastic/elasticsearch/issues/101926#issuecomment-1803420029), this PR changes deployments to low priority. Low priority deployments don't require specific processor allocations, allowing them to run in constrained environments. The test can now succeed in single-processor test environments where all processors are already allocated. 

Since we don't test BWC for pre-8.6.0 versions, where priority was introduced, this change fixes the test. 

Closes #101926