### PR TITLE
Refactor canMatch execution to expose time range filter to caller

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -893,7 +893,7 @@ public final class DateFieldMapper extends FieldMapper {
                     ++fromInclusive;
                 }
                 // we set the time range filter from during rewrite, because this may be the only time we ever parse it,
-                // in case the shard if filtered out and does not run the query phase or all its docs are within the bounds.
+                // in case the shard gets filtered out and does not run the query phase or all its docs are within the bounds.
                 context.setTimeRangeFilterFromMillis(fieldName, fromInclusive, resolution);
             }
 

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -721,13 +721,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                 if (orig.canReturnNullResponseIfMatchNoDocs()) {
                     assert orig.scroll() == null;
                     ShardSearchRequest clone = new ShardSearchRequest(orig);
-                    CanMatchContext canMatchContext = new CanMatchContext(
-                        clone,
-                        indicesService::indexServiceSafe,
-                        this::findReaderContext,
-                        defaultKeepAlive,
-                        maxKeepAlive
-                    );
+                    CanMatchContext canMatchContext = createCanMatchContext(clone);
                     CanMatchShardResponse canMatchResp = canMatch(canMatchContext, false);
                     if (canMatchResp.canMatch() == false) {
                         l.onResponse(QuerySearchResult.nullInstance());
@@ -1942,8 +1936,10 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             final IndexService indexService = indicesService.indexServiceSafe(shardSearchRequest.shardId().getIndex());
             final IndexShard indexShard = indexService.getShard(shardSearchRequest.shardId().id());
             try {
-                // TODO remove the exception handling as it's now in canMatch itself
-                responses.add(new CanMatchNodeResponse.ResponseOrFailure(canMatch(shardSearchRequest)));
+                // TODO remove the exception handling as it's now in canMatch itself - the failure no longer needs to be serialized
+                CanMatchContext canMatchContext = createCanMatchContext(shardSearchRequest);
+                CanMatchShardResponse canMatchShardResponse = canMatch(canMatchContext, true);
+                responses.add(new CanMatchNodeResponse.ResponseOrFailure(canMatchShardResponse));
                 indexShard.getSearchOperationListener().onCanMatchPhase(System.nanoTime() - shardCanMatchStartTimeInNanos);
             } catch (Exception e) {
                 responses.add(new CanMatchNodeResponse.ResponseOrFailure(e));
@@ -1958,14 +1954,12 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
      * won't match any documents on the current shard. Exceptions are handled within the method, and never re-thrown.
      */
     public CanMatchShardResponse canMatch(ShardSearchRequest request) {
-        CanMatchContext canMatchContext = new CanMatchContext(
-            request,
-            indicesService::indexServiceSafe,
-            this::findReaderContext,
-            defaultKeepAlive,
-            maxKeepAlive
-        );
+        CanMatchContext canMatchContext = createCanMatchContext(request);
         return canMatch(canMatchContext, true);
+    }
+
+    CanMatchContext createCanMatchContext(ShardSearchRequest request) {
+        return new CanMatchContext(request, indicesService::indexServiceSafe, this::findReaderContext, defaultKeepAlive, maxKeepAlive);
     }
 
     static class CanMatchContext {
@@ -1976,6 +1970,8 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         private final long maxKeepAlive;
 
         private IndexService indexService;
+
+        private long timeRangeFilterFromMillis;
 
         CanMatchContext(
             ShardSearchRequest request,
@@ -2024,12 +2020,17 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             }
             return this.indexService;
         }
+
+        void setTimeRangeFilterFromMillis(long timeRangeFilterFromMillis) {
+            this.timeRangeFilterFromMillis = timeRangeFilterFromMillis;
+        }
     }
 
     static CanMatchShardResponse canMatch(CanMatchContext canMatchContext, boolean checkRefreshPending) {
         assert canMatchContext.request.searchType() == SearchType.QUERY_THEN_FETCH
             : "unexpected search type: " + canMatchContext.request.searchType();
         Releasable releasable = null;
+        QueryRewriteContext queryRewriteContext = null;
         try {
             IndexService indexService;
             final boolean hasRefreshPending;
@@ -2042,7 +2043,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                     readerContext = canMatchContext.findReaderContext();
                     releasable = readerContext.markAsUsed(canMatchContext.getKeepAlive());
                     indexService = readerContext.indexService();
-                    QueryRewriteContext queryRewriteContext = canMatchContext.getQueryRewriteContext(indexService);
+                    queryRewriteContext = canMatchContext.getQueryRewriteContext(indexService);
                     if (queryStillMatchesAfterRewrite(canMatchContext.request, queryRewriteContext) == false) {
                         return new CanMatchShardResponse(false, null);
                     }
@@ -2051,10 +2052,8 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                     if (canMatchContext.request.readerId().isRetryable() == false) {
                         return new CanMatchShardResponse(true, null);
                     }
-                    if (queryStillMatchesAfterRewrite(
-                        canMatchContext.request,
-                        canMatchContext.getQueryRewriteContext(canMatchContext.getIndexService())
-                    ) == false) {
+                    queryRewriteContext = canMatchContext.getQueryRewriteContext(canMatchContext.getIndexService());
+                    if (queryStillMatchesAfterRewrite(canMatchContext.request, queryRewriteContext) == false) {
                         return new CanMatchShardResponse(false, null);
                     }
                     final Engine.SearcherSupplier searcherSupplier = canMatchContext.getShard().acquireSearcherSupplier();
@@ -2067,10 +2066,8 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                 }
                 canMatchSearcher = searcher;
             } else {
-                if (queryStillMatchesAfterRewrite(
-                    canMatchContext.request,
-                    canMatchContext.getQueryRewriteContext(canMatchContext.getIndexService())
-                ) == false) {
+                queryRewriteContext = canMatchContext.getQueryRewriteContext(canMatchContext.getIndexService());
+                if (queryStillMatchesAfterRewrite(canMatchContext.request, queryRewriteContext) == false) {
                     return new CanMatchShardResponse(false, null);
                 }
                 boolean needsWaitForRefresh = canMatchContext.request.waitForCheckpoint() != UNASSIGNED_SEQ_NO;
@@ -2083,6 +2080,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             }
             try (canMatchSearcher) {
                 SearchExecutionContext context = canMatchContext.getSearchExecutionContext(canMatchSearcher);
+                queryRewriteContext = context;
                 final boolean canMatch = queryStillMatchesAfterRewrite(canMatchContext.request, context);
                 if (canMatch || hasRefreshPending) {
                     FieldSortBuilder sortBuilder = FieldSortBuilder.getPrimaryFieldSortOrNull(canMatchContext.request.source());
@@ -2094,6 +2092,9 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         } catch (Exception e) {
             return new CanMatchShardResponse(true, null);
         } finally {
+            if (queryRewriteContext != null) {
+                canMatchContext.setTimeRangeFilterFromMillis(queryRewriteContext.getTimeRangeFilterFromMillis());
+            }
             Releasables.close(releasable);
         }
     }

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -1971,7 +1971,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
 
         private IndexService indexService;
 
-        private long timeRangeFilterFromMillis;
+        private Long timeRangeFilterFromMillis;
 
         CanMatchContext(
             ShardSearchRequest request,
@@ -2021,8 +2021,12 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
             return this.indexService;
         }
 
-        void setTimeRangeFilterFromMillis(long timeRangeFilterFromMillis) {
+        void setTimeRangeFilterFromMillis(Long timeRangeFilterFromMillis) {
             this.timeRangeFilterFromMillis = timeRangeFilterFromMillis;
+        }
+
+        Long getTimeRangeFilterFromMillis() {
+            return timeRangeFilterFromMillis;
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.fielddata.FieldDataContext;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.LeafFieldData;
+import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperBuilderContext;
@@ -43,10 +44,12 @@ import org.elasticsearch.index.mapper.RootObjectMapper;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.MatchNoneQueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
+import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.IndexShardTestCase;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.script.ScriptCompiler;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.internal.AliasFilter;
@@ -61,7 +64,10 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -110,6 +116,17 @@ public class SearchServiceTests extends IndexShardTestCase {
         SortField sortField = new SortField("field", SortField.Type.STRING);
         MinAndMax<BytesRef> expectedMinAndMax = new MinAndMax<>(new BytesRef("value"), new BytesRef("value"));
         doTestCanMatch(searchRequest, sortField, true, expectedMinAndMax, false);
+    }
+
+    public void testCanMatchTimeRangeFilter() throws IOException {
+        SearchRequest searchRequest = new SearchRequest().allowPartialSearchResults(false)
+            .source(new SearchSourceBuilder().query(new RangeQueryBuilder("@timestamp").from("2025-12-15")));
+        SearchService.CanMatchContext canMatchContext = doTestCanMatch(searchRequest, null, false, null, false);
+        LocalDateTime localDateTime = LocalDateTime.of(2025, 12, 15, 0, 0);
+        assertEquals(
+            localDateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+            canMatchContext.getTimeRangeFilterFromMillis().longValue()
+        );
     }
 
     public void testCanMatchKeywordSortedQueryMatchNoneWithException() throws IOException {
@@ -370,7 +387,7 @@ public class SearchServiceTests extends IndexShardTestCase {
         }
     }
 
-    private void doTestCanMatch(
+    private SearchService.CanMatchContext doTestCanMatch(
         SearchRequest searchRequest,
         SortField sortField,
         boolean expectedCanMatch,
@@ -392,7 +409,7 @@ public class SearchServiceTests extends IndexShardTestCase {
         IndexShard indexShard = newShard(true);
         try {
             recoverShardFromStore(indexShard);
-            assertTrue(indexDoc(indexShard, "_doc", "id", "{\"field\":\"value\"}").isCreated());
+            assertTrue(indexDoc(indexShard, "_doc", "id", "{\"field\":\"value\", \"@timestamp\":\"2025-12-09\"}").isCreated());
             assertTrue(indexShard.refresh("test").refreshed());
             try (Engine.Searcher searcher = indexShard.acquireSearcher("test")) {
                 SearchExecutionContext searchExecutionContext = createSearchExecutionContext(
@@ -416,7 +433,7 @@ public class SearchServiceTests extends IndexShardTestCase {
                     assertEquals(expectedMinAndMax.getMin(), minAndMax.getMin());
                     assertEquals(expectedMinAndMax.getMin(), minAndMax.getMax());
                 }
-
+                return canMatchContext;
             }
         } finally {
             closeShards(indexShard);
@@ -443,9 +460,16 @@ public class SearchServiceTests extends IndexShardTestCase {
             Collections.emptyMap()
         );
         KeywordFieldMapper keywordFieldMapper = new KeywordFieldMapper.Builder("field", IndexVersion.current()).build(root);
+        DateFieldMapper dateFieldMapper = new DateFieldMapper.Builder(
+            "@timestamp",
+            DateFieldMapper.Resolution.MILLISECONDS,
+            null,
+            ScriptCompiler.NONE,
+            indexSettings
+        ).build(root);
         MappingLookup mappingLookup = MappingLookup.fromMappers(
             mapping,
-            Collections.singletonList(keywordFieldMapper),
+            List.of(keywordFieldMapper, dateFieldMapper),
             Collections.emptyList()
         );
         return new SearchExecutionContext(

--- a/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
@@ -66,6 +66,7 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -124,7 +125,7 @@ public class SearchServiceTests extends IndexShardTestCase {
         SearchService.CanMatchContext canMatchContext = doTestCanMatch(searchRequest, null, false, null, false);
         LocalDateTime localDateTime = LocalDateTime.of(2025, 12, 15, 0, 0);
         assertEquals(
-            localDateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+            localDateTime.atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
             canMatchContext.getTimeRangeFilterFromMillis().longValue()
         );
     }

--- a/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
@@ -65,7 +65,6 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.List;


### PR DESCRIPTION
We recently introduced metrics attributs to track search latencies at the shard and coord level.

With #137196 we are introducing such attributes to the can match phase latency metrics. The time range filter is not currently accessible when recording the metrics. This commit exposes it.