### PR TITLE
rest-api-spec: fix documentation URLs

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/esql.get_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/esql.get_query.json
@@ -1,7 +1,7 @@
 {
   "esql.get_query": {
     "documentation": {
-      "url": null,
+      "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-esql-get-query",
       "description": "Get a specific running ES|QL query information"
     },
     "stability": "experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/esql.list_queries.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/esql.list_queries.json
@@ -1,7 +1,7 @@
 {
   "esql.list_queries": {
     "documentation": {
-      "url": null,
+      "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-esql-list-queries",
       "description": "Get running ES|QL queries information"
     },
     "stability": "experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.validate_detector.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.validate_detector.json
@@ -1,7 +1,7 @@
 {
   "ml.validate_detector": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/machine-learning/current/ml-jobs.html",
+      "url": null,
       "description": "Validate an anomaly detection job"
     },
     "stability": "stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/project.tags.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/project.tags.json
@@ -1,10 +1,10 @@
 {
   "project.tags": {
     "documentation": {
-      "url": null,
+      "url": "https://www.elastic.co/docs/api/doc/elasticsearch-serverless/operation/operation-project-tags",
       "description": "Return tags defined for the project"
     },
-    "stability": "experimental",
+    "stability": "stable",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/schema.json
+++ b/rest-api-spec/src/main/resources/schema.json
@@ -60,6 +60,9 @@
                     "properties": {
                       "stability": {
                         "const": "stable"
+                      },
+                      "visibility": {
+                        "const": "public"
                       }
                     }
                   },


### PR DESCRIPTION
This fixes some of the drift since I opened https://github.com/elastic/elasticsearch/pull/133386.