### PR TITLE
[8.19] Fix flakiness on YAML tests for Sparse Vector (#137202)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -406,3 +406,4 @@ tests:
   - class: org.elasticsearch.xpack.esql.plugin.DataNodeRequestSenderIT
     method: testSearchWhileRelocating
     issue: https://github.com/elastic/elasticsearch/issues/128500
+

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/sparse_vector_search.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/sparse_vector_search.yml
@@ -99,7 +99,7 @@ teardown:
         Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
         Content-Type: application/json
       indices.delete:
-        index: ["sparse_vector_pruning_test", "test-sparse-vector-without-pruning", "test-sparse-vector-with-pruning"]
+        index: [ "index-with-sparse-vector", "sparse_vector_pruning_test", "test-sparse-vector-without-pruning", "test-sparse-vector-with-pruning", "test-sparse-vector-pruning-default" ]
         ignore: 404
   - do:
       headers:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix flakiness on YAML tests for Sparse Vector (#137202)](https://github.com/elastic/elasticsearch/pull/137202)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)