### PR TITLE
Reindex-from-remote: Fail on manual slicing param

### DIFF
--- a/docs/changelog/137275.yaml
+++ b/docs/changelog/137275.yaml
@@ -1,0 +1,6 @@
+pr: 137275
+summary: "Reindex-from-remote: Fail on manual slicing param"
+area: Indices APIs
+type: bug
+issues:
+ - 136269

--- a/server/src/main/java/org/elasticsearch/index/reindex/ReindexRequest.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/ReindexRequest.java
@@ -116,6 +116,12 @@ public class ReindexRequest extends AbstractBulkIndexByScrollRequest<ReindexRequ
             if (getSlices() == AbstractBulkByScrollRequest.AUTO_SLICES || getSlices() > 1) {
                 e = addValidationError("reindex from remote sources doesn't support slices > 1 but was [" + getSlices() + "]", e);
             }
+            if (getSearchRequest().source().slice() != null) {
+                e = addValidationError(
+                    "reindex from remote sources doesn't support source.slice but was [" + getSearchRequest().source().slice() + "]",
+                    e
+                );
+            }
             if (getRemoteInfo().getUsername() != null && getRemoteInfo().getPassword() == null) {
                 e = addValidationError("reindex from remote source included username but not password", e);
             }


### PR DESCRIPTION
When the `_reindex` API is used with a remote source (`source.remote` is set in the request body), neither manual slicing (via `source.slice` in the request body) nor automatic slicing (via the `slices` URL parameter) are supported.

Prior to this change, on sending a request with a remote source and manual slicing enabled, the manual slicing specification would be ignored, and the complete source would be reindexed without slicing. After this change, the API will return a response with an HTTP code 400 (Bad Request) instead.

The new behaviour more correctly indicates to the user that the requested functionality is not available, rather than silently ignoring part of their request.

Note that:

- Prior to this change, sending a request with a remote source and *automatic* slicing enabled already resulted in the correct 400 response.

- The [docs](https://www.elastic.co/docs/reference/elasticsearch/rest-apis/reindex-indices#docs-reindex-slice) already correctly stated "Reindexing from remote clusters does not support manual or automatic slicing."

- As a drive-by, this change also adds a unit test for the validation with the `slices` parameter set to `auto`. (Previously, only the case where it was set to a number greater than 1 was tested.)

Closes #136269

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
