### PR TITLE
rest-api-spec: fix type of enums

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/async_search.submit.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/async_search.submit.json
@@ -117,7 +117,7 @@
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.aliases.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.aliases.json
@@ -59,7 +59,7 @@
         "default": false
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.indices.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.indices.json
@@ -108,7 +108,7 @@
         "default": false
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segments.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segments.json
@@ -107,7 +107,7 @@
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified). Only allowed when providing an index expression."
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.health.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.health.json
@@ -35,7 +35,7 @@
     },
     "params": {
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.state.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.state.json
@@ -105,7 +105,7 @@
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/count.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/count.json
@@ -55,7 +55,7 @@
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
@@ -78,7 +78,7 @@
         "description": "What to do when the delete by query hits version conflicts?"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/eql.search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/eql.search.json
@@ -72,7 +72,7 @@
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/field_caps.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/field_caps.json
@@ -54,7 +54,7 @@
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.add_block.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.add_block.json
@@ -24,8 +24,14 @@
               "description": "A comma separated list of indices to add a block to"
             },
             "block": {
-              "type": "string",
-              "description": "The block to add (one of read, write, read_only or metadata)"
+              "type": "enum",
+              "description": "The block to add (one of read, write, read_only or metadata)",
+              "options": [
+                "metadata",
+                "read",
+                "read_only",
+                "write"
+              ]
             }
           }
         }
@@ -53,7 +59,7 @@
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.clear_cache.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.clear_cache.json
@@ -57,7 +57,7 @@
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.close.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.close.json
@@ -49,7 +49,7 @@
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete.json
@@ -49,7 +49,7 @@
         "description": "Ignore if a wildcard expression resolves to no concrete indices (default: false)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_data_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_data_lifecycle.json
@@ -29,7 +29,7 @@
     },
     "params": {
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_data_stream.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_data_stream.json
@@ -29,7 +29,7 @@
     },
     "params": {
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_data_stream_options.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_data_stream_options.json
@@ -29,7 +29,7 @@
     },
     "params": {
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.disk_usage.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.disk_usage.json
@@ -49,7 +49,7 @@
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists.json
@@ -44,7 +44,7 @@
         "description": "Ignore if a wildcard expression resolves to no concrete indices (default: false)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_alias.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_alias.json
@@ -55,7 +55,7 @@
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.field_usage_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.field_usage_stats.json
@@ -42,7 +42,7 @@
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.flush.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.flush.json
@@ -57,7 +57,7 @@
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.forcemerge.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.forcemerge.json
@@ -47,7 +47,7 @@
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get.json
@@ -44,7 +44,7 @@
         "description": "Ignore if a wildcard expression resolves to no concrete indices (default: false)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",
@@ -56,7 +56,7 @@
         "description": "Whether wildcard expressions should get expanded to open or closed indices (default: open)"
       },
       "features": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "aliases",
           "mappings",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_alias.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_alias.json
@@ -73,7 +73,7 @@
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_lifecycle.json
@@ -29,7 +29,7 @@
     },
     "params": {
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_stream.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_stream.json
@@ -35,7 +35,7 @@
     },
     "params": {
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_stream_options.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_stream_options.json
@@ -29,7 +29,7 @@
     },
     "params": {
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_field_mapping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_field_mapping.json
@@ -60,7 +60,7 @@
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_mapping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_mapping.json
@@ -45,7 +45,7 @@
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_settings.json
@@ -78,7 +78,7 @@
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.open.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.open.json
@@ -49,7 +49,7 @@
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_data_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_data_lifecycle.json
@@ -32,7 +32,7 @@
     },
     "params": {
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_data_stream_options.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_data_stream_options.json
@@ -32,7 +32,7 @@
     },
     "params": {
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_mapping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_mapping.json
@@ -53,7 +53,7 @@
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_settings.json
@@ -68,7 +68,7 @@
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.recovery.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.recovery.json
@@ -55,7 +55,7 @@
         "default": true
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.refresh.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.refresh.json
@@ -47,7 +47,7 @@
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.reload_search_analyzers.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.reload_search_analyzers.json
@@ -38,7 +38,7 @@
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.remove_block.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.remove_block.json
@@ -24,8 +24,14 @@
               "description": "A comma separated list of indices to remove a block from"
             },
             "block": {
-              "type": "string",
-              "description": "The block to remove (one of read, write, read_only or metadata)"
+              "type": "enum",
+              "description": "The block to remove (one of read, write, read_only or metadata)",
+              "options": [
+                "metadata",
+                "read",
+                "read_only",
+                "write"
+              ]
             }
           }
         }
