### PR TITLE
Unmutes #134639

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -363,9 +363,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.plugin.CanMatchIT
   method: testAliasFilters
   issue: https://github.com/elastic/elasticsearch/issues/134512
-- class: org.elasticsearch.xpack.esql.analysis.AnalyzerTests
-  method: testDenseVectorImplicitCastingKnnQueryParams
-  issue: https://github.com/elastic/elasticsearch/issues/134639
 - class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
   method: testOldRepoAccess
   issue: https://github.com/elastic/elasticsearch/issues/120148


### PR DESCRIPTION
Closes #134639

Unmutes #134639, as this test failure has been fixed now that https://github.com/elastic/elasticsearch/pull/136327 has been merged.

