### PR TITLE
Fixing data stream support in random sampling

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_sample/30_with_data_streams.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_sample/30_with_data_streams.yml
@@ -1,0 +1,275 @@
+---
+"Test get sample for basic sample config":
+  - requires:
+      cluster_features: [ "random_sampling" ]
+      reason: requires feature 'random_sampling' to get random samples
+
+  - do:
+      indices.put_index_template:
+        name: my-template1
+        body:
+          index_patterns: [sample_test]
+          template:
+            settings:
+              index.number_of_shards: 1
+              index.number_of_replicas: 0
+            mappings:
+              dynamic: strict
+              properties:
+                animal:
+                  type: text
+                foo:
+                  type: text
+          data_stream: {}
+
+  - do:
+      indices.create_data_stream:
+        name: sample_test
+  - is_true: acknowledged
+
+  - do:
+      indices.rollover:
+        alias: sample_test
+        wait_for_active_shards: 1
+  - match: { rolled_over: true }
+
+  - do:
+      indices.put_sample_configuration:
+        index: sample_test
+        body:
+          rate: 1.0
+          max_samples: 100
+
+  - do:
+      indices.get_sample:
+        index: sample_test
+  - match: { sample: [] }
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "sample_test"}}'
+          - '{"animal": "dog", "foo": "bar"}'
+          - '{"index": {"_index": "sample_test"}}'
+          - '{"animal": "cat", "foo": "baz"}'
+
+  - do:
+      indices.get_sample:
+        index: sample_test
+  - length: { sample: 2 }
+  - match: { sample.0.index: "sample_test" }
+  - match: { sample.0.source.animal: "dog" }
+  - match: { sample.0.source.foo: "bar" }
+  - match: { sample.1.source.animal: "cat" }
+  - match: { sample.1.source.foo: "baz" }
+
+---
+"Test get sample for conditional sample config":
+  - requires:
+      cluster_features: [ "random_sampling" ]
+      reason: requires feature 'random_sampling' to get random samples
+
+  - do:
+      indices.put_index_template:
+        name: my-template1
+        body:
+          index_patterns: [sample_test]
+          template:
+            settings:
+              index.number_of_shards: 1
+              index.number_of_replicas: 0
+            mappings:
+              dynamic: strict
+              properties:
+                animal:
+                  type: text
+                foo:
+                  type: text
+          data_stream: {}
+
+  - do:
+      indices.create_data_stream:
+        name: sample_test
+  - is_true: acknowledged
+
+  - do:
+      indices.rollover:
+        alias: sample_test
+        wait_for_active_shards: 1
+  - match: { rolled_over: true }
+
+  - do:
+      indices.put_sample_configuration:
+        index: sample_test
+        body:
+          rate: 1.0
+          max_samples: 100
+          if: "ctx?.animal == 'dog'"
+
+  - do:
+      indices.get_sample:
+        index: sample_test
+  - match: { sample: [] }
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "sample_test"}}'
+          - '{"animal": "dog", "foo": "bar"}'
+          - '{"index": {"_index": "sample_test"}}'
+          - '{"animal": "cat", "foo": "baz"}'
+
+  - do:
+      indices.get_sample:
+        index: sample_test
+  - length: { sample: 1 }
+  - match: { sample.0.index: "sample_test" }
+  - match: { sample.0.source.animal: "dog" }
+  - match: { sample.0.source.foo: "bar" }
+
+---
+"Test that deleting sample config deletes sample":
+  - requires:
+      cluster_features: [ "random_sampling" ]
+      reason: requires feature 'random_sampling' to get random samples
+
+  - do:
+      indices.put_index_template:
+        name: my-template1
+        body:
+          index_patterns: [sample_test]
+          template:
+            settings:
+              index.number_of_shards: 1
+              index.number_of_replicas: 0
+            mappings:
+              dynamic: strict
+              properties:
+                animal:
+                  type: text
+                foo:
+                  type: text
+          data_stream: {}
+
+  - do:
+      indices.create_data_stream:
+        name: sample_test
+  - is_true: acknowledged
+
+  - do:
+      indices.rollover:
+        alias: sample_test
+        wait_for_active_shards: 1
+  - match: { rolled_over: true }
+
+  - do:
+      indices.put_sample_configuration:
+        index: sample_test
+        body:
+          rate: 1.0
+          max_samples: 100
+
+  - do:
+      indices.get_sample:
+        index: sample_test
+  - match: { sample: [] }
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "sample_test"}}'
+          - '{"animal": "dog", "foo": "bar"}'
+
+  - do:
+      indices.get_sample:
+        index: sample_test
+  - length: { sample: 1 }
+
+  - do:
+      indices.delete_sample_configuration:
+        index: sample_test
+
+  - do:
+      indices.get_sample:
+        index: sample_test
+      catch: missing
+
+---
+"Test that deleting index deletes sample":
+  - requires:
+      cluster_features: [ "random_sampling" ]
+      reason: requires feature 'random_sampling' to get random samples
+
+  - do:
+      indices.put_index_template:
+        name: my-template1
+        body:
+          index_patterns: [sample_test]
+          template:
+            settings:
+              index.number_of_shards: 1
+              index.number_of_replicas: 0
+            mappings:
+              dynamic: strict
+              properties:
+                animal:
+                  type: text
+                foo:
+                  type: text
+          data_stream: {}
+
+  - do:
+      indices.create_data_stream:
+        name: sample_test
+  - is_true: acknowledged
+
+  - do:
+      indices.rollover:
+        alias: sample_test
+        wait_for_active_shards: 1
+  - match: { rolled_over: true }
+
+  - do:
+      indices.put_sample_configuration:
+        index: sample_test
+        body:
+          rate: 1.0
+          max_samples: 100
+
+  - do:
+      indices.get_sample:
+        index: sample_test
+  - match: { sample: [] }
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "sample_test"}}'
+          - '{"animal": "dog", "foo": "bar"}'
+          - '{"index": {"_index": "sample_test"}}'
+          - '{"animal": "cat", "foo": "baz"}'
+
+  - do:
+      indices.get_sample:
+        index: sample_test
+  - length: { sample: 2 }
+
+  - do:
+      indices.delete_data_stream:
+        name: sample_test
+  - is_true: acknowledged
+
+  - do:
+      indices.get_sample_configuration:
+        index: sample_test
+      catch: missing
+
+  - do:
+      indices.get_sample:
+        index: sample_test
+      catch: missing
+

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_sample/30_with_data_streams.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_sample/30_with_data_streams.yml
@@ -275,6 +275,9 @@
 
 ---
 teardown:
