### PR TITLE
[9.2] Catch exceptions from mapperService in StoreRecovery.recoverFromLocalShards (#137077)

### DIFF
--- a/docs/changelog/137077.yaml
+++ b/docs/changelog/137077.yaml
@@ -1,0 +1,5 @@
+pr: 137077
+summary: Catch exceptions from `mapperService` in `StoreRecovery.recoverFromLocalShards`
+area: Recovery
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
@@ -128,15 +128,16 @@ public final class StoreRecovery {
                 mappingUpdateConsumer.accept(sourceMetadata.mapping(), mappingStep);
             }
             mappingStep.addListener(outerListener.delegateFailure((listener, ignored) -> {
-                indexShard.mapperService().merge(sourceMetadata, MapperService.MergeReason.MAPPING_RECOVERY);
-                // now that the mapping is merged we can validate the index sort configuration.
-                Sort indexSort = indexShard.getIndexSort();
-                final boolean hasNested = indexShard.mapperService().hasNested();
-                final boolean isSplit = sourceMetadata.getNumberOfShards() < indexShard.indexSettings().getNumberOfShards();
-
                 final var recoveryListener = recoveryListener(indexShard, listener);
-                logger.debug("starting recovery from local shards {}", shards);
+
                 try {
+                    indexShard.mapperService().merge(sourceMetadata, MapperService.MergeReason.MAPPING_RECOVERY);
+                    // now that the mapping is merged we can validate the index sort configuration.
+                    Sort indexSort = indexShard.getIndexSort();
+                    final boolean hasNested = indexShard.mapperService().hasNested();
+                    final boolean isSplit = sourceMetadata.getNumberOfShards() < indexShard.indexSettings().getNumberOfShards();
+
+                    logger.debug("starting recovery from local shards {}", shards);
                     final Directory directory = indexShard.store().directory(); // don't close this directory!!
                     final Directory[] sources = shards.stream().map(LocalShardSnapshot::getSnapshotDirectory).toArray(Directory[]::new);
                     final long maxSeqNo = shards.stream().mapToLong(LocalShardSnapshot::maxSeqNo).max().getAsLong();

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -209,6 +209,8 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.oneOf;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
 
 /**
  * Simple unit-test IndexShard related operations.
@@ -3415,6 +3417,14 @@ public class IndexShardTests extends IndexShardTestCase {
                 future.actionGet();
             });
             closeShards(differentIndex);
+
+            // check that an error from the mapper service is handled correctly
+            final PlainActionFuture<Boolean> badMapperFuture = new PlainActionFuture<>();
+            final IndexShard badMapper = spy(targetShard);
+            doThrow(IllegalArgumentException.class).when(badMapper).mapperService();
+            final BiConsumer<MappingMetadata, ActionListener<Void>> noopConsumer = (mapping, listener) -> listener.onResponse(null);
+            badMapper.recoverFromLocalShards(noopConsumer, List.of(sourceShard), badMapperFuture);
+            assertThrows(IndexShardRecoveryException.class, badMapperFuture::actionGet);
 
             final PlainActionFuture<Boolean> future = new PlainActionFuture<>();
             targetShard.recoverFromLocalShards(mappingConsumer, Arrays.asList(sourceShard), future);


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Catch exceptions from mapperService in StoreRecovery.recoverFromLocalShards (#137077)