### PR TITLE
[9.2] ESQL: fix handling equality with MV constants properly (#137032)

### DIFF
--- a/docs/changelog/137032.yaml
+++ b/docs/changelog/137032.yaml
@@ -1,0 +1,7 @@
+pr: 137032
+summary: Fix handling equality with MV constants properly
+area: ES|QL
+type: bug
+issues:
+ - 136998
+ - 136939

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/folding.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/folding.csv-spec
@@ -103,3 +103,69 @@ a:s    | b:s      | x:i | y:s          | z:s
 "some" | "string" | 4   | "somestring" | "anotherstring"
 ;
 
+mvBoolean_Equals_MultiValueConstant
+required_capability: fix_mv_constant_equals_field
+
+FROM employees
+| WHERE is_rehired == ([true, false])
+| KEEP is_rehired
+;
+warning:Line 2:9: evaluation of [is_rehired == ([true, false])] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:9: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+    is_rehired:boolean
+;
+
+computedBoolean_Equals_MultiValueConstant
+required_capability: fix_mv_constant_equals_field
+
+FROM employees
+| EVAL x = gender IS NULL
+| WHERE x == [true, false]
+| KEEP x
+;
+warning:Line 3:9: evaluation of [x == [true, false]] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 3:9: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+    x:boolean
+;
+
+computedBoolean_Equals_SingleMultiValueConstant
+required_capability: fix_mv_constant_equals_field
+
+FROM employees
+| EVAL x = gender IS NULL
+| WHERE x == [true]
+| KEEP x
+| LIMIT 1
+;
+
+    x:boolean
+    true
+;
+
+mvDouble_IN_MultiValueConstant
+required_capability: fix_mv_constant_equals_field
+
+FROM employees
+| WHERE salary_change IN ([1,2,3])
+| KEEP salary_change
+;
+warning:Line 2:9: evaluation of [salary_change IN ([1,2,3])] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:9: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+    salary_change:double
+;
+
+mvDouble_Equals_MultiValueConstant
+required_capability: fix_mv_constant_equals_field
+
+FROM employees
+| WHERE salary_change == [1,2,3]
+| KEEP salary_change
+;
+warning:Line 2:9: evaluation of [salary_change == [1,2,3]] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:9: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+    salary_change:double
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -2579,6 +2579,54 @@ warning:Line 2:9: java.lang.IllegalArgumentException: single-value function enco
 2023-10-23T13:55:01.544Z|Connected to 10.1.0.1
 ;
 
+mvStringEqualsMultiValueConstant
+required_capability: fix_mv_constant_equals_field
+FROM mv_text
+| WHERE message == ["Connected to 10.1.0.1", "Banana"]
+| KEEP @timestamp, message
+;
+warning:Line 2:9: evaluation of [message == [\"Connected to 10.1.0.1\", \"Banana\"]] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:9: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+    @timestamp:date     | message:text
+;
+
+mvString_IN_MultiValueConstant
+required_capability: fix_mv_constant_equals_field
+FROM mv_text
+| WHERE message IN (["Connected to 10.1.0.1", "Banana"])
+| KEEP @timestamp, message
+;
+warning:Line 2:9: evaluation of [message IN ([\"Connected to 10.1.0.1\", \"Banana\"])] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:9: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+    @timestamp:date     | message:text
+;
+
+mvKeyword_IN_MultiValueConstant
+required_capability: fix_mv_constant_equals_field
+FROM employees
+| WHERE job_positions IN (["Tech Lead" , "Data Scientist", "Senior Team Lead"])
+| KEEP emp_no, job_positions
+;
+warning:Line 2:9: evaluation of [job_positions IN ([\"Tech Lead\" , \"Data Scientist\", \"Senior Team Lead\"])] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:9: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+    emp_no:integer     | job_positions:keyword
+;
+
+mvKeywordEqualsMultiValueConstant
+required_capability: fix_mv_constant_equals_field
+FROM employees
+| WHERE job_positions == ["Tech Lead" , "Data Scientist", "Senior Team Lead"]
+| KEEP emp_no, job_positions
+;
+warning:Line 2:9: evaluation of [job_positions == [\"Tech Lead\" , \"Data Scientist\", \"Senior Team Lead\"]] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:9: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+    emp_no:integer     | job_positions:keyword
+;
+
 url_encode sample for docs
 required_capability: url_encode
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1637,6 +1637,7 @@ public class EsqlCapabilities {
          */
         LOOKUP_JOIN_SEMANTIC_FILTER_DEDUP,
 
+        FIX_MV_CONSTANT_EQUALS_FIELD,
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;


### PR DESCRIPTION
Backports the following commits to 9.2:
 - ESQL: fix handling equality with MV constants properly (#137032)