### PR TITLE
[9.2] [Inference API] Rename Elastic Inference Service rerank model/endpoint (#137030)

### DIFF
--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceGetModelsWithElasticInferenceServiceIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceGetModelsWithElasticInferenceServiceIT.java
@@ -52,7 +52,7 @@ public class InferenceGetModelsWithElasticInferenceServiceIT extends BaseMockEIS
         assertInferenceIdTaskType(allModels, ".rainbow-sprinkles-elastic", TaskType.CHAT_COMPLETION);
         assertInferenceIdTaskType(allModels, ".elser-2-elastic", TaskType.SPARSE_EMBEDDING);
         assertInferenceIdTaskType(allModels, ".jina-embeddings-v3", TaskType.TEXT_EMBEDDING);
-        assertInferenceIdTaskType(allModels, ".rerank-v1-elastic", TaskType.RERANK);
+        assertInferenceIdTaskType(allModels, ".elastic-rerank-v1", TaskType.RERANK);
     }
 
     private static void assertInferenceIdTaskType(List<Map<String, Object>> models, String inferenceId, TaskType taskType) {

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/MockElasticInferenceServiceAuthorizationServer.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/MockElasticInferenceServiceAuthorizationServer.java
@@ -47,7 +47,7 @@ public class MockElasticInferenceServiceAuthorizationServer implements TestRule 
                       "task_types": ["embed/text/dense"]
                     },
                   {
-                      "model_name": "rerank-v1",
+                      "model_name": "elastic-rerank-v1",
                       "task_types": ["rerank/text/text-similarity"]
                     }
                 ]

--- a/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/InferenceRevokeDefaultEndpointsIT.java
+++ b/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/InferenceRevokeDefaultEndpointsIT.java
@@ -207,7 +207,7 @@ public class InferenceRevokeDefaultEndpointsIT extends ESSingleNodeTestCase {
                           "task_types": ["embed/text/dense"]
                         },
                         {
-                          "model_name": "rerank-v1",
+                          "model_name": "elastic-rerank-v1",
                           "task_types": ["rerank/text/text-similarity"]
                         }
                     ]
@@ -244,7 +244,7 @@ public class InferenceRevokeDefaultEndpointsIT extends ESSingleNodeTestCase {
                             service
                         ),
                         new InferenceService.DefaultConfigId(
-                            ".rerank-v1-elastic",
+                            ".elastic-rerank-v1",
                             MinimalServiceSettings.rerank(ElasticInferenceService.NAME),
                             service
                         )
