### PR TITLE
[9.2] Xcontent fix for chunk scorer (#137218)

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/ChunkScorerConfig.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/ChunkScorerConfig.java
@@ -11,6 +11,8 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.inference.ChunkingSettings;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.inference.chunking.ChunkingSettingsBuilder;
 import org.elasticsearch.xpack.inference.chunking.SentenceBoundaryChunkingSettings;
 
@@ -18,7 +20,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
 
-public class ChunkScorerConfig implements Writeable {
+public class ChunkScorerConfig implements Writeable, ToXContentObject {
 
     public final Integer size;
     private final String inferenceText;
@@ -96,5 +98,16 @@ public class ChunkScorerConfig implements Writeable {
     @Override
     public int hashCode() {
         return Objects.hash(size, inferenceText, chunkingSettings);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field("size", size);
+        builder.field("inference_text", inferenceText);
+        builder.field("chunking_settings");
+        chunkingSettings.toXContent(builder, params);
+        builder.endObject();
+        return builder;
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Xcontent fix for chunk scorer (#137218)](https://github.com/elastic/elasticsearch/pull/137218)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)