### PR TITLE
Disabling `StackTemplateRegistryTests#testRegistryIsUpToDate` on Windows

### DIFF
--- a/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/StackTemplateRegistryTests.java
+++ b/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/StackTemplateRegistryTests.java
@@ -56,6 +56,7 @@ import org.elasticsearch.xpack.core.template.IngestPipelineConfig;
 import org.elasticsearch.xpack.core.template.LifecyclePolicyConfig;
 import org.junit.After;
 import org.junit.Before;
+import org.apache.lucene.util.Constants;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -538,6 +539,7 @@ public class StackTemplateRegistryTests extends ESTestCase {
     }
 
     public void testRegistryIsUpToDate() throws Exception {
+        assumeFalse("This test relies on text files checksum, which is inconsistent between Windows and Linux", Constants.WINDOWS);
         CRC32 crc32 = new CRC32();
         for (IndexTemplateConfig config : StackTemplateRegistry.getComponentTemplateConfigsAsConfigs()) {
             crc32.update(loadTemplate(config.getFileName()));

--- a/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/StackTemplateRegistryTests.java
+++ b/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/StackTemplateRegistryTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.stack;
 
+import org.apache.lucene.util.Constants;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
@@ -56,7 +57,6 @@ import org.elasticsearch.xpack.core.template.IngestPipelineConfig;
 import org.elasticsearch.xpack.core.template.LifecyclePolicyConfig;
 import org.junit.After;
 import org.junit.Before;
-import org.apache.lucene.util.Constants;
 
 import java.io.IOException;
 import java.io.InputStream;


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/136795
