### PR TITLE
[9.2] rest-api-spec: Add missing options to enum types (#136640)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segments.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segments.json
@@ -108,7 +108,13 @@
       },
       "expand_wildcards": {
         "type": "enum",
-        "options": ["open", "closed", "hidden", "none", "all"],
+        "options": [
+          "open",
+          "closed",
+          "hidden",
+          "none",
+          "all"
+        ],
         "default": "open",
         "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both."
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.sync_job_list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.sync_job_list.json
@@ -33,8 +33,17 @@
         "description": "specifies a max number of results to get (default: 100)"
       },
       "status": {
-        "type": "string",
-        "description": "Sync job status, which sync jobs are fetched for"
+        "type": "enum",
+        "description": "A sync job status to fetch connector sync jobs for",
+        "options": [
+          "canceling",
+          "canceled",
+          "completed",
+          "error",
+          "in_progress",
+          "pending",
+          "suspended"
+        ]
       },
       "connector_id": {
         "type": "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/esql.async_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/esql.async_query.json
@@ -26,8 +26,18 @@
     },
     "params": {
       "format": {
-        "type": "string",
-        "description": "a short version of the Accept header, e.g. json, yaml"
+        "type": "enum",
+        "description": "A short version of the Accept header, e.g. json, yaml.\n\n`csv`, `tsv`, and `txt` formats will return results in a tabular format, excluding other metadata fields from the response.\n\nFor async requests, nothing will be returned if the async query doesn't finish within the timeout.\nThe query ID and running status are available in the `X-Elasticsearch-Async-Id` and `X-Elasticsearch-Async-Is-Running` HTTP headers of the response, respectively.",
+        "options": [
+          "csv",
+          "json",
+          "tsv",
+          "txt",
+          "yaml",
+          "cbor",
+          "smile",
+          "arrow"
+        ]
       },
       "delimiter": {
         "type": "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/esql.async_query_get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/esql.async_query_get.json
@@ -29,8 +29,18 @@
     },
     "params": {
       "format": {
-        "type": "string",
-        "description": "a short version of the Accept header, e.g. json, yaml"
+        "type": "enum",
+        "description": "A short version of the Accept header, for example `json` or `yaml`.",
+        "options": [
+          "csv",
+          "json",
+          "tsv",
+          "txt",
+          "yaml",
+          "cbor",
+          "smile",
+          "arrow"
+        ]
       },
       "wait_for_completion_timeout": {
         "type": "time",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/esql.query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/esql.query.json
@@ -26,8 +26,18 @@
     },
     "params": {
       "format": {
-        "type": "string",
-        "description": "a short version of the Accept header, e.g. json, yaml"
+        "type": "enum",
+        "description": "A short version of the Accept header, e.g. json, yaml.\n\n`csv`, `tsv`, and `txt` formats will return results in a tabular format, excluding other metadata fields from the response.",
+        "options": [
+          "csv",
+          "json",
+          "tsv",
+          "txt",
+          "yaml",
+          "cbor",
+          "smile",
+          "arrow"
+        ]
       },
       "delimiter": {
         "type": "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_trained_models.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_trained_models.json
@@ -40,8 +40,15 @@
         "default": true
       },
       "include": {
-        "type": "string",
-        "description": "A comma-separate list of fields to optionally include. Valid options are 'definition' and 'total_feature_importance'. Default is none."
+        "type": "enum",
+        "description": "A comma delimited string of optional fields to include in the response\nbody.",
+        "options": [
+          "definition",
+          "feature_importance_baseline",
+          "hyperparameters",
+          "total_feature_importance",
+          "definition_status"
+        ]
       },
       "decompress_definition": {
         "type": "boolean",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.start_trained_model_deployment.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.start_trained_model_deployment.json
@@ -51,9 +51,12 @@
         "default": 1
       },
       "priority": {
-        "type": "string",
+        "type": "enum",
         "description": "The deployment priority.",
-        "default": "normal"
+        "options": [
+          "normal",
+          "low"
+        ]
       },
       "queue_capacity": {
         "type": "int",
@@ -66,11 +69,11 @@
         "default": "20s"
       },
       "wait_for": {
-        "type": "string",
-        "description": "The allocation status for which to wait",
+        "type": "enum",
+        "description": "Specifies the allocation status to wait for before returning.",
         "options": [
-          "starting",
           "started",
+          "starting",
           "fully_allocated"
         ],
         "default": "started"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/simulate.ingest.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/simulate.ingest.json
@@ -44,8 +44,12 @@
         "description": "The pipeline id to preprocess incoming documents with if no pipeline is given for a particular document"
       },
       "merge_type": {
-        "type": "string",
-        "description": "The mapping merge type if mapping overrides are being provided in mapping_addition. The allowed values are one of index or template. The index option merges mappings the way they would be merged into an existing index. The template option merges mappings the way they would be merged into a template.",
+        "type": "enum",
+        "description": "The mapping merge type if mapping overrides are being provided in mapping_addition.\nThe allowed values are one of index or template.\nThe index option merges mappings the way they would be merged into an existing index.\nThe template option merges mappings the way they would be merged into a template.",
+        "options": [
+          "index",
+          "template"
+        ],
         "default": "index"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/sql.query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/sql.query.json
@@ -27,8 +27,17 @@
     },
     "params": {
       "format": {
-        "type": "string",
-        "description": "a short version of the Accept header, e.g. json, yaml"
+        "type": "enum",
+        "description": "The format for the response.\nYou can also specify a format using the `Accept` HTTP header.\nIf you specify both this parameter and the `Accept` HTTP header, this parameter takes precedence.",
+        "options": [
+          "csv",
+          "json",
+          "tsv",
+          "txt",
+          "yaml",
+          "cbor",
+          "smile"
+        ]
       },
       "project_routing": {
         "type": "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/text_structure.find_field_structure.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/text_structure.find_field_structure.json
@@ -73,9 +73,13 @@
         "description": "Optional parameter to specify the Grok pattern that should be used to extract fields from messages in a semi-structured text file"
       },
       "ecs_compatibility": {
-        "type": "string",
-        "default": "disabled",
-        "description": "Optional parameter to specify the compatibility mode with ECS Grok patterns - may be either 'v1' or 'disabled'"
+        "type": "enum",
+        "description": "The mode of compatibility with ECS compliant Grok patterns.\nUse this parameter to specify whether to use ECS Grok patterns instead of legacy ones when the structure finder creates a Grok pattern.\nThis setting primarily has an impact when a whole message Grok pattern such as `%{CATALINALOG}` matches the input.\nIf the structure finder identifies a common structure but has no idea of the meaning then generic field names such as `path`, `ipaddress`, `field1`, and `field2` are used in the `grok_pattern` output.\nThe intention in that situation is that a user who knows the meanings will rename the fields before using them.",
+        "options": [
+          "disabled",
+          "v1"
+        ],
+        "default": "disabled"
       },
       "timestamp_field": {
         "type": "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/text_structure.find_message_structure.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/text_structure.find_message_structure.json
@@ -62,9 +62,13 @@
         "description": "Optional parameter to specify the Grok pattern that should be used to extract fields from messages in a semi-structured text file"
       },
       "ecs_compatibility": {
-        "type": "string",
-        "default": "disabled",
-        "description": "Optional parameter to specify the compatibility mode with ECS Grok patterns - may be either 'v1' or 'disabled'"
+        "type": "enum",
+        "description": "The mode of compatibility with ECS compliant Grok patterns.\nUse this parameter to specify whether to use ECS Grok patterns instead of legacy ones when the structure finder creates a Grok pattern.\nThis setting primarily has an impact when a whole message Grok pattern such as `%{CATALINALOG}` matches the input.\nIf the structure finder identifies a common structure but has no idea of meaning then generic field names such as `path`, `ipaddress`, `field1`, and `field2` are used in the `grok_pattern` output, with the intention that a user who knows the meanings rename these fields before using it.",
+        "options": [
+          "disabled",
+          "v1"
+        ],
+        "default": "disabled"
       },
       "timestamp_field": {
         "type": "string",

--- a/rest-api-spec/src/main/resources/schema.json
+++ b/rest-api-spec/src/main/resources/schema.json
@@ -256,7 +256,7 @@
                     "type": "array",
                     "items": {
                         "type": "string",
-                        "pattern": "^[a-zA-Z_]+$"
+                        "pattern": "^[_a-zA-Z][_a-zA-Z0-9]*$"
                     },
                     "title": "Valid options when type is an enum"
                 },


### PR DESCRIPTION
Backports the following commits to 9.2:
 - rest-api-spec: Add missing options to enum types (#136640)