### PR TITLE
Populate cross cluster info after index resolution

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/index/IndexResolution.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/index/IndexResolution.java
@@ -41,6 +41,10 @@ public final class IndexResolution {
         return new IndexResolution(null, invalid, Set.of(), Map.of());
     }
 
+    public static IndexResolution empty(String indexPattern) {
+        return valid(new EsIndex(indexPattern, Map.of(), Map.of()));
+    }
+
     public static IndexResolution notFound(String name) {
         Objects.requireNonNull(name, "name must not be null");
         return invalid("Unknown index [" + name + "]");

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlCCSUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlCCSUtils.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.esql.session;
 
 import org.elasticsearch.ElasticsearchSecurityException;
-import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesFailure;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/IndexResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/IndexResolver.java
@@ -99,7 +99,7 @@ public class IndexResolver {
             (l, versionedResolution) -> l.onResponse(versionedResolution.inner())
         );
 
-        resolveAsMergedMappingAndRetrieveMinimumVersion(
+        resolve(
             indexWildcard,
             fieldNames,
             requestFilter,
@@ -114,7 +114,7 @@ public class IndexResolver {
      * Resolves a pattern to one (potentially compound meaning that spawns multiple indices) mapping. Also retrieves the minimum transport
      * version available in the cluster (and remotes).
      */
-    public void resolveAsMergedMappingAndRetrieveMinimumVersion(
+    public void resolve(
         String indexWildcard,
         Set<String> fieldNames,
         QueryBuilder requestFilter,


### PR DESCRIPTION
Today we populate cross cluster state in esql execution info before performing main field caps.

This has several issues:
* it is populated from merged across different views main index patterns. This could Result in incorrect set of remotes when multiple patterns have exclusions in them (for example `logs-*,-*2024` + `metrics-*,-*2025` would incorrectly exclude logs-2025 and metrics-2024. This in turn can exclude the entire remote if those are the only indices on it).
* This performs `org.elasticsearch.indices.IndicesExpressionGrouper#groupIndices` that could not correctly expand flat/cps expressions.

This change moves cross cluster info population to after main field caps result is received.