### PR TITLE
[ESQL] Support first/last functions

### DIFF
--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorImplementer.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorImplementer.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -764,74 +763,6 @@ public class AggregatorImplementer {
                 name += "Array";
             }
             return name + "State";
-        }
-    }
-
-    public record AggregationParameter(String name, TypeName type, boolean isArray) {
-        public String blockName() {
-            return name + "Block";
-        }
-
-        public String vectorName() {
-            return name + "Vector";
-        }
-
-        public String scratchName() {
-            if (isBytesRef() == false) {
-                throw new IllegalStateException("can't build scratch for non-BytesRef");
-            }
-            return name + "Scratch";
-        }
-
-        public String valueName() {
-            return name + "Value";
-        }
-
-        public String startName() {
-            return name + "Start";
-        }
-
-        public String endName() {
-            return name + "End";
-        }
-
-        public String offsetName() {
-            return name + "Offset";
-        }
-
-        public String arrayType() {
-            return type.toString().replace("[]", "");
-        }
-
-        public String readMethod() {
-            String type = this.type.toString();
-            int lastDot = type.lastIndexOf('.');
-            return "get" + capitalize(lastDot >= 0 ? type.substring(lastDot + 1) : type);
-        }
-
-        public void read(MethodSpec.Builder builder, boolean vector) {
-            StringBuilder pattern = new StringBuilder("$T $L = $L.$L(");
-            List<Object> params = new ArrayList<>();
-            params.add(type);
-            params.add(valueName());
-            params.add(vector ? vectorName() : blockName());
-            params.add(readMethod());
-            if (vector) {
-                pattern.append("valuesPosition");
-            } else {
-                pattern.append("$L");
-                params.add(offsetName());
-            }
-            if (isBytesRef()) {
-                pattern.append(", $L");
-                params.add(scratchName());
-            }
-            pattern.append(")");
-            builder.addStatement(pattern.toString(), params.toArray());
-        }
-
-        public boolean isBytesRef() {
-            return Objects.equals(type, BYTES_REF);
         }
     }
 

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/GroupingAggregatorImplementer.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/GroupingAggregatorImplementer.java
@@ -17,7 +17,6 @@ import com.squareup.javapoet.TypeSpec;
 
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
-import org.elasticsearch.compute.gen.AggregatorImplementer.AggregationParameter;
 import org.elasticsearch.compute.gen.AggregatorImplementer.AggregationState;
 import org.elasticsearch.compute.gen.argument.Argument;
 import org.elasticsearch.compute.gen.argument.BlockArgument;
@@ -92,7 +91,8 @@ public class GroupingAggregatorImplementer {
     private final List<AggregatorImplementer.IntermediateStateDesc> intermediateState;
 
     private final AggregationState aggState;
-    private final List<AggregationParameter> aggParams;
+    private final List<Argument> aggParams;
+    private final boolean hasOnlyBlockArguments;
 
     public GroupingAggregatorImplementer(
         Elements elements,
@@ -118,15 +118,16 @@ public class GroupingAggregatorImplementer {
             requireName("combine"),
             combineArgs(aggState)
         );
-        this.aggParams = combine.getParameters().stream().skip(aggState.declaredType().isPrimitive() ? 1 : 2).flatMap(v -> {
+
+        this.aggParams = combine.getParameters().stream().skip(aggState.declaredType().isPrimitive() ? 1 : 2).map(v -> {
             Argument a = Argument.fromParameter(types, v);
-            return switch (a) {
-                case StandardArgument sa -> Stream.of(new AggregationParameter(sa.name(), sa.type(), false));
-                case BlockArgument ba -> Stream.of(new AggregationParameter(ba.name(), Types.elementType(ba.type()), true));
-                case PositionArgument pa -> Stream.of();
-                default -> throw new IllegalArgumentException("unsupported argument [" + declarationType + "][" + a + "]");
-            };
-        }).toList();
+            if ((a instanceof StandardArgument || a instanceof BlockArgument || a instanceof PositionArgument) == false) {
+                throw new IllegalArgumentException("unsupported argument [" + declarationType + "][" + a + "]");
+            }
+            return a;
+        }).filter(a -> a instanceof PositionArgument == false).toList();
+
+        this.hasOnlyBlockArguments = this.aggParams.stream().allMatch(a -> a instanceof BlockArgument);
 
         this.createParameters = init.getParameters()
             .stream()
@@ -203,7 +204,9 @@ public class GroupingAggregatorImplementer {
         builder.addMethod(prepareProcessRawInputPage());
         for (ClassName groupIdClass : GROUP_IDS_CLASSES) {
             builder.addMethod(addRawInputLoop(groupIdClass, false));
-            builder.addMethod(addRawInputLoop(groupIdClass, true));
+            if (hasOnlyBlockArguments == false) {
+                builder.addMethod(addRawInputLoop(groupIdClass, true));
+            }
             builder.addMethod(addIntermediateInput(groupIdClass));
         }
         builder.addMethod(maybeEnableGroupIdTracking());
@@ -323,16 +326,17 @@ public class GroupingAggregatorImplementer {
         builder.addParameter(SEEN_GROUP_IDS, "seenGroupIds").addParameter(PAGE, "page");
 
         for (int i = 0; i < aggParams.size(); i++) {
-            AggregationParameter p = aggParams.get(i);
-            builder.addStatement("$T $L = page.getBlock(channels.get($L))", blockType(p.type()), p.blockName(), i);
+            Argument a = aggParams.get(i);
+            builder.addStatement("$T $L = page.getBlock(channels.get($L))", a.dataType(true), a.blockName(), i);
         }
-        for (AggregationParameter p : aggParams) {
-            builder.addStatement("$T $L = $L.asVector()", vectorType(p.type()), p.vectorName(), p.blockName());
-            builder.beginControlFlow("if ($L == null)", p.vectorName());
+
+        for (Argument a : aggParams) {
+            builder.addStatement("$T $L = $L.asVector()", vectorType(a.elementType()), (a instanceof BlockArgument) ? (a.name() + "Vector") : a.vectorName(), a.blockName());
+            builder.beginControlFlow("if ($L == null)", (a instanceof BlockArgument) ? (a.name() + "Vector") : a.vectorName());
             {
                 builder.addStatement(
                     "maybeEnableGroupIdTracking(seenGroupIds, "
-                        + aggParams.stream().map(AggregationParameter::blockName).collect(joining(", "))
+                        + aggParams.stream().map(arg -> arg.blockName()).collect(joining(", "))
                         + ")"
                 );
                 returnAddInput(builder, false);
@@ -351,9 +355,9 @@ public class GroupingAggregatorImplementer {
             StringBuilder pattern = new StringBuilder("return $T.wrapAddInput(addInput, state");
             List<Object> params = new ArrayList<>();
             params.add(declarationType);
-            for (AggregationParameter p : aggParams) {
+            for (Argument a : aggParams) {
                 pattern.append(", $L");
-                params.add(valuesAreVector ? p.vectorName() : p.blockName());
+                params.add(valuesAreVector ? a.vectorName() : a.blockName());
             }
             pattern.append(")");
             builder.addStatement(pattern.toString(), params.toArray());
@@ -366,12 +370,12 @@ public class GroupingAggregatorImplementer {
         MethodSpec.Builder builder = MethodSpec.methodBuilder("maybeEnableGroupIdTracking");
         builder.addModifiers(Modifier.PRIVATE).returns(TypeName.VOID);
         builder.addParameter(SEEN_GROUP_IDS, "seenGroupIds");
-        for (AggregationParameter p : aggParams) {
-            builder.addParameter(blockType(p.type()), p.blockName());
+        for (Argument a : aggParams) {
+            builder.addParameter(a.dataType(true), a.blockName());
         }
 
-        for (AggregationParameter p : aggParams) {
-            builder.beginControlFlow("if ($L.mayHaveNulls())", p.blockName());
+        for (Argument a : aggParams) {
+            builder.beginControlFlow("if ($L.mayHaveNulls())", a.blockName());
             builder.addStatement("state.enableGroupIdTracking(seenGroupIds)");
             builder.endControlFlow();
         }
@@ -390,11 +394,17 @@ public class GroupingAggregatorImplementer {
             MethodSpec.Builder builder = MethodSpec.methodBuilder("add").addAnnotation(Override.class).addModifiers(Modifier.PUBLIC);
             builder.addParameter(TypeName.INT, "positionOffset").addParameter(groupIdsType, "groupIds");
 
+            if (hasOnlyBlockArguments && valuesAreVector) {
+                builder.addComment("This type does not support vectors because all values are multi-valued");
+                typeBuilder.addMethod(builder.build());
+                continue;
+            }
+
             StringBuilder pattern = new StringBuilder("addRawInput(positionOffset, groupIds");
             List<Object> params = new ArrayList<>();
-            for (AggregationParameter p : aggParams) {
+            for (Argument a : aggParams) {
                 pattern.append(", $L");
-                params.add(valuesAreVector ? p.vectorName() : p.blockName());
+                params.add(valuesAreVector ? a.vectorName() : a.blockName());
             }
             pattern.append(")");
             builder.addStatement(pattern.toString(), params.toArray());
@@ -419,20 +429,22 @@ public class GroupingAggregatorImplementer {
         builder.addModifiers(Modifier.PRIVATE);
         builder.addParameter(TypeName.INT, "positionOffset").addParameter(groupsType, "groups");
 
-        for (AggregationParameter p : aggParams) {
+        for (Argument a : aggParams) {
+            boolean isBlockArgument = a instanceof BlockArgument;
+            TypeName typeName = isBlockArgument ? Types.elementType(a.type()) : a.type();
             builder.addParameter(
-                valuesAreVector ? vectorType(p.type()) : blockType(p.type()),
-                valuesAreVector ? p.vectorName() : p.blockName()
+                valuesAreVector ? vectorType(typeName) : blockType(typeName),
+                valuesAreVector ? a.vectorName() : a.blockName()
             );
         }
-        for (AggregationParameter p : aggParams) {
-            if (p.isBytesRef()) {
+        for (Argument a : aggParams) {
+            if (a.isBytesRef()) {
                 // Add bytes_ref scratch var that will be used for bytes_ref blocks/vectors
-                builder.addStatement("$T $L = new $T()", BYTES_REF, p.scratchName(), BYTES_REF);
+                builder.addStatement("$T $L = new $T()", BYTES_REF, a.scratchName(), BYTES_REF);
             }
         }
 
-        if (aggParams.getFirst().isArray() && valuesAreVector) {
+        if (hasOnlyBlockArguments && valuesAreVector) {
             builder.addComment("This type does not support vectors because all values are multi-valued");
             return builder.build();
         }
@@ -446,8 +458,8 @@ public class GroupingAggregatorImplementer {
             }
             builder.addStatement("int valuesPosition = groupPosition + positionOffset");
             if (valuesAreVector == false) {
-                for (AggregationParameter p : aggParams) {
-                    builder.beginControlFlow("if ($L.isNull(valuesPosition))", p.blockName());
+                for (Argument a : aggParams) {
+                    builder.beginControlFlow("if ($L.isNull(valuesPosition))", a.blockName());
                     builder.addStatement("continue");
                     builder.endControlFlow();
                 }
@@ -468,12 +480,12 @@ public class GroupingAggregatorImplementer {
             }
 
             if (valuesAreVector) {
-                for (AggregationParameter a : aggParams) {
-                    a.read(builder, true);
+                for (Argument a : aggParams) {
+                    a.read(builder, a.vectorName(), "valuesPosition");
                 }
                 combineRawInput(builder);
             } else {
-                if (aggParams.getFirst().isArray()) {
+                if (hasOnlyBlockArguments) {
                     if (aggParams.size() > 1) {
                         throw new IllegalArgumentException("array mode not supported for multiple args");
                     }
@@ -486,21 +498,21 @@ public class GroupingAggregatorImplementer {
                         )
                     );
                 } else {
-                    for (AggregationParameter p : aggParams) {
-                        builder.addStatement("int $L = $L.getFirstValueIndex(valuesPosition)", p.startName(), p.blockName());
-                        builder.addStatement("int $L = $L + $L.getValueCount(valuesPosition)", p.endName(), p.startName(), p.blockName());
+                    for (Argument a : aggParams) {
+                        builder.addStatement("int $L = $L.getFirstValueIndex(valuesPosition)", a.startName(), a.blockName());
+                        builder.addStatement("int $L = $L + $L.getValueCount(valuesPosition)", a.endName(), a.startName(), a.blockName());
                         builder.beginControlFlow(
                             "for (int $L = $L; $L < $L; $L++)",
-                            p.offsetName(),
-                            p.startName(),
-                            p.offsetName(),
-                            p.endName(),
-                            p.offsetName()
+                            a.offsetName(),
+                            a.startName(),
+                            a.offsetName(),
+                            a.endName(),
+                            a.offsetName()
                         );
-                        p.read(builder, false);
+                        a.read(builder, a.blockName(), a.offsetName());
                     }
                     combineRawInput(builder);
-                    for (AggregationParameter a : aggParams) {
+                    for (Argument a : aggParams) {
                         builder.endControlFlow();
                     }
                 }
@@ -530,12 +542,12 @@ public class GroupingAggregatorImplementer {
             pattern.append("$T.combine(state, groupId");
             params.add(declarationType);
         }
-        if (aggParams.getFirst().isArray()) {
+        if (hasOnlyBlockArguments) {
             pattern.append(", p");
         }
-        for (AggregationParameter p : aggParams) {
+        for (Argument a : aggParams) {
             pattern.append(", $L");
-            params.add(p.valueName());
+            params.add(a.valueName());
         }
         if (returnType.isPrimitive()) {
             pattern.append(")");
@@ -552,7 +564,11 @@ public class GroupingAggregatorImplementer {
             requireArgs(
                 Stream.concat(
                     Stream.of(requireType(GROUPING_AGGREGATOR_FUNCTION_ADD_INPUT), requireType(aggState.declaredType())),
-                    aggParams.stream().map(p -> requireType(valuesAreVector ? vectorType(p.type()) : blockType(p.type())))
+                    aggParams.stream().map(a -> {
+                        boolean isBlockArgument = a instanceof BlockArgument;
+                        TypeName typeName = isBlockArgument ? Types.elementType(a.type()) : a.type();
+                        return requireType(valuesAreVector ? vectorType(typeName) : blockType(typeName));
+                    })
                 ).toArray(Methods.TypeMatcher[]::new)
             )
         ) != null;

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/GroupingAggregatorImplementer.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/GroupingAggregatorImplementer.java
@@ -331,7 +331,12 @@ public class GroupingAggregatorImplementer {
         }
 
         for (Argument a : aggParams) {
-            builder.addStatement("$T $L = $L.asVector()", vectorType(a.elementType()), (a instanceof BlockArgument) ? (a.name() + "Vector") : a.vectorName(), a.blockName());
+            builder.addStatement(
+                "$T $L = $L.asVector()",
+                vectorType(a.elementType()),
+                (a instanceof BlockArgument) ? (a.name() + "Vector") : a.vectorName(),
+                a.blockName()
+            );
             builder.beginControlFlow("if ($L == null)", (a instanceof BlockArgument) ? (a.name() + "Vector") : a.vectorName());
             {
                 builder.addStatement(

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialExtentCartesianShapeDocValuesGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialExtentCartesianShapeDocValuesGroupingAggregatorFunction.java
@@ -91,17 +91,17 @@ public final class SpatialExtentCartesianShapeDocValuesGroupingAggregatorFunctio
     return new GroupingAggregatorFunction.AddInput() {
       @Override
       public void add(int positionOffset, IntArrayBlock groupIds) {
-        addRawInput(positionOffset, groupIds, valuesVector);
+        // This type does not support vectors because all values are multi-valued
       }
 
       @Override
       public void add(int positionOffset, IntBigArrayBlock groupIds) {
-        addRawInput(positionOffset, groupIds, valuesVector);
+        // This type does not support vectors because all values are multi-valued
       }
 
       @Override
       public void add(int positionOffset, IntVector groupIds) {
-        addRawInput(positionOffset, groupIds, valuesVector);
+        // This type does not support vectors because all values are multi-valued
       }
 
       @Override
@@ -126,10 +126,6 @@ public final class SpatialExtentCartesianShapeDocValuesGroupingAggregatorFunctio
         SpatialExtentCartesianShapeDocValuesAggregator.combine(state, groupId, valuesPosition, valuesBlock);
       }
     }
-  }
-
-  private void addRawInput(int positionOffset, IntArrayBlock groups, IntVector valuesVector) {
-    // This type does not support vectors because all values are multi-valued
   }
 
   @Override
@@ -189,10 +185,6 @@ public final class SpatialExtentCartesianShapeDocValuesGroupingAggregatorFunctio
     }
   }
 
-  private void addRawInput(int positionOffset, IntBigArrayBlock groups, IntVector valuesVector) {
-    // This type does not support vectors because all values are multi-valued
-  }
-
   @Override
   public void addIntermediateInput(int positionOffset, IntBigArrayBlock groups, Page page) {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
@@ -241,10 +233,6 @@ public final class SpatialExtentCartesianShapeDocValuesGroupingAggregatorFunctio
       int groupId = groups.getInt(groupPosition);
       SpatialExtentCartesianShapeDocValuesAggregator.combine(state, groupId, valuesPosition, valuesBlock);
     }
-  }
-
-  private void addRawInput(int positionOffset, IntVector groups, IntVector valuesVector) {
-    // This type does not support vectors because all values are multi-valued
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialExtentGeoShapeDocValuesGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialExtentGeoShapeDocValuesGroupingAggregatorFunction.java
@@ -93,17 +93,17 @@ public final class SpatialExtentGeoShapeDocValuesGroupingAggregatorFunction impl
     return new GroupingAggregatorFunction.AddInput() {
       @Override
       public void add(int positionOffset, IntArrayBlock groupIds) {
-        addRawInput(positionOffset, groupIds, valuesVector);
+        // This type does not support vectors because all values are multi-valued
       }
 
       @Override
       public void add(int positionOffset, IntBigArrayBlock groupIds) {
-        addRawInput(positionOffset, groupIds, valuesVector);
+        // This type does not support vectors because all values are multi-valued
       }
 
       @Override
       public void add(int positionOffset, IntVector groupIds) {
-        addRawInput(positionOffset, groupIds, valuesVector);
+        // This type does not support vectors because all values are multi-valued
       }
 
       @Override
@@ -128,10 +128,6 @@ public final class SpatialExtentGeoShapeDocValuesGroupingAggregatorFunction impl
         SpatialExtentGeoShapeDocValuesAggregator.combine(state, groupId, valuesPosition, valuesBlock);
       }
     }
-  }
-
-  private void addRawInput(int positionOffset, IntArrayBlock groups, IntVector valuesVector) {
-    // This type does not support vectors because all values are multi-valued
   }
 
   @Override
@@ -201,10 +197,6 @@ public final class SpatialExtentGeoShapeDocValuesGroupingAggregatorFunction impl
     }
   }
 
-  private void addRawInput(int positionOffset, IntBigArrayBlock groups, IntVector valuesVector) {
-    // This type does not support vectors because all values are multi-valued
-  }
-
   @Override
   public void addIntermediateInput(int positionOffset, IntBigArrayBlock groups, Page page) {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
@@ -263,10 +255,6 @@ public final class SpatialExtentGeoShapeDocValuesGroupingAggregatorFunction impl
       int groupId = groups.getInt(groupPosition);
       SpatialExtentGeoShapeDocValuesAggregator.combine(state, groupId, valuesPosition, valuesBlock);
     }
-  }
-
-  private void addRawInput(int positionOffset, IntVector groups, IntVector valuesVector) {
-    // This type does not support vectors because all values are multi-valued
   }
 
   @Override


### PR DESCRIPTION
- Change `GroupingAggregatorImplementer` to use `Argument` instead of `AggregationParameter`.
- Compiling esql module resulted in 2 modified `SpatialExtent*` classes, where the no-op vector methods are removed and the call to them was replaced with a comment.
