### PR TITLE
Stop using shortcuts in function_score YAML tests

### DIFF
--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/random_sampler.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/random_sampler.yml
@@ -158,7 +158,9 @@ setup:
           {
             "query": {
               "function_score": {
-                "random_score": {}
+                "functions": {
+                    "random_score": {}
+                }
               }
             },
             "aggs": {
@@ -183,7 +185,9 @@ setup:
           {
             "query": {
               "function_score": {
-                "random_score": {}
+                "functions": {
+                  "random_score": {}
+                }
               }
             },
             "aggs": {

--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/time_series.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/time_series.yml
@@ -161,10 +161,11 @@ setup:
         body:
           query:
             function_score:
-              field_value_factor:
-                field: "val"
-                factor: 0.1
-                missing: 1
+              functions:
+                field_value_factor:
+                  field: "val"
+                  factor: 0.1
+                  missing: 1
           size: 0
           min_score: 0.3
           aggs:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/610_function_score.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/610_function_score.yml
@@ -49,9 +49,11 @@
                   "text": "bar"
                 }
               },
-              "random_score": {
-                "seed": 10,
-                "field": "_seq_no"
+              "functions": {
+                "random_score": {
+                  "seed": 10,
+                  "field": "_seq_no"
+                }
               }
             }
 
@@ -70,9 +72,11 @@
                   "text": "bar"
                 }
               },
-              "random_score": {
-                "seed": 10,
-                "field": "uuid"
+              "functions": {
+                "random_score": {
+                  "seed": 10,
+                  "field": "_id"
+                }
               }
             }
 
@@ -132,8 +136,10 @@
                   "text": "bar"
                 }
               },
-              "random_score": {
-                "seed": 10
+              "functions": {
+                "random_score": {
+                  "seed": 10
+                }
               }
             }
   - length: { hits.hits: 2 }
@@ -172,11 +178,13 @@
               "query": {
                 "match_all": {}
               },
-              "field_value_factor": {
-                "field": "qty",
-                "factor": 1.2,
-                "missing": 1,
-                "modifier": "ln1p"
+              "functions": {
+                "field_value_factor": {
+                  "field": "qty",
+                  "factor": 1.2,
+                  "missing": 1,
+                  "modifier": "ln1p"
+                }
               }
             }
   - match: { status: 400 }


### PR DESCRIPTION
Those shortcuts are [not supported by the Elasticsearch specification](https://github.com/elastic/elasticsearch-specification/pull/2852#issuecomment-2383564729). This is a common source of issues for users:

 * https://github.com/elastic/elasticsearch-net/issues/6060
 * https://github.com/elastic/elasticsearch-java/issues/989
 * https://github.com/elastic/elasticsearch-net/issues/7410
 * https://github.com/elastic/elasticsearch-net/issues/8119
 * https://github.com/elastic/elasticsearch-java/issues/917
 * https://discuss.elastic.co/t/using-function-score-query-with-field-weighting-without-nest/369244
 * https://discuss.elastic.co/t/constructing-a-functionscorequery-using-nest/290251
 * https://discuss.elastic.co/t/using-function-score-query-with-field-weighting-without-nest/369244

I'm suggesting here that we stop documenting the "shortcut" version, where the function is inlined, and instead always recommend using "functions," which accepts a single object as well as an array.

What do you think?