### PR TITLE
[9.1] rest-api-spec: add missing expand_wildcards parameter (#137561)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.data_streams_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.data_streams_stats.json
@@ -32,6 +32,20 @@
           }
         }
       ]
+    },
+    "params": {
+      "expand_wildcards": {
+        "type": "list",
+        "description": "Whether to expand wildcard expressions to concrete data stream names that are open, closed or both.",
+        "default": "open,closed",
+        "options": [
+          "all",
+          "closed",
+          "hidden",
+          "none",
+          "open"
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
Backports the following commits to 9.1:
 - rest-api-spec: add missing expand_wildcards parameter (#137561)