### PR TITLE
ILM: Refresh phase definitions on lifecycle swap

### DIFF
--- a/modules/data-streams/build.gradle
+++ b/modules/data-streams/build.gradle
@@ -14,7 +14,7 @@ esplugin {
 restResources {
   restApi {
     include 'bulk', 'count', 'search', '_common', 'indices', 'index', 'cluster', 'rank_eval', 'reindex', 'update_by_query', 'delete_by_query',
-      'eql', 'data_stream', 'ingest', 'cat', 'capabilities', 'reindex'
+      'eql', 'data_stream', 'ingest', 'cat', 'capabilities', 'reindex', 'ilm'
   }
 }
 

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/rest/RestUpdateDataStreamSettingsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/rest/RestUpdateDataStreamSettingsAction.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.PUT;
 
@@ -57,5 +58,10 @@ public class RestUpdateDataStreamSettingsAction extends BaseRestHandler {
             putDataStreamRequest,
             new RestRefCountedChunkedToXContentListener<>(channel)
         );
+    }
+
+    @Override
+    public Set<String> supportedCapabilities() {
+        return Set.of("ilm_phase_refresh_on_index_policy_change");
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNewPolicyProjectMetadataModifier.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNewPolicyProjectMetadataModifier.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+/**
+ * Allow modules to atomically modify ProjectMetadata when an index <code>index.lifecycle.name</code> changes.
+ */
+public interface IndexNewPolicyProjectMetadataModifier {
+
+    /**
+     * Notify that {@link IndexMetadata#LIFECYCLE_NAME} setting changed for an index.
+     * Can but doesn't need to modify the provided {@link ProjectMetadata.Builder}.
+     * We will have to modify the ProjectMetadata anyway to update the index settings so no need to indicate whether a change was made.
+     */
+    void potentiallyModify(ProjectMetadata currentProject, ProjectMetadata.Builder builder, String indexName, String newLifecyclePolicy);
+}

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -44,6 +44,7 @@ import org.elasticsearch.cluster.metadata.DataStreamFailureStoreSettings;
 import org.elasticsearch.cluster.metadata.DataStreamGlobalRetentionSettings;
 import org.elasticsearch.cluster.metadata.IndexMetadataVerifier;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.IndexNewPolicyProjectMetadataModifier;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.MetadataCreateDataStreamService;
 import org.elasticsearch.cluster.metadata.MetadataCreateIndexService;
@@ -1062,6 +1063,12 @@ class NodeConstruction {
             // Return both
             return Stream.of(componentObjects, componentsFromInjector).flatMap(Collection::stream).toList();
         }).toList();
