### PR TITLE
rest-api-spec: add missing expand_wildcards parameter

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.data_streams_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.data_streams_stats.json
@@ -32,6 +32,20 @@
           }
         }
       ]
+    },
+    "params": {
+      "expand_wildcards": {
+        "type": "list",
+        "description": "Whether to expand wildcard expressions to concrete data stream names that are open, closed or both.",
+        "default": "open,closed",
+        "options": [
+          "all",
+          "closed",
+          "hidden",
+          "none",
+          "open"
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
Implemented here: https://github.com/elastic/elasticsearch/blob/ffe6943bca6baf313d0347822b80d92fad6ab0e2/server/src/main/java/org/elasticsearch/action/datastreams/DataStreamsStatsAction.java#L46-L52