### PR TITLE
Enable security for OTLPMetricsIndexingRestIT

### DIFF
--- a/x-pack/plugin/otel-data/src/javaRestTest/java/org/elasticsearch/xpack/oteldata/otlp/OTLPMetricsIndexingRestIT.java
+++ b/x-pack/plugin/otel-data/src/javaRestTest/java/org/elasticsearch/xpack/oteldata/otlp/OTLPMetricsIndexingRestIT.java
@@ -76,6 +76,7 @@ public class OTLPMetricsIndexingRestIT extends ESRestTestCase {
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
         .distribution(DistributionType.DEFAULT)
         .user(USER, PASS, "superuser", false)
+        .setting("xpack.security.enabled", "true")
         .setting("xpack.security.autoconfiguration.enabled", "false")
         .setting("xpack.license.self_generated.type", "trial")
         .setting("xpack.ml.enabled", "false")


### PR DESCRIPTION
Security must be explicity enabled to make tests in fips mode pass.

Relates: #137325

