### PR TITLE
[9.1] rest-api-spec: fix documentation URLs (#137559)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/esql.get_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/esql.get_query.json
@@ -1,7 +1,7 @@
 {
   "esql.get_query": {
     "documentation": {
-      "url": null,
+      "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-esql-get-query",
       "description": "Get a specific running ES|QL query information"
     },
     "stability": "experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/esql.list_queries.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/esql.list_queries.json
@@ -1,7 +1,7 @@
 {
   "esql.list_queries": {
     "documentation": {
-      "url": null,
+      "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-esql-list-queries",
       "description": "Get running ES|QL queries information"
     },
     "stability": "experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.validate_detector.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.validate_detector.json
@@ -1,7 +1,7 @@
 {
   "ml.validate_detector": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/machine-learning/current/ml-jobs.html",
+      "url": null,
       "description": "Validate an anomaly detection job"
     },
     "stability": "stable",

--- a/rest-api-spec/src/main/resources/schema.json
+++ b/rest-api-spec/src/main/resources/schema.json
@@ -60,6 +60,9 @@
                     "properties": {
                       "stability": {
                         "const": "stable"
+                      },
+                      "visibility": {
+                        "const": "public"
                       }
                     }
                   },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [rest-api-spec: fix documentation URLs (#137559)](https://github.com/elastic/elasticsearch/pull/137559)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)