### PR TITLE
[9.2] ESQL: Unmute gen tests that fail due to wrong optimization (#137000)

### DIFF
--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
@@ -66,7 +66,6 @@ public abstract class GenerativeRestTest extends ESRestTestCase implements Query
         "Plan \\[ProjectExec\\[\\[<no-fields>.* optimized incorrectly due to missing references",
         "The incoming YAML document exceeds the limit:", // still to investigate, but it seems to be specific to the test framework
         "Data too large", // Circuit breaker exceptions eg. https://github.com/elastic/elasticsearch/issues/130072
-        "optimized incorrectly due to missing references", // https://github.com/elastic/elasticsearch/issues/131509
         "long overflow", // https://github.com/elastic/elasticsearch/issues/135759
         "can't build page out of released blocks", // https://github.com/elastic/elasticsearch/issues/135679
 


### PR DESCRIPTION
Backports the following commits to 9.2:
 - ESQL: Unmute gen tests that fail due to wrong optimization (#137000)