### PR TITLE
[9.2] [Inference API] Propagate dimensions for dense text embedding generation using EIS (#137328)

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceDenseTextEmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceDenseTextEmbeddingsRequest.java
@@ -56,7 +56,12 @@ public class ElasticInferenceServiceDenseTextEmbeddingsRequest extends ElasticIn
         var httpPost = new HttpPost(uri);
         var usageContext = ElasticInferenceServiceUsageContext.fromInputType(inputType);
         var requestEntity = Strings.toString(
-            new ElasticInferenceServiceDenseTextEmbeddingsRequestEntity(inputs, model.getServiceSettings().modelId(), usageContext)
+            new ElasticInferenceServiceDenseTextEmbeddingsRequestEntity(
+                inputs,
+                model.getServiceSettings().modelId(),
+                usageContext,
+                model.getServiceSettings().dimensions()
+            )
         );
 
         ByteArrayEntity byteEntity = new ByteArrayEntity(requestEntity.getBytes(StandardCharsets.UTF_8));

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceDenseTextEmbeddingsRequestEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceDenseTextEmbeddingsRequestEntity.java
@@ -19,12 +19,14 @@ import java.util.Objects;
 public record ElasticInferenceServiceDenseTextEmbeddingsRequestEntity(
     List<String> inputs,
     String modelId,
-    @Nullable ElasticInferenceServiceUsageContext usageContext
+    @Nullable ElasticInferenceServiceUsageContext usageContext,
+    @Nullable Integer dimensions
 ) implements ToXContentObject {
 
     private static final String INPUT_FIELD = "input";
     private static final String MODEL_FIELD = "model";
     private static final String USAGE_CONTEXT = "usage_context";
+    private static final String DIMENSIONS = "dimensions";
 
     public ElasticInferenceServiceDenseTextEmbeddingsRequestEntity {
         Objects.requireNonNull(inputs);
@@ -47,6 +49,11 @@ public record ElasticInferenceServiceDenseTextEmbeddingsRequestEntity(
         // optional field
         if (Objects.nonNull(usageContext) && usageContext != ElasticInferenceServiceUsageContext.UNSPECIFIED) {
             builder.field(USAGE_CONTEXT, usageContext);
+        }
+
+        // optional field
+        if (Objects.nonNull(dimensions)) {
+            builder.field(DIMENSIONS, dimensions);
         }
 
         builder.endObject();

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceDenseTextEmbeddingsRequestEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceDenseTextEmbeddingsRequestEntityTests.java
@@ -25,7 +25,8 @@ public class ElasticInferenceServiceDenseTextEmbeddingsRequestEntityTests extend
         var entity = new ElasticInferenceServiceDenseTextEmbeddingsRequestEntity(
             List.of("abc"),
             "my-model-id",
-            ElasticInferenceServiceUsageContext.UNSPECIFIED
+            ElasticInferenceServiceUsageContext.UNSPECIFIED,
+            null
         );
         String xContentString = xContentEntityToString(entity);
         assertThat(xContentString, equalToIgnoringWhitespaceInJsonString("""
@@ -39,7 +40,8 @@ public class ElasticInferenceServiceDenseTextEmbeddingsRequestEntityTests extend
         var entity = new ElasticInferenceServiceDenseTextEmbeddingsRequestEntity(
             List.of("abc", "def"),
             "my-model-id",
-            ElasticInferenceServiceUsageContext.UNSPECIFIED
+            ElasticInferenceServiceUsageContext.UNSPECIFIED,
+            null
         );
         String xContentString = xContentEntityToString(entity);
         assertThat(xContentString, equalToIgnoringWhitespaceInJsonString("""
@@ -57,7 +59,8 @@ public class ElasticInferenceServiceDenseTextEmbeddingsRequestEntityTests extend
         var entity = new ElasticInferenceServiceDenseTextEmbeddingsRequestEntity(
             List.of("abc"),
             "my-model-id",
-            ElasticInferenceServiceUsageContext.SEARCH
+            ElasticInferenceServiceUsageContext.SEARCH,
+            null
         );
         String xContentString = xContentEntityToString(entity);
         assertThat(xContentString, equalToIgnoringWhitespaceInJsonString("""
@@ -73,7 +76,8 @@ public class ElasticInferenceServiceDenseTextEmbeddingsRequestEntityTests extend
         var entity = new ElasticInferenceServiceDenseTextEmbeddingsRequestEntity(
             List.of("abc"),
             "my-model-id",
-            ElasticInferenceServiceUsageContext.INGEST
+            ElasticInferenceServiceUsageContext.INGEST,
+            null
         );
         String xContentString = xContentEntityToString(entity);
         assertThat(xContentString, equalToIgnoringWhitespaceInJsonString("""
@@ -85,11 +89,29 @@ public class ElasticInferenceServiceDenseTextEmbeddingsRequestEntityTests extend
             """));
     }
 
+    public void testToXContent_SingleInput_DimensionsSpecified() throws IOException {
+        var entity = new ElasticInferenceServiceDenseTextEmbeddingsRequestEntity(
+            List.of("abc"),
+            "my-model-id",
+            ElasticInferenceServiceUsageContext.UNSPECIFIED,
+            100
+        );
+        String xContentString = xContentEntityToString(entity);
+        assertThat(xContentString, equalToIgnoringWhitespaceInJsonString("""
+            {
+                "input": ["abc"],
+                "model": "my-model-id",
+                "dimensions": 100
+            }
+            """));
+    }
+
     public void testToXContent_MultipleInputs_SearchUsageContext() throws IOException {
         var entity = new ElasticInferenceServiceDenseTextEmbeddingsRequestEntity(
             List.of("first input", "second input", "third input"),
             "my-dense-model",
-            ElasticInferenceServiceUsageContext.SEARCH
+            ElasticInferenceServiceUsageContext.SEARCH,
+            null
         );
         String xContentString = xContentEntityToString(entity);
         assertThat(xContentString, equalToIgnoringWhitespaceInJsonString("""
@@ -109,7 +131,8 @@ public class ElasticInferenceServiceDenseTextEmbeddingsRequestEntityTests extend
         var entity = new ElasticInferenceServiceDenseTextEmbeddingsRequestEntity(
             List.of("document one", "document two"),
             "embedding-model-v2",
-            ElasticInferenceServiceUsageContext.INGEST
+            ElasticInferenceServiceUsageContext.INGEST,
+            null
         );
         String xContentString = xContentEntityToString(entity);
         assertThat(xContentString, equalToIgnoringWhitespaceInJsonString("""
@@ -128,7 +151,8 @@ public class ElasticInferenceServiceDenseTextEmbeddingsRequestEntityTests extend
         var entity = new ElasticInferenceServiceDenseTextEmbeddingsRequestEntity(
             List.of(""),
             "my-model-id",
-            ElasticInferenceServiceUsageContext.UNSPECIFIED
+            ElasticInferenceServiceUsageContext.UNSPECIFIED,
+            null
         );
         String xContentString = xContentEntityToString(entity);
         assertThat(xContentString, equalToIgnoringWhitespaceInJsonString("""


### PR DESCRIPTION
Backports the following commits to 9.2:
 - [Inference API] Propagate dimensions for dense text embedding generation using EIS (#137328)