### PR TITLE
ESQL: Make _tsid presentable

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/topN.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/topN.csv-spec
@@ -168,3 +168,21 @@ FROM employees
 avg_worked_seconds:long | birth_date:date      | emp_no:i | gender:k | height:d | height.float:d     | height.half_float:d | height.scaled_float:d | hire_date:date       | is_rehired:bool      | job_positions:k     | languages:i | languages.byte:i | languages.long:l | languages.short:short | salary:i | salary_change:d | salary_change.int:i | salary_change.keyword:k | salary_change.long:l | still_hired:bool | name:k  | first_name:k | last_name:k
 349086555               | 1961-09-01T00:00:00Z | 10056    | F        | 1.57     | 1.5700000524520874 | 1.5703125           | 1.57                  | 1990-02-01T00:00:00Z | [false, false, true] | [Senior Team Lead]  | 2           | 2                | 2                | 2                     | 33370    | [-5.17, 10.99]  | [-5, 10]            | [-5.17, 10.99]          | [-5, 10]             | true             | Brendon | Bernini      | Brendon
 ;
+
+sortingByTsidMetadataField
+required_capability: ts_command_v0
+required_capability: metadata_tsid_field
+
+TS k8s METADATA _tsid
+| SORT events_received ASC
+| LIMIT 5
+| KEEP events_received, @timestamp, cluster, pod
+;
+
+events_received:long | @timestamp:datetime | cluster:keyword | pod:keyword
+1                    | 2024-05-10T00:00:00.000Z | qa              | one
+1                    | 2024-05-10T00:00:00.000Z | qa              | two
+1                    | 2024-05-10T00:00:00.000Z | qa              | three
+1                    | 2024-05-10T00:00:00.000Z | prod            | one
+1                    | 2024-05-10T00:00:00.000Z | prod            | two
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/PositionToXContent.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/PositionToXContent.java
@@ -28,6 +28,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
 
 import java.io.IOException;
 
@@ -107,6 +108,10 @@ public abstract class PositionToXContent {
                         // cbor needs a zero offset because of a bug in jackson
                         // https://github.com/FasterXML/jackson-dataformats-binary/issues/366
                         val = BytesRef.deepCopyOf(scratch);
+                    }
+
+                    if (columnInfo.name().equalsIgnoreCase(MetadataAttribute.TSID_FIELD)) {
+                        return builder.value(TimeSeriesIdFieldMapper.encodeTsid(val));
                     }
                     return builder.utf8Value(val.bytes, val.offset, val.length);
                 }


### PR DESCRIPTION
- Add an ability to present the TSID_DATA_TYPE as KEYWORD.
- Add tests for the TopN optimization with METADATA _tsid.