### PR TITLE
[8.19] rest-api-spec: fix documentation URLs (#137559)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.validate_detector.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.validate_detector.json
@@ -1,7 +1,7 @@
 {
   "ml.validate_detector": {
     "documentation": {
-      "url": "https://www.elastic.co/docs/api/doc/elasticsearch/v8",
+      "url": null,
       "description": "Validate an anomaly detection job"
     },
     "stability": "stable",

--- a/rest-api-spec/src/main/resources/schema.json
+++ b/rest-api-spec/src/main/resources/schema.json
@@ -60,6 +60,9 @@
                     "properties": {
                       "stability": {
                         "const": "stable"
+                      },
+                      "visibility": {
+                        "const": "public"
                       }
                     }
                   },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [rest-api-spec: fix documentation URLs (#137559)](https://github.com/elastic/elasticsearch/pull/137559)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)