### PR TITLE
Rename UnassignedInfo#AllocationStatus to #FailedAllocationStatus

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/routing/allocation/ShardsAvailabilityHealthIndicatorBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/routing/allocation/ShardsAvailabilityHealthIndicatorBenchmark.java
@@ -116,7 +116,7 @@ public class ShardsAvailabilityHealthIndicatorBenchmark {
             System.nanoTime(),
             System.currentTimeMillis(),
             false,
-            UnassignedInfo.AllocationStatus.DECIDERS_NO,
+            UnassignedInfo.FailedAllocationStatus.DECIDERS_NO,
             failedNodeIds,
             null
         );

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainIT.java
@@ -19,7 +19,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
-import org.elasticsearch.cluster.routing.UnassignedInfo.AllocationStatus;
+import org.elasticsearch.cluster.routing.UnassignedInfo.FailedAllocationStatus;
 import org.elasticsearch.cluster.routing.UnassignedInfo.Reason;
 import org.elasticsearch.cluster.routing.allocation.AllocateUnassignedDecision;
 import org.elasticsearch.cluster.routing.allocation.AllocationDecision;
@@ -103,8 +103,8 @@ public final class ClusterAllocationExplainIT extends ESIntegTestCase {
         assertNotNull(unassignedInfo);
         assertEquals(Reason.NODE_LEFT, unassignedInfo.reason());
         assertTrue(
-            unassignedInfo.lastAllocationStatus() == AllocationStatus.FETCHING_SHARD_DATA
-                || unassignedInfo.lastAllocationStatus() == AllocationStatus.NO_VALID_SHARD_COPY
+            unassignedInfo.lastFailedAllocationStatus() == FailedAllocationStatus.FETCHING_SHARD_DATA
+                || unassignedInfo.lastFailedAllocationStatus() == FailedAllocationStatus.NO_VALID_SHARD_COPY
         );
 
         // verify cluster info
@@ -192,7 +192,7 @@ public final class ClusterAllocationExplainIT extends ESIntegTestCase {
         // verify unassigned info
         assertNotNull(unassignedInfo);
         assertEquals(Reason.NODE_LEFT, unassignedInfo.reason());
-        assertEquals(AllocationStatus.NO_ATTEMPT, unassignedInfo.lastAllocationStatus());
+        assertEquals(FailedAllocationStatus.NO_ATTEMPT, unassignedInfo.lastFailedAllocationStatus());
 
         // verify cluster info
         verifyClusterInfo(clusterInfo, includeDiskInfo, 2);
@@ -322,7 +322,7 @@ public final class ClusterAllocationExplainIT extends ESIntegTestCase {
         // verify unassigned info
         assertNotNull(unassignedInfo);
         assertEquals(Reason.NODE_LEFT, unassignedInfo.reason());
-        assertEquals(AllocationStatus.NO_ATTEMPT, unassignedInfo.lastAllocationStatus());
+        assertEquals(FailedAllocationStatus.NO_ATTEMPT, unassignedInfo.lastFailedAllocationStatus());
 
         // verify cluster info
         verifyClusterInfo(clusterInfo, includeDiskInfo, 3);
@@ -434,7 +434,7 @@ public final class ClusterAllocationExplainIT extends ESIntegTestCase {
         // verify unassigned info
         assertNotNull(unassignedInfo);
         assertEquals(Reason.INDEX_CREATED, unassignedInfo.reason());
-        assertEquals(AllocationStatus.DECIDERS_NO, unassignedInfo.lastAllocationStatus());
+        assertEquals(FailedAllocationStatus.DECIDERS_NO, unassignedInfo.lastFailedAllocationStatus());
 
         // verify cluster info
         verifyClusterInfo(clusterInfo, includeDiskInfo, 2);

--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
@@ -405,8 +405,8 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
                 IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
                 assertTrue(shardRoutingTable.primaryShard().unassigned());
                 assertEquals(
-                    UnassignedInfo.AllocationStatus.DECIDERS_NO,
-                    shardRoutingTable.primaryShard().unassignedInfo().lastAllocationStatus()
+                    UnassignedInfo.FailedAllocationStatus.DECIDERS_NO,
+                    shardRoutingTable.primaryShard().unassignedInfo().lastFailedAllocationStatus()
                 );
                 assertThat(shardRoutingTable.primaryShard().unassignedInfo().failedAllocations(), greaterThan(0));
             }
@@ -477,8 +477,8 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
                 IndexShardRoutingTable shardRoutingTable = indexRoutingTable.shard(i);
                 assertTrue(shardRoutingTable.primaryShard().unassigned());
                 assertEquals(
-                    UnassignedInfo.AllocationStatus.DECIDERS_NO,
-                    shardRoutingTable.primaryShard().unassignedInfo().lastAllocationStatus()
+                    UnassignedInfo.FailedAllocationStatus.DECIDERS_NO,
+                    shardRoutingTable.primaryShard().unassignedInfo().lastFailedAllocationStatus()
                 );
                 assertThat(shardRoutingTable.primaryShard().unassignedInfo().failedAllocations(), greaterThan(0));
             }

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -690,7 +690,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
             if (shard.primary()) {
                 assertThat(shard.state(), equalTo(ShardRoutingState.UNASSIGNED));
                 assertThat(shard.recoverySource().getType(), equalTo(RecoverySource.Type.SNAPSHOT));
-                assertThat(shard.unassignedInfo().lastAllocationStatus(), equalTo(UnassignedInfo.AllocationStatus.DECIDERS_NO));
+                assertThat(shard.unassignedInfo().lastFailedAllocationStatus(), equalTo(UnassignedInfo.FailedAllocationStatus.DECIDERS_NO));
                 checkUnassignedInfo.accept(shard.unassignedInfo());
             }
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplanation.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplanation.java
@@ -229,7 +229,7 @@ public final class ClusterAllocationExplanation implements ChunkedToXContentObje
         if (details != null) {
             builder.field("details", details);
         }
-        builder.field("last_allocation_status", AllocationDecision.fromAllocationStatus(unassignedInfo.lastAllocationStatus()));
+        builder.field("last_allocation_status", AllocationDecision.fromAllocationStatus(unassignedInfo.lastFailedAllocationStatus()));
         builder.endObject();
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/health/ClusterShardHealth.java
+++ b/server/src/main/java/org/elasticsearch/cluster/health/ClusterShardHealth.java
@@ -14,7 +14,7 @@ import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
-import org.elasticsearch.cluster.routing.UnassignedInfo.AllocationStatus;
+import org.elasticsearch.cluster.routing.UnassignedInfo.FailedAllocationStatus;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -190,7 +190,7 @@ public final class ClusterShardHealth implements Writeable, ToXContentFragment {
         assert shardRouting.recoverySource() != null : "cannot invoke on a shard that has no recovery source" + shardRouting;
         final UnassignedInfo unassignedInfo = shardRouting.unassignedInfo();
         RecoverySource.Type recoveryType = shardRouting.recoverySource().getType();
-        if (unassignedInfo.lastAllocationStatus() != AllocationStatus.DECIDERS_NO
+        if (unassignedInfo.lastFailedAllocationStatus() != FailedAllocationStatus.DECIDERS_NO
             && unassignedInfo.failedAllocations() == 0
             && (recoveryType == RecoverySource.Type.EMPTY_STORE
                 || recoveryType == RecoverySource.Type.LOCAL_SHARDS

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
@@ -581,7 +581,7 @@ public class IndexRoutingTable implements SimpleDiffable<IndexRoutingTable> {
                     unassignedInfo.unassignedTimeNanos(),
                     unassignedInfo.unassignedTimeMillis(),
                     unassignedInfo.delayed(),
-                    unassignedInfo.lastAllocationStatus(),
+                    unassignedInfo.lastFailedAllocationStatus(),
                     unassignedInfo.failedNodeIds(),
                     previousNodes.get(shardCopy)
                 );

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationDecision.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationDecision.java
@@ -9,7 +9,7 @@
 
 package org.elasticsearch.cluster.routing.allocation;
 
-import org.elasticsearch.cluster.routing.UnassignedInfo.AllocationStatus;
+import org.elasticsearch.cluster.routing.UnassignedInfo.FailedAllocationStatus;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -89,13 +89,13 @@ public enum AllocationDecision implements Writeable {
     }
 
     /**
-     * Gets an {@link AllocationDecision} from a {@link AllocationStatus}.
+     * Gets an {@link AllocationDecision} from a {@link FailedAllocationStatus}.
      */
-    public static AllocationDecision fromAllocationStatus(AllocationStatus allocationStatus) {
-        if (allocationStatus == null) {
+    public static AllocationDecision fromAllocationStatus(FailedAllocationStatus failedAllocationStatus) {
+        if (failedAllocationStatus == null) {
             return YES;
         } else {
-            return switch (allocationStatus) {
+            return switch (failedAllocationStatus) {
                 case DECIDERS_THROTTLED -> THROTTLED;
                 case FETCHING_SHARD_DATA -> AWAITING_INFO;
                 case DELAYED_ALLOCATION -> ALLOCATION_DELAYED;

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
@@ -34,7 +34,7 @@ import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingRoleStrategy;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
-import org.elasticsearch.cluster.routing.UnassignedInfo.AllocationStatus;
+import org.elasticsearch.cluster.routing.UnassignedInfo.FailedAllocationStatus;
 import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
 import org.elasticsearch.cluster.routing.allocation.allocator.ShardsAllocator;
 import org.elasticsearch.cluster.routing.allocation.command.AllocationCommands;
@@ -250,7 +250,7 @@ public class AllocationService {
                     currentNanoTime,
                     System.currentTimeMillis(),
                     false,
-                    AllocationStatus.NO_ATTEMPT,
+                    FailedAllocationStatus.NO_ATTEMPT,
                     failedNodeIds,
                     shardToFail.currentNodeId()
                 );
@@ -501,7 +501,7 @@ public class AllocationService {
                                 unassignedInfo.unassignedTimeNanos(),
                                 unassignedInfo.unassignedTimeMillis(),
                                 false,
-                                unassignedInfo.lastAllocationStatus(),
+                                unassignedInfo.lastFailedAllocationStatus(),
                                 unassignedInfo.failedNodeIds(),
                                 unassignedInfo.lastAllocatedNodeId()
                             ),
@@ -730,7 +730,7 @@ public class AllocationService {
                     allocation.getCurrentNanoTime(),
                     System.currentTimeMillis(),
                     delayed,
-                    AllocationStatus.NO_ATTEMPT,
+                    FailedAllocationStatus.NO_ATTEMPT,
                     Collections.emptySet(),
                     shardRouting.currentNodeId()
                 );
@@ -853,7 +853,7 @@ public class AllocationService {
             RoutingAllocation allocation,
             UnassignedAllocationHandler unassignedAllocationHandler
         ) {
-            unassignedAllocationHandler.removeAndIgnore(AllocationStatus.NO_VALID_SHARD_COPY, allocation.changes());
+            unassignedAllocationHandler.removeAndIgnore(FailedAllocationStatus.NO_VALID_SHARD_COPY, allocation.changes());
         }
 
         @Override
@@ -876,7 +876,7 @@ public class AllocationService {
                     )
                 );
             }
-            return AllocateUnassignedDecision.no(AllocationStatus.NO_VALID_SHARD_COPY, nodeAllocationResults);
+            return AllocateUnassignedDecision.no(FailedAllocationStatus.NO_VALID_SHARD_COPY, nodeAllocationResults);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ExistingShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ExistingShardsAllocator.java
@@ -110,7 +110,7 @@ public interface ExistingShardsAllocator {
          *
          * @param attempt the result of the allocation attempt
          */
-        void removeAndIgnore(UnassignedInfo.AllocationStatus attempt, RoutingChangesObserver changes);
+        void removeAndIgnore(UnassignedInfo.FailedAllocationStatus attempt, RoutingChangesObserver changes);
 
         /**
          * updates the unassigned info and recovery source on the current unassigned shard

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -24,7 +24,7 @@ import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
-import org.elasticsearch.cluster.routing.UnassignedInfo.AllocationStatus;
+import org.elasticsearch.cluster.routing.UnassignedInfo.FailedAllocationStatus;
 import org.elasticsearch.cluster.routing.allocation.AllocateUnassignedDecision;
 import org.elasticsearch.cluster.routing.allocation.AllocationDecision;
 import org.elasticsearch.cluster.routing.allocation.MoveDecision;
@@ -272,7 +272,7 @@ public class BalancedShardsAllocator implements ShardsAllocator {
         while (unassignedIterator.hasNext()) {
             final ShardRouting shardRouting = unassignedIterator.next();
             final UnassignedInfo unassignedInfo = shardRouting.unassignedInfo();
-            if (shardRouting.primary() && unassignedInfo.lastAllocationStatus() == AllocationStatus.NO_ATTEMPT) {
+            if (shardRouting.primary() && unassignedInfo.lastFailedAllocationStatus() == FailedAllocationStatus.NO_ATTEMPT) {
                 unassignedIterator.updateUnassigned(
                     new UnassignedInfo(
                         unassignedInfo.reason(),
@@ -282,7 +282,7 @@ public class BalancedShardsAllocator implements ShardsAllocator {
                         unassignedInfo.unassignedTimeNanos(),
                         unassignedInfo.unassignedTimeMillis(),
                         unassignedInfo.delayed(),
-                        AllocationStatus.DECIDERS_NO,
+                        FailedAllocationStatus.DECIDERS_NO,
                         unassignedInfo.failedNodeIds(),
                         unassignedInfo.lastAllocatedNodeId()
                     ),
@@ -1265,7 +1265,7 @@ public class BalancedShardsAllocator implements ShardsAllocator {
 
                         if (minNode != null) {
                             // throttle decision scenario
-                            assert allocationDecision.getAllocationStatus() == AllocationStatus.DECIDERS_THROTTLED;
+                            assert allocationDecision.getAllocationStatus() == FailedAllocationStatus.DECIDERS_THROTTLED;
                             final long shardSize = getExpectedShardSize(shard, ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE, allocation);
                             minNode.addShard(projectIndex(shard), shard.initialize(minNode.getNodeId(), null, shardSize));
                             // If we see a throttle decision in simulation, there must be other shards that got assigned before it.
@@ -1318,7 +1318,7 @@ public class BalancedShardsAllocator implements ShardsAllocator {
             Decision shardLevelDecision = allocation.deciders().canAllocate(shard, allocation);
             if (shardLevelDecision.type() == Type.NO && explain == false) {
                 // NO decision for allocating the shard, irrespective of any particular node, so exit early
-                return AllocateUnassignedDecision.no(AllocationStatus.DECIDERS_NO, null);
+                return AllocateUnassignedDecision.no(FailedAllocationStatus.DECIDERS_NO, null);
             }
 
             /* find an node with minimal weight we can allocate on*/

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java
@@ -23,7 +23,7 @@ import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
-import org.elasticsearch.cluster.routing.UnassignedInfo.AllocationStatus;
+import org.elasticsearch.cluster.routing.UnassignedInfo.FailedAllocationStatus;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.common.FrequencyCappedAction;
@@ -219,7 +219,7 @@ public class DesiredBalanceReconciler {
             while (unassignedIterator.hasNext()) {
                 final ShardRouting shardRouting = unassignedIterator.next();
                 final UnassignedInfo unassignedInfo = shardRouting.unassignedInfo();
-                if (shardRouting.primary() && unassignedInfo.lastAllocationStatus() == AllocationStatus.NO_ATTEMPT) {
+                if (shardRouting.primary() && unassignedInfo.lastFailedAllocationStatus() == FailedAllocationStatus.NO_ATTEMPT) {
                     unassignedIterator.updateUnassigned(
                         new UnassignedInfo(
                             unassignedInfo.reason(),
@@ -229,7 +229,7 @@ public class DesiredBalanceReconciler {
                             unassignedInfo.unassignedTimeNanos(),
                             unassignedInfo.unassignedTimeMillis(),
                             unassignedInfo.delayed(),
-                            AllocationStatus.DECIDERS_NO,
+                            FailedAllocationStatus.DECIDERS_NO,
                             unassignedInfo.failedNodeIds(),
                             unassignedInfo.lastAllocatedNodeId()
                         ),
@@ -299,11 +299,11 @@ public class DesiredBalanceReconciler {
                     // An ignored shard copy is one that has no desired balance assignment.
                     final boolean ignored = assignment == null || isIgnored(routingNodes, shard, assignment);
 
-                    AllocationStatus unallocatedStatus;
+                    FailedAllocationStatus unallocatedStatus;
                     if (ignored) {
-                        unallocatedStatus = AllocationStatus.NO_ATTEMPT;
+                        unallocatedStatus = FailedAllocationStatus.NO_ATTEMPT;
                     } else {
-                        unallocatedStatus = AllocationStatus.DECIDERS_NO;
+                        unallocatedStatus = FailedAllocationStatus.DECIDERS_NO;
                         final var nodeIdsIterator = new NodeIdsIterator(shard, assignment, routingNodes);
                         while (nodeIdsIterator.hasNext()) {
                             final var nodeId = nodeIdsIterator.next();
@@ -341,7 +341,7 @@ public class DesiredBalanceReconciler {
                                 }
                                 case THROTTLE -> {
                                     nodeIdsIterator.wasThrottled = true;
-                                    unallocatedStatus = AllocationStatus.DECIDERS_THROTTLED;
+                                    unallocatedStatus = FailedAllocationStatus.DECIDERS_THROTTLED;
                                     logger.debug("Couldn't assign shard [{}] to [{}]: {}", shard.shardId(), nodeId, decision);
                                 }
                                 case NO -> {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocateEmptyPrimaryAllocationCommand.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocateEmptyPrimaryAllocationCommand.java
@@ -161,7 +161,7 @@ public class AllocateEmptyPrimaryAllocationCommand extends BasePrimaryAllocation
                 System.nanoTime(),
                 System.currentTimeMillis(),
                 false,
-                shardRouting.unassignedInfo().lastAllocationStatus(),
+                shardRouting.unassignedInfo().lastFailedAllocationStatus(),
                 Collections.emptySet(),
                 null
             );

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/shards/ShardsAvailabilityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/shards/ShardsAvailabilityHealthIndicatorService.java
@@ -607,7 +607,7 @@ public class ShardsAvailabilityHealthIndicatorService implements HealthIndicator
 
         Optional<UnassignedInfo> ui = Optional.ofNullable(routing.unassignedInfo());
         return ui.filter(info -> info.failedAllocations() == 0)
-            .filter(info -> info.lastAllocationStatus() != UnassignedInfo.AllocationStatus.DECIDERS_NO)
+            .filter(info -> info.lastFailedAllocationStatus() != UnassignedInfo.FailedAllocationStatus.DECIDERS_NO)
             .filter(info -> info.unassignedTimeMillis() > replicaUnassignedCutoffTime)
             .isPresent();
     }
@@ -647,7 +647,7 @@ public class ShardsAvailabilityHealthIndicatorService implements HealthIndicator
     List<Diagnosis.Definition> diagnoseUnassignedShardRouting(ShardRouting shardRouting, ClusterState state) {
         List<Diagnosis.Definition> diagnosisDefs = new ArrayList<>();
         LOGGER.trace("Diagnosing unassigned shard [{}] due to reason [{}]", shardRouting.shardId(), shardRouting.unassignedInfo());
-        switch (shardRouting.unassignedInfo().lastAllocationStatus()) {
+        switch (shardRouting.unassignedInfo().lastFailedAllocationStatus()) {
             case NO_VALID_SHARD_COPY -> diagnosisDefs.add(ACTION_RESTORE_FROM_SNAPSHOT);
             case NO_ATTEMPT -> {
                 if (shardRouting.unassignedInfo().delayed()) {

--- a/server/src/main/java/org/elasticsearch/gateway/PrimaryShardAllocator.java
+++ b/server/src/main/java/org/elasticsearch/gateway/PrimaryShardAllocator.java
@@ -16,8 +16,7 @@ import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.ShardRouting;
-import org.elasticsearch.cluster.routing.UnassignedInfo;
-import org.elasticsearch.cluster.routing.UnassignedInfo.AllocationStatus;
+import org.elasticsearch.cluster.routing.UnassignedInfo.FailedAllocationStatus;
 import org.elasticsearch.cluster.routing.allocation.AllocateUnassignedDecision;
 import org.elasticsearch.cluster.routing.allocation.NodeAllocationResult;
 import org.elasticsearch.cluster.routing.allocation.NodeAllocationResult.ShardStoreInfo;
@@ -83,7 +82,7 @@ public abstract class PrimaryShardAllocator extends BaseGatewayShardAllocator {
             if (explain) {
                 nodeDecisions = buildDecisionsForAllNodes(unassignedShard, allocation);
             }
-            return AllocateUnassignedDecision.no(UnassignedInfo.AllocationStatus.FETCHING_SHARD_DATA, nodeDecisions);
+            return AllocateUnassignedDecision.no(FailedAllocationStatus.FETCHING_SHARD_DATA, nodeDecisions);
         }
 
         final FetchResult<NodeGatewayStartedShards> shardState = fetchData(unassignedShard, allocation);
@@ -93,7 +92,7 @@ public abstract class PrimaryShardAllocator extends BaseGatewayShardAllocator {
             if (explain) {
                 nodeDecisions = buildDecisionsForAllNodes(unassignedShard, allocation);
             }
-            return AllocateUnassignedDecision.no(AllocationStatus.FETCHING_SHARD_DATA, nodeDecisions);
+            return AllocateUnassignedDecision.no(FailedAllocationStatus.FETCHING_SHARD_DATA, nodeDecisions);
         }
 
         // don't create a new IndexSetting object for every shard as this could cause a lot of garbage
@@ -143,7 +142,7 @@ public abstract class PrimaryShardAllocator extends BaseGatewayShardAllocator {
                     nodeShardsResult.allocationsFound
                 );
                 return AllocateUnassignedDecision.no(
-                    AllocationStatus.NO_VALID_SHARD_COPY,
+                    FailedAllocationStatus.NO_VALID_SHARD_COPY,
                     explain ? buildNodeDecisions(null, shardState, inSyncAllocationIds) : null
                 );
             }
@@ -220,13 +219,13 @@ public abstract class PrimaryShardAllocator extends BaseGatewayShardAllocator {
             nodeResults = buildNodeDecisions(nodesToAllocate, shardState, inSyncAllocationIds);
         }
         if (allocation.hasPendingAsyncFetch()) {
-            return AllocateUnassignedDecision.no(AllocationStatus.FETCHING_SHARD_DATA, nodeResults);
+            return AllocateUnassignedDecision.no(FailedAllocationStatus.FETCHING_SHARD_DATA, nodeResults);
         } else if (node != null) {
             return AllocateUnassignedDecision.yes(node, allocationId, nodeResults, false);
         } else if (throttled) {
             return AllocateUnassignedDecision.throttle(nodeResults);
         } else {
-            return AllocateUnassignedDecision.no(AllocationStatus.DECIDERS_NO, nodeResults, true);
+            return AllocateUnassignedDecision.no(FailedAllocationStatus.DECIDERS_NO, nodeResults, true);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -969,7 +969,7 @@ public final class RestoreService implements ClusterStateApplier {
         public void unassignedInfoUpdated(ShardRouting unassignedShard, UnassignedInfo newUnassignedInfo) {
             RecoverySource recoverySource = unassignedShard.recoverySource();
             if (recoverySource.getType() == RecoverySource.Type.SNAPSHOT) {
-                if (newUnassignedInfo.lastAllocationStatus() == UnassignedInfo.AllocationStatus.DECIDERS_NO) {
+                if (newUnassignedInfo.lastFailedAllocationStatus() == UnassignedInfo.FailedAllocationStatus.DECIDERS_NO) {
                     String reason = "shard could not be allocated to any of the nodes";
                     changes(recoverySource).put(
                         unassignedShard.shardId(),

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainActionTests.java
@@ -113,7 +113,7 @@ public class ClusterAllocationExplainActionTests extends ESTestCase {
                         """,
                     shard.unassignedInfo().reason(),
                     UnassignedInfo.DATE_TIME_FORMATTER.format(Instant.ofEpochMilli(shard.unassignedInfo().unassignedTimeMillis())),
-                    AllocationDecision.fromAllocationStatus(shard.unassignedInfo().lastAllocationStatus())
+                    AllocationDecision.fromAllocationStatus(shard.unassignedInfo().lastFailedAllocationStatus())
                 )
                 : "",
             cae.getCurrentNode().getId(),

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplanationTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplanationTests.java
@@ -170,7 +170,10 @@ public final class ClusterAllocationExplanationTests extends ESTestCase {
             MoveDecision moveDecision = MoveDecision.rebalance(Decision.YES, Decision.YES, AllocationDecision.NO, null, 3, null);
             shardAllocationDecision = new ShardAllocationDecision(AllocateUnassignedDecision.NOT_TAKEN, moveDecision);
         } else {
-            AllocateUnassignedDecision allocateDecision = AllocateUnassignedDecision.no(UnassignedInfo.AllocationStatus.DECIDERS_NO, null);
+            AllocateUnassignedDecision allocateDecision = AllocateUnassignedDecision.no(
+                UnassignedInfo.FailedAllocationStatus.DECIDERS_NO,
+                null
+            );
             shardAllocationDecision = new ShardAllocationDecision(allocateDecision, MoveDecision.NOT_TAKEN);
         }
         return new ClusterAllocationExplanation(specificShard, shardRouting, node, null, null, shardAllocationDecision);

--- a/server/src/test/java/org/elasticsearch/cluster/health/ClusterStateHealthTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/health/ClusterStateHealthTests.java
@@ -629,7 +629,7 @@ public class ClusterStateHealthTests extends ESTestCase {
                 if (primaryShard.unassignedInfo().failedAllocations() > 0) {
                     return false;
                 }
-                if (primaryShard.unassignedInfo().lastAllocationStatus() == UnassignedInfo.AllocationStatus.DECIDERS_NO) {
+                if (primaryShard.unassignedInfo().lastFailedAllocationStatus() == UnassignedInfo.FailedAllocationStatus.DECIDERS_NO) {
                     return false;
                 }
             }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/AllocationIdTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/AllocationIdTests.java
@@ -129,7 +129,7 @@ public class AllocationIdTests extends ESTestCase {
                 System.nanoTime(),
                 System.currentTimeMillis(),
                 false,
-                UnassignedInfo.AllocationStatus.NO_ATTEMPT,
+                UnassignedInfo.FailedAllocationStatus.NO_ATTEMPT,
                 Collections.emptySet(),
                 randomAlphaOfLength(10)
             )

--- a/server/src/test/java/org/elasticsearch/cluster/routing/UnassignedInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/UnassignedInfoTests.java
@@ -25,7 +25,7 @@ import org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.RecoverySource.SnapshotRecoverySource;
-import org.elasticsearch.cluster.routing.UnassignedInfo.AllocationStatus;
+import org.elasticsearch.cluster.routing.UnassignedInfo.FailedAllocationStatus;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.routing.allocation.FailedShard;
 import org.elasticsearch.common.UUIDs;
@@ -113,7 +113,7 @@ public class UnassignedInfoTests extends ESAllocationTestCase {
                 System.nanoTime(),
                 System.currentTimeMillis(),
                 false,
-                AllocationStatus.NO_ATTEMPT,
+                FailedAllocationStatus.NO_ATTEMPT,
                 failedNodes,
                 null
             );
@@ -131,7 +131,7 @@ public class UnassignedInfoTests extends ESAllocationTestCase {
                 System.nanoTime(),
                 System.currentTimeMillis(),
                 false,
-                AllocationStatus.NO_ATTEMPT,
+                FailedAllocationStatus.NO_ATTEMPT,
                 Set.of(),
                 lastAssignedNodeId
             );
@@ -795,7 +795,7 @@ public class UnassignedInfoTests extends ESAllocationTestCase {
             baseTime,
             System.currentTimeMillis(),
             randomBoolean(),
-            AllocationStatus.NO_ATTEMPT,
+            FailedAllocationStatus.NO_ATTEMPT,
             Set.of(),
             lastNodeId
         );
@@ -906,12 +906,12 @@ public class UnassignedInfoTests extends ESAllocationTestCase {
     }
 
     public void testAllocationStatusSerialization() throws IOException {
-        for (AllocationStatus allocationStatus : AllocationStatus.values()) {
+        for (FailedAllocationStatus failedAllocationStatus : FailedAllocationStatus.values()) {
             BytesStreamOutput out = new BytesStreamOutput();
-            allocationStatus.writeTo(out);
+            failedAllocationStatus.writeTo(out);
             ByteBufferStreamInput in = new ByteBufferStreamInput(ByteBuffer.wrap(out.bytes().toBytesRef().bytes));
-            AllocationStatus readStatus = AllocationStatus.readFrom(in);
-            assertThat(readStatus, equalTo(allocationStatus));
+            FailedAllocationStatus readStatus = FailedAllocationStatus.readFrom(in);
+            assertThat(readStatus, equalTo(failedAllocationStatus));
         }
     }
 
@@ -943,7 +943,7 @@ public class UnassignedInfoTests extends ESAllocationTestCase {
             System.nanoTime(),
             System.currentTimeMillis(),
             delayedFlag,
-            UnassignedInfo.AllocationStatus.NO_ATTEMPT,
+            FailedAllocationStatus.NO_ATTEMPT,
             reason == UnassignedInfo.Reason.ALLOCATION_FAILED ? Set.of(randomIdentifier()) : Set.of(),
             lastAllocatedNodeId
         );
@@ -972,6 +972,6 @@ public class UnassignedInfoTests extends ESAllocationTestCase {
         if (info.message() != null) {
             assertThat("details", summary, containsString("details[" + info.message() + ']'));
         }
-        assertThat("allocation_status", summary, containsString("allocation_status[" + info.lastAllocationStatus().value() + ']'));
+        assertThat("allocation_status", summary, containsString("allocation_status[" + info.lastFailedAllocationStatus().value() + ']'));
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationDecisionTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationDecisionTests.java
@@ -9,7 +9,7 @@
 
 package org.elasticsearch.cluster.routing.allocation;
 
-import org.elasticsearch.cluster.routing.UnassignedInfo.AllocationStatus;
+import org.elasticsearch.cluster.routing.UnassignedInfo.FailedAllocationStatus;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision.Type;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.test.ESTestCase;
@@ -70,23 +70,23 @@ public class AllocationDecisionTests extends ESTestCase {
     }
 
     /**
-     * Tests getting a {@link AllocationDecision} from {@link AllocationStatus}.
+     * Tests getting a {@link AllocationDecision} from {@link FailedAllocationStatus}.
      */
     public void testFromAllocationStatus() {
-        AllocationStatus allocationStatus = rarely() ? null : randomFrom(AllocationStatus.values());
-        AllocationDecision allocationDecision = AllocationDecision.fromAllocationStatus(allocationStatus);
+        FailedAllocationStatus failedAllocationStatus = rarely() ? null : randomFrom(FailedAllocationStatus.values());
+        AllocationDecision allocationDecision = AllocationDecision.fromAllocationStatus(failedAllocationStatus);
         AllocationDecision expected;
-        if (allocationStatus == null) {
+        if (failedAllocationStatus == null) {
             expected = AllocationDecision.YES;
-        } else if (allocationStatus == AllocationStatus.DECIDERS_THROTTLED) {
+        } else if (failedAllocationStatus == FailedAllocationStatus.DECIDERS_THROTTLED) {
             expected = AllocationDecision.THROTTLED;
-        } else if (allocationStatus == AllocationStatus.FETCHING_SHARD_DATA) {
+        } else if (failedAllocationStatus == FailedAllocationStatus.FETCHING_SHARD_DATA) {
             expected = AllocationDecision.AWAITING_INFO;
-        } else if (allocationStatus == AllocationStatus.DELAYED_ALLOCATION) {
+        } else if (failedAllocationStatus == FailedAllocationStatus.DELAYED_ALLOCATION) {
             expected = AllocationDecision.ALLOCATION_DELAYED;
-        } else if (allocationStatus == AllocationStatus.NO_VALID_SHARD_COPY) {
+        } else if (failedAllocationStatus == FailedAllocationStatus.NO_VALID_SHARD_COPY) {
             expected = AllocationDecision.NO_VALID_SHARD_COPY;
-        } else if (allocationStatus == AllocationStatus.NO_ATTEMPT) {
+        } else if (failedAllocationStatus == FailedAllocationStatus.NO_ATTEMPT) {
             expected = AllocationDecision.NO_ATTEMPT;
         } else {
             expected = AllocationDecision.NO;

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationFailuresResetTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationFailuresResetTests.java
@@ -76,7 +76,7 @@ public class AllocationFailuresResetTests extends ESTestCase {
             0,
             0,
             false,
-            UnassignedInfo.AllocationStatus.NO_ATTEMPT,
+            UnassignedInfo.FailedAllocationStatus.NO_ATTEMPT,
             Set.of(),
             null
         );

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationServiceTests.java
@@ -60,7 +60,7 @@ import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
 import static org.elasticsearch.cluster.routing.RoutingNodesHelper.shardsWithState;
-import static org.elasticsearch.cluster.routing.UnassignedInfo.AllocationStatus.DECIDERS_NO;
+import static org.elasticsearch.cluster.routing.UnassignedInfo.FailedAllocationStatus.DECIDERS_NO;
 import static org.elasticsearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider.CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_INCOMING_RECOVERIES_SETTING;
 import static org.elasticsearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider.CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_OUTGOING_RECOVERIES_SETTING;
 import static org.elasticsearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider.CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_PRIMARIES_RECOVERIES_SETTING;
@@ -315,7 +315,7 @@ public class AllocationServiceTests extends ESTestCase {
         assertTrue(shardAllocationDecision.isDecisionTaken());
         assertThat(
             shardAllocationDecision.getAllocateDecision().getAllocationStatus(),
-            equalTo(UnassignedInfo.AllocationStatus.NO_VALID_SHARD_COPY)
+            equalTo(UnassignedInfo.FailedAllocationStatus.NO_VALID_SHARD_COPY)
         );
         assertThat(shardAllocationDecision.getAllocateDecision().getAllocationDecision(), equalTo(AllocationDecision.NO_VALID_SHARD_COPY));
         assertThat(shardAllocationDecision.getAllocateDecision().getExplanation(), equalTo(Explanations.Allocation.NO_COPIES));

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ClusterRebalanceRoutingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ClusterRebalanceRoutingTests.java
@@ -599,7 +599,7 @@ public class ClusterRebalanceRoutingTests extends ESAllocationTestCase {
                     UnassignedAllocationHandler unassignedAllocationHandler
                 ) {
                     if (allocateTest1.get() == false && "test1".equals(shardRouting.index().getName())) {
-                        unassignedAllocationHandler.removeAndIgnore(UnassignedInfo.AllocationStatus.NO_ATTEMPT, allocation.changes());
+                        unassignedAllocationHandler.removeAndIgnore(UnassignedInfo.FailedAllocationStatus.NO_ATTEMPT, allocation.changes());
                     } else {
                         super.allocateUnassigned(shardRouting, allocation, unassignedAllocationHandler);
                     }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputerTests.java
@@ -199,7 +199,7 @@ public class DesiredBalanceComputerTests extends ESAllocationTestCase {
                         .replicaShards()
                         .get(0)
                         .unassignedInfo()
-                        .lastAllocationStatus() == UnassignedInfo.AllocationStatus.DECIDERS_NO ? 1 : 2
+                        .lastFailedAllocationStatus() == UnassignedInfo.FailedAllocationStatus.DECIDERS_NO ? 1 : 2
                 ),
                 new ShardId(index, 1),
                 new ShardAssignment(Set.of("node-0", "node-1"), 2, 0, 0)
@@ -230,7 +230,9 @@ public class DesiredBalanceComputerTests extends ESAllocationTestCase {
                     Set.of("node-0"),
                     2,
                     1,
-                    originalReplicaShard.unassignedInfo().lastAllocationStatus() == UnassignedInfo.AllocationStatus.DECIDERS_NO ? 0 : 1
+                    originalReplicaShard.unassignedInfo().lastFailedAllocationStatus() == UnassignedInfo.FailedAllocationStatus.DECIDERS_NO
+                        ? 0
+                        : 1
                 ),
                 new ShardId(index, 1),
                 new ShardAssignment(Set.of("node-0", "node-1"), 2, 0, 0)
@@ -257,7 +259,7 @@ public class DesiredBalanceComputerTests extends ESAllocationTestCase {
                         0,
                         0,
                         false,
-                        UnassignedInfo.AllocationStatus.NO_ATTEMPT,
+                        UnassignedInfo.FailedAllocationStatus.NO_ATTEMPT,
                         Set.of(),
                         "node-2"
                     ),
@@ -1392,7 +1394,7 @@ public class DesiredBalanceComputerTests extends ESAllocationTestCase {
                     if (shardRouting.primary()) {
                         unassignedIterator.initialize("node-0", null, 0L, allocation.changes());
                     } else {
-                        unassignedIterator.removeAndIgnore(UnassignedInfo.AllocationStatus.NO_ATTEMPT, allocation.changes());
+                        unassignedIterator.removeAndIgnore(UnassignedInfo.FailedAllocationStatus.NO_ATTEMPT, allocation.changes());
                     }
                 }
 
@@ -1914,9 +1916,9 @@ public class DesiredBalanceComputerTests extends ESAllocationTestCase {
                     unassignedInfo.unassignedTimeMillis(),
                     unassignedInfo.delayed(),
                     randomFrom(
-                        UnassignedInfo.AllocationStatus.DECIDERS_NO,
-                        UnassignedInfo.AllocationStatus.NO_ATTEMPT,
-                        UnassignedInfo.AllocationStatus.DECIDERS_THROTTLED
+                        UnassignedInfo.FailedAllocationStatus.DECIDERS_NO,
+                        UnassignedInfo.FailedAllocationStatus.NO_ATTEMPT,
+                        UnassignedInfo.FailedAllocationStatus.DECIDERS_THROTTLED
                     ),
                     unassignedInfo.failedNodeIds(),
                     unassignedInfo.lastAllocatedNodeId()
@@ -1943,7 +1945,7 @@ public class DesiredBalanceComputerTests extends ESAllocationTestCase {
                     } else if (isCorrespondingPrimaryStarted(shardRouting, allocation)) {
                         unassignedIterator.initialize("node-1", null, 0L, allocation.changes());
                     } else {
-                        unassignedIterator.removeAndIgnore(UnassignedInfo.AllocationStatus.NO_ATTEMPT, allocation.changes());
+                        unassignedIterator.removeAndIgnore(UnassignedInfo.FailedAllocationStatus.NO_ATTEMPT, allocation.changes());
                     }
                 }
             }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocatorTests.java
@@ -112,15 +112,15 @@ public class DesiredBalanceShardsAllocatorTests extends ESAllocationTestCase {
     public void testGatewayAllocatorStillFetching() {
         testAllocate(
             (shardRouting, allocation, unassignedAllocationHandler) -> unassignedAllocationHandler.removeAndIgnore(
-                UnassignedInfo.AllocationStatus.FETCHING_SHARD_DATA,
+                UnassignedInfo.FailedAllocationStatus.FETCHING_SHARD_DATA,
                 allocation.changes()
             ),
             routingTable -> {
                 var shardRouting = routingTable.shardRoutingTable("test-index", 0).primaryShard();
                 assertFalse(shardRouting.assignedToNode());
                 assertThat(
-                    shardRouting.unassignedInfo().lastAllocationStatus(),
-                    equalTo(UnassignedInfo.AllocationStatus.FETCHING_SHARD_DATA)
+                    shardRouting.unassignedInfo().lastFailedAllocationStatus(),
+                    equalTo(UnassignedInfo.FailedAllocationStatus.FETCHING_SHARD_DATA)
                 );
             }
         );
@@ -130,7 +130,10 @@ public class DesiredBalanceShardsAllocatorTests extends ESAllocationTestCase {
         testAllocate((shardRouting, allocation, unassignedAllocationHandler) -> {}, routingTable -> {
             var shardRouting = routingTable.shardRoutingTable("test-index", 0).primaryShard();
             assertTrue(shardRouting.assignedToNode());// assigned by a followup reconciliation
-            assertThat(shardRouting.unassignedInfo().lastAllocationStatus(), equalTo(UnassignedInfo.AllocationStatus.NO_ATTEMPT));
+            assertThat(
+                shardRouting.unassignedInfo().lastFailedAllocationStatus(),
+                equalTo(UnassignedInfo.FailedAllocationStatus.NO_ATTEMPT)
+            );
         });
     }
 
@@ -262,7 +265,7 @@ public class DesiredBalanceShardsAllocatorTests extends ESAllocationTestCase {
             unassignedTimeNanos,
             TimeValue.nsecToMSec(unassignedTimeNanos),
             true,
-            UnassignedInfo.AllocationStatus.NO_ATTEMPT,
+            UnassignedInfo.FailedAllocationStatus.NO_ATTEMPT,
             Set.of(),
             "node-3"
         );
@@ -320,7 +323,7 @@ public class DesiredBalanceShardsAllocatorTests extends ESAllocationTestCase {
             new AllocationDeciders(List.of()),
             createGatewayAllocator(
                 (shardRouting, allocation, unassignedAllocationHandler) -> unassignedAllocationHandler.removeAndIgnore(
-                    UnassignedInfo.AllocationStatus.NO_ATTEMPT,
+                    UnassignedInfo.FailedAllocationStatus.NO_ATTEMPT,
                     allocation.changes()
                 )
             ),
@@ -380,7 +383,7 @@ public class DesiredBalanceShardsAllocatorTests extends ESAllocationTestCase {
 
         var gatewayAllocator = createGatewayAllocator((shardRouting, allocation, unassignedAllocationHandler) -> {
             if (shardRouting.getIndexName().equals(ignoredIndexName)) {
-                unassignedAllocationHandler.removeAndIgnore(UnassignedInfo.AllocationStatus.NO_ATTEMPT, allocation.changes());
+                unassignedAllocationHandler.removeAndIgnore(UnassignedInfo.FailedAllocationStatus.NO_ATTEMPT, allocation.changes());
             }
         });
         var shardsAllocator = new ShardsAllocator() {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
@@ -38,7 +38,7 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
-import org.elasticsearch.cluster.routing.UnassignedInfo.AllocationStatus;
+import org.elasticsearch.cluster.routing.UnassignedInfo.FailedAllocationStatus;
 import org.elasticsearch.cluster.routing.UnassignedInfo.Reason;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings;
@@ -939,8 +939,8 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
                 fooRouting.unassignedInfo().unassignedTimeMillis(),
                 false,
                 fooRouting.recoverySource().getType() == RecoverySource.Type.EMPTY_STORE
-                    ? AllocationStatus.DECIDERS_NO
-                    : AllocationStatus.NO_VALID_SHARD_COPY,
+                    ? FailedAllocationStatus.DECIDERS_NO
+                    : FailedAllocationStatus.NO_VALID_SHARD_COPY,
                 fooRouting.unassignedInfo().failedNodeIds(),
                 fooRouting.unassignedInfo().lastAllocatedNodeId()
             ),
@@ -1268,7 +1268,7 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
         assertThat(
             shardsWithState(clusterState.getRoutingNodes(), UNASSIGNED).stream()
                 .map(ShardRouting::unassignedInfo)
-                .allMatch(unassignedInfo -> AllocationStatus.NO_ATTEMPT.equals(unassignedInfo.lastAllocationStatus())),
+                .allMatch(unassignedInfo -> FailedAllocationStatus.NO_ATTEMPT.equals(unassignedInfo.lastFailedAllocationStatus())),
             is(true)
         );
         assertThat(shardsWithState(clusterState.getRoutingNodes(), UNASSIGNED).size(), equalTo(1));
@@ -1290,7 +1290,7 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
         assertThat(
             shardsWithState(clusterState.getRoutingNodes(), UNASSIGNED).stream()
                 .map(ShardRouting::unassignedInfo)
-                .allMatch(unassignedInfo -> AllocationStatus.FETCHING_SHARD_DATA.equals(unassignedInfo.lastAllocationStatus())),
+                .allMatch(unassignedInfo -> FailedAllocationStatus.FETCHING_SHARD_DATA.equals(unassignedInfo.lastFailedAllocationStatus())),
             is(true)
         );
         assertThat(shardsWithState(clusterState.getRoutingNodes(), UNASSIGNED).size(), equalTo(1));

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDeciderTests.java
@@ -128,7 +128,7 @@ public class RestoreInProgressAllocationDeciderTests extends ESAllocationTestCas
                 currentInfo.unassignedTimeNanos(),
                 currentInfo.unassignedTimeMillis(),
                 currentInfo.delayed(),
-                currentInfo.lastAllocationStatus(),
+                currentInfo.lastFailedAllocationStatus(),
                 currentInfo.failedNodeIds(),
                 currentInfo.lastAllocatedNodeId()
             );

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/shards/ShardsAvailabilityHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/shards/ShardsAvailabilityHealthIndicatorServiceTests.java
@@ -466,7 +466,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                                 0,
                                 0,
                                 false,
-                                UnassignedInfo.AllocationStatus.NO_ATTEMPT,
+                                UnassignedInfo.FailedAllocationStatus.NO_ATTEMPT,
                                 Set.of(),
                                 null
                             )
@@ -2633,7 +2633,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                     allocation.unassignedTimeNanos != null ? allocation.unassignedTimeNanos : 0,
                     0,
                     false,
-                    UnassignedInfo.AllocationStatus.DELAYED_ALLOCATION,
+                    UnassignedInfo.FailedAllocationStatus.DELAYED_ALLOCATION,
                     Set.of(),
                     allocation.nodeId
                 )
@@ -2691,7 +2691,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
             0,
             0,
             false,
-            UnassignedInfo.AllocationStatus.NO_VALID_SHARD_COPY,
+            UnassignedInfo.FailedAllocationStatus.NO_VALID_SHARD_COPY,
             Collections.emptySet(),
             null
         );
@@ -2706,7 +2706,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
             0,
             0,
             false,
-            UnassignedInfo.AllocationStatus.NO_ATTEMPT,
+            UnassignedInfo.FailedAllocationStatus.NO_ATTEMPT,
             Collections.emptySet(),
             null
         );
@@ -2722,7 +2722,10 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
             unassignedTime.nanos(),
             unassignedTime.millis(),
             randomBoolean(),
-            randomValueOtherThan(UnassignedInfo.AllocationStatus.DECIDERS_NO, () -> randomFrom(UnassignedInfo.AllocationStatus.values())),
+            randomValueOtherThan(
+                UnassignedInfo.FailedAllocationStatus.DECIDERS_NO,
+                () -> randomFrom(UnassignedInfo.FailedAllocationStatus.values())
+            ),
             Set.of(),
             reason == UnassignedInfo.Reason.NODE_LEFT ? null : randomAlphaOfLength(20)
         );
@@ -2741,7 +2744,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
             unassignedTime.nanos(),
             unassignedTime.millis(),
             false,
-            UnassignedInfo.AllocationStatus.DECIDERS_NO,
+            UnassignedInfo.FailedAllocationStatus.DECIDERS_NO,
             Collections.emptySet(),
             null
         );

--- a/server/src/test/java/org/elasticsearch/gateway/PrimaryShardAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/PrimaryShardAllocatorTests.java
@@ -29,7 +29,7 @@ import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
-import org.elasticsearch.cluster.routing.UnassignedInfo.AllocationStatus;
+import org.elasticsearch.cluster.routing.UnassignedInfo.FailedAllocationStatus;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
@@ -288,8 +288,8 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
         List<ShardRouting> ignored = allocation.routingNodes().unassigned().ignored();
         assertEquals(ignored.size(), 1);
         assertEquals(
-            ignored.get(0).unassignedInfo().lastAllocationStatus(),
-            forceDecisionNo ? AllocationStatus.DECIDERS_NO : AllocationStatus.DECIDERS_THROTTLED
+            ignored.get(0).unassignedInfo().lastFailedAllocationStatus(),
+            forceDecisionNo ? FailedAllocationStatus.DECIDERS_NO : FailedAllocationStatus.DECIDERS_THROTTLED
         );
         assertTrue(shardsWithState(allocation.routingNodes(), ShardRoutingState.INITIALIZING).isEmpty());
     }
@@ -316,7 +316,7 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
         assertThat(allocation.routingNodesChanged(), equalTo(true));
         List<ShardRouting> ignored = allocation.routingNodes().unassigned().ignored();
         assertEquals(ignored.size(), 1);
-        assertEquals(ignored.get(0).unassignedInfo().lastAllocationStatus(), AllocationStatus.DECIDERS_THROTTLED);
+        assertEquals(ignored.get(0).unassignedInfo().lastFailedAllocationStatus(), FailedAllocationStatus.DECIDERS_THROTTLED);
         assertTrue(shardsWithState(allocation.routingNodes(), ShardRoutingState.INITIALIZING).isEmpty());
     }
 
@@ -456,7 +456,7 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
         assertThat(allocation.routingNodesChanged(), equalTo(true));
         assertThat(allocation.routingNodes().unassigned().ignored().isEmpty(), equalTo(false));
         ShardRouting ignoredRouting = allocation.routingNodes().unassigned().ignored().get(0);
-        assertThat(ignoredRouting.unassignedInfo().lastAllocationStatus(), equalTo(AllocationStatus.FETCHING_SHARD_DATA));
+        assertThat(ignoredRouting.unassignedInfo().lastFailedAllocationStatus(), equalTo(FailedAllocationStatus.FETCHING_SHARD_DATA));
         assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
     }
 

--- a/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorTests.java
@@ -216,7 +216,7 @@ public class ReplicaShardAllocatorTests extends ESAllocationTestCase {
                 System.nanoTime(),
                 System.currentTimeMillis(),
                 false,
-                UnassignedInfo.AllocationStatus.NO_ATTEMPT,
+                UnassignedInfo.FailedAllocationStatus.NO_ATTEMPT,
                 failedNodeIds,
                 null
             );
@@ -435,7 +435,7 @@ public class ReplicaShardAllocatorTests extends ESAllocationTestCase {
                 System.nanoTime(),
                 System.currentTimeMillis(),
                 false,
-                UnassignedInfo.AllocationStatus.NO_ATTEMPT,
+                UnassignedInfo.FailedAllocationStatus.NO_ATTEMPT,
                 Set.of("node-4"),
                 null
             );
@@ -488,7 +488,7 @@ public class ReplicaShardAllocatorTests extends ESAllocationTestCase {
             System.nanoTime(),
             System.currentTimeMillis(),
             false,
-            UnassignedInfo.AllocationStatus.NO_ATTEMPT,
+            UnassignedInfo.FailedAllocationStatus.NO_ATTEMPT,
             failedNodes,
             null
         );
@@ -548,7 +548,7 @@ public class ReplicaShardAllocatorTests extends ESAllocationTestCase {
                                         System.nanoTime(),
                                         System.currentTimeMillis(),
                                         delayed,
-                                        UnassignedInfo.AllocationStatus.NO_ATTEMPT,
+                                        UnassignedInfo.FailedAllocationStatus.NO_ATTEMPT,
                                         Collections.emptySet(),
                                         lastAllocatedNodeId
                                     ),

--- a/test/framework/src/main/java/org/elasticsearch/cluster/ESAllocationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/ESAllocationTestCase.java
@@ -493,7 +493,7 @@ public abstract class ESAllocationTestCase extends ESTestCase {
                 return;
             }
             if (shardRouting.unassignedInfo().delayed()) {
-                unassignedAllocationHandler.removeAndIgnore(UnassignedInfo.AllocationStatus.DELAYED_ALLOCATION, allocation.changes());
+                unassignedAllocationHandler.removeAndIgnore(UnassignedInfo.FailedAllocationStatus.DELAYED_ALLOCATION, allocation.changes());
             }
         }
     }

--- a/test/framework/src/main/java/org/elasticsearch/cluster/routing/TestShardRouting.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/routing/TestShardRouting.java
@@ -282,7 +282,7 @@ public class TestShardRouting {
             unassignedTimeNanos,
             unassignedTimeMillis,
             delayed,
-            UnassignedInfo.AllocationStatus.NO_ATTEMPT,
+            UnassignedInfo.FailedAllocationStatus.NO_ATTEMPT,
             Set.of(),
             lastAllocatedNodeId
         );

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CheckShrinkReadyStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CheckShrinkReadyStepTests.java
@@ -659,7 +659,7 @@ public class CheckShrinkReadyStepTests extends AbstractStepTestCase<CheckShrinkR
             System.nanoTime(),
             System.currentTimeMillis(),
             delayed,
-            UnassignedInfo.AllocationStatus.NO_ATTEMPT,
+            UnassignedInfo.FailedAllocationStatus.NO_ATTEMPT,
             Set.of(),
             lastAllocatedNodeId
         );

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/assignment/FailedAllocationStatusTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/assignment/FailedAllocationStatusTests.java
@@ -15,7 +15,7 @@ import java.io.IOException;
 
 import static org.hamcrest.Matchers.equalTo;
 
-public class AllocationStatusTests extends AbstractXContentSerializingTestCase<AllocationStatus> {
+public class FailedAllocationStatusTests extends AbstractXContentSerializingTestCase<AllocationStatus> {
 
     public static AllocationStatus randomInstance() {
         return new AllocationStatus(randomInt(10), randomIntBetween(1, 10));

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/PartiallyCachedShardAllocationIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/PartiallyCachedShardAllocationIntegTests.java
@@ -244,7 +244,7 @@ public class PartiallyCachedShardAllocationIntegTests extends BaseFrozenSearchab
                 assertThat(
                     Strings.toString(explanation),
                     explanation.getShardAllocationDecision().getAllocateDecision().getAllocationStatus(),
-                    equalTo(UnassignedInfo.AllocationStatus.FETCHING_SHARD_DATA)
+                    equalTo(UnassignedInfo.FailedAllocationStatus.FETCHING_SHARD_DATA)
                 );
 
             } catch (IndexNotFoundException e) {
@@ -261,7 +261,7 @@ public class PartiallyCachedShardAllocationIntegTests extends BaseFrozenSearchab
         assertThat(
             Strings.toString(explanation),
             explanation.getShardAllocationDecision().getAllocateDecision().getAllocationStatus(),
-            equalTo(UnassignedInfo.AllocationStatus.FETCHING_SHARD_DATA)
+            equalTo(UnassignedInfo.FailedAllocationStatus.FETCHING_SHARD_DATA)
         );
 
         // Unblock the other new node, but maybe inject a few errors

--- a/x-pack/plugin/shutdown/src/test/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusActionTests.java
+++ b/x-pack/plugin/shutdown/src/test/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusActionTests.java
@@ -896,7 +896,7 @@ public class TransportGetShutdownStatusActionTests extends ESTestCase {
             System.nanoTime(),
             System.currentTimeMillis(),
             false,
-            UnassignedInfo.AllocationStatus.NO_ATTEMPT,
+            UnassignedInfo.FailedAllocationStatus.NO_ATTEMPT,
             Set.of(),
             nodeId
         );


### PR DESCRIPTION
There are a LOT of allocation status enums.
This name better represents the meaning,
as there are no successful enum values.

Relates ES-12833

---------

Simple IntelliJ aided rename, but lots of files. Left a comment on the source point for the rename.