### PR TITLE
Fix dimension values aggregator

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -501,9 +501,6 @@ tests:
 - class: org.elasticsearch.readiness.ReadinessClusterIT
   method: testReadinessDuringRestartsNormalOrder
   issue: https://github.com/elastic/elasticsearch/issues/136955
-- class: org.elasticsearch.xpack.esql.expression.function.aggregate.DimensionValuesByteRefGroupingAggregatorFunctionTests
-  method: testSimple
-  issue: https://github.com/elastic/elasticsearch/issues/137378
 - class: org.elasticsearch.xpack.ilm.TimeSeriesDataStreamsIT
   method: testSearchableSnapshotAction
   issue: https://github.com/elastic/elasticsearch/issues/137167

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/DimensionValuesByteRefGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/DimensionValuesByteRefGroupingAggregatorFunction.java
@@ -237,16 +237,17 @@ public final class DimensionValuesByteRefGroupingAggregatorFunction implements G
     @Override
     public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
         int positionCount = selected.getPositionCount();
-        boolean allSelected = positionCount == maxGroupId + 1;
+        boolean allSelected = positionCount > maxGroupId;
         if (allSelected) {
             for (int i = 0; i < selected.getPositionCount(); i++) {
-                if (selected.getInt(i) == i) {
+                if (selected.getInt(i) != i) {
                     allSelected = false;
                     break;
                 }
             }
         }
         if (allSelected) {
+            fillNullsUpTo(positionCount);
             blocks[offset] = builder.build();
             return;
         }


### PR DESCRIPTION
This change fixes a mistake in the dimension values aggregator. The bug prevented the shortcut in production (not correctness issue) and caused incorrect results in tests when using a block hash that reserves 0 for nulls. This change corrects the issue and randomly uses two types of block hash in tests: one that reserves group 0 for nulls and one that does not.

Closes #137378