### PR TITLE
Set multiple log levels in a shared context.

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
@@ -349,12 +349,13 @@ public class LogConfigurator {
             final Level level = Loggers.LOG_DEFAULT_LEVEL_SETTING.get(settings);
             Loggers.setLevel(LogManager.getRootLogger(), level);
         }
+        final var context = Loggers.newContext();
         Loggers.LOG_LEVEL_SETTING.getAllConcreteSettings(settings)
             // do not set a log level for a logger named level (from the default log setting)
             .filter(s -> s.getKey().equals(Loggers.LOG_DEFAULT_LEVEL_SETTING.getKey()) == false)
             .forEach(s -> {
                 final Level level = s.get(settings);
-                Loggers.setLevel(LogManager.getLogger(s.getKey().substring("logger.".length())), level);
+                Loggers.setLevel(LogManager.getLogger(s.getKey().substring("logger.".length())), level, context);
             });
     }
 

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -194,6 +194,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
 
         @Override
         public void apply(Settings value, Settings current, Settings previous) {
+            var context = Loggers.newContext();
             for (String key : value.keySet()) {
                 assert loggerPredicate.test(key);
                 String component = key.substring("logger.".length());
@@ -203,12 +204,12 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 if ("_root".equals(component)) {
                     final String rootLevel = value.get(key);
                     if (rootLevel == null) {
-                        Loggers.setLevel(LogManager.getRootLogger(), Loggers.LOG_DEFAULT_LEVEL_SETTING.get(settings));
+                        Loggers.setLevel(LogManager.getRootLogger(), Loggers.LOG_DEFAULT_LEVEL_SETTING.get(settings), context);
                     } else {
-                        Loggers.setLevel(LogManager.getRootLogger(), rootLevel);
+                        Loggers.setLevel(LogManager.getRootLogger(), rootLevel, context);
                     }
                 } else {
-                    Loggers.setLevel(LogManager.getLogger(component), value.get(key));
+                    Loggers.setLevel(LogManager.getLogger(component), value.get(key), context);
                 }
             }
         }


### PR DESCRIPTION
The configuration context ensures a consistent result when changing levels of multiple, potentially dependent loggers regardless of the order of operations within that context.

Relates to #65208, #137149