### PR TITLE
rest-api-spec: fix more default values

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segments.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.segments.json
@@ -96,14 +96,17 @@
       },
       "ignore_unavailable": {
         "type": "boolean",
+        "default": false,
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed). Only allowed when providing an index expression."
       },
       "ignore_throttled": {
         "type": "boolean",
+        "default": false,
         "description": "Whether specified concrete, expanded or aliased indices should be ignored when throttled. Only allowed when providing an index expression."
       },
       "allow_no_indices": {
         "type": "boolean",
+        "default": true,
         "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified). Only allowed when providing an index expression."
       },
       "expand_wildcards": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.resolve_index.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.resolve_index.json
@@ -58,7 +58,6 @@
           "logsdb",
           "lookup"
         ],
-        "default": "",
         "description": "Filter indices by index mode. Comma-separated list of IndexMode. Empty means no filter."
       },
       "project_routing": {


### PR DESCRIPTION
I fixed default values before in https://github.com/elastic/elasticsearch/pull/136191 and others, but the specification keeps evolving.