### PR TITLE
Enable _otlp usage with `create_doc`, `auto_configure` privileges

### DIFF
--- a/docs/changelog/137325.yaml
+++ b/docs/changelog/137325.yaml
@@ -1,5 +1,5 @@
 pr: 137325
 summary: "Enable `_otlp` usage with `create_doc`, `auto_configure` privileges"
 area: TSDB
-type: "bug, enhancement"
+type: "bug"
 issues: []

--- a/docs/changelog/137325.yaml
+++ b/docs/changelog/137325.yaml
@@ -1,0 +1,5 @@
+pr: 137325
+summary: "Enable `_otlp` usage with `create_doc`, `auto_configure` privileges"
+area: TSDB
+type: "bug, enhancement"
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilege.java
@@ -98,20 +98,23 @@ public final class IndexPrivilege extends Privilege {
     private static final Automaton CREATE_AUTOMATON = patterns(
         "indices:data/write/index*",
         "indices:data/write/bulk*",
-        "indices:data/write/simulate/bulk*"
+        "indices:data/write/simulate/bulk*",
+        "indices:data/write/otlp/*"
     );
     private static final Automaton CREATE_DOC_AUTOMATON = patterns(
         "indices:data/write/index",
         "indices:data/write/index[*",
         "indices:data/write/index:op_type/create",
         "indices:data/write/bulk*",
-        "indices:data/write/simulate/bulk*"
+        "indices:data/write/simulate/bulk*",
+        "indices:data/write/otlp/*"
     );
     private static final Automaton INDEX_AUTOMATON = patterns(
         "indices:data/write/index*",
         "indices:data/write/bulk*",
         "indices:data/write/update*",
-        "indices:data/write/simulate/bulk*"
+        "indices:data/write/simulate/bulk*",
+        "indices:data/write/otlp/*"
     );
     private static final Automaton DELETE_AUTOMATON = patterns("indices:data/write/delete*", "indices:data/write/bulk*");
     private static final Automaton WRITE_AUTOMATON = patterns("indices:data/write/*", TransportAutoPutMappingAction.TYPE.name());

--- a/x-pack/plugin/otel-data/src/javaRestTest/java/org/elasticsearch/xpack/oteldata/otlp/OTLPMetricsIndexingRestIT.java
+++ b/x-pack/plugin/otel-data/src/javaRestTest/java/org/elasticsearch/xpack/oteldata/otlp/OTLPMetricsIndexingRestIT.java
@@ -96,7 +96,7 @@ public class OTLPMetricsIndexingRestIT extends ESRestTestCase {
     public void beforeTest() throws Exception {
         exporter = OtlpHttpMetricExporter.builder()
             .setEndpoint(getClusterHosts().getFirst().toURI() + "/_otlp/v1/metrics")
-            .addHeader("Authorization", basicAuthHeaderValue(USER, new SecureString(PASS.toCharArray())))
+            .addHeader("Authorization", "ApiKey " + createApiKey())
             .build();
         meterProvider = SdkMeterProvider.builder()
             .registerMetricReader(
@@ -107,6 +107,28 @@ public class OTLPMetricsIndexingRestIT extends ESRestTestCase {
             )
             .build();
         assertBusy(() -> assertOK(client().performRequest(new Request("GET", "_index_template/metrics-otel@template"))));
+    }
+
+    private static String createApiKey() throws IOException {
+        // Create API key with create_doc privilege for metrics-* index
+        Request createApiKeyRequest = new Request("POST", "/_security/api_key");
+        createApiKeyRequest.setJsonEntity("""
+            {
+              "name": "otel-metrics-test-key",
+              "role_descriptors": {
+                "metrics_writer": {
+                  "index": [
+                    {
+                      "names": ["metrics-*"],
+                      "privileges": ["create_doc", "auto_configure"]
+                    }
+                  ]
+                }
+              }
+            }
+            """);
+        ObjectPath createApiKeyResponse = ObjectPath.createFromResponse(client().performRequest(createApiKeyRequest));
+        return createApiKeyResponse.evaluate("encoded");
     }
 
     @Override


### PR DESCRIPTION
Previously, the full `write` privilege was required, now the more fine-grained `create_doc` privilege is enough. It still checks the permissions in the internal _bulk request again. For example, the request would fail if we used the `index` instead of the `create` op_type within the `OTLPMetricsTransportAction`.