+
+        final List<IndexNewPolicyProjectMetadataModifier> listeners = pluginComponents.stream()
+            .map(c -> c instanceof IndexNewPolicyProjectMetadataModifier modifier ? modifier : null)
+            .filter(Objects::nonNull)
+            .toList();
+        metadataUpdateSettingsService.setNewPolicyModifiersOnce(listeners);
 
         var terminationHandlers = pluginsService.loadServiceProviders(TerminationHandlerProvider.class)
             .stream()

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestUpdateSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestUpdateSettingsAction.java
@@ -61,4 +61,9 @@ public class RestUpdateSettingsAction extends BaseRestHandler {
     protected Set<String> responseParams() {
         return Settings.FORMAT_PARAMS;
     }
+
+    @Override
+    public Set<String> supportedCapabilities() {
+        return Set.of("ilm_phase_refresh_on_index_policy_change");
+    }
 }

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/ChangePolicyForDataStreamIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/ChangePolicyForDataStreamIT.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ilm;
+
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.core.Strings;
+import org.elasticsearch.xpack.IlmESRestTestCase;
+import org.elasticsearch.xpack.core.ilm.PhaseCompleteStep;
+import org.elasticsearch.xpack.core.ilm.RolloverAction;
+import org.elasticsearch.xpack.core.ilm.SetPriorityAction;
+import org.elasticsearch.xpack.core.ilm.Step.StepKey;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.elasticsearch.xpack.TimeSeriesRestDriver.createNewSingletonPolicy;
+import static org.elasticsearch.xpack.TimeSeriesRestDriver.explainIndex;
+import static org.elasticsearch.xpack.TimeSeriesRestDriver.getStepKeyForIndex;
+import static org.elasticsearch.xpack.TimeSeriesRestDriver.indexDocument;
+import static org.hamcrest.Matchers.equalTo;
+
+public class ChangePolicyForDataStreamIT extends IlmESRestTestCase {
+
+    /**
+     * This test verifies that after changing the lifecycle policy for a data stream,
+     * ILM will use the updated phase definition from new policy for the current phase (if compatible).
+     * <p>
+     * The test creates two policies:
+     * - the first with a hot phase requiring 1000 documents to rollover
+     * - the second with a hot phase requiring 2 documents to rollover
+     * <p>
+     * A data stream is created with the first policy and the test ensures it is on the rollover step.
+     * The data stream policy is then changed to the second policy.
+     * A document is indexed which should trigger the rollover given it should now use rollover criteria from second policy.
+     */
+    public void testChangePolicyForDataStream() throws Exception {
+        final String oldPolicy = "old_policy";
+        final String newPolicy = "new_policy";
+        final String dataStream = "logs-ds";
+        final String template = "template-ds";
+
+        // old_policy: hot rollover=1000
+        createNewSingletonPolicy(
+            client(),
+            oldPolicy,
+            "hot",
+            new RolloverAction(null, null, null, 1000L, null, null, null, null, null, null)
+        );
+        // new_policy: hot rollover=2
+        createNewSingletonPolicy(client(), newPolicy, "hot", new RolloverAction(null, null, null, 2L, null, null, null, null, null, null));
+
+        // data stream has old policy
+        createComposableTemplateWithPolicy(template, dataStream + "*", oldPolicy);
+
+        // create DS
+        indexDocument(client(), dataStream, true);
+
+        // wait until the only backing index is moved to wait-for-rollover-ready by ILM
+        assertBusy(() -> {
+            final List<String> backing = getDataStreamBackingIndexNames(dataStream);
+            assertThat(backing.size(), equalTo(1));
+            final String writeIdx = backing.getFirst();
+            assertThat(getStepKeyForIndex(client(), writeIdx), equalTo(new StepKey("hot", RolloverAction.NAME, "check-rollover-ready")));
+        }, 30, TimeUnit.SECONDS);
+
+        // swap DS policy to new_policy via data stream settings
+        updateDataStreamPolicy(dataStream, newPolicy);
+
+        // confirm `_ilm/explain` reflects new_policy on the current write index
+        {
+            final String writeIdx = getDataStreamBackingIndexNames(dataStream).getFirst();
+            final var explain = explainIndex(client(), writeIdx);
+            assertThat(explain.get("phase"), equalTo("hot"));
+            @SuppressWarnings("unchecked")
+            var phaseExec = (java.util.Map<String, Object>) explain.get("phase_execution");
+            assertNotNull(phaseExec);
+            assertThat(phaseExec.get("policy"), equalTo(newPolicy));
+        }
+
+        // index document to trigger rollover criteria on new policy
+        indexDocument(client(), dataStream, true);
+
+        // assert ILM performed rollover and original index completed hot
+        assertBusy(() -> {
+            final List<String> backing = getDataStreamBackingIndexNames(dataStream);
+            assertThat(backing.size(), equalTo(2));
+            final String original = backing.getFirst();
+            assertThat(getStepKeyForIndex(client(), original), equalTo(PhaseCompleteStep.finalStep("hot").getKey()));
+        }, 30, TimeUnit.SECONDS);
+    }
+
+    /**
+     * This test verifies that if we update a data stream lifecycle policy, to a policy where we can't refresh the cached steps
+     * (in this case, we replace a step), that the cached step definition is kept and used for the index until it moves to the next phase.
+     */
+    public void testDataStreamHonoursCachedPhaseAfterPolicyUpdate() throws Exception {
+        final String oldPolicy = "old_policy";
+        final String newPolicy = "new_policy";
+        final String dataStream = "logs-ds";
+        final String template = "template-ds";
+
+        // start with rollover=2
+        createNewSingletonPolicy(client(), oldPolicy, "hot", new RolloverAction(null, null, null, 2L, null, null, null, null, null, null));
+        // no rollover, will be incompatible with current step
+        createNewSingletonPolicy(client(), newPolicy, "hot", new SetPriorityAction(200));
+
+        // create DS with policy
+        createComposableTemplateWithPolicy(template, dataStream + "*", oldPolicy);
+        indexDocument(client(), dataStream, true);
+
+        // wait until the only backing index is moved to wait-for-rollover-ready by ILM
+        assertBusy(() -> {
+            final List<String> backing = getDataStreamBackingIndexNames(dataStream);
+            assertThat(backing.size(), equalTo(1));
+            final String writeIdx = backing.getFirst();
+            assertThat(getStepKeyForIndex(client(), writeIdx), equalTo(new StepKey("hot", RolloverAction.NAME, "check-rollover-ready")));
+        }, 30, TimeUnit.SECONDS);
+
+        // swap the DS to a policy that has no rollover (incompatible current step), so cached step is kept
+        updateDataStreamPolicy(dataStream, newPolicy);
+
+        // confirm `_ilm/explain` reflects old_policy within the phase execution, i.e. cached step is kept
+        {
+            final String writeIdx = getDataStreamBackingIndexNames(dataStream).getFirst();
+            final var explain = explainIndex(client(), writeIdx);
+            assertThat(explain.get("phase"), equalTo("hot"));
+            @SuppressWarnings("unchecked")
+            var phaseExec = (java.util.Map<String, Object>) explain.get("phase_execution");
+            assertNotNull(phaseExec);
+            assertThat(phaseExec.get("policy"), equalTo(oldPolicy));
+        }
+
+        // index another document to trigger rollover from cached step
+        indexDocument(client(), dataStream, true);
+
+        // verify first index rolled over due to new policy and has finished hot phase,
+        // and new index uses new policy too, and has finished hot phase since no rollover step
+        assertBusy(() -> {
+            final List<String> backing = getDataStreamBackingIndexNames(dataStream);
+            assertThat(backing.size(), equalTo(2));
+            final String previousIndex = backing.getFirst();
+            final String newIndex = backing.getLast();
+            assertThat(getStepKeyForIndex(client(), previousIndex), equalTo(PhaseCompleteStep.finalStep("hot").getKey()));
+            assertThat(getStepKeyForIndex(client(), newIndex), equalTo(PhaseCompleteStep.finalStep("hot").getKey()));
+        }, 30, TimeUnit.SECONDS);
+    }
+
+    private void updateDataStreamPolicy(final String dataStreamName, final String policyName) throws Exception {
+        final Request req = new Request("PUT", "/_data_stream/" + dataStreamName + "/_settings");
+        req.setEntity(new StringEntity("{ \"index.lifecycle.name\": \"" + policyName + "\" }", ContentType.APPLICATION_JSON));
+        assertOK(client().performRequest(req));
+    }
+
+    private void createComposableTemplateWithPolicy(final String templateName, final String indexPattern, final String policyName)
+        throws Exception {
+        final String body = Strings.format("""
+            {
+              "index_patterns": "%s",
+              "data_stream": {},
+              "template": {
+                "settings": {
+                  "index.lifecycle.name": "%s"
+                }
+              }
+            }
+            """, indexPattern, policyName);
+        final Request req = new Request("PUT", "_index_template/" + templateName);
+        req.setEntity(new StringEntity(body, ContentType.APPLICATION_JSON));
+        assertOK(client().performRequest(req));
+    }
+}

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/package-info.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/package-info.java
@@ -80,10 +80,12 @@
  * defined in the {@link org.elasticsearch.xpack.ilm.PolicyStepsRegistry}.
  * Once all the steps of a policy are executed successfully the policy execution will reach the
  * {@link org.elasticsearch.xpack.core.ilm.TerminalPolicyStep} and any changes made to the policy definition will not have any effect on
