### PR TITLE
entitlements: Grant entitlements for bc-fips 2.1 compat

### DIFF
--- a/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementChecker.java
+++ b/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementChecker.java
@@ -192,8 +192,6 @@ public interface EntitlementChecker {
 
     void check$java_lang_System$$setOut(Class<?> callerClass, PrintStream out);
 
-    void check$java_lang_Runtime$addShutdownHook(Class<?> callerClass, Runtime runtime, Thread hook);
-
     void check$java_lang_Runtime$removeShutdownHook(Class<?> callerClass, Runtime runtime, Thread hook);
 
     void check$java_lang_Thread$$setDefaultUncaughtExceptionHandler(Class<?> callerClass, Thread.UncaughtExceptionHandler ueh);

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/SystemActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/SystemActions.java
@@ -55,11 +55,6 @@ class SystemActions {
     private static final Thread NO_OP_SHUTDOWN_HOOK = new Thread(() -> {}, "Shutdown hook for testing");
 
     @EntitlementTest(expectedAccess = ALWAYS_DENIED)
-    static void runtimeAddShutdownHook() {
-        Runtime.getRuntime().addShutdownHook(NO_OP_SHUTDOWN_HOOK);
-    }
-
-    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
     static void runtimeRemoveShutdownHook() {
         Runtime.getRuntime().removeShutdownHook(NO_OP_SHUTDOWN_HOOK);
     }

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/bootstrap/HardcodedEntitlements.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/bootstrap/HardcodedEntitlements.java
@@ -184,8 +184,6 @@ class HardcodedEntitlements {
             )
         );
 
-        // conditionally add FIPS entitlements if FIPS only functionality is enforced
-        if (Booleans.parseBoolean(System.getProperty("org.bouncycastle.fips.approved_only"), false)) {
             // if custom trust store is set, grant read access to its location, otherwise use the default JDK trust store
             String trustStore = System.getProperty("javax.net.ssl.trustStore");
             Path trustStorePath = trustStore != null
@@ -207,11 +205,20 @@ class HardcodedEntitlements {
                     // read to lib dir is required for checksum validation
                     List.of(
                         new FilesEntitlement(List.of(FilesEntitlement.FileData.ofBaseDirPath(LIB, READ))),
-                        new ManageThreadsEntitlement()
+                        new ManageThreadsEntitlement(),
+                        new LoadNativeLibrariesEntitlement()
+                    )
+                ),
+                new Scope(
+                    "bc.rng.jent",
+                    // read to lib dir is required for checksum validation
+                    List.of(
+                        new FilesEntitlement(List.of(FilesEntitlement.FileData.ofBaseDirPath(LIB, READ))),
+                        new ManageThreadsEntitlement(),
+                        new LoadNativeLibrariesEntitlement()
                     )
                 )
             );
-        }
         return serverScopes;
     }
 

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/ElasticsearchEntitlementChecker.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/ElasticsearchEntitlementChecker.java
@@ -304,11 +304,6 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
     }
 
     @Override
-    public void check$java_lang_Runtime$addShutdownHook(Class<?> callerClass, Runtime runtime, Thread hook) {
-        policyChecker.checkChangeJVMGlobalState(callerClass);
-    }
-
-    @Override
     public void check$java_lang_Runtime$removeShutdownHook(Class<?> callerClass, Runtime runtime, Thread hook) {
         policyChecker.checkChangeJVMGlobalState(callerClass);
     }


### PR DESCRIPTION
Runtime.addShutdownHook is always forbidden, but new versions of
bc-fips and bc-rng-jent require it. There is no policy entitlement to
allow it, thus lift the forbidden policy.

bc-fips 2.1.0 has native libraries capability, thus grant loading
native libraries.

bc.rng.jent also uses native libraries, thus grant loading native
libraries to that scope.

Unconditionally grant these entitlements to allow running with bc-fips
in unapproved mode or with non-fips bc-lts.

Note that bc-fips supports both system and security properties to
specify approved mode, thus existing conditional skips bc-fips
codepath in valid configurations.