@@ -53,7 +59,7 @@
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.resolve_cluster.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.resolve_cluster.json
@@ -50,7 +50,7 @@
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified). Only allowed when providing an index expression."
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.resolve_index.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.resolve_index.json
@@ -29,7 +29,7 @@
     },
     "params": {
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",
@@ -51,7 +51,7 @@
         "default": true
       },
       "mode": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "standard",
           "time_series",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.segments.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.segments.json
@@ -45,7 +45,7 @@
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.shard_stores.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.shard_stores.json
@@ -54,7 +54,7 @@
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.stats.json
@@ -135,7 +135,7 @@
         "default": false
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.validate_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.validate_query.json
@@ -55,7 +55,7 @@
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.delete.json
@@ -32,8 +32,15 @@
           ],
           "parts": {
             "task_type": {
-              "type": "string",
-              "description": "The task type"
+              "type": "enum",
+              "description": "The task type",
+              "options": [
+                "sparse_embedding",
+                "text_embedding",
+                "rerank",
+                "completion",
+                "chat_completion"
+              ]
             },
             "inference_id": {
               "type": "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.get.json
@@ -38,8 +38,15 @@
           ],
           "parts": {
             "task_type": {
-              "type": "string",
-              "description": "The task type"
+              "type": "enum",
+              "description": "The task type",
+              "options": [
+                "sparse_embedding",
+                "text_embedding",
+                "rerank",
+                "completion",
+                "chat_completion"
+              ]
             },
             "inference_id": {
               "type": "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.inference.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.inference.json
@@ -35,8 +35,15 @@
           ],
           "parts": {
             "task_type": {
-              "type": "string",
-              "description": "The task type"
+              "type": "enum",
+              "description": "The task type",
+              "options": [
+                "sparse_embedding",
+                "text_embedding",
+                "rerank",
+                "completion",
+                "chat_completion"
+              ]
             },
             "inference_id": {
               "type": "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put.json
@@ -35,8 +35,15 @@
           ],
           "parts": {
             "task_type": {
-              "type": "string",
-              "description": "The task type"
+              "type": "enum",
+              "description": "The task type",
+              "options": [
+                "sparse_embedding",
+                "text_embedding",
+                "rerank",
+                "completion",
+                "chat_completion"
+              ]
             },
             "inference_id": {
               "type": "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_ai21.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_ai21.json
@@ -23,8 +23,12 @@
           ],
           "parts": {
             "task_type": {
-              "type": "string",
-              "description": "The task type"
+              "type": "enum",
+              "description": "The task type",
+              "options": [
+                "completion",
+                "chat_completion"
+              ]
             },
             "ai21_inference_id": {
               "type": "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_alibabacloud.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_alibabacloud.json
@@ -23,8 +23,14 @@
           ],
           "parts": {
             "task_type": {
-              "type": "string",
-              "description": "The task type"
+              "type": "enum",
+              "description": "The task type",
+              "options": [
+                "completion",
+                "rerank",
+                "space_embedding",
+                "text_embedding"
+              ]
             },
             "alibabacloud_inference_id": {
               "type": "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_amazonbedrock.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_amazonbedrock.json
@@ -23,8 +23,12 @@
           ],
           "parts": {
             "task_type": {
-              "type": "string",
-              "description": "The task type"
+              "type": "enum",
+              "description": "The task type",
+              "options": [
+                "completion",
+                "text_embedding"
+              ]
             },
             "amazonbedrock_inference_id": {
               "type": "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_amazonsagemaker.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_amazonsagemaker.json
@@ -23,8 +23,15 @@
           ],
           "parts": {
             "task_type": {
-              "type": "string",
-              "description": "The task type"
+              "type": "enum",
+              "description": "The task type",
+              "options": [
+                "text_embedding",
+                "completion",
+                "chat_completion",
+                "sparse_embedding",
+                "rerank"
+              ]
             },
             "amazonsagemaker_inference_id": {
               "type": "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_anthropic.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_anthropic.json
@@ -23,8 +23,11 @@
           ],
           "parts": {
             "task_type": {
-              "type": "string",
-              "description": "The task type"
+              "type": "enum",
+              "description": "The task type",
+              "options": [
+                "completion"
+              ]
             },
             "anthropic_inference_id": {
               "type": "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_azureaistudio.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_azureaistudio.json
@@ -23,8 +23,13 @@
           ],
           "parts": {
             "task_type": {
-              "type": "string",
-              "description": "The task type"
+              "type": "enum",
+              "description": "The task type",
+              "options": [
+                "completion",
+                "rerank",
+                "text_embedding"
+              ]
             },
             "azureaistudio_inference_id": {
               "type": "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_azureopenai.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_azureopenai.json
@@ -23,8 +23,12 @@
           ],
           "parts": {
             "task_type": {
-              "type": "string",
-              "description": "The task type"
+              "type": "enum",
+              "description": "The task type",
+              "options": [
+                "completion",
+                "text_embedding"
+              ]
             },
             "azureopenai_inference_id": {
               "type": "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_cohere.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_cohere.json
@@ -23,8 +23,13 @@
           ],
           "parts": {
             "task_type": {
-              "type": "string",
-              "description": "The task type"
+              "type": "enum",
+              "description": "The task type",
+              "options": [
+                "completion",
+                "rerank",
+                "text_embedding"
+              ]
             },
             "cohere_inference_id": {
               "type": "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_contextualai.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_contextualai.json
@@ -23,8 +23,11 @@
           ],
           "parts": {
             "task_type": {
-              "type": "string",
-              "description": "The task type"
+              "type": "enum",
+              "description": "The task type",
+              "options": [
+                "rerank"
+              ]
             },
             "contextualai_inference_id": {
               "type": "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_custom.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_custom.json
@@ -23,8 +23,14 @@
           ],
           "parts": {
             "task_type": {
-              "type": "string",
-              "description": "The task type"
+              "type": "enum",
+              "description": "The task type",
+              "options": [
+                "text_embedding",
+                "sparse_embedding",
+                "rerank",
+                "completion"
+              ]
             },
             "custom_inference_id": {
               "type": "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_deepseek.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_deepseek.json
@@ -23,8 +23,12 @@
           ],
           "parts": {
             "task_type": {
-              "type": "string",
-              "description": "The task type"
+              "type": "enum",
+              "description": "The task type",
+              "options": [
+                "completion",
+                "chat_completion"
+              ]
             },
             "deepseek_inference_id": {
               "type": "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_elasticsearch.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_elasticsearch.json
@@ -23,8 +23,13 @@
           ],
           "parts": {
             "task_type": {
-              "type": "string",
-              "description": "The task type"
+              "type": "enum",
+              "description": "The task type",
+              "options": [
+                "rerank",
+                "sparse_embedding",
+                "text_embedding"
+              ]
             },
             "elasticsearch_inference_id": {
               "type": "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_elser.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_elser.json
@@ -27,8 +27,11 @@
           ],
           "parts": {
             "task_type": {
-              "type": "string",
-              "description": "The task type"
+              "type": "enum",
+              "description": "The task type",
+              "options": [
+                "sparse_embedding"
+              ]
             },
             "elser_inference_id": {
               "type": "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_googleaistudio.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_googleaistudio.json
@@ -23,8 +23,12 @@
           ],
           "parts": {
             "task_type": {
-              "type": "string",
-              "description": "The task type"
+              "type": "enum",
+              "description": "The task type",
+              "options": [
+                "completion",
+                "text_embedding"
+              ]
             },
             "googleaistudio_inference_id": {
               "type": "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_googlevertexai.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_googlevertexai.json
@@ -23,8 +23,14 @@
           ],
           "parts": {
             "task_type": {
-              "type": "string",
-              "description": "The task type"
+              "type": "enum",
+              "description": "The task type",
+              "options": [
+                "rerank",
+                "text_embedding",
+                "completion",
+                "chat_completion"
+              ]
             },
             "googlevertexai_inference_id": {
               "type": "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_hugging_face.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_hugging_face.json
@@ -23,8 +23,14 @@
           ],
           "parts": {
             "task_type": {
-              "type": "string",
-              "description": "The task type"
+              "type": "enum",
+              "description": "The task type",
+              "options": [
+                "chat_completion",
+                "completion",
+                "rerank",
+                "text_embedding"
+              ]
             },
             "huggingface_inference_id": {
               "type": "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_jinaai.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_jinaai.json
@@ -23,8 +23,12 @@
           ],
           "parts": {
             "task_type": {
-              "type": "string",
-              "description": "The task type"
+              "type": "enum",
+              "description": "The task type",
+              "options": [
+                "rerank",
+                "text_embedding"
+              ]
             },
             "jinaai_inference_id": {
               "type": "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_llama.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_llama.json
@@ -23,8 +23,13 @@
           ],
           "parts": {
             "task_type": {
-              "type": "string",
-              "description": "The task type"
+              "type": "enum",
+              "description": "The task type",
+              "options": [
+                "text_embedding",
+                "completion",
+                "chat_completion"
+              ]
             },
             "llama_inference_id": {
               "type": "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_mistral.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_mistral.json
@@ -23,8 +23,13 @@
           ],
           "parts": {
             "task_type": {
-              "type": "string",
-              "description": "The task type"
+              "type": "enum",
+              "description": "The task type",
+              "options": [
+                "text_embedding",
+                "completion",
+                "chat_completion"
+              ]
             },
             "mistral_inference_id": {
               "type": "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_openai.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_openai.json
@@ -23,8 +23,13 @@
           ],
           "parts": {
             "task_type": {
-              "type": "string",
-              "description": "The task type"
+              "type": "enum",
+              "description": "The task type",
+              "options": [
+                "chat_completion",
+                "completion",
+                "text_embedding"
+              ]
             },
             "openai_inference_id": {
               "type": "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_voyageai.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_voyageai.json
@@ -23,8 +23,12 @@
           ],
           "parts": {
             "task_type": {
-              "type": "string",
-              "description": "The task type"
+              "type": "enum",
+              "description": "The task type",
+              "options": [
+                "text_embedding",
+                "rerank"
+              ]
             },
             "voyageai_inference_id": {
               "type": "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_watsonx.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_watsonx.json
@@ -23,8 +23,13 @@
           ],
           "parts": {
             "task_type": {
-              "type": "string",
-              "description": "The task type"
+              "type": "enum",
+              "description": "The task type",
+              "options": [
+                "text_embedding",
+                "chat_completion",
+                "completion"
+              ]
             },
             "watsonx_inference_id": {
               "type": "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.update.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.update.json
@@ -35,8 +35,15 @@
           ],
           "parts": {
             "task_type": {
-              "type": "string",
-              "description": "The task type"
+              "type": "enum",
+              "description": "The task type",
+              "options": [
+                "sparse_embedding",
+                "text_embedding",
+                "rerank",
+                "completion",
+                "chat_completion"
+              ]
             },
             "inference_id": {
               "type": "string",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_datafeed.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_datafeed.json
@@ -51,7 +51,7 @@
         "description": "Ignore indices that are marked as throttled (default: true)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_job.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_job.json
@@ -47,7 +47,7 @@
         "description": "Ignore indices that are marked as throttled (default: true). Only set if datafeed_config is provided."
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.update_datafeed.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.update_datafeed.json
@@ -51,7 +51,7 @@
         "description": "Ignore indices that are marked as throttled (default: true)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/msearch.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/msearch.json
@@ -94,7 +94,7 @@
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/open_point_in_time.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/open_point_in_time.json
@@ -45,7 +45,7 @@
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/rank_eval.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/rank_eval.json
@@ -50,7 +50,7 @@
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
@@ -106,7 +106,7 @@
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.post_behavioral_analytics_event.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.post_behavioral_analytics_event.json
@@ -31,8 +31,13 @@
               "description": "The name of behavioral analytics collection"
             },
             "event_type": {
-              "type": "string",
-              "description": "Behavioral analytics event type. Available: page_view, search, search_click"
+              "type": "enum",
+              "description": "Behavioral analytics event type. Available: page_view, search, search_click",
+              "options": [
+                "page_view",
+                "search",
+                "search_click"
+              ]
             }
           }
         }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_shards.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_shards.json
@@ -60,7 +60,7 @@
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_template.json
@@ -55,7 +55,7 @@
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/searchable_snapshots.clear_cache.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/searchable_snapshots.clear_cache.json
@@ -43,7 +43,7 @@
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
@@ -78,7 +78,7 @@
         "description": "What to do when the update by query hits version conflicts?"
       },
       "expand_wildcards": {
-        "type": "enum",
+        "type": "list",
         "options": [
           "open",
           "closed",


### PR DESCRIPTION
Sometimes enums are comma-separated, in which cases they are lists with options. In other cases, they were specified as string without options, which was incorrect.