### PR TITLE
Shard started reroute high priority

### DIFF
--- a/docs/changelog/137306.yaml
+++ b/docs/changelog/137306.yaml
@@ -1,0 +1,5 @@
+pr: 137306
+summary: Shard started reroute high priority
+area: Allocation
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -829,7 +829,7 @@ public class ShardStateAction {
         public void clusterStatePublished(ClusterState newClusterState) {
             rerouteService.reroute(
                 "reroute after starting shards",
-                Priority.NORMAL,
+                Priority.HIGH,
                 ActionListener.wrap(
                     r -> logger.trace("reroute after starting shards succeeded"),
                     e -> logger.debug("reroute after starting shards failed", e)


### PR DESCRIPTION
We executed shard started at urgent priority, but the subsequent reroute were at normal priority, causing subsequent recoveries to possibly come after other less important actions. Now do the reroute at high priority.
