### PR TITLE
add optional exception type prefix

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_tsdb.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_tsdb.yml
@@ -860,5 +860,5 @@ error on rename timestamp:
             | RENAME @timestamp AS newTs
             | STATS max(rate(k8s.pod.network.tx))  BY tbucket = bucket(newTs, 1hour)
 
-  - match: { error.reason: "Found 1 problem\nline 3:13: Rate aggregation requires @timestamp field, but @timestamp was renamed or dropped" }
+  - match: { error.reason: '/(verification_exception:\ )?Found\ 1\ problem\nline\ 3:13:\ Rate\ aggregation\ requires\ @timestamp\ field,\ but\ @timestamp\ was\ renamed\ or\ dropped/' }
 


### PR DESCRIPTION
I have no idea why ESQL only puts the `verification_exception:` prefix on this error message sometimes, but that's what regex match is for.  The goal of the test is to make sure that the message itself is correct.