### PR TITLE
Fix thread-safety of FixedCapacityExponentialHistogram.valueCount

### DIFF
--- a/libs/exponential-histogram/src/test/java/org/elasticsearch/exponentialhistogram/FixedCapacityExponentialHistogramTests.java
+++ b/libs/exponential-histogram/src/test/java/org/elasticsearch/exponentialhistogram/FixedCapacityExponentialHistogramTests.java
@@ -24,10 +24,38 @@ package org.elasticsearch.exponentialhistogram;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.unit.ByteSizeValue;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.IntStream;
+
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 
 public class FixedCapacityExponentialHistogramTests extends ExponentialHistogramTestCase {
+
+    public void testConcurrentHashCode() throws ExecutionException, InterruptedException {
+        List<ExponentialHistogram> originalHistograms = IntStream.range(0, 1000)
+            .mapToObj(i -> ExponentialHistogramTestUtils.randomHistogram())
+            .toList();
+
+        List<? extends ExponentialHistogram> copies = originalHistograms.stream()
+            .map(histo -> ExponentialHistogram.builder(histo, ExponentialHistogramCircuitBreaker.noop()).build())
+            .toList();
+
+        // Compute potentially lazy data correctly on the originals
+        originalHistograms.forEach(Object::hashCode);
+        concurrentTest(() -> {
+            for (int i = 0; i < originalHistograms.size(); i++) {
+                ExponentialHistogram original = originalHistograms.get(i);
+                ExponentialHistogram copy = copies.get(i);
+                assertThat(copy.hashCode(), equalTo(original.hashCode()));
+            }
+        });
+    }
 
     public void testValueCountUpdatedCorrectly() {
 
@@ -68,5 +96,22 @@ public class FixedCapacityExponentialHistogramTests extends ExponentialHistogram
             assertThat(esBreaker.getUsed(), equalTo(histogram.ramBytesUsed()));
         }
         assertThat(esBreaker.getUsed(), equalTo(0L));
+    }
+
+    protected void concurrentTest(Runnable r) throws InterruptedException, ExecutionException {
+        int threads = 5;
+        int tasks = threads * 2;
+        ExecutorService exec = Executors.newFixedThreadPool(threads);
+        try {
+            List<Future<?>> results = new ArrayList<>();
+            for (int t = 0; t < tasks; t++) {
+                results.add(exec.submit(r));
+            }
+            for (Future<?> f : results) {
+                f.get();
+            }
+        } finally {
+            exec.shutdown();
+        }
     }
 }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
@@ -1060,13 +1060,6 @@ public final class EsqlTestUtils {
             ExponentialHistogramCircuitBreaker.noop(),
             rawValues
         );
-        /*
-         * hashcode mutates the histogram by doing some lazy work.
-         * That can change the value of the hashCode if you call it concurrently....
-         * This works around that by running it once up front. Jonas will have a
-         * look at this one soon.
-         */
-        histo.hashCode();
         return histo;
     }
 


### PR DESCRIPTION
Follow up for #137350, fixes the actual root cause and removes the workaround.

The `FixedCapacityExponentialHistogram` is mutable to allow for an efficient construction and reuse within the exponential histogram lib. However, the class is private to the library, meaning that it can only be accessed via the `ExponentialHistogram` interface from outside of the library.

The `ExponentialHistogram` interface does not allow for mutations, therefore `FixedCapacityExponentialHistogram` when viewed (and exclusively owned) this way should be thread safe. 

Prior to this PR this was not the case: We lazily compute the sum of the counts for buckets and cache it as needed.
To make this as efficient as possible, e.g. even after adding more buckets to the histogram, we remember for how many buckets we cached the sum and only add new ones on top.

Calling `valueCount()` would mutate and read the relevant members in a loop, leading to a race condition.
This PR (a) reproduces the problem in a test and (b) fixes it by replacing the racy member accesses with single reference load and store, which are therefore atomic.