### PR TITLE
ESQL: Fix PushQueryIt again

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -498,9 +498,6 @@ tests:
 - class: org.elasticsearch.smoketest.SmokeTestIngestWithAllDepsClientYamlTestSuiteIT
   method: test {yaml=ingest/100_sampling_with_reroute/Test get sample with multiple reroutes}
   issue: https://github.com/elastic/elasticsearch/issues/137457
-- class: org.elasticsearch.xpack.esql.qa.single_node.PushQueriesIT
-  method: testEqualityAndOther {SEMANTIC_TEXT_WITH_KEYWORD}
-  issue: https://github.com/elastic/elasticsearch/issues/137491
 - class: org.elasticsearch.xpack.ilm.CCRIndexLifecycleIT
   method: testBasicCCRAndILMIntegration {targetCluster=FOLLOWER}
   issue: https://github.com/elastic/elasticsearch/issues/137494

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/PushQueriesIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/PushQueriesIT.java
@@ -178,10 +178,11 @@ public class PushQueriesIT extends ESRestTestCase {
             case CONSTANT_KEYWORD, MATCH_ONLY_TEXT_WITH_KEYWORD -> List.of("*:*");
             case SEMANTIC_TEXT_WITH_KEYWORD ->
                 /*
-                 * single_value_match is here because there are extra documents hiding in the index
-                 * that don't have the `foo` field.
+                 * FieldExistsQuery is because there are extra documents hiding in the index
+                 * that don't have the `foo` field. "*:*" is because sometimes we end up on
+                 * a shard where all `foo = 1`.
                  */
-                List.of("FieldExistsQuery [field=foo]", "foo:[1 TO 1]");
+                List.of("FieldExistsQuery [field=foo]", "foo:[1 TO 1]", "*:*");
         };
         ComputeSignature dataNodeSignature = switch (type) {
             case AUTO, CONSTANT_KEYWORD, KEYWORD, TEXT_WITH_KEYWORD -> ComputeSignature.FILTER_IN_QUERY;


### PR DESCRIPTION
Allow for `*:*` in some cases. That's ok. We're filtering in the compute engine anyway.

Closes #137491
