### PR TITLE
ESQL: Work around concurrent serialization bug

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -504,9 +504,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
   method: test {p0=esql/40_tsdb/error on rename timestamp}
   issue: https://github.com/elastic/elasticsearch/issues/137259
-- class: org.elasticsearch.xpack.esql.plan.physical.ShowExecSerializationTests
-  method: testConcurrentSerialization
-  issue: https://github.com/elastic/elasticsearch/issues/137338
 - class: org.elasticsearch.readiness.ReadinessClusterIT
   method: testReadinessDuringRestartsNormalOrder
   issue: https://github.com/elastic/elasticsearch/issues/136955

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractWireTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractWireTestCase.java
@@ -200,8 +200,8 @@ public abstract class AbstractWireTestCase<T> extends ESTestCase {
                     for (int r = 0; r < rounds; r++) {
                         assertSerialization(testInstance);
                     }
-                } catch (IOException e) {
-                    throw new AssertionError("error serializing", e);
+                } catch (IOException | AssertionError e) {
+                    throw new AssertionError("error serializing [" + testInstance + "]", e);
                 }
             });
         } finally {

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
@@ -1060,6 +1060,13 @@ public final class EsqlTestUtils {
             ExponentialHistogramCircuitBreaker.noop(),
             rawValues
         );
+        /*
+         * hashcode mutates the histogram by doing some lazy work.
+         * That can change the value of the hashCode if you call it concurrently....
+         * This works around that by running it once up front. Jonas will have a
+         * look at this one soon.
+         */
+        histo.hashCode();
         return histo;
     }
 


### PR DESCRIPTION
The bug still exists in the underlying code, but it isn't released so I'm working around it by doing an eager call to `hashCode`. We'll fix the real bug real soon.

Closes #137338
