### PR TITLE
rest-api-spec: fix and expand deprecation information

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/clear_scroll.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/clear_scroll.json
@@ -32,7 +32,9 @@
             "scroll_id": {
               "type": "list",
               "description": "A comma-separated list of scroll IDs to clear",
-              "deprecated": true
+              "deprecated": {
+                "version": "7.0.0"
+              }
             }
           },
           "deprecated": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/clear_scroll.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/clear_scroll.json
@@ -33,7 +33,8 @@
               "type": "list",
               "description": "A comma-separated list of scroll IDs to clear",
               "deprecated": {
-                "version": "7.0.0"
+                "version": "7.0.0",
+                "description": "A scroll id can be quite large and should be specified as part of the body"
               }
             }
           },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.exists_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.exists_component_template.json
@@ -34,7 +34,10 @@
         "description": "Timeout for waiting for new cluster state in case it is blocked"
       },
       "local": {
-        "deprecated": true,
+        "deprecated": {
+          "version": "9.0.0",
+          "description": "This parameter has no effect, is now deprecated, and will be removed in a future version."
+        },
         "type": "boolean",
         "default": false,
         "description": "Return local information, do not retrieve the state from master node (default: false)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_component_template.json
@@ -40,7 +40,10 @@
         "description": "Timeout for waiting for new cluster state in case it is blocked"
       },
       "local": {
-        "deprecated": true,
+        "deprecated": {
+          "version": "9.0.0",
+          "description": "This parameter has no effect, is now deprecated, and will be removed in a future version."
+        },
         "type": "boolean",
         "default": false,
         "description": "Return local information, do not retrieve the state from master node (default: false)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.state.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.state.json
@@ -71,7 +71,10 @@
     },
     "params": {
       "local": {
-        "deprecated": true,
+        "deprecated": {
+          "version": "9.0.0",
+          "description": "This parameter has no effect, is now deprecated, and will be removed in a future version."
+        },
         "type": "boolean",
         "default": false,
         "description": "Return local information, do not retrieve the state from master node (default: false)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/count.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/count.json
@@ -46,7 +46,8 @@
       },
       "ignore_throttled": {
         "deprecated": {
-          "version": "7.16.0"
+          "version": "7.16.0",
+          "description": "This parameter is deprecated because frozen indices have been deprecated."
         },
         "type": "boolean",
         "default": true,

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/count.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/count.json
@@ -45,6 +45,9 @@
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "ignore_throttled": {
+        "deprecated": {
+          "version": "7.16.0"
+        },
         "type": "boolean",
         "default": true,
         "description": "Whether specified concrete, expanded or aliased indices should be ignored when throttled"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
@@ -127,6 +127,10 @@
         "description": "Maximum number of documents to process (default: all documents)"
       },
       "sort": {
+        "deprecated": {
+          "version": "9.0.0",
+          "description": "This query parameter is not supported and will be removed in a future version"
+        },
         "type": "list",
         "description": "A comma-separated list of <field>:<direction> pairs"
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_template.json
@@ -6,6 +6,9 @@
     },
     "stability": "stable",
     "visibility": "public",
+    "deprecated": {
+      "version": "7.8.0"
+    },
     "headers": {
       "accept": [
         "application/json"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_template.json
@@ -7,7 +7,8 @@
     "stability": "stable",
     "visibility": "public",
     "deprecated": {
-      "version": "7.8.0"
+      "version": "7.8.0",
+      "description": "Legacy index templates are deprecated in favor of composable templates"
     },
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.exists_template.json
@@ -39,7 +39,10 @@
         "description": "Timeout for waiting for new cluster state in case it is blocked"
       },
       "local": {
-        "deprecated": true,
+        "deprecated": {
+          "version": "9.0.0",
+          "description": "This parameter has no effect, is now deprecated, and will be removed in a future version."
+        },
         "type": "boolean",
         "default": false,
         "description": "Return local information, do not retrieve the state from master node (default: false)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_index_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_index_template.json
@@ -45,7 +45,10 @@
         "description": "Timeout for waiting for new cluster state in case it is blocked"
       },
       "local": {
-        "deprecated": true,
+        "deprecated": {
+          "version": "9.0.0",
+          "description": "This parameter has no effect, is now deprecated, and will be removed in a future version."
+        },
         "type": "boolean",
         "default": false,
         "description": "Return local information, do not retrieve the state from master node (default: false)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_mapping.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_mapping.json
@@ -63,7 +63,10 @@
       },
       "local": {
         "type": "boolean",
-        "deprecated": true,
+        "deprecated": {
+          "version": "7.8.0",
+          "description": "This parameter is a no-op and field mappings are always retrieved locally."
+        },
         "default": false,
         "description": "Return local information, do not retrieve the state from master node (default: false)"
       }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_settings.json
@@ -95,7 +95,10 @@
         "description": "Return settings in flat format (default: false)"
       },
       "local": {
-        "deprecated": true,
+        "deprecated": {
+          "version": "9.1.0",
+          "description": "This parameter is a no-op and settings are always retrieved locally."
+        },
         "type": "boolean",
         "default": false,
         "description": "Return local information, do not retrieve the state from master node (default: false)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_template.json
@@ -7,7 +7,8 @@
     "stability": "stable",
     "visibility": "public",
     "deprecated": {
-      "version": "7.8.0"
+      "version": "7.8.0",
+      "description": "Legacy index templates are deprecated in favor of composable templates"
     },
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_template.json
@@ -6,6 +6,9 @@
     },
     "stability": "stable",
     "visibility": "public",
+    "deprecated": {
+      "version": "7.8.0"
+    },
     "headers": {
       "accept": [
         "application/json"
@@ -45,7 +48,10 @@
         "description": "Timeout for waiting for new cluster state in case it is blocked"
       },
       "local": {
-        "deprecated": true,
+        "deprecated": {
+          "version": "9.0.0",
+          "description": "This parameter is a no-op and templates are always retrieved locally."
+        },
         "type": "boolean",
         "default": false,
         "description": "Return local information, do not retrieve the state from master node (default: false)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_template.json
@@ -6,6 +6,9 @@
     },
     "stability": "stable",
     "visibility": "public",
+    "deprecated": {
+      "version": "7.8.0"
+    },
     "headers": {
       "accept": [
         "application/json"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_template.json
@@ -7,7 +7,8 @@
     "stability": "stable",
     "visibility": "public",
     "deprecated": {
-      "version": "7.8.0"
+      "version": "7.8.0",
+      "description": "Legacy index templates are deprecated in favor of composable templates"
     },
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.resolve_cluster.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.resolve_cluster.json
@@ -41,7 +41,8 @@
       },
       "ignore_throttled": {
         "deprecated": {
-          "version": "7.16.0"
+          "version": "7.16.0",
+          "description": "This parameter is deprecated because frozen indices have been deprecated."
         },
         "type": "boolean",
         "default": false,

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.resolve_cluster.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.resolve_cluster.json
@@ -40,6 +40,9 @@
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed). Only allowed when providing an index expression."
       },
       "ignore_throttled": {
+        "deprecated": {
+          "version": "7.16.0"
+        },
         "type": "boolean",
         "default": false,
         "description": "Whether specified concrete, expanded or aliased indices should be ignored when throttled. Only allowed when providing an index expression."

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/license.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/license.get.json
@@ -29,7 +29,9 @@
       },
       "accept_enterprise": {
         "type": "boolean",
-        "deprecated": true,
+        "deprecated": {
+          "version": "7.6.0"
+        },
         "default": true,
         "description": "Supported for backwards compatibility with 7.x. If this param is used it must be set to true"
       }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/license.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/license.get.json
@@ -30,7 +30,8 @@
       "accept_enterprise": {
         "type": "boolean",
         "deprecated": {
-          "version": "7.6.0"
+          "version": "7.6.0",
+          "description": "This parameter no longer has any effect"
         },
         "default": true,
         "description": "Supported for backwards compatibility with 7.x. If this param is used it must be set to true"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.flush_job.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.flush_job.json
@@ -6,6 +6,10 @@
     },
     "stability": "stable",
     "visibility": "public",
+    "deprecated": {
+      "version": "9.1.0",
+      "description": "Forcing any buffered data to be processed is deprecated, in a future major version a datafeed will be required."
+    },
     "headers": {
       "accept": [
         "application/json"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.post_data.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.post_data.json
@@ -6,6 +6,10 @@
     },
     "stability": "stable",
     "visibility": "public",
+    "deprecated": {
+      "version": "7.11.0",
+      "description": "Posting data directly to anomaly detection jobs is deprecated, in a future major version a datafeed will be required."
+    },
     "headers": {
       "accept": [
         "application/json"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_datafeed.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_datafeed.json
@@ -47,7 +47,8 @@
       },
       "ignore_throttled": {
         "deprecated": {
-          "version": "7.16.0"
+          "version": "7.16.0",
+          "description": "This parameter is deprecated because frozen indices have been deprecated."
         },
         "type": "boolean",
         "default": true,

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_datafeed.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_datafeed.json
@@ -46,6 +46,9 @@
         "description": "Ignore if the source indices expressions resolves to no concrete indices (default: true)"
       },
       "ignore_throttled": {
+        "deprecated": {
+          "version": "7.16.0"
+        },
         "type": "boolean",
         "default": true,
         "description": "Ignore indices that are marked as throttled (default: true)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_job.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_job.json
@@ -42,6 +42,9 @@
         "description": "Ignore if the source indices expressions resolves to no concrete indices (default: true). Only set if datafeed_config is provided."
       },
       "ignore_throttled": {
+        "deprecated": {
+          "version": "7.16.0"
+        },
         "type": "boolean",
         "default": true,
         "description": "Ignore indices that are marked as throttled (default: true). Only set if datafeed_config is provided."

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_job.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_job.json
@@ -43,7 +43,8 @@
       },
       "ignore_throttled": {
         "deprecated": {
-          "version": "7.16.0"
+          "version": "7.16.0",
+          "description": "This parameter is deprecated because frozen indices have been deprecated."
         },
         "type": "boolean",
         "default": true,

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.update_datafeed.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.update_datafeed.json
@@ -47,7 +47,8 @@
       },
       "ignore_throttled": {
         "deprecated": {
-          "version": "7.16.0"
+          "version": "7.16.0",
+          "description": "This parameter is deprecated because frozen indices have been deprecated."
         },
         "type": "boolean",
         "default": true,

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.update_datafeed.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.update_datafeed.json
@@ -46,6 +46,9 @@
         "description": "Ignore if the source indices expressions resolves to no concrete indices (default: true)"
       },
       "ignore_throttled": {
+        "deprecated": {
+          "version": "7.16.0"
+        },
         "type": "boolean",
         "default": true,
         "description": "Ignore indices that are marked as throttled (default: true)"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/monitoring.bulk.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/monitoring.bulk.json
@@ -34,8 +34,10 @@
               "type": "string",
               "description": "Default document type for items which don't provide one",
               "deprecated": {
-                "version": "7.0.0"
+                "version": "7.0.0",
+                "description": "Specifying types in urls has been deprecated"
               }
+            }
           },
           "deprecated": {
             "version": "7.0.0",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/monitoring.bulk.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/monitoring.bulk.json
@@ -33,8 +33,9 @@
             "type": {
               "type": "string",
               "description": "Default document type for items which don't provide one",
-              "deprecated": true
-            }
+              "deprecated": {
+                "version": "7.0.0"
+              }
           },
           "deprecated": {
             "version": "7.0.0",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/msearch.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/msearch.json
@@ -86,7 +86,8 @@
       "ignore_throttled": {
         "type": "boolean",
         "deprecated": {
-          "version": "7.16.0"
+          "version": "7.16.0",
+          "description": "This parameter is deprecated because frozen indices have been deprecated."
         },
         "default": false,
         "description": "Whether specified concrete, expanded or aliased indices should be ignored when throttled"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/msearch.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/msearch.json
@@ -85,7 +85,9 @@
       },
       "ignore_throttled": {
         "type": "boolean",
-        "deprecated": true,
+        "deprecated": {
+          "version": "7.16.0"
+        },
         "default": false,
         "description": "Whether specified concrete, expanded or aliased indices should be ignored when throttled"
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.delete_job.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.delete_job.json
@@ -7,7 +7,8 @@
     "stability": "experimental",
     "visibility": "public",
     "deprecated": {
-      "version": "8.11.0"
+      "version": "8.11.0",
+      "description": "Rollup APIs are deprecated, use downsampling with time series data stream instead"
     },
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.delete_job.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.delete_job.json
@@ -6,6 +6,9 @@
     },
     "stability": "experimental",
     "visibility": "public",
+    "deprecated": {
+      "version": "8.11.0"
+    },
     "headers": {
       "accept": [
         "application/json"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.get_jobs.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.get_jobs.json
@@ -7,8 +7,9 @@
     "stability": "experimental",
     "visibility": "public",
     "deprecated": {
-      "version": "8.11.0"
-    }
+      "version": "8.11.0",
+      "description": "Rollup APIs are deprecated, use downsampling with time series data stream instead"
+    },
     "headers": {
       "accept": [
         "application/json"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.get_jobs.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.get_jobs.json
@@ -6,6 +6,9 @@
     },
     "stability": "experimental",
     "visibility": "public",
+    "deprecated": {
+      "version": "8.11.0"
+    }
     "headers": {
       "accept": [
         "application/json"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.get_rollup_caps.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.get_rollup_caps.json
@@ -7,7 +7,8 @@
     "stability": "experimental",
     "visibility": "public",
     "deprecated": {
-      "version": "8.11.0"
+      "version": "8.11.0",
+      "description": "Rollup APIs are deprecated, use downsampling with time series data stream instead"
     },
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.get_rollup_caps.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.get_rollup_caps.json
@@ -6,6 +6,9 @@
     },
     "stability": "experimental",
     "visibility": "public",
+    "deprecated": {
+      "version": "8.11.0"
+    },
     "headers": {
       "accept": [
         "application/json"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.get_rollup_index_caps.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.get_rollup_index_caps.json
@@ -7,7 +7,8 @@
     "stability": "experimental",
     "visibility": "public",
     "deprecated": {
-      "version": "8.11.0"
+      "version": "8.11.0",
+      "description": "Rollup APIs are deprecated, use downsampling with time series data stream instead"
     },
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.get_rollup_index_caps.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.get_rollup_index_caps.json
@@ -6,6 +6,9 @@
     },
     "stability": "experimental",
     "visibility": "public",
+    "deprecated": {
+      "version": "8.11.0"
+    },
     "headers": {
       "accept": [
         "application/json"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.put_job.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.put_job.json
@@ -7,7 +7,8 @@
     "stability": "experimental",
     "visibility": "public",
     "deprecated": {
-      "version": "8.11.0"
+      "version": "8.11.0",
+      "description": "Rollup APIs are deprecated, use downsampling with time series data stream instead"
     },
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.put_job.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.put_job.json
@@ -6,6 +6,9 @@
     },
     "stability": "experimental",
     "visibility": "public",
+    "deprecated": {
+      "version": "8.11.0"
+    },
     "headers": {
       "accept": [
         "application/json"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.rollup_search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.rollup_search.json
@@ -7,7 +7,8 @@
     "stability": "experimental",
     "visibility": "public",
     "deprecated": {
-      "version": "8.11.0"
+      "version": "8.11.0",
+      "description": "Rollup APIs are deprecated, use downsampling with time series data stream instead"
     },
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.rollup_search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.rollup_search.json
@@ -6,6 +6,9 @@
     },
     "stability": "experimental",
     "visibility": "public",
+    "deprecated": {
+      "version": "8.11.0"
+    },
     "headers": {
       "accept": [
         "application/json"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.start_job.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.start_job.json
@@ -7,7 +7,8 @@
     "stability": "experimental",
     "visibility": "public",
     "deprecated": {
-      "version": "8.11.0"
+      "version": "8.11.0",
+      "description": "Rollup APIs are deprecated, use downsampling with time series data stream instead"
     },
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.start_job.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.start_job.json
@@ -6,6 +6,9 @@
     },
     "stability": "experimental",
     "visibility": "public",
+    "deprecated": {
+      "version": "8.11.0"
+    },
     "headers": {
       "accept": [
         "application/json"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.stop_job.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.stop_job.json
@@ -7,7 +7,8 @@
     "stability": "experimental",
     "visibility": "public",
     "deprecated": {
-      "version": "8.11.0"
+      "version": "8.11.0",
+      "description": "Rollup APIs are deprecated, use downsampling with time series data stream instead"
     },
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.stop_job.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.stop_job.json
@@ -6,6 +6,9 @@
     },
     "stability": "experimental",
     "visibility": "public",
+    "deprecated": {
+      "version": "8.11.0"
+    },
     "headers": {
       "accept": [
         "application/json"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/scroll.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/scroll.json
@@ -34,7 +34,8 @@
               "type": "string",
               "description": "The scroll ID",
               "deprecated": {
-                "version": "7.0.0"
+                "version": "7.0.0",
+                "description": "A scroll id can be quite large and should be specified as part of the body"
               }
             }
           },
@@ -53,7 +54,8 @@
       },
       "scroll_id": {
         "deprecated": {
-          "version": "7.0.0"
+          "version": "7.0.0",
+          "description": "A scroll id can be quite large and should be specified as part of the body"
         },
         "type": "string",
         "description": "The scroll ID for scrolled search"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/scroll.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/scroll.json
@@ -33,7 +33,9 @@
             "scroll_id": {
               "type": "string",
               "description": "The scroll ID",
-              "deprecated": true
+              "deprecated": {
+                "version": "7.0.0"
+              }
             }
           },
           "deprecated": {
@@ -50,6 +52,9 @@
         "description": "Specify how long a consistent view of the index should be maintained for scrolled search"
       },
       "scroll_id": {
+        "deprecated": {
+          "version": "7.0.0"
+        },
         "type": "string",
         "description": "The scroll ID for scrolled search"
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
@@ -97,7 +97,8 @@
       },
       "ignore_throttled": {
         "deprecated": {
-          "version": "7.16.0"
+          "version": "7.16.0",
+          "description": "This parameter is deprecated because frozen indices have been deprecated."
         },
         "type": "boolean",
         "default": true,

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
@@ -96,6 +96,9 @@
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "ignore_throttled": {
+        "deprecated": {
+          "version": "7.16.0"
+        },
         "type": "boolean",
         "default": true,
         "description": "Whether specified concrete, expanded or aliased indices should be ignored when throttled"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_template.json
@@ -46,7 +46,8 @@
       },
       "ignore_throttled": {
         "deprecated": {
-          "version": "7.16.0"
+          "version": "7.16.0",
+          "description": "This parameter is deprecated because frozen indices have been deprecated."
         },
         "type": "boolean",
         "default": true,

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_template.json
@@ -45,6 +45,9 @@
         "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)"
       },
       "ignore_throttled": {
+        "deprecated": {
+          "version": "7.16.0"
+        },
         "type": "boolean",
         "default": true,
         "description": "Whether specified concrete, expanded or aliased indices should be ignored when throttled"

--- a/rest-api-spec/src/main/resources/schema.json
+++ b/rest-api-spec/src/main/resources/schema.json
@@ -268,10 +268,7 @@
                     "title": "Default value"
                 },
                 "deprecated": {
-                    "oneOf": [
-                      { "$ref": "#/definitions/Deprecated" },
-                      { "type": "boolean" }
-                    ]
+                    "$ref": "#/definitions/Deprecated"
                 },
                 "description": {
                     "type": "string",


### PR DESCRIPTION
The Elasticsearch specification requires the version number when deprecating a parameter or API. Specifying the version will help generate the rest-api-spec from the Elasticsearch specification. In other cases, the deprecation information was simply missing.