+  - requires:
+      cluster_features: [ "random_sampling" ]
+      reason: requires feature 'random_sampling' to get random samples
 
   - do:
       indices.delete_data_stream:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_sample/30_with_data_streams.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_sample/30_with_data_streams.yml
@@ -273,3 +273,13 @@
         index: sample_test
       catch: missing
 
+---
+teardown:
+
+  - do:
+      indices.delete_data_stream:
+        name: sample_test*
+
+  - do:
+      indices.get_all_sample_configuration: {}
+  - length: { $body: 0 }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_sample_stats/30_with_data_streams.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_sample_stats/30_with_data_streams.yml
@@ -1,0 +1,435 @@
+---
+"Test get sample stats for basic sample config":
+  - requires:
+      cluster_features: [ "random_sampling" ]
+      reason: requires feature 'random_sampling' to get random samples
+
+  - do:
+      indices.put_index_template:
+        name: my-template1
+        body:
+          index_patterns: [sample_test]
+          template:
+            settings:
+              index.number_of_shards: 1
+              index.number_of_replicas: 0
+            mappings:
+              dynamic: strict
+              properties:
+                animal:
+                  type: text
+                foo:
+                  type: text
+          data_stream: {}
+
+  - do:
+      indices.create_data_stream:
+        name: sample_test
+  - is_true: acknowledged
+
+  - do:
+      indices.rollover:
+        alias: sample_test
+        wait_for_active_shards: 1
+  - match: { rolled_over: true }
+
+  - do:
+      indices.put_sample_configuration:
+        index: sample_test
+        body:
+          rate: 1.0
+          max_samples: 100
+
+  - do:
+      indices.get_sample_stats:
+        index: sample_test
+        human: true
+  - match: { potential_samples: 0 }
+  - match: { samples_rejected_for_max_samples_exceeded: 0 }
+  - match: { samples_rejected_for_condition: 0 }
+  - match: { samples_rejected_for_rate: 0 }
+  - match: { samples_rejected_for_exception: 0 }
+  - match: { samples_rejected_for_size: 0 }
+  - match: { samples_accepted: 0 }
+  - match: { time_sampling_millis: 0 }
+  - match: { time_sampling: "0s" }
+  - match: { time_evaluating_condition_millis: 0 }
+  - match: { time_evaluating_condition: "0s" }
+  - match: { time_compiling_condition_millis: 0 }
+  - match: { time_compiling_condition: "0s" }
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "sample_test"}}'
+          - '{"animal": "dog", "foo": "bar"}'
+          - '{"index": {"_index": "sample_test"}}'
+          - '{"animal": "cat", "foo": "baz"}'
+
+  - do:
+      indices.get_sample_stats:
+        index: sample_test
+        human: true
+  - match: { potential_samples: 2 }
+  - match: { samples_rejected_for_max_samples_exceeded: 0 }
+  - match: { samples_rejected_for_condition: 0 }
+  - match: { samples_rejected_for_rate: 0 }
+  - match: { samples_rejected_for_exception: 0 }
+  - match: { samples_rejected_for_size: 0 }
+  - match: { samples_accepted: 2 }
+  - match: { time_evaluating_condition_millis: 0 }
+  - match: { time_evaluating_condition: "0s" }
+  - match: { time_compiling_condition_millis: 0 }
+  - match: { time_compiling_condition: "0s" }
+  - match: { last_exception: null }
+
+---
+"Test get sample stats for conditional sample config":
+  - requires:
+      cluster_features: [ "random_sampling" ]
+      reason: requires feature 'random_sampling' to get random samples
+
+  - do:
+      indices.put_index_template:
+        name: my-template1
+        body:
+          index_patterns: [sample_test]
+          template:
+            settings:
+              index.number_of_shards: 1
+              index.number_of_replicas: 0
+            mappings:
+              dynamic: strict
+              properties:
+                animal:
+                  type: text
+                foo:
+                  type: text
+          data_stream: {}
+
+  - do:
+      indices.create_data_stream:
+        name: sample_test
+  - is_true: acknowledged
+
+  - do:
+      indices.rollover:
+        alias: sample_test
+        wait_for_active_shards: 1
+  - match: { rolled_over: true }
+
+  - do:
+      indices.put_sample_configuration:
+        index: sample_test
+        body:
+          rate: 1.0
+          max_samples: 100
+          if: "ctx?.animal == 'dog'"
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "sample_test"}}'
+          - '{"animal": "dog", "foo": "bar"}'
+          - '{"index": {"_index": "sample_test"}}'
+          - '{"animal": "cat", "foo": "baz"}'
+
+  - do:
+      indices.get_sample_stats:
+        index: sample_test
+        human: true
+  - match: { potential_samples: 2 }
+  - match: { samples_rejected_for_max_samples_exceeded: 0 }
+  - match: { samples_rejected_for_condition: 1 }
+  - match: { samples_rejected_for_rate: 0 }
+  - match: { samples_rejected_for_exception: 0 }
+  - match: { samples_rejected_for_size: 0 }
+  - match: { samples_accepted: 1 }
+  - match: { last_exception: null }
+
+---
+"Test that deleting sample config deletes sample stats":
+  - requires:
+      cluster_features: [ "random_sampling" ]
+      reason: requires feature 'random_sampling' to get random samples
+
+  - do:
+      indices.put_index_template:
+        name: my-template1
+        body:
+          index_patterns: [sample_test]
+          template:
+            settings:
+              index.number_of_shards: 1
+              index.number_of_replicas: 0
+            mappings:
+              dynamic: strict
+              properties:
+                animal:
+                  type: text
+                foo:
+                  type: text
+          data_stream: {}
+
+  - do:
+      indices.create_data_stream:
+        name: sample_test
+  - is_true: acknowledged
+
+  - do:
+      indices.rollover:
+        alias: sample_test
+        wait_for_active_shards: 1
+  - match: { rolled_over: true }
+
+  - do:
+      indices.put_sample_configuration:
+        index: sample_test
+        body:
+          rate: 1.0
+          max_samples: 100
+
+  - do:
+      indices.get_sample_stats:
+        index: sample_test
+        human: true
+  - match: { potential_samples: 0 }
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "sample_test"}}'
+          - '{"animal": "dog", "foo": "bar"}'
+
+  - do:
+      indices.get_sample_stats:
+        index: sample_test
+        human: true
+  - match: { potential_samples: 1 }
+
+  - do:
+      indices.delete_sample_configuration:
+        index: sample_test
+
+  - do:
+      indices.get_sample_stats:
+        index: sample_test
+      catch: missing
+
+---
+"Test that deleting index deletes sample stats":
+  - requires:
+      cluster_features: [ "random_sampling" ]
+      reason: requires feature 'random_sampling' to get random samples
+
+  - do:
+      indices.put_index_template:
+        name: my-template1
+        body:
+          index_patterns: [sample_test]
+          template:
+            settings:
+              index.number_of_shards: 1
+              index.number_of_replicas: 0
+            mappings:
+              dynamic: strict
+              properties:
+                animal:
+                  type: text
+                foo:
+                  type: text
+          data_stream: {}
+
+  - do:
+      indices.create_data_stream:
+        name: sample_test
+  - is_true: acknowledged
+
+  - do:
+      indices.rollover:
+        alias: sample_test
+        wait_for_active_shards: 1
+  - match: { rolled_over: true }
+
+  - do:
+      indices.put_sample_configuration:
+        index: sample_test
+        body:
+          rate: 1.0
+          max_samples: 100
+
+  - do:
+      indices.get_sample_stats:
+        index: sample_test
+        human: true
+  - match: { potential_samples: 0 }
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "sample_test"}}'
+          - '{"animal": "dog", "foo": "bar"}'
+          - '{"index": {"_index": "sample_test"}}'
+          - '{"animal": "cat", "foo": "baz"}'
+
+  - do:
+      indices.get_sample_stats:
+        index: sample_test
+        human: true
+  - match: { potential_samples: 2 }
+
+  - do:
+      indices.delete_data_stream:
+        name: sample_test
+
+  - do:
+      indices.get_sample:
+        index: sample_test
+      catch: missing
+
+  - do:
+      indices.get_sample_stats:
+        index: sample_test
+      catch: missing
+
+---
+"Test get sample stats for exceeds size":
+  - requires:
+      cluster_features: [ "random_sampling" ]
+      reason: requires feature 'random_sampling' to get random samples
+
+  - do:
+      indices.put_index_template:
+        name: my-template1
+        body:
+          index_patterns: [sample_test]
+          template:
+            settings:
+              index.number_of_shards: 1
+              index.number_of_replicas: 0
+            mappings:
+              dynamic: strict
+              properties:
+                animal:
+                  type: text
+                foo:
+                  type: text
+          data_stream: {}
+
+  - do:
+      indices.create_data_stream:
+        name: sample_test
+  - is_true: acknowledged
+
+  - do:
+      indices.rollover:
+        alias: sample_test
+        wait_for_active_shards: 1
+  - match: { rolled_over: true }
+
+  - do:
+      indices.put_sample_configuration:
+        index: sample_test
+        body:
+          rate: 1.0
+          max_samples: 1
+
+  - do:
+      indices.get_sample_stats:
+        index: sample_test
+        human: true
+  - match: { potential_samples: 0 }
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "sample_test"}}'
+          - '{"animal": "dog", "foo": "bar"}'
+          - '{"index": {"_index": "sample_test"}}'
+          - '{"animal": "cat", "foo": "baz"}'
+
+  - do:
+      indices.get_sample_stats:
+        index: sample_test
+        human: true
+  - match: { potential_samples: 2 }
+  - match: { samples_rejected_for_max_samples_exceeded: 1 }
+  - match: { samples_rejected_for_condition: 0 }
+  - match: { samples_rejected_for_rate: 0 }
+  - match: { samples_rejected_for_exception: 0 }
+  - match: { samples_rejected_for_size: 0 }
+  - match: { samples_accepted: 1 }
+  - match: { time_evaluating_condition_millis: 0 }
+  - match: { time_evaluating_condition: "0s" }
+  - match: { time_compiling_condition_millis: 0 }
+  - match: { time_compiling_condition: "0s" }
+
+---
+"Test get sample stats for conditional with exception":
+  - requires:
+      cluster_features: [ "random_sampling" ]
+      reason: requires feature 'random_sampling' to get random samples
+
+  - do:
+      indices.put_index_template:
+        name: my-template1
+        body:
+          index_patterns: [sample_test]
+          template:
+            settings:
+              index.number_of_shards: 1
+              index.number_of_replicas: 0
+            mappings:
+              dynamic: strict
+              properties:
+                animal:
+                  type: text
+                foo:
+                  type: text
+          data_stream: {}
+
+  - do:
+      indices.create_data_stream:
+        name: sample_test
+  - is_true: acknowledged
+
+  - do:
+      indices.rollover:
+        alias: sample_test
+        wait_for_active_shards: 1
+  - match: { rolled_over: true }
+
+  - do:
+      indices.put_sample_configuration:
+        index: sample_test
+        body:
+          rate: 1.0
+          max_samples: 100
+          if: "ctx?.animal > 0"
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "sample_test"}}'
+          - '{"animal": "dog", "foo": "bar"}'
+          - '{"index": {"_index": "sample_test"}}'
+          - '{"animal": "cat", "foo": "baz"}'
+
+  - do:
+      indices.get_sample_stats:
+        index: sample_test
+        human: true
+  - match: { potential_samples: 2 }
+  - match: { samples_rejected_for_max_samples_exceeded: 0 }
+  - match: { samples_rejected_for_condition: 0 }
+  - match: { samples_rejected_for_rate: 0 }
+  - match: { samples_rejected_for_exception: 2 }
+  - match: { samples_rejected_for_size: 0 }
+  - match: { samples_accepted: 0 }
+  - match: { last_exception.type: "script_exception" }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_sample_stats/30_with_data_streams.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_sample_stats/30_with_data_streams.yml
@@ -436,6 +436,9 @@
 
 ---
 teardown:
