### PR TITLE
Fixed inconsistency in the isSyntheticSourceEnabled flag

### DIFF
--- a/docs/changelog/137297.yaml
+++ b/docs/changelog/137297.yaml
@@ -1,0 +1,5 @@
+pr: 137297
+summary: Fixed inconsistency in the `isSyntheticSourceEnabled` flag
+area: Mapping
+type: bug
+issues: []

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
@@ -100,7 +100,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
 
     }
 
-    public static class Builder extends BuilderWithSyntheticSourceContext {
+    public static class Builder extends TextFamilyBuilder {
 
         private final Parameter<Map<String, String>> meta = Parameter.metaParam();
 
@@ -112,10 +112,9 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
             IndexVersion indexCreatedVersion,
             IndexAnalyzers indexAnalyzers,
             boolean storedFieldInBinaryFormat,
-            boolean isSyntheticSourceEnabled,
             boolean isWithinMultiField
         ) {
-            super(name, indexCreatedVersion, isSyntheticSourceEnabled, isWithinMultiField);
+            super(name, indexCreatedVersion, isWithinMultiField);
             this.analyzers = new TextParams.Analyzers(
                 indexAnalyzers,
                 m -> ((MatchOnlyTextFieldMapper) m).indexAnalyzer,
@@ -169,7 +168,6 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
             n,
             c.indexVersionCreated(),
             c.getIndexAnalyzers(),
-            isSyntheticSourceStoredFieldInBinaryFormat(c.indexVersionCreated()),
             SourceFieldMapper.isSynthetic(c.getIndexSettings()),
             c.isWithinMultiField()
         )
@@ -677,14 +675,8 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(
-            leafName(),
-            indexCreatedVersion,
-            indexAnalyzers,
-            storedFieldInBinaryFormat,
-            fieldType().isSyntheticSourceEnabled(),
-            fieldType().isWithinMultiField()
-        ).init(this);
+        return new Builder(leafName(), indexCreatedVersion, indexAnalyzers, storedFieldInBinaryFormat, fieldType().isWithinMultiField())
+            .init(this);
     }
 
     @Override

--- a/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
+++ b/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
@@ -81,7 +81,7 @@ public class AnnotatedTextFieldMapper extends FieldMapper {
         );
     }
 
