### PR TITLE
ESQL: Add BytesRefsFromBinaryBlockLoader

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/BytesRefsFromBinaryBlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/blockloader/docvalues/BytesRefsFromBinaryBlockLoader.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper.blockloader.docvalues;
+
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.core.Nullable;
+
+import java.io.IOException;
+
+public class BytesRefsFromBinaryBlockLoader extends BlockDocValuesReader.DocValuesBlockLoader {
+
+    private final String fieldName;
+
+    public BytesRefsFromBinaryBlockLoader(String fieldName) {
+        this.fieldName = fieldName;
+    }
+
+    @Override
+    public Builder builder(BlockFactory factory, int expectedCount) {
+        return factory.bytesRefs(expectedCount);
+    }
+
+    @Override
+    public AllReader reader(LeafReaderContext context) throws IOException {
+        BinaryDocValues docValues = context.reader().getBinaryDocValues(fieldName);
+        return createReader(docValues);
+    }
+
+    public static AllReader createReader(@Nullable BinaryDocValues docValues) {
+        if (docValues == null) {
+            return new ConstantNullsReader();
+        }
+        return new BytesRefsFromBinary(docValues);
+    }
+
+    /**
+     * Read BinaryDocValues with no additional structure in the BytesRefs.
+     * Each BytesRef from the doc values maps directly to a value in the block loader.
+     */
+    static class BytesRefsFromBinary extends BytesRefsFromCustomBinaryBlockLoader.AbstractBytesRefsFromBinary {
+
+        BytesRefsFromBinary(BinaryDocValues docValues) {
+            super(docValues);
+        }
+
+        @Override
+        public void read(int doc, BytesRefBuilder builder) throws IOException {
+            if (false == docValues.advanceExact(doc)) {
+                builder.appendNull();
+                return;
+            }
+            BytesRef bytes = docValues.binaryValue();
+            builder.appendBytesRef(bytes);
+        }
+
+        @Override
+        public String toString() {
+            return "BlockDocValuesReader.Bytes";
+        }
+    }
+}

--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextBlockLoader.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextBlockLoader.java
@@ -7,11 +7,9 @@
 
 package org.elasticsearch.xpack.logsdb.patterntext;
 
-import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.index.mapper.blockloader.docvalues.BlockDocValuesReader;
-import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromCustomBinaryBlockLoader;
+import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromBinaryBlockLoader;
 
 import java.io.IOException;
 
@@ -31,34 +29,7 @@ public class PatternTextBlockLoader extends BlockDocValuesReader.DocValuesBlockL
     @Override
     public AllReader reader(LeafReaderContext context) throws IOException {
         var docValues = docValuesSupplier.get(context.reader());
-        if (docValues == null) {
-            return new ConstantNullsReader();
-        }
-        return new BytesRefsFromBinary(docValues);
+        return BytesRefsFromBinaryBlockLoader.createReader(docValues);
     }
 
-    /**
-     * Read BinaryDocValues with no additional structure in the BytesRefs.
-     * Each BytesRef from the doc values maps directly to a value in the block loader.
-     */
-    public static class BytesRefsFromBinary extends BytesRefsFromCustomBinaryBlockLoader.AbstractBytesRefsFromBinary {
-        public BytesRefsFromBinary(BinaryDocValues docValues) {
-            super(docValues);
-        }
-
-        @Override
-        public void read(int doc, BytesRefBuilder builder) throws IOException {
-            if (false == docValues.advanceExact(doc)) {
-                builder.appendNull();
-                return;
-            }
-            BytesRef bytes = docValues.binaryValue();
-            builder.appendBytesRef(bytes);
-        }
-
-        @Override
-        public String toString() {
-            return "BlockDocValuesReader.Bytes";
-        }
-    }
 }


### PR DESCRIPTION
For the blockloader for `exponential_histograms` I'd like to reuse the existing doc values BlockLoader implementations ([PR](https://github.com/elastic/elasticsearch/pulls/JonasKunz).

For unformatted `BinaryDocValues` we don't have a `BlockLoader` implementation yet, just an `AllReader` implementation (`BytesRefsFromBinary`). That reader was recently moved outside of the `server` project in https://github.com/elastic/elasticsearch/pull/137063.

I'd like to reuse that to profit from potential future optimizations in the loader, so this PR introduces a reusable `BytesRefsFromBinaryBlockLoader` class.
