### PR TITLE
[ML] Fix flaky ForecastIT#testOverflowToDisk

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -94,9 +94,6 @@ tests:
 - class: org.elasticsearch.smoketest.MlWithSecurityIT
   method: test {yaml=ml/sparse_vector_search/Test sparse_vector search with query vector and pruning config}
   issue: https://github.com/elastic/elasticsearch/issues/119548
-- class: org.elasticsearch.xpack.ml.integration.ForecastIT
-  method: testOverflowToDisk
-  issue: https://github.com/elastic/elasticsearch/issues/117740
 - class: org.elasticsearch.multi_cluster.MultiClusterYamlTestSuiteIT
   issue: https://github.com/elastic/elasticsearch/issues/119983
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT


### PR DESCRIPTION
What's going on:
- Forecasts start in SCHEDULED status, then transition to STARTED, then FINISHED
- The document may be indexed but not immediately searchable

Race condition:
- Document exists but is still SCHEDULED when first checked, and assertBusy may catch it in this state if the native process is slow to start
-  waitForecastToFinish may check before the document is indexed or searchable
- Document is indexed but not refreshed, so getForecastStats() doesn't find it initially

Hence, this PR mitigates the possible race condition by doing two things:
- Refresh the index before checking forecast stats to ensure recently indexed documents are visible.
- Modify waitForecastToFinish to first wait for document existence, then wait for FINISHED status.


Fixes [#117740](https://github.com/elastic/elasticsearch/issues/117740)