### PR TITLE
ESQL: Exclude types under construction from AllSupportedFieldsTestCase

### DIFF
--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AllSupportedFieldsTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AllSupportedFieldsTestCase.java
@@ -506,6 +506,10 @@ public class AllSupportedFieldsTestCase extends ESRestTestCase {
      * Is the type supported in indices?
      */
     private static boolean supportedInIndex(DataType t) {
+        if (DataType.UNDER_CONSTRUCTION.contains(t)) {
+            // These tests don't deal with types under construction
+            return false;
+        }
         return switch (t) {
             // These are supported but implied by the index process.
             // TODO: current versions already support _tsid; update this once we can tell whether all nodes support it.


### PR DESCRIPTION
Extracted from #136964.

While implementing the BlockLoader and CSV-tests for the new `exponential_histogram` type, `AllSupportedFieldsTestCase` suddenly started failing due to [createAllTypesDoc](https://github.com/elastic/elasticsearch/blob/772e6a18997f3f5594f783072f7e35dac626d62f/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AllSupportedFieldsTestCase.java#L420) not being implemented for this type.

The javadoc of the test states
```
/**
 * Creates indices with all supported fields and fetches values from them to
 * confirm that release builds correctly handle data types, even if they were
 * introduced in later versions.
 * <p>
 *     Entirely skipped in snapshot builds; data types that are under
 *     construction are normally tested well enough in spec tests, skipping
 *     old versions via {@link org.elasticsearch.xpack.esql.action.EsqlCapabilities}.
```

So IIUC adding new under-construction types shouldn't cause test failures in this test. Therefore this PR proposes to properly do this, even for future new types under construction.