+  - requires:
+      cluster_features: [ "random_sampling" ]
+      reason: requires feature 'random_sampling' to get random samples
 
   - do:
       indices.delete_data_stream:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_sample_stats/30_with_data_streams.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_sample_stats/30_with_data_streams.yml
@@ -433,3 +433,14 @@
   - match: { samples_rejected_for_size: 0 }
   - match: { samples_accepted: 0 }
   - match: { last_exception.type: "script_exception" }
+
+---
+teardown:
+
+  - do:
+      indices.delete_data_stream:
+        name: sample_test*
+
+  - do:
+      indices.get_all_sample_configuration: {}
+  - length: { $body: 0 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/ingest/SamplingServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/ingest/SamplingServiceIT.java
@@ -17,15 +17,25 @@ import org.elasticsearch.action.admin.indices.delete.TransportDeleteIndexAction;
 import org.elasticsearch.action.admin.indices.sampling.GetSampleAction;
 import org.elasticsearch.action.admin.indices.sampling.PutSampleConfigurationAction;
 import org.elasticsearch.action.admin.indices.sampling.SamplingConfiguration;
+import org.elasticsearch.action.admin.indices.template.put.TransportPutComposableIndexTemplateAction;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.bulk.TransportBulkAction;
+import org.elasticsearch.action.datastreams.CreateDataStreamAction;
+import org.elasticsearch.action.datastreams.DeleteDataStreamAction;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.metadata.Template;
+import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.datastreams.DataStreamsPlugin;
+import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.After;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +46,12 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.hamcrest.Matchers.equalTo;
 
 public class SamplingServiceIT extends ESIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(DataStreamsPlugin.class);
+    }
+
     public void testTTL() throws Exception {
         assumeTrue("Requires sampling feature flag", RANDOM_SAMPLING_FEATURE_FLAG);
         assertAcked(
@@ -95,6 +111,66 @@ public class SamplingServiceIT extends ESIntegTestCase {
             .actionGet();
         assertThat(getSampleResponse.getSample().size(), equalTo(10));
         client().execute(TransportDeleteIndexAction.TYPE, new DeleteIndexRequest(indexName)).actionGet();
+        assertBusy(() -> {
+            for (SamplingService samplingService : internalCluster().getInstances(SamplingService.class)) {
+                assertThat(samplingService.getLocalSample(ProjectId.DEFAULT, indexName), equalTo(List.of()));
+            }
+        });
+    }
+
+    public void testDeleteDataStream() throws Exception {
+        assumeTrue("Requires sampling feature flag", RANDOM_SAMPLING_FEATURE_FLAG);
+        String indexName = randomIdentifier();
+        var template = ComposableIndexTemplate.builder()
+            .indexPatterns(List.of(indexName))
+
+            .template(new Template(Settings.EMPTY, CompressedXContent.fromJSON("""
+                {
+                  "_doc":{
+                    "dynamic":true,
+                    "properties":{
+                      "foo":{
+                        "type":"text"
+                      },
+                      "bar":{
+                        "type":"text"
+                      }
+                    }
+                  }
+                }
+                """), null))
+            .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate(false, false))
+            .build();
+        var request = new TransportPutComposableIndexTemplateAction.Request("logs-template");
+        request.indexTemplate(template);
+        safeGet(client().execute(TransportPutComposableIndexTemplateAction.TYPE, request));
+        client().execute(
+            CreateDataStreamAction.INSTANCE,
+            new CreateDataStreamAction.Request(TimeValue.THIRTY_SECONDS, TimeValue.THIRTY_SECONDS, indexName)
+        ).actionGet();
+        ensureYellow(indexName);
+        PutSampleConfigurationAction.Request putSampleConfigRequest = new PutSampleConfigurationAction.Request(
+            new SamplingConfiguration(1.0d, 10, null, null, null),
+            TimeValue.THIRTY_SECONDS,
+            TimeValue.THIRTY_SECONDS
+        ).indices(indexName);
+        client().execute(PutSampleConfigurationAction.INSTANCE, putSampleConfigRequest).actionGet();
+        for (int i = 0; i < 5; i++) {
+            BulkRequest bulkRequest = new BulkRequest();
+            for (int j = 0; j < 20; j++) {
+                IndexRequest indexRequest = new IndexRequest(indexName);
+                indexRequest.create(true);
+                indexRequest.source(Map.of("@timestamp", 12345, "foo", randomBoolean() ? 3L : randomLong(), "bar", randomBoolean()));
+                bulkRequest.add(indexRequest);
+            }
+            BulkResponse bulkResponse = client().execute(TransportBulkAction.TYPE, bulkRequest).actionGet();
+            assertThat(bulkResponse.hasFailures(), equalTo(false));
+        }
+        GetSampleAction.Response getSampleResponse = client().execute(GetSampleAction.INSTANCE, new GetSampleAction.Request(indexName))
+            .actionGet();
+        assertThat(getSampleResponse.getSample().size(), equalTo(10));
+        client().execute(DeleteDataStreamAction.INSTANCE, new DeleteDataStreamAction.Request(TimeValue.THIRTY_SECONDS, indexName))
+            .actionGet();
         assertBusy(() -> {
             for (SamplingService samplingService : internalCluster().getInstances(SamplingService.class)) {
                 assertThat(samplingService.getLocalSample(ProjectId.DEFAULT, indexName), equalTo(List.of()));

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/sampling/GetSampleStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/sampling/GetSampleStatsAction.java
@@ -61,6 +61,11 @@ public class GetSampleStatsAction extends ActionType<GetSampleStatsAction.Respon
         }
 
         @Override
+        public boolean includeDataStreams() {
+            return true;
+        }
+
+        @Override
         public ActionRequestValidationException validate() {
             if (this.indexName.contains("*")) {
                 return (ActionRequestValidationException) new ActionRequestValidationException().addValidationError(

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/sampling/TransportDeleteSampleConfigurationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/sampling/TransportDeleteSampleConfigurationAction.java
@@ -76,9 +76,8 @@ public class TransportDeleteSampleConfigurationAction extends AcknowledgedTransp
         ClusterState state,
         ActionListener<AcknowledgedResponse> listener
     ) throws Exception {
-        // throws IndexNotFoundException if any index does not exist or more than one index is resolved
         try {
-            indexNameExpressionResolver.concreteIndexNames(state, request);
+            SamplingService.throwIndexNotFoundExceptionIfNotDataStreamOrIndex(indexNameExpressionResolver, projectResolver, state, request);
         } catch (IndexNotFoundException e) {
             listener.onFailure(e);
             return;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/sampling/TransportGetSampleAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/sampling/TransportGetSampleAction.java
@@ -75,7 +75,12 @@ public class TransportGetSampleAction extends TransportNodesAction<Request, Resp
 
     @Override
     protected Response newResponse(Request request, List<NodeResponse> nodeResponses, List<FailedNodeException> failures) {
-        indexNameExpressionResolver.concreteIndexNames(clusterService.state(), request);
+        SamplingService.throwIndexNotFoundExceptionIfNotDataStreamOrIndex(
+            indexNameExpressionResolver,
+            projectResolver,
+            clusterService.state(),
+            request
+        );
         SamplingMetadata samplingMetadata = projectResolver.getProjectMetadata(clusterService.state()).custom(SamplingMetadata.TYPE);
         final int maxSamples;
         if (samplingMetadata == null) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/sampling/TransportGetSampleStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/sampling/TransportGetSampleStatsAction.java
@@ -75,7 +75,12 @@ public class TransportGetSampleStatsAction extends TransportNodesAction<Request,
 
     @Override
     protected Response newResponse(Request request, List<NodeResponse> nodeResponses, List<FailedNodeException> failures) {
-        indexNameExpressionResolver.concreteIndexNames(clusterService.state(), request);
+        SamplingService.throwIndexNotFoundExceptionIfNotDataStreamOrIndex(
+            indexNameExpressionResolver,
+            projectResolver,
+            clusterService.state(),
+            request
+        );
         SamplingConfiguration samplingConfiguration = samplingService.getSamplingConfiguration(
             projectResolver.getProjectMetadata(clusterService.state()),
             request.indices()[0]

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/sampling/TransportPutSampleConfigurationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/sampling/TransportPutSampleConfigurationAction.java
@@ -75,9 +75,8 @@ public class TransportPutSampleConfigurationAction extends AcknowledgedTransport
         ClusterState state,
         ActionListener<AcknowledgedResponse> listener
     ) throws Exception {
-        // throws IndexNotFoundException if any index does not exist or more than one index is resolved
         try {
-            indexNameExpressionResolver.concreteIndexNames(state, request);
+            SamplingService.throwIndexNotFoundExceptionIfNotDataStreamOrIndex(indexNameExpressionResolver, projectResolver, state, request);
         } catch (IndexNotFoundException e) {
             listener.onFailure(e);
             return;

--- a/server/src/main/java/org/elasticsearch/ingest/SamplingService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/SamplingService.java
@@ -25,6 +25,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateAckListener;
 import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.SimpleBatchedAckListenerTaskExecutor;
+import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -521,6 +522,22 @@ public class SamplingService extends AbstractLifecycleComponent implements Clust
                     if (samplingConfiguration != null) {
                         logger.debug("Deleting sample configuration for {} because the index has been deleted", indexName);
                         deleteSampleConfiguration(projectId, indexName);
+                    }
+                }
+            }
+        }
+        if (currentProject.dataStreams() != previousProject.dataStreams()) {
+            for (DataStream dataStream : previousProject.dataStreams().values()) {
+                DataStream current = currentProject.dataStreams().get(dataStream.getName());
+                if (current == null) {
+                    String dataStreamName = dataStream.getName();
+                    SamplingConfiguration samplingConfiguration = getSamplingConfiguration(
+                        event.state().projectState(projectId).metadata(),
+                        dataStreamName
+                    );
+                    if (samplingConfiguration != null) {
+                        logger.debug("Deleting sample configuration for {} because the data stream has been deleted", dataStreamName);
+                        deleteSampleConfiguration(projectId, dataStreamName);
                     }
                 }
             }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/sampling/TransportDeleteSampleConfigurationActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/sampling/TransportDeleteSampleConfigurationActionTests.java
@@ -69,6 +69,9 @@ public class TransportDeleteSampleConfigurationActionTests extends ESTestCase {
         ThreadPool threadPool = mock(ThreadPool.class);
         ActionFilters actionFilters = mock(ActionFilters.class);
         projectResolver = mock(ProjectResolver.class);
+        when(projectResolver.getProjectMetadata((ClusterState) any())).thenReturn(
+            ClusterState.EMPTY_STATE.projectState(ProjectId.DEFAULT).metadata()
+        );
         indexNameExpressionResolver = mock(IndexNameExpressionResolver.class);
         samplingService = mock(SamplingService.class);
 

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/sampling/TransportPutSampleConfigurationActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/sampling/TransportPutSampleConfigurationActionTests.java
@@ -65,6 +65,9 @@ public class TransportPutSampleConfigurationActionTests extends ESTestCase {
         ThreadPool threadPool = mock(ThreadPool.class);
         ActionFilters actionFilters = mock(ActionFilters.class);
         projectResolver = mock(ProjectResolver.class);
+        when(projectResolver.getProjectMetadata((ClusterState) any())).thenReturn(
+            ClusterState.EMPTY_STATE.projectState(ProjectId.DEFAULT).metadata()
+        );
         indexNameExpressionResolver = mock(IndexNameExpressionResolver.class);
         samplingService = mock(SamplingService.class);
 


### PR DESCRIPTION
There were some parts of random sampling that would break when using data streams instead of ordinary indices. This fixes those, and adds some tests.