### PR TITLE
[9.1] [Cyera] - Fix Cannot execute ILM policy delete step (#134894)

### DIFF
--- a/docs/changelog/134894.yml
+++ b/docs/changelog/134894.yml
@@ -1,0 +1,6 @@
+pr: 134894
+summary: "[Cyera] Add `manage`, `create_index`, `read`, `index`, `write`, `delete`, permission for third party agent indices `kibana_system`"
+area: Authorization
+type: enhancement
+issues:
+  - 134183

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -536,7 +536,7 @@ class KibanaOwnedReservedRoleDescriptors {
                         TransportDeleteIndexAction.TYPE.name()
                     )
                     .build(),
-                // For ExtraHop, QualysGAV, SentinelOne Application Dataset and Island Browser specific actions.
+                // For ExtraHop, QualysGAV, SentinelOne Application Dataset, Island Browser and Cyera specific actions.
                 // Kibana reads, writes and manages this index
                 // for configured ILM policies.
                 RoleDescriptor.IndicesPrivileges.builder()
@@ -545,7 +545,10 @@ class KibanaOwnedReservedRoleDescriptors {
                         "logs-qualys_gav.asset-*",
                         "logs-sentinel_one.application-*",
                         "logs-island_browser.user-*",
-                        "logs-island_browser.device-*"
+                        "logs-island_browser.device-*",
+                        "logs-cyera.classification-*",
+                        "logs-cyera.issue-*",
+                        "logs-cyera.datastore-*"
                     )
                     .privileges(
                         "manage",

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1915,7 +1915,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
             assertThat(kibanaRole.indices().allowedIndicesMatcher(RolloverAction.NAME).test(indexAbstraction), is(true));
         });
 
-        // Tests for third-party agent indices (ExtraHop, QualysGAV, SentinelOne, Island Browser) that `kibana_system`
+        // Tests for third-party agent indices (ExtraHop, QualysGAV, SentinelOne, Island Browser, Cyera) that `kibana_system`
         // has full management access to
         // This includes read, write, create, delete, and all ILM-related management actions.
         Arrays.asList(
@@ -1923,7 +1923,10 @@ public class ReservedRolesStoreTests extends ESTestCase {
             "logs-qualys_gav.asset-" + randomAlphaOfLength(randomIntBetween(1, 10)),
             "logs-sentinel_one.application-" + randomAlphaOfLength(randomIntBetween(1, 10)),
             "logs-island_browser.user-" + randomAlphaOfLength(randomIntBetween(1, 10)),
-            "logs-island_browser.device-" + randomAlphaOfLength(randomIntBetween(1, 10))
+            "logs-island_browser.device-" + randomAlphaOfLength(randomIntBetween(1, 10)),
+            "logs-cyera.classification-" + randomAlphaOfLength(randomIntBetween(1, 10)),
+            "logs-cyera.issue-" + randomAlphaOfLength(randomIntBetween(1, 10)),
+            "logs-cyera.datastore-" + randomAlphaOfLength(randomIntBetween(1, 10))
         ).forEach((index_qualys_extra_hop) -> {
             final IndexAbstraction indexAbstraction = mockIndexAbstraction(index_qualys_extra_hop);
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Cyera] - Fix Cannot execute ILM policy delete step (#134894)](https://github.com/elastic/elasticsearch/pull/134894)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)