### PR TITLE
[9.2] [Inference API] Rename E5 model/inference endpoint in EIS to JinaAI counterpart (#137028)

### DIFF
--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceGetModelsWithElasticInferenceServiceIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceGetModelsWithElasticInferenceServiceIT.java
@@ -51,7 +51,7 @@ public class InferenceGetModelsWithElasticInferenceServiceIT extends BaseMockEIS
 
         assertInferenceIdTaskType(allModels, ".rainbow-sprinkles-elastic", TaskType.CHAT_COMPLETION);
         assertInferenceIdTaskType(allModels, ".elser-2-elastic", TaskType.SPARSE_EMBEDDING);
-        assertInferenceIdTaskType(allModels, ".multilingual-embed-v1-elastic", TaskType.TEXT_EMBEDDING);
+        assertInferenceIdTaskType(allModels, ".jina-embeddings-v3", TaskType.TEXT_EMBEDDING);
         assertInferenceIdTaskType(allModels, ".rerank-v1-elastic", TaskType.RERANK);
     }
 

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/MockElasticInferenceServiceAuthorizationServer.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/MockElasticInferenceServiceAuthorizationServer.java
@@ -43,7 +43,7 @@ public class MockElasticInferenceServiceAuthorizationServer implements TestRule 
                       "task_types": ["embed/text/sparse"]
                     },
                     {
-                      "model_name": "multilingual-embed-v1",
+                      "model_name": "jina-embeddings-v3",
                       "task_types": ["embed/text/dense"]
                     },
                   {

--- a/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/InferenceRevokeDefaultEndpointsIT.java
+++ b/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/InferenceRevokeDefaultEndpointsIT.java
@@ -203,7 +203,7 @@ public class InferenceRevokeDefaultEndpointsIT extends ESSingleNodeTestCase {
                           "task_types": ["chat"]
                         },
                         {
-                          "model_name": "multilingual-embed-v1",
+                          "model_name": "jina-embeddings-v3",
                           "task_types": ["embed/text/dense"]
                         },
                         {
@@ -234,7 +234,7 @@ public class InferenceRevokeDefaultEndpointsIT extends ESSingleNodeTestCase {
                             service
                         ),
                         new InferenceService.DefaultConfigId(
-                            ".multilingual-embed-v1-elastic",
+                            ".jina-embeddings-v3",
                             MinimalServiceSettings.textEmbedding(
                                 ElasticInferenceService.NAME,
                                 ElasticInferenceService.DENSE_TEXT_EMBEDDINGS_DIMENSIONS,
@@ -258,10 +258,7 @@ public class InferenceRevokeDefaultEndpointsIT extends ESSingleNodeTestCase {
                 PlainActionFuture<List<Model>> listener = new PlainActionFuture<>();
                 service.defaultConfigs(listener);
                 assertThat(listener.actionGet(TIMEOUT).get(0).getConfigurations().getInferenceEntityId(), is(".elser-2-elastic"));
-                assertThat(
-                    listener.actionGet(TIMEOUT).get(1).getConfigurations().getInferenceEntityId(),
-                    is(".multilingual-embed-v1-elastic")
-                );
+                assertThat(listener.actionGet(TIMEOUT).get(1).getConfigurations().getInferenceEntityId(), is(".jina-embeddings-v3"));
                 assertThat(listener.actionGet(TIMEOUT).get(2).getConfigurations().getInferenceEntityId(), is(".rainbow-sprinkles-elastic"));
                 assertThat(listener.actionGet(TIMEOUT).get(3).getConfigurations().getInferenceEntityId(), is(".rerank-v1-elastic"));
 
@@ -287,7 +284,7 @@ public class InferenceRevokeDefaultEndpointsIT extends ESSingleNodeTestCase {
                           "task_types": ["rerank/text/text-similarity"]
                         },
                         {
-                          "model_name": "multilingual-embed-v1",
+                          "model_name": "jina-embeddings-v3",
                           "task_types": ["embed/text/dense"]
                         }
                     ]
@@ -309,7 +306,7 @@ public class InferenceRevokeDefaultEndpointsIT extends ESSingleNodeTestCase {
                             service
                         ),
                         new InferenceService.DefaultConfigId(
-                            ".multilingual-embed-v1-elastic",
+                            ".jina-embeddings-v3",
                             MinimalServiceSettings.textEmbedding(
                                 ElasticInferenceService.NAME,
                                 ElasticInferenceService.DENSE_TEXT_EMBEDDINGS_DIMENSIONS,

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceService.java
@@ -117,8 +117,8 @@ public class ElasticInferenceService extends SenderService {
     static final String DEFAULT_ELSER_ENDPOINT_ID_V2 = defaultEndpointId("elser-2");
 
     // multilingual-text-embed
-    static final String DEFAULT_MULTILINGUAL_EMBED_MODEL_ID = "multilingual-embed-v1";
-    static final String DEFAULT_MULTILINGUAL_EMBED_ENDPOINT_ID = defaultEndpointId(DEFAULT_MULTILINGUAL_EMBED_MODEL_ID);
+    static final String DEFAULT_MULTILINGUAL_EMBED_MODEL_ID = "jina-embeddings-v3";
+    static final String DEFAULT_MULTILINGUAL_EMBED_ENDPOINT_ID = ".jina-embeddings-v3";
 
     // rerank-v1
     static final String DEFAULT_RERANK_MODEL_ID_V1 = "rerank-v1";

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
@@ -1238,7 +1238,7 @@ public class ElasticInferenceServiceTests extends ESSingleNodeTestCase {
                       "task_types": ["embed/text/sparse"]
                     },
                     {
-                      "model_name": "multilingual-embed-v1",
+                      "model_name": "jina-embeddings-v3",
                       "task_types": ["embed/text/dense"]
                     },
                   {
@@ -1266,7 +1266,7 @@ public class ElasticInferenceServiceTests extends ESSingleNodeTestCase {
                             service
                         ),
                         new InferenceService.DefaultConfigId(
-                            ".multilingual-embed-v1-elastic",
+                            ".jina-embeddings-v3",
                             MinimalServiceSettings.textEmbedding(
                                 ElasticInferenceService.NAME,
                                 ElasticInferenceService.DENSE_TEXT_EMBEDDINGS_DIMENSIONS,
@@ -1298,7 +1298,7 @@ public class ElasticInferenceServiceTests extends ESSingleNodeTestCase {
             var models = listener.actionGet(TIMEOUT);
             assertThat(models.size(), is(4));
             assertThat(models.get(0).getConfigurations().getInferenceEntityId(), is(".elser-2-elastic"));
-            assertThat(models.get(1).getConfigurations().getInferenceEntityId(), is(".multilingual-embed-v1-elastic"));
+            assertThat(models.get(1).getConfigurations().getInferenceEntityId(), is(".jina-embeddings-v3"));
             assertThat(models.get(2).getConfigurations().getInferenceEntityId(), is(".rainbow-sprinkles-elastic"));
             assertThat(models.get(3).getConfigurations().getInferenceEntityId(), is(".rerank-v1-elastic"));
         }


### PR DESCRIPTION
Backports the following commits to 9.2:
 - [Inference API] Rename E5 model/inference endpoint in EIS to JinaAI counterpart (#137028)