### PR TITLE
[9.1] [ES-12998] Invoking gradle continue flag on periodic runs to allow for more information on test failures (#136900)

### DIFF
--- a/.buildkite/pipelines/periodic-fwc.template.yml
+++ b/.buildkite/pipelines/periodic-fwc.template.yml
@@ -1,6 +1,6 @@
 steps:
   - label: "{{matrix.FWC_VERSION}} / fwc"
-    command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v$$FWC_VERSION#fwcTest -Dtests.bwc.snapshot=false
+    command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v$$FWC_VERSION#fwcTest -Dtests.bwc.snapshot=false
     timeout_in_minutes: 300
     agents:
       provider: gcp

--- a/.buildkite/pipelines/periodic-fwc.yml
+++ b/.buildkite/pipelines/periodic-fwc.yml
@@ -1,7 +1,7 @@
 # This file is auto-generated. See .buildkite/pipelines/periodic-fwc.template.yml
 steps:
   - label: "{{matrix.FWC_VERSION}} / fwc"
-    command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v$$FWC_VERSION#fwcTest -Dtests.bwc.snapshot=false
+    command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v$$FWC_VERSION#fwcTest -Dtests.bwc.snapshot=false
     timeout_in_minutes: 300
     agents:
       provider: gcp

--- a/.buildkite/pipelines/periodic.bwc.template.yml
+++ b/.buildkite/pipelines/periodic.bwc.template.yml
@@ -1,5 +1,5 @@
       - label: $BWC_VERSION / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v$BWC_VERSION#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v$BWC_VERSION#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp

--- a/.buildkite/pipelines/periodic.template.yml
+++ b/.buildkite/pipelines/periodic.template.yml
@@ -2,13 +2,14 @@ steps:
   - group: bwc
     steps: $BWC_STEPS
   - label: concurrent-search-tests
-    command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dtests.jvm.argline=-Des.concurrent_search=true -Des.concurrent_search=true functionalTests
+    command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true -Dtests.jvm.argline=-Des.concurrent_search=true -Des.concurrent_search=true functionalTests
     timeout_in_minutes: 420
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
       diskSizeGb: 350
       machineType: custom-32-98304
+
   - label: encryption-at-rest
     command: .buildkite/scripts/encryption-at-rest.sh
     timeout_in_minutes: 420
@@ -17,6 +18,7 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       diskSizeGb: 350
       machineType: custom-32-98304
+
   - label: eql-correctness
     command: .buildkite/scripts/eql-correctness.sh
     timeout_in_minutes: 300
@@ -25,6 +27,7 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+
   - label: example-plugins
     command: |-
       cd $$WORKSPACE/plugins/examples
@@ -36,10 +39,11 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+
   - group: java-fips-matrix
     steps:
       - label: "{{matrix.ES_RUNTIME_JAVA}} / {{matrix.GRADLE_TASK}} / java-fips-matrix"
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dtests.fips.enabled=true $$GRADLE_TASK
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true -Dtests.fips.enabled=true $$GRADLE_TASK
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -61,8 +65,9 @@ steps:
         env:
           ES_RUNTIME_JAVA: "{{matrix.ES_RUNTIME_JAVA}}"
           GRADLE_TASK: "{{matrix.GRADLE_TASK}}"
+
       - label: "{{matrix.ES_RUNTIME_JAVA}} / {{matrix.BWC_VERSION}} / java-fips-matrix-bwc"
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dtests.fips.enabled=true v$$BWC_VERSION#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true -Dtests.fips.enabled=true v$$BWC_VERSION#bwcTest
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -77,10 +82,11 @@ steps:
         env:
           ES_RUNTIME_JAVA: "{{matrix.ES_RUNTIME_JAVA}}"
           BWC_VERSION: "{{matrix.BWC_VERSION}}"
+
   - group: java-matrix
     steps:
       - label: "{{matrix.ES_RUNTIME_JAVA}} / {{matrix.GRADLE_TASK}} / java-matrix"
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true $$GRADLE_TASK
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true $$GRADLE_TASK
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -104,8 +110,9 @@ steps:
         env:
           ES_RUNTIME_JAVA: "{{matrix.ES_RUNTIME_JAVA}}"
           GRADLE_TASK: "{{matrix.GRADLE_TASK}}"
+
       - label: "{{matrix.ES_RUNTIME_JAVA}} / {{matrix.BWC_VERSION}} / java-matrix-bwc"
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v$$BWC_VERSION#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v$$BWC_VERSION#bwcTest
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -121,6 +128,7 @@ steps:
         env:
           ES_RUNTIME_JAVA: "{{matrix.ES_RUNTIME_JAVA}}"
           BWC_VERSION: "{{matrix.BWC_VERSION}}"
+
   - label: release-tests
     command: .buildkite/scripts/release-tests.sh
     timeout_in_minutes: 360
@@ -129,14 +137,16 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       diskSizeGb: 350
       machineType: custom-32-98304
+
   - label: single-processor-node-tests
-    command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dtests.configure_test_clusters_with_one_processor=true functionalTests
+    command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true -Dtests.configure_test_clusters_with_one_processor=true functionalTests
     timeout_in_minutes: 420
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
       diskSizeGb: 350
       machineType: custom-32-98304
+
   - group: third-party tests
     steps:
       - label: third-party / azure-sas
@@ -144,7 +154,7 @@ steps:
           export azure_storage_container=elasticsearch-ci-thirdparty-sas
           export azure_storage_base_path=$BUILDKITE_BRANCH
 
-          .ci/scripts/run-gradle.sh azureThirdPartyTest
+          .ci/scripts/run-gradle.sh --continue azureThirdPartyTest
         env:
           USE_3RD_PARTY_AZURE_SAS_CREDENTIALS: "true"
         timeout_in_minutes: 30
@@ -153,12 +163,13 @@ steps:
           image: family/elasticsearch-ubuntu-2404
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+
       - label: third-party / azure
         command: |
           export azure_storage_container=elasticsearch-ci-thirdparty
           export azure_storage_base_path=$BUILDKITE_BRANCH
 
-          .ci/scripts/run-gradle.sh azureThirdPartyTest
+          .ci/scripts/run-gradle.sh --continue azureThirdPartyTest
         env:
           USE_3RD_PARTY_AZURE_CREDENTIALS: "true"
         timeout_in_minutes: 30
@@ -167,12 +178,13 @@ steps:
           image: family/elasticsearch-ubuntu-2404
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+
       - label: third-party / gcs
         command: |
           export google_storage_bucket=elasticsearch-ci-thirdparty
           export google_storage_base_path=$BUILDKITE_BRANCH
 
-          .ci/scripts/run-gradle.sh gcsThirdPartyTest
+          .ci/scripts/run-gradle.sh --continue gcsThirdPartyTest
         env:
           USE_3RD_PARTY_GCS_CREDENTIALS: "true"
         timeout_in_minutes: 30
@@ -181,21 +193,23 @@ steps:
           image: family/elasticsearch-ubuntu-2404
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+
       - label: third-party / geoip
         command: |
-          .ci/scripts/run-gradle.sh :modules:ingest-geoip:internalClusterTest -Dtests.jvm.argline="-Dgeoip_use_service=true"
+          .ci/scripts/run-gradle.sh --continue :modules:ingest-geoip:internalClusterTest -Dtests.jvm.argline="-Dgeoip_use_service=true"
         timeout_in_minutes: 30
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+
       - label: third-party / s3
         command: |
           export amazon_s3_bucket=elasticsearch-ci.us-west-2
           export amazon_s3_base_path=$BUILDKITE_BRANCH
 
-          .ci/scripts/run-gradle.sh s3ThirdPartyTest
+          .ci/scripts/run-gradle.sh --continue s3ThirdPartyTest
         env:
           USE_3RD_PARTY_S3_CREDENTIALS: "true"
         timeout_in_minutes: 30
@@ -204,9 +218,10 @@ steps:
           image: family/elasticsearch-ubuntu-2404
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+
       - label: third-party / ms-graph
         command: |
-          .ci/scripts/run-gradle.sh msGraphThirdPartyTest
+          .ci/scripts/run-gradle.sh --continue msGraphThirdPartyTest
         env:
           USE_3RD_PARTY_MS_GRAPH_CREDENTIALS: "true"
         timeout_in_minutes: 30
@@ -215,10 +230,11 @@ steps:
           image: family/elasticsearch-ubuntu-2404
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+
   - group: lucene-compat
     steps:
       - label: "{{matrix.LUCENE_VERSION}} / lucene-compat"
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints -Dtests.bwc.main.version=$$ES_VERSION -Dtests.bwc.refspec.main=$$ES_COMMIT luceneBwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints -Dtests.bwc.main.version=$$ES_VERSION -Dtests.bwc.refspec.main=$$ES_COMMIT luceneBwcTest
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -236,6 +252,7 @@ steps:
         env:
           ES_VERSION: "{{matrix.ES_VERSION}}"
           ES_COMMIT: "{{matrix.ES_COMMIT}}"
+
   - label: Upload Snyk Dependency Graph
     command: .ci/scripts/run-gradle.sh uploadSnykDependencyGraph -PsnykTargetReference=$BUILDKITE_BRANCH
     env:
@@ -247,6 +264,7 @@ steps:
       machineType: n2-standard-8
       buildDirectory: /dev/shm/bk
     if: build.branch =~ /^(main|\d+\.\d+|\d+\.x)$$/
+
   - label: check-branch-consistency
     command: .ci/scripts/run-gradle.sh branchConsistency
     timeout_in_minutes: 15
@@ -254,6 +272,7 @@ steps:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
       machineType: n2-standard-2
+
   - label: check-branch-protection-rules
     command: .buildkite/scripts/branch-protection.sh
     timeout_in_minutes: 5

--- a/.buildkite/pipelines/periodic.yml
+++ b/.buildkite/pipelines/periodic.yml
@@ -3,7 +3,7 @@ steps:
   - group: bwc
     steps:
       - label: 8.0.1 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.0.1#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.0.1#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -22,7 +22,7 @@ steps:
               limit: 3
 
       - label: 8.1.3 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.1.3#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.1.3#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -41,7 +41,7 @@ steps:
               limit: 3
 
       - label: 8.2.3 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.2.3#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.2.3#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -60,7 +60,7 @@ steps:
               limit: 3
 
       - label: 8.3.3 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.3.3#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.3.3#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -79,7 +79,7 @@ steps:
               limit: 3
 
       - label: 8.4.3 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.4.3#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.4.3#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -98,7 +98,7 @@ steps:
               limit: 3
 
       - label: 8.5.3 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.5.3#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.5.3#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -117,7 +117,7 @@ steps:
               limit: 3
 
       - label: 8.6.2 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.6.2#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.6.2#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -136,7 +136,7 @@ steps:
               limit: 3
 
       - label: 8.7.1 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.7.1#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.7.1#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -155,7 +155,7 @@ steps:
               limit: 3
 
       - label: 8.8.2 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.8.2#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.8.2#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -174,7 +174,7 @@ steps:
               limit: 3
 
       - label: 8.9.2 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.9.2#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.9.2#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -193,7 +193,7 @@ steps:
               limit: 3
 
       - label: 8.10.4 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.10.4#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.10.4#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -212,7 +212,7 @@ steps:
               limit: 3
 
       - label: 8.11.4 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.11.4#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.11.4#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -231,7 +231,7 @@ steps:
               limit: 3
 
       - label: 8.12.2 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.12.2#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.12.2#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -250,7 +250,7 @@ steps:
               limit: 3
 
       - label: 8.13.4 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.13.4#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.13.4#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -269,7 +269,7 @@ steps:
               limit: 3
 
       - label: 8.14.3 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.14.3#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.14.3#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -288,7 +288,7 @@ steps:
               limit: 3
 
       - label: 8.15.5 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.15.5#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.15.5#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -307,7 +307,7 @@ steps:
               limit: 3
 
       - label: 8.16.6 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.16.6#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.16.6#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -326,7 +326,7 @@ steps:
               limit: 3
 
       - label: 8.17.10 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.17.10#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.17.10#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -345,7 +345,7 @@ steps:
               limit: 3
 
       - label: 8.18.8 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.18.8#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.18.8#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -364,7 +364,7 @@ steps:
               limit: 3
 
       - label: 8.19.7 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.19.7#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.19.7#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -383,7 +383,7 @@ steps:
               limit: 3
 
       - label: 9.0.8 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v9.0.8#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v9.0.8#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -402,7 +402,7 @@ steps:
               limit: 3
 
       - label: 9.1.7 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v9.1.7#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v9.1.7#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -421,13 +421,14 @@ steps:
               limit: 3
 
   - label: concurrent-search-tests
-    command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dtests.jvm.argline=-Des.concurrent_search=true -Des.concurrent_search=true functionalTests
+    command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true -Dtests.jvm.argline=-Des.concurrent_search=true -Des.concurrent_search=true functionalTests
     timeout_in_minutes: 420
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
       diskSizeGb: 350
       machineType: custom-32-98304
+
   - label: encryption-at-rest
     command: .buildkite/scripts/encryption-at-rest.sh
     timeout_in_minutes: 420
@@ -436,6 +437,7 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       diskSizeGb: 350
       machineType: custom-32-98304
+
   - label: eql-correctness
     command: .buildkite/scripts/eql-correctness.sh
     timeout_in_minutes: 300
@@ -444,6 +446,7 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+
   - label: example-plugins
     command: |-
       cd $$WORKSPACE/plugins/examples
@@ -455,10 +458,11 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+
   - group: java-fips-matrix
     steps:
       - label: "{{matrix.ES_RUNTIME_JAVA}} / {{matrix.GRADLE_TASK}} / java-fips-matrix"
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dtests.fips.enabled=true $$GRADLE_TASK
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true -Dtests.fips.enabled=true $$GRADLE_TASK
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -480,8 +484,9 @@ steps:
         env:
           ES_RUNTIME_JAVA: "{{matrix.ES_RUNTIME_JAVA}}"
           GRADLE_TASK: "{{matrix.GRADLE_TASK}}"
+
       - label: "{{matrix.ES_RUNTIME_JAVA}} / {{matrix.BWC_VERSION}} / java-fips-matrix-bwc"
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dtests.fips.enabled=true v$$BWC_VERSION#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true -Dtests.fips.enabled=true v$$BWC_VERSION#bwcTest
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -496,10 +501,11 @@ steps:
         env:
           ES_RUNTIME_JAVA: "{{matrix.ES_RUNTIME_JAVA}}"
           BWC_VERSION: "{{matrix.BWC_VERSION}}"
+
   - group: java-matrix
     steps:
       - label: "{{matrix.ES_RUNTIME_JAVA}} / {{matrix.GRADLE_TASK}} / java-matrix"
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true $$GRADLE_TASK
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true $$GRADLE_TASK
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -523,8 +529,9 @@ steps:
         env:
           ES_RUNTIME_JAVA: "{{matrix.ES_RUNTIME_JAVA}}"
           GRADLE_TASK: "{{matrix.GRADLE_TASK}}"
+
       - label: "{{matrix.ES_RUNTIME_JAVA}} / {{matrix.BWC_VERSION}} / java-matrix-bwc"
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v$$BWC_VERSION#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v$$BWC_VERSION#bwcTest
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -540,6 +547,7 @@ steps:
         env:
           ES_RUNTIME_JAVA: "{{matrix.ES_RUNTIME_JAVA}}"
           BWC_VERSION: "{{matrix.BWC_VERSION}}"
+
   - label: release-tests
     command: .buildkite/scripts/release-tests.sh
     timeout_in_minutes: 360
@@ -548,14 +556,16 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       diskSizeGb: 350
       machineType: custom-32-98304
+
   - label: single-processor-node-tests
-    command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dtests.configure_test_clusters_with_one_processor=true functionalTests
+    command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true -Dtests.configure_test_clusters_with_one_processor=true functionalTests
     timeout_in_minutes: 420
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
       diskSizeGb: 350
       machineType: custom-32-98304
+
   - group: third-party tests
     steps:
       - label: third-party / azure-sas
@@ -563,7 +573,7 @@ steps:
           export azure_storage_container=elasticsearch-ci-thirdparty-sas
           export azure_storage_base_path=$BUILDKITE_BRANCH
 
-          .ci/scripts/run-gradle.sh azureThirdPartyTest
+          .ci/scripts/run-gradle.sh --continue azureThirdPartyTest
         env:
           USE_3RD_PARTY_AZURE_SAS_CREDENTIALS: "true"
         timeout_in_minutes: 30
@@ -572,12 +582,13 @@ steps:
           image: family/elasticsearch-ubuntu-2404
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+
       - label: third-party / azure
         command: |
           export azure_storage_container=elasticsearch-ci-thirdparty
           export azure_storage_base_path=$BUILDKITE_BRANCH
 
-          .ci/scripts/run-gradle.sh azureThirdPartyTest
+          .ci/scripts/run-gradle.sh --continue azureThirdPartyTest
         env:
           USE_3RD_PARTY_AZURE_CREDENTIALS: "true"
         timeout_in_minutes: 30
@@ -586,12 +597,13 @@ steps:
           image: family/elasticsearch-ubuntu-2404
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+
       - label: third-party / gcs
         command: |
           export google_storage_bucket=elasticsearch-ci-thirdparty
           export google_storage_base_path=$BUILDKITE_BRANCH
 
-          .ci/scripts/run-gradle.sh gcsThirdPartyTest
+          .ci/scripts/run-gradle.sh --continue gcsThirdPartyTest
         env:
           USE_3RD_PARTY_GCS_CREDENTIALS: "true"
         timeout_in_minutes: 30
@@ -600,21 +612,23 @@ steps:
           image: family/elasticsearch-ubuntu-2404
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+
       - label: third-party / geoip
         command: |
-          .ci/scripts/run-gradle.sh :modules:ingest-geoip:internalClusterTest -Dtests.jvm.argline="-Dgeoip_use_service=true"
+          .ci/scripts/run-gradle.sh --continue :modules:ingest-geoip:internalClusterTest -Dtests.jvm.argline="-Dgeoip_use_service=true"
         timeout_in_minutes: 30
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+
       - label: third-party / s3
         command: |
           export amazon_s3_bucket=elasticsearch-ci.us-west-2
           export amazon_s3_base_path=$BUILDKITE_BRANCH
 
-          .ci/scripts/run-gradle.sh s3ThirdPartyTest
+          .ci/scripts/run-gradle.sh --continue s3ThirdPartyTest
         env:
           USE_3RD_PARTY_S3_CREDENTIALS: "true"
         timeout_in_minutes: 30
@@ -623,9 +637,10 @@ steps:
           image: family/elasticsearch-ubuntu-2404
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+
       - label: third-party / ms-graph
         command: |
-          .ci/scripts/run-gradle.sh msGraphThirdPartyTest
+          .ci/scripts/run-gradle.sh --continue msGraphThirdPartyTest
         env:
           USE_3RD_PARTY_MS_GRAPH_CREDENTIALS: "true"
         timeout_in_minutes: 30
@@ -634,10 +649,11 @@ steps:
           image: family/elasticsearch-ubuntu-2404
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+
   - group: lucene-compat
     steps:
       - label: "{{matrix.LUCENE_VERSION}} / lucene-compat"
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints -Dtests.bwc.main.version=$$ES_VERSION -Dtests.bwc.refspec.main=$$ES_COMMIT luceneBwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-file-fingerprints -Dtests.bwc.main.version=$$ES_VERSION -Dtests.bwc.refspec.main=$$ES_COMMIT luceneBwcTest
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -655,6 +671,7 @@ steps:
         env:
           ES_VERSION: "{{matrix.ES_VERSION}}"
           ES_COMMIT: "{{matrix.ES_COMMIT}}"
+
   - label: Upload Snyk Dependency Graph
     command: .ci/scripts/run-gradle.sh uploadSnykDependencyGraph -PsnykTargetReference=$BUILDKITE_BRANCH
     env:
@@ -666,6 +683,7 @@ steps:
       machineType: n2-standard-8
       buildDirectory: /dev/shm/bk
     if: build.branch =~ /^(main|\d+\.\d+|\d+\.x)$$/
+
   - label: check-branch-consistency
     command: .ci/scripts/run-gradle.sh branchConsistency
     timeout_in_minutes: 15
@@ -673,6 +691,7 @@ steps:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
       machineType: n2-standard-2
+
   - label: check-branch-protection-rules
     command: .buildkite/scripts/branch-protection.sh
     timeout_in_minutes: 5


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[ES-12998] Invoking gradle continue flag on periodic runs to allow for more information on test failures (#136900)](https://github.com/elastic/elasticsearch/pull/136900)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

[ES-12998]: https://elasticco.atlassian.net/browse/ES-12998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