### PR TITLE
Fix block loader for sorted ordinals

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/SingletonOrdinalsBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/SingletonOrdinalsBuilder.java
@@ -72,6 +72,7 @@ public class SingletonOrdinalsBuilder implements BlockLoader.SingletonOrdinalsBu
         Arrays.fill(ords, count, count + length, ord);
         this.minOrd = Math.min(this.minOrd, ord);
         this.maxOrd = Math.max(this.maxOrd, ord);
+        this.count += length;
         return this;
     }
 
@@ -256,6 +257,10 @@ public class SingletonOrdinalsBuilder implements BlockLoader.SingletonOrdinalsBu
 
     @Override
     public BytesRefBlock build() {
+        if (count != ords.length) {
+            assert false : "expected " + ords.length + " values but got " + count;
+            throw new IllegalStateException("expected " + ords.length + " values but got " + count);
+        }
         var constantBlock = tryBuildConstantBlock();
         if (constantBlock != null) {
             return constantBlock;

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/read/SingletonOrdinalsBuilderTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/read/SingletonOrdinalsBuilderTests.java
@@ -191,8 +191,8 @@ public class SingletonOrdinalsBuilderTests extends ComputeTestCase {
                         var b2 = new SingletonOrdinalsBuilder(factory, ctx.reader().getSortedDocValues("f"), batchSize, randomBoolean())
                     ) {
                         for (int i = 0; i < batchSize; i++) {
-                            b1.appendOrd(ord);
-                            b2.appendOrd(ord);
+                            appendOrd(b1, ord);
+                            appendOrd(b2, ord);
                         }
                         try (BytesRefBlock block1 = b1.build(); BytesRefBlock block2 = b2.buildRegularBlock()) {
                             assertThat(block1, equalTo(block2));
@@ -201,6 +201,20 @@ public class SingletonOrdinalsBuilderTests extends ComputeTestCase {
                     }
                 }
             }
+        }
+    }
+
+    private void appendOrd(SingletonOrdinalsBuilder builder, int ord) {
+        if (randomBoolean()) {
+            builder.appendOrd(ord);
+        } else if (randomBoolean()) {
+            int prefix = between(0, 2);
+            int suffix = between(0, 2);
+            int[] ords = new int[prefix + 1 + suffix];
+            ords[prefix] = ord;
+            builder.appendOrds(ords, prefix, 1, ord, ord);
+        } else {
+            builder.appendOrds(ord, 1);
         }
     }
 


### PR DESCRIPTION
I broke the block loader for sorted ordinals in #137076, and our tests didn’t catch it because we tested with the TestBuilder instead of the real builder. 


Relates #137076.
