### PR TITLE
Test utility for `POST _features/_reset`

### DIFF
--- a/qa/system-indices/src/javaRestTest/java/org/elasticsearch/system/indices/FeatureUpgradeApiIT.java
+++ b/qa/system-indices/src/javaRestTest/java/org/elasticsearch/system/indices/FeatureUpgradeApiIT.java
@@ -29,7 +29,7 @@ public class FeatureUpgradeApiIT extends AbstractSystemIndicesIT {
 
     @After
     public void resetFeatures() throws Exception {
-        client().performRequest(new Request("POST", "/_features/_reset"));
+        performPostFeaturesReset(client());
     }
 
     public void testCreatingSystemIndex() throws Exception {

--- a/qa/system-indices/src/javaRestTest/java/org/elasticsearch/system/indices/NetNewSystemIndicesIT.java
+++ b/qa/system-indices/src/javaRestTest/java/org/elasticsearch/system/indices/NetNewSystemIndicesIT.java
@@ -94,6 +94,6 @@ public class NetNewSystemIndicesIT extends AbstractSystemIndicesIT {
 
     @After
     public void resetFeatures() throws Exception {
-        client().performRequest(new Request("POST", "/_features/_reset"));
+        performPostFeaturesReset(client());
     }
 }

--- a/qa/system-indices/src/javaRestTest/java/org/elasticsearch/system/indices/SystemAliasIT.java
+++ b/qa/system-indices/src/javaRestTest/java/org/elasticsearch/system/indices/SystemAliasIT.java
@@ -26,7 +26,7 @@ public class SystemAliasIT extends AbstractSystemIndicesIT {
 
     @After
     public void resetFeatures() throws Exception {
-        client().performRequest(new Request("POST", "/_features/_reset"));
+        performPostFeaturesReset(client());
     }
 
     public void testCreatingSystemIndexWithAlias() throws Exception {

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -925,6 +925,16 @@ public abstract class ESRestTestCase extends ESTestCase {
         return false;
     }
 
+    /**
+     * Invoke {@code POST /_features/_reset?error_trace&master_timeout=-1} with the given {@link RestClient}.
+     */
+    public static void performPostFeaturesReset(RestClient restClient) throws IOException {
+        final var request = new Request(HttpPost.METHOD_NAME, "/_features/_reset");
+        request.addParameter("error_trace", "true");
+        request.addParameter("master_timeout", "-1");
+        assertOK(restClient.performRequest(request));
+    }
+
     private void wipeCluster() throws Exception {
         waitForClusterUpdates();
 
@@ -951,8 +961,7 @@ public abstract class ESRestTestCase extends ESTestCase {
         wipeSnapshots();
 
         if (resetFeatureStates()) {
-            final Request postRequest = new Request("POST", "/_features/_reset");
-            cleanupClient().performRequest(postRequest);
+            performPostFeaturesReset(cleanupClient());
         }
 
         // wipe data streams before indices so that the backing indices for data streams are handled properly

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/integration/MlRestTestStateCleaner.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/integration/MlRestTestStateCleaner.java
@@ -17,6 +17,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.test.rest.ESRestTestCase.performPostFeaturesReset;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 
@@ -33,7 +34,7 @@ public class MlRestTestStateCleaner {
     public void resetFeatures() throws IOException {
         deletePipelinesWithInferenceProcessors();
         // This resets all features, not just ML, but they should have been getting reset between tests anyway so it shouldn't matter
-        adminClient.performRequest(new Request("POST", "/_features/_reset"));
+        performPostFeaturesReset(adminClient);
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/plugin/deprecation/qa/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/MlDeprecationIT.java
+++ b/x-pack/plugin/deprecation/qa/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/MlDeprecationIT.java
@@ -59,8 +59,7 @@ public class MlDeprecationIT extends ESRestTestCase {
 
     @After
     public void resetFeatures() throws IOException {
-        Response response = adminClient().performRequest(new Request("POST", "/_features/_reset"));
-        assertOK(response);
+        performPostFeaturesReset(adminClient());
     }
 
     @Override

--- a/x-pack/plugin/ml/qa/disabled/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlPluginDisabledIT.java
+++ b/x-pack/plugin/ml/qa/disabled/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlPluginDisabledIT.java
@@ -75,8 +75,7 @@ public class MlPluginDisabledIT extends ESRestTestCase {
     }
 
     public void testMlFeatureReset() throws IOException {
-        Request request = new Request("POST", "/_features/_reset");
-        assertOK(client().performRequest(request));
+        performPostFeaturesReset(client());
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/plugin/ml/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/InferenceTestCase.java
+++ b/x-pack/plugin/ml/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/InferenceTestCase.java
@@ -33,7 +33,7 @@ public abstract class InferenceTestCase extends ESRestTestCase {
         }
         createdPipelines.clear();
         waitForStats();
-        adminClient().performRequest(new Request("POST", "/_features/_reset"));
+        performPostFeaturesReset(adminClient());
     }
 
     void deletePipeline(String pipelineId) throws IOException {

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TestFeatureResetIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TestFeatureResetIT.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.transform.integration;
 
-import org.apache.http.client.methods.HttpPost;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
@@ -95,7 +94,7 @@ public class TestFeatureResetIT extends TransformRestTestCase {
 
         startTransform(continuousTransformId, RequestOptions.DEFAULT);
 
-        assertOK(client().performRequest(new Request(HttpPost.METHOD_NAME, "/_features/_reset")));
+        performPostFeaturesReset(client());
 
         Response response = adminClient().performRequest(new Request("GET", "/_cluster/state?metric=metadata"));
         Map<String, Object> metadata = (Map<String, Object>) ESRestTestCase.entityAsMap(response).get("metadata");

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformGetAndGetStatsIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformGetAndGetStatsIT.java
@@ -66,7 +66,7 @@ public class TransformGetAndGetStatsIT extends TransformRestTestCase {
 
     @After
     public void clearOutTransforms() throws Exception {
-        adminClient().performRequest(new Request("POST", "/_features/_reset"));
+        performPostFeaturesReset(adminClient());
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
@@ -648,7 +648,7 @@ public abstract class TransformRestTestCase extends TransformCommonRestTestCase 
         ensureNoInitializingShards();
         logAudits();
         if (preserveClusterUponCompletion() == false) {
-            adminClient().performRequest(new Request("POST", "/_features/_reset"));
+            performPostFeaturesReset(adminClient());
         }
     }
 

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformTaskFailedStateIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformTaskFailedStateIT.java
@@ -54,7 +54,7 @@ public class TransformTaskFailedStateIT extends TransformRestTestCase {
 
     @After
     public void cleanUpPotentiallyFailedTransform() throws Exception {
-        adminClient().performRequest(new Request("POST", "/_features/_reset"));
+        performPostFeaturesReset(adminClient());
     }
 
     public void testForceStopFailedTransform() throws Exception {

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformUpgradeModeIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformUpgradeModeIT.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.transform.integration;
 
-import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
@@ -53,7 +52,7 @@ public class TransformUpgradeModeIT extends TransformRestTestCase {
 
     @After
     public void clearOutTransforms() throws Exception {
-        adminClient().performRequest(new Request("POST", "/_features/_reset"));
+        performPostFeaturesReset(adminClient());
     }
 
     public void testUpgradeMode() throws Exception {


### PR DESCRIPTION
We call `POST _features/_reset` in various places in the tests, only
sometimes asserting that the response is `200 OK`. This commit extracts
a utility that makes it harder to miss this assertion. It also adds the
`?error_trace` parameter so that on failure the details are visible in
the response, and `?master_timeout=-1` to avoid spurious timeouts if CI
is running a little slow.