### PR TITLE
Add downsample YAML tests to rest-resources-zip

### DIFF
--- a/x-pack/rest-resources-zip/build.gradle
+++ b/x-pack/rest-resources-zip/build.gradle
@@ -27,6 +27,7 @@ dependencies {
   compatApis project(path: ':x-pack:plugin', configuration: 'restCompatSpecs')
   freeCompatTests project(path: ':rest-api-spec', configuration: 'restCompatTests')
   platinumTests project(path: ':x-pack:plugin', configuration: 'restXpackTests')
+  platinumTests project(path: ':x-pack:plugin:downsample:qa:rest', configuration: 'restXpackTests')
   platinumTests project(path: ':x-pack:plugin:eql:qa:rest', configuration: 'restXpackTests')
   platinumTests project(path: ':x-pack:plugin:ent-search', configuration: 'restXpackTests')
   platinumTests project(path: ':x-pack:plugin:inference', configuration: 'restXpackTests')


### PR DESCRIPTION
I realized when reviewing https://github.com/elastic/elasticsearch-specification/pull/5496 that we don't currently include the downsample YAML tests in the Elasticsearch specification validation.

Tested like this:

```
./gradlew restResourcesZip
ls x-pack/rest-resources-zip/build/distributions/rest-api-spec/test/platinum/downsample
```