### PR TITLE
Unmute GenerativeMetricsIT and add allowed error

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -447,9 +447,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.FieldExtractorIT
   method: testByteFieldWithIntSubfieldTooBig {NONE}
   issue: https://github.com/elastic/elasticsearch/issues/137034
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeMetricsIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/137071
 - class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
   method: testDatafeedTimingStats_DatafeedRecreated
   issue: https://github.com/elastic/elasticsearch/issues/137207

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
@@ -81,7 +81,8 @@ public abstract class GenerativeRestTest extends ESRestTestCase implements Query
         "time_series aggregate.* can only be used with the TS command",
         "implicit time-series aggregation function .* doesn't support type .*",
         "INLINE STATS .* can only be used after STATS when used with TS command",
-        "cannot group by a metric field .* in a time-series aggregation"
+        "cannot group by a metric field .* in a time-series aggregation",
+        "Output has changed from \\[.*\\] to \\[.*\\]" // https://github.com/elastic/elasticsearch/issues/134794
     );
 
     public static final Set<Pattern> ALLOWED_ERROR_PATTERNS = ALLOWED_ERRORS.stream()


### PR DESCRIPTION
This commit unmutes the GenerativeMetricsIT test and temporarily re-adds an error message to the list of allowed errors while we work on a better fix to the bug in the meanwhile.

Resolves https://github.com/elastic/elasticsearch/issues/137071
