### PR TITLE
[8.19] Error if installed plugin is inside plugins folder (#137398)

### DIFF
--- a/docs/changelog/137398.yaml
+++ b/docs/changelog/137398.yaml
@@ -1,0 +1,6 @@
+pr: 137398
+summary: Error if installed plugin is inside plugins folder
+area: Infra/Plugins
+type: enhancement
+issues:
+ - 27401


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Error if installed plugin is inside plugins folder (#137398)](https://github.com/elastic/elasticsearch/pull/137398)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)