### PR TITLE
[ML] Partial fix for deployment disappearing

### DIFF
--- a/docs/changelog/137216.yaml
+++ b/docs/changelog/137216.yaml
@@ -1,0 +1,5 @@
+pr: 137216
+summary: Partial fix for deployment disappearing
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -751,7 +751,7 @@ public class MachineLearning extends Plugin
     public static final Setting<TimeValue> SCALE_UP_COOLDOWN_TIME = Setting.timeSetting(
         "xpack.ml.trained_models.adaptive_allocations.scale_up_cooldown_time",
         TimeValue.timeValueMinutes(5),
-        TimeValue.timeValueMinutes(1),
+        TimeValue.timeValueSeconds(1),
         Property.Dynamic,
         Setting.Property.NodeScope
     );
@@ -766,7 +766,7 @@ public class MachineLearning extends Plugin
     public static final Setting<TimeValue> SCALE_TO_ZERO_AFTER_NO_REQUESTS_TIME = Setting.timeSetting(
         "xpack.ml.trained_models.adaptive_allocations.scale_to_zero_time",
         TimeValue.timeValueHours(24),
-        TimeValue.timeValueMinutes(1),
+        TimeValue.timeValueSeconds(1),
         Property.Dynamic,
         Setting.Property.NodeScope
     );

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AssignmentPlanner.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AssignmentPlanner.java
@@ -51,7 +51,7 @@ public class AssignmentPlanner {
     public AssignmentPlanner(List<Node> nodes, List<AssignmentPlan.Deployment> deployments) {
         this.nodes = nodes.stream().sorted(Comparator.comparing(Node::id)).toList();
         this.deployments = deployments.stream()
-//            .filter(deployment -> deployment.allocations() > 0)
+            // .filter(deployment -> deployment.allocations() > 0)
             .sorted(Comparator.comparing(AssignmentPlan.Deployment::deploymentId))
             .toList();
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AssignmentPlanner.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AssignmentPlanner.java
@@ -51,7 +51,7 @@ public class AssignmentPlanner {
     public AssignmentPlanner(List<Node> nodes, List<AssignmentPlan.Deployment> deployments) {
         this.nodes = nodes.stream().sorted(Comparator.comparing(Node::id)).toList();
         this.deployments = deployments.stream()
-            .filter(deployment -> deployment.allocations() > 0)
+//            .filter(deployment -> deployment.allocations() > 0)
             .sorted(Comparator.comparing(AssignmentPlan.Deployment::deploymentId))
             .toList();
     }


### PR DESCRIPTION
WIP

This PR is just to show the changes I made to be able to test the issue here: https://github.com/elastic/elasticsearch/issues/137134

To make the reproduction faster I temporarily changed the code to allow the times to be shorter:

```
PUT /_cluster/settings
{
  "persistent": {
    "xpack.ml.trained_models.adaptive_allocations.scale_to_zero_time": "10s",
    "xpack.ml.trained_models.adaptive_allocations.scale_up_cooldown_time": "10s",
    "logger.org.elasticsearch.xpack.ml.inference.assignment": "DEBUG"
  }
}
```

Then we can follow the steps in the issue to reproduce, which are:

1. Create deployment via creating inference endpoint

```
PUT _inference/rerank/mytest-old
{
    "service": "elasticsearch",
    "service_settings": {
        "num_threads": 1,
        "model_id": ".rerank-v1",
        "adaptive_allocations": {
            "enabled": true,
            "min_number_of_allocations": 0,
            "max_number_of_allocations": 2
        }
    }
}
```

2. Wait for `mytest-old` to scale to zero ~10 seconds

```
GET _ml/trained_models/_stats
```

3. Create a new deployment via inference endpoint, `mytest-old` should still exist, but it will have an allocation which is not intended.

```
PUT _inference/rerank/mytest-new3
{
    "service": "elasticsearch",
    "service_settings": {
        "num_threads": 1,
        "model_id": ".rerank-v1",
        "adaptive_allocations": {
            "enabled": true,
            "min_number_of_allocations": 0,
            "max_number_of_allocations": 2
        }
    }
}
```

```
GET _ml/trained_models/_stats
```