### PR TITLE
[docs] Update category field to use keyword type in full text tutorial

### DIFF
--- a/docs/reference/query-languages/query-dsl/full-text-filter-tutorial.md
+++ b/docs/reference/query-languages/query-dsl/full-text-filter-tutorial.md
@@ -497,7 +497,7 @@ GET /cooking_blog/_search
       "should": [
         {
           "term": {
-            "category": "Main Course"
+            "category.keyword": "Main Course"
           }
         },
         {


### PR DESCRIPTION
closes https://github.com/elastic/docs-content/issues/3329

using `term` query on an analyzed field won't match correctly, doesn't impact flow of this specific tutorial but is strictly the correct approach