- * the already completed policies. Even more, any changes made to the policy HOT phase will have *no* effect on the already in-progress HOT
- * phase executions (the phase JSON representation being cached into the index metadata). However, a policy update to the WARM phase will
- * *have* an effect on the policies that are currently in the HOT execution state as the entire WARM phase will be reloaded from the
- * policy definition when transitioning to the phase.
+ * the already completed policies.
+ * While executing a phase, ILM caches that phase's definition in the index metadata. When a policy is updated,
+ * ILM will attempt to safely refresh the cached definition for indices currently in that phase if the phase's set of
+ * step keys is unchanged (for example, parameter-only changes such as rollover thresholds). If the updated policy
+ * removes/changes steps such that the step keys differ, or the current step no longer exists, ILM does not refresh the
+ * cached phase; instead, the updated policy takes effect on subsequent phase transitions.
  *
  * If a step execution fails, the policy execution state for the index will be moved into the
  * {@link org.elasticsearch.xpack.core.ilm.ErrorStep}.


### PR DESCRIPTION
If we change an index, or data stream `index.lifecycle.name` from one lifecycle policy to another one, refresh phase definition if possible.

Performs the same behavior as `PUT /_ilm/policy/{policy}`, updates indices to have the new phase definition, if possible.

approaches (the one taken, and potential ones, in order of preference):
1. (current) add a listener into server that can modify ProjectMetadata atomically within MetadataUpdateSettingsService
1.1. pros: atomic, "scalpel" approach, check only specific indices that change, uses same approach and code as `PUT _ilm/policy/{policy}` to update phase definitions
1.2. cons: needs scaffolding in server, interface is as generic as can be but might never be used for other purposes
2. in ILM we periodically and on cluster state updates scan over all indices and update phase definitions if we move a phase, we could also check if any index phase definition can be refreshed
2.1. pros: no scaffolding in server, specific to ILM
2.2. cons: brute-force scanning over all indices, not atomic (index can have new policy assigned but phase definition is outdated), ILM doesn't care about each cluster state change, it can miss some updates and will run on latest, i'd have to figure out how to `only try update phase definition once`
3. do something with index settings, adding a listener to setting updates. seems quite unwieldy from quick research, non-atomic, i believe node-local so master task to update phase definition might run multiple times. seems like it'll entail a good bit of extra research and code to do correctly



Closes #129800 
