### PR TITLE
Increase the number of buckets in the queue latency histogram

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/TaskExecutionTimeTrackingEsThreadPoolExecutor.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/TaskExecutionTimeTrackingEsThreadPoolExecutor.java
@@ -39,7 +39,8 @@ import static org.elasticsearch.threadpool.ThreadPool.THREAD_POOL_METRIC_NAME_UT
  * An extension to thread pool executor, which tracks statistics for the task execution time.
  */
 public final class TaskExecutionTimeTrackingEsThreadPoolExecutor extends EsThreadPoolExecutor {
-    public static final int QUEUE_LATENCY_HISTOGRAM_BUCKETS = 18;
+    // 20 buckets means the upper bound on the largest bound bucket will be 2^18 ~= 4 minutes 20 seconds
+    public static final int QUEUE_LATENCY_HISTOGRAM_BUCKETS = 20;
     private static final int[] LATENCY_PERCENTILES_TO_REPORT = { 50, 90, 99 };
 
     private final Function<Runnable, WrappedRunnable> runnableWrapper;

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/TaskExecutionTimeTrackingEsThreadPoolExecutor.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/TaskExecutionTimeTrackingEsThreadPoolExecutor.java
@@ -39,7 +39,7 @@ import static org.elasticsearch.threadpool.ThreadPool.THREAD_POOL_METRIC_NAME_UT
  * An extension to thread pool executor, which tracks statistics for the task execution time.
  */
 public final class TaskExecutionTimeTrackingEsThreadPoolExecutor extends EsThreadPoolExecutor {
-    // 20 buckets means the upper bound on the largest bound bucket will be 2^18 ~= 4 minutes 20 seconds
+    // 20 buckets means the upper bound on the largest bound bucket will be 2^18 ms (~= 4 minutes 20 seconds)
     public static final int QUEUE_LATENCY_HISTOGRAM_BUCKETS = 20;
     private static final int[] LATENCY_PERCENTILES_TO_REPORT = { 50, 90, 99 };
 


### PR DESCRIPTION
Previously the queue latency histogram had 18 buckets, which meant any percentile over ~65s would be calculated as `Long.MAX_VALUE` ms (292,471,208 years).

This change adds two more buckets to the histogram allowing us to represent values up to ~ 4 minutes 20 seconds, hopefully covering the vast majority of queue latencies we're likely to see.