### PR TITLE
Add note about response lifecycles in `SubscribableListener`

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/SubscribableListener.java
+++ b/server/src/main/java/org/elasticsearch/action/support/SubscribableListener.java
@@ -114,8 +114,7 @@ import java.util.concurrent.Executor;
  *     ... if {@code step1} sometimes completes quickly then it may complete {@code l1} before even invoking the {@link #andThen}, which
  *     could cause a use-after-release bug when combined with the usual refcounting discipline which releases a reference to the response
  *     after the waiting listener's {@link ActionListener#onResponse} returns. The caller must take steps to keep responses alive until
- *     they are no longer needed.
- *     </li>
+ *     they are no longer needed.</li>
  * </ul>
  */
 public class SubscribableListener<T> implements ActionListener<T> {

--- a/server/src/main/java/org/elasticsearch/action/support/SubscribableListener.java
+++ b/server/src/main/java/org/elasticsearch/action/support/SubscribableListener.java
@@ -112,7 +112,9 @@ import java.util.concurrent.Executor;
  *         SubscribableListener.newForked(l1 -> step1(l1)).andThen(l2 -> step2(l2))...
  *     }</pre>
  *     ... if {@code step1} sometimes completes quickly then it may complete {@code l1} before even invoking the {@link #andThen}, which
- *     could cause a use-after-release bug. The caller must take steps to keep responses alive until they are no longer needed.
+ *     could cause a use-after-release bug when combined with the usual refcounting discipline which releases a reference to the response
+ *     after the waiting listener's {@link ActionListener#onResponse} returns. The caller must take steps to keep responses alive until
+ *     they are no longer needed.
  *     </li>
  * </ul>
  */


### PR DESCRIPTION
It's not obvious from these docs that you have to do extra work if the
responses in the chain have nontrivial lifecycles. This commit adds some
docs to call this out.