### PR TITLE
Pass XContentParserConfiguration into ChecksumBlobStoreFormat

### DIFF
--- a/docs/changelog/137335.yaml
+++ b/docs/changelog/137335.yaml
@@ -1,0 +1,5 @@
+pr: 137335
+summary: Pass XContentParserConfiguration into `ChecksumBlobStoreFormat`
+area: Distributed
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1329,11 +1329,17 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 try {
                     // As per ES-12539, there is no need to load the entire IndexMetadata object just to read the shard count
                     // Instead, we read the minimum fields necessary, including the setting index.number_of_shards
-                    XContentParserConfiguration xContentParserConfiguration = XContentParserConfiguration.EMPTY.withDeprecationHandler(LoggingDeprecationHandler.INSTANCE)
-                        .withFiltering(Set.of("*.settings", "*.mapping_version", "*.settings_version", "*.aliases_version"), null, false);
+                    XContentParserConfiguration xContentParserConfiguration = XContentParserConfiguration.EMPTY.withDeprecationHandler(
+                        LoggingDeprecationHandler.INSTANCE
+                    ).withFiltering(Set.of("*.settings", "*.mapping_version", "*.settings_version", "*.aliases_version"), null, false);
                     updateShardCount(
-                        INDEX_METADATA_FORMAT.read(getProjectRepo(), indexContainer, indexMetaGeneration, namedXContentRegistry, xContentParserConfiguration)
-                            .getNumberOfShards()
+                        INDEX_METADATA_FORMAT.read(
+                            getProjectRepo(),
+                            indexContainer,
+                            indexMetaGeneration,
+                            namedXContentRegistry,
+                            xContentParserConfiguration
+                        ).getNumberOfShards()
                     );
                 } catch (Exception ex) {
                     logger.warn(() -> format("[%s] [%s] failed to read metadata for index", indexMetaGeneration, indexId.getName()), ex);

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/ChecksumBlobStoreFormat.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/ChecksumBlobStoreFormat.java
@@ -136,8 +136,13 @@ public final class ChecksumBlobStoreFormat<T> {
      * @return the deserialized object of type {@code T} read from the blob
      * @throws IOException if an I/O error occurs while reading or parsing the blob
      */
-    public T read(ProjectRepo projectRepo, BlobContainer blobContainer, String name, NamedXContentRegistry namedXContentRegistry, XContentParserConfiguration xContentParserConfiguration)
-        throws IOException {
+    public T read(
+        ProjectRepo projectRepo,
+        BlobContainer blobContainer,
+        String name,
+        NamedXContentRegistry namedXContentRegistry,
+        XContentParserConfiguration xContentParserConfiguration
+    ) throws IOException {
         String blobName = blobName(name);
         try (InputStream in = blobContainer.readBlob(OperationPurpose.SNAPSHOT_METADATA, blobName)) {
             return deserialize(projectRepo, namedXContentRegistry, in, xContentParserConfiguration);
@@ -152,7 +157,12 @@ public final class ChecksumBlobStoreFormat<T> {
         return deserialize(projectRepo, namedXContentRegistry, input, null);
     }
 
-    public T deserialize(ProjectRepo projectRepo, NamedXContentRegistry namedXContentRegistry, InputStream input, XContentParserConfiguration xContentParserConfiguration) throws IOException {
+    public T deserialize(
+        ProjectRepo projectRepo,
+        NamedXContentRegistry namedXContentRegistry,
+        InputStream input,
+        XContentParserConfiguration xContentParserConfiguration
+    ) throws IOException {
         final DeserializeMetaBlobInputStream deserializeMetaBlobInputStream = new DeserializeMetaBlobInputStream(input);
         try {
             CodecUtil.checkHeader(new InputStreamDataInput(deserializeMetaBlobInputStream), codec, VERSION, VERSION);
@@ -185,7 +195,7 @@ public final class ChecksumBlobStoreFormat<T> {
                         XContentParser parser = XContentHelper.createParserNotCompressed(
                             xContentParserConfiguration == null
                                 ? XContentParserConfiguration.EMPTY.withRegistry(namedXContentRegistry)
-                                .withDeprecationHandler(LoggingDeprecationHandler.INSTANCE)
+                                    .withDeprecationHandler(LoggingDeprecationHandler.INSTANCE)
                                 : xContentParserConfiguration,
                             bytesReference,
                             XContentType.SMILE
@@ -417,10 +427,10 @@ public final class ChecksumBlobStoreFormat<T> {
                     // in order to write the footer we need to prevent closing the actual index input.
                 }
             };
-                 XContentBuilder builder = XContentFactory.contentBuilder(
-                     XContentType.SMILE,
-                     compress ? CompressorFactory.COMPRESSOR.threadLocalOutputStream(indexOutputOutputStream) : indexOutputOutputStream
-                 )
+                XContentBuilder builder = XContentFactory.contentBuilder(
+                    XContentType.SMILE,
+                    compress ? CompressorFactory.COMPRESSOR.threadLocalOutputStream(indexOutputOutputStream) : indexOutputOutputStream
+                )
             ) {
                 ToXContent.Params params = extraParams.isEmpty()
                     ? SNAPSHOT_ONLY_FORMAT_PARAMS

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/ChecksumBlobStoreFormat.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/ChecksumBlobStoreFormat.java
@@ -208,7 +208,13 @@ public final class ChecksumBlobStoreFormat<T> {
             } else {
                 try (
                     XContentParser parser = XContentType.SMILE.xContent()
-                        .createParser(namedXContentRegistry, LoggingDeprecationHandler.INSTANCE, wrappedStream)
+                        .createParser(
+                            xContentParserConfiguration == null
+                                ? XContentParserConfiguration.EMPTY.withRegistry(namedXContentRegistry)
+                                    .withDeprecationHandler(LoggingDeprecationHandler.INSTANCE)
+                                : xContentParserConfiguration,
+                            wrappedStream
+                        )
                 ) {
                     result = reader.apply(projectRepo, parser);
                     XContentParserUtils.ensureExpectedToken(null, parser.nextToken(), parser);


### PR DESCRIPTION
Passes an optional parameter into `ChecksumBlobStoreFormat.read` to 
specify the `XContentParserConfiguration` of the parser

