### PR TITLE
[8.19] Fix APM tracer to respect recording status of spans (#137015)

### DIFF
--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/tracing/APMTracer.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/tracing/APMTracer.java
@@ -188,6 +188,17 @@ public class APMTracer extends AbstractLifecycleComponent implements org.elastic
                 spanBuilder.setStartTimestamp(startTime);
             }
             final Span span = spanBuilder.startSpan();
+            // If the agent decided not to record this span (e.g., due to transaction_max_spans), isRecording() will be false.
+            if (span.isRecording() == false) {
+                logger.trace("Span [{}] [{}] will not be recorded, e.g. due to transaction_max_spans reached", spanId, spanName);
+                // It's good practice to end the no-op span immediately to release any resources.
+                span.end();
+                // Returning null from computeIfAbsent means no value will be inserted into the map.
+                return null;
+            }
+
+            // If we are here, the span is real and being recorded.
+            logger.trace("Successfully started tracing [{}] [{}]", spanId, spanName);
             final Context contextForNewSpan = Context.current().with(span);
 
             updateThreadContext(traceContext, services, contextForNewSpan);


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Fix APM tracer to respect recording status of spans (#137015)