### PR TITLE
[9.1] [CI] Workaround for Windows packaging tests hang on uploading artifacts (#137206)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchBuildCompletePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchBuildCompletePlugin.java
@@ -44,6 +44,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
@@ -178,7 +179,11 @@ public abstract class ElasticsearchBuildCompletePlugin implements Plugin<Project
                     try {
                         // we are very generious here, as the upload can take
                         // a long time depending on its size
-                        pb.start().waitFor(30, java.util.concurrent.TimeUnit.MINUTES);
+                        long timeoutSec = calculateUploadWaitTimeoutSeconds(uploadFile);
+                        boolean completedInTime = pb.start().waitFor(timeoutSec, TimeUnit.SECONDS);
+                        if (completedInTime == false) {
+                            System.out.println("Timed out waiting for buildkite artifact upload after " + timeoutSec + " seconds");
+                        }
                     } catch (InterruptedException e) {
                         System.out.println("Failed to upload buildkite artifact " + e.getMessage());
                     }
@@ -277,6 +282,15 @@ public abstract class ElasticsearchBuildCompletePlugin implements Plugin<Project
         @NotNull
         private static String calculateArchivePath(Path path, Path projectPath) {
             return path.startsWith(projectPath) ? projectPath.relativize(path).toString() : path.getFileName().toString();
+        }
+
+        private static long calculateUploadWaitTimeoutSeconds(File file) {
+            long fileSizeBytes = file.length();
+            long fileSizeMB = fileSizeBytes / (1024 * 1024);
+
+            // Allocate 4 seconds per MB (assumes ~250 KB/s upload speed)
+            // with min 10 seconds and max 30 minutes
+            return Math.max(10, Math.min(1800, fileSizeMB * 4));
         }
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[CI] Workaround for Windows packaging tests hang on uploading artifacts (#137206)](https://github.com/elastic/elasticsearch/pull/137206)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)