### PR TITLE
Remove deprecated constant for default elser inference id

### DIFF
--- a/docs/changelog/137329.yaml
+++ b/docs/changelog/137329.yaml
@@ -1,5 +1,0 @@
-pr: 137329
-summary: Followup default EIS fix
-area: Relevance
-type: bug
-issues: []

--- a/docs/changelog/137329.yaml
+++ b/docs/changelog/137329.yaml
@@ -1,0 +1,5 @@
+pr: 137329
+summary: Followup default EIS fix
+area: Relevance
+type: bug
+issues: []

--- a/docs/changelog/137329.yaml
+++ b/docs/changelog/137329.yaml
@@ -1,5 +1,5 @@
 pr: 137329
 summary: Followup default EIS fix
 area: Relevance
-type: bug
+type: tech debt
 issues: []

--- a/docs/changelog/137329.yaml
+++ b/docs/changelog/137329.yaml
@@ -1,5 +1,5 @@
 pr: 137329
 summary: Followup default EIS fix
 area: Relevance
-type: tech debt
+type: bug
 issues: []

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
@@ -156,11 +156,7 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
     public static final String CONTENT_TYPE = "semantic_text";
     public static final String DEFAULT_FALLBACK_ELSER_INFERENCE_ID = DEFAULT_ELSER_ID;
     public static final String DEFAULT_EIS_ELSER_INFERENCE_ID = DEFAULT_ELSER_ENDPOINT_ID_V2;
-    /**
-     * @deprecated Replaced by {@link #DEFAULT_EIS_ELSER_INFERENCE_ID}.
-     */
-    @Deprecated(since = "9.3.0", forRemoval = false)
-    public static final String DEFAULT_ELSER_2_INFERENCE_ID = DEFAULT_EIS_ELSER_INFERENCE_ID;
+
     public static final String UNSUPPORTED_INDEX_MESSAGE = "["
         + CONTENT_TYPE
         + "] is available on indices created with 8.11 or higher. Please create a new index to use ["

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapperTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapperTests.java
@@ -882,7 +882,7 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
                     + "] with model settings ["
                     + previousModelSettings
                     + "] is not compatible with new inference endpoint ["
-                    + DEFAULT_ELSER_2_INFERENCE_ID
+                    + DEFAULT_EIS_ELSER_INFERENCE_ID
                     + "] with model settings ["
                     + newModelSettings
                     + "]"

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapperTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapperTests.java
@@ -115,7 +115,6 @@ import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.TEXT_FI
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.getChunksFieldName;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextField.getEmbeddingsFieldName;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextFieldMapper.DEFAULT_EIS_ELSER_INFERENCE_ID;
-import static org.elasticsearch.xpack.inference.mapper.SemanticTextFieldMapper.DEFAULT_ELSER_2_INFERENCE_ID;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextFieldMapper.DEFAULT_FALLBACK_ELSER_INFERENCE_ID;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextFieldMapper.DEFAULT_RESCORE_OVERSAMPLE;
 import static org.elasticsearch.xpack.inference.mapper.SemanticTextFieldMapper.INDEX_OPTIONS_FIELD;
@@ -686,10 +685,10 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
         assertSemanticTextField(mapperService, fieldName, true, null, null);
 
         MinimalServiceSettings newModelSettings = MinimalServiceSettings.sparseEmbedding("new_service");
-        givenModelSettings(DEFAULT_ELSER_2_INFERENCE_ID, newModelSettings);
+        givenModelSettings(DEFAULT_EIS_ELSER_INFERENCE_ID, newModelSettings);
         merge(mapperService, mapping(b -> b.startObject(fieldName).field("type", "semantic_text").endObject()));
 
-        assertInferenceEndpoints(mapperService, fieldName, DEFAULT_ELSER_2_INFERENCE_ID, DEFAULT_ELSER_2_INFERENCE_ID);
+        assertInferenceEndpoints(mapperService, fieldName, DEFAULT_EIS_ELSER_INFERENCE_ID, DEFAULT_EIS_ELSER_INFERENCE_ID);
         assertSemanticTextField(mapperService, fieldName, true, null, null);
         SemanticTextFieldMapper semanticFieldMapper = getSemanticFieldMapper(mapperService, fieldName);
         assertThat(semanticFieldMapper.fieldType().getModelSettings(), equalTo(newModelSettings));
@@ -866,7 +865,7 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
         assertSemanticTextField(mapperService, fieldName, true, null, null);
 
         MinimalServiceSettings newModelSettings = MinimalServiceSettings.sparseEmbedding("new_service");
-        givenModelSettings(DEFAULT_ELSER_2_INFERENCE_ID, newModelSettings);
+        givenModelSettings(DEFAULT_EIS_ELSER_INFERENCE_ID, newModelSettings);
 
         Exception exc = expectThrows(
             IllegalArgumentException.class,


### PR DESCRIPTION
Followup on this [PR](https://github.com/elastic/elasticsearch/pull/134708/) to remove the old constant being used in SemanticMapperTests pulled from main.
