### PR TITLE
Tighten assertions in MoveDecision static method helpers

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/MoveDecision.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/MoveDecision.java
@@ -93,8 +93,8 @@ public final class MoveDecision extends AbstractAllocationDecision {
      * be forced to move to another node.
      */
     public static MoveDecision createRemainYesDecision(Decision canRemainDecision) {
-        assert canRemainDecision.type() != Type.NO;
-        assert canRemainDecision.type() != Type.NOT_PREFERRED;
+        assert canRemainDecision != null;
+        assert canRemainDecision.type() == Type.YES : "create decision with MoveDecision#move instead";
         if (canRemainDecision == Decision.YES) {
             return CACHED_STAY_DECISION;
         }
@@ -117,7 +117,7 @@ public final class MoveDecision extends AbstractAllocationDecision {
         @Nullable List<NodeAllocationResult> nodeDecisions
     ) {
         assert canRemainDecision != null;
-        assert canRemainDecision.type() != Type.YES : "create decision with MoveDecision#stay instead";
+        assert canRemainDecision.type() != Type.YES : "create decision with MoveDecision#createRemainYesDecision instead";
         if (nodeDecisions == null && moveDecision == AllocationDecision.NO) {
             // the final decision is NO (no node to move the shard to) and we are not in explain mode, return a cached version
             return CACHED_CANNOT_MOVE_DECISION;

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/MoveDecision.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/MoveDecision.java
@@ -94,7 +94,8 @@ public final class MoveDecision extends AbstractAllocationDecision {
      */
     public static MoveDecision createRemainYesDecision(Decision canRemainDecision) {
         assert canRemainDecision != null;
-        assert canRemainDecision.type() == Type.YES : "create decision with MoveDecision#move instead";
+        assert canRemainDecision.type() == Type.YES
+            : "Create decision with MoveDecision#move instead. canRemain Decision: " + canRemainDecision;
         if (canRemainDecision == Decision.YES) {
             return CACHED_STAY_DECISION;
         }
@@ -117,7 +118,8 @@ public final class MoveDecision extends AbstractAllocationDecision {
         @Nullable List<NodeAllocationResult> nodeDecisions
     ) {
         assert canRemainDecision != null;
-        assert canRemainDecision.type() != Type.YES : "create decision with MoveDecision#createRemainYesDecision instead";
+        assert canRemainDecision.type() != Type.YES
+            : "Create decision with MoveDecision#createRemainYesDecision instead. canRemain Decision: " + canRemainDecision;
         if (nodeDecisions == null && moveDecision == AllocationDecision.NO) {
             // the final decision is NO (no node to move the shard to) and we are not in explain mode, return a cached version
             return CACHED_CANNOT_MOVE_DECISION;

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/MoveDecisionTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/MoveDecisionTests.java
@@ -56,6 +56,10 @@ public class MoveDecisionTests extends ESTestCase {
         assertEquals(stay1.getExplanation(), stay2.getExplanation());
     }
 
+    public void testMoveDecisionThrowsOnYes() {
+        assertThrows(AssertionError.class, () -> MoveDecision.move(Decision.YES, AllocationDecision.NO, null, null));
+    }
+
     public void testStayDecision() {
         MoveDecision stay = MoveDecision.createRemainYesDecision(Decision.YES);
         assertTrue(stay.canRemain());
@@ -64,18 +68,15 @@ public class MoveDecisionTests extends ESTestCase {
         assertNull(stay.getNodeDecisions());
         assertEquals(AllocationDecision.NO_ATTEMPT, stay.getAllocationDecision());
 
-        stay = MoveDecision.createRemainYesDecision(Decision.YES);
-        assertTrue(stay.canRemain());
-        assertFalse(stay.cannotRemainAndCanMove());
-        assertTrue(stay.isDecisionTaken());
-        assertNull(stay.getNodeDecisions());
-        assertEquals(AllocationDecision.NO_ATTEMPT, stay.getAllocationDecision());
+        assertThrows(AssertionError.class, () -> MoveDecision.createRemainYesDecision(Decision.NO));
+        assertThrows(AssertionError.class, () -> MoveDecision.createRemainYesDecision(Decision.NOT_PREFERRED));
+        assertThrows(AssertionError.class, () -> MoveDecision.createRemainYesDecision(Decision.THROTTLE));
     }
 
     public void testDecisionWithNodeExplanations() {
         DiscoveryNode node1 = DiscoveryNodeUtils.builder("node1").roles(emptySet()).build();
         DiscoveryNode node2 = DiscoveryNodeUtils.builder("node2").roles(emptySet()).build();
-        Decision nodeDecision = randomFrom(Decision.NO, Decision.THROTTLE, Decision.YES);
+        Decision nodeDecision = randomFrom(Decision.NO, Decision.THROTTLE, Decision.YES, Decision.NOT_PREFERRED);
         List<NodeAllocationResult> nodeDecisions = new ArrayList<>();
         nodeDecisions.add(new NodeAllocationResult(node1, nodeDecision, 2));
         nodeDecisions.add(new NodeAllocationResult(node2, nodeDecision, 1));
@@ -101,7 +102,7 @@ public class MoveDecisionTests extends ESTestCase {
         nodeDecisions.add(
             new NodeAllocationResult(
                 node2,
-                finalDecision.allowed() ? Decision.YES : randomFrom(Decision.NO, Decision.THROTTLE, Decision.YES),
+                finalDecision.allowed() ? Decision.YES : randomFrom(Decision.NO, Decision.THROTTLE, Decision.YES, Decision.NOT_PREFERRED),
                 1
             )
         );


### PR DESCRIPTION
I suspect assertions could be added to `MoveDecision#rebalance` but I haven't taken a look at that code so far.