### PR TITLE
[8.19] [ES-12998] Invoking gradle continue flag on periodic runs to allow for more information on test failures (#136900)

### DIFF
--- a/.buildkite/pipelines/periodic-fwc.template.yml
+++ b/.buildkite/pipelines/periodic-fwc.template.yml
@@ -1,6 +1,6 @@
 steps:
   - label: "{{matrix.FWC_VERSION}} / fwc"
-    command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v$$FWC_VERSION#fwcTest -Dtests.bwc.snapshot=false
+    command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v$$FWC_VERSION#fwcTest -Dtests.bwc.snapshot=false
     timeout_in_minutes: 300
     agents:
       provider: gcp

--- a/.buildkite/pipelines/periodic-fwc.yml
+++ b/.buildkite/pipelines/periodic-fwc.yml
@@ -1,7 +1,7 @@
 # This file is auto-generated. See .buildkite/pipelines/periodic-fwc.template.yml
 steps:
   - label: "{{matrix.FWC_VERSION}} / fwc"
-    command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v$$FWC_VERSION#fwcTest -Dtests.bwc.snapshot=false
+    command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v$$FWC_VERSION#fwcTest -Dtests.bwc.snapshot=false
     timeout_in_minutes: 300
     agents:
       provider: gcp

--- a/.buildkite/pipelines/periodic.bwc.template.yml
+++ b/.buildkite/pipelines/periodic.bwc.template.yml
@@ -1,5 +1,5 @@
       - label: $BWC_VERSION / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v$BWC_VERSION#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v$BWC_VERSION#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp

--- a/.buildkite/pipelines/periodic.template.yml
+++ b/.buildkite/pipelines/periodic.template.yml
@@ -2,13 +2,14 @@ steps:
   - group: bwc
     steps: $BWC_STEPS
   - label: concurrent-search-tests
-    command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dtests.jvm.argline=-Des.concurrent_search=true -Des.concurrent_search=true functionalTests
+    command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true -Dtests.jvm.argline=-Des.concurrent_search=true -Des.concurrent_search=true functionalTests
     timeout_in_minutes: 420
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
       diskSizeGb: 350
       machineType: custom-32-98304
+
   - label: encryption-at-rest
     command: .buildkite/scripts/encryption-at-rest.sh
     timeout_in_minutes: 420
@@ -17,6 +18,7 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       diskSizeGb: 350
       machineType: custom-32-98304
+
   - label: eql-correctness
     command: .buildkite/scripts/eql-correctness.sh
     timeout_in_minutes: 300
@@ -25,6 +27,7 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+
   - label: example-plugins
     command: |-
       cd $$WORKSPACE/plugins/examples
@@ -36,10 +39,11 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+
   - group: java-fips-matrix
     steps:
       - label: "{{matrix.ES_RUNTIME_JAVA}} / {{matrix.GRADLE_TASK}} / java-fips-matrix"
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dtests.fips.enabled=true $$GRADLE_TASK
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true -Dtests.fips.enabled=true $$GRADLE_TASK
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -61,8 +65,9 @@ steps:
         env:
           ES_RUNTIME_JAVA: "{{matrix.ES_RUNTIME_JAVA}}"
           GRADLE_TASK: "{{matrix.GRADLE_TASK}}"
+
       - label: "{{matrix.ES_RUNTIME_JAVA}} / {{matrix.BWC_VERSION}} / java-fips-matrix-bwc"
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dtests.fips.enabled=true v$$BWC_VERSION#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true -Dtests.fips.enabled=true v$$BWC_VERSION#bwcTest
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -77,10 +82,11 @@ steps:
         env:
           ES_RUNTIME_JAVA: "{{matrix.ES_RUNTIME_JAVA}}"
           BWC_VERSION: "{{matrix.BWC_VERSION}}"
+
   - group: java-matrix
     steps:
       - label: "{{matrix.ES_RUNTIME_JAVA}} / {{matrix.GRADLE_TASK}} / java-matrix"
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true $$GRADLE_TASK
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true $$GRADLE_TASK
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -106,8 +112,9 @@ steps:
         env:
           ES_RUNTIME_JAVA: "{{matrix.ES_RUNTIME_JAVA}}"
           GRADLE_TASK: "{{matrix.GRADLE_TASK}}"
+
       - label: "{{matrix.ES_RUNTIME_JAVA}} / {{matrix.BWC_VERSION}} / java-matrix-bwc"
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v$$BWC_VERSION#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v$$BWC_VERSION#bwcTest
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -126,6 +133,7 @@ steps:
         env:
           ES_RUNTIME_JAVA: "{{matrix.ES_RUNTIME_JAVA}}"
           BWC_VERSION: "{{matrix.BWC_VERSION}}"
+
   - label: release-tests
     command: .buildkite/scripts/release-tests.sh
     timeout_in_minutes: 360
@@ -134,14 +142,16 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       diskSizeGb: 350
       machineType: custom-32-98304
+
   - label: single-processor-node-tests
-    command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dtests.configure_test_clusters_with_one_processor=true functionalTests
+    command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true -Dtests.configure_test_clusters_with_one_processor=true functionalTests
     timeout_in_minutes: 420
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
       diskSizeGb: 350
       machineType: custom-32-98304
+
   - group: third-party tests
     steps:
       - label: third-party / azure-sas
@@ -149,7 +159,7 @@ steps:
           export azure_storage_container=elasticsearch-ci-thirdparty-sas
           export azure_storage_base_path=$BUILDKITE_BRANCH
 
-          .ci/scripts/run-gradle.sh azureThirdPartyTest
+          .ci/scripts/run-gradle.sh --continue azureThirdPartyTest
         env:
           USE_3RD_PARTY_AZURE_SAS_CREDENTIALS: "true"
         timeout_in_minutes: 30
@@ -158,12 +168,13 @@ steps:
           image: family/elasticsearch-ubuntu-2404
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+
       - label: third-party / azure
         command: |
           export azure_storage_container=elasticsearch-ci-thirdparty
           export azure_storage_base_path=$BUILDKITE_BRANCH
 
-          .ci/scripts/run-gradle.sh azureThirdPartyTest
+          .ci/scripts/run-gradle.sh --continue azureThirdPartyTest
         env:
           USE_3RD_PARTY_AZURE_CREDENTIALS: "true"
         timeout_in_minutes: 30
@@ -172,12 +183,13 @@ steps:
           image: family/elasticsearch-ubuntu-2404
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+
       - label: third-party / gcs
         command: |
           export google_storage_bucket=elasticsearch-ci-thirdparty
           export google_storage_base_path=$BUILDKITE_BRANCH
 
-          .ci/scripts/run-gradle.sh gcsThirdPartyTest
+          .ci/scripts/run-gradle.sh --continue gcsThirdPartyTest
         env:
           USE_3RD_PARTY_GCS_CREDENTIALS: "true"
         timeout_in_minutes: 30
@@ -186,21 +198,23 @@ steps:
           image: family/elasticsearch-ubuntu-2404
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+
       - label: third-party / geoip
         command: |
-          .ci/scripts/run-gradle.sh :modules:ingest-geoip:internalClusterTest -Dtests.jvm.argline="-Dgeoip_use_service=true"
+          .ci/scripts/run-gradle.sh --continue :modules:ingest-geoip:internalClusterTest -Dtests.jvm.argline="-Dgeoip_use_service=true"
         timeout_in_minutes: 30
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+
       - label: third-party / s3
         command: |
           export amazon_s3_bucket=elasticsearch-ci.us-west-2
           export amazon_s3_base_path=$BUILDKITE_BRANCH
 
-          .ci/scripts/run-gradle.sh s3ThirdPartyTest
+          .ci/scripts/run-gradle.sh --continue s3ThirdPartyTest
         env:
           USE_3RD_PARTY_S3_CREDENTIALS: "true"
         timeout_in_minutes: 30
@@ -209,9 +223,10 @@ steps:
           image: family/elasticsearch-ubuntu-2404
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+
       - label: third-party / ms-graph
         command: |
-          .ci/scripts/run-gradle.sh msGraphThirdPartyTest
+          .ci/scripts/run-gradle.sh --continue msGraphThirdPartyTest
         env:
           USE_3RD_PARTY_MS_GRAPH_CREDENTIALS: "true"
         timeout_in_minutes: 30
@@ -231,6 +246,7 @@ steps:
       machineType: n2-standard-8
       buildDirectory: /dev/shm/bk
     if: build.branch =~ /^(main|\d+\.\d+|\d+\.x)$$/
+
   - label: check-branch-consistency
     command: .ci/scripts/run-gradle.sh branchConsistency
     timeout_in_minutes: 15
@@ -238,6 +254,7 @@ steps:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
       machineType: n2-standard-2
+
   - label: check-branch-protection-rules
     command: .buildkite/scripts/branch-protection.sh
     timeout_in_minutes: 5

--- a/.buildkite/pipelines/periodic.yml
+++ b/.buildkite/pipelines/periodic.yml
@@ -345,7 +345,7 @@ steps:
               limit: 3
 
       - label: 8.0.1 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.0.1#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.0.1#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -364,7 +364,7 @@ steps:
               limit: 3
 
       - label: 8.1.3 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.1.3#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.1.3#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -383,7 +383,7 @@ steps:
               limit: 3
 
       - label: 8.2.3 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.2.3#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.2.3#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -402,7 +402,7 @@ steps:
               limit: 3
 
       - label: 8.3.3 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.3.3#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.3.3#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -421,7 +421,7 @@ steps:
               limit: 3
 
       - label: 8.4.3 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.4.3#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.4.3#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -440,7 +440,7 @@ steps:
               limit: 3
 
       - label: 8.5.3 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.5.3#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.5.3#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -459,7 +459,7 @@ steps:
               limit: 3
 
       - label: 8.6.2 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.6.2#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.6.2#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -478,7 +478,7 @@ steps:
               limit: 3
 
       - label: 8.7.1 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.7.1#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.7.1#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -497,7 +497,7 @@ steps:
               limit: 3
 
       - label: 8.8.2 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.8.2#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.8.2#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -516,7 +516,7 @@ steps:
               limit: 3
 
       - label: 8.9.2 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.9.2#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.9.2#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -535,7 +535,7 @@ steps:
               limit: 3
 
       - label: 8.10.4 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.10.4#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.10.4#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -554,7 +554,7 @@ steps:
               limit: 3
 
       - label: 8.11.4 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.11.4#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.11.4#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -573,7 +573,7 @@ steps:
               limit: 3
 
       - label: 8.12.2 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.12.2#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.12.2#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -592,7 +592,7 @@ steps:
               limit: 3
 
       - label: 8.13.4 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.13.4#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.13.4#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -611,7 +611,7 @@ steps:
               limit: 3
 
       - label: 8.14.3 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.14.3#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.14.3#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -630,7 +630,7 @@ steps:
               limit: 3
 
       - label: 8.15.5 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.15.5#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.15.5#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -649,7 +649,7 @@ steps:
               limit: 3
 
       - label: 8.16.6 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.16.6#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.16.6#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -668,7 +668,7 @@ steps:
               limit: 3
 
       - label: 8.17.10 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.17.10#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.17.10#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -687,7 +687,7 @@ steps:
               limit: 3
 
       - label: 8.18.8 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.18.8#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.18.8#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -706,7 +706,7 @@ steps:
               limit: 3
 
       - label: 8.19.7 / bwc
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.19.7#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v8.19.7#bwcTest
         timeout_in_minutes: 300
         agents:
           provider: gcp
@@ -725,13 +725,14 @@ steps:
               limit: 3
 
   - label: concurrent-search-tests
-    command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dtests.jvm.argline=-Des.concurrent_search=true -Des.concurrent_search=true functionalTests
+    command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true -Dtests.jvm.argline=-Des.concurrent_search=true -Des.concurrent_search=true functionalTests
     timeout_in_minutes: 420
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
       diskSizeGb: 350
       machineType: custom-32-98304
+
   - label: encryption-at-rest
     command: .buildkite/scripts/encryption-at-rest.sh
     timeout_in_minutes: 420
@@ -740,6 +741,7 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       diskSizeGb: 350
       machineType: custom-32-98304
+
   - label: eql-correctness
     command: .buildkite/scripts/eql-correctness.sh
     timeout_in_minutes: 300
@@ -748,6 +750,7 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+
   - label: example-plugins
     command: |-
       cd $$WORKSPACE/plugins/examples
@@ -759,10 +762,11 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+
   - group: java-fips-matrix
     steps:
       - label: "{{matrix.ES_RUNTIME_JAVA}} / {{matrix.GRADLE_TASK}} / java-fips-matrix"
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dtests.fips.enabled=true $$GRADLE_TASK
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true -Dtests.fips.enabled=true $$GRADLE_TASK
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -784,8 +788,9 @@ steps:
         env:
           ES_RUNTIME_JAVA: "{{matrix.ES_RUNTIME_JAVA}}"
           GRADLE_TASK: "{{matrix.GRADLE_TASK}}"
+
       - label: "{{matrix.ES_RUNTIME_JAVA}} / {{matrix.BWC_VERSION}} / java-fips-matrix-bwc"
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dtests.fips.enabled=true v$$BWC_VERSION#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true -Dtests.fips.enabled=true v$$BWC_VERSION#bwcTest
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -800,10 +805,11 @@ steps:
         env:
           ES_RUNTIME_JAVA: "{{matrix.ES_RUNTIME_JAVA}}"
           BWC_VERSION: "{{matrix.BWC_VERSION}}"
+
   - group: java-matrix
     steps:
       - label: "{{matrix.ES_RUNTIME_JAVA}} / {{matrix.GRADLE_TASK}} / java-matrix"
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true $$GRADLE_TASK
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true $$GRADLE_TASK
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -829,8 +835,9 @@ steps:
         env:
           ES_RUNTIME_JAVA: "{{matrix.ES_RUNTIME_JAVA}}"
           GRADLE_TASK: "{{matrix.GRADLE_TASK}}"
+
       - label: "{{matrix.ES_RUNTIME_JAVA}} / {{matrix.BWC_VERSION}} / java-matrix-bwc"
-        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v$$BWC_VERSION#bwcTest
+        command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true v$$BWC_VERSION#bwcTest
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -849,6 +856,7 @@ steps:
         env:
           ES_RUNTIME_JAVA: "{{matrix.ES_RUNTIME_JAVA}}"
           BWC_VERSION: "{{matrix.BWC_VERSION}}"
+
   - label: release-tests
     command: .buildkite/scripts/release-tests.sh
     timeout_in_minutes: 360
@@ -857,14 +865,16 @@ steps:
       image: family/elasticsearch-ubuntu-2404
       diskSizeGb: 350
       machineType: custom-32-98304
+
   - label: single-processor-node-tests
-    command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dtests.configure_test_clusters_with_one_processor=true functionalTests
+    command: .ci/scripts/run-gradle.sh --continue -Dbwc.checkout.align=true -Dtests.configure_test_clusters_with_one_processor=true functionalTests
     timeout_in_minutes: 420
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
       diskSizeGb: 350
       machineType: custom-32-98304
+
   - group: third-party tests
     steps:
       - label: third-party / azure-sas
@@ -872,7 +882,7 @@ steps:
           export azure_storage_container=elasticsearch-ci-thirdparty-sas
           export azure_storage_base_path=$BUILDKITE_BRANCH
 
-          .ci/scripts/run-gradle.sh azureThirdPartyTest
+          .ci/scripts/run-gradle.sh --continue azureThirdPartyTest
         env:
           USE_3RD_PARTY_AZURE_SAS_CREDENTIALS: "true"
         timeout_in_minutes: 30
@@ -881,12 +891,13 @@ steps:
           image: family/elasticsearch-ubuntu-2404
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+
       - label: third-party / azure
         command: |
           export azure_storage_container=elasticsearch-ci-thirdparty
           export azure_storage_base_path=$BUILDKITE_BRANCH
 
-          .ci/scripts/run-gradle.sh azureThirdPartyTest
+          .ci/scripts/run-gradle.sh --continue azureThirdPartyTest
         env:
           USE_3RD_PARTY_AZURE_CREDENTIALS: "true"
         timeout_in_minutes: 30
@@ -895,12 +906,13 @@ steps:
           image: family/elasticsearch-ubuntu-2404
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+
       - label: third-party / gcs
         command: |
           export google_storage_bucket=elasticsearch-ci-thirdparty
           export google_storage_base_path=$BUILDKITE_BRANCH
 
-          .ci/scripts/run-gradle.sh gcsThirdPartyTest
+          .ci/scripts/run-gradle.sh --continue gcsThirdPartyTest
         env:
           USE_3RD_PARTY_GCS_CREDENTIALS: "true"
         timeout_in_minutes: 30
@@ -909,21 +921,23 @@ steps:
           image: family/elasticsearch-ubuntu-2404
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+
       - label: third-party / geoip
         command: |
-          .ci/scripts/run-gradle.sh :modules:ingest-geoip:internalClusterTest -Dtests.jvm.argline="-Dgeoip_use_service=true"
+          .ci/scripts/run-gradle.sh --continue :modules:ingest-geoip:internalClusterTest -Dtests.jvm.argline="-Dgeoip_use_service=true"
         timeout_in_minutes: 30
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2404
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+
       - label: third-party / s3
         command: |
           export amazon_s3_bucket=elasticsearch-ci.us-west-2
           export amazon_s3_base_path=$BUILDKITE_BRANCH
 
-          .ci/scripts/run-gradle.sh s3ThirdPartyTest
+          .ci/scripts/run-gradle.sh --continue s3ThirdPartyTest
         env:
           USE_3RD_PARTY_S3_CREDENTIALS: "true"
         timeout_in_minutes: 30
@@ -932,9 +946,10 @@ steps:
           image: family/elasticsearch-ubuntu-2404
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+
       - label: third-party / ms-graph
         command: |
-          .ci/scripts/run-gradle.sh msGraphThirdPartyTest
+          .ci/scripts/run-gradle.sh --continue msGraphThirdPartyTest
         env:
           USE_3RD_PARTY_MS_GRAPH_CREDENTIALS: "true"
         timeout_in_minutes: 30
@@ -954,6 +969,7 @@ steps:
       machineType: n2-standard-8
       buildDirectory: /dev/shm/bk
     if: build.branch =~ /^(main|\d+\.\d+|\d+\.x)$$/
+
   - label: check-branch-consistency
     command: .ci/scripts/run-gradle.sh branchConsistency
     timeout_in_minutes: 15
@@ -961,6 +977,7 @@ steps:
       provider: gcp
       image: family/elasticsearch-ubuntu-2404
       machineType: n2-standard-2
+
   - label: check-branch-protection-rules
     command: .buildkite/scripts/branch-protection.sh
     timeout_in_minutes: 5


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ES-12998] Invoking gradle continue flag on periodic runs to allow for more information on test failures (#136900)](https://github.com/elastic/elasticsearch/pull/136900)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

[ES-12998]: https://elasticco.atlassian.net/browse/ES-12998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