### PR TITLE
Use DV rewrites where possible in Keyword queries

### DIFF
--- a/docs/changelog/137536.yaml
+++ b/docs/changelog/137536.yaml
@@ -1,0 +1,5 @@
+pr: 137536
+summary: Use DV rewrites where possible in Keyword queries
+area: Search
+type: enhancement
+issues: []


### PR DESCRIPTION
Keyword automaton queries against doc-values-only fields can use standard MultiTermQuery
implementations with `DOC_VALUES_REWRITE` rewrite methods.  These should be
considerably faster and more efficient than the scripted query implementations.