### PR TITLE
Fix: ILMDownsampleDisruptionIT.testILMDownsampleRollingRestart

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -510,9 +510,6 @@ tests:
 - class: org.elasticsearch.xpack.security.CoreWithSecurityClientYamlTestSuiteIT
   method: test {yaml=indices.validate_query/20_query_string/validate_query with query_string parameters}
   issue: https://github.com/elastic/elasticsearch/issues/137391
-- class: org.elasticsearch.xpack.downsample.ILMDownsampleDisruptionIT
-  method: testILMDownsampleRollingRestart
-  issue: https://github.com/elastic/elasticsearch/issues/136585
 
 # Examples:
 #

--- a/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/ILMDownsampleDisruptionIT.java
+++ b/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/ILMDownsampleDisruptionIT.java
@@ -14,7 +14,6 @@ import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.elasticsearch.action.downsample.DownsampleConfig;
-import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
@@ -52,7 +51,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.core.Strings.format;
@@ -61,7 +59,6 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResp
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.xpack.core.rollup.ConfigTestHelpers.randomInterval;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.notNullValue;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0, numClientNodes = 4)
 public class ILMDownsampleDisruptionIT extends DownsamplingIntegTestCase {

--- a/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/ILMDownsampleDisruptionIT.java
+++ b/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/ILMDownsampleDisruptionIT.java
@@ -176,8 +176,7 @@ public class ILMDownsampleDisruptionIT extends DownsamplingIntegTestCase {
         // We assert that ILM successfully completed the phase
         logger.info("Waiting for ILM to complete the phase for index [{}]", targetIndex);
         ClusterServiceUtils.addTemporaryStateListener(clusterState -> {
-            IndexMetadata indexMetadata = getIndexMetadataByIndexName(clusterState, targetIndex);
-            // We expect a single project available in this cluster
+            IndexMetadata indexMetadata = clusterState.metadata().getProject().index(targetIndex);
             return indexMetadata.getLifecycleExecutionState() != null
                 && Objects.equals(indexMetadata.getLifecycleExecutionState().step(), PhaseCompleteStep.NAME);
         });
@@ -228,20 +227,5 @@ public class ILMDownsampleDisruptionIT extends DownsamplingIntegTestCase {
                 assertTrue(targetIndexSearch.getHits().getHits().length > 0);
             }
         );
-    }
-
-    /**
-     * We assume the index exists and its index name is unique.
-     * @return the index metadata found in any project that contains an index with this name.
-     */
-    private IndexMetadata getIndexMetadataByIndexName(ClusterState clusterState, String indexName) {
-        AtomicReference<IndexMetadata> indexMetadata = new AtomicReference<>();
-        clusterState.forEachProject(projectState -> {
-            if (projectState.metadata().hasIndex(indexName)) {
-                indexMetadata.set(projectState.metadata().index(indexName));
-            }
-        });
-        assertThat(indexMetadata.get(), notNullValue());
-        return indexMetadata.get();
     }
 }

--- a/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/ILMDownsampleDisruptionIT.java
+++ b/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/ILMDownsampleDisruptionIT.java
@@ -169,7 +169,7 @@ public class ILMDownsampleDisruptionIT extends DownsamplingIntegTestCase {
         startDownsampleTaskViaIlm(sourceIndex, targetIndex);
         assertBusy(() -> assertTargetIndex(cluster, targetIndex, indexedDocs));
         ensureGreen(targetIndex);
-        // We assert that ILM successfully completed the phase
+        // We wait for ILM to successfully complete the phase
         logger.info("Waiting for ILM to complete the phase for index [{}]", targetIndex);
         awaitClusterState(clusterState -> {
             IndexMetadata indexMetadata = clusterState.metadata().getProject().index(targetIndex);

--- a/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/ILMDownsampleDisruptionIT.java
+++ b/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/ILMDownsampleDisruptionIT.java
@@ -23,7 +23,6 @@ import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
-import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -172,7 +171,7 @@ public class ILMDownsampleDisruptionIT extends DownsamplingIntegTestCase {
         ensureGreen(targetIndex);
         // We assert that ILM successfully completed the phase
         logger.info("Waiting for ILM to complete the phase for index [{}]", targetIndex);
-        ClusterServiceUtils.addTemporaryStateListener(clusterState -> {
+        awaitClusterState(clusterState -> {
             IndexMetadata indexMetadata = clusterState.metadata().getProject().index(targetIndex);
             return indexMetadata.getLifecycleExecutionState() != null
                 && Objects.equals(indexMetadata.getLifecycleExecutionState().step(), PhaseCompleteStep.NAME);


### PR DESCRIPTION
This PR stabilises `testILMDownsampleRollingRestart` and closes #136585. 

This test started failing more often after https://github.com/elastic/elasticsearch/pull/135834 because this change increased the chance of manifesting https://github.com/elastic/elasticsearch/issues/137422.

To reduce this chance we wait for ILM to finish the phase before we end the test.

Closes #136585