### PR TITLE
TransportClusterSearchShardsAction runs locally

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsRequest.java
@@ -9,22 +9,20 @@
 
 package org.elasticsearch.action.admin.cluster.shards;
 
-import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.master.MasterNodeReadRequest;
+import org.elasticsearch.action.support.local.LocalClusterStateRequest;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.core.UpdateForV10;
 
 import java.io.IOException;
 import java.util.Objects;
 
-public final class ClusterSearchShardsRequest extends MasterNodeReadRequest<ClusterSearchShardsRequest>
-    implements
-        IndicesRequest.Replaceable {
+public final class ClusterSearchShardsRequest extends LocalClusterStateRequest implements IndicesRequest.Replaceable {
 
     private String[] indices = Strings.EMPTY_ARRAY;
     @Nullable
@@ -38,26 +36,17 @@ public final class ClusterSearchShardsRequest extends MasterNodeReadRequest<Clus
         indices(indices);
     }
 
+    /**
+     * AP prior to 9.3 {@link TransportClusterSearchShardsAction} was a {@link TransportMasterNodeReadAction}
+     * so for BwC we must remain able to read these requests until we no longer need to support calling this action remotely.
+     */
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED_COORDINATION)
     public ClusterSearchShardsRequest(StreamInput in) throws IOException {
         super(in);
         indices = in.readStringArray();
         routing = in.readOptionalString();
         preference = in.readOptionalString();
         indicesOptions = IndicesOptions.readIndicesOptions(in);
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
-        out.writeStringArray(indices);
-        out.writeOptionalString(routing);
-        out.writeOptionalString(preference);
-        indicesOptions.writeIndicesOptions(out);
-    }
-
-    @Override
-    public ActionRequestValidationException validate() {
-        return null;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/TransportClusterSearchShardsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/TransportClusterSearchShardsAction.java
@@ -57,6 +57,7 @@ public class TransportClusterSearchShardsAction extends TransportLocalClusterSta
      * we no longer need to support calling this action remotely.
      */
     @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED_COORDINATION)
+    @SuppressWarnings("this-escape")
     @Inject
     public TransportClusterSearchShardsAction(
         TransportService transportService,

--- a/server/src/main/java/org/elasticsearch/action/search/SearchShardsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchShardsResponse.java
@@ -14,11 +14,14 @@ import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ResolvedIndexExpressions;
 import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsGroup;
 import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsResponse;
+import org.elasticsearch.action.admin.cluster.shards.TransportClusterSearchShardsAction;
+import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.UpdateForV10;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.search.internal.AliasFilter;
@@ -63,6 +66,11 @@ public final class SearchShardsResponse extends ActionResponse {
         this(groups, nodes, aliasFilters, null);
     }
 
+    /**
+     * AP prior to 9.3 {@link TransportClusterSearchShardsAction} was a {@link TransportMasterNodeReadAction}
+     * so for BwC we must remain able to read these responses until we no longer need to support calling this action remotely.
+     */
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED_COORDINATION)
     public SearchShardsResponse(StreamInput in) throws IOException {
         this.groups = in.readCollectionAsList(SearchShardsGroup::new);
         this.nodes = in.readCollectionAsList(DiscoveryNode::new);
@@ -74,6 +82,11 @@ public final class SearchShardsResponse extends ActionResponse {
         }
     }
 
+    /**
+     * AP prior to 9.3 {@link TransportClusterSearchShardsAction} was a {@link TransportMasterNodeReadAction}
+     * so for BwC we must remain able to write these responses until we no longer need to support calling this action remotely.
+     */
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED_COORDINATION)
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeCollection(groups);

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -1160,7 +1160,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                     ClusterSearchShardsRequest searchShardsRequest = new ClusterSearchShardsRequest(
                         MasterNodeRequest.INFINITE_MASTER_NODE_TIMEOUT,
                         indices
-                    ).indicesOptions(searchShardsIdxOpts).local(true).preference(preference).routing(routing);
+                    ).indicesOptions(searchShardsIdxOpts).preference(preference).routing(routing);
                     transportService.sendRequest(
                         connection,
                         TransportClusterSearchShardsAction.TYPE.name(),

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterSearchShardsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterSearchShardsAction.java
@@ -48,10 +48,10 @@ public class RestClusterSearchShardsAction extends BaseRestHandler {
             RestUtils.getMasterNodeTimeout(request),
             Strings.splitStringByCommaToArray(request.param("index"))
         );
-        clusterSearchShardsRequest.local(request.paramAsBoolean("local", clusterSearchShardsRequest.local()));
         clusterSearchShardsRequest.routing(request.param("routing"));
         clusterSearchShardsRequest.preference(request.param("preference"));
         clusterSearchShardsRequest.indicesOptions(IndicesOptions.fromRequest(request, clusterSearchShardsRequest.indicesOptions()));
+        RestUtils.consumeDeprecatedLocalParameter(request);
         return channel -> client.execute(
             TransportClusterSearchShardsAction.TYPE,
             clusterSearchShardsRequest,


### PR DESCRIPTION
This action only need cluster state and can be run any node. Make sure to keep necessary serialization and deserialization for BwC.

Relates https://github.com/elastic/elasticsearch/issues/101805