### PR TITLE
[9.2] rest-api-spec: add missing timeout to Inference APIs (#137563)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.chat_completion_unified.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.chat_completion_unified.json
@@ -33,6 +33,13 @@
     "body": {
       "description": "The inference payload",
       "required": true
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference request to complete.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.completion.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.completion.json
@@ -33,6 +33,13 @@
     "body": {
       "description": "The inference payload",
       "required": true
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference request to complete.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.inference.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.inference.json
@@ -49,6 +49,13 @@
     "body": {
       "description": "The inference payload",
       "required": true
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "The amount of time to wait for the inference request to complete.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put.json
@@ -49,6 +49,13 @@
     "body": {
       "description": "The inference endpoint's task and service settings",
       "required": true
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_ai21.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_ai21.json
@@ -37,6 +37,13 @@
     "body": {
       "description": "The inference endpoint's task and service settings",
       "required": true
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_alibabacloud.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_alibabacloud.json
@@ -37,6 +37,13 @@
     "body": {
       "description": "The inference endpoint's task and service settings",
       "required": true
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_amazonbedrock.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_amazonbedrock.json
@@ -37,6 +37,13 @@
     "body": {
       "description": "The inference endpoint's task and service settings",
       "required": true
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_amazonsagemaker.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_amazonsagemaker.json
@@ -37,6 +37,13 @@
     "body": {
       "description": "The inference endpoint's task and service settings",
       "required": true
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_anthropic.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_anthropic.json
@@ -37,6 +37,13 @@
     "body": {
       "description": "The inference endpoint's task and service settings",
       "required": true
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_azureaistudio.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_azureaistudio.json
@@ -37,6 +37,13 @@
     "body": {
       "description": "The inference endpoint's task and service settings",
       "required": true
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_azureopenai.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_azureopenai.json
@@ -37,6 +37,13 @@
     "body": {
       "description": "The inference endpoint's task and service settings",
       "required": true
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_cohere.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_cohere.json
@@ -37,6 +37,13 @@
     "body": {
       "description": "The inference endpoint's task and service settings",
       "required": true
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_contextualai.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_contextualai.json
@@ -37,6 +37,13 @@
     "body": {
       "description": "The inference endpoint's task and service settings",
       "required": true
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_deepseek.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_deepseek.json
@@ -37,6 +37,13 @@
     "body": {
       "description": "The inference endpoint's task and service settings",
       "required": true
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_elasticsearch.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_elasticsearch.json
@@ -37,6 +37,13 @@
     "body": {
       "description": "The inference endpoint's task and service settings",
       "required": true
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_elser.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_elser.json
@@ -41,6 +41,13 @@
     "body": {
       "description": "The inference endpoint's task and service settings",
       "required": true
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_googleaistudio.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_googleaistudio.json
@@ -37,6 +37,13 @@
     "body": {
       "description": "The inference endpoint's task and service settings",
       "required": true
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_googlevertexai.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_googlevertexai.json
@@ -37,6 +37,13 @@
     "body": {
       "description": "The inference endpoint's task and service settings",
       "required": true
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_hugging_face.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_hugging_face.json
@@ -37,6 +37,13 @@
     "body": {
       "description": "The inference endpoint's task and service settings",
       "required": true
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_jinaai.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_jinaai.json
@@ -37,6 +37,13 @@
     "body": {
       "description": "The inference endpoint's task and service settings",
       "required": true
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_llama.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_llama.json
@@ -37,6 +37,13 @@
     "body": {
       "description": "The inference endpoint's task and service settings",
       "required": true
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_mistral.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_mistral.json
@@ -37,6 +37,13 @@
     "body": {
       "description": "The inference endpoint's task and service settings",
       "required": true
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_openai.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_openai.json
@@ -37,6 +37,13 @@
     "body": {
       "description": "The inference endpoint's task and service settings",
       "required": true
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_voyageai.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_voyageai.json
@@ -37,6 +37,13 @@
     "body": {
       "description": "The inference endpoint's task and service settings",
       "required": true
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_watsonx.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_watsonx.json
@@ -37,6 +37,13 @@
     "body": {
       "description": "The inference endpoint's task and service settings",
       "required": true
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.rerank.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.rerank.json
@@ -33,6 +33,13 @@
     "body": {
       "description": "The inference payload",
       "required": true
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "The amount of time to wait for the inference request to complete.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.sparse_embedding.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.sparse_embedding.json
@@ -33,6 +33,13 @@
     "body": {
       "description": "The inference payload",
       "required": true
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference request to complete.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.stream_completion.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.stream_completion.json
@@ -33,6 +33,13 @@
     "body": {
       "description": "The inference payload",
       "required": true
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "The amount of time to wait for the inference request to complete.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.text_embedding.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.text_embedding.json
@@ -33,6 +33,13 @@
     "body": {
       "description": "The inference payload",
       "required": true
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference request to complete.",
+        "default": "30s"
+      }
     }
   }
 }


### PR DESCRIPTION
Backports the following commits to 9.2:
 - rest-api-spec: add missing timeout to Inference APIs (#137563)