### PR TITLE
[Sentinel One] - Fix Cannot execute ILM policy delete step for threat event

### DIFF
--- a/docs/changelog/137222.yaml
+++ b/docs/changelog/137222.yaml
@@ -1,0 +1,6 @@
+pr: 137222
+summary: "[Sentinel One] Add `manage`, `create_index`, `read`, `index`, `write`, `delete`, permission for third-party agent indices in the `Kibana system` to support the threat event data stream."
+area: Authorization
+type: enhancement
+issues:
+  - 240901

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -550,7 +550,7 @@ class KibanaOwnedReservedRoleDescriptors {
                         TransportDeleteIndexAction.TYPE.name()
                     )
                     .build(),
-                // For ExtraHop, QualysGAV, SentinelOne Application Dataset, Island Browser and Cyera specific actions.
+                // For ExtraHop, QualysGAV, SentinelOne, Island Browser and Cyera specific actions.
                 // Kibana reads, writes and manages this index
                 // for configured ILM policies.
                 RoleDescriptor.IndicesPrivileges.builder()
@@ -558,6 +558,7 @@ class KibanaOwnedReservedRoleDescriptors {
                         "logs-extrahop.investigation-*",
                         "logs-qualys_gav.asset-*",
                         "logs-sentinel_one.application-*",
+                        "logs-sentinel_one.threat_event-*",
                         "logs-island_browser.user-*",
                         "logs-island_browser.device-*",
                         "logs-cyera.classification-*",

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1984,6 +1984,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
             "logs-extrahop.investigation-" + randomAlphaOfLength(randomIntBetween(1, 10)),
             "logs-qualys_gav.asset-" + randomAlphaOfLength(randomIntBetween(1, 10)),
             "logs-sentinel_one.application-" + randomAlphaOfLength(randomIntBetween(1, 10)),
+            "logs-sentinel_one.threat_event-" + randomAlphaOfLength(randomIntBetween(1, 10)),
             "logs-island_browser.user-" + randomAlphaOfLength(randomIntBetween(1, 10)),
             "logs-island_browser.device-" + randomAlphaOfLength(randomIntBetween(1, 10)),
             "logs-cyera.classification-" + randomAlphaOfLength(randomIntBetween(1, 10)),


### PR DESCRIPTION
**PR Description:**
This PR focuses on the short term solution which add the `logs-sentinel_one.threat_event-*`  indices under the `kibana_system `role with deletion privileges to prevent a failed deletion error when the index enters the deletion phase for the ILM lifecycle, in upcoming [PR](https://github.com/elastic/integrations/pull/15771). As it ships transform pipeline too hence read, write permissions are also required.

Current behavior:

It shows permission issue while deleting the index.

Similar Issues : https://github.com/elastic/kibana/issues/197390, https://github.com/elastic/elasticsearch/issues/131825

Closing https://github.com/elastic/kibana/issues/240901
NOTE: We would need this to be backported to at least 8.18.0 and above.