-    public static class Builder extends BuilderWithSyntheticSourceContext {
+    public static class Builder extends TextFamilyBuilder {
 
         final Parameter<SimilarityProvider> similarity = TextParams.similarity(m -> builder(m).similarity.getValue());
         final Parameter<String> indexOptions = TextParams.textIndexOptions(m -> builder(m).indexOptions.getValue());
@@ -100,7 +100,7 @@ public class AnnotatedTextFieldMapper extends FieldMapper {
             boolean isSyntheticSourceEnabled,
             boolean isWithinMultiField
         ) {
-            super(name, indexCreatedVersion, isSyntheticSourceEnabled, isWithinMultiField);
+            super(name, indexCreatedVersion, isWithinMultiField);
             this.analyzers = new TextParams.Analyzers(
                 indexAnalyzers,
                 m -> builder(m).analyzers.getIndexAnalyzer(),
@@ -111,7 +111,7 @@ public class AnnotatedTextFieldMapper extends FieldMapper {
                 if (TextFieldMapper.keywordMultiFieldsNotStoredWhenIgnoredIndexVersionCheck(indexCreatedVersion())) {
                     return false;
                 }
-                return isSyntheticSourceEnabled() && multiFieldsBuilder.hasSyntheticSourceCompatibleKeywordField() == false;
+                return isSyntheticSourceEnabled && multiFieldsBuilder.hasSyntheticSourceCompatibleKeywordField() == false;
             });
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -1663,30 +1663,19 @@ public abstract class FieldMapper extends Mapper {
     /**
      * Creates mappers for fields that require additional context for supporting synthetic source.
      */
-    public abstract static class BuilderWithSyntheticSourceContext extends Builder {
+    public abstract static class TextFamilyBuilder extends Builder {
 
         private final IndexVersion indexCreatedVersion;
-        private final boolean isSyntheticSourceEnabled;
         private final boolean isWithinMultiField;
 
-        protected BuilderWithSyntheticSourceContext(
-            String name,
-            IndexVersion indexCreatedVersion,
-            boolean isSyntheticSourceEnabled,
-            boolean isWithinMultiField
-        ) {
+        protected TextFamilyBuilder(String name, IndexVersion indexCreatedVersion, boolean isWithinMultiField) {
             super(name);
             this.indexCreatedVersion = indexCreatedVersion;
-            this.isSyntheticSourceEnabled = isSyntheticSourceEnabled;
             this.isWithinMultiField = isWithinMultiField;
         }
 
         public IndexVersion indexCreatedVersion() {
             return indexCreatedVersion;
-        }
-
-        public boolean isSyntheticSourceEnabled() {
-            return isSyntheticSourceEnabled;
         }
 
         public boolean isWithinMultiField() {

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
@@ -557,6 +557,10 @@ public class SourceFieldMapper extends MetadataFieldMapper {
         return mode == Mode.SYNTHETIC;
     }
 
+    /**
+     * Caution: this function is not aware of the legacy "mappings._source.mode" parameter that some legacy indices might use. You should
+     * prefer to get information about synthetic source from {@link MapperBuilderContext}.
+     */
     public static boolean isSynthetic(IndexSettings indexSettings) {
         return IndexSettings.INDEX_MAPPER_SOURCE_MODE_SETTING.get(indexSettings.getSettings()) == SourceFieldMapper.Mode.SYNTHETIC;
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -238,7 +238,7 @@ public final class TextFieldMapper extends FieldMapper {
         return new FielddataFrequencyFilter(minFrequency, maxFrequency, minSegmentSize);
     }
 
-    public static class Builder extends BuilderWithSyntheticSourceContext {
+    public static class Builder extends TextFamilyBuilder {
 
         private final Parameter<Boolean> store;
         private final Parameter<Boolean> norms;
@@ -301,7 +301,7 @@ public final class TextFieldMapper extends FieldMapper {
             boolean isSyntheticSourceEnabled,
             boolean isWithinMultiField
         ) {
-            super(name, indexCreatedVersion, isSyntheticSourceEnabled, isWithinMultiField);
+            super(name, indexCreatedVersion, isWithinMultiField);
 
             this.indexMode = indexMode;
             this.analyzers = new TextParams.Analyzers(
@@ -409,7 +409,7 @@ public final class TextFieldMapper extends FieldMapper {
                     index.getValue(),
                     store.getValue(),
                     tsi,
-                    isSyntheticSourceEnabled(),
+                    context.isSourceSynthetic(),
                     isWithinMultiField(),
                     SyntheticSourceHelper.syntheticSourceDelegate(fieldType.stored(), multiFields),
                     meta.getValue(),

--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextFieldMapper.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextFieldMapper.java
@@ -29,7 +29,6 @@ import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperBuilderContext;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MappingParserContext;
-import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.index.mapper.SourceLoader;
 import org.elasticsearch.index.mapper.StringStoredFieldFieldLoader;
 import org.elasticsearch.index.mapper.TextParams;
@@ -88,7 +87,7 @@ public class PatternTextFieldMapper extends FieldMapper {
         }
     }
 
-    public static class Builder extends BuilderWithSyntheticSourceContext {
+    public static class Builder extends TextFamilyBuilder {
 
         private final IndexSettings indexSettings;
         private final Parameter<Map<String, String>> meta = Parameter.metaParam();
@@ -97,23 +96,11 @@ public class PatternTextFieldMapper extends FieldMapper {
         private final Parameter<Boolean> disableTemplating;
 
         public Builder(String name, MappingParserContext context) {
-            this(
-                name,
-                context.indexVersionCreated(),
-                context.getIndexSettings(),
-                SourceFieldMapper.isSynthetic(context.getIndexSettings()),
-                context.isWithinMultiField()
-            );
+            this(name, context.indexVersionCreated(), context.getIndexSettings(), context.isWithinMultiField());
         }
 
-        public Builder(
-            String name,
-            IndexVersion indexCreatedVersion,
-            IndexSettings indexSettings,
-            boolean isSyntheticSourceEnabled,
-            boolean isWithinMultiField
-        ) {
-            super(name, indexCreatedVersion, isSyntheticSourceEnabled, isWithinMultiField);
+        public Builder(String name, IndexVersion indexCreatedVersion, IndexSettings indexSettings, boolean isWithinMultiField) {
+            super(name, indexCreatedVersion, isWithinMultiField);
             this.indexSettings = indexSettings;
             this.analyzer = analyzerParam(name, m -> ((PatternTextFieldMapper) m).analyzer);
             this.disableTemplating = disableTemplatingParameter(indexSettings);
@@ -249,13 +236,7 @@ public class PatternTextFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(
-            leafName(),
-            indexCreatedVersion,
-            indexSettings,
-            fieldType().isSyntheticSourceEnabled(),
-            fieldType().isWithinMultiField()
-        ).init(this);
+        return new Builder(leafName(), indexCreatedVersion, indexSettings, fieldType().isWithinMultiField()).init(this);
     }
 
     @Override


### PR DESCRIPTION
This addresses https://github.com/elastic/elasticsearch/issues/136345.

Note, this only addresses the new edge case described in the issue. The existing edge cases around `FieldMapper.Builder` are still present, but arguably are not as significant. For more context, read the issue above.

Luckily, only text fields were impacted by by this, as they're the only ones using `builder.isSyntheticSourceEnabled()` when initializing a field type. Keyword, match only text, annotated text, etc., all use `MappingBuilderContext` for that information.