### PR TITLE
[ML] Fix mixed cluster tests where nodes action is not available

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -456,27 +456,12 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.BasicDistributedJobsIT
   method: testFailOverBasics
   issue: https://github.com/elastic/elasticsearch/issues/136778
-- class: org.elasticsearch.xpack.inference.qa.mixed.CohereServiceMixedIT
-  method: testRerank
-  issue: https://github.com/elastic/elasticsearch/issues/136872
-- class: org.elasticsearch.xpack.inference.qa.mixed.CohereServiceMixedIT
-  method: testCohereEmbeddings
-  issue: https://github.com/elastic/elasticsearch/issues/136779
 - class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
   method: testRemoteClusterOnlyCCSWithFailuresOnAllShards
   issue: https://github.com/elastic/elasticsearch/issues/136894
-- class: org.elasticsearch.xpack.esql.qa.mixed.FieldExtractorIT
-  method: testTextFieldWithIpSubfieldMalformed {STORED}
-  issue: https://github.com/elastic/elasticsearch/issues/136917
-- class: org.elasticsearch.xpack.esql.qa.mixed.FieldExtractorIT
-  method: testTextFieldWithKeywordSubfield {STORED}
-  issue: https://github.com/elastic/elasticsearch/issues/136918
 - class: org.elasticsearch.xpack.esql.optimizer.rules.logical.HoistRemoteEnrichTopNTests
   method: testTopNSortExpressionWithinRemoteEnrichAliasing
   issue: https://github.com/elastic/elasticsearch/issues/136957
-- class: org.elasticsearch.xpack.esql.qa.mixed.FieldExtractorIT
-  method: testByteFieldWithIntSubfieldTooBig {NONE}
-  issue: https://github.com/elastic/elasticsearch/issues/137034
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeMetricsIT
   method: test
   issue: https://github.com/elastic/elasticsearch/issues/137071

--- a/x-pack/plugin/ml/src/main/java/module-info.java
+++ b/x-pack/plugin/ml/src/main/java/module-info.java
@@ -32,6 +32,7 @@ module org.elasticsearch.ml {
     opens org.elasticsearch.xpack.ml to org.elasticsearch.painless.spi; // whitelist resource access
     opens org.elasticsearch.xpack.ml.utils; // for exact.properties access
 
+    provides org.elasticsearch.features.FeatureSpecification with org.elasticsearch.xpack.ml.MachineLearningFeatures;
     provides org.elasticsearch.painless.spi.PainlessExtension with org.elasticsearch.xpack.ml.MachineLearningPainlessExtension;
     provides org.elasticsearch.xpack.autoscaling.AutoscalingExtension with org.elasticsearch.xpack.ml.autoscaling.MlAutoscalingExtension;
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningFeatures.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningFeatures.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml;
+
+import org.elasticsearch.features.FeatureSpecification;
+import org.elasticsearch.features.NodeFeature;
+
+import java.util.Set;
+
+public class MachineLearningFeatures implements FeatureSpecification {
+
+    public static final NodeFeature COMPONENTS_RESET_ACTION = new NodeFeature("ml.components.reset");
+
+    public Set<NodeFeature> getFeatures() {
+        return Set.of(COMPONENTS_RESET_ACTION);
+    }
+}


### PR DESCRIPTION
The ML feature reset code calls uses the `TransportResetMlComponentsAction` to perform cleanup actions on every ml node. In a mixed cluster `TransportResetMlComponentsAction` is not available on every node which caused a fatal error taking down the test cluster. This has been failing pretty much all mixed version cluster tests if the newer node in the cluster executed the reset as the older node would not have the action.

```
fatal error java.lang.AssertionError: cluster:internal/xpack/ml/auditor/reset[n] 
```

The fix is to add a cluster feature and test for that before running the action. 
 
Closes #136872 #136779 #136917 #136918 #137034