### PR TITLE
ESQL: Fix incorrect exponential histogram sub-block serialization.

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ExponentialHistogramArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ExponentialHistogramArrayBlock.java
@@ -291,12 +291,12 @@ final class ExponentialHistogramArrayBlock extends AbstractNonThreadSafeRefCount
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        minima.writeTo(out);
-        maxima.writeTo(out);
-        sums.writeTo(out);
-        valueCounts.writeTo(out);
-        zeroThresholds.writeTo(out);
-        encodedHistograms.writeTo(out);
+        Block.writeTypedBlock(minima, out);
+        Block.writeTypedBlock(maxima, out);
+        Block.writeTypedBlock(sums, out);
+        Block.writeTypedBlock(valueCounts, out);
+        Block.writeTypedBlock(zeroThresholds, out);
+        Block.writeTypedBlock(encodedHistograms, out);
     }
 
     public static ExponentialHistogramArrayBlock readFrom(BlockStreamInput in) throws IOException {
@@ -309,12 +309,12 @@ final class ExponentialHistogramArrayBlock extends AbstractNonThreadSafeRefCount
 
         boolean success = false;
         try {
-            minima = DoubleBlock.readFrom(in);
-            maxima = DoubleBlock.readFrom(in);
-            sums = DoubleBlock.readFrom(in);
-            valueCounts = LongBlock.readFrom(in);
-            zeroThresholds = DoubleBlock.readFrom(in);
-            encodedHistograms = BytesRefBlock.readFrom(in);
+            minima = (DoubleBlock) Block.readTypedBlock(in);
+            maxima = (DoubleBlock) Block.readTypedBlock(in);
+            sums = (DoubleBlock) Block.readTypedBlock(in);
+            valueCounts = (LongBlock) Block.readTypedBlock(in);
+            zeroThresholds = (DoubleBlock) Block.readTypedBlock(in);
+            encodedHistograms = (BytesRefBlock) Block.readTypedBlock(in);
             success = true;
         } finally {
             if (success == false) {

--- a/x-pack/plugin/esql/compute/test/src/main/java/org/elasticsearch/compute/test/BlockTestUtils.java
+++ b/x-pack/plugin/esql/compute/test/src/main/java/org/elasticsearch/compute/test/BlockTestUtils.java
@@ -374,7 +374,7 @@ public class BlockTestUtils {
         }
     }
 
-    static ExponentialHistogram randomExponentialHistogram() {
+    public static ExponentialHistogram randomExponentialHistogram() {
         // TODO(b/133393): allow (index,scale) based zero thresholds as soon as we support them in the block
         // ideally Replace this with the shared random generation in ExponentialHistogramTestUtils
         boolean hasNegativeValues = randomBoolean();


### PR DESCRIPTION
Follow-up for https://github.com/elastic/elasticsearch/pull/133393#discussion_r2467574784.

Adds a test-case which would surface the error due to the previous, wrong implementation and fixes the serialization/deserialization logic.