### PR TITLE
[GPU] Extend CuVSResourcesManager

### DIFF
--- a/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/codec/CuVSResourceManager.java
+++ b/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/codec/CuVSResourceManager.java
@@ -290,6 +290,7 @@ public interface CuVSResourceManager {
         }
 
         void unlock() {
+            unlockAction.run();
             unlockAction = NOT_LOCKED;
         }
 

--- a/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/codec/CuVSResourceManager.java
+++ b/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/codec/CuVSResourceManager.java
@@ -7,9 +7,9 @@
 
 package org.elasticsearch.xpack.gpu.codec;
 
+import com.nvidia.cuvs.CagraIndexParams;
 import com.nvidia.cuvs.CuVSMatrix;
 import com.nvidia.cuvs.CuVSResources;
-import com.nvidia.cuvs.GPUInfoProvider;
 import com.nvidia.cuvs.spi.CuVSProvider;
 
 import org.elasticsearch.core.Strings;
@@ -47,10 +47,12 @@ public interface CuVSResourceManager {
      * effect on GPU memory and compute usage to determine whether to give out
      * another resource or wait for a resources to be returned before giving out another.
      */
-    // numVectors and dims are currently unused, but could be used along with GPU metadata,
-    // memory, generation, etc, when acquiring for 10M x 1536 dims, or 100,000 x 128 dims,
-    // to give out a resources or not.
-    ManagedCuVSResources acquire(int numVectors, int dims, CuVSMatrix.DataType dataType) throws InterruptedException;
+    ManagedCuVSResources acquire(
+        int numVectors,
+        int dims,
+        CuVSMatrix.DataType dataType,
+        CagraIndexParams.CagraGraphBuildAlgo graphBuildAlgo
+    ) throws InterruptedException;
 
     /** Marks the resources as finished with regard to compute. */
     void finishedComputation(ManagedCuVSResources resources);
@@ -80,31 +82,31 @@ public interface CuVSResourceManager {
         static class Holder {
             static final PoolingCuVSResourceManager INSTANCE = new PoolingCuVSResourceManager(
                 MAX_RESOURCES,
-                CuVSProvider.provider().gpuInfoProvider()
+                new RealGPUMemoryService(CuVSProvider.provider().gpuInfoProvider())
             );
         }
 
         private final ManagedCuVSResources[] pool;
         private final int capacity;
-        private final GPUInfoProvider gpuInfoProvider;
+        private final GPUMemoryService gpuMemoryService;
         private int createdCount;
 
         ReentrantLock lock = new ReentrantLock();
         Condition enoughResourcesCondition = lock.newCondition();
 
-        public PoolingCuVSResourceManager(int capacity, GPUInfoProvider gpuInfoProvider) {
+        PoolingCuVSResourceManager(int capacity, GPUMemoryService gpuMemoryService) {
             if (capacity < 1 || capacity > MAX_RESOURCES) {
                 throw new IllegalArgumentException("Resource count must be between 1 and " + MAX_RESOURCES);
             }
             this.capacity = capacity;
-            this.gpuInfoProvider = gpuInfoProvider;
+            this.gpuMemoryService = gpuMemoryService;
             this.pool = new ManagedCuVSResources[MAX_RESOURCES];
         }
 
         private ManagedCuVSResources getResourceFromPool() {
             for (int i = 0; i < createdCount; ++i) {
                 var res = pool[i];
-                if (res.locked == false) {
+                if (res.isLocked() == false) {
                     return res;
                 }
             }
@@ -120,7 +122,7 @@ public interface CuVSResourceManager {
             int lockedResources = 0;
             for (int i = 0; i < createdCount; ++i) {
                 var res = pool[i];
-                if (res.locked) {
+                if (res.isLocked()) {
                     lockedResources++;
                 }
             }
@@ -128,35 +130,41 @@ public interface CuVSResourceManager {
         }
 
         @Override
-        public ManagedCuVSResources acquire(int numVectors, int dims, CuVSMatrix.DataType dataType) throws InterruptedException {
+        public ManagedCuVSResources acquire(
+            int numVectors,
+            int dims,
+            CuVSMatrix.DataType dataType,
+            CagraIndexParams.CagraGraphBuildAlgo graphBuildAlgo
+        ) throws InterruptedException {
             try {
                 var started = System.nanoTime();
                 lock.lock();
 
                 boolean allConditionsMet = false;
                 ManagedCuVSResources res = null;
+
+                long requiredMemoryInBytes = estimateRequiredMemory(numVectors, dims, dataType, graphBuildAlgo);
+                logger.debug(
+                    "Estimated memory for [{}] vectors, [{}] dims of type [{}] is [{} B]",
+                    numVectors,
+                    dims,
+                    dataType.name(),
+                    requiredMemoryInBytes
+                );
+
                 while (allConditionsMet == false) {
                     res = getResourceFromPool();
 
                     final boolean enoughMemory;
                     if (res != null) {
-                        long requiredMemoryInBytes = estimateRequiredMemory(numVectors, dims, dataType);
-                        logger.debug(
-                            "Estimated memory for [{}] vectors, [{}] dims of type [{}] is [{} B]",
-                            numVectors,
-                            dims,
-                            dataType.name(),
-                            requiredMemoryInBytes
-                        );
-
                         // Check immutable constraints
-                        long totalDeviceMemoryInBytes = gpuInfoProvider.getCurrentInfo(res).totalDeviceMemoryInBytes();
-                        if (requiredMemoryInBytes > totalDeviceMemoryInBytes) {
+                        long totalMemoryInBytes = gpuMemoryService.totalMemoryInBytes(res);
+                        if (requiredMemoryInBytes > totalMemoryInBytes) {
                             String message = Strings.format(
                                 "Requested GPU memory for [%d] vectors, [%d] dims is greater than the GPU total memory [%d B]",
                                 numVectors,
                                 dims,
-                                totalDeviceMemoryInBytes
+                                totalMemoryInBytes
                             );
                             logger.error(message);
                             throw new IllegalArgumentException(message);
@@ -169,9 +177,9 @@ public interface CuVSResourceManager {
                         }
 
                         // Check resources availability
-                        long freeDeviceMemoryInBytes = gpuInfoProvider.getCurrentInfo(res).freeDeviceMemoryInBytes();
-                        enoughMemory = requiredMemoryInBytes <= freeDeviceMemoryInBytes;
-                        logger.debug("Free device memory [{} B], enoughMemory[{}]", freeDeviceMemoryInBytes, enoughMemory);
+                        long availableMemoryInBytes = gpuMemoryService.availableMemoryInBytes(res);
+                        enoughMemory = requiredMemoryInBytes <= availableMemoryInBytes;
+                        logger.debug("Free device memory [{} B], enoughMemory[{}]", availableMemoryInBytes, enoughMemory);
                     } else {
                         logger.debug("No resources available in pool");
                         enoughMemory = false;
@@ -184,14 +192,20 @@ public interface CuVSResourceManager {
                 }
                 var elapsed = started - System.nanoTime();
                 logger.debug("Resource acquired in [{}ms]", elapsed / 1_000_000.0);
-                res.locked = true;
+                gpuMemoryService.reserveMemory(requiredMemoryInBytes);
+                res.lock(() -> gpuMemoryService.releaseMemory(requiredMemoryInBytes));
                 return res;
             } finally {
                 lock.unlock();
             }
         }
 
-        private long estimateRequiredMemory(int numVectors, int dims, CuVSMatrix.DataType dataType) {
+        private long estimateRequiredMemory(
+            int numVectors,
+            int dims,
+            CuVSMatrix.DataType dataType,
+            CagraIndexParams.CagraGraphBuildAlgo graphBuildAlgo
+        ) {
             int elementTypeBytes = switch (dataType) {
                 case FLOAT -> Float.BYTES;
                 case INT, UINT -> Integer.BYTES;
@@ -217,8 +231,8 @@ public interface CuVSResourceManager {
             logger.debug("Releasing resources to pool");
             try {
                 lock.lock();
-                assert resources.locked;
-                resources.locked = false;
+                assert resources.isLocked();
+                resources.unlock();
                 enoughResourcesCondition.signalAll();
             } finally {
                 lock.unlock();
@@ -238,8 +252,9 @@ public interface CuVSResourceManager {
     /** A managed resource. Cannot be closed. */
     final class ManagedCuVSResources implements CuVSResources {
 
-        final CuVSResources delegate;
-        boolean locked = false;
+        private final CuVSResources delegate;
+        private static final Runnable NOT_LOCKED = () -> {};
+        private Runnable unlockAction = NOT_LOCKED;
 
         ManagedCuVSResources(CuVSResources resources) {
             this.delegate = resources;
@@ -268,6 +283,18 @@ public interface CuVSResourceManager {
         @Override
         public String toString() {
             return "ManagedCuVSResources[delegate=" + delegate + "]";
+        }
+
+        void lock(Runnable unlockAction) {
+            this.unlockAction = unlockAction;
+        }
+
+        void unlock() {
+            unlockAction = NOT_LOCKED;
+        }
+
+        boolean isLocked() {
+            return unlockAction != NOT_LOCKED;
         }
     }
 }

--- a/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/codec/ES92GpuHnswVectorsWriter.java
+++ b/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/codec/ES92GpuHnswVectorsWriter.java
@@ -193,7 +193,12 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
                 try (
                     var resourcesHolder = new ResourcesHolder(
                         cuVSResourceManager,
-                        cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), CuVSMatrix.DataType.FLOAT)
+                        cuVSResourceManager.acquire(
+                            numVectors,
+                            fieldInfo.getVectorDimension(),
+                            CuVSMatrix.DataType.FLOAT,
+                            CagraIndexParams.CagraGraphBuildAlgo.NN_DESCENT
+                        )
                     )
                 ) {
                     var builder = CuVSMatrix.deviceBuilder(
@@ -533,7 +538,12 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
                         var dataset = DatasetUtilsImpl.fromMemorySegment(packedSegment, numVectors, packedRowSize, dataType);
                         var resourcesHolder = new ResourcesHolder(
                             cuVSResourceManager,
-                            cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), dataType)
+                            cuVSResourceManager.acquire(
+                                numVectors,
+                                fieldInfo.getVectorDimension(),
+                                dataType,
+                                CagraIndexParams.CagraGraphBuildAlgo.NN_DESCENT
+                            )
                         )
                     ) {
                         generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset);
@@ -557,7 +567,12 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
                     var dataset = builder.build();
                     var resourcesHolder = new ResourcesHolder(
                         cuVSResourceManager,
-                        cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), dataType)
+                        cuVSResourceManager.acquire(
+                            numVectors,
+                            fieldInfo.getVectorDimension(),
+                            dataType,
+                            CagraIndexParams.CagraGraphBuildAlgo.NN_DESCENT
+                        )
                     )
                 ) {
                     generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset);
@@ -578,7 +593,12 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
                 var dataset = builder.build();
                 var resourcesHolder = new ResourcesHolder(
                     cuVSResourceManager,
-                    cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), dataType)
+                    cuVSResourceManager.acquire(
+                        numVectors,
+                        fieldInfo.getVectorDimension(),
+                        dataType,
+                        CagraIndexParams.CagraGraphBuildAlgo.NN_DESCENT
+                    )
                 )
             ) {
                 generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset);
@@ -605,7 +625,12 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
                         .fromInput(memorySegmentAccessInput, numVectors, fieldInfo.getVectorDimension(), dataType);
                     var resourcesHolder = new ResourcesHolder(
                         cuVSResourceManager,
-                        cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), dataType)
+                        cuVSResourceManager.acquire(
+                            numVectors,
+                            fieldInfo.getVectorDimension(),
+                            dataType,
+                            CagraIndexParams.CagraGraphBuildAlgo.NN_DESCENT
+                        )
                     )
                 ) {
                     generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset);
@@ -628,7 +653,12 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
                     var dataset = builder.build();
                     var resourcesHolder = new ResourcesHolder(
                         cuVSResourceManager,
-                        cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), dataType)
+                        cuVSResourceManager.acquire(
+                            numVectors,
+                            fieldInfo.getVectorDimension(),
+                            dataType,
+                            CagraIndexParams.CagraGraphBuildAlgo.NN_DESCENT
+                        )
                     )
                 ) {
                     generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset);
@@ -650,7 +680,12 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
                 var dataset = builder.build();
                 var resourcesHolder = new ResourcesHolder(
                     cuVSResourceManager,
-                    cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), dataType)
+                    cuVSResourceManager.acquire(
+                        numVectors,
+                        fieldInfo.getVectorDimension(),
+                        dataType,
+                        CagraIndexParams.CagraGraphBuildAlgo.NN_DESCENT
+                    )
                 )
             ) {
                 generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset);

--- a/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/codec/ES92GpuHnswVectorsWriter.java
+++ b/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/codec/ES92GpuHnswVectorsWriter.java
@@ -178,6 +178,8 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
             var started = System.nanoTime();
             var fieldInfo = field.fieldInfo;
 
+            CagraIndexParams cagraIndexParams = createCagraIndexParams(fieldInfo.getVectorSimilarityFunction());
+
             var numVectors = field.flatFieldVectorsWriter.getVectors().size();
             if (numVectors < MIN_NUM_VECTORS_FOR_GPU_BUILD) {
                 if (logger.isDebugEnabled()) {
@@ -193,12 +195,7 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
                 try (
                     var resourcesHolder = new ResourcesHolder(
                         cuVSResourceManager,
-                        cuVSResourceManager.acquire(
-                            numVectors,
-                            fieldInfo.getVectorDimension(),
-                            CuVSMatrix.DataType.FLOAT,
-                            CagraIndexParams.CagraGraphBuildAlgo.NN_DESCENT
-                        )
+                        cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), CuVSMatrix.DataType.FLOAT, cagraIndexParams)
                     )
                 ) {
                     var builder = CuVSMatrix.deviceBuilder(
@@ -211,7 +208,7 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
                         builder.addVector(vector);
                     }
                     try (var dataset = builder.build()) {
-                        flushFieldWithGpuGraph(resourcesHolder, fieldInfo, dataset, sortMap);
+                        flushFieldWithGpuGraph(resourcesHolder, fieldInfo, dataset, sortMap, cagraIndexParams);
                     }
                 }
             }
@@ -229,13 +226,18 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
         }
     }
 
-    private void flushFieldWithGpuGraph(ResourcesHolder resourcesHolder, FieldInfo fieldInfo, CuVSMatrix dataset, Sorter.DocMap sortMap)
-        throws IOException {
+    private void flushFieldWithGpuGraph(
+        ResourcesHolder resourcesHolder,
+        FieldInfo fieldInfo,
+        CuVSMatrix dataset,
+        Sorter.DocMap sortMap,
+        CagraIndexParams cagraIndexParams
+    ) throws IOException {
         if (sortMap == null) {
-            generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset);
+            generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset, cagraIndexParams);
         } else {
             // TODO: use sortMap
-            generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset);
+            generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset, cagraIndexParams);
         }
     }
 
@@ -267,14 +269,19 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
         return total;
     }
 
-    private void generateGpuGraphAndWriteMeta(ResourcesHolder resourcesHolder, FieldInfo fieldInfo, CuVSMatrix dataset) throws IOException {
+    private void generateGpuGraphAndWriteMeta(
+        ResourcesHolder resourcesHolder,
+        FieldInfo fieldInfo,
+        CuVSMatrix dataset,
+        CagraIndexParams cagraIndexParams
+    ) throws IOException {
         try {
             assert dataset.size() >= MIN_NUM_VECTORS_FOR_GPU_BUILD;
 
             long vectorIndexOffset = vectorIndex.getFilePointer();
             int[][] graphLevelNodeOffsets = new int[1][];
             final HnswGraph graph;
-            try (var index = buildGPUIndex(resourcesHolder.resources(), fieldInfo.getVectorSimilarityFunction(), dataset)) {
+            try (var index = buildGPUIndex(resourcesHolder.resources(), cagraIndexParams, dataset)) {
                 assert index != null : "GPU index should be built for field: " + fieldInfo.name;
                 var deviceGraph = index.getGraph();
                 var graphSize = deviceGraph.size() * deviceGraph.columns() * Integer.BYTES;
@@ -314,9 +321,20 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
 
     private CagraIndex buildGPUIndex(
         CuVSResourceManager.ManagedCuVSResources cuVSResources,
-        VectorSimilarityFunction similarityFunction,
+        CagraIndexParams cagraIndexParams,
         CuVSMatrix dataset
     ) throws Throwable {
+        long startTime = System.nanoTime();
+        var indexBuilder = CagraIndex.newBuilder(cuVSResources).withDataset(dataset).withIndexParams(cagraIndexParams);
+        var index = indexBuilder.build();
+        cuVSResourceManager.finishedComputation(cuVSResources);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Carga index created in: {} ms; #num vectors: {}", (System.nanoTime() - startTime) / 1_000_000.0, dataset.size());
+        }
+        return index;
+    }
+
+    private CagraIndexParams createCagraIndexParams(VectorSimilarityFunction similarityFunction) {
         CagraIndexParams.CuvsDistanceType distanceType = switch (similarityFunction) {
             case COSINE -> CagraIndexParams.CuvsDistanceType.CosineExpanded;
             case EUCLIDEAN -> CagraIndexParams.CuvsDistanceType.L2Expanded;
@@ -333,22 +351,13 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
         };
 
         // TODO: expose cagra index params for algorithm, NNDescentNumIterations
-        CagraIndexParams params = new CagraIndexParams.Builder().withNumWriterThreads(1) // TODO: how many CPU threads we can use?
+        return new CagraIndexParams.Builder().withNumWriterThreads(1) // TODO: how many CPU threads we can use?
             .withCagraGraphBuildAlgo(CagraIndexParams.CagraGraphBuildAlgo.NN_DESCENT)
             .withGraphDegree(M)
             .withIntermediateGraphDegree(beamWidth)
             .withNNDescentNumIterations(5)
             .withMetric(distanceType)
             .build();
-
-        long startTime = System.nanoTime();
-        var indexBuilder = CagraIndex.newBuilder(cuVSResources).withDataset(dataset).withIndexParams(params);
-        var index = indexBuilder.build();
-        cuVSResourceManager.finishedComputation(cuVSResources);
-        if (logger.isDebugEnabled()) {
-            logger.debug("Carga index created in: {} ms; #num vectors: {}", (System.nanoTime() - startTime) / 1_000_000.0, dataset.size());
-        }
-        return index;
     }
 
     private HnswGraph writeGraph(CuVSMatrix cagraGraph, int[][] levelNodeOffsets) throws IOException {
@@ -505,6 +514,9 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
         var vectorValues = randomScorerSupplier == null
             ? null
             : VectorsFormatReflectionUtils.getByteScoringSupplierVectorOrNull(randomScorerSupplier);
+
+        CagraIndexParams cagraIndexParams = createCagraIndexParams(fieldInfo.getVectorSimilarityFunction());
+
         if (vectorValues != null) {
             IndexInput slice = vectorValues.getSlice();
             var input = FilterIndexInput.unwrapOnlyTest(slice);
@@ -538,15 +550,10 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
                         var dataset = DatasetUtilsImpl.fromMemorySegment(packedSegment, numVectors, packedRowSize, dataType);
                         var resourcesHolder = new ResourcesHolder(
                             cuVSResourceManager,
-                            cuVSResourceManager.acquire(
-                                numVectors,
-                                fieldInfo.getVectorDimension(),
-                                dataType,
-                                CagraIndexParams.CagraGraphBuildAlgo.NN_DESCENT
-                            )
+                            cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), dataType, cagraIndexParams)
                         )
                     ) {
-                        generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset);
+                        generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset, cagraIndexParams);
                     }
                 }
             } else {
@@ -567,15 +574,10 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
                     var dataset = builder.build();
                     var resourcesHolder = new ResourcesHolder(
                         cuVSResourceManager,
-                        cuVSResourceManager.acquire(
-                            numVectors,
-                            fieldInfo.getVectorDimension(),
-                            dataType,
-                            CagraIndexParams.CagraGraphBuildAlgo.NN_DESCENT
-                        )
+                        cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), dataType, cagraIndexParams)
                     )
                 ) {
-                    generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset);
+                    generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset, cagraIndexParams);
                 }
             }
         } else {
@@ -593,15 +595,10 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
                 var dataset = builder.build();
                 var resourcesHolder = new ResourcesHolder(
                     cuVSResourceManager,
-                    cuVSResourceManager.acquire(
-                        numVectors,
-                        fieldInfo.getVectorDimension(),
-                        dataType,
-                        CagraIndexParams.CagraGraphBuildAlgo.NN_DESCENT
-                    )
+                    cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), dataType, cagraIndexParams)
                 )
             ) {
-                generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset);
+                generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset, cagraIndexParams);
             }
         }
     }
@@ -615,6 +612,8 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
         var vectorValues = randomScorerSupplier == null
             ? null
             : VectorsFormatReflectionUtils.getFloatScoringSupplierVectorOrNull(randomScorerSupplier);
+        CagraIndexParams cagraIndexParams = createCagraIndexParams(fieldInfo.getVectorSimilarityFunction());
+
         if (vectorValues != null) {
             IndexInput slice = vectorValues.getSlice();
             var input = FilterIndexInput.unwrapOnlyTest(slice);
@@ -625,15 +624,10 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
                         .fromInput(memorySegmentAccessInput, numVectors, fieldInfo.getVectorDimension(), dataType);
                     var resourcesHolder = new ResourcesHolder(
                         cuVSResourceManager,
-                        cuVSResourceManager.acquire(
-                            numVectors,
-                            fieldInfo.getVectorDimension(),
-                            dataType,
-                            CagraIndexParams.CagraGraphBuildAlgo.NN_DESCENT
-                        )
+                        cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), dataType, cagraIndexParams)
                     )
                 ) {
-                    generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset);
+                    generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset, cagraIndexParams);
                 }
             } else {
                 logger.info(
@@ -653,15 +647,10 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
                     var dataset = builder.build();
                     var resourcesHolder = new ResourcesHolder(
                         cuVSResourceManager,
-                        cuVSResourceManager.acquire(
-                            numVectors,
-                            fieldInfo.getVectorDimension(),
-                            dataType,
-                            CagraIndexParams.CagraGraphBuildAlgo.NN_DESCENT
-                        )
+                        cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), dataType, cagraIndexParams)
                     )
                 ) {
-                    generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset);
+                    generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset, cagraIndexParams);
                 }
             }
         } else {
@@ -680,15 +669,10 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
                 var dataset = builder.build();
                 var resourcesHolder = new ResourcesHolder(
                     cuVSResourceManager,
-                    cuVSResourceManager.acquire(
-                        numVectors,
-                        fieldInfo.getVectorDimension(),
-                        dataType,
-                        CagraIndexParams.CagraGraphBuildAlgo.NN_DESCENT
-                    )
+                    cuVSResourceManager.acquire(numVectors, fieldInfo.getVectorDimension(), dataType, cagraIndexParams)
                 )
             ) {
-                generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset);
+                generateGpuGraphAndWriteMeta(resourcesHolder, fieldInfo, dataset, cagraIndexParams);
             }
         }
     }

--- a/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/codec/GPUMemoryService.java
+++ b/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/codec/GPUMemoryService.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.gpu.codec;
+
+import com.nvidia.cuvs.CuVSResources;
+
+interface GPUMemoryService {
+
+    long totalMemoryInBytes(CuVSResources res);
+
+    long availableMemoryInBytes(CuVSResources res);
+
+    void reserveMemory(long memoryInBytes);
+
+    void releaseMemory(long memoryInBytes);
+}

--- a/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/codec/GPUMemoryService.java
+++ b/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/codec/GPUMemoryService.java
@@ -9,6 +9,9 @@ package org.elasticsearch.xpack.gpu.codec;
 
 import com.nvidia.cuvs.CuVSResources;
 
+/**
+ * Abstracts GPU memory tracking (total vs available)
+ */
 interface GPUMemoryService {
 
     long totalMemoryInBytes(CuVSResources res);

--- a/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/codec/RealGPUMemoryService.java
+++ b/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/codec/RealGPUMemoryService.java
@@ -10,6 +10,10 @@ package org.elasticsearch.xpack.gpu.codec;
 import com.nvidia.cuvs.CuVSResources;
 import com.nvidia.cuvs.GPUInfoProvider;
 
+/**
+ * A {@link GPUMemoryService} that tracks how much memory is currently used/available on a GPU by using the GPU free/total memory APIs
+ * (via a {@link GPUInfoProvider})
+ */
 class RealGPUMemoryService implements GPUMemoryService {
     private final GPUInfoProvider gpuInfoProvider;
 

--- a/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/codec/RealGPUMemoryService.java
+++ b/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/codec/RealGPUMemoryService.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.gpu.codec;
+
+import com.nvidia.cuvs.CuVSResources;
+import com.nvidia.cuvs.GPUInfoProvider;
+
+class RealGPUMemoryService implements GPUMemoryService {
+    private final GPUInfoProvider gpuInfoProvider;
+
+    RealGPUMemoryService(GPUInfoProvider gpuInfoProvider) {
+        this.gpuInfoProvider = gpuInfoProvider;
+    }
+
+    @Override
+    public long totalMemoryInBytes(CuVSResources res) {
+        return gpuInfoProvider.getCurrentInfo(res).totalDeviceMemoryInBytes();
+    }
+
+    @Override
+    public long availableMemoryInBytes(CuVSResources res) {
+        return gpuInfoProvider.getCurrentInfo(res).freeDeviceMemoryInBytes();
+    }
+
+    @Override
+    public void reserveMemory(long memoryInBytes) {
+        // No-op
+    }
+
+    @Override
+    public void releaseMemory(long memoryInBytes) {
+        // No-op
+    }
+}

--- a/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/codec/TrackingGPUMemoryService.java
+++ b/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/codec/TrackingGPUMemoryService.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.gpu.codec;
+
+import com.nvidia.cuvs.CuVSResources;
+
+class TrackingGPUMemoryService implements GPUMemoryService {
+
+    private final long totalMemoryInBytes;
+    private long availableMemoryInBytes;
+
+    TrackingGPUMemoryService(long totalMemoryInBytes) {
+        this.totalMemoryInBytes = totalMemoryInBytes;
+        this.availableMemoryInBytes = totalMemoryInBytes;
+    }
+
+    @Override
+    public long totalMemoryInBytes(CuVSResources res) {
+        return totalMemoryInBytes;
+    }
+
+    @Override
+    public long availableMemoryInBytes(CuVSResources res) {
+        return availableMemoryInBytes;
+    }
+
+    @Override
+    public void reserveMemory(long memoryInBytes) {
+        availableMemoryInBytes -= memoryInBytes;
+    }
+
+    @Override
+    public void releaseMemory(long memoryInBytes) {
+        availableMemoryInBytes += memoryInBytes;
+    }
+}

--- a/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/codec/TrackingGPUMemoryService.java
+++ b/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/codec/TrackingGPUMemoryService.java
@@ -9,6 +9,12 @@ package org.elasticsearch.xpack.gpu.codec;
 
 import com.nvidia.cuvs.CuVSResources;
 
+/**
+ * A {@link GPUMemoryService} that tracks manually how much memory is currently estimated to be used/available on a GPU.
+ * This implementation is useful when we are not able to use a "Real memory" measurement; for example, if we are using pooled RMM memory,
+ * the pool will permanently occupy most of the GPU RAM, allocations will happen inside the pool, and the "Real memory" measurement API
+ * will always report a (tiny) fixed amount of free memory (whatever is not in the pool).
+ */
 class TrackingGPUMemoryService implements GPUMemoryService {
 
     private final long totalMemoryInBytes;


### PR DESCRIPTION
`CuVSResourcesManager` has the purpose of controlling access to resources to ensure a correct level of parallelism (allowing more than 1 GPU thread, but having a reasonable upper bound) and controlling the amount of GPU memory needed to prevent CUDA out-of-memory errors.

This PR extends the memory control part by introducing different strategies for memory accounting ("real", based on API calls to the device, and "tracking", which remembers the amount of memory requested during acquisition) and different estimations based on the CAGRA graph build algorithm. 

The former will allow us to use pooled memory (where the amount of available memory will be different from the free device memory), the latter to use the IVFPQ CAGRA graph build algorithm for larger datasets.