### PR TITLE
Fix visibility of sampling config rest specs

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_sample_configuration.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_sample_configuration.json
@@ -5,7 +5,8 @@
       "description": "Delete sampling configuration for an index or data stream"
     },
     "stability": "experimental",
-    "visibility": "public",
+    "visibility": "feature_flag",
+    "feature_flag": "random_sampling",
     "headers": {
       "accept": [
         "application/json"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_all_sample_configuration.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_all_sample_configuration.json
@@ -5,7 +5,8 @@
       "description": "Get sampling configurations for all indices and data streams"
     },
     "stability": "experimental",
-    "visibility": "public",
+    "visibility": "feature_flag",
+    "feature_flag": "random_sampling",
     "headers": {
       "accept": [
         "application/json"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_sample_configuration.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_sample_configuration.json
@@ -5,7 +5,8 @@
       "description": "Get sampling configuration for an index or data stream"
     },
     "stability": "experimental",
-    "visibility": "public",
+    "visibility": "feature_flag",
+    "feature_flag": "random_sampling",
     "headers": {
       "accept": [
         "application/json"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_sample_configuration.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_sample_configuration.json
@@ -5,7 +5,8 @@
       "description": "Configure sampling for an index or data stream"
     },
     "stability": "experimental",
-    "visibility": "public",
+    "visibility": "feature_flag",
+    "feature_flag": "random_sampling",
     "headers": {
       "accept": [
         "application/json"


### PR DESCRIPTION
The sampling config endpoints are behind a feature flag. this PR updates the rest api spec to reflect that visibility