### PR TITLE
[9.1] Reindex-from-remote: Fail on manual slicing param (#137275)

### DIFF
--- a/docs/changelog/137275.yaml
+++ b/docs/changelog/137275.yaml
@@ -1,0 +1,6 @@
+pr: 137275
+summary: "Reindex-from-remote: Fail on manual slicing param"
+area: Indices APIs
+type: bug
+issues:
+ - 136269

--- a/server/src/main/java/org/elasticsearch/index/reindex/ReindexRequest.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/ReindexRequest.java
@@ -115,6 +115,12 @@ public class ReindexRequest extends AbstractBulkIndexByScrollRequest<ReindexRequ
             if (getSlices() == AbstractBulkByScrollRequest.AUTO_SLICES || getSlices() > 1) {
                 e = addValidationError("reindex from remote sources doesn't support slices > 1 but was [" + getSlices() + "]", e);
             }
+            if (getSearchRequest().source().slice() != null) {
+                e = addValidationError(
+                    "reindex from remote sources doesn't support source.slice but was [" + getSearchRequest().source().slice() + "]",
+                    e
+                );
+            }
             if (getRemoteInfo().getUsername() != null && getRemoteInfo().getPassword() == null) {
                 e = addValidationError("reindex from remote source included username but not password", e);
             }


### PR DESCRIPTION
Backports the following commits to 9.1:
 - Reindex-from-remote: Fail on manual slicing param (#137275)