### PR TITLE
Skip generation of stacktraces for APM spans.

### DIFF
--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/APMJvmOptions.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/APMJvmOptions.java
@@ -81,7 +81,10 @@ class APMJvmOptions {
         "metrics_interval", "120s",
         "breakdown_metrics", "false",
         "central_config", "false",
-        "transaction_sample_rate", "0.2"
+        "transaction_sample_rate", "0.2",
+        // Don't collect stacktraces for spans, typically these are of little use as
+        // always pointing to APMTracer.stopTrace invoked from TaskManager
+        "stack_trace_limit", "0"
         );
     // end::noformat
 


### PR DESCRIPTION
For ES, these stacktraces are generally of fairly little use as these would almost always point to APMTracer.stopTrace being called from TaskManager.unregister.

Because of above and as part of the effort to reduce costs of tracing and make it more lightweight, we should just not include stacktraces at all.

Relates to ES-12935