### PR TITLE
[Sampling] update sampling config get all response to fit elastic standards

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_all_sample_configuration/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_all_sample_configuration/10_basic.yml
@@ -26,7 +26,7 @@ teardown:
       indices.get_all_sample_configuration: {}
 
   # Should return an empty array
-  - length: { $body: 0 }
+  - length: { configurations: 0 }
 
 ---
 "Get all sampling configurations with single configuration":
@@ -49,12 +49,12 @@ teardown:
       indices.get_all_sample_configuration:
         human: true
 
-  - length: { $body: 1 }
-  - match: { 0.index: "test-single-config-index" }
-  - match: { 0.configuration.rate: 0.5 }
-  - match: { 0.configuration.max_samples: 100 }
-  - match: { 0.configuration.max_size: "10mb" }
-  - match: { 0.configuration.time_to_live: "1h" }
+  - length: { configurations: 1 }
+  - match: { configurations.0.index: "test-single-config-index" }
+  - match: { configurations.0.configuration.rate: 0.5 }
+  - match: { configurations.0.configuration.max_samples: 100 }
+  - match: { configurations.0.configuration.max_size: "10mb" }
+  - match: { configurations.0.configuration.time_to_live: "1h" }
 
 ---
 "Get all sampling configurations with multiple configurations":
@@ -102,14 +102,14 @@ teardown:
       indices.get_all_sample_configuration:
         human: true
 
-  - length: { $body: 3 }
+  - length: { configurations: 3 }
   # Note: Array order may vary, so we just verify all 3 configurations exist
-  - is_true: 0.index
-  - is_true: 0.configuration
-  - is_true: 1.index
-  - is_true: 1.configuration
-  - is_true: 2.index
-  - is_true: 2.configuration
+  - is_true: configurations.0.index
+  - is_true: configurations.0.configuration
+  - is_true: configurations.1.index
+  - is_true: configurations.1.configuration
+  - is_true: configurations.2.index
+  - is_true: configurations.2.configuration
 
 ---
 "Get all sampling configurations with mixed indices":
@@ -148,11 +148,11 @@ teardown:
         human: true
 
   # Should only return configured indices (2 items)
-  - length: { $body: 2 }
-  - is_true: 0.index
-  - is_true: 0.configuration
-  - is_true: 1.index
-  - is_true: 1.configuration
+  - length: { configurations: 2 }
+  - is_true: configurations.0.index
+  - is_true: configurations.0.configuration
+  - is_true: configurations.1.index
+  - is_true: configurations.1.configuration
 
 ---
 "Get all sampling configurations after update":
@@ -174,10 +174,10 @@ teardown:
       indices.get_all_sample_configuration:
         human: true
 
-  - length: { $body: 1 }
-  - match: { 0.index: "test-update-all-index" }
-  - match: { 0.configuration.rate: 0.2 }
-  - match: { 0.configuration.max_samples: 30 }
+  - length: { configurations: 1 }
+  - match: { configurations.0.index: "test-update-all-index" }
+  - match: { configurations.0.configuration.rate: 0.2 }
+  - match: { configurations.0.configuration.max_samples: 30 }
 
   # Update configuration
   - do:
@@ -195,11 +195,11 @@ teardown:
       indices.get_all_sample_configuration:
         human: true
 
-  - length: { $body: 1 }
-  - match: { 0.index: "test-update-all-index" }
-  - match: { 0.configuration.rate: 0.9 }
-  - match: { 0.configuration.max_samples: 150 }
-  - match: { 0.configuration.max_size: "15mb" }
+  - length: { configurations: 1 }
+  - match: { configurations.0.index: "test-update-all-index" }
+  - match: { configurations.0.configuration.rate: 0.9 }
+  - match: { configurations.0.configuration.max_samples: 150 }
+  - match: { configurations.0.configuration.max_size: "15mb" }
 
 ---
 "Get all sampling configurations after deletion":
@@ -234,7 +234,7 @@ teardown:
       indices.get_all_sample_configuration:
         human: true
 
-  - length: { $body: 2 }
+  - length: { configurations: 2 }
 
   # Delete one configuration
   - do:
@@ -248,7 +248,7 @@ teardown:
       indices.get_all_sample_configuration:
         human: true
 
-  - length: { $body: 1 }
-  - match: { 0.index: "test-delete-all-index-2" }
-  - match: { 0.configuration.rate: 0.8 }
-  - match: { 0.configuration.max_samples: 200 }
+  - length: { configurations: 1 }
+  - match: { configurations.0.index: "test-delete-all-index-2" }
+  - match: { configurations.0.configuration.rate: 0.8 }
+  - match: { configurations.0.configuration.max_samples: 200 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/sampling/GetAllSampleConfigurationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/sampling/GetAllSampleConfigurationAction.java
@@ -192,7 +192,7 @@ public class GetAllSampleConfigurationAction extends ActionType<GetAllSampleConf
         }
 
         private XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
-            builder.startArray();
+            builder.startObject().startArray("configurations");
             for (Map.Entry<String, SamplingConfiguration> entry : indexToSamplingConfigMap.entrySet()) {
                 builder.startObject();
                 builder.field("index", entry.getKey());
@@ -200,6 +200,7 @@ public class GetAllSampleConfigurationAction extends ActionType<GetAllSampleConf
                 builder.endObject();
             }
             builder.endArray();
+            builder.endObject();
             return builder;
         }
     }


### PR DESCRIPTION
When attempting to create the rest api spec for the new sampling config APIs, i encountered an error due to the get_all_sample_configuration response's array not being named.

This PR updates the get_all_sample_configuration response to name the returned array in order to conform with elastic API standards. 