@@ -257,10 +257,11 @@ public class InferenceRevokeDefaultEndpointsIT extends ESSingleNodeTestCase {
 
                 PlainActionFuture<List<Model>> listener = new PlainActionFuture<>();
                 service.defaultConfigs(listener);
-                assertThat(listener.actionGet(TIMEOUT).get(0).getConfigurations().getInferenceEntityId(), is(".elser-2-elastic"));
-                assertThat(listener.actionGet(TIMEOUT).get(1).getConfigurations().getInferenceEntityId(), is(".jina-embeddings-v3"));
-                assertThat(listener.actionGet(TIMEOUT).get(2).getConfigurations().getInferenceEntityId(), is(".rainbow-sprinkles-elastic"));
-                assertThat(listener.actionGet(TIMEOUT).get(3).getConfigurations().getInferenceEntityId(), is(".rerank-v1-elastic"));
+
+                assertThat(listener.actionGet(TIMEOUT).get(0).getConfigurations().getInferenceEntityId(), is(".elastic-rerank-v1"));
+                assertThat(listener.actionGet(TIMEOUT).get(1).getConfigurations().getInferenceEntityId(), is(".elser-2-elastic"));
+                assertThat(listener.actionGet(TIMEOUT).get(2).getConfigurations().getInferenceEntityId(), is(".jina-embeddings-v3"));
+                assertThat(listener.actionGet(TIMEOUT).get(3).getConfigurations().getInferenceEntityId(), is(".rainbow-sprinkles-elastic"));
 
                 var getModelListener = new PlainActionFuture<UnparsedModel>();
                 // persists the default endpoints
@@ -280,7 +281,7 @@ public class InferenceRevokeDefaultEndpointsIT extends ESSingleNodeTestCase {
                           "task_types": ["embed/text/sparse"]
                         },
                         {
-                          "model_name": "rerank-v1",
+                          "model_name": "elastic-rerank-v1",
                           "task_types": ["rerank/text/text-similarity"]
                         },
                         {
@@ -316,7 +317,7 @@ public class InferenceRevokeDefaultEndpointsIT extends ESSingleNodeTestCase {
                             service
                         ),
                         new InferenceService.DefaultConfigId(
-                            ".rerank-v1-elastic",
+                            ".elastic-rerank-v1",
                             MinimalServiceSettings.rerank(ElasticInferenceService.NAME),
                             service
                         )

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceService.java
@@ -121,8 +121,8 @@ public class ElasticInferenceService extends SenderService {
     static final String DEFAULT_MULTILINGUAL_EMBED_ENDPOINT_ID = ".jina-embeddings-v3";
 
     // rerank-v1
-    static final String DEFAULT_RERANK_MODEL_ID_V1 = "rerank-v1";
-    static final String DEFAULT_RERANK_ENDPOINT_ID_V1 = defaultEndpointId(DEFAULT_RERANK_MODEL_ID_V1);
+    static final String DEFAULT_RERANK_MODEL_ID_V1 = "elastic-rerank-v1";
+    static final String DEFAULT_RERANK_ENDPOINT_ID_V1 = ".elastic-rerank-v1";
 
     /**
      * The task types that the {@link InferenceAction.Request} can accept.

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
@@ -1242,7 +1242,7 @@ public class ElasticInferenceServiceTests extends ESSingleNodeTestCase {
                       "task_types": ["embed/text/dense"]
                     },
                   {
-                      "model_name": "rerank-v1",
+                      "model_name": "elastic-rerank-v1",
                       "task_types": ["rerank/text/text-similarity"]
                     }
                 ]
@@ -1260,6 +1260,11 @@ public class ElasticInferenceServiceTests extends ESSingleNodeTestCase {
                 service.defaultConfigIds(),
                 is(
                     List.of(
+                        new InferenceService.DefaultConfigId(
+                            ".elastic-rerank-v1",
+                            MinimalServiceSettings.rerank(ElasticInferenceService.NAME),
+                            service
+                        ),
                         new InferenceService.DefaultConfigId(
                             ".elser-2-elastic",
                             MinimalServiceSettings.sparseEmbedding(ElasticInferenceService.NAME),
@@ -1279,11 +1284,6 @@ public class ElasticInferenceServiceTests extends ESSingleNodeTestCase {
                             ".rainbow-sprinkles-elastic",
                             MinimalServiceSettings.chatCompletion(ElasticInferenceService.NAME),
                             service
-                        ),
-                        new InferenceService.DefaultConfigId(
-                            ".rerank-v1-elastic",
-                            MinimalServiceSettings.rerank(ElasticInferenceService.NAME),
-                            service
                         )
                     )
                 )
@@ -1297,10 +1297,10 @@ public class ElasticInferenceServiceTests extends ESSingleNodeTestCase {
             service.defaultConfigs(listener);
             var models = listener.actionGet(TIMEOUT);
             assertThat(models.size(), is(4));
-            assertThat(models.get(0).getConfigurations().getInferenceEntityId(), is(".elser-2-elastic"));
-            assertThat(models.get(1).getConfigurations().getInferenceEntityId(), is(".jina-embeddings-v3"));
-            assertThat(models.get(2).getConfigurations().getInferenceEntityId(), is(".rainbow-sprinkles-elastic"));
-            assertThat(models.get(3).getConfigurations().getInferenceEntityId(), is(".rerank-v1-elastic"));
+            assertThat(models.get(0).getConfigurations().getInferenceEntityId(), is(".elastic-rerank-v1"));
+            assertThat(models.get(1).getConfigurations().getInferenceEntityId(), is(".elser-2-elastic"));
+            assertThat(models.get(2).getConfigurations().getInferenceEntityId(), is(".jina-embeddings-v3"));
+            assertThat(models.get(3).getConfigurations().getInferenceEntityId(), is(".rainbow-sprinkles-elastic"));
         }
     }
 


### PR DESCRIPTION
Backports the following commits to 9.2:
 - [Inference API] Rename Elastic Inference Service rerank model/endpoint (#137030)