### PR TITLE
Unmute FullClusterRestartIT tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -435,33 +435,6 @@ tests:
 - class: org.elasticsearch.test.rest.yaml.CcsCommonYamlTestSuiteIT
   method: test {p0=field_caps/10_basic/Field caps for number field with only doc values}
   issue: https://github.com/elastic/elasticsearch/issues/136244
-- class: org.elasticsearch.xpack.restart.FullClusterRestartIT
-  method: testDataStreams {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/136353
-- class: org.elasticsearch.xpack.restart.FullClusterRestartIT
-  method: testServiceAccountApiKey {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/136390
-- class: org.elasticsearch.xpack.restart.FullClusterRestartIT
-  method: testWatcher {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/136391
-- class: org.elasticsearch.xpack.restart.FullClusterRestartIT
-  method: testSingleDoc {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/136392
-- class: org.elasticsearch.xpack.restart.FullClusterRestartIT
-  method: testTransformLegacyTemplateCleanup {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/136393
-- class: org.elasticsearch.xpack.restart.FullClusterRestartIT
-  method: testApiKeySuperuser {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/136394
-- class: org.elasticsearch.xpack.restart.FullClusterRestartIT
-  method: testSecurityNativeRealm {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/136395
-- class: org.elasticsearch.xpack.restart.FullClusterRestartIT
-  method: testSlmPolicyAndStats {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/136399
-- class: org.elasticsearch.xpack.restart.FullClusterRestartIT
-  method: testRollupAfterRestart {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/136437
 - class: org.elasticsearch.test.rest.yaml.RcsCcsCommonYamlTestSuiteIT
   method: test {p0=search.vectors/200_dense_vector_docvalue_fields/Enable docvalue_fields parameter for dense_vector fields}
   issue: https://github.com/elastic/elasticsearch/issues/136443


### PR DESCRIPTION
While investigating https://github.com/elastic/elasticsearch/issues/136395, we realized that the failure is very likely related to changes in TransportVersion, later reversed.

This PR unmutes all FullClusterRestartIT tests muted on the same day, as it is very likely they are all related.

Fixes: https://github.com/elastic/elasticsearch/issues/136353 
Fixes: https://github.com/elastic/elasticsearch/issues/136390
Fixes: https://github.com/elastic/elasticsearch/issues/136391
Fixes: https://github.com/elastic/elasticsearch/issues/136392
Fixes: https://github.com/elastic/elasticsearch/issues/136393
Fixes: https://github.com/elastic/elasticsearch/issues/136394
Fixes: https://github.com/elastic/elasticsearch/issues/136395
Fixes: https://github.com/elastic/elasticsearch/issues/136399
Fixes: https://github.com/elastic/elasticsearch/issues/136437