### PR TITLE
[Sampling] Improving random sampling performance by lazily calling getSamplingConfiguration()

### DIFF
--- a/server/src/main/java/org/elasticsearch/ingest/SamplingService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/SamplingService.java
@@ -210,16 +210,24 @@ public class SamplingService extends AbstractLifecycleComponent implements Clust
             return;
         }
         long startTime = statsTimeSupplier.getAsLong();
-        SamplingConfiguration samplingConfig = getSamplingConfiguration(projectMetadata, indexName);
-        if (samplingConfig == null) {
-            return;
-        }
-        SoftReference<SampleInfo> sampleInfoReference = samples.compute(
-            new ProjectIndex(projectMetadata.id(), indexName),
-            (k, v) -> v == null || v.get() == null ? new SoftReference<>(new SampleInfo(samplingConfig.maxSamples())) : v
-        );
+        SoftReference<SampleInfo> sampleInfoReference = samples.compute(new ProjectIndex(projectMetadata.id(), indexName), (k, v) -> {
+            if (v == null || v.get() == null) {
+                SamplingConfiguration samplingConfig = getSamplingConfiguration(projectMetadata, indexName);
+                if (samplingConfig == null) {
+                    /*
+                     * Calls to getSamplingConfiguration() are relatively expensive. So we store the NONE object here to indicate that there
+                     * was no sampling configuration. This way we don't have to do the lookup every single time for every index that has no
+                     * sampling configuration. If a sampling configuration is added for this index, this NONE sample will be removed by
+                     * the cluster state change listener.
+                     */
+                    return new SoftReference<>(SampleInfo.NONE);
+                }
+                return new SoftReference<>(new SampleInfo(samplingConfig.maxSamples()));
+            }
+            return v;
+        });
         SampleInfo sampleInfo = sampleInfoReference.get();
-        if (sampleInfo == null) {
+        if (sampleInfo == null || sampleInfo == SampleInfo.NONE) {
             return;
         }
         SampleStats stats = sampleInfo.stats;
@@ -228,6 +236,10 @@ public class SamplingService extends AbstractLifecycleComponent implements Clust
             if (sampleInfo.isFull) {
                 stats.samplesRejectedForMaxSamplesExceeded.increment();
                 return;
+            }
+            SamplingConfiguration samplingConfig = getSamplingConfiguration(projectMetadata, indexName);
+            if (samplingConfig == null) {
+                return; // it was not null above, but has since become null because the index was deleted asynchronously
             }
             if (sampleInfo.getSizeInBytes() + indexRequest.source().length() > samplingConfig.maxSize().getBytes()) {
                 stats.samplesRejectedForSize.increment();
@@ -475,7 +487,12 @@ public class SamplingService extends AbstractLifecycleComponent implements Clust
                 if (oldSampleConfigsMap.containsKey(indexName) && entry.getValue().equals(oldSampleConfigsMap.get(indexName)) == false) {
                     logger.debug("Removing sample info for {} because its configuration has changed", indexName);
                     samples.remove(new ProjectIndex(projectId, indexName));
-                }
+                } else if (oldSampleConfigsMap.containsKey(indexName) == false
+                    && samples.containsKey(new ProjectIndex(projectId, indexName))) {
+                        // There had previously been a NONE sample here. There is a real config now, so delete the NONE sample
+                        logger.debug("Removing sample info for {} because its configuration has been created", indexName);
+                        samples.remove(new ProjectIndex(projectId, indexName));
+                    }
             }
         }
     }
@@ -1003,6 +1020,7 @@ public class SamplingService extends AbstractLifecycleComponent implements Clust
      * This is used internally to store information about a sample in the samples Map.
      */
     private static final class SampleInfo {
+        public static final SampleInfo NONE = new SampleInfo(0);
         private final RawDocument[] rawDocuments;
         /*
          * This stores the maximum index in rawDocuments that has data currently. This is incremented speculatively before writing data to


### PR DESCRIPTION
In doing some profiling and looking at sampling stats, I realized that calls to getSamplingConfiguration() were relatively expensive. I'm assuming the most common cases by far are:

1. An index is configured for a sample, but it has already reached it's max samples limit
2. An index is not configured for sampling at all but some other index is

For 1, I moved the call to getSamplingConfiguration() to _after_ the `isFull` check. So when we're not getting past the isFull check, we just never call getSamplingConfiguration().
For 2, I added a NONE SampleInfo marker, letting us know that there is no need to lookup the configuration for this index. If a configuration is later added for the index, the clusterChanged() method removes this NONE sample.

The script I was running to profile this does the following:
Creates a sampling configuration for index1
Bulk loads dozens of entries into index1 and index2 tens of thousands of times
Creates a sampling configuration for index2
Bulk loads some entries into index2.

With this change, it looks much better in the profiler -- I never see calls to getSamplingConfiguration() now. And the reported stats from sampling go from ~1000ns/doc to ~55ns/doc (on my laptop with this particular test).