### PR TITLE
[9.1] rest-api-spec: add missing timeout to Inference APIs (#137563)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.chat_completion_unified.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.chat_completion_unified.json
@@ -32,6 +32,13 @@
     },
     "body": {
       "description": "The inference payload"
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference request to complete.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.completion.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.completion.json
@@ -32,6 +32,13 @@
     },
     "body": {
       "description": "The inference payload"
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference request to complete.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.inference.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.inference.json
@@ -48,6 +48,13 @@
     },
     "body": {
       "description": "The inference payload"
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "The amount of time to wait for the inference request to complete.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put.json
@@ -48,6 +48,13 @@
     },
     "body": {
       "description": "The inference endpoint's task and service settings"
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_alibabacloud.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_alibabacloud.json
@@ -36,6 +36,13 @@
     },
     "body": {
       "description": "The inference endpoint's task and service settings"
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_amazonbedrock.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_amazonbedrock.json
@@ -36,6 +36,13 @@
     },
     "body": {
       "description": "The inference endpoint's task and service settings"
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_amazonsagemaker.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_amazonsagemaker.json
@@ -36,6 +36,13 @@
     },
     "body": {
       "description": "The inference endpoint's task and service settings"
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_anthropic.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_anthropic.json
@@ -36,6 +36,13 @@
     },
     "body": {
       "description": "The inference endpoint's task and service settings"
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_azureaistudio.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_azureaistudio.json
@@ -36,6 +36,13 @@
     },
     "body": {
       "description": "The inference endpoint's task and service settings"
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_azureopenai.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_azureopenai.json
@@ -36,6 +36,13 @@
     },
     "body": {
       "description": "The inference endpoint's task and service settings"
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_cohere.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_cohere.json
@@ -36,6 +36,13 @@
     },
     "body": {
       "description": "The inference endpoint's task and service settings"
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_deepseek.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_deepseek.json
@@ -36,6 +36,13 @@
     },
     "body": {
       "description": "The inference endpoint's task and service settings"
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_elasticsearch.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_elasticsearch.json
@@ -36,6 +36,13 @@
     },
     "body": {
       "description": "The inference endpoint's task and service settings"
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_elser.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_elser.json
@@ -40,6 +40,13 @@
     },
     "body": {
       "description": "The inference endpoint's task and service settings"
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_googleaistudio.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_googleaistudio.json
@@ -36,6 +36,13 @@
     },
     "body": {
       "description": "The inference endpoint's task and service settings"
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_googlevertexai.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_googlevertexai.json
@@ -36,6 +36,13 @@
     },
     "body": {
       "description": "The inference endpoint's task and service settings"
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_hugging_face.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_hugging_face.json
@@ -36,6 +36,13 @@
     },
     "body": {
       "description": "The inference endpoint's task and service settings"
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_jinaai.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_jinaai.json
@@ -36,6 +36,13 @@
     },
     "body": {
       "description": "The inference endpoint's task and service settings"
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_mistral.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_mistral.json
@@ -36,6 +36,13 @@
     },
     "body": {
       "description": "The inference endpoint's task and service settings"
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_openai.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_openai.json
@@ -36,6 +36,13 @@
     },
     "body": {
       "description": "The inference endpoint's task and service settings"
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_voyageai.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_voyageai.json
@@ -36,6 +36,13 @@
     },
     "body": {
       "description": "The inference endpoint's task and service settings"
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_watsonx.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_watsonx.json
@@ -36,6 +36,13 @@
     },
     "body": {
       "description": "The inference endpoint's task and service settings"
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.rerank.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.rerank.json
@@ -32,6 +32,13 @@
     },
     "body": {
       "description": "The inference payload"
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "The amount of time to wait for the inference request to complete.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.sparse_embedding.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.sparse_embedding.json
@@ -32,6 +32,13 @@
     },
     "body": {
       "description": "The inference payload"
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference request to complete.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.stream_completion.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.stream_completion.json
@@ -32,6 +32,13 @@
     },
     "body": {
       "description": "The inference payload"
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "The amount of time to wait for the inference request to complete.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.text_embedding.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.text_embedding.json
@@ -32,6 +32,13 @@
     },
     "body": {
       "description": "The inference payload"
+    },
+    "params": {
+      "timeout": {
+        "type": "time",
+        "description": "Specifies the amount of time to wait for the inference request to complete.",
+        "default": "30s"
+      }
     }
   }
 }


### PR DESCRIPTION
Backports https://github.com/elastic/elasticsearch/pull/137563