### PR TITLE
Revert "Re-enable some performance updates to ES|QL spec tests (#136781)

### DIFF
--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/MultiClusterSpecIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/MultiClusterSpecIT.java
@@ -15,7 +15,6 @@ import org.apache.http.HttpHost;
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
-import org.elasticsearch.client.ResponseListener;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.IOUtils;
@@ -39,8 +38,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -254,7 +251,10 @@ public class MultiClusterSpecIT extends EsqlSpecTestCase {
                     return bulkClient.performRequest(request);
                 } else {
                     Request[] clones = cloneRequests(request, 2);
-                    return runInParallel(localClient, remoteClient, clones);
+                    Response resp1 = remoteClient.performRequest(clones[0]);
+                    Response resp2 = localClient.performRequest(clones[1]);
+                    assertEquals(resp1.getStatusLine().getStatusCode(), resp2.getStatusLine().getStatusCode());
+                    return resp2;
                 }
         });
         doAnswer(invocation -> {
@@ -287,44 +287,6 @@ public class MultiClusterSpecIT extends EsqlSpecTestCase {
             }
         }
         return clones;
-    }
-
-    /**
-     * Run {@link #cloneRequests cloned} requests in parallel.
-     */
-    static Response runInParallel(RestClient localClient, RestClient remoteClient, Request[] clones) throws Throwable {
-        CompletableFuture<Response> remoteResponse = new CompletableFuture<>();
-        CompletableFuture<Response> localResponse = new CompletableFuture<>();
-        remoteClient.performRequestAsync(clones[0], new ResponseListener() {
-            @Override
-            public void onSuccess(Response response) {
-                remoteResponse.complete(response);
-            }
-
-            @Override
-            public void onFailure(Exception exception) {
-                remoteResponse.completeExceptionally(exception);
-            }
-        });
-        localClient.performRequestAsync(clones[1], new ResponseListener() {
-            @Override
-            public void onSuccess(Response response) {
-                localResponse.complete(response);
-            }
-
-            @Override
-            public void onFailure(Exception exception) {
-                localResponse.completeExceptionally(exception);
-            }
-        });
-        try {
-            Response remote = remoteResponse.get();
-            Response local = localResponse.get();
-            assertEquals(remote.getStatusLine().getStatusCode(), local.getStatusLine().getStatusCode());
-            return local;
-        } catch (ExecutionException e) {
-            throw e.getCause();
-        }
     }
 
     /**


### PR DESCRIPTION
This reverts commit 4d3e27f1958b915a0b512309be4966a4cb08586e.

Yesterday we merged two performance updates to ES|QL Spec tests that had been reverted two months back after noticing some increased test flakiness. However, we immediately saw increased failures due to one of them, so we reverted it. Having done that we continue to see other failures, that may or may not be related to the remaining performance update. This PR reverts that too.