### PR TITLE
ESQL: Fix test class casing

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -534,9 +534,6 @@ tests:
 - class: org.elasticsearch.cluster.routing.allocation.decider.WriteLoadConstraintDeciderIT
   method: testCanRemainNotPreferredIsIgnoredWhenAllOtherNodesReturnNotPreferred
   issue: https://github.com/elastic/elasticsearch/issues/137162
-- class: org.elasticsearch.xpack.esql.plan.logical.CommandLicenseTests
-  method: testLicenseCheck
-  issue: https://github.com/elastic/elasticsearch/issues/137168
 
 # Examples:
 #

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/StdDevOverTimeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/StdDevOverTimeTests.java
@@ -17,8 +17,8 @@ import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 import java.util.List;
 import java.util.function.Supplier;
 
-public class StddevOverTimeTests extends AbstractFunctionTestCase {
-    public StddevOverTimeTests(Supplier<TestCaseSupplier.TestCase> testCaseSupplier) {
+public class StdDevOverTimeTests extends AbstractFunctionTestCase {
+    public StdDevOverTimeTests(Supplier<TestCaseSupplier.TestCase> testCaseSupplier) {
         testCase = testCaseSupplier.get();
     }
 


### PR DESCRIPTION
Fix https://github.com/elastic/elasticsearch/issues/137168
Fix https://github.com/elastic/elasticsearch/issues/137154

Inconsistent casing of the test class for StdDevOverTime seems to have tripped other tests that dynamically load classes (`EsqlNodeSubclassTests`).