### PR TITLE
[9.1] Fix race condition in async task reschedule test (#137405)

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/AbstractAsyncTaskTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/AbstractAsyncTaskTests.java
@@ -62,6 +62,8 @@ public class AbstractAsyncTaskTests extends ESTestCase {
                     logger.error("barrier1 interrupted", e);
                     fail("interrupted");
                 }
+                barrier1.reset();
+
                 count.incrementAndGet();
                 try {
                     barrier2.await();
@@ -69,6 +71,8 @@ public class AbstractAsyncTaskTests extends ESTestCase {
                     logger.error("barrier2 interrupted", e);
                     fail("interrupted");
                 }
+                barrier2.reset();
+
                 if (shouldRunThrowException) {
                     throw new RuntimeException("foo");
                 }
@@ -83,8 +87,8 @@ public class AbstractAsyncTaskTests extends ESTestCase {
         assertTrue(task.isScheduled());
         barrier2.await();
         assertEquals(1, count.get());
-        barrier1.reset();
-        barrier2.reset();
+
+        // wait for the rescheduled task to begin running
         barrier1.await();
         assertTrue(task.isScheduled());
         task.close();


### PR DESCRIPTION
Backports the following commits to 9.1:
 - Fix race condition in async task reschedule test (#137405)