### PR TITLE
ESQL: Extends constant MVs handling with warnings to general binary comparisons (#137387)

### DIFF
--- a/docs/changelog/137387.yaml
+++ b/docs/changelog/137387.yaml
@@ -1,0 +1,5 @@
+pr: 137387
+summary: Extends constant MVs handling with warnings to general binary comparisons
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/folding.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/folding.csv-spec
@@ -116,6 +116,19 @@ warning:Line 2:9: java.lang.IllegalArgumentException: single-value function enco
     is_rehired:boolean
 ;
 
+mvBoolean_NotEquals_MultiValueConstant
+required_capability: fix_mv_constant_equals_field
+
+FROM employees
+| WHERE is_rehired != ([true, false])
+| KEEP is_rehired
+;
+warning:Line 2:9: evaluation of [is_rehired != ([true, false])] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:9: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+    is_rehired:boolean
+;
+
 computedBoolean_Equals_MultiValueConstant
 required_capability: fix_mv_constant_equals_field
 
@@ -125,6 +138,20 @@ FROM employees
 | KEEP x
 ;
 warning:Line 3:9: evaluation of [x == [true, false]] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 3:9: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+    x:boolean
+;
+
+computedBoolean_NotEquals_MultiValueConstant
+required_capability: fix_mv_constant_comparison_field
+
+FROM employees
+| EVAL x = gender IS NULL
+| WHERE x != [true, false]
+| KEEP x
+;
+warning:Line 3:9: evaluation of [x != [true, false]] failed, treating result as null. Only first 20 failures recorded.
 warning:Line 3:9: java.lang.IllegalArgumentException: single-value function encountered multi-value
 
     x:boolean
@@ -169,3 +196,120 @@ warning:Line 2:9: java.lang.IllegalArgumentException: single-value function enco
 
     salary_change:double
 ;
+
+svDouble_NotEquals_MultiValueConstant
+required_capability: fix_mv_constant_comparison_field
+
+FROM employees
+| WHERE salary::double != [1,2,3]
+| KEEP salary
+;
+warning:Line 2:9: evaluation of [salary::double != [1,2,3]] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:9: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+    salary:integer
+;
+
+integer_GreaterThan_MultiValueConstant
+required_capability: fix_mv_constant_comparison_field
+
+FROM employees
+| WHERE salary > [1,2,3]
+| KEEP salary
+;
+warning:Line 2:9: evaluation of [salary > [1,2,3]] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:9: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+    salary:integer
+;
+
+keyword_GreaterThan_MultiValueConstant
+required_capability: fix_mv_constant_comparison_field
+
+FROM employees
+| WHERE first_name > ["A","B"]
+| KEEP first_name
+;
+warning:Line 2:9: evaluation of [first_name > [\"A\",\"B\"]] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:9: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+    first_name:keyword
+;
+
+dateNanos_GreaterThan_MultiValueConstant
+required_capability: fix_mv_constant_comparison_field
+
+FROM date_nanos
+| WHERE nanos > [1.0,2.0]::date_nanos
+;
+warning:Line 2:9: evaluation of [nanos > [1.0,2.0]::date_nanos] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:9: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+    millis:date     |     nanos:date_nanos     |      num:long      
+;
+
+long_GreaterThan_MultiValueConstant
+required_capability: fix_mv_constant_comparison_field
+
+FROM date_nanos
+| WHERE num > [1,2]
+;
+warning:Line 2:9: evaluation of [num > [1,2]] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:9: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+    millis:date     |     nanos:date_nanos     |      num:long      
+;
+
+version_GreaterThan_MultiValueConstant
+required_capability: fix_mv_constant_comparison_field
+
+FROM apps
+| WHERE version > to_ver(["1.2.3.4","127.0.0.1"])
+;
+warning:Line 2:9: evaluation of [version > to_ver([\"1.2.3.4\",\"127.0.0.1\"])] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:9: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+       id:i       |     name:s      |    version:v
+;    
+
+ip_GreaterThanOrLessThan_MultiValueConstant
+required_capability: fix_mv_constant_comparison_field
+
+from hosts
+| where ip1 > ["1.2.3.4","127.0.0.1"]::ip OR ip0 < to_ip(["1.2.3.4","127.0.0.1"])
+| keep ip1, ip0
+;
+warning:Line 2:9: evaluation of [ip1 > [\"1.2.3.4\",\"127.0.0.1\"]::ip] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:9: java.lang.IllegalArgumentException: single-value function encountered multi-value
+warning:Line 2:46: evaluation of [ip0 < to_ip([\"1.2.3.4\",\"127.0.0.1\"])] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:46: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+    ip1:ip     |     ip0:ip
+;
+
+ul_GreaterThan_MultiValueConstant
+required_capability: fix_mv_constant_comparison_field
+
+from ul_logs
+| where bytes_in > [16002960716282089759, 17281501450843634251]
+| keep bytes_in
+;
+warning:Line 2:9: evaluation of [bytes_in > [16002960716282089759, 17281501450843634251]] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:9: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+    bytes_in:ul
+;
+
+ul_NotEquals_MultiValueConstant
+required_capability: fix_mv_constant_comparison_field
+
+from ul_logs
+| where bytes_in != [16002960716282089759, 17281501450843634251]
+| keep bytes_in
+;
+warning:Line 2:9: evaluation of [bytes_in != [16002960716282089759, 17281501450843634251]] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:9: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+    bytes_in:ul
+;
+

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -2591,6 +2591,18 @@ warning:Line 2:9: java.lang.IllegalArgumentException: single-value function enco
     @timestamp:date     | message:text
 ;
 
+mvStringNotEqualsMultiValueConstant
+required_capability: fix_mv_constant_comparison_field
+FROM mv_text
+| WHERE message != ["Connected to 10.1.0.1", "Banana"]
+| KEEP @timestamp, message
+;
+warning:Line 2:9: evaluation of [message != [\"Connected to 10.1.0.1\", \"Banana\"]] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:9: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+    @timestamp:date     | message:text
+;
+
 mvString_IN_MultiValueConstant
 required_capability: fix_mv_constant_equals_field
 FROM mv_text
@@ -2622,6 +2634,18 @@ FROM employees
 | KEEP emp_no, job_positions
 ;
 warning:Line 2:9: evaluation of [job_positions == [\"Tech Lead\" , \"Data Scientist\", \"Senior Team Lead\"]] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:9: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+    emp_no:integer     | job_positions:keyword
+;
+
+mvKeywordNotEqualsMultiValueConstant
+required_capability: fix_mv_constant_comparison_field
+FROM employees
+| WHERE job_positions != ["Tech Lead" , "Data Scientist", "Senior Team Lead"]
+| KEEP emp_no, job_positions
+;
+warning:Line 2:9: evaluation of [job_positions != [\"Tech Lead\" , \"Data Scientist\", \"Senior Team Lead\"]] failed, treating result as null. Only first 20 failures recorded.
 warning:Line 2:9: java.lang.IllegalArgumentException: single-value function encountered multi-value
 
     emp_no:integer     | job_positions:keyword

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1651,6 +1651,7 @@ public class EsqlCapabilities {
          */
         FIX_REPLACE_ALIASING_EVAL_WITH_PROJECT_SHADOWING,
 
+        FIX_MV_CONSTANT_COMPARISON_FIELD,
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;


### PR DESCRIPTION
Backports https://github.com/elastic/elasticsearch/pull/137387.

(cherry picked from commit 5e35a4eb0e6e536e680e9c6ac79f4c3a9511134d)