### PR TITLE
x-pack: add bcmail-fips entitlement

### DIFF
--- a/x-pack/plugin/watcher/src/main/plugin-metadata/entitlement-policy.yaml
+++ b/x-pack/plugin/watcher/src/main/plugin-metadata/entitlement-policy.yaml
@@ -13,4 +13,6 @@ ALL-UNNAMED:
     - relative_path: ".mailcap"
       relative_to: "home"
       mode: "read"
+    - path: "/usr/share/elasticsearch/lib/bcmail-fips.jar"
+      mode: "read"
 


### PR DESCRIPTION
watcher plugin requires access to bcmail-fips jar, thus grant it.
