### PR TITLE
[8.19] Catch exceptions from mapperService in StoreRecovery.recoverFromLocalShards (#137077)

### DIFF
--- a/docs/changelog/137077.yaml
+++ b/docs/changelog/137077.yaml
@@ -1,0 +1,5 @@
+pr: 137077
+summary: Catch exceptions from `mapperService` in `StoreRecovery.recoverFromLocalShards`
+area: Recovery
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
@@ -126,15 +126,16 @@ public final class StoreRecovery {
                 mappingUpdateConsumer.accept(sourceMetadata.mapping(), mappingStep);
             }
             mappingStep.addListener(outerListener.delegateFailure((listener, ignored) -> {
-                indexShard.mapperService().merge(sourceMetadata, MapperService.MergeReason.MAPPING_RECOVERY);
-                // now that the mapping is merged we can validate the index sort configuration.
-                Sort indexSort = indexShard.getIndexSort();
-                final boolean hasNested = indexShard.mapperService().hasNested();
-                final boolean isSplit = sourceMetadata.getNumberOfShards() < indexShard.indexSettings().getNumberOfShards();
-
                 final var recoveryListener = recoveryListener(indexShard, listener);
-                logger.debug("starting recovery from local shards {}", shards);
+
                 try {
+                    indexShard.mapperService().merge(sourceMetadata, MapperService.MergeReason.MAPPING_RECOVERY);
+                    // now that the mapping is merged we can validate the index sort configuration.
+                    Sort indexSort = indexShard.getIndexSort();
+                    final boolean hasNested = indexShard.mapperService().hasNested();
+                    final boolean isSplit = sourceMetadata.getNumberOfShards() < indexShard.indexSettings().getNumberOfShards();
+
+                    logger.debug("starting recovery from local shards {}", shards);
                     final Directory directory = indexShard.store().directory(); // don't close this directory!!
                     final Directory[] sources = shards.stream().map(LocalShardSnapshot::getSnapshotDirectory).toArray(Directory[]::new);
                     final long maxSeqNo = shards.stream().mapToLong(LocalShardSnapshot::maxSeqNo).max().getAsLong();


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Catch exceptions from mapperService in StoreRecovery.recoverFromLocalShards (#137077)