### PR TITLE
Move `RegisteredPolicySnapshots` XContent registry entry to `ClusterModule`

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/ClusterModule.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterModule.java
@@ -412,6 +412,13 @@ public class ClusterModule extends AbstractModule {
                 StreamsMetadata::fromXContent
             )
         );
+        entries.add(
+            new NamedXContentRegistry.Entry(
+                Metadata.ProjectCustom.class,
+                new ParseField(RegisteredPolicySnapshots.TYPE),
+                RegisteredPolicySnapshots::parse
+            )
+        );
         return entries;
     }
 

--- a/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycle.java
+++ b/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycle.java
@@ -30,7 +30,6 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.reservedstate.ReservedClusterStateHandler;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestHandler;
-import org.elasticsearch.snapshots.RegisteredPolicySnapshots;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ParseField;
@@ -166,11 +165,6 @@ public class SnapshotLifecycle extends Plugin implements ActionPlugin, HealthPlu
                 Metadata.ProjectCustom.class,
                 new ParseField(SnapshotLifecycleMetadata.TYPE),
                 parser -> SnapshotLifecycleMetadata.PARSER.parse(parser, null)
-            ),
-            new NamedXContentRegistry.Entry(
-                Metadata.ProjectCustom.class,
-                new ParseField(RegisteredPolicySnapshots.TYPE),
-                RegisteredPolicySnapshots::parse
             )
         );
     }


### PR DESCRIPTION
This `ProjectCustom` class is currently registered as a writeable in `ClusterModule` and its XContent entry is registered in the SLM plugin. We use `RegisteredPolicySnapshots` in the `SnapshotsService`, so we should move its XContent entry to `ClusterModule` as well.

This avoids the following warning from showing up in some tests:
> Skipping unknown custom [ProjectCustom] object with type
registered_snapshots