### PR TITLE
Xcontent fix for chunk scorer

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/ChunkScorerConfig.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/ChunkScorerConfig.java
@@ -11,6 +11,8 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.inference.ChunkingSettings;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsBuilder;
 import org.elasticsearch.xpack.core.inference.chunking.SentenceBoundaryChunkingSettings;
 
@@ -18,7 +20,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
 
-public class ChunkScorerConfig implements Writeable {
+public class ChunkScorerConfig implements Writeable, ToXContentObject {
 
     public final Integer size;
     private final String inferenceText;
@@ -96,5 +98,16 @@ public class ChunkScorerConfig implements Writeable {
     @Override
     public int hashCode() {
         return Objects.hash(size, inferenceText, chunkingSettings);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field("size", size);
+        builder.field("inference_text", inferenceText);
+        builder.field("chunking_settings");
+        chunkingSettings.toXContent(builder, params);
+        builder.endObject();
+        return builder;
     }
 }


### PR DESCRIPTION
Small fix to require `ChunkScorerConfig` to produce an XContent object. 

This prevents errors in calling `toString()` on parent objects that contain this. 