### PR TITLE
[9.1] Add downsample YAML tests to rest-resources-zip (#137308)

### DIFF
--- a/x-pack/rest-resources-zip/build.gradle
+++ b/x-pack/rest-resources-zip/build.gradle
@@ -27,6 +27,7 @@ dependencies {
   compatApis project(path: ':x-pack:plugin', configuration: 'restCompatSpecs')
   freeCompatTests project(path: ':rest-api-spec', configuration: 'restCompatTests')
   platinumTests project(path: ':x-pack:plugin', configuration: 'restXpackTests')
+  platinumTests project(path: ':x-pack:plugin:downsample:qa:rest', configuration: 'restXpackTests')
   platinumTests project(path: ':x-pack:plugin:eql:qa:rest', configuration: 'restXpackTests')
   platinumTests project(path: ':x-pack:plugin:ent-search', configuration: 'restXpackTests')
   platinumTests project(path: ':x-pack:plugin:inference', configuration: 'restXpackTests')


### PR DESCRIPTION
Backports the following commits to 9.1:
 - Add downsample YAML tests to rest-resources-zip (#137308)