### PR TITLE
[ML] Create generic dense embedding results classes

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/results/DenseEmbeddingByteResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/results/DenseEmbeddingByteResults.java
@@ -31,10 +31,10 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * Writes a dense embedding result in the follow json format
+ * Writes a dense embedding result in the following json format
  * <pre>
  * {
- *     "text_embedding_bytes": [
+ *     "embedding_bytes": [
  *         {
  *             "embedding": [
  *                 23
@@ -50,9 +50,8 @@ import java.util.Objects;
  * </pre>
  */
 public record DenseEmbeddingByteResults(List<Embedding> embeddings) implements DenseEmbeddingResults<DenseEmbeddingByteResults.Embedding> {
-    // This name is a holdover from before this class was renamed
-    public static final String NAME = "text_embedding_service_byte_results";
-    public static final String TEXT_EMBEDDING_BYTES = "text_embedding_bytes";
+    public static final String NAME = "dense_embedding_byte_results";
+    public static final String EMBEDDINGS_BYTES = "embeddings_bytes";
 
     public DenseEmbeddingByteResults(StreamInput in) throws IOException {
         this(in.readCollectionAsList(DenseEmbeddingByteResults.Embedding::new));
@@ -68,7 +67,7 @@ public record DenseEmbeddingByteResults(List<Embedding> embeddings) implements D
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-        return ChunkedToXContentHelper.array(TEXT_EMBEDDING_BYTES, embeddings.iterator());
+        return ChunkedToXContentHelper.array(EMBEDDINGS_BYTES, embeddings.iterator());
     }
 
     @Override
@@ -84,13 +83,13 @@ public record DenseEmbeddingByteResults(List<Embedding> embeddings) implements D
     @Override
     public List<? extends InferenceResults> transformToCoordinationFormat() {
         return embeddings.stream()
-            .map(embedding -> new MlDenseEmbeddingResults(TEXT_EMBEDDING_BYTES, embedding.toDoubleArray(), false))
+            .map(embedding -> new MlDenseEmbeddingResults(EMBEDDINGS_BYTES, embedding.toDoubleArray(), false))
             .toList();
     }
 
     public Map<String, Object> asMap() {
         Map<String, Object> map = new LinkedHashMap<>();
-        map.put(TEXT_EMBEDDING_BYTES, embeddings);
+        map.put(EMBEDDINGS_BYTES, embeddings);
 
         return map;
     }
@@ -115,8 +114,6 @@ public record DenseEmbeddingByteResults(List<Embedding> embeddings) implements D
             Writeable,
             ToXContentObject,
             EmbeddingResults.Embedding<Embedding> {
-
-        public static final String EMBEDDING = "embedding";
 
         public Embedding(byte[] values) {
             this(values, null, 1);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/results/EmbeddingResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/results/EmbeddingResults.java
@@ -22,6 +22,8 @@ import java.util.List;
  */
 public interface EmbeddingResults<E extends EmbeddingResults.Embedding<E>> extends InferenceServiceResults {
 
+    String EMBEDDING = "embedding";
+
     /**
      * A resulting embedding for one of the input texts to the inference service.
      */

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/results/LegacyDenseEmbeddingBitResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/results/LegacyDenseEmbeddingBitResults.java
@@ -24,10 +24,10 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * Writes a dense embedding result in the following json format.
+ * Writes a dense embedding result in the follow json format.
  * <pre>
  * {
- *     "embeddings_bits": [
+ *     "text_embedding_bits": [
  *         {
  *             "embedding": [
  *                 23
@@ -41,17 +41,22 @@ import java.util.Objects;
  *     ]
  * }
  * </pre>
+ *
+ * @deprecated for removal in the next major, to be replaced with {@link DenseEmbeddingBitResults}, which is identical to this class other
+ * than using {@value DenseEmbeddingBitResults#EMBEDDINGS_BITS} instead of {@value #TEXT_EMBEDDING_BITS} in the result
  */
 // Note: inheriting from DenseEmbeddingByteResults gives a bad implementation of the
 // Embedding.merge method for bits. TODO: implement a proper merge method
-public record DenseEmbeddingBitResults(List<DenseEmbeddingByteResults.Embedding> embeddings)
+@Deprecated(forRemoval = true)
+public record LegacyDenseEmbeddingBitResults(List<LegacyDenseEmbeddingByteResults.Embedding> embeddings)
     implements
-        DenseEmbeddingResults<DenseEmbeddingByteResults.Embedding> {
-    public static final String NAME = "dense_embedding_bit_results";
-    public static final String EMBEDDINGS_BITS = "embeddings_bits";
+        DenseEmbeddingResults<LegacyDenseEmbeddingByteResults.Embedding> {
+    // This name is a holdover from before this class was renamed
+    public static final String NAME = "text_embedding_service_bit_results";
+    public static final String TEXT_EMBEDDING_BITS = "text_embedding_bits";
 
-    public DenseEmbeddingBitResults(StreamInput in) throws IOException {
-        this(in.readCollectionAsList(DenseEmbeddingByteResults.Embedding::new));
+    public LegacyDenseEmbeddingBitResults(StreamInput in) throws IOException {
+        this(in.readCollectionAsList(LegacyDenseEmbeddingByteResults.Embedding::new));
     }
 
     @Override
@@ -65,7 +70,7 @@ public record DenseEmbeddingBitResults(List<DenseEmbeddingByteResults.Embedding>
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-        return ChunkedToXContentHelper.array(EMBEDDINGS_BITS, embeddings.iterator());
+        return ChunkedToXContentHelper.array(TEXT_EMBEDDING_BITS, embeddings.iterator());
     }
 
     @Override
@@ -81,13 +86,13 @@ public record DenseEmbeddingBitResults(List<DenseEmbeddingByteResults.Embedding>
     @Override
     public List<? extends InferenceResults> transformToCoordinationFormat() {
         return embeddings.stream()
-            .map(embedding -> new MlDenseEmbeddingResults(EMBEDDINGS_BITS, embedding.toDoubleArray(), false))
+            .map(embedding -> new MlDenseEmbeddingResults(TEXT_EMBEDDING_BITS, embedding.toDoubleArray(), false))
             .toList();
     }
 
     public Map<String, Object> asMap() {
         Map<String, Object> map = new LinkedHashMap<>();
-        map.put(EMBEDDINGS_BITS, embeddings);
+        map.put(TEXT_EMBEDDING_BITS, embeddings);
 
         return map;
     }
@@ -96,7 +101,7 @@ public record DenseEmbeddingBitResults(List<DenseEmbeddingByteResults.Embedding>
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        DenseEmbeddingBitResults that = (DenseEmbeddingBitResults) o;
+        LegacyDenseEmbeddingBitResults that = (LegacyDenseEmbeddingBitResults) o;
         return Objects.equals(embeddings, that.embeddings);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/results/SparseEmbeddingResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/results/SparseEmbeddingResults.java
@@ -120,7 +120,6 @@ public record SparseEmbeddingResults(List<Embedding> embeddings) implements Embe
             ToXContentObject,
             EmbeddingResults.Embedding<Embedding> {
 
-        public static final String EMBEDDING = "embedding";
         public static final String IS_TRUNCATED = "is_truncated";
 
         public Embedding(StreamInput in) throws IOException {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/chunking/EmbeddingRequestChunkerTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/chunking/EmbeddingRequestChunkerTests.java
@@ -14,9 +14,9 @@ import org.elasticsearch.inference.WeightedToken;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.inference.results.ChunkedInferenceEmbedding;
 import org.elasticsearch.xpack.core.inference.results.ChunkedInferenceError;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingBitResults;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingByteResults;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingBitResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingByteResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResults;
 import org.hamcrest.Matchers;
 
@@ -393,12 +393,12 @@ public class EmbeddingRequestChunkerTests extends ESTestCase {
         // Produce inference results for each request, with increasing weights.
         float weight = 0f;
         for (var batch : batches) {
-            var embeddings = new ArrayList<DenseEmbeddingFloatResults.Embedding>();
+            var embeddings = new ArrayList<LegacyDenseEmbeddingFloatResults.Embedding>();
             for (int i = 0; i < batch.batch().requests().size(); i++) {
                 weight += 1 / 16384f;
-                embeddings.add(new DenseEmbeddingFloatResults.Embedding(new float[] { weight }));
+                embeddings.add(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { weight }));
             }
-            batch.listener().onResponse(new DenseEmbeddingFloatResults(embeddings));
+            batch.listener().onResponse(new LegacyDenseEmbeddingFloatResults(embeddings));
         }
 
         assertNotNull(finalListener.results);
@@ -410,8 +410,8 @@ public class EmbeddingRequestChunkerTests extends ESTestCase {
         ChunkedInferenceEmbedding chunkedEmbedding = (ChunkedInferenceEmbedding) inference;
         assertThat(chunkedEmbedding.chunks(), hasSize(1));
         assertThat(getMatchedText(inputs.get(0).input(), chunkedEmbedding.chunks().get(0).offset()), equalTo("1st small"));
-        assertThat(chunkedEmbedding.chunks().get(0).embedding(), instanceOf(DenseEmbeddingFloatResults.Embedding.class));
-        DenseEmbeddingFloatResults.Embedding embedding = (DenseEmbeddingFloatResults.Embedding) chunkedEmbedding.chunks()
+        assertThat(chunkedEmbedding.chunks().get(0).embedding(), instanceOf(LegacyDenseEmbeddingFloatResults.Embedding.class));
+        LegacyDenseEmbeddingFloatResults.Embedding embedding = (LegacyDenseEmbeddingFloatResults.Embedding) chunkedEmbedding.chunks()
             .get(0)
             .embedding();
         assertThat(embedding.values(), equalTo(new float[] { 1 / 16384f }));
@@ -429,8 +429,8 @@ public class EmbeddingRequestChunkerTests extends ESTestCase {
         // is the average of the weights 2/16384 ... 21/16384.
         assertThat(getMatchedText(inputs.get(1).input(), chunkedEmbedding.chunks().get(0).offset()), startsWith("word0 word1 "));
         assertThat(getMatchedText(inputs.get(1).input(), chunkedEmbedding.chunks().get(0).offset()), endsWith(" word398 word399"));
-        assertThat(chunkedEmbedding.chunks().get(0).embedding(), instanceOf(DenseEmbeddingFloatResults.Embedding.class));
-        embedding = (DenseEmbeddingFloatResults.Embedding) chunkedEmbedding.chunks().get(0).embedding();
+        assertThat(chunkedEmbedding.chunks().get(0).embedding(), instanceOf(LegacyDenseEmbeddingFloatResults.Embedding.class));
+        embedding = (LegacyDenseEmbeddingFloatResults.Embedding) chunkedEmbedding.chunks().get(0).embedding();
         assertThat(embedding.values(), equalTo(new float[] { (2 + 21) / (2 * 16384f) }));
 
         // The last merged chunk consists of 19 small chunks (so 380 words) and the weight
@@ -440,8 +440,8 @@ public class EmbeddingRequestChunkerTests extends ESTestCase {
             startsWith(" word199620 word199621 ")
         );
         assertThat(getMatchedText(inputs.get(1).input(), chunkedEmbedding.chunks().get(511).offset()), endsWith(" word199998 word199999"));
-        assertThat(chunkedEmbedding.chunks().get(511).embedding(), instanceOf(DenseEmbeddingFloatResults.Embedding.class));
-        embedding = (DenseEmbeddingFloatResults.Embedding) chunkedEmbedding.chunks().get(511).embedding();
+        assertThat(chunkedEmbedding.chunks().get(511).embedding(), instanceOf(LegacyDenseEmbeddingFloatResults.Embedding.class));
+        embedding = (LegacyDenseEmbeddingFloatResults.Embedding) chunkedEmbedding.chunks().get(511).embedding();
         assertThat(embedding.values(), equalTo(new float[] { (9983 + 10001) / (2 * 16384f) }));
 
         // The last input has the token with weight 10002/16384.
@@ -450,8 +450,8 @@ public class EmbeddingRequestChunkerTests extends ESTestCase {
         chunkedEmbedding = (ChunkedInferenceEmbedding) inference;
         assertThat(chunkedEmbedding.chunks(), hasSize(1));
         assertThat(getMatchedText(inputs.get(2).input(), chunkedEmbedding.chunks().get(0).offset()), equalTo("2nd small"));
-        assertThat(chunkedEmbedding.chunks().get(0).embedding(), instanceOf(DenseEmbeddingFloatResults.Embedding.class));
-        embedding = (DenseEmbeddingFloatResults.Embedding) chunkedEmbedding.chunks().get(0).embedding();
+        assertThat(chunkedEmbedding.chunks().get(0).embedding(), instanceOf(LegacyDenseEmbeddingFloatResults.Embedding.class));
+        embedding = (LegacyDenseEmbeddingFloatResults.Embedding) chunkedEmbedding.chunks().get(0).embedding();
         assertThat(embedding.values(), equalTo(new float[] { 10002 / 16384f }));
     }
 
@@ -486,12 +486,12 @@ public class EmbeddingRequestChunkerTests extends ESTestCase {
         // Produce inference results for each request, with increasing weights.
         byte weight = 0;
         for (var batch : batches) {
-            var embeddings = new ArrayList<DenseEmbeddingByteResults.Embedding>();
+            var embeddings = new ArrayList<LegacyDenseEmbeddingByteResults.Embedding>();
             for (int i = 0; i < batch.batch().requests().size(); i++) {
                 weight += 1;
-                embeddings.add(new DenseEmbeddingByteResults.Embedding(new byte[] { weight }));
+                embeddings.add(new LegacyDenseEmbeddingByteResults.Embedding(new byte[] { weight }));
             }
-            batch.listener().onResponse(new DenseEmbeddingByteResults(embeddings));
+            batch.listener().onResponse(new LegacyDenseEmbeddingByteResults(embeddings));
         }
 
         assertNotNull(finalListener.results);
@@ -503,8 +503,10 @@ public class EmbeddingRequestChunkerTests extends ESTestCase {
         ChunkedInferenceEmbedding chunkedEmbedding = (ChunkedInferenceEmbedding) inference;
         assertThat(chunkedEmbedding.chunks(), hasSize(1));
         assertThat(getMatchedText(inputs.get(0).input(), chunkedEmbedding.chunks().get(0).offset()), equalTo("1st small"));
-        assertThat(chunkedEmbedding.chunks().get(0).embedding(), instanceOf(DenseEmbeddingByteResults.Embedding.class));
-        DenseEmbeddingByteResults.Embedding embedding = (DenseEmbeddingByteResults.Embedding) chunkedEmbedding.chunks().get(0).embedding();
+        assertThat(chunkedEmbedding.chunks().get(0).embedding(), instanceOf(LegacyDenseEmbeddingByteResults.Embedding.class));
+        LegacyDenseEmbeddingByteResults.Embedding embedding = (LegacyDenseEmbeddingByteResults.Embedding) chunkedEmbedding.chunks()
+            .get(0)
+            .embedding();
         assertThat(embedding.values(), equalTo(new byte[] { 1 }));
 
         // The very long passage "word0 word1 ... word199999" is split into 10000 chunks for
@@ -520,8 +522,8 @@ public class EmbeddingRequestChunkerTests extends ESTestCase {
         // is the average of the weights 2 ... 21, so 11.5, which is rounded to 12.
         assertThat(getMatchedText(inputs.get(1).input(), chunkedEmbedding.chunks().get(0).offset()), startsWith("word0 word1 "));
         assertThat(getMatchedText(inputs.get(1).input(), chunkedEmbedding.chunks().get(0).offset()), endsWith(" word398 word399"));
-        assertThat(chunkedEmbedding.chunks().get(0).embedding(), instanceOf(DenseEmbeddingByteResults.Embedding.class));
-        embedding = (DenseEmbeddingByteResults.Embedding) chunkedEmbedding.chunks().get(0).embedding();
+        assertThat(chunkedEmbedding.chunks().get(0).embedding(), instanceOf(LegacyDenseEmbeddingByteResults.Embedding.class));
+        embedding = (LegacyDenseEmbeddingByteResults.Embedding) chunkedEmbedding.chunks().get(0).embedding();
         assertThat(embedding.values(), equalTo(new byte[] { 12 }));
 
         // The last merged chunk consists of 19 small chunks (so 380 words) and the weight
@@ -532,8 +534,8 @@ public class EmbeddingRequestChunkerTests extends ESTestCase {
             startsWith(" word199620 word199621 ")
         );
         assertThat(getMatchedText(inputs.get(1).input(), chunkedEmbedding.chunks().get(511).offset()), endsWith(" word199998 word199999"));
-        assertThat(chunkedEmbedding.chunks().get(511).embedding(), instanceOf(DenseEmbeddingByteResults.Embedding.class));
-        embedding = (DenseEmbeddingByteResults.Embedding) chunkedEmbedding.chunks().get(511).embedding();
+        assertThat(chunkedEmbedding.chunks().get(511).embedding(), instanceOf(LegacyDenseEmbeddingByteResults.Embedding.class));
+        embedding = (LegacyDenseEmbeddingByteResults.Embedding) chunkedEmbedding.chunks().get(511).embedding();
         assertThat(embedding.values(), equalTo(new byte[] { 8 }));
 
         // The last input has the token with weight 10002 % 256 = 18
@@ -542,8 +544,8 @@ public class EmbeddingRequestChunkerTests extends ESTestCase {
         chunkedEmbedding = (ChunkedInferenceEmbedding) inference;
         assertThat(chunkedEmbedding.chunks(), hasSize(1));
         assertThat(getMatchedText(inputs.get(2).input(), chunkedEmbedding.chunks().get(0).offset()), equalTo("2nd small"));
-        assertThat(chunkedEmbedding.chunks().get(0).embedding(), instanceOf(DenseEmbeddingByteResults.Embedding.class));
-        embedding = (DenseEmbeddingByteResults.Embedding) chunkedEmbedding.chunks().get(0).embedding();
+        assertThat(chunkedEmbedding.chunks().get(0).embedding(), instanceOf(LegacyDenseEmbeddingByteResults.Embedding.class));
+        embedding = (LegacyDenseEmbeddingByteResults.Embedding) chunkedEmbedding.chunks().get(0).embedding();
         assertThat(embedding.values(), equalTo(new byte[] { 18 }));
     }
 
@@ -572,18 +574,18 @@ public class EmbeddingRequestChunkerTests extends ESTestCase {
 
         // 4 inputs in 2 batches
         {
-            var embeddings = new ArrayList<DenseEmbeddingFloatResults.Embedding>();
+            var embeddings = new ArrayList<LegacyDenseEmbeddingFloatResults.Embedding>();
             for (int i = 0; i < batchSize; i++) {
-                embeddings.add(new DenseEmbeddingFloatResults.Embedding(new float[] { randomFloat() }));
+                embeddings.add(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { randomFloat() }));
             }
-            batches.get(0).listener().onResponse(new DenseEmbeddingFloatResults(embeddings));
+            batches.get(0).listener().onResponse(new LegacyDenseEmbeddingFloatResults(embeddings));
         }
         {
-            var embeddings = new ArrayList<DenseEmbeddingFloatResults.Embedding>();
+            var embeddings = new ArrayList<LegacyDenseEmbeddingFloatResults.Embedding>();
             for (int i = 0; i < 4; i++) { // 4 requests in the 2nd batch
-                embeddings.add(new DenseEmbeddingFloatResults.Embedding(new float[] { randomFloat() }));
+                embeddings.add(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { randomFloat() }));
             }
-            batches.get(1).listener().onResponse(new DenseEmbeddingFloatResults(embeddings));
+            batches.get(1).listener().onResponse(new LegacyDenseEmbeddingFloatResults(embeddings));
         }
 
         assertNotNull(finalListener.results);
@@ -652,18 +654,18 @@ public class EmbeddingRequestChunkerTests extends ESTestCase {
 
         // 4 inputs in 2 batches
         {
-            var embeddings = new ArrayList<DenseEmbeddingByteResults.Embedding>();
+            var embeddings = new ArrayList<LegacyDenseEmbeddingByteResults.Embedding>();
             for (int i = 0; i < batchSize; i++) {
-                embeddings.add(new DenseEmbeddingByteResults.Embedding(new byte[] { randomByte() }));
+                embeddings.add(new LegacyDenseEmbeddingByteResults.Embedding(new byte[] { randomByte() }));
             }
-            batches.get(0).listener().onResponse(new DenseEmbeddingByteResults(embeddings));
+            batches.get(0).listener().onResponse(new LegacyDenseEmbeddingByteResults(embeddings));
         }
         {
-            var embeddings = new ArrayList<DenseEmbeddingByteResults.Embedding>();
+            var embeddings = new ArrayList<LegacyDenseEmbeddingByteResults.Embedding>();
             for (int i = 0; i < 4; i++) { // 4 requests in the 2nd batch
-                embeddings.add(new DenseEmbeddingByteResults.Embedding(new byte[] { randomByte() }));
+                embeddings.add(new LegacyDenseEmbeddingByteResults.Embedding(new byte[] { randomByte() }));
             }
-            batches.get(1).listener().onResponse(new DenseEmbeddingByteResults(embeddings));
+            batches.get(1).listener().onResponse(new LegacyDenseEmbeddingByteResults(embeddings));
         }
 
         assertNotNull(finalListener.results);
@@ -729,18 +731,18 @@ public class EmbeddingRequestChunkerTests extends ESTestCase {
 
         // 4 inputs in 2 batches
         {
-            var embeddings = new ArrayList<DenseEmbeddingByteResults.Embedding>();
+            var embeddings = new ArrayList<LegacyDenseEmbeddingByteResults.Embedding>();
             for (int i = 0; i < batchSize; i++) {
-                embeddings.add(new DenseEmbeddingByteResults.Embedding(new byte[] { randomByte() }));
+                embeddings.add(new LegacyDenseEmbeddingByteResults.Embedding(new byte[] { randomByte() }));
             }
-            batches.get(0).listener().onResponse(new DenseEmbeddingBitResults(embeddings));
+            batches.get(0).listener().onResponse(new LegacyDenseEmbeddingBitResults(embeddings));
         }
         {
-            var embeddings = new ArrayList<DenseEmbeddingByteResults.Embedding>();
+            var embeddings = new ArrayList<LegacyDenseEmbeddingByteResults.Embedding>();
             for (int i = 0; i < 4; i++) { // 4 requests in the 2nd batch
-                embeddings.add(new DenseEmbeddingByteResults.Embedding(new byte[] { randomByte() }));
+                embeddings.add(new LegacyDenseEmbeddingByteResults.Embedding(new byte[] { randomByte() }));
             }
-            batches.get(1).listener().onResponse(new DenseEmbeddingBitResults(embeddings));
+            batches.get(1).listener().onResponse(new LegacyDenseEmbeddingBitResults(embeddings));
         }
 
         assertNotNull(finalListener.results);
@@ -894,10 +896,10 @@ public class EmbeddingRequestChunkerTests extends ESTestCase {
         var batches = new EmbeddingRequestChunker<>(inputs, 10, 100, 0).batchRequestsWithListeners(listener);
         assertThat(batches, hasSize(1));
 
-        var embeddings = new ArrayList<DenseEmbeddingFloatResults.Embedding>();
-        embeddings.add(new DenseEmbeddingFloatResults.Embedding(new float[] { randomFloat() }));
-        embeddings.add(new DenseEmbeddingFloatResults.Embedding(new float[] { randomFloat() }));
-        batches.get(0).listener().onResponse(new DenseEmbeddingFloatResults(embeddings));
+        var embeddings = new ArrayList<LegacyDenseEmbeddingFloatResults.Embedding>();
+        embeddings.add(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { randomFloat() }));
+        embeddings.add(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { randomFloat() }));
+        batches.get(0).listener().onResponse(new LegacyDenseEmbeddingFloatResults(embeddings));
         assertEquals("Error the number of embedding responses [2] does not equal the number of requests [3]", failureMessage.get());
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/results/DenseEmbeddingByteResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/results/DenseEmbeddingByteResultsTests.java
@@ -49,7 +49,7 @@ public class DenseEmbeddingByteResultsTests extends AbstractWireSerializingTestC
         String xContentResult = Strings.toString(entity, true, true);
         assertThat(xContentResult, is("""
             {
-              "text_embedding_bytes" : [
+              "embeddings_bytes" : [
                 {
                   "embedding" : [
                     23
@@ -70,7 +70,7 @@ public class DenseEmbeddingByteResultsTests extends AbstractWireSerializingTestC
         String xContentResult = Strings.toString(entity, true, true);
         assertThat(xContentResult, is("""
             {
-              "text_embedding_bytes" : [
+              "embeddings_bytes" : [
                 {
                   "embedding" : [
                     23
@@ -97,8 +97,8 @@ public class DenseEmbeddingByteResultsTests extends AbstractWireSerializingTestC
             results,
             is(
                 List.of(
-                    new MlDenseEmbeddingResults(DenseEmbeddingByteResults.TEXT_EMBEDDING_BYTES, new double[] { 23F, 24F }, false),
-                    new MlDenseEmbeddingResults(DenseEmbeddingByteResults.TEXT_EMBEDDING_BYTES, new double[] { 25F, 26F }, false)
+                    new MlDenseEmbeddingResults(DenseEmbeddingByteResults.EMBEDDINGS_BYTES, new double[] { 23F, 24F }, false),
+                    new MlDenseEmbeddingResults(DenseEmbeddingByteResults.EMBEDDINGS_BYTES, new double[] { 25F, 26F }, false)
                 )
             )
         );
@@ -149,10 +149,10 @@ public class DenseEmbeddingByteResultsTests extends AbstractWireSerializingTestC
         }
     }
 
-    public static Map<String, Object> buildExpectationByte(List<List<Byte>> embeddings) {
+    public static Map<String, Object> buildExpectationByte(List<byte[]> embeddings) {
         return Map.of(
-            DenseEmbeddingByteResults.TEXT_EMBEDDING_BYTES,
-            embeddings.stream().map(embedding -> Map.of(DenseEmbeddingByteResults.Embedding.EMBEDDING, embedding)).toList()
+            DenseEmbeddingByteResults.EMBEDDINGS_BYTES,
+            embeddings.stream().map(DenseEmbeddingByteResults.Embedding::new).toList()
         );
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/results/DenseEmbeddingFloatResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/results/DenseEmbeddingFloatResultsTests.java
@@ -48,7 +48,7 @@ public class DenseEmbeddingFloatResultsTests extends AbstractWireSerializingTest
         String xContentResult = Strings.toString(entity, true, true);
         assertThat(xContentResult, is("""
             {
-              "text_embedding" : [
+              "embeddings" : [
                 {
                   "embedding" : [
                     0.1
@@ -70,7 +70,7 @@ public class DenseEmbeddingFloatResultsTests extends AbstractWireSerializingTest
         String xContentResult = Strings.toString(entity, true, true);
         assertThat(xContentResult, is("""
             {
-              "text_embedding" : [
+              "embeddings" : [
                 {
                   "embedding" : [
                     0.1
@@ -97,8 +97,8 @@ public class DenseEmbeddingFloatResultsTests extends AbstractWireSerializingTest
             results,
             is(
                 List.of(
-                    new MlDenseEmbeddingResults(DenseEmbeddingFloatResults.TEXT_EMBEDDING, new double[] { 0.1F, 0.2F }, false),
-                    new MlDenseEmbeddingResults(DenseEmbeddingFloatResults.TEXT_EMBEDDING, new double[] { 0.3F, 0.4F }, false)
+                    new MlDenseEmbeddingResults(DenseEmbeddingFloatResults.EMBEDDINGS, new double[] { 0.1F, 0.2F }, false),
+                    new MlDenseEmbeddingResults(DenseEmbeddingFloatResults.EMBEDDINGS, new double[] { 0.3F, 0.4F }, false)
                 )
             )
         );
@@ -150,20 +150,17 @@ public class DenseEmbeddingFloatResultsTests extends AbstractWireSerializingTest
     }
 
     public static Map<String, Object> buildExpectationFloat(List<float[]> embeddings) {
-        return Map.of(
-            DenseEmbeddingFloatResults.TEXT_EMBEDDING,
-            embeddings.stream().map(DenseEmbeddingFloatResults.Embedding::new).toList()
-        );
+        return Map.of(DenseEmbeddingFloatResults.EMBEDDINGS, embeddings.stream().map(DenseEmbeddingFloatResults.Embedding::new).toList());
     }
 
     public static Map<String, Object> buildExpectationByte(List<byte[]> embeddings) {
         return Map.of(
-            DenseEmbeddingByteResults.TEXT_EMBEDDING_BYTES,
+            DenseEmbeddingByteResults.EMBEDDINGS_BYTES,
             embeddings.stream().map(DenseEmbeddingByteResults.Embedding::new).toList()
         );
     }
 
     public static Map<String, Object> buildExpectationBinary(List<byte[]> embeddings) {
-        return Map.of("text_embedding_bits", embeddings.stream().map(DenseEmbeddingByteResults.Embedding::new).toList());
+        return Map.of(DenseEmbeddingBitResults.EMBEDDINGS_BITS, embeddings.stream().map(DenseEmbeddingByteResults.Embedding::new).toList());
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/results/LegacyDenseEmbeddingBitResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/results/LegacyDenseEmbeddingBitResultsTests.java
@@ -19,19 +19,20 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.is;
 
-public class DenseEmbeddingBitResultsTests extends AbstractWireSerializingTestCase<DenseEmbeddingBitResults> {
-    public static DenseEmbeddingBitResults createRandomResults() {
+@SuppressWarnings("removal")
+public class LegacyDenseEmbeddingBitResultsTests extends AbstractWireSerializingTestCase<LegacyDenseEmbeddingBitResults> {
+    public static LegacyDenseEmbeddingBitResults createRandomResults() {
         int embeddings = randomIntBetween(1, 10);
-        List<DenseEmbeddingByteResults.Embedding> embeddingResults = new ArrayList<>(embeddings);
+        List<LegacyDenseEmbeddingByteResults.Embedding> embeddingResults = new ArrayList<>(embeddings);
 
         for (int i = 0; i < embeddings; i++) {
             embeddingResults.add(createRandomEmbedding());
         }
 
-        return new DenseEmbeddingBitResults(embeddingResults);
+        return new LegacyDenseEmbeddingBitResults(embeddingResults);
     }
 
-    private static DenseEmbeddingByteResults.Embedding createRandomEmbedding() {
+    private static LegacyDenseEmbeddingByteResults.Embedding createRandomEmbedding() {
         int columns = randomIntBetween(1, 10);
         byte[] bytes = new byte[columns];
 
@@ -39,16 +40,16 @@ public class DenseEmbeddingBitResultsTests extends AbstractWireSerializingTestCa
             bytes[i] = randomByte();
         }
 
-        return new DenseEmbeddingByteResults.Embedding(bytes);
+        return new LegacyDenseEmbeddingByteResults.Embedding(bytes);
     }
 
     public void testToXContent_CreatesTheRightFormatForASingleEmbedding() throws IOException {
-        var entity = new DenseEmbeddingBitResults(List.of(new DenseEmbeddingByteResults.Embedding(new byte[] { (byte) 23 })));
+        var entity = new LegacyDenseEmbeddingBitResults(List.of(new LegacyDenseEmbeddingByteResults.Embedding(new byte[] { (byte) 23 })));
 
         String xContentResult = Strings.toString(entity, true, true);
         assertThat(xContentResult, is("""
             {
-              "embeddings_bits" : [
+              "text_embedding_bits" : [
                 {
                   "embedding" : [
                     23
@@ -59,17 +60,17 @@ public class DenseEmbeddingBitResultsTests extends AbstractWireSerializingTestCa
     }
 
     public void testToXContent_CreatesTheRightFormatForMultipleEmbeddings() throws IOException {
-        var entity = new DenseEmbeddingBitResults(
+        var entity = new LegacyDenseEmbeddingBitResults(
             List.of(
-                new DenseEmbeddingByteResults.Embedding(new byte[] { (byte) 23 }),
-                new DenseEmbeddingByteResults.Embedding(new byte[] { (byte) 24 })
+                new LegacyDenseEmbeddingByteResults.Embedding(new byte[] { (byte) 23 }),
+                new LegacyDenseEmbeddingByteResults.Embedding(new byte[] { (byte) 24 })
             )
         );
 
         String xContentResult = Strings.toString(entity, true, true);
         assertThat(xContentResult, is("""
             {
-              "embeddings_bits" : [
+              "text_embedding_bits" : [
                 {
                   "embedding" : [
                     23
@@ -85,10 +86,10 @@ public class DenseEmbeddingBitResultsTests extends AbstractWireSerializingTestCa
     }
 
     public void testTransformToCoordinationFormat() {
-        var results = new DenseEmbeddingBitResults(
+        var results = new LegacyDenseEmbeddingBitResults(
             List.of(
-                new DenseEmbeddingByteResults.Embedding(new byte[] { (byte) 23, (byte) 24 }),
-                new DenseEmbeddingByteResults.Embedding(new byte[] { (byte) 25, (byte) 26 })
+                new LegacyDenseEmbeddingByteResults.Embedding(new byte[] { (byte) 23, (byte) 24 }),
+                new LegacyDenseEmbeddingByteResults.Embedding(new byte[] { (byte) 25, (byte) 26 })
             )
         ).transformToCoordinationFormat();
 
@@ -96,18 +97,18 @@ public class DenseEmbeddingBitResultsTests extends AbstractWireSerializingTestCa
             results,
             is(
                 List.of(
-                    new MlDenseEmbeddingResults(DenseEmbeddingBitResults.EMBEDDINGS_BITS, new double[] { 23F, 24F }, false),
-                    new MlDenseEmbeddingResults(DenseEmbeddingBitResults.EMBEDDINGS_BITS, new double[] { 25F, 26F }, false)
+                    new MlDenseEmbeddingResults(LegacyDenseEmbeddingBitResults.TEXT_EMBEDDING_BITS, new double[] { 23F, 24F }, false),
+                    new MlDenseEmbeddingResults(LegacyDenseEmbeddingBitResults.TEXT_EMBEDDING_BITS, new double[] { 25F, 26F }, false)
                 )
             )
         );
     }
 
     public void testGetFirstEmbeddingSize() {
-        var firstEmbeddingSize = new DenseEmbeddingBitResults(
+        var firstEmbeddingSize = new LegacyDenseEmbeddingBitResults(
             List.of(
-                new DenseEmbeddingByteResults.Embedding(new byte[] { (byte) 23, (byte) 24 }),
-                new DenseEmbeddingByteResults.Embedding(new byte[] { (byte) 25, (byte) 26 })
+                new LegacyDenseEmbeddingByteResults.Embedding(new byte[] { (byte) 23, (byte) 24 }),
+                new LegacyDenseEmbeddingByteResults.Embedding(new byte[] { (byte) 25, (byte) 26 })
             )
         ).getFirstEmbeddingSize();
 
@@ -115,30 +116,33 @@ public class DenseEmbeddingBitResultsTests extends AbstractWireSerializingTestCa
     }
 
     @Override
-    protected Writeable.Reader<DenseEmbeddingBitResults> instanceReader() {
-        return DenseEmbeddingBitResults::new;
+    protected Writeable.Reader<LegacyDenseEmbeddingBitResults> instanceReader() {
+        return LegacyDenseEmbeddingBitResults::new;
     }
 
     @Override
-    protected DenseEmbeddingBitResults createTestInstance() {
+    protected LegacyDenseEmbeddingBitResults createTestInstance() {
         return createRandomResults();
     }
 
     @Override
-    protected DenseEmbeddingBitResults mutateInstance(DenseEmbeddingBitResults instance) throws IOException {
+    protected LegacyDenseEmbeddingBitResults mutateInstance(LegacyDenseEmbeddingBitResults instance) throws IOException {
         // if true we reduce the embeddings list by a random amount, if false we add an embedding to the list
         if (randomBoolean()) {
             // -1 to remove at least one item from the list
             int end = randomInt(instance.embeddings().size() - 1);
-            return new DenseEmbeddingBitResults(instance.embeddings().subList(0, end));
+            return new LegacyDenseEmbeddingBitResults(instance.embeddings().subList(0, end));
         } else {
-            List<DenseEmbeddingByteResults.Embedding> embeddings = new ArrayList<>(instance.embeddings());
+            List<LegacyDenseEmbeddingByteResults.Embedding> embeddings = new ArrayList<>(instance.embeddings());
             embeddings.add(createRandomEmbedding());
-            return new DenseEmbeddingBitResults(embeddings);
+            return new LegacyDenseEmbeddingBitResults(embeddings);
         }
     }
 
     public static Map<String, Object> buildExpectationBinary(List<byte[]> embeddings) {
-        return Map.of(DenseEmbeddingBitResults.EMBEDDINGS_BITS, embeddings.stream().map(DenseEmbeddingByteResults.Embedding::new).toList());
+        return Map.of(
+            LegacyDenseEmbeddingBitResults.TEXT_EMBEDDING_BITS,
+            embeddings.stream().map(LegacyDenseEmbeddingByteResults.Embedding::new).toList()
+        );
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/results/LegacyDenseEmbeddingByteResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/results/LegacyDenseEmbeddingByteResultsTests.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.inference.results;
+
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.xpack.core.ml.inference.results.MlDenseEmbeddingResults;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+@SuppressWarnings("removal")
+public class LegacyDenseEmbeddingByteResultsTests extends AbstractWireSerializingTestCase<LegacyDenseEmbeddingByteResults> {
+    public static LegacyDenseEmbeddingByteResults createRandomResults() {
+        int embeddings = randomIntBetween(1, 10);
+        List<LegacyDenseEmbeddingByteResults.Embedding> embeddingResults = new ArrayList<>(embeddings);
+
+        for (int i = 0; i < embeddings; i++) {
+            embeddingResults.add(createRandomEmbedding());
+        }
+
+        return new LegacyDenseEmbeddingByteResults(embeddingResults);
+    }
+
+    private static LegacyDenseEmbeddingByteResults.Embedding createRandomEmbedding() {
+        int columns = randomIntBetween(1, 10);
+        byte[] bytes = new byte[columns];
+
+        for (int i = 0; i < columns; i++) {
+            bytes[i] = randomByte();
+        }
+
+        return new LegacyDenseEmbeddingByteResults.Embedding(bytes);
+    }
+
+    public void testToXContent_CreatesTheRightFormatForASingleEmbedding() throws IOException {
+        var entity = new LegacyDenseEmbeddingByteResults(List.of(new LegacyDenseEmbeddingByteResults.Embedding(new byte[] { (byte) 23 })));
+
+        String xContentResult = Strings.toString(entity, true, true);
+        assertThat(xContentResult, is("""
+            {
+              "text_embedding_bytes" : [
+                {
+                  "embedding" : [
+                    23
+                  ]
+                }
+              ]
+            }"""));
+    }
+
+    public void testToXContent_CreatesTheRightFormatForMultipleEmbeddings() throws IOException {
+        var entity = new LegacyDenseEmbeddingByteResults(
+            List.of(
+                new LegacyDenseEmbeddingByteResults.Embedding(new byte[] { (byte) 23 }),
+                new LegacyDenseEmbeddingByteResults.Embedding(new byte[] { (byte) 24 })
+            )
+        );
+
+        String xContentResult = Strings.toString(entity, true, true);
+        assertThat(xContentResult, is("""
+            {
+              "text_embedding_bytes" : [
+                {
+                  "embedding" : [
+                    23
+                  ]
+                },
+                {
+                  "embedding" : [
+                    24
+                  ]
+                }
+              ]
+            }"""));
+    }
+
+    public void testTransformToCoordinationFormat() {
+        var results = new LegacyDenseEmbeddingByteResults(
+            List.of(
+                new LegacyDenseEmbeddingByteResults.Embedding(new byte[] { (byte) 23, (byte) 24 }),
+                new LegacyDenseEmbeddingByteResults.Embedding(new byte[] { (byte) 25, (byte) 26 })
+            )
+        ).transformToCoordinationFormat();
+
+        assertThat(
+            results,
+            is(
+                List.of(
+                    new MlDenseEmbeddingResults(LegacyDenseEmbeddingByteResults.TEXT_EMBEDDING_BYTES, new double[] { 23F, 24F }, false),
+                    new MlDenseEmbeddingResults(LegacyDenseEmbeddingByteResults.TEXT_EMBEDDING_BYTES, new double[] { 25F, 26F }, false)
+                )
+            )
+        );
+    }
+
+    public void testGetFirstEmbeddingSize() {
+        var firstEmbeddingSize = new LegacyDenseEmbeddingByteResults(
+            List.of(
+                new LegacyDenseEmbeddingByteResults.Embedding(new byte[] { (byte) 23, (byte) 24 }),
+                new LegacyDenseEmbeddingByteResults.Embedding(new byte[] { (byte) 25, (byte) 26 })
+            )
+        ).getFirstEmbeddingSize();
+
+        assertThat(firstEmbeddingSize, is(2));
+    }
+
+    public void testEmbeddingMerge() {
+        LegacyDenseEmbeddingByteResults.Embedding embedding1 = new LegacyDenseEmbeddingByteResults.Embedding(new byte[] { 1, 1, -128 });
+        LegacyDenseEmbeddingByteResults.Embedding embedding2 = new LegacyDenseEmbeddingByteResults.Embedding(new byte[] { 1, 0, 127 });
+        LegacyDenseEmbeddingByteResults.Embedding embedding3 = new LegacyDenseEmbeddingByteResults.Embedding(new byte[] { 0, 0, 100 });
+        LegacyDenseEmbeddingByteResults.Embedding mergedEmbedding = embedding1.merge(embedding2);
+        assertThat(mergedEmbedding, equalTo(new LegacyDenseEmbeddingByteResults.Embedding(new byte[] { 1, 1, 0 })));
+        mergedEmbedding = mergedEmbedding.merge(embedding3);
+        assertThat(mergedEmbedding, equalTo(new LegacyDenseEmbeddingByteResults.Embedding(new byte[] { 1, 0, 33 })));
+    }
+
+    @Override
+    protected Writeable.Reader<LegacyDenseEmbeddingByteResults> instanceReader() {
+        return LegacyDenseEmbeddingByteResults::new;
+    }
+
+    @Override
+    protected LegacyDenseEmbeddingByteResults createTestInstance() {
+        return createRandomResults();
+    }
+
+    @Override
+    protected LegacyDenseEmbeddingByteResults mutateInstance(LegacyDenseEmbeddingByteResults instance) throws IOException {
+        // if true we reduce the embeddings list by a random amount, if false we add an embedding to the list
+        if (randomBoolean()) {
+            // -1 to remove at least one item from the list
+            int end = randomInt(instance.embeddings().size() - 1);
+            return new LegacyDenseEmbeddingByteResults(instance.embeddings().subList(0, end));
+        } else {
+            List<LegacyDenseEmbeddingByteResults.Embedding> embeddings = new ArrayList<>(instance.embeddings());
+            embeddings.add(createRandomEmbedding());
+            return new LegacyDenseEmbeddingByteResults(embeddings);
+        }
+    }
+
+    public static Map<String, Object> buildExpectationByte(List<byte[]> embeddings) {
+        return Map.of(
+            LegacyDenseEmbeddingByteResults.TEXT_EMBEDDING_BYTES,
+            embeddings.stream().map(LegacyDenseEmbeddingByteResults.Embedding::new).toList()
+        );
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/results/LegacyDenseEmbeddingFloatResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/results/LegacyDenseEmbeddingFloatResultsTests.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.inference.results;
+
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.xpack.core.ml.inference.results.MlDenseEmbeddingResults;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+@SuppressWarnings("removal")
+public class LegacyDenseEmbeddingFloatResultsTests extends AbstractWireSerializingTestCase<LegacyDenseEmbeddingFloatResults> {
+    public static LegacyDenseEmbeddingFloatResults createRandomResults() {
+        int embeddings = randomIntBetween(1, 10);
+        List<LegacyDenseEmbeddingFloatResults.Embedding> embeddingResults = new ArrayList<>(embeddings);
+
+        for (int i = 0; i < embeddings; i++) {
+            embeddingResults.add(createRandomEmbedding());
+        }
+
+        return new LegacyDenseEmbeddingFloatResults(embeddingResults);
+    }
+
+    private static LegacyDenseEmbeddingFloatResults.Embedding createRandomEmbedding() {
+        int columns = randomIntBetween(1, 10);
+        float[] floats = new float[columns];
+        for (int i = 0; i < columns; i++) {
+            floats[i] = randomFloat();
+        }
+
+        return new LegacyDenseEmbeddingFloatResults.Embedding(floats);
+    }
+
+    public void testToXContent_CreatesTheRightFormatForASingleEmbedding() throws IOException {
+        var entity = new LegacyDenseEmbeddingFloatResults(List.of(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.1F })));
+
+        String xContentResult = Strings.toString(entity, true, true);
+        assertThat(xContentResult, is("""
+            {
+              "text_embedding" : [
+                {
+                  "embedding" : [
+                    0.1
+                  ]
+                }
+              ]
+            }"""));
+    }
+
+    public void testToXContent_CreatesTheRightFormatForMultipleEmbeddings() throws IOException {
+        var entity = new LegacyDenseEmbeddingFloatResults(
+            List.of(
+                new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.1F }),
+                new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.2F })
+            )
+
+        );
+
+        String xContentResult = Strings.toString(entity, true, true);
+        assertThat(xContentResult, is("""
+            {
+              "text_embedding" : [
+                {
+                  "embedding" : [
+                    0.1
+                  ]
+                },
+                {
+                  "embedding" : [
+                    0.2
+                  ]
+                }
+              ]
+            }"""));
+    }
+
+    public void testTransformToCoordinationFormat() {
+        var results = new LegacyDenseEmbeddingFloatResults(
+            List.of(
+                new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.1F, 0.2F }),
+                new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.3F, 0.4F })
+            )
+        ).transformToCoordinationFormat();
+
+        assertThat(
+            results,
+            is(
+                List.of(
+                    new MlDenseEmbeddingResults(LegacyDenseEmbeddingFloatResults.TEXT_EMBEDDING, new double[] { 0.1F, 0.2F }, false),
+                    new MlDenseEmbeddingResults(LegacyDenseEmbeddingFloatResults.TEXT_EMBEDDING, new double[] { 0.3F, 0.4F }, false)
+                )
+            )
+        );
+    }
+
+    public void testGetFirstEmbeddingSize() {
+        var firstEmbeddingSize = new LegacyDenseEmbeddingFloatResults(
+            List.of(
+                new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.1F, 0.2F }),
+                new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.3F, 0.4F })
+            )
+        ).getFirstEmbeddingSize();
+
+        assertThat(firstEmbeddingSize, is(2));
+    }
+
+    public void testEmbeddingMerge() {
+        LegacyDenseEmbeddingFloatResults.Embedding embedding1 = new LegacyDenseEmbeddingFloatResults.Embedding(
+            new float[] { 0.1f, 0.2f, 0.3f, 0.4f }
+        );
+        LegacyDenseEmbeddingFloatResults.Embedding embedding2 = new LegacyDenseEmbeddingFloatResults.Embedding(
+            new float[] { 0.0f, 0.4f, 0.1f, 1.0f }
+        );
+        LegacyDenseEmbeddingFloatResults.Embedding embedding3 = new LegacyDenseEmbeddingFloatResults.Embedding(
+            new float[] { 0.2f, 0.9f, 0.8f, 0.1f }
+        );
+        LegacyDenseEmbeddingFloatResults.Embedding mergedEmbedding = embedding1.merge(embedding2);
+        assertThat(mergedEmbedding, equalTo(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.05f, 0.3f, 0.2f, 0.7f })));
+        mergedEmbedding = mergedEmbedding.merge(embedding3);
+        assertThat(mergedEmbedding, equalTo(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.1f, 0.5f, 0.4f, 0.5f })));
+    }
+
+    @Override
+    protected Writeable.Reader<LegacyDenseEmbeddingFloatResults> instanceReader() {
+        return LegacyDenseEmbeddingFloatResults::new;
+    }
+
+    @Override
+    protected LegacyDenseEmbeddingFloatResults createTestInstance() {
+        return createRandomResults();
+    }
+
+    @Override
+    protected LegacyDenseEmbeddingFloatResults mutateInstance(LegacyDenseEmbeddingFloatResults instance) throws IOException {
+        // if true we reduce the embeddings list by a random amount, if false we add an embedding to the list
+        if (randomBoolean()) {
+            // -1 to remove at least one item from the list
+            int end = randomInt(instance.embeddings().size() - 1);
+            return new LegacyDenseEmbeddingFloatResults(instance.embeddings().subList(0, end));
+        } else {
+            List<LegacyDenseEmbeddingFloatResults.Embedding> embeddings = new ArrayList<>(instance.embeddings());
+            embeddings.add(createRandomEmbedding());
+            return new LegacyDenseEmbeddingFloatResults(embeddings);
+        }
+    }
+
+    public static Map<String, Object> buildExpectationFloat(List<float[]> embeddings) {
+        return Map.of(
+            LegacyDenseEmbeddingFloatResults.TEXT_EMBEDDING,
+            embeddings.stream().map(LegacyDenseEmbeddingFloatResults.Embedding::new).toList()
+        );
+    }
+
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/results/SparseEmbeddingResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/results/SparseEmbeddingResultsTests.java
@@ -207,7 +207,7 @@ public class SparseEmbeddingResultsTests extends AbstractWireSerializingTestCase
             embeddings.stream()
                 .map(
                     embedding -> Map.of(
-                        SparseEmbeddingResults.Embedding.EMBEDDING,
+                        EmbeddingResults.EMBEDDING,
                         embedding.tokens,
                         SparseEmbeddingResults.Embedding.IS_TRUNCATED,
                         embedding.isTruncated

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/inference/textembedding/TextEmbeddingOperatorOutputBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/inference/textembedding/TextEmbeddingOperatorOutputBuilder.java
@@ -12,9 +12,9 @@ import org.elasticsearch.compute.data.FloatBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingByteResults;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingByteResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.esql.inference.InferenceOperator;
 
 /**
@@ -91,15 +91,15 @@ class TextEmbeddingOperatorOutputBuilder implements InferenceOperator.OutputBuil
      */
     private static float[] getEmbeddingAsFloatArray(DenseEmbeddingResults<?> embedding) {
         return switch (embedding.embeddings().get(0)) {
-            case DenseEmbeddingFloatResults.Embedding floatEmbedding -> floatEmbedding.values();
-            case DenseEmbeddingByteResults.Embedding byteEmbedding -> toFloatArray(byteEmbedding.values());
+            case LegacyDenseEmbeddingFloatResults.Embedding floatEmbedding -> floatEmbedding.values();
+            case LegacyDenseEmbeddingByteResults.Embedding byteEmbedding -> toFloatArray(byteEmbedding.values());
             default -> throw new IllegalArgumentException(
                 "Unsupported embedding type: "
                     + embedding.embeddings().get(0).getClass().getName()
                     + ". Expected "
-                    + DenseEmbeddingFloatResults.Embedding.class.getSimpleName()
+                    + LegacyDenseEmbeddingFloatResults.Embedding.class.getSimpleName()
                     + " or "
-                    + DenseEmbeddingByteResults.Embedding.class.getSimpleName()
+                    + LegacyDenseEmbeddingByteResults.Embedding.class.getSimpleName()
                     + "."
             );
         };

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/inference/InferenceFunctionEvaluatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/inference/InferenceFunctionEvaluatorTests.java
@@ -16,7 +16,7 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FoldContext;
@@ -250,7 +250,7 @@ public class InferenceFunctionEvaluatorTests extends ComputeTestCase {
     }
 
     private InferenceAction.Response inferenceResponse(float[] embedding) {
-        DenseEmbeddingFloatResults.Embedding embeddingResult = new DenseEmbeddingFloatResults.Embedding(embedding);
-        return new InferenceAction.Response(new DenseEmbeddingFloatResults(List.of(embeddingResult)));
+        LegacyDenseEmbeddingFloatResults.Embedding embeddingResult = new LegacyDenseEmbeddingFloatResults.Embedding(embedding);
+        return new InferenceAction.Response(new LegacyDenseEmbeddingFloatResults(List.of(embeddingResult)));
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/inference/textembedding/TextEmbeddingOperatorOutputBuilderTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/inference/textembedding/TextEmbeddingOperatorOutputBuilderTests.java
@@ -15,8 +15,8 @@ import org.elasticsearch.compute.test.ComputeTestCase;
 import org.elasticsearch.compute.test.RandomBlock;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingByteResults;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingByteResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 
 import java.util.List;
 
@@ -206,19 +206,19 @@ public class TextEmbeddingOperatorOutputBuilderTests extends ComputeTestCase {
     }
 
     private static InferenceAction.Response createFloatEmbeddingResponse(float[] embedding) {
-        var embeddingResult = new DenseEmbeddingFloatResults.Embedding(embedding);
-        var denseEmbeddingResults = new DenseEmbeddingFloatResults(List.of(embeddingResult));
+        var embeddingResult = new LegacyDenseEmbeddingFloatResults.Embedding(embedding);
+        var denseEmbeddingResults = new LegacyDenseEmbeddingFloatResults(List.of(embeddingResult));
         return new InferenceAction.Response(denseEmbeddingResults);
     }
 
     private static InferenceAction.Response createByteEmbeddingResponse(byte[] embedding) {
-        var embeddingResult = new DenseEmbeddingByteResults.Embedding(embedding);
-        var denseEmbeddingResults = new DenseEmbeddingByteResults(List.of(embeddingResult));
+        var embeddingResult = new LegacyDenseEmbeddingByteResults.Embedding(embedding);
+        var denseEmbeddingResults = new LegacyDenseEmbeddingByteResults(List.of(embeddingResult));
         return new InferenceAction.Response(denseEmbeddingResults);
     }
 
     private static InferenceAction.Response createEmptyFloatEmbeddingResponse() {
-        var denseEmbeddingResults = new DenseEmbeddingFloatResults(List.of());
+        var denseEmbeddingResults = new LegacyDenseEmbeddingFloatResults(List.of());
         return new InferenceAction.Response(denseEmbeddingResults);
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/inference/textembedding/TextEmbeddingOperatorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/inference/textembedding/TextEmbeddingOperatorTests.java
@@ -13,7 +13,7 @@ import org.elasticsearch.compute.data.FloatBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.Operator;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.esql.inference.InferenceOperatorTestCase;
 import org.hamcrest.Matcher;
 import org.junit.Before;
@@ -23,7 +23,7 @@ import java.util.List;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
-public class TextEmbeddingOperatorTests extends InferenceOperatorTestCase<DenseEmbeddingFloatResults> {
+public class TextEmbeddingOperatorTests extends InferenceOperatorTestCase<LegacyDenseEmbeddingFloatResults> {
     private static final String SIMPLE_INFERENCE_ID = "test_text_embedding";
     private static final int EMBEDDING_DIMENSION = 384; // Common embedding dimension
 
@@ -89,15 +89,15 @@ public class TextEmbeddingOperatorTests extends InferenceOperatorTestCase<DenseE
     }
 
     @Override
-    protected DenseEmbeddingFloatResults mockInferenceResult(InferenceAction.Request request) {
+    protected LegacyDenseEmbeddingFloatResults mockInferenceResult(InferenceAction.Request request) {
         // For text embedding, we expect one input text per request
         String inputText = request.getInput().get(0);
 
         // Generate a deterministic mock embedding based on the input text
         float[] mockEmbedding = generateMockEmbedding(inputText, EMBEDDING_DIMENSION);
 
-        var embeddingResult = new DenseEmbeddingFloatResults.Embedding(mockEmbedding);
-        return new DenseEmbeddingFloatResults(List.of(embeddingResult));
+        var embeddingResult = new LegacyDenseEmbeddingFloatResults.Embedding(mockEmbedding);
+        return new LegacyDenseEmbeddingFloatResults(List.of(embeddingResult));
     }
 
     @Override

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/DefaultEndPointsIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/DefaultEndPointsIT.java
@@ -13,6 +13,7 @@ import org.elasticsearch.client.ResponseListener;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalService;
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -120,7 +121,7 @@ public class DefaultEndPointsIT extends InferenceBaseRestTest {
         var inputs = List.of("Hello World", "Goodnight moon");
         var queryParams = Map.of("timeout", "120s");
         var results = infer(ElasticsearchInternalService.DEFAULT_E5_ID, TaskType.TEXT_EMBEDDING, inputs, queryParams);
-        var embeddings = (List<Map<String, Object>>) results.get("text_embedding");
+        var embeddings = (List<Map<String, Object>>) results.get(LegacyDenseEmbeddingFloatResults.TEXT_EMBEDDING);
         assertThat(results.toString(), embeddings, hasSize(2));
     }
 

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceBaseRestTest.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceBaseRestTest.java
@@ -25,6 +25,9 @@ import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.RankedDocsResults;
+import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResults;
 import org.elasticsearch.xpack.inference.external.response.streaming.ServerSentEvent;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -515,15 +518,15 @@ public class InferenceBaseRestTest extends ESRestTestCase {
     protected void assertNonEmptyInferenceResults(Map<String, Object> resultMap, int expectedNumberOfResults, TaskType taskType) {
         switch (taskType) {
             case RERANK -> {
-                var results = (List<Map<String, Object>>) resultMap.get(TaskType.RERANK.toString());
+                var results = (List<Map<String, Object>>) resultMap.get(RankedDocsResults.RERANK);
                 assertThat(results, hasSize(expectedNumberOfResults));
             }
             case SPARSE_EMBEDDING -> {
-                var results = (List<Map<String, Object>>) resultMap.get(TaskType.SPARSE_EMBEDDING.toString());
+                var results = (List<Map<String, Object>>) resultMap.get(SparseEmbeddingResults.SPARSE_EMBEDDING);
                 assertThat(results, hasSize(expectedNumberOfResults));
             }
             case TEXT_EMBEDDING -> {
-                var results = (List<Map<String, Object>>) resultMap.get(TaskType.TEXT_EMBEDDING.toString());
+                var results = (List<Map<String, Object>>) resultMap.get(LegacyDenseEmbeddingFloatResults.TEXT_EMBEDDING);
                 assertThat(results, hasSize(expectedNumberOfResults));
             }
             default -> fail("test with task type [" + taskType + "] are not supported yet");

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/TextEmbeddingCrudIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/TextEmbeddingCrudIT.java
@@ -11,6 +11,8 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.plugins.Platforms;
+import org.elasticsearch.xpack.core.inference.results.EmbeddingResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 
 import java.io.IOException;
 import java.util.List;
@@ -41,9 +43,12 @@ public class TextEmbeddingCrudIT extends InferenceBaseRestTest {
             TaskType.TEXT_EMBEDDING,
             List.of("hello world", "this is the second document")
         );
-        assertTrue(((List) ((Map) ((List) results.get("text_embedding")).get(0)).get("embedding")).size() > 1);
+        assertTrue(
+            ((List) ((Map) ((List) results.get(LegacyDenseEmbeddingFloatResults.TEXT_EMBEDDING)).get(0)).get(EmbeddingResults.EMBEDDING))
+                .size() > 1
+        );
         // there exists embeddings
-        assertTrue(((List) results.get("text_embedding")).size() == 2);
+        assertTrue(((List) results.get(LegacyDenseEmbeddingFloatResults.TEXT_EMBEDDING)).size() == 2);
         // there are two sets of embeddings
         deleteTextEmbeddingModel(inferenceEntityId);
     }
@@ -60,9 +65,13 @@ public class TextEmbeddingCrudIT extends InferenceBaseRestTest {
                 TaskType.TEXT_EMBEDDING,
                 List.of("hello world", "this is the second document")
             );
-            assertTrue(((List) ((Map) ((List) results.get("text_embedding")).get(0)).get("embedding")).size() > 1);
+            assertTrue(
+                ((List) ((Map) ((List) results.get(LegacyDenseEmbeddingFloatResults.TEXT_EMBEDDING)).get(0)).get(
+                    EmbeddingResults.EMBEDDING
+                )).size() > 1
+            );
             // there exists embeddings
-            assertTrue(((List) results.get("text_embedding")).size() == 2);
+            assertTrue(((List) results.get(LegacyDenseEmbeddingFloatResults.TEXT_EMBEDDING)).size() == 2);
             // there are two sets of embeddings
             deleteTextEmbeddingModel(inferenceEntityId);
         } else {

--- a/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestDenseInferenceServiceExtension.java
+++ b/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestDenseInferenceServiceExtension.java
@@ -36,7 +36,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.inference.results.ChunkedInferenceEmbedding;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -167,8 +167,8 @@ public class TestDenseInferenceServiceExtension implements InferenceServiceExten
             }
         }
 
-        private DenseEmbeddingFloatResults makeResults(List<String> input, ServiceSettings serviceSettings) {
-            List<DenseEmbeddingFloatResults.Embedding> embeddings = new ArrayList<>();
+        private LegacyDenseEmbeddingFloatResults makeResults(List<String> input, ServiceSettings serviceSettings) {
+            List<LegacyDenseEmbeddingFloatResults.Embedding> embeddings = new ArrayList<>();
             for (String inputString : input) {
                 List<Float> floatEmbeddings = generateEmbedding(
                     inputString,
@@ -176,18 +176,18 @@ public class TestDenseInferenceServiceExtension implements InferenceServiceExten
                     serviceSettings.elementType(),
                     serviceSettings.similarity()
                 );
-                embeddings.add(DenseEmbeddingFloatResults.Embedding.of(floatEmbeddings));
+                embeddings.add(LegacyDenseEmbeddingFloatResults.Embedding.of(floatEmbeddings));
             }
-            return new DenseEmbeddingFloatResults(embeddings);
+            return new LegacyDenseEmbeddingFloatResults(embeddings);
         }
 
         private List<ChunkedInference> makeChunkedResults(List<ChunkInferenceInput> inputs, ServiceSettings serviceSettings) {
             var results = new ArrayList<ChunkedInference>();
             for (ChunkInferenceInput input : inputs) {
                 List<ChunkedInput> chunkedInput = chunkInputs(input);
-                List<DenseEmbeddingFloatResults.Chunk> chunks = chunkedInput.stream()
+                List<LegacyDenseEmbeddingFloatResults.Chunk> chunks = chunkedInput.stream()
                     .map(
-                        c -> new DenseEmbeddingFloatResults.Chunk(
+                        c -> new LegacyDenseEmbeddingFloatResults.Chunk(
                             makeResults(List.of(c.input()), serviceSettings).embeddings().get(0),
                             new ChunkedInference.TextOffset(c.startOffset(), c.endOffset())
                         )

--- a/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestStreamingCompletionServiceExtension.java
+++ b/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestStreamingCompletionServiceExtension.java
@@ -35,7 +35,7 @@ import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.inference.DequeUtils;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.StreamingChatCompletionResults;
 import org.elasticsearch.xpack.core.inference.results.StreamingUnifiedChatCompletionResults;
 
@@ -189,16 +189,16 @@ public class TestStreamingCompletionServiceExtension implements InferenceService
             });
         }
 
-        private DenseEmbeddingFloatResults makeDenseEmbeddingResults(List<String> input) {
-            var embeddings = new ArrayList<DenseEmbeddingFloatResults.Embedding>();
+        private LegacyDenseEmbeddingFloatResults makeDenseEmbeddingResults(List<String> input) {
+            var embeddings = new ArrayList<LegacyDenseEmbeddingFloatResults.Embedding>();
             for (int i = 0; i < input.size(); i++) {
                 var values = new float[5];
                 for (int j = 0; j < 5; j++) {
                     values[j] = random.nextFloat();
                 }
-                embeddings.add(new DenseEmbeddingFloatResults.Embedding(values));
+                embeddings.add(new LegacyDenseEmbeddingFloatResults.Embedding(values));
             }
-            return new DenseEmbeddingFloatResults(embeddings);
+            return new LegacyDenseEmbeddingFloatResults(embeddings);
         }
 
         private InferenceServiceResults.Result completionChunk(String delta) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceNamedWriteablesProvider.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceNamedWriteablesProvider.java
@@ -21,6 +21,8 @@ import org.elasticsearch.inference.UnifiedCompletionRequest;
 import org.elasticsearch.xpack.core.inference.results.ChatCompletionResults;
 import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingByteResults;
 import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingByteResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.RankedDocsResults;
 import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResults;
 import org.elasticsearch.xpack.core.inference.results.StreamingChatCompletionResults;
@@ -625,6 +627,20 @@ public class InferenceNamedWriteablesProvider {
     private static void addInferenceResultsNamedWriteables(List<NamedWriteableRegistry.Entry> namedWriteables) {
         namedWriteables.add(
             new NamedWriteableRegistry.Entry(InferenceServiceResults.class, SparseEmbeddingResults.NAME, SparseEmbeddingResults::new)
+        );
+        namedWriteables.add(
+            new NamedWriteableRegistry.Entry(
+                InferenceServiceResults.class,
+                LegacyDenseEmbeddingFloatResults.NAME,
+                LegacyDenseEmbeddingFloatResults::new
+            )
+        );
+        namedWriteables.add(
+            new NamedWriteableRegistry.Entry(
+                InferenceServiceResults.class,
+                LegacyDenseEmbeddingByteResults.NAME,
+                LegacyDenseEmbeddingByteResults::new
+            )
         );
         namedWriteables.add(
             new NamedWriteableRegistry.Entry(

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/response/elastic/ElasticInferenceServiceDenseTextEmbeddingsResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/response/elastic/ElasticInferenceServiceDenseTextEmbeddingsResponseEntity.java
@@ -13,7 +13,7 @@ import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.request.Request;
 
@@ -57,7 +57,7 @@ public class ElasticInferenceServiceDenseTextEmbeddingsResponseEntity {
      *     </code>
      * </pre>
      */
-    public static DenseEmbeddingFloatResults fromResponse(Request request, HttpResult response) throws IOException {
+    public static LegacyDenseEmbeddingFloatResults fromResponse(Request request, HttpResult response) throws IOException {
         try (var p = XContentFactory.xContent(XContentType.JSON).createParser(XContentParserConfiguration.EMPTY, response.body())) {
             return EmbeddingFloatResult.PARSER.apply(p, null).toDenseEmbeddingFloatResults();
         }
@@ -81,9 +81,9 @@ public class ElasticInferenceServiceDenseTextEmbeddingsResponseEntity {
             }, new ParseField("data"), org.elasticsearch.xcontent.ObjectParser.ValueType.OBJECT_ARRAY);
         }
 
-        public DenseEmbeddingFloatResults toDenseEmbeddingFloatResults() {
-            return new DenseEmbeddingFloatResults(
-                embeddingResults.stream().map(entry -> DenseEmbeddingFloatResults.Embedding.of(entry.embedding)).toList()
+        public LegacyDenseEmbeddingFloatResults toDenseEmbeddingFloatResults() {
+            return new LegacyDenseEmbeddingFloatResults(
+                embeddingResults.stream().map(entry -> LegacyDenseEmbeddingFloatResults.Embedding.of(entry.embedding)).toList()
             );
         }
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/response/AlibabaCloudSearchEmbeddingsResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/response/AlibabaCloudSearchEmbeddingsResponseEntity.java
@@ -9,7 +9,7 @@ package org.elasticsearch.xpack.inference.services.alibabacloudsearch.response;
 
 import org.elasticsearch.common.xcontent.XContentParserUtils;
 import org.elasticsearch.xcontent.XContentParser;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.request.Request;
 
@@ -70,20 +70,20 @@ public class AlibabaCloudSearchEmbeddingsResponseEntity extends AlibabaCloudSear
      * </code>
      * </pre>
      */
-    public static DenseEmbeddingFloatResults fromResponse(Request request, HttpResult response) throws IOException {
+    public static LegacyDenseEmbeddingFloatResults fromResponse(Request request, HttpResult response) throws IOException {
         return fromResponse(request, response, parser -> {
             positionParserAtTokenAfterField(parser, "embeddings", FAILED_TO_FIND_FIELD_TEMPLATE);
 
-            List<DenseEmbeddingFloatResults.Embedding> embeddingList = XContentParserUtils.parseList(
+            List<LegacyDenseEmbeddingFloatResults.Embedding> embeddingList = XContentParserUtils.parseList(
                 parser,
                 AlibabaCloudSearchEmbeddingsResponseEntity::parseEmbeddingObject
             );
 
-            return new DenseEmbeddingFloatResults(embeddingList);
+            return new LegacyDenseEmbeddingFloatResults(embeddingList);
         });
     }
 
-    private static DenseEmbeddingFloatResults.Embedding parseEmbeddingObject(XContentParser parser) throws IOException {
+    private static LegacyDenseEmbeddingFloatResults.Embedding parseEmbeddingObject(XContentParser parser) throws IOException {
         XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
 
         positionParserAtTokenAfterField(parser, "embedding", FAILED_TO_FIND_FIELD_TEMPLATE);
@@ -95,7 +95,7 @@ public class AlibabaCloudSearchEmbeddingsResponseEntity extends AlibabaCloudSear
         // if there are additional fields within this object, lets skip them, so we can begin parsing the next embedding array
         parser.skipChildren();
 
-        return DenseEmbeddingFloatResults.Embedding.of(embeddingValues);
+        return LegacyDenseEmbeddingFloatResults.Embedding.of(embeddingValues);
     }
 
     private static float parseEmbeddingList(XContentParser parser) throws IOException {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/response/embeddings/AmazonBedrockEmbeddingsResponse.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/amazonbedrock/response/embeddings/AmazonBedrockEmbeddingsResponse.java
@@ -16,7 +16,7 @@ import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.response.XContentUtils;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.AmazonBedrockProvider;
 import org.elasticsearch.xpack.inference.services.amazonbedrock.request.AmazonBedrockRequest;
@@ -48,7 +48,7 @@ public class AmazonBedrockEmbeddingsResponse extends AmazonBedrockResponse {
         throw new ElasticsearchException("unexpected request type [" + request.getClass() + "]");
     }
 
-    public static DenseEmbeddingFloatResults fromResponse(InvokeModelResponse response, AmazonBedrockProvider provider) {
+    public static LegacyDenseEmbeddingFloatResults fromResponse(InvokeModelResponse response, AmazonBedrockProvider provider) {
         var charset = StandardCharsets.UTF_8;
         var bodyText = String.valueOf(charset.decode(response.body().asByteBuffer()));
 
@@ -63,14 +63,16 @@ public class AmazonBedrockEmbeddingsResponse extends AmazonBedrockResponse {
 
             var embeddingList = parseEmbeddings(jsonParser, provider);
 
-            return new DenseEmbeddingFloatResults(embeddingList);
+            return new LegacyDenseEmbeddingFloatResults(embeddingList);
         } catch (IOException e) {
             throw new ElasticsearchException(e);
         }
     }
 
-    private static List<DenseEmbeddingFloatResults.Embedding> parseEmbeddings(XContentParser jsonParser, AmazonBedrockProvider provider)
-        throws IOException {
+    private static List<LegacyDenseEmbeddingFloatResults.Embedding> parseEmbeddings(
+        XContentParser jsonParser,
+        AmazonBedrockProvider provider
+    ) throws IOException {
         switch (provider) {
             case AMAZONTITAN -> {
                 return parseTitanEmbeddings(jsonParser);
@@ -82,7 +84,7 @@ public class AmazonBedrockEmbeddingsResponse extends AmazonBedrockResponse {
         }
     }
 
-    private static List<DenseEmbeddingFloatResults.Embedding> parseTitanEmbeddings(XContentParser parser) throws IOException {
+    private static List<LegacyDenseEmbeddingFloatResults.Embedding> parseTitanEmbeddings(XContentParser parser) throws IOException {
         /*
         Titan response:
         {
@@ -92,11 +94,11 @@ public class AmazonBedrockEmbeddingsResponse extends AmazonBedrockResponse {
         */
         positionParserAtTokenAfterField(parser, "embedding", FAILED_TO_FIND_FIELD_TEMPLATE);
         List<Float> embeddingValuesList = parseList(parser, XContentUtils::parseFloat);
-        var embeddingValues = DenseEmbeddingFloatResults.Embedding.of(embeddingValuesList);
+        var embeddingValues = LegacyDenseEmbeddingFloatResults.Embedding.of(embeddingValuesList);
         return List.of(embeddingValues);
     }
 
-    private static List<DenseEmbeddingFloatResults.Embedding> parseCohereEmbeddings(XContentParser parser) throws IOException {
+    private static List<LegacyDenseEmbeddingFloatResults.Embedding> parseCohereEmbeddings(XContentParser parser) throws IOException {
         /*
         Cohere response:
         {
@@ -111,7 +113,7 @@ public class AmazonBedrockEmbeddingsResponse extends AmazonBedrockResponse {
          */
         positionParserAtTokenAfterField(parser, "embeddings", FAILED_TO_FIND_FIELD_TEMPLATE);
 
-        List<DenseEmbeddingFloatResults.Embedding> embeddingList = parseList(
+        List<LegacyDenseEmbeddingFloatResults.Embedding> embeddingList = parseList(
             parser,
             AmazonBedrockEmbeddingsResponse::parseCohereEmbeddingsListItem
         );
@@ -119,9 +121,9 @@ public class AmazonBedrockEmbeddingsResponse extends AmazonBedrockResponse {
         return embeddingList;
     }
 
-    private static DenseEmbeddingFloatResults.Embedding parseCohereEmbeddingsListItem(XContentParser parser) throws IOException {
+    private static LegacyDenseEmbeddingFloatResults.Embedding parseCohereEmbeddingsListItem(XContentParser parser) throws IOException {
         List<Float> embeddingValuesList = parseList(parser, XContentUtils::parseFloat);
-        return DenseEmbeddingFloatResults.Embedding.of(embeddingValuesList);
+        return LegacyDenseEmbeddingFloatResults.Embedding.of(embeddingValuesList);
     }
 
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/response/CohereEmbeddingsResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/response/CohereEmbeddingsResponseEntity.java
@@ -15,9 +15,9 @@ import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingBitResults;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingByteResults;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingBitResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingByteResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.request.Request;
 import org.elasticsearch.xpack.inference.external.response.XContentUtils;
@@ -189,20 +189,20 @@ public class CohereEmbeddingsResponseEntity {
         // Cohere returns array of binary embeddings encoded as bytes with int8 precision so we can reuse the byte parser
         var embeddingList = parseList(parser, CohereEmbeddingsResponseEntity::parseByteArrayEntry);
 
-        return new DenseEmbeddingBitResults(embeddingList);
+        return new LegacyDenseEmbeddingBitResults(embeddingList);
     }
 
     private static InferenceServiceResults parseByteEmbeddingsArray(XContentParser parser) throws IOException {
         var embeddingList = parseList(parser, CohereEmbeddingsResponseEntity::parseByteArrayEntry);
 
-        return new DenseEmbeddingByteResults(embeddingList);
+        return new LegacyDenseEmbeddingByteResults(embeddingList);
     }
 
-    private static DenseEmbeddingByteResults.Embedding parseByteArrayEntry(XContentParser parser) throws IOException {
+    private static LegacyDenseEmbeddingByteResults.Embedding parseByteArrayEntry(XContentParser parser) throws IOException {
         ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
         List<Byte> embeddingValuesList = parseList(parser, CohereEmbeddingsResponseEntity::parseEmbeddingInt8Entry);
 
-        return DenseEmbeddingByteResults.Embedding.of(embeddingValuesList);
+        return LegacyDenseEmbeddingByteResults.Embedding.of(embeddingValuesList);
     }
 
     private static Byte parseEmbeddingInt8Entry(XContentParser parser) throws IOException {
@@ -223,13 +223,13 @@ public class CohereEmbeddingsResponseEntity {
     private static InferenceServiceResults parseFloatEmbeddingsArray(XContentParser parser) throws IOException {
         var embeddingList = parseList(parser, CohereEmbeddingsResponseEntity::parseFloatArrayEntry);
 
-        return new DenseEmbeddingFloatResults(embeddingList);
+        return new LegacyDenseEmbeddingFloatResults(embeddingList);
     }
 
-    private static DenseEmbeddingFloatResults.Embedding parseFloatArrayEntry(XContentParser parser) throws IOException {
+    private static LegacyDenseEmbeddingFloatResults.Embedding parseFloatArrayEntry(XContentParser parser) throws IOException {
         ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
         List<Float> embeddingValuesList = parseList(parser, XContentUtils::parseFloat);
-        return DenseEmbeddingFloatResults.Embedding.of(embeddingValuesList);
+        return LegacyDenseEmbeddingFloatResults.Embedding.of(embeddingValuesList);
     }
 
     private CohereEmbeddingsResponseEntity() {}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/custom/response/DenseEmbeddingResponseParser.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/custom/response/DenseEmbeddingResponseParser.java
@@ -14,9 +14,9 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingBitResults;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingByteResults;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingBitResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingByteResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.common.MapPathExtractor;
 import org.elasticsearch.xpack.inference.services.custom.CustomServiceEmbeddingType;
 
@@ -174,7 +174,7 @@ public class DenseEmbeddingResponseParser extends BaseCustomResponseParser {
 
     private static class FloatEmbeddings implements EmbeddingConverter {
 
-        private final List<DenseEmbeddingFloatResults.Embedding> embeddings;
+        private final List<LegacyDenseEmbeddingFloatResults.Embedding> embeddings;
 
         FloatEmbeddings() {
             this.embeddings = new ArrayList<>();
@@ -182,17 +182,17 @@ public class DenseEmbeddingResponseParser extends BaseCustomResponseParser {
 
         public void toEmbedding(Object entry, String fieldName) {
             var embeddingsAsListFloats = convertToListOfFloats(entry, fieldName);
-            embeddings.add(DenseEmbeddingFloatResults.Embedding.of(embeddingsAsListFloats));
+            embeddings.add(LegacyDenseEmbeddingFloatResults.Embedding.of(embeddingsAsListFloats));
         }
 
-        public DenseEmbeddingFloatResults getResults() {
-            return new DenseEmbeddingFloatResults(embeddings);
+        public LegacyDenseEmbeddingFloatResults getResults() {
+            return new LegacyDenseEmbeddingFloatResults(embeddings);
         }
     }
 
     private static class ByteEmbeddings implements EmbeddingConverter {
 
-        private final List<DenseEmbeddingByteResults.Embedding> embeddings;
+        private final List<LegacyDenseEmbeddingByteResults.Embedding> embeddings;
 
         ByteEmbeddings() {
             this.embeddings = new ArrayList<>();
@@ -200,17 +200,17 @@ public class DenseEmbeddingResponseParser extends BaseCustomResponseParser {
 
         public void toEmbedding(Object entry, String fieldName) {
             var convertedEmbeddings = convertToListOfBytes(entry, fieldName);
-            this.embeddings.add(DenseEmbeddingByteResults.Embedding.of(convertedEmbeddings));
+            this.embeddings.add(LegacyDenseEmbeddingByteResults.Embedding.of(convertedEmbeddings));
         }
 
-        public DenseEmbeddingByteResults getResults() {
-            return new DenseEmbeddingByteResults(embeddings);
+        public LegacyDenseEmbeddingByteResults getResults() {
+            return new LegacyDenseEmbeddingByteResults(embeddings);
         }
     }
 
     private static class BitEmbeddings implements EmbeddingConverter {
 
-        private final List<DenseEmbeddingByteResults.Embedding> embeddings;
+        private final List<LegacyDenseEmbeddingByteResults.Embedding> embeddings;
 
         BitEmbeddings() {
             this.embeddings = new ArrayList<>();
@@ -218,11 +218,11 @@ public class DenseEmbeddingResponseParser extends BaseCustomResponseParser {
 
         public void toEmbedding(Object entry, String fieldName) {
             var convertedEmbeddings = convertToListOfBits(entry, fieldName);
-            this.embeddings.add(DenseEmbeddingByteResults.Embedding.of(convertedEmbeddings));
+            this.embeddings.add(LegacyDenseEmbeddingByteResults.Embedding.of(convertedEmbeddings));
         }
 
-        public DenseEmbeddingBitResults getResults() {
-            return new DenseEmbeddingBitResults(embeddings);
+        public LegacyDenseEmbeddingBitResults getResults() {
+            return new LegacyDenseEmbeddingBitResults(embeddings);
         }
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
@@ -41,7 +41,7 @@ import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsBuilder;
 import org.elasticsearch.xpack.core.inference.chunking.EmbeddingRequestChunker;
 import org.elasticsearch.xpack.core.inference.chunking.RerankRequestChunker;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.RankedDocsResults;
 import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResults;
 import org.elasticsearch.xpack.core.ml.action.GetDeploymentStatsAction;
@@ -642,7 +642,7 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
         );
 
         ActionListener<InferModelAction.Response> mlResultsListener = listener.delegateFailureAndWrap(
-            (l, inferenceResult) -> l.onResponse(DenseEmbeddingFloatResults.of(inferenceResult.getInferenceResults()))
+            (l, inferenceResult) -> l.onResponse(LegacyDenseEmbeddingFloatResults.of(inferenceResult.getInferenceResults()))
         );
 
         var maybeDeployListener = mlResultsListener.delegateResponse(
@@ -772,11 +772,11 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
         ActionListener<InferenceServiceResults> chunkPartListener
     ) {
         if (taskType == TaskType.TEXT_EMBEDDING) {
-            var translated = new ArrayList<DenseEmbeddingFloatResults.Embedding>();
+            var translated = new ArrayList<LegacyDenseEmbeddingFloatResults.Embedding>();
 
             for (var inferenceResult : inferenceResults) {
                 if (inferenceResult instanceof MlDenseEmbeddingResults mlTextEmbeddingResult) {
-                    translated.add(new DenseEmbeddingFloatResults.Embedding(mlTextEmbeddingResult.getInferenceAsFloat()));
+                    translated.add(new LegacyDenseEmbeddingFloatResults.Embedding(mlTextEmbeddingResult.getInferenceAsFloat()));
                 } else if (inferenceResult instanceof ErrorInferenceResults error) {
                     chunkPartListener.onFailure(error.getException());
                     return;
@@ -787,7 +787,7 @@ public class ElasticsearchInternalService extends BaseElasticsearchInternalServi
                     return;
                 }
             }
-            chunkPartListener.onResponse(new DenseEmbeddingFloatResults(translated));
+            chunkPartListener.onResponse(new LegacyDenseEmbeddingFloatResults(translated));
         } else { // sparse
             var translated = new ArrayList<SparseEmbeddingResults.Embedding>();
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googleaistudio/response/GoogleAiStudioEmbeddingsResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googleaistudio/response/GoogleAiStudioEmbeddingsResponseEntity.java
@@ -12,7 +12,7 @@ import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.request.Request;
 import org.elasticsearch.xpack.inference.external.response.XContentUtils;
@@ -70,7 +70,7 @@ public class GoogleAiStudioEmbeddingsResponseEntity {
      * </pre>
      */
 
-    public static DenseEmbeddingFloatResults fromResponse(Request request, HttpResult response) throws IOException {
+    public static LegacyDenseEmbeddingFloatResults fromResponse(Request request, HttpResult response) throws IOException {
         var parserConfig = XContentParserConfiguration.EMPTY.withDeprecationHandler(LoggingDeprecationHandler.INSTANCE);
 
         try (XContentParser jsonParser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, response.body())) {
@@ -81,16 +81,16 @@ public class GoogleAiStudioEmbeddingsResponseEntity {
 
             positionParserAtTokenAfterField(jsonParser, "embeddings", FAILED_TO_FIND_FIELD_TEMPLATE);
 
-            List<DenseEmbeddingFloatResults.Embedding> embeddingList = parseList(
+            List<LegacyDenseEmbeddingFloatResults.Embedding> embeddingList = parseList(
                 jsonParser,
                 GoogleAiStudioEmbeddingsResponseEntity::parseEmbeddingObject
             );
 
-            return new DenseEmbeddingFloatResults(embeddingList);
+            return new LegacyDenseEmbeddingFloatResults(embeddingList);
         }
     }
 
-    private static DenseEmbeddingFloatResults.Embedding parseEmbeddingObject(XContentParser parser) throws IOException {
+    private static LegacyDenseEmbeddingFloatResults.Embedding parseEmbeddingObject(XContentParser parser) throws IOException {
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
 
         positionParserAtTokenAfterField(parser, "values", FAILED_TO_FIND_FIELD_TEMPLATE);
@@ -99,7 +99,7 @@ public class GoogleAiStudioEmbeddingsResponseEntity {
         // parse and discard the rest of the object
         consumeUntilObjectEnd(parser);
 
-        return DenseEmbeddingFloatResults.Embedding.of(embeddingValuesList);
+        return LegacyDenseEmbeddingFloatResults.Embedding.of(embeddingValuesList);
     }
 
     private GoogleAiStudioEmbeddingsResponseEntity() {}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/response/GoogleVertexAiEmbeddingsResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/response/GoogleVertexAiEmbeddingsResponseEntity.java
@@ -13,7 +13,7 @@ import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.request.Request;
 
@@ -64,7 +64,7 @@ public class GoogleVertexAiEmbeddingsResponseEntity {
      * </pre>
      */
 
-    public static DenseEmbeddingFloatResults fromResponse(Request request, HttpResult response) throws IOException {
+    public static LegacyDenseEmbeddingFloatResults fromResponse(Request request, HttpResult response) throws IOException {
         var parserConfig = XContentParserConfiguration.EMPTY.withDeprecationHandler(LoggingDeprecationHandler.INSTANCE);
 
         try (XContentParser jsonParser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, response.body())) {
@@ -75,16 +75,16 @@ public class GoogleVertexAiEmbeddingsResponseEntity {
 
             positionParserAtTokenAfterField(jsonParser, "predictions", FAILED_TO_FIND_FIELD_TEMPLATE);
 
-            List<DenseEmbeddingFloatResults.Embedding> embeddingList = parseList(
+            List<LegacyDenseEmbeddingFloatResults.Embedding> embeddingList = parseList(
                 jsonParser,
                 GoogleVertexAiEmbeddingsResponseEntity::parseEmbeddingObject
             );
 
-            return new DenseEmbeddingFloatResults(embeddingList);
+            return new LegacyDenseEmbeddingFloatResults(embeddingList);
         }
     }
 
-    private static DenseEmbeddingFloatResults.Embedding parseEmbeddingObject(XContentParser parser) throws IOException {
+    private static LegacyDenseEmbeddingFloatResults.Embedding parseEmbeddingObject(XContentParser parser) throws IOException {
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
 
         positionParserAtTokenAfterField(parser, "embeddings", FAILED_TO_FIND_FIELD_TEMPLATE);
@@ -99,7 +99,7 @@ public class GoogleVertexAiEmbeddingsResponseEntity {
         consumeUntilObjectEnd(parser);
         consumeUntilObjectEnd(parser);
 
-        return DenseEmbeddingFloatResults.Embedding.of(embeddingValueList);
+        return LegacyDenseEmbeddingFloatResults.Embedding.of(embeddingValueList);
     }
 
     private static float parseEmbeddingList(XContentParser parser) throws IOException {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/elser/HuggingFaceElserService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/elser/HuggingFaceElserService.java
@@ -26,8 +26,8 @@ import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.inference.configuration.SettingsConfigurationFieldType;
 import org.elasticsearch.xpack.core.inference.results.ChunkedInferenceEmbedding;
 import org.elasticsearch.xpack.core.inference.results.ChunkedInferenceError;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.EmbeddingResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResults;
 import org.elasticsearch.xpack.core.ml.inference.results.ErrorInferenceResults;
 import org.elasticsearch.xpack.inference.external.http.sender.EmbeddingsInput;
@@ -127,7 +127,7 @@ public class HuggingFaceElserService extends HuggingFaceBaseService {
         List<ChunkInferenceInput> inputs,
         InferenceServiceResults inferenceResults
     ) {
-        if (inferenceResults instanceof DenseEmbeddingFloatResults denseEmbeddingResults) {
+        if (inferenceResults instanceof LegacyDenseEmbeddingFloatResults denseEmbeddingResults) {
             validateInputSizeAgainstEmbeddings(ChunkInferenceInput.inputs(inputs), denseEmbeddingResults.embeddings().size());
 
             var results = new ArrayList<ChunkedInference>(inputs.size());
@@ -153,7 +153,7 @@ public class HuggingFaceElserService extends HuggingFaceBaseService {
         } else {
             String expectedClasses = Strings.format(
                 "One of [%s,%s]",
-                DenseEmbeddingFloatResults.class.getSimpleName(),
+                LegacyDenseEmbeddingFloatResults.class.getSimpleName(),
                 SparseEmbeddingResults.class.getSimpleName()
             );
             throw createInvalidChunkedResultException(expectedClasses, inferenceResults.getWriteableName());

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/response/HuggingFaceEmbeddingsResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/response/HuggingFaceEmbeddingsResponseEntity.java
@@ -12,7 +12,7 @@ import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.request.Request;
 import org.elasticsearch.xpack.inference.external.response.XContentUtils;
@@ -33,7 +33,7 @@ public class HuggingFaceEmbeddingsResponseEntity {
      * Parse the response from hugging face. The known formats are an array of arrays and object with an {@code embeddings} field containing
      * an array of arrays.
      */
-    public static DenseEmbeddingFloatResults fromResponse(Request request, HttpResult response) throws IOException {
+    public static LegacyDenseEmbeddingFloatResults fromResponse(Request request, HttpResult response) throws IOException {
         var parserConfig = XContentParserConfiguration.EMPTY.withDeprecationHandler(LoggingDeprecationHandler.INSTANCE);
 
         try (XContentParser jsonParser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, response.body())) {
@@ -91,13 +91,13 @@ public class HuggingFaceEmbeddingsResponseEntity {
      * <a href="https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2">sentence-transformers/all-MiniLM-L6-v2</a>
      * <a href="https://huggingface.co/sentence-transformers/all-MiniLM-L12-v2">sentence-transformers/all-MiniLM-L12-v2</a>
      */
-    private static DenseEmbeddingFloatResults parseArrayFormat(XContentParser parser) throws IOException {
-        List<DenseEmbeddingFloatResults.Embedding> embeddingList = parseList(
+    private static LegacyDenseEmbeddingFloatResults parseArrayFormat(XContentParser parser) throws IOException {
+        List<LegacyDenseEmbeddingFloatResults.Embedding> embeddingList = parseList(
             parser,
             HuggingFaceEmbeddingsResponseEntity::parseEmbeddingEntry
         );
 
-        return new DenseEmbeddingFloatResults(embeddingList);
+        return new LegacyDenseEmbeddingFloatResults(embeddingList);
     }
 
     /**
@@ -136,22 +136,22 @@ public class HuggingFaceEmbeddingsResponseEntity {
      * <a href="https://huggingface.co/intfloat/multilingual-e5-small">intfloat/multilingual-e5-small</a>
      * <a href="https://huggingface.co/sentence-transformers/all-mpnet-base-v2">sentence-transformers/all-mpnet-base-v2</a>
      */
-    private static DenseEmbeddingFloatResults parseObjectFormat(XContentParser parser) throws IOException {
+    private static LegacyDenseEmbeddingFloatResults parseObjectFormat(XContentParser parser) throws IOException {
         positionParserAtTokenAfterField(parser, "embeddings", FAILED_TO_FIND_FIELD_TEMPLATE);
 
-        List<DenseEmbeddingFloatResults.Embedding> embeddingList = parseList(
+        List<LegacyDenseEmbeddingFloatResults.Embedding> embeddingList = parseList(
             parser,
             HuggingFaceEmbeddingsResponseEntity::parseEmbeddingEntry
         );
 
-        return new DenseEmbeddingFloatResults(embeddingList);
+        return new LegacyDenseEmbeddingFloatResults(embeddingList);
     }
 
-    private static DenseEmbeddingFloatResults.Embedding parseEmbeddingEntry(XContentParser parser) throws IOException {
+    private static LegacyDenseEmbeddingFloatResults.Embedding parseEmbeddingEntry(XContentParser parser) throws IOException {
         ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
 
         List<Float> embeddingValuesList = parseList(parser, XContentUtils::parseFloat);
-        return DenseEmbeddingFloatResults.Embedding.of(embeddingValuesList);
+        return LegacyDenseEmbeddingFloatResults.Embedding.of(embeddingValuesList);
     }
 
     private HuggingFaceEmbeddingsResponseEntity() {}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/response/IbmWatsonxEmbeddingsResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/response/IbmWatsonxEmbeddingsResponseEntity.java
@@ -12,7 +12,7 @@ import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.request.Request;
 import org.elasticsearch.xpack.inference.external.response.XContentUtils;
@@ -30,7 +30,7 @@ public class IbmWatsonxEmbeddingsResponseEntity {
 
     private static final String FAILED_TO_FIND_FIELD_TEMPLATE = "Failed to find required field [%s] in IBM watsonx embeddings response";
 
-    public static DenseEmbeddingFloatResults fromResponse(Request request, HttpResult response) throws IOException {
+    public static LegacyDenseEmbeddingFloatResults fromResponse(Request request, HttpResult response) throws IOException {
         var parserConfig = XContentParserConfiguration.EMPTY.withDeprecationHandler(LoggingDeprecationHandler.INSTANCE);
 
         try (XContentParser jsonParser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, response.body())) {
@@ -41,16 +41,16 @@ public class IbmWatsonxEmbeddingsResponseEntity {
 
             positionParserAtTokenAfterField(jsonParser, "results", FAILED_TO_FIND_FIELD_TEMPLATE);
 
-            List<DenseEmbeddingFloatResults.Embedding> embeddingList = parseList(
+            List<LegacyDenseEmbeddingFloatResults.Embedding> embeddingList = parseList(
                 jsonParser,
                 IbmWatsonxEmbeddingsResponseEntity::parseEmbeddingObject
             );
 
-            return new DenseEmbeddingFloatResults(embeddingList);
+            return new LegacyDenseEmbeddingFloatResults(embeddingList);
         }
     }
 
-    private static DenseEmbeddingFloatResults.Embedding parseEmbeddingObject(XContentParser parser) throws IOException {
+    private static LegacyDenseEmbeddingFloatResults.Embedding parseEmbeddingObject(XContentParser parser) throws IOException {
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
 
         positionParserAtTokenAfterField(parser, "embedding", FAILED_TO_FIND_FIELD_TEMPLATE);
@@ -59,7 +59,7 @@ public class IbmWatsonxEmbeddingsResponseEntity {
         // parse and discard the rest of the object
         consumeUntilObjectEnd(parser);
 
-        return DenseEmbeddingFloatResults.Embedding.of(embeddingValuesList);
+        return LegacyDenseEmbeddingFloatResults.Embedding.of(embeddingValuesList);
     }
 
     private IbmWatsonxEmbeddingsResponseEntity() {}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/response/JinaAIEmbeddingsResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/response/JinaAIEmbeddingsResponseEntity.java
@@ -15,9 +15,9 @@ import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingBitResults;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingByteResults;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingBitResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingByteResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.request.Request;
 import org.elasticsearch.xpack.inference.external.response.XContentUtils;
@@ -126,15 +126,15 @@ public class JinaAIEmbeddingsResponseEntity {
     }
 
     private static InferenceServiceResults parseFloatDataObject(XContentParser jsonParser) throws IOException {
-        List<DenseEmbeddingFloatResults.Embedding> embeddingList = parseList(
+        List<LegacyDenseEmbeddingFloatResults.Embedding> embeddingList = parseList(
             jsonParser,
             JinaAIEmbeddingsResponseEntity::parseFloatEmbeddingObject
         );
 
-        return new DenseEmbeddingFloatResults(embeddingList);
+        return new LegacyDenseEmbeddingFloatResults(embeddingList);
     }
 
-    private static DenseEmbeddingFloatResults.Embedding parseFloatEmbeddingObject(XContentParser parser) throws IOException {
+    private static LegacyDenseEmbeddingFloatResults.Embedding parseFloatEmbeddingObject(XContentParser parser) throws IOException {
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
 
         positionParserAtTokenAfterField(parser, "embedding", FAILED_TO_FIND_FIELD_TEMPLATE);
@@ -143,19 +143,19 @@ public class JinaAIEmbeddingsResponseEntity {
         // parse and discard the rest of the object
         consumeUntilObjectEnd(parser);
 
-        return DenseEmbeddingFloatResults.Embedding.of(embeddingValuesList);
+        return LegacyDenseEmbeddingFloatResults.Embedding.of(embeddingValuesList);
     }
 
     private static InferenceServiceResults parseBitDataObject(XContentParser jsonParser) throws IOException {
-        List<DenseEmbeddingByteResults.Embedding> embeddingList = parseList(
+        List<LegacyDenseEmbeddingByteResults.Embedding> embeddingList = parseList(
             jsonParser,
             JinaAIEmbeddingsResponseEntity::parseBitEmbeddingObject
         );
 
-        return new DenseEmbeddingBitResults(embeddingList);
+        return new LegacyDenseEmbeddingBitResults(embeddingList);
     }
 
-    private static DenseEmbeddingByteResults.Embedding parseBitEmbeddingObject(XContentParser parser) throws IOException {
+    private static LegacyDenseEmbeddingByteResults.Embedding parseBitEmbeddingObject(XContentParser parser) throws IOException {
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
 
         positionParserAtTokenAfterField(parser, "embedding", FAILED_TO_FIND_FIELD_TEMPLATE);
@@ -164,7 +164,7 @@ public class JinaAIEmbeddingsResponseEntity {
         // parse and discard the rest of the object
         consumeUntilObjectEnd(parser);
 
-        return DenseEmbeddingByteResults.Embedding.of(embeddingList);
+        return LegacyDenseEmbeddingByteResults.Embedding.of(embeddingList);
     }
 
     private static Byte parseEmbeddingInt8Entry(XContentParser parser) throws IOException {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/response/OpenAiEmbeddingsResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/response/OpenAiEmbeddingsResponseEntity.java
@@ -12,7 +12,7 @@ import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.request.Request;
 
@@ -65,7 +65,7 @@ public class OpenAiEmbeddingsResponseEntity {
      * </code>
      * </pre>
      */
-    public static DenseEmbeddingFloatResults fromResponse(Request request, HttpResult response) throws IOException {
+    public static LegacyDenseEmbeddingFloatResults fromResponse(Request request, HttpResult response) throws IOException {
         try (var p = XContentFactory.xContent(XContentType.JSON).createParser(XContentParserConfiguration.EMPTY, response.body())) {
             return EmbeddingFloatResult.PARSER.apply(p, null).toDenseEmbeddingFloatResults();
         }
@@ -83,9 +83,9 @@ public class OpenAiEmbeddingsResponseEntity {
             PARSER.declareObjectArray(constructorArg(), EmbeddingFloatResultEntry.PARSER::apply, new ParseField("data"));
         }
 
-        public DenseEmbeddingFloatResults toDenseEmbeddingFloatResults() {
-            return new DenseEmbeddingFloatResults(
-                embeddingResults.stream().map(entry -> DenseEmbeddingFloatResults.Embedding.of(entry.embedding)).toList()
+        public LegacyDenseEmbeddingFloatResults toDenseEmbeddingFloatResults() {
+            return new LegacyDenseEmbeddingFloatResults(
+                embeddingResults.stream().map(entry -> LegacyDenseEmbeddingFloatResults.Embedding.of(entry.embedding)).toList()
             );
         }
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/sagemaker/schema/elastic/ElasticTextEmbeddingPayload.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/sagemaker/schema/elastic/ElasticTextEmbeddingPayload.java
@@ -24,10 +24,11 @@ import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingBitResults;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingByteResults;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingResults;
+import org.elasticsearch.xpack.core.inference.results.EmbeddingResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingBitResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingByteResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.services.sagemaker.SageMakerInferenceRequest;
 import org.elasticsearch.xpack.inference.services.sagemaker.model.SageMakerModel;
 import org.elasticsearch.xpack.inference.services.sagemaker.schema.SageMakerStoredServiceSchema;
@@ -58,7 +59,7 @@ import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractSim
  */
 public class ElasticTextEmbeddingPayload implements ElasticPayload {
     private static final EnumSet<TaskType> SUPPORTED_TASKS = EnumSet.of(TaskType.TEXT_EMBEDDING);
-    private static final ParseField EMBEDDING = new ParseField("embedding");
+    private static final ParseField EMBEDDING = new ParseField(EmbeddingResults.EMBEDDING);
 
     private static final TransportVersion ML_INFERENCE_SAGEMAKER_ELASTIC = TransportVersion.fromName("ml_inference_sagemaker_elastic");
 
@@ -120,12 +121,12 @@ public class ElasticTextEmbeddingPayload implements ElasticPayload {
      * }
      */
     private static class TextEmbeddingBinary {
-        private static final ParseField TEXT_EMBEDDING_BITS = new ParseField(DenseEmbeddingBitResults.TEXT_EMBEDDING_BITS);
+        private static final ParseField TEXT_EMBEDDING_BITS = new ParseField(LegacyDenseEmbeddingBitResults.TEXT_EMBEDDING_BITS);
         @SuppressWarnings("unchecked")
-        private static final ConstructingObjectParser<DenseEmbeddingBitResults, Void> PARSER = new ConstructingObjectParser<>(
-            DenseEmbeddingBitResults.class.getSimpleName(),
+        private static final ConstructingObjectParser<LegacyDenseEmbeddingBitResults, Void> PARSER = new ConstructingObjectParser<>(
+            LegacyDenseEmbeddingBitResults.class.getSimpleName(),
             IGNORE_UNKNOWN_FIELDS,
-            args -> new DenseEmbeddingBitResults((List<DenseEmbeddingByteResults.Embedding>) args[0])
+            args -> new LegacyDenseEmbeddingBitResults((List<LegacyDenseEmbeddingByteResults.Embedding>) args[0])
         );
 
         static {
@@ -151,20 +152,20 @@ public class ElasticTextEmbeddingPayload implements ElasticPayload {
      * }
      */
     private static class TextEmbeddingBytes {
-        private static final ParseField TEXT_EMBEDDING_BYTES = new ParseField(DenseEmbeddingByteResults.TEXT_EMBEDDING_BYTES);
+        private static final ParseField TEXT_EMBEDDING_BYTES = new ParseField(LegacyDenseEmbeddingByteResults.TEXT_EMBEDDING_BYTES);
         @SuppressWarnings("unchecked")
-        private static final ConstructingObjectParser<DenseEmbeddingByteResults, Void> PARSER = new ConstructingObjectParser<>(
-            DenseEmbeddingByteResults.class.getSimpleName(),
+        private static final ConstructingObjectParser<LegacyDenseEmbeddingByteResults, Void> PARSER = new ConstructingObjectParser<>(
+            LegacyDenseEmbeddingByteResults.class.getSimpleName(),
             IGNORE_UNKNOWN_FIELDS,
-            args -> new DenseEmbeddingByteResults((List<DenseEmbeddingByteResults.Embedding>) args[0])
+            args -> new LegacyDenseEmbeddingByteResults((List<LegacyDenseEmbeddingByteResults.Embedding>) args[0])
         );
 
         @SuppressWarnings("unchecked")
-        private static final ConstructingObjectParser<DenseEmbeddingByteResults.Embedding, Void> BYTE_PARSER =
+        private static final ConstructingObjectParser<LegacyDenseEmbeddingByteResults.Embedding, Void> BYTE_PARSER =
             new ConstructingObjectParser<>(
-                DenseEmbeddingByteResults.Embedding.class.getSimpleName(),
+                LegacyDenseEmbeddingByteResults.Embedding.class.getSimpleName(),
                 IGNORE_UNKNOWN_FIELDS,
-                args -> DenseEmbeddingByteResults.Embedding.of((List<Byte>) args[0])
+                args -> LegacyDenseEmbeddingByteResults.Embedding.of((List<Byte>) args[0])
             );
 
         static {
@@ -197,20 +198,20 @@ public class ElasticTextEmbeddingPayload implements ElasticPayload {
      * }
      */
     private static class TextEmbeddingFloat {
-        private static final ParseField TEXT_EMBEDDING_FLOAT = new ParseField(DenseEmbeddingFloatResults.TEXT_EMBEDDING);
+        private static final ParseField TEXT_EMBEDDING_FLOAT = new ParseField(LegacyDenseEmbeddingFloatResults.TEXT_EMBEDDING);
         @SuppressWarnings("unchecked")
-        private static final ConstructingObjectParser<DenseEmbeddingFloatResults, Void> PARSER = new ConstructingObjectParser<>(
-            DenseEmbeddingFloatResults.class.getSimpleName(),
+        private static final ConstructingObjectParser<LegacyDenseEmbeddingFloatResults, Void> PARSER = new ConstructingObjectParser<>(
+            LegacyDenseEmbeddingFloatResults.class.getSimpleName(),
             IGNORE_UNKNOWN_FIELDS,
-            args -> new DenseEmbeddingFloatResults((List<DenseEmbeddingFloatResults.Embedding>) args[0])
+            args -> new LegacyDenseEmbeddingFloatResults((List<LegacyDenseEmbeddingFloatResults.Embedding>) args[0])
         );
 
         @SuppressWarnings("unchecked")
-        private static final ConstructingObjectParser<DenseEmbeddingFloatResults.Embedding, Void> FLOAT_PARSER =
+        private static final ConstructingObjectParser<LegacyDenseEmbeddingFloatResults.Embedding, Void> FLOAT_PARSER =
             new ConstructingObjectParser<>(
-                DenseEmbeddingFloatResults.Embedding.class.getSimpleName(),
+                LegacyDenseEmbeddingFloatResults.Embedding.class.getSimpleName(),
                 IGNORE_UNKNOWN_FIELDS,
-                args -> DenseEmbeddingFloatResults.Embedding.of((List<Float>) args[0])
+                args -> LegacyDenseEmbeddingFloatResults.Embedding.of((List<Float>) args[0])
             );
 
         static {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/sagemaker/schema/openai/OpenAiTextEmbeddingPayload.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/sagemaker/schema/openai/OpenAiTextEmbeddingPayload.java
@@ -25,7 +25,7 @@ import org.elasticsearch.xcontent.XContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.json.JsonXContent;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.services.openai.response.OpenAiEmbeddingsResponseEntity;
 import org.elasticsearch.xpack.inference.services.sagemaker.SageMakerInferenceRequest;
 import org.elasticsearch.xpack.inference.services.sagemaker.model.SageMakerModel;
@@ -116,7 +116,7 @@ public class OpenAiTextEmbeddingPayload implements SageMakerSchemaPayload {
     }
 
     @Override
-    public DenseEmbeddingFloatResults responseBody(SageMakerModel model, InvokeEndpointResponse response) throws Exception {
+    public LegacyDenseEmbeddingFloatResults responseBody(SageMakerModel model, InvokeEndpointResponse response) throws Exception {
         try (var p = jsonXContent.createParser(XContentParserConfiguration.EMPTY, response.body().asInputStream())) {
             return OpenAiEmbeddingsResponseEntity.EmbeddingFloatResult.PARSER.apply(p, null).toDenseEmbeddingFloatResults();
         }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/validation/ElasticsearchInternalServiceModelValidator.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/validation/ElasticsearchInternalServiceModelValidator.java
@@ -17,8 +17,8 @@ import org.elasticsearch.inference.Model;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.inference.validation.ServiceIntegrationValidator;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.services.elasticsearch.CustomElandEmbeddingModel;
 
 public class ElasticsearchInternalServiceModelValidator implements ModelValidator {
@@ -79,7 +79,7 @@ public class ElasticsearchInternalServiceModelValidator implements ModelValidato
             throw new ElasticsearchStatusException(
                 "Validation call did not return expected results type."
                     + "Expected a result of type ["
-                    + DenseEmbeddingFloatResults.NAME
+                    + LegacyDenseEmbeddingFloatResults.NAME
                     + "] got ["
                     + (results == null ? "null" : results.getWriteableName())
                     + "]",

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/voyageai/response/VoyageAIEmbeddingsResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/voyageai/response/VoyageAIEmbeddingsResponseEntity.java
@@ -15,9 +15,9 @@ import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingBitResults;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingByteResults;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingBitResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingByteResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.request.Request;
 import org.elasticsearch.xpack.inference.services.voyageai.embeddings.VoyageAIEmbeddingType;
@@ -75,9 +75,9 @@ public class VoyageAIEmbeddingsResponseEntity {
             }
         }
 
-        public DenseEmbeddingByteResults.Embedding toInferenceByteEmbedding() {
+        public LegacyDenseEmbeddingByteResults.Embedding toInferenceByteEmbedding() {
             embedding.forEach(EmbeddingInt8ResultEntry::checkByteBounds);
-            return DenseEmbeddingByteResults.Embedding.of(embedding.stream().map(Integer::byteValue).toList());
+            return LegacyDenseEmbeddingByteResults.Embedding.of(embedding.stream().map(Integer::byteValue).toList());
         }
     }
 
@@ -108,8 +108,8 @@ public class VoyageAIEmbeddingsResponseEntity {
             PARSER.declareFloatArray(constructorArg(), new ParseField("embedding"));
         }
 
-        public DenseEmbeddingFloatResults.Embedding toInferenceFloatEmbedding() {
-            return DenseEmbeddingFloatResults.Embedding.of(embedding);
+        public LegacyDenseEmbeddingFloatResults.Embedding toInferenceFloatEmbedding() {
+            return LegacyDenseEmbeddingFloatResults.Embedding.of(embedding);
         }
     }
 
@@ -166,22 +166,22 @@ public class VoyageAIEmbeddingsResponseEntity {
             if (embeddingType == null || embeddingType == VoyageAIEmbeddingType.FLOAT) {
                 var embeddingResult = EmbeddingFloatResult.PARSER.apply(jsonParser, null);
 
-                List<DenseEmbeddingFloatResults.Embedding> embeddingList = embeddingResult.entries.stream()
+                List<LegacyDenseEmbeddingFloatResults.Embedding> embeddingList = embeddingResult.entries.stream()
                     .map(EmbeddingFloatResultEntry::toInferenceFloatEmbedding)
                     .toList();
-                return new DenseEmbeddingFloatResults(embeddingList);
+                return new LegacyDenseEmbeddingFloatResults(embeddingList);
             } else if (embeddingType == VoyageAIEmbeddingType.INT8) {
                 var embeddingResult = EmbeddingInt8Result.PARSER.apply(jsonParser, null);
-                List<DenseEmbeddingByteResults.Embedding> embeddingList = embeddingResult.entries.stream()
+                List<LegacyDenseEmbeddingByteResults.Embedding> embeddingList = embeddingResult.entries.stream()
                     .map(EmbeddingInt8ResultEntry::toInferenceByteEmbedding)
                     .toList();
-                return new DenseEmbeddingByteResults(embeddingList);
+                return new LegacyDenseEmbeddingByteResults(embeddingList);
             } else if (embeddingType == VoyageAIEmbeddingType.BIT || embeddingType == VoyageAIEmbeddingType.BINARY) {
                 var embeddingResult = EmbeddingInt8Result.PARSER.apply(jsonParser, null);
-                List<DenseEmbeddingByteResults.Embedding> embeddingList = embeddingResult.entries.stream()
+                List<LegacyDenseEmbeddingByteResults.Embedding> embeddingList = embeddingResult.entries.stream()
                     .map(EmbeddingInt8ResultEntry::toInferenceByteEmbedding)
                     .toList();
-                return new DenseEmbeddingBitResults(embeddingList);
+                return new LegacyDenseEmbeddingBitResults(embeddingList);
             } else {
                 throw new IllegalArgumentException(
                     "Illegal embedding_type value: " + embeddingType + ". Supported types are: " + VALID_EMBEDDING_TYPES_STRING

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/InferenceActionResponseTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/InferenceActionResponseTests.java
@@ -12,7 +12,7 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResultsTests;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResultsTests;
 import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResultsTests;
 import org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCase;
 import org.elasticsearch.xpack.core.ml.inference.MlInferenceNamedXContentProvider;
@@ -43,7 +43,9 @@ public class InferenceActionResponseTests extends AbstractBWCWireSerializationTe
     }
 
     private InferenceServiceResults getRandomResults() {
-        return randomBoolean() ? DenseEmbeddingFloatResultsTests.createRandomResults() : SparseEmbeddingResultsTests.createRandomResults();
+        return randomBoolean()
+            ? LegacyDenseEmbeddingFloatResultsTests.createRandomResults()
+            : SparseEmbeddingResultsTests.createRandomResults();
     }
 
     @Override

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/HttpRequestSenderTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/HttpRequestSenderTests.java
@@ -48,7 +48,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.elasticsearch.core.Strings.format;
-import static org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResultsTests.buildExpectationFloat;
+import static org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResultsTests.buildExpectationFloat;
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityExecutors;
 import static org.elasticsearch.xpack.inference.Utils.mockClusterServiceEmpty;
 import static org.elasticsearch.xpack.inference.external.http.Utils.entityAsMap;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldTests.java
@@ -28,9 +28,9 @@ import org.elasticsearch.xpack.core.inference.chunking.NoneChunkingSettings;
 import org.elasticsearch.xpack.core.inference.chunking.SentenceBoundaryChunkingSettings;
 import org.elasticsearch.xpack.core.inference.chunking.WordBoundaryChunkingSettings;
 import org.elasticsearch.xpack.core.inference.results.ChunkedInferenceEmbedding;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingByteResults;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.EmbeddingResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingByteResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResults;
 import org.elasticsearch.xpack.core.utils.FloatConversionUtils;
 import org.elasticsearch.xpack.inference.model.TestModel;
@@ -211,7 +211,7 @@ public class SemanticTextFieldTests extends AbstractXContentTestCase<SemanticTex
             }
             chunks.add(
                 new EmbeddingResults.Chunk(
-                    new DenseEmbeddingByteResults.Embedding(values),
+                    new LegacyDenseEmbeddingByteResults.Embedding(values),
                     new ChunkedInference.TextOffset(0, input.length())
                 )
             );
@@ -233,7 +233,7 @@ public class SemanticTextFieldTests extends AbstractXContentTestCase<SemanticTex
             }
             chunks.add(
                 new EmbeddingResults.Chunk(
-                    new DenseEmbeddingFloatResults.Embedding(values),
+                    new LegacyDenseEmbeddingFloatResults.Embedding(values),
                     new ChunkedInference.TextOffset(0, input.length())
                 )
             );
@@ -415,8 +415,8 @@ public class SemanticTextFieldTests extends AbstractXContentTestCase<SemanticTex
                         ChunkedInference.TextOffset offset = createOffset(useLegacyFormat, entryChunk, matchedText);
                         double[] values = parseDenseVector(entryChunk.rawEmbeddings(), embeddingLength, field.contentType());
                         EmbeddingResults.Embedding<?> embedding = switch (elementType) {
-                            case FLOAT -> new DenseEmbeddingFloatResults.Embedding(FloatConversionUtils.floatArrayOf(values));
-                            case BYTE, BIT -> new DenseEmbeddingByteResults.Embedding(byteArrayOf(values));
+                            case FLOAT -> new LegacyDenseEmbeddingFloatResults.Embedding(FloatConversionUtils.floatArrayOf(values));
+                            case BYTE, BIT -> new LegacyDenseEmbeddingByteResults.Embedding(byteArrayOf(values));
                         };
                         chunks.add(new EmbeddingResults.Chunk(embedding, offset));
                     }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/queries/MockInferenceClient.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/queries/MockInferenceClient.java
@@ -20,7 +20,7 @@ import org.elasticsearch.inference.WeightedToken;
 import org.elasticsearch.test.client.NoOpClient;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResults;
 import org.elasticsearch.xpack.core.ml.action.CoordinatedInferenceAction;
 import org.elasticsearch.xpack.core.ml.action.InferModelAction;
@@ -59,7 +59,7 @@ public class MockInferenceClient extends NoOpClient {
                 if (inferenceResults instanceof TextExpansionResults textExpansionResults) {
                     inferenceServiceResults = SparseEmbeddingResults.of(List.of(textExpansionResults));
                 } else if (inferenceResults instanceof MlDenseEmbeddingResults mlDenseEmbeddingResults) {
-                    inferenceServiceResults = DenseEmbeddingFloatResults.of(List.of(mlDenseEmbeddingResults));
+                    inferenceServiceResults = LegacyDenseEmbeddingFloatResults.of(List.of(mlDenseEmbeddingResults));
                 } else {
                     throw new IllegalStateException("Unexpected inference results type [" + inferenceResults.getWriteableName() + "]");
                 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/queries/SemanticQueryBuilderTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/queries/SemanticQueryBuilderTests.java
@@ -66,7 +66,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.core.XPackClientPlugin;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResults;
 import org.elasticsearch.xpack.core.ml.inference.results.MlDenseEmbeddingResults;
 import org.elasticsearch.xpack.core.ml.inference.results.TextExpansionResults;
@@ -349,7 +349,7 @@ public class SemanticQueryBuilderTests extends AbstractQueryTestCase<SemanticQue
         Arrays.fill(inference, 1.0);
         MlDenseEmbeddingResults textEmbeddingResults = new MlDenseEmbeddingResults(DEFAULT_RESULTS_FIELD, inference, false);
 
-        return new InferenceAction.Response(DenseEmbeddingFloatResults.of(List.of(textEmbeddingResults)));
+        return new InferenceAction.Response(LegacyDenseEmbeddingFloatResults.of(List.of(textEmbeddingResults)));
     }
 
     @Override

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rest/BaseInferenceActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/rest/BaseInferenceActionTests.java
@@ -23,7 +23,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.InferenceContext;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.action.InferenceActionProxy;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingByteResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingByteResults;
 import org.elasticsearch.xpack.inference.InferencePlugin;
 import org.junit.Before;
 
@@ -234,7 +234,7 @@ public class BaseInferenceActionTests extends RestActionTestCase {
 
     static InferenceAction.Response createResponse() {
         return new InferenceAction.Response(
-            new DenseEmbeddingByteResults(List.of(new DenseEmbeddingByteResults.Embedding(new byte[] { (byte) -1 })))
+            new LegacyDenseEmbeddingByteResults(List.of(new LegacyDenseEmbeddingByteResults.Embedding(new byte[] { (byte) -1 })))
         );
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/AlibabaCloudSearchServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/AlibabaCloudSearchServiceTests.java
@@ -34,7 +34,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsTests;
 import org.elasticsearch.xpack.core.inference.results.ChunkedInferenceEmbedding;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResults;
 import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResultsTests;
 import org.elasticsearch.xpack.inference.InputTypeTests;
@@ -516,7 +516,7 @@ public class AlibabaCloudSearchServiceTests extends InferenceServiceTestCase {
             var firstResult = results.getFirst();
             assertThat(firstResult, instanceOf(ChunkedInferenceEmbedding.class));
             Class<?> expectedClass = switch (taskType) {
-                case TEXT_EMBEDDING -> DenseEmbeddingFloatResults.Chunk.class;
+                case TEXT_EMBEDDING -> LegacyDenseEmbeddingFloatResults.Chunk.class;
                 case SPARSE_EMBEDDING -> SparseEmbeddingResults.Chunk.class;
                 default -> null;
             };
@@ -650,10 +650,10 @@ public class AlibabaCloudSearchServiceTests extends InferenceServiceTestCase {
         ) {
             public ExecutableAction accept(AlibabaCloudSearchActionVisitor visitor, Map<String, Object> taskSettings) {
                 return (inferenceInputs, timeout, listener) -> {
-                    DenseEmbeddingFloatResults results = new DenseEmbeddingFloatResults(
+                    LegacyDenseEmbeddingFloatResults results = new LegacyDenseEmbeddingFloatResults(
                         List.of(
-                            new DenseEmbeddingFloatResults.Embedding(new float[] { 0.0123f, -0.0123f }),
-                            new DenseEmbeddingFloatResults.Embedding(new float[] { 0.0456f, -0.0456f })
+                            new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.0123f, -0.0123f }),
+                            new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.0456f, -0.0456f })
                         )
                     );
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/action/AlibabaCloudSearchActionCreatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/action/AlibabaCloudSearchActionCreatorTests.java
@@ -21,7 +21,7 @@ import org.elasticsearch.test.http.MockWebServer;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.results.ChatCompletionResults;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.RankedDocsResults;
 import org.elasticsearch.xpack.core.inference.results.RankedDocsResultsTests;
 import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResults;
@@ -50,7 +50,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.xpack.core.inference.results.ChatCompletionResultsTests.buildExpectationCompletion;
-import static org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResultsTests.buildExpectationFloat;
+import static org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResultsTests.buildExpectationFloat;
 import static org.elasticsearch.xpack.core.inference.results.RankedDocsResultsTests.buildExpectationRerank;
 import static org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResultsTests.buildExpectationSparseEmbeddings;
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityExecutors;
@@ -88,7 +88,7 @@ public class AlibabaCloudSearchActionCreatorTests extends ESTestCase {
         float[] values = { 0.1111111f, 0.2222222f, 0.3333333f };
         doAnswer(invocation -> {
             ActionListener<InferenceServiceResults> listener = invocation.getArgument(3);
-            listener.onResponse(new DenseEmbeddingFloatResults(List.of(new DenseEmbeddingFloatResults.Embedding(values))));
+            listener.onResponse(new LegacyDenseEmbeddingFloatResults(List.of(new LegacyDenseEmbeddingFloatResults.Embedding(values))));
 
             return Void.TYPE;
         }).when(sender).send(any(), any(), any(), any());

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/response/AlibabaCloudSearchEmbeddingsResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/alibabacloudsearch/response/AlibabaCloudSearchEmbeddingsResponseEntityTests.java
@@ -9,7 +9,7 @@ package org.elasticsearch.xpack.inference.services.alibabacloudsearch.response;
 
 import org.apache.http.HttpResponse;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.services.alibabacloudsearch.request.AlibabaCloudSearchRequest;
 
@@ -50,14 +50,14 @@ public class AlibabaCloudSearchEmbeddingsResponseEntityTests extends ESTestCase 
         URI uri = new URI("mock_uri");
         when(request.getURI()).thenReturn(uri);
 
-        DenseEmbeddingFloatResults parsedResults = AlibabaCloudSearchEmbeddingsResponseEntity.fromResponse(
+        LegacyDenseEmbeddingFloatResults parsedResults = AlibabaCloudSearchEmbeddingsResponseEntity.fromResponse(
             request,
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
         assertThat(
             parsedResults.embeddings(),
-            is(List.of(new DenseEmbeddingFloatResults.Embedding(new float[] { -0.02868066355586052f, 0.022033605724573135f })))
+            is(List.of(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { -0.02868066355586052f, 0.022033605724573135f })))
         );
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/AmazonBedrockServiceTests.java
@@ -38,7 +38,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.results.ChatCompletionResults;
 import org.elasticsearch.xpack.core.inference.results.ChunkedInferenceEmbedding;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.Utils;
 import org.elasticsearch.xpack.inference.common.amazon.AwsSecretSettings;
 import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSender;
@@ -72,7 +72,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXC
 import static org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsTests.createRandomChunkingSettings;
 import static org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsTests.createRandomChunkingSettingsMap;
 import static org.elasticsearch.xpack.core.inference.results.ChatCompletionResultsTests.buildExpectationCompletion;
-import static org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResultsTests.buildExpectationFloat;
+import static org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResultsTests.buildExpectationFloat;
 import static org.elasticsearch.xpack.inference.Utils.getInvalidModel;
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityExecutors;
 import static org.elasticsearch.xpack.inference.Utils.mockClusterServiceEmpty;
@@ -1026,7 +1026,9 @@ public class AmazonBedrockServiceTests extends InferenceServiceTestCase {
             );
             var requestSender = (AmazonBedrockMockRequestSender) amazonBedrockFactory.createSender()
         ) {
-            var results = new DenseEmbeddingFloatResults(List.of(new DenseEmbeddingFloatResults.Embedding(new float[] { 0.123F, 0.678F })));
+            var results = new LegacyDenseEmbeddingFloatResults(
+                List.of(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.123F, 0.678F }))
+            );
             requestSender.enqueue(results);
             PlainActionFuture<InferenceServiceResults> listener = new PlainActionFuture<>();
             service.infer(
@@ -1067,8 +1069,8 @@ public class AmazonBedrockServiceTests extends InferenceServiceTestCase {
             )
         ) {
             try (var requestSender = (AmazonBedrockMockRequestSender) amazonBedrockFactory.createSender()) {
-                var results = new DenseEmbeddingFloatResults(
-                    List.of(new DenseEmbeddingFloatResults.Embedding(new float[] { 0.123F, 0.678F }))
+                var results = new LegacyDenseEmbeddingFloatResults(
+                    List.of(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.123F, 0.678F }))
                 );
                 requestSender.enqueue(results);
 
@@ -1343,14 +1345,14 @@ public class AmazonBedrockServiceTests extends InferenceServiceTestCase {
         ) {
             try (var requestSender = (AmazonBedrockMockRequestSender) amazonBedrockFactory.createSender()) {
                 {
-                    var mockResults1 = new DenseEmbeddingFloatResults(
-                        List.of(new DenseEmbeddingFloatResults.Embedding(new float[] { 0.123F, 0.678F }))
+                    var mockResults1 = new LegacyDenseEmbeddingFloatResults(
+                        List.of(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.123F, 0.678F }))
                     );
                     requestSender.enqueue(mockResults1);
                 }
                 {
-                    var mockResults2 = new DenseEmbeddingFloatResults(
-                        List.of(new DenseEmbeddingFloatResults.Embedding(new float[] { 0.223F, 0.278F }))
+                    var mockResults2 = new LegacyDenseEmbeddingFloatResults(
+                        List.of(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.223F, 0.278F }))
                     );
                     requestSender.enqueue(mockResults2);
                 }
@@ -1373,10 +1375,10 @@ public class AmazonBedrockServiceTests extends InferenceServiceTestCase {
                     var floatResult = (ChunkedInferenceEmbedding) results.get(0);
                     assertThat(floatResult.chunks(), hasSize(1));
                     assertEquals(new ChunkedInference.TextOffset(0, 1), floatResult.chunks().get(0).offset());
-                    assertThat(floatResult.chunks().get(0).embedding(), instanceOf(DenseEmbeddingFloatResults.Embedding.class));
+                    assertThat(floatResult.chunks().get(0).embedding(), instanceOf(LegacyDenseEmbeddingFloatResults.Embedding.class));
                     assertArrayEquals(
                         new float[] { 0.123F, 0.678F },
-                        ((DenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values(),
+                        ((LegacyDenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values(),
                         0.0f
                     );
                 }
@@ -1385,10 +1387,10 @@ public class AmazonBedrockServiceTests extends InferenceServiceTestCase {
                     var floatResult = (ChunkedInferenceEmbedding) results.get(1);
                     assertThat(floatResult.chunks(), hasSize(1));
                     assertEquals(new ChunkedInference.TextOffset(0, 2), floatResult.chunks().get(0).offset());
-                    assertThat(floatResult.chunks().get(0).embedding(), instanceOf(DenseEmbeddingFloatResults.Embedding.class));
+                    assertThat(floatResult.chunks().get(0).embedding(), instanceOf(LegacyDenseEmbeddingFloatResults.Embedding.class));
                     assertArrayEquals(
                         new float[] { 0.223F, 0.278F },
-                        ((DenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values(),
+                        ((LegacyDenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values(),
                         0.0f
                     );
                 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/action/AmazonBedrockActionCreatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/action/AmazonBedrockActionCreatorTests.java
@@ -15,7 +15,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.results.ChatCompletionResults;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.InputTypeTests;
 import org.elasticsearch.xpack.inference.external.http.sender.ChatCompletionInput;
 import org.elasticsearch.xpack.inference.external.http.sender.EmbeddingsInput;
@@ -33,7 +33,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.xpack.core.inference.results.ChatCompletionResultsTests.buildExpectationCompletion;
-import static org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResultsTests.buildExpectationFloat;
+import static org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResultsTests.buildExpectationFloat;
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityExecutors;
 import static org.hamcrest.Matchers.is;
 
@@ -53,8 +53,8 @@ public class AmazonBedrockActionCreatorTests extends ESTestCase {
 
     public void testEmbeddingsRequestAction_Titan() throws IOException {
         var serviceComponents = ServiceComponentsTests.createWithEmptySettings(threadPool);
-        var mockedFloatResults = List.of(new DenseEmbeddingFloatResults.Embedding(new float[] { 0.0123F, -0.0123F }));
-        var mockedResult = new DenseEmbeddingFloatResults(mockedFloatResults);
+        var mockedFloatResults = List.of(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.0123F, -0.0123F }));
+        var mockedResult = new LegacyDenseEmbeddingFloatResults(mockedFloatResults);
         try (var sender = new AmazonBedrockMockRequestSender()) {
             sender.enqueue(mockedResult);
             var creator = new AmazonBedrockActionCreator(sender, serviceComponents, TIMEOUT);
@@ -91,8 +91,8 @@ public class AmazonBedrockActionCreatorTests extends ESTestCase {
 
     public void testEmbeddingsRequestAction_Cohere() throws IOException {
         var serviceComponents = ServiceComponentsTests.createWithEmptySettings(threadPool);
-        var mockedFloatResults = List.of(new DenseEmbeddingFloatResults.Embedding(new float[] { 0.0123F, -0.0123F }));
-        var mockedResult = new DenseEmbeddingFloatResults(mockedFloatResults);
+        var mockedFloatResults = List.of(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.0123F, -0.0123F }));
+        var mockedResult = new LegacyDenseEmbeddingFloatResults(mockedFloatResults);
         try (var sender = new AmazonBedrockMockRequestSender()) {
             sender.enqueue(mockedResult);
             var creator = new AmazonBedrockActionCreator(sender, serviceComponents, TIMEOUT);

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/client/AmazonBedrockExecutorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/client/AmazonBedrockExecutorTests.java
@@ -34,7 +34,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static org.elasticsearch.xpack.core.inference.results.ChatCompletionResultsTests.buildExpectationCompletion;
-import static org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResultsTests.buildExpectationFloat;
+import static org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResultsTests.buildExpectationFloat;
 import static org.elasticsearch.xpack.inference.common.TruncatorTests.createTruncator;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/client/AmazonBedrockRequestSenderTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/amazonbedrock/client/AmazonBedrockRequestSenderTests.java
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.elasticsearch.xpack.core.inference.results.ChatCompletionResultsTests.buildExpectationCompletion;
-import static org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResultsTests.buildExpectationFloat;
+import static org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResultsTests.buildExpectationFloat;
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityExecutors;
 import static org.elasticsearch.xpack.inference.Utils.mockClusterServiceEmpty;
 import static org.elasticsearch.xpack.inference.services.amazonbedrock.client.AmazonBedrockExecutorTests.TEST_AMAZON_TITAN_EMBEDDINGS_RESULT;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/AzureAiStudioServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/AzureAiStudioServiceTests.java
@@ -39,7 +39,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.results.ChatCompletionResults;
 import org.elasticsearch.xpack.core.inference.results.ChunkedInferenceEmbedding;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.RankedDocsResults;
 import org.elasticsearch.xpack.inference.external.http.HttpClientManager;
 import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSender;
@@ -1347,10 +1347,10 @@ public class AzureAiStudioServiceTests extends InferenceServiceTestCase {
                 var floatResult = (ChunkedInferenceEmbedding) results.get(0);
                 assertThat(floatResult.chunks(), hasSize(1));
                 assertEquals(new ChunkedInference.TextOffset(0, 1), floatResult.chunks().get(0).offset());
-                assertThat(floatResult.chunks().get(0).embedding(), instanceOf(DenseEmbeddingFloatResults.Embedding.class));
+                assertThat(floatResult.chunks().get(0).embedding(), instanceOf(LegacyDenseEmbeddingFloatResults.Embedding.class));
                 assertArrayEquals(
                     new float[] { 0.0123f, -0.0123f },
-                    ((DenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values(),
+                    ((LegacyDenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values(),
                     0.0f
                 );
             }
@@ -1359,10 +1359,10 @@ public class AzureAiStudioServiceTests extends InferenceServiceTestCase {
                 var floatResult = (ChunkedInferenceEmbedding) results.get(1);
                 assertThat(floatResult.chunks(), hasSize(1));
                 assertEquals(new ChunkedInference.TextOffset(0, 2), floatResult.chunks().get(0).offset());
-                assertThat(floatResult.chunks().get(0).embedding(), instanceOf(DenseEmbeddingFloatResults.Embedding.class));
+                assertThat(floatResult.chunks().get(0).embedding(), instanceOf(LegacyDenseEmbeddingFloatResults.Embedding.class));
                 assertArrayEquals(
                     new float[] { 1.0123f, -1.0123f },
-                    ((DenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values(),
+                    ((LegacyDenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values(),
                     0.0f
                 );
             }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/action/AzureAiStudioActionAndCreatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/action/AzureAiStudioActionAndCreatorTests.java
@@ -46,7 +46,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.xpack.core.inference.results.ChatCompletionResultsTests.buildExpectationCompletion;
-import static org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResultsTests.buildExpectationFloat;
+import static org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResultsTests.buildExpectationFloat;
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityExecutors;
 import static org.elasticsearch.xpack.inference.Utils.mockClusterServiceEmpty;
 import static org.elasticsearch.xpack.inference.external.http.Utils.entityAsMap;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/response/AzureAiStudioEmbeddingsResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/response/AzureAiStudioEmbeddingsResponseEntityTests.java
@@ -9,7 +9,7 @@ package org.elasticsearch.xpack.inference.services.azureaistudio.response;
 
 import org.apache.http.HttpResponse;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.request.Request;
 
@@ -50,11 +50,14 @@ public class AzureAiStudioEmbeddingsResponseEntityTests extends ESTestCase {
 
         var entity = new AzureAiStudioEmbeddingsResponseEntity();
 
-        var parsedResults = (DenseEmbeddingFloatResults) entity.apply(
+        var parsedResults = (LegacyDenseEmbeddingFloatResults) entity.apply(
             mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
-        assertThat(parsedResults.embeddings(), is(List.of(DenseEmbeddingFloatResults.Embedding.of(List.of(0.014539449F, -0.015288644F)))));
+        assertThat(
+            parsedResults.embeddings(),
+            is(List.of(LegacyDenseEmbeddingFloatResults.Embedding.of(List.of(0.014539449F, -0.015288644F))))
+        );
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureopenai/AzureOpenAiServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureopenai/AzureOpenAiServiceTests.java
@@ -37,7 +37,7 @@ import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.results.ChunkedInferenceEmbedding;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpClientManager;
 import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSender;
 import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSenderTests;
@@ -65,7 +65,7 @@ import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 import static org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsTests.createRandomChunkingSettings;
 import static org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsTests.createRandomChunkingSettingsMap;
-import static org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResultsTests.buildExpectationFloat;
+import static org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResultsTests.buildExpectationFloat;
 import static org.elasticsearch.xpack.inference.Utils.getInvalidModel;
 import static org.elasticsearch.xpack.inference.Utils.getPersistedConfigMap;
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityExecutors;
@@ -1007,10 +1007,10 @@ public class AzureOpenAiServiceTests extends InferenceServiceTestCase {
                 var floatResult = (ChunkedInferenceEmbedding) results.get(0);
                 assertThat(floatResult.chunks(), hasSize(1));
                 assertEquals(new ChunkedInference.TextOffset(0, 1), floatResult.chunks().get(0).offset());
-                assertThat(floatResult.chunks().get(0).embedding(), instanceOf(DenseEmbeddingFloatResults.Embedding.class));
+                assertThat(floatResult.chunks().get(0).embedding(), instanceOf(LegacyDenseEmbeddingFloatResults.Embedding.class));
                 assertArrayEquals(
                     new float[] { 0.123f, -0.123f },
-                    ((DenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values(),
+                    ((LegacyDenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values(),
                     0.0f
                 );
             }
@@ -1019,10 +1019,10 @@ public class AzureOpenAiServiceTests extends InferenceServiceTestCase {
                 var floatResult = (ChunkedInferenceEmbedding) results.get(1);
                 assertThat(floatResult.chunks(), hasSize(1));
                 assertEquals(new ChunkedInference.TextOffset(0, 2), floatResult.chunks().get(0).offset());
-                assertThat(floatResult.chunks().get(0).embedding(), instanceOf(DenseEmbeddingFloatResults.Embedding.class));
+                assertThat(floatResult.chunks().get(0).embedding(), instanceOf(LegacyDenseEmbeddingFloatResults.Embedding.class));
                 assertArrayEquals(
                     new float[] { 1.123f, -1.123f },
-                    ((DenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values(),
+                    ((LegacyDenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values(),
                     0.0f
                 );
             }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureopenai/action/AzureOpenAiActionCreatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureopenai/action/AzureOpenAiActionCreatorTests.java
@@ -42,7 +42,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.core.Strings.format;
-import static org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResultsTests.buildExpectationFloat;
+import static org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResultsTests.buildExpectationFloat;
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityExecutors;
 import static org.elasticsearch.xpack.inference.Utils.mockClusterServiceEmpty;
 import static org.elasticsearch.xpack.inference.external.http.Utils.entityAsMap;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureopenai/action/AzureOpenAiEmbeddingsActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureopenai/action/AzureOpenAiEmbeddingsActionTests.java
@@ -44,7 +44,7 @@ import java.net.URISyntaxException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResultsTests.buildExpectationFloat;
+import static org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResultsTests.buildExpectationFloat;
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityExecutors;
 import static org.elasticsearch.xpack.inference.Utils.mockClusterServiceEmpty;
 import static org.elasticsearch.xpack.inference.external.action.ActionUtils.constructFailedToSendRequestMessage;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/CohereServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/CohereServiceTests.java
@@ -42,8 +42,8 @@ import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.results.ChunkedInferenceEmbedding;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingByteResults;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingByteResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpClientManager;
 import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSender;
 import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSenderTests;
@@ -77,7 +77,7 @@ import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 import static org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsTests.createRandomChunkingSettings;
 import static org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsTests.createRandomChunkingSettingsMap;
-import static org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResultsTests.buildExpectationFloat;
+import static org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResultsTests.buildExpectationFloat;
 import static org.elasticsearch.xpack.core.inference.results.RankedDocsResultsTests.buildExpectationRerank;
 import static org.elasticsearch.xpack.inference.Utils.getInvalidModel;
 import static org.elasticsearch.xpack.inference.Utils.getPersistedConfigMap;
@@ -1435,7 +1435,7 @@ public class CohereServiceTests extends InferenceServiceTestCase {
                 assertEquals(new ChunkedInference.TextOffset(0, 1), floatResult.chunks().get(0).offset());
                 assertArrayEquals(
                     new float[] { 0.123f, -0.123f },
-                    ((DenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values(),
+                    ((LegacyDenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values(),
                     0.0f
                 );
             }
@@ -1446,7 +1446,7 @@ public class CohereServiceTests extends InferenceServiceTestCase {
                 assertEquals(new ChunkedInference.TextOffset(0, 2), floatResult.chunks().get(0).offset());
                 assertArrayEquals(
                     new float[] { 0.223f, -0.223f },
-                    ((DenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values(),
+                    ((LegacyDenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values(),
                     0.0f
                 );
             }
@@ -1529,10 +1529,10 @@ public class CohereServiceTests extends InferenceServiceTestCase {
                 var byteResult = (ChunkedInferenceEmbedding) results.get(0);
                 assertThat(byteResult.chunks(), hasSize(1));
                 assertEquals(new ChunkedInference.TextOffset(0, 1), byteResult.chunks().get(0).offset());
-                assertThat(byteResult.chunks().get(0).embedding(), instanceOf(DenseEmbeddingByteResults.Embedding.class));
+                assertThat(byteResult.chunks().get(0).embedding(), instanceOf(LegacyDenseEmbeddingByteResults.Embedding.class));
                 assertArrayEquals(
                     new byte[] { 23, -23 },
-                    ((DenseEmbeddingByteResults.Embedding) byteResult.chunks().get(0).embedding()).values()
+                    ((LegacyDenseEmbeddingByteResults.Embedding) byteResult.chunks().get(0).embedding()).values()
                 );
             }
             {
@@ -1540,10 +1540,10 @@ public class CohereServiceTests extends InferenceServiceTestCase {
                 var byteResult = (ChunkedInferenceEmbedding) results.get(1);
                 assertThat(byteResult.chunks(), hasSize(1));
                 assertEquals(new ChunkedInference.TextOffset(0, 2), byteResult.chunks().get(0).offset());
-                assertThat(byteResult.chunks().get(0).embedding(), instanceOf(DenseEmbeddingByteResults.Embedding.class));
+                assertThat(byteResult.chunks().get(0).embedding(), instanceOf(LegacyDenseEmbeddingByteResults.Embedding.class));
                 assertArrayEquals(
                     new byte[] { 24, -24 },
-                    ((DenseEmbeddingByteResults.Embedding) byteResult.chunks().get(0).embedding()).values()
+                    ((LegacyDenseEmbeddingByteResults.Embedding) byteResult.chunks().get(0).embedding()).values()
                 );
             }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/action/CohereActionCreatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/action/CohereActionCreatorTests.java
@@ -40,7 +40,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.xpack.core.inference.results.ChatCompletionResultsTests.buildExpectationCompletion;
-import static org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResultsTests.buildExpectationFloat;
+import static org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResultsTests.buildExpectationFloat;
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityExecutors;
 import static org.elasticsearch.xpack.inference.Utils.mockClusterServiceEmpty;
 import static org.elasticsearch.xpack.inference.external.http.Utils.entityAsMap;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/action/CohereEmbeddingsActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/action/CohereEmbeddingsActionTests.java
@@ -44,8 +44,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import static org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResultsTests.buildExpectationByte;
-import static org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResultsTests.buildExpectationFloat;
+import static org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingByteResultsTests.buildExpectationByte;
+import static org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResultsTests.buildExpectationFloat;
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityExecutors;
 import static org.elasticsearch.xpack.inference.Utils.mockClusterServiceEmpty;
 import static org.elasticsearch.xpack.inference.external.http.Utils.entityAsMap;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/response/CohereEmbeddingsResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/response/CohereEmbeddingsResponseEntityTests.java
@@ -10,9 +10,9 @@ package org.elasticsearch.xpack.inference.services.cohere.response;
 import org.apache.http.HttpResponse;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingBitResults;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingByteResults;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingBitResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingByteResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.request.Request;
 import org.hamcrest.MatcherAssert;
@@ -56,10 +56,10 @@ public class CohereEmbeddingsResponseEntityTests extends ESTestCase {
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
-        MatcherAssert.assertThat(parsedResults, instanceOf(DenseEmbeddingFloatResults.class));
+        MatcherAssert.assertThat(parsedResults, instanceOf(LegacyDenseEmbeddingFloatResults.class));
         MatcherAssert.assertThat(
-            ((DenseEmbeddingFloatResults) parsedResults).embeddings(),
-            is(List.of(new DenseEmbeddingFloatResults.Embedding(new float[] { -0.0018434525F, 0.01777649F })))
+            ((LegacyDenseEmbeddingFloatResults) parsedResults).embeddings(),
+            is(List.of(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { -0.0018434525F, 0.01777649F })))
         );
     }
 
@@ -90,14 +90,14 @@ public class CohereEmbeddingsResponseEntityTests extends ESTestCase {
             }
             """;
 
-        DenseEmbeddingFloatResults parsedResults = (DenseEmbeddingFloatResults) CohereEmbeddingsResponseEntity.fromResponse(
+        LegacyDenseEmbeddingFloatResults parsedResults = (LegacyDenseEmbeddingFloatResults) CohereEmbeddingsResponseEntity.fromResponse(
             mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
         MatcherAssert.assertThat(
             parsedResults.embeddings(),
-            is(List.of(new DenseEmbeddingFloatResults.Embedding(new float[] { -0.0018434525F, 0.01777649F })))
+            is(List.of(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { -0.0018434525F, 0.01777649F })))
         );
     }
 
@@ -134,14 +134,14 @@ public class CohereEmbeddingsResponseEntityTests extends ESTestCase {
             }
             """;
 
-        DenseEmbeddingFloatResults parsedResults = (DenseEmbeddingFloatResults) CohereEmbeddingsResponseEntity.fromResponse(
+        LegacyDenseEmbeddingFloatResults parsedResults = (LegacyDenseEmbeddingFloatResults) CohereEmbeddingsResponseEntity.fromResponse(
             mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
         MatcherAssert.assertThat(
             parsedResults.embeddings(),
-            is(List.of(new DenseEmbeddingFloatResults.Embedding(new float[] { -0.0018434525F, 0.01777649F })))
+            is(List.of(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { -0.0018434525F, 0.01777649F })))
         );
     }
 
@@ -178,14 +178,14 @@ public class CohereEmbeddingsResponseEntityTests extends ESTestCase {
             }
             """;
 
-        DenseEmbeddingByteResults parsedResults = (DenseEmbeddingByteResults) CohereEmbeddingsResponseEntity.fromResponse(
+        LegacyDenseEmbeddingByteResults parsedResults = (LegacyDenseEmbeddingByteResults) CohereEmbeddingsResponseEntity.fromResponse(
             mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
         MatcherAssert.assertThat(
             parsedResults.embeddings(),
-            is(List.of(new DenseEmbeddingByteResults.Embedding(new byte[] { (byte) -1, (byte) 0 })))
+            is(List.of(new LegacyDenseEmbeddingByteResults.Embedding(new byte[] { (byte) -1, (byte) 0 })))
         );
     }
 
@@ -216,14 +216,14 @@ public class CohereEmbeddingsResponseEntityTests extends ESTestCase {
             }
             """;
 
-        DenseEmbeddingByteResults parsedResults = (DenseEmbeddingByteResults) CohereEmbeddingsResponseEntity.fromResponse(
+        LegacyDenseEmbeddingByteResults parsedResults = (LegacyDenseEmbeddingByteResults) CohereEmbeddingsResponseEntity.fromResponse(
             mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
         MatcherAssert.assertThat(
             parsedResults.embeddings(),
-            is(List.of(new DenseEmbeddingByteResults.Embedding(new byte[] { (byte) -1, (byte) 0 })))
+            is(List.of(new LegacyDenseEmbeddingByteResults.Embedding(new byte[] { (byte) -1, (byte) 0 })))
         );
     }
 
@@ -257,14 +257,18 @@ public class CohereEmbeddingsResponseEntityTests extends ESTestCase {
             }
             """;
 
-        DenseEmbeddingBitResults parsedResults = (DenseEmbeddingBitResults) CohereEmbeddingsResponseEntity.fromResponse(
+        LegacyDenseEmbeddingBitResults parsedResults = (LegacyDenseEmbeddingBitResults) CohereEmbeddingsResponseEntity.fromResponse(
             mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
         MatcherAssert.assertThat(
             parsedResults.embeddings(),
-            is(List.of(new DenseEmbeddingByteResults.Embedding(new byte[] { (byte) -55, (byte) 74, (byte) 101, (byte) 67, (byte) 83 })))
+            is(
+                List.of(
+                    new LegacyDenseEmbeddingByteResults.Embedding(new byte[] { (byte) -55, (byte) 74, (byte) 101, (byte) 67, (byte) 83 })
+                )
+            )
         );
     }
 
@@ -297,7 +301,7 @@ public class CohereEmbeddingsResponseEntityTests extends ESTestCase {
             }
             """;
 
-        DenseEmbeddingFloatResults parsedResults = (DenseEmbeddingFloatResults) CohereEmbeddingsResponseEntity.fromResponse(
+        LegacyDenseEmbeddingFloatResults parsedResults = (LegacyDenseEmbeddingFloatResults) CohereEmbeddingsResponseEntity.fromResponse(
             mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
@@ -306,8 +310,8 @@ public class CohereEmbeddingsResponseEntityTests extends ESTestCase {
             parsedResults.embeddings(),
             is(
                 List.of(
-                    new DenseEmbeddingFloatResults.Embedding(new float[] { -0.0018434525F, 0.01777649F }),
-                    new DenseEmbeddingFloatResults.Embedding(new float[] { -0.123F, 0.123F })
+                    new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { -0.0018434525F, 0.01777649F }),
+                    new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { -0.123F, 0.123F })
                 )
             )
         );
@@ -344,7 +348,7 @@ public class CohereEmbeddingsResponseEntityTests extends ESTestCase {
             }
             """;
 
-        DenseEmbeddingFloatResults parsedResults = (DenseEmbeddingFloatResults) CohereEmbeddingsResponseEntity.fromResponse(
+        LegacyDenseEmbeddingFloatResults parsedResults = (LegacyDenseEmbeddingFloatResults) CohereEmbeddingsResponseEntity.fromResponse(
             mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
@@ -353,8 +357,8 @@ public class CohereEmbeddingsResponseEntityTests extends ESTestCase {
             parsedResults.embeddings(),
             is(
                 List.of(
-                    new DenseEmbeddingFloatResults.Embedding(new float[] { -0.0018434525F, 0.01777649F }),
-                    new DenseEmbeddingFloatResults.Embedding(new float[] { -0.123F, 0.123F })
+                    new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { -0.0018434525F, 0.01777649F }),
+                    new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { -0.123F, 0.123F })
                 )
             )
         );
@@ -397,7 +401,7 @@ public class CohereEmbeddingsResponseEntityTests extends ESTestCase {
             }
             """;
 
-        DenseEmbeddingBitResults parsedResults = (DenseEmbeddingBitResults) CohereEmbeddingsResponseEntity.fromResponse(
+        LegacyDenseEmbeddingBitResults parsedResults = (LegacyDenseEmbeddingBitResults) CohereEmbeddingsResponseEntity.fromResponse(
             mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
@@ -406,8 +410,8 @@ public class CohereEmbeddingsResponseEntityTests extends ESTestCase {
             parsedResults.embeddings(),
             is(
                 List.of(
-                    new DenseEmbeddingByteResults.Embedding(new byte[] { (byte) -55, (byte) 74, (byte) 101, (byte) 67 }),
-                    new DenseEmbeddingByteResults.Embedding(new byte[] { (byte) 34, (byte) -64, (byte) 97, (byte) 65, (byte) -42 })
+                    new LegacyDenseEmbeddingByteResults.Embedding(new byte[] { (byte) -55, (byte) 74, (byte) 101, (byte) 67 }),
+                    new LegacyDenseEmbeddingByteResults.Embedding(new byte[] { (byte) 34, (byte) -64, (byte) 97, (byte) 65, (byte) -42 })
                 )
             )
         );

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/custom/CustomServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/custom/CustomServiceTests.java
@@ -29,7 +29,7 @@ import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsTests;
 import org.elasticsearch.xpack.core.inference.results.ChatCompletionResults;
 import org.elasticsearch.xpack.core.inference.results.ChunkedInferenceEmbedding;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.RankedDocsResults;
 import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResults;
 import org.elasticsearch.xpack.inference.external.http.HttpClientManager;
@@ -412,12 +412,12 @@ public class CustomServiceTests extends AbstractInferenceServiceTests {
             );
 
             InferenceServiceResults results = listener.actionGet(TIMEOUT);
-            assertThat(results, instanceOf(DenseEmbeddingFloatResults.class));
+            assertThat(results, instanceOf(LegacyDenseEmbeddingFloatResults.class));
 
-            var embeddingResults = (DenseEmbeddingFloatResults) results;
+            var embeddingResults = (LegacyDenseEmbeddingFloatResults) results;
             assertThat(
                 embeddingResults.embeddings(),
-                is(List.of(new DenseEmbeddingFloatResults.Embedding(new float[] { 0.0123F, -0.0123F })))
+                is(List.of(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.0123F, -0.0123F })))
             );
         }
     }
@@ -732,10 +732,10 @@ public class CustomServiceTests extends AbstractInferenceServiceTests {
                 var floatResult = (ChunkedInferenceEmbedding) results.get(0);
                 assertThat(floatResult.chunks(), hasSize(1));
                 assertEquals(new ChunkedInference.TextOffset(0, 1), floatResult.chunks().get(0).offset());
-                assertThat(floatResult.chunks().get(0).embedding(), Matchers.instanceOf(DenseEmbeddingFloatResults.Embedding.class));
+                assertThat(floatResult.chunks().get(0).embedding(), Matchers.instanceOf(LegacyDenseEmbeddingFloatResults.Embedding.class));
                 assertArrayEquals(
                     new float[] { 0.123f, -0.123f },
-                    ((DenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values(),
+                    ((LegacyDenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values(),
                     0.0f
                 );
             }
@@ -744,10 +744,10 @@ public class CustomServiceTests extends AbstractInferenceServiceTests {
                 var floatResult = (ChunkedInferenceEmbedding) results.get(1);
                 assertThat(floatResult.chunks(), hasSize(1));
                 assertEquals(new ChunkedInference.TextOffset(0, 2), floatResult.chunks().get(0).offset());
-                assertThat(floatResult.chunks().get(0).embedding(), Matchers.instanceOf(DenseEmbeddingFloatResults.Embedding.class));
+                assertThat(floatResult.chunks().get(0).embedding(), Matchers.instanceOf(LegacyDenseEmbeddingFloatResults.Embedding.class));
                 assertArrayEquals(
                     new float[] { 0.223f, -0.223f },
-                    ((DenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values(),
+                    ((LegacyDenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values(),
                     0.0f
                 );
             }
@@ -807,10 +807,10 @@ public class CustomServiceTests extends AbstractInferenceServiceTests {
                 var floatResult = (ChunkedInferenceEmbedding) results.get(0);
                 assertThat(floatResult.chunks(), hasSize(1));
                 assertEquals(new ChunkedInference.TextOffset(0, 1), floatResult.chunks().get(0).offset());
-                assertThat(floatResult.chunks().get(0).embedding(), Matchers.instanceOf(DenseEmbeddingFloatResults.Embedding.class));
+                assertThat(floatResult.chunks().get(0).embedding(), Matchers.instanceOf(LegacyDenseEmbeddingFloatResults.Embedding.class));
                 assertArrayEquals(
                     new float[] { 0.123f, -0.123f },
-                    ((DenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values(),
+                    ((LegacyDenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values(),
                     0.0f
                 );
             }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/custom/response/CustomResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/custom/response/CustomResponseEntityTests.java
@@ -13,7 +13,7 @@ import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.inference.WeightedToken;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.inference.results.ChatCompletionResults;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.RankedDocsResults;
 import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
@@ -73,10 +73,10 @@ public class CustomResponseEntityTests extends ESTestCase {
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
-        assertThat(results, instanceOf(DenseEmbeddingFloatResults.class));
+        assertThat(results, instanceOf(LegacyDenseEmbeddingFloatResults.class));
         assertThat(
-            ((DenseEmbeddingFloatResults) results).embeddings(),
-            is(List.of(new DenseEmbeddingFloatResults.Embedding(new float[] { -0.02868066355586052f, 0.022033605724573135f })))
+            ((LegacyDenseEmbeddingFloatResults) results).embeddings(),
+            is(List.of(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { -0.02868066355586052f, 0.022033605724573135f })))
         );
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/custom/response/DenseEmbeddingResponseParserTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/custom/response/DenseEmbeddingResponseParserTests.java
@@ -16,9 +16,9 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingBitResults;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingByteResults;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingBitResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingByteResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCase;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.services.custom.CustomServiceEmbeddingType;
@@ -121,15 +121,15 @@ public class DenseEmbeddingResponseParserTests extends AbstractBWCWireSerializat
             """;
 
         var parser = new DenseEmbeddingResponseParser("$.data[*].embedding", CustomServiceEmbeddingType.FLOAT);
-        DenseEmbeddingFloatResults parsedResults = (DenseEmbeddingFloatResults) parser.parse(
+        LegacyDenseEmbeddingFloatResults parsedResults = (LegacyDenseEmbeddingFloatResults) parser.parse(
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
         assertThat(
             parsedResults,
             is(
-                new DenseEmbeddingFloatResults(
-                    List.of(new DenseEmbeddingFloatResults.Embedding(new float[] { 0.014539449F, -0.015288644F }))
+                new LegacyDenseEmbeddingFloatResults(
+                    List.of(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.014539449F, -0.015288644F }))
                 )
             )
         );
@@ -158,13 +158,13 @@ public class DenseEmbeddingResponseParserTests extends AbstractBWCWireSerializat
             """;
 
         var parser = new DenseEmbeddingResponseParser("$.data[*].embedding", CustomServiceEmbeddingType.BYTE);
-        DenseEmbeddingByteResults parsedResults = (DenseEmbeddingByteResults) parser.parse(
+        LegacyDenseEmbeddingByteResults parsedResults = (LegacyDenseEmbeddingByteResults) parser.parse(
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
         assertThat(
             parsedResults,
-            is(new DenseEmbeddingByteResults(List.of(new DenseEmbeddingByteResults.Embedding(new byte[] { 1, -2 }))))
+            is(new LegacyDenseEmbeddingByteResults(List.of(new LegacyDenseEmbeddingByteResults.Embedding(new byte[] { 1, -2 }))))
         );
     }
 
@@ -191,11 +191,14 @@ public class DenseEmbeddingResponseParserTests extends AbstractBWCWireSerializat
             """;
 
         var parser = new DenseEmbeddingResponseParser("$.data[*].embedding", CustomServiceEmbeddingType.BIT);
-        DenseEmbeddingBitResults parsedResults = (DenseEmbeddingBitResults) parser.parse(
+        LegacyDenseEmbeddingBitResults parsedResults = (LegacyDenseEmbeddingBitResults) parser.parse(
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
-        assertThat(parsedResults, is(new DenseEmbeddingBitResults(List.of(new DenseEmbeddingByteResults.Embedding(new byte[] { 1, -2 })))));
+        assertThat(
+            parsedResults,
+            is(new LegacyDenseEmbeddingBitResults(List.of(new LegacyDenseEmbeddingByteResults.Embedding(new byte[] { 1, -2 }))))
+        );
     }
 
     public void testParse_MultipleEmbeddings() throws IOException {
@@ -229,17 +232,17 @@ public class DenseEmbeddingResponseParserTests extends AbstractBWCWireSerializat
             """;
 
         var parser = new DenseEmbeddingResponseParser("$.data[*].embedding", CustomServiceEmbeddingType.FLOAT);
-        DenseEmbeddingFloatResults parsedResults = (DenseEmbeddingFloatResults) parser.parse(
+        LegacyDenseEmbeddingFloatResults parsedResults = (LegacyDenseEmbeddingFloatResults) parser.parse(
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
         assertThat(
             parsedResults,
             is(
-                new DenseEmbeddingFloatResults(
+                new LegacyDenseEmbeddingFloatResults(
                     List.of(
-                        new DenseEmbeddingFloatResults.Embedding(new float[] { 0.014539449F, -0.015288644F }),
-                        new DenseEmbeddingFloatResults.Embedding(new float[] { 1F, -2F })
+                        new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.014539449F, -0.015288644F }),
+                        new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 1F, -2F })
                     )
                 )
             )

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
@@ -40,7 +40,7 @@ import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.results.ChunkedInferenceEmbedding;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResultsTests;
 import org.elasticsearch.xpack.core.inference.results.UnifiedChatCompletionException;
 import org.elasticsearch.xpack.inference.InferencePlugin;
@@ -889,9 +889,9 @@ public class ElasticInferenceServiceTests extends ESSingleNodeTestCase {
                 var denseResult = (ChunkedInferenceEmbedding) results.getFirst();
                 assertThat(denseResult.chunks(), hasSize(1));
                 assertEquals(new ChunkedInference.TextOffset(0, "hello world".length()), denseResult.chunks().getFirst().offset());
-                assertThat(denseResult.chunks().get(0).embedding(), instanceOf(DenseEmbeddingFloatResults.Embedding.class));
+                assertThat(denseResult.chunks().get(0).embedding(), instanceOf(LegacyDenseEmbeddingFloatResults.Embedding.class));
 
-                var embedding = (DenseEmbeddingFloatResults.Embedding) denseResult.chunks().get(0).embedding();
+                var embedding = (LegacyDenseEmbeddingFloatResults.Embedding) denseResult.chunks().get(0).embedding();
                 assertArrayEquals(new float[] { 0.123f, -0.456f, 0.789f }, embedding.values(), 0.0f);
             }
 
@@ -901,9 +901,9 @@ public class ElasticInferenceServiceTests extends ESSingleNodeTestCase {
                 var denseResult = (ChunkedInferenceEmbedding) results.get(1);
                 assertThat(denseResult.chunks(), hasSize(1));
                 assertEquals(new ChunkedInference.TextOffset(0, "dense embedding".length()), denseResult.chunks().getFirst().offset());
-                assertThat(denseResult.chunks().getFirst().embedding(), instanceOf(DenseEmbeddingFloatResults.Embedding.class));
+                assertThat(denseResult.chunks().getFirst().embedding(), instanceOf(LegacyDenseEmbeddingFloatResults.Embedding.class));
 
-                var embedding = (DenseEmbeddingFloatResults.Embedding) denseResult.chunks().get(0).embedding();
+                var embedding = (LegacyDenseEmbeddingFloatResults.Embedding) denseResult.chunks().get(0).embedding();
                 assertArrayEquals(new float[] { 0.987f, -0.654f, 0.321f }, embedding.values(), 0.0f);
             }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/action/ElasticInferenceServiceActionCreatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/action/ElasticInferenceServiceActionCreatorTests.java
@@ -20,7 +20,7 @@ import org.elasticsearch.test.http.MockWebServer;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.RankedDocsResultsTests;
 import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResultsTests;
 import org.elasticsearch.xpack.inference.external.http.HttpClientManager;
@@ -298,8 +298,8 @@ public class ElasticInferenceServiceActionCreatorTests extends ESTestCase {
 
             var result = listener.actionGet(TIMEOUT);
 
-            assertThat(result, instanceOf(DenseEmbeddingFloatResults.class));
-            var textEmbeddingResults = (DenseEmbeddingFloatResults) result;
+            assertThat(result, instanceOf(LegacyDenseEmbeddingFloatResults.class));
+            var textEmbeddingResults = (LegacyDenseEmbeddingFloatResults) result;
             assertThat(textEmbeddingResults.embeddings(), hasSize(2));
 
             var firstEmbedding = textEmbeddingResults.embeddings().get(0);
@@ -354,8 +354,8 @@ public class ElasticInferenceServiceActionCreatorTests extends ESTestCase {
 
             var result = listener.actionGet(TIMEOUT);
 
-            assertThat(result, instanceOf(DenseEmbeddingFloatResults.class));
-            var textEmbeddingResults = (DenseEmbeddingFloatResults) result;
+            assertThat(result, instanceOf(LegacyDenseEmbeddingFloatResults.class));
+            var textEmbeddingResults = (LegacyDenseEmbeddingFloatResults) result;
             assertThat(textEmbeddingResults.embeddings(), hasSize(1));
 
             var embedding = textEmbeddingResults.embeddings().get(0);
@@ -447,8 +447,8 @@ public class ElasticInferenceServiceActionCreatorTests extends ESTestCase {
 
             var result = listener.actionGet(TIMEOUT);
 
-            assertThat(result, instanceOf(DenseEmbeddingFloatResults.class));
-            var textEmbeddingResults = (DenseEmbeddingFloatResults) result;
+            assertThat(result, instanceOf(LegacyDenseEmbeddingFloatResults.class));
+            var textEmbeddingResults = (LegacyDenseEmbeddingFloatResults) result;
             assertThat(textEmbeddingResults.embeddings(), hasSize(0));
 
             assertThat(webServer.requests(), hasSize(1));

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/response/ElasticInferenceServiceDenseTextEmbeddingsResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/response/ElasticInferenceServiceDenseTextEmbeddingsResponseEntityTests.java
@@ -9,7 +9,7 @@ package org.elasticsearch.xpack.inference.services.elastic.response;
 
 import org.apache.http.HttpResponse;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.request.Request;
 import org.elasticsearch.xpack.inference.external.response.elastic.ElasticInferenceServiceDenseTextEmbeddingsResponseEntity;
@@ -35,7 +35,7 @@ public class ElasticInferenceServiceDenseTextEmbeddingsResponseEntityTests exten
             }
             """;
 
-        DenseEmbeddingFloatResults parsedResults = ElasticInferenceServiceDenseTextEmbeddingsResponseEntity.fromResponse(
+        LegacyDenseEmbeddingFloatResults parsedResults = ElasticInferenceServiceDenseTextEmbeddingsResponseEntity.fromResponse(
             mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
@@ -64,7 +64,7 @@ public class ElasticInferenceServiceDenseTextEmbeddingsResponseEntityTests exten
             }
             """;
 
-        DenseEmbeddingFloatResults parsedResults = ElasticInferenceServiceDenseTextEmbeddingsResponseEntity.fromResponse(
+        LegacyDenseEmbeddingFloatResults parsedResults = ElasticInferenceServiceDenseTextEmbeddingsResponseEntity.fromResponse(
             mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
@@ -85,7 +85,7 @@ public class ElasticInferenceServiceDenseTextEmbeddingsResponseEntityTests exten
             }
             """;
 
-        DenseEmbeddingFloatResults parsedResults = ElasticInferenceServiceDenseTextEmbeddingsResponseEntity.fromResponse(
+        LegacyDenseEmbeddingFloatResults parsedResults = ElasticInferenceServiceDenseTextEmbeddingsResponseEntity.fromResponse(
             mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
@@ -111,7 +111,7 @@ public class ElasticInferenceServiceDenseTextEmbeddingsResponseEntityTests exten
             }
             """;
 
-        DenseEmbeddingFloatResults parsedResults = ElasticInferenceServiceDenseTextEmbeddingsResponseEntity.fromResponse(
+        LegacyDenseEmbeddingFloatResults parsedResults = ElasticInferenceServiceDenseTextEmbeddingsResponseEntity.fromResponse(
             mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceTests.java
@@ -56,7 +56,7 @@ import org.elasticsearch.xpack.core.inference.chunking.RerankRequestChunker;
 import org.elasticsearch.xpack.core.inference.chunking.WordBoundaryChunkingSettings;
 import org.elasticsearch.xpack.core.inference.results.ChunkedInferenceEmbedding;
 import org.elasticsearch.xpack.core.inference.results.ChunkedInferenceError;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.RankedDocsResults;
 import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResults;
 import org.elasticsearch.xpack.core.ml.MachineLearningField;
@@ -1136,20 +1136,20 @@ public class ElasticsearchInternalServiceTests extends InferenceServiceTestCase 
             assertThat(chunkedResponse.get(0), instanceOf(ChunkedInferenceEmbedding.class));
             var result1 = (ChunkedInferenceEmbedding) chunkedResponse.get(0);
             assertThat(result1.chunks(), hasSize(1));
-            assertThat(result1.chunks().get(0).embedding(), instanceOf(DenseEmbeddingFloatResults.Embedding.class));
+            assertThat(result1.chunks().get(0).embedding(), instanceOf(LegacyDenseEmbeddingFloatResults.Embedding.class));
             assertArrayEquals(
                 ((MlDenseEmbeddingResults) mlTrainedModelResults.get(0)).getInferenceAsFloat(),
-                ((DenseEmbeddingFloatResults.Embedding) result1.chunks().get(0).embedding()).values(),
+                ((LegacyDenseEmbeddingFloatResults.Embedding) result1.chunks().get(0).embedding()).values(),
                 0.0001f
             );
             assertEquals(new ChunkedInference.TextOffset(0, 1), result1.chunks().get(0).offset());
             assertThat(chunkedResponse.get(1), instanceOf(ChunkedInferenceEmbedding.class));
             var result2 = (ChunkedInferenceEmbedding) chunkedResponse.get(1);
             assertThat(result2.chunks(), hasSize(1));
-            assertThat(result2.chunks().get(0).embedding(), instanceOf(DenseEmbeddingFloatResults.Embedding.class));
+            assertThat(result2.chunks().get(0).embedding(), instanceOf(LegacyDenseEmbeddingFloatResults.Embedding.class));
             assertArrayEquals(
                 ((MlDenseEmbeddingResults) mlTrainedModelResults.get(1)).getInferenceAsFloat(),
-                ((DenseEmbeddingFloatResults.Embedding) result2.chunks().get(0).embedding()).values(),
+                ((LegacyDenseEmbeddingFloatResults.Embedding) result2.chunks().get(0).embedding()).values(),
                 0.0001f
             );
             assertEquals(new ChunkedInference.TextOffset(0, 2), result2.chunks().get(0).offset());

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googleaistudio/GoogleAiStudioServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googleaistudio/GoogleAiStudioServiceTests.java
@@ -39,7 +39,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.results.ChatCompletionResults;
 import org.elasticsearch.xpack.core.inference.results.ChunkedInferenceEmbedding;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpClientManager;
 import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSender;
 import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSenderTests;
@@ -68,7 +68,7 @@ import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 import static org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsTests.createRandomChunkingSettings;
 import static org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsTests.createRandomChunkingSettingsMap;
-import static org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResultsTests.buildExpectationFloat;
+import static org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResultsTests.buildExpectationFloat;
 import static org.elasticsearch.xpack.inference.Utils.getInvalidModel;
 import static org.elasticsearch.xpack.inference.Utils.getPersistedConfigMap;
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityExecutors;
@@ -941,11 +941,11 @@ public class GoogleAiStudioServiceTests extends InferenceServiceTestCase {
                 var floatResult = (ChunkedInferenceEmbedding) results.get(0);
                 assertThat(floatResult.chunks(), hasSize(1));
                 assertEquals(new ChunkedInference.TextOffset(0, input.get(0).input().length()), floatResult.chunks().get(0).offset());
-                assertThat(floatResult.chunks().get(0).embedding(), Matchers.instanceOf(DenseEmbeddingFloatResults.Embedding.class));
+                assertThat(floatResult.chunks().get(0).embedding(), Matchers.instanceOf(LegacyDenseEmbeddingFloatResults.Embedding.class));
                 assertTrue(
                     Arrays.equals(
                         new float[] { 0.0123f, -0.0123f },
-                        ((DenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values()
+                        ((LegacyDenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values()
                     )
                 );
             }
@@ -956,11 +956,11 @@ public class GoogleAiStudioServiceTests extends InferenceServiceTestCase {
                 var floatResult = (ChunkedInferenceEmbedding) results.get(1);
                 assertThat(floatResult.chunks(), hasSize(1));
                 assertEquals(new ChunkedInference.TextOffset(0, input.get(1).input().length()), floatResult.chunks().get(0).offset());
-                assertThat(floatResult.chunks().get(0).embedding(), Matchers.instanceOf(DenseEmbeddingFloatResults.Embedding.class));
+                assertThat(floatResult.chunks().get(0).embedding(), Matchers.instanceOf(LegacyDenseEmbeddingFloatResults.Embedding.class));
                 assertTrue(
                     Arrays.equals(
                         new float[] { 0.0456f, -0.0456f },
-                        ((DenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values()
+                        ((LegacyDenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values()
                     )
                 );
             }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googleaistudio/action/GoogleAiStudioEmbeddingsActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googleaistudio/action/GoogleAiStudioEmbeddingsActionTests.java
@@ -40,7 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import static org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResultsTests.buildExpectationFloat;
+import static org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResultsTests.buildExpectationFloat;
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityExecutors;
 import static org.elasticsearch.xpack.inference.Utils.mockClusterServiceEmpty;
 import static org.elasticsearch.xpack.inference.external.action.ActionUtils.constructFailedToSendRequestMessage;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googleaistudio/response/GoogleAiStudioEmbeddingsResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googleaistudio/response/GoogleAiStudioEmbeddingsResponseEntityTests.java
@@ -9,7 +9,7 @@ package org.elasticsearch.xpack.inference.services.googleaistudio.response;
 
 import org.apache.http.HttpResponse;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.request.Request;
 
@@ -36,12 +36,15 @@ public class GoogleAiStudioEmbeddingsResponseEntityTests extends ESTestCase {
             }
             """;
 
-        DenseEmbeddingFloatResults parsedResults = GoogleAiStudioEmbeddingsResponseEntity.fromResponse(
+        LegacyDenseEmbeddingFloatResults parsedResults = GoogleAiStudioEmbeddingsResponseEntity.fromResponse(
             mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
-        assertThat(parsedResults.embeddings(), is(List.of(DenseEmbeddingFloatResults.Embedding.of(List.of(-0.00606332F, 0.058092743F)))));
+        assertThat(
+            parsedResults.embeddings(),
+            is(List.of(LegacyDenseEmbeddingFloatResults.Embedding.of(List.of(-0.00606332F, 0.058092743F))))
+        );
     }
 
     public void testFromResponse_CreatesResultsForMultipleItems() throws IOException {
@@ -64,7 +67,7 @@ public class GoogleAiStudioEmbeddingsResponseEntityTests extends ESTestCase {
             }
             """;
 
-        DenseEmbeddingFloatResults parsedResults = GoogleAiStudioEmbeddingsResponseEntity.fromResponse(
+        LegacyDenseEmbeddingFloatResults parsedResults = GoogleAiStudioEmbeddingsResponseEntity.fromResponse(
             mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
@@ -73,8 +76,8 @@ public class GoogleAiStudioEmbeddingsResponseEntityTests extends ESTestCase {
             parsedResults.embeddings(),
             is(
                 List.of(
-                    DenseEmbeddingFloatResults.Embedding.of(List.of(-0.00606332F, 0.058092743F)),
-                    DenseEmbeddingFloatResults.Embedding.of(List.of(0.030681048F, 0.01714732F))
+                    LegacyDenseEmbeddingFloatResults.Embedding.of(List.of(-0.00606332F, 0.058092743F)),
+                    LegacyDenseEmbeddingFloatResults.Embedding.of(List.of(0.030681048F, 0.01714732F))
                 )
             )
         );

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/response/GoogleVertexAiEmbeddingsResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/googlevertexai/response/GoogleVertexAiEmbeddingsResponseEntityTests.java
@@ -9,7 +9,7 @@ package org.elasticsearch.xpack.inference.services.googlevertexai.response;
 
 import org.apache.http.HttpResponse;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.request.Request;
 
@@ -42,12 +42,12 @@ public class GoogleVertexAiEmbeddingsResponseEntityTests extends ESTestCase {
                  }
             """;
 
-        DenseEmbeddingFloatResults parsedResults = GoogleVertexAiEmbeddingsResponseEntity.fromResponse(
+        LegacyDenseEmbeddingFloatResults parsedResults = GoogleVertexAiEmbeddingsResponseEntity.fromResponse(
             mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
-        assertThat(parsedResults.embeddings(), is(List.of(DenseEmbeddingFloatResults.Embedding.of(List.of(-0.123F, 0.123F)))));
+        assertThat(parsedResults.embeddings(), is(List.of(LegacyDenseEmbeddingFloatResults.Embedding.of(List.of(-0.123F, 0.123F)))));
     }
 
     public void testFromResponse_CreatesResultsForMultipleItems() throws IOException {
@@ -82,7 +82,7 @@ public class GoogleVertexAiEmbeddingsResponseEntityTests extends ESTestCase {
                  }
             """;
 
-        DenseEmbeddingFloatResults parsedResults = GoogleVertexAiEmbeddingsResponseEntity.fromResponse(
+        LegacyDenseEmbeddingFloatResults parsedResults = GoogleVertexAiEmbeddingsResponseEntity.fromResponse(
             mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
@@ -91,8 +91,8 @@ public class GoogleVertexAiEmbeddingsResponseEntityTests extends ESTestCase {
             parsedResults.embeddings(),
             is(
                 List.of(
-                    DenseEmbeddingFloatResults.Embedding.of(List.of(-0.123F, 0.123F)),
-                    DenseEmbeddingFloatResults.Embedding.of(List.of(-0.456F, 0.456F))
+                    LegacyDenseEmbeddingFloatResults.Embedding.of(List.of(-0.123F, 0.123F)),
+                    LegacyDenseEmbeddingFloatResults.Embedding.of(List.of(-0.456F, 0.456F))
                 )
             )
         );

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceServiceTests.java
@@ -42,7 +42,7 @@ import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.results.ChunkedInferenceEmbedding;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResultsTests;
 import org.elasticsearch.xpack.core.inference.results.UnifiedChatCompletionException;
 import org.elasticsearch.xpack.inference.external.http.HttpClientManager;
@@ -77,7 +77,7 @@ import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 import static org.elasticsearch.xcontent.ToXContent.EMPTY_PARAMS;
 import static org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsTests.createRandomChunkingSettingsMap;
-import static org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResultsTests.buildExpectationFloat;
+import static org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResultsTests.buildExpectationFloat;
 import static org.elasticsearch.xpack.inference.Utils.getInvalidModel;
 import static org.elasticsearch.xpack.inference.Utils.getPersistedConfigMap;
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityExecutors;
@@ -1213,10 +1213,10 @@ public class HuggingFaceServiceTests extends InferenceServiceTestCase {
             var embeddingResult = (ChunkedInferenceEmbedding) result;
             assertThat(embeddingResult.chunks(), hasSize(1));
             assertThat(embeddingResult.chunks().get(0).offset(), is(new ChunkedInference.TextOffset(0, "abc".length())));
-            assertThat(embeddingResult.chunks().get(0).embedding(), Matchers.instanceOf(DenseEmbeddingFloatResults.Embedding.class));
+            assertThat(embeddingResult.chunks().get(0).embedding(), Matchers.instanceOf(LegacyDenseEmbeddingFloatResults.Embedding.class));
             assertArrayEquals(
                 new float[] { -0.0123f, 0.0123f },
-                ((DenseEmbeddingFloatResults.Embedding) embeddingResult.chunks().get(0).embedding()).values(),
+                ((LegacyDenseEmbeddingFloatResults.Embedding) embeddingResult.chunks().get(0).embedding()).values(),
                 0.001f
             );
             assertThat(webServer.requests(), hasSize(1));
@@ -1267,10 +1267,10 @@ public class HuggingFaceServiceTests extends InferenceServiceTestCase {
                 var floatResult = (ChunkedInferenceEmbedding) results.get(0);
                 assertThat(floatResult.chunks(), hasSize(1));
                 assertEquals(new ChunkedInference.TextOffset(0, 3), floatResult.chunks().get(0).offset());
-                assertThat(floatResult.chunks().get(0).embedding(), Matchers.instanceOf(DenseEmbeddingFloatResults.Embedding.class));
+                assertThat(floatResult.chunks().get(0).embedding(), Matchers.instanceOf(LegacyDenseEmbeddingFloatResults.Embedding.class));
                 assertArrayEquals(
                     new float[] { 0.123f, -0.123f },
-                    ((DenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values(),
+                    ((LegacyDenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values(),
                     0.0f
                 );
             }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/action/HuggingFaceActionCreatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/action/HuggingFaceActionCreatorTests.java
@@ -19,7 +19,7 @@ import org.elasticsearch.test.http.MockWebServer;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResultsTests;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResultsTests;
 import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResultsTests;
 import org.elasticsearch.xpack.inference.InputTypeTests;
 import org.elasticsearch.xpack.inference.common.TruncatorTests;
@@ -233,7 +233,7 @@ public class HuggingFaceActionCreatorTests extends ESTestCase {
 
             assertThat(
                 result.asMap(),
-                is(DenseEmbeddingFloatResultsTests.buildExpectationFloat(List.of(new float[] { -0.0123F, 0.123F })))
+                is(LegacyDenseEmbeddingFloatResultsTests.buildExpectationFloat(List.of(new float[] { -0.0123F, 0.123F })))
             );
 
             assertThat(webServer.requests(), hasSize(1));
@@ -421,7 +421,7 @@ public class HuggingFaceActionCreatorTests extends ESTestCase {
 
             assertThat(
                 result.asMap(),
-                is(DenseEmbeddingFloatResultsTests.buildExpectationFloat(List.of(new float[] { -0.0123F, 0.123F })))
+                is(LegacyDenseEmbeddingFloatResultsTests.buildExpectationFloat(List.of(new float[] { -0.0123F, 0.123F })))
             );
 
             assertThat(webServer.requests(), hasSize(2));
@@ -486,7 +486,7 @@ public class HuggingFaceActionCreatorTests extends ESTestCase {
 
             assertThat(
                 result.asMap(),
-                is(DenseEmbeddingFloatResultsTests.buildExpectationFloat(List.of(new float[] { -0.0123F, 0.123F })))
+                is(LegacyDenseEmbeddingFloatResultsTests.buildExpectationFloat(List.of(new float[] { -0.0123F, 0.123F })))
             );
 
             assertThat(webServer.requests(), hasSize(1));

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/response/HuggingFaceEmbeddingsResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/response/HuggingFaceEmbeddingsResponseEntityTests.java
@@ -10,7 +10,7 @@ package org.elasticsearch.xpack.inference.services.huggingface.response;
 import org.apache.http.HttpResponse;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.request.Request;
 
@@ -32,14 +32,14 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
             ]
             """;
 
-        DenseEmbeddingFloatResults parsedResults = HuggingFaceEmbeddingsResponseEntity.fromResponse(
+        LegacyDenseEmbeddingFloatResults parsedResults = HuggingFaceEmbeddingsResponseEntity.fromResponse(
             mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
         assertThat(
             parsedResults.embeddings(),
-            is(List.of(new DenseEmbeddingFloatResults.Embedding(new float[] { 0.014539449F, -0.015288644F })))
+            is(List.of(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.014539449F, -0.015288644F })))
         );
     }
 
@@ -55,14 +55,14 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
             }
             """;
 
-        DenseEmbeddingFloatResults parsedResults = HuggingFaceEmbeddingsResponseEntity.fromResponse(
+        LegacyDenseEmbeddingFloatResults parsedResults = HuggingFaceEmbeddingsResponseEntity.fromResponse(
             mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
         assertThat(
             parsedResults.embeddings(),
-            is(List.of(new DenseEmbeddingFloatResults.Embedding(new float[] { 0.014539449F, -0.015288644F })))
+            is(List.of(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.014539449F, -0.015288644F })))
         );
     }
 
@@ -80,7 +80,7 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
             ]
             """;
 
-        DenseEmbeddingFloatResults parsedResults = HuggingFaceEmbeddingsResponseEntity.fromResponse(
+        LegacyDenseEmbeddingFloatResults parsedResults = HuggingFaceEmbeddingsResponseEntity.fromResponse(
             mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
@@ -89,8 +89,8 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
             parsedResults.embeddings(),
             is(
                 List.of(
-                    new DenseEmbeddingFloatResults.Embedding(new float[] { 0.014539449F, -0.015288644F }),
-                    new DenseEmbeddingFloatResults.Embedding(new float[] { 0.0123F, -0.0123F })
+                    new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.014539449F, -0.015288644F }),
+                    new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.0123F, -0.0123F })
                 )
             )
         );
@@ -112,7 +112,7 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
             }
             """;
 
-        DenseEmbeddingFloatResults parsedResults = HuggingFaceEmbeddingsResponseEntity.fromResponse(
+        LegacyDenseEmbeddingFloatResults parsedResults = HuggingFaceEmbeddingsResponseEntity.fromResponse(
             mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
@@ -121,8 +121,8 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
             parsedResults.embeddings(),
             is(
                 List.of(
-                    new DenseEmbeddingFloatResults.Embedding(new float[] { 0.014539449F, -0.015288644F }),
-                    new DenseEmbeddingFloatResults.Embedding(new float[] { 0.0123F, -0.0123F })
+                    new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.014539449F, -0.015288644F }),
+                    new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.0123F, -0.0123F })
                 )
             )
         );
@@ -255,12 +255,12 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
             ]
             """;
 
-        DenseEmbeddingFloatResults parsedResults = HuggingFaceEmbeddingsResponseEntity.fromResponse(
+        LegacyDenseEmbeddingFloatResults parsedResults = HuggingFaceEmbeddingsResponseEntity.fromResponse(
             mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
-        assertThat(parsedResults.embeddings(), is(List.of(new DenseEmbeddingFloatResults.Embedding(new float[] { 1.0F }))));
+        assertThat(parsedResults.embeddings(), is(List.of(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 1.0F }))));
     }
 
     public void testFromResponse_SucceedsWhenEmbeddingValueIsInt_ObjectFormat() throws IOException {
@@ -274,12 +274,12 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
             }
             """;
 
-        DenseEmbeddingFloatResults parsedResults = HuggingFaceEmbeddingsResponseEntity.fromResponse(
+        LegacyDenseEmbeddingFloatResults parsedResults = HuggingFaceEmbeddingsResponseEntity.fromResponse(
             mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
-        assertThat(parsedResults.embeddings(), is(List.of(new DenseEmbeddingFloatResults.Embedding(new float[] { 1.0F }))));
+        assertThat(parsedResults.embeddings(), is(List.of(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 1.0F }))));
     }
 
     public void testFromResponse_SucceedsWhenEmbeddingValueIsLong_ArrayFormat() throws IOException {
@@ -291,12 +291,12 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
             ]
             """;
 
-        DenseEmbeddingFloatResults parsedResults = HuggingFaceEmbeddingsResponseEntity.fromResponse(
+        LegacyDenseEmbeddingFloatResults parsedResults = HuggingFaceEmbeddingsResponseEntity.fromResponse(
             mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
-        assertThat(parsedResults.embeddings(), is(List.of(new DenseEmbeddingFloatResults.Embedding(new float[] { 4.0294965E10F }))));
+        assertThat(parsedResults.embeddings(), is(List.of(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 4.0294965E10F }))));
     }
 
     public void testFromResponse_SucceedsWhenEmbeddingValueIsLong_ObjectFormat() throws IOException {
@@ -310,12 +310,12 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
             }
             """;
 
-        DenseEmbeddingFloatResults parsedResults = HuggingFaceEmbeddingsResponseEntity.fromResponse(
+        LegacyDenseEmbeddingFloatResults parsedResults = HuggingFaceEmbeddingsResponseEntity.fromResponse(
             mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
-        assertThat(parsedResults.embeddings(), is(List.of(new DenseEmbeddingFloatResults.Embedding(new float[] { 4.0294965E10F }))));
+        assertThat(parsedResults.embeddings(), is(List.of(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 4.0294965E10F }))));
     }
 
     public void testFromResponse_FailsWhenEmbeddingValueIsAnObject_ObjectFormat() {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxServiceTests.java
@@ -38,7 +38,7 @@ import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.results.ChunkedInferenceEmbedding;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.common.Truncator;
 import org.elasticsearch.xpack.inference.external.http.HttpClientManager;
 import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSender;
@@ -72,7 +72,7 @@ import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 import static org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsTests.createRandomChunkingSettings;
 import static org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsTests.createRandomChunkingSettingsMap;
-import static org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResultsTests.buildExpectationFloat;
+import static org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResultsTests.buildExpectationFloat;
 import static org.elasticsearch.xpack.inference.Utils.getInvalidModel;
 import static org.elasticsearch.xpack.inference.Utils.getPersistedConfigMap;
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityExecutors;
@@ -789,11 +789,11 @@ public class IbmWatsonxServiceTests extends InferenceServiceTestCase {
                 var floatResult = (ChunkedInferenceEmbedding) results.get(0);
                 assertThat(floatResult.chunks(), hasSize(1));
                 assertEquals(new ChunkedInference.TextOffset(0, input.get(0).input().length()), floatResult.chunks().get(0).offset());
-                assertThat(floatResult.chunks().get(0).embedding(), Matchers.instanceOf(DenseEmbeddingFloatResults.Embedding.class));
+                assertThat(floatResult.chunks().get(0).embedding(), Matchers.instanceOf(LegacyDenseEmbeddingFloatResults.Embedding.class));
                 assertTrue(
                     Arrays.equals(
                         new float[] { 0.0123f, -0.0123f },
-                        ((DenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values()
+                        ((LegacyDenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values()
                     )
                 );
             }
@@ -804,11 +804,11 @@ public class IbmWatsonxServiceTests extends InferenceServiceTestCase {
                 var floatResult = (ChunkedInferenceEmbedding) results.get(1);
                 assertThat(floatResult.chunks(), hasSize(1));
                 assertEquals(new ChunkedInference.TextOffset(0, input.get(1).input().length()), floatResult.chunks().get(0).offset());
-                assertThat(floatResult.chunks().get(0).embedding(), Matchers.instanceOf(DenseEmbeddingFloatResults.Embedding.class));
+                assertThat(floatResult.chunks().get(0).embedding(), Matchers.instanceOf(LegacyDenseEmbeddingFloatResults.Embedding.class));
                 assertTrue(
                     Arrays.equals(
                         new float[] { 0.0456f, -0.0456f },
-                        ((DenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values()
+                        ((LegacyDenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values()
                     )
                 );
             }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/action/IbmWatsonxEmbeddingsActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/action/IbmWatsonxEmbeddingsActionTests.java
@@ -44,7 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import static org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResultsTests.buildExpectationFloat;
+import static org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResultsTests.buildExpectationFloat;
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityExecutors;
 import static org.elasticsearch.xpack.inference.Utils.mockClusterServiceEmpty;
 import static org.elasticsearch.xpack.inference.external.action.ActionUtils.constructFailedToSendRequestMessage;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/response/IbmWatsonxEmbeddingsResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/response/IbmWatsonxEmbeddingsResponseEntityTests.java
@@ -9,7 +9,7 @@ package org.elasticsearch.xpack.inference.services.ibmwatsonx.response;
 
 import org.apache.http.HttpResponse;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.request.Request;
 
@@ -36,12 +36,15 @@ public class IbmWatsonxEmbeddingsResponseEntityTests extends ESTestCase {
             }
             """;
 
-        DenseEmbeddingFloatResults parsedResults = IbmWatsonxEmbeddingsResponseEntity.fromResponse(
+        LegacyDenseEmbeddingFloatResults parsedResults = IbmWatsonxEmbeddingsResponseEntity.fromResponse(
             mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
-        assertThat(parsedResults.embeddings(), is(List.of(DenseEmbeddingFloatResults.Embedding.of(List.of(-0.00606332F, 0.058092743F)))));
+        assertThat(
+            parsedResults.embeddings(),
+            is(List.of(LegacyDenseEmbeddingFloatResults.Embedding.of(List.of(-0.00606332F, 0.058092743F))))
+        );
     }
 
     public void testFromResponse_CreatesResultsForMultipleItems() throws IOException {
@@ -66,7 +69,7 @@ public class IbmWatsonxEmbeddingsResponseEntityTests extends ESTestCase {
             }
             """;
 
-        DenseEmbeddingFloatResults parsedResults = IbmWatsonxEmbeddingsResponseEntity.fromResponse(
+        LegacyDenseEmbeddingFloatResults parsedResults = IbmWatsonxEmbeddingsResponseEntity.fromResponse(
             mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
@@ -75,8 +78,8 @@ public class IbmWatsonxEmbeddingsResponseEntityTests extends ESTestCase {
             parsedResults.embeddings(),
             is(
                 List.of(
-                    DenseEmbeddingFloatResults.Embedding.of(List.of(-0.00606332F, 0.058092743F)),
-                    DenseEmbeddingFloatResults.Embedding.of(List.of(0.030681048F, 0.01714732F))
+                    LegacyDenseEmbeddingFloatResults.Embedding.of(List.of(-0.00606332F, 0.058092743F)),
+                    LegacyDenseEmbeddingFloatResults.Embedding.of(List.of(0.030681048F, 0.01714732F))
                 )
             )
         );

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIServiceTests.java
@@ -38,7 +38,7 @@ import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.results.ChunkedInferenceEmbedding;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpClientManager;
 import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSender;
 import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSenderTests;
@@ -67,7 +67,7 @@ import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 import static org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsTests.createRandomChunkingSettings;
 import static org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsTests.createRandomChunkingSettingsMap;
-import static org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResultsTests.buildExpectationFloat;
+import static org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResultsTests.buildExpectationFloat;
 import static org.elasticsearch.xpack.inference.Utils.getInvalidModel;
 import static org.elasticsearch.xpack.inference.Utils.getPersistedConfigMap;
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityExecutors;
@@ -1688,10 +1688,10 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
                 var floatResult = (ChunkedInferenceEmbedding) results.get(0);
                 assertThat(floatResult.chunks(), hasSize(1));
                 assertEquals(new ChunkedInference.TextOffset(0, 1), floatResult.chunks().get(0).offset());
-                assertThat(floatResult.chunks().get(0).embedding(), Matchers.instanceOf(DenseEmbeddingFloatResults.Embedding.class));
+                assertThat(floatResult.chunks().get(0).embedding(), Matchers.instanceOf(LegacyDenseEmbeddingFloatResults.Embedding.class));
                 assertArrayEquals(
                     new float[] { 0.123f, -0.123f },
-                    ((DenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values(),
+                    ((LegacyDenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values(),
                     0.0f
                 );
             }
@@ -1700,10 +1700,10 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
                 var floatResult = (ChunkedInferenceEmbedding) results.get(1);
                 assertThat(floatResult.chunks(), hasSize(1));
                 assertEquals(new ChunkedInference.TextOffset(0, 2), floatResult.chunks().get(0).offset());
-                assertThat(floatResult.chunks().get(0).embedding(), Matchers.instanceOf(DenseEmbeddingFloatResults.Embedding.class));
+                assertThat(floatResult.chunks().get(0).embedding(), Matchers.instanceOf(LegacyDenseEmbeddingFloatResults.Embedding.class));
                 assertArrayEquals(
                     new float[] { 0.223f, -0.223f },
-                    ((DenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values(),
+                    ((LegacyDenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values(),
                     0.0f
                 );
             }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/jinaai/response/JinaAIEmbeddingsResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/jinaai/response/JinaAIEmbeddingsResponseEntityTests.java
@@ -11,9 +11,9 @@ import org.apache.http.HttpResponse;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingBitResults;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingByteResults;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingBitResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingByteResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.InputTypeTests;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.services.jinaai.embeddings.JinaAIEmbeddingType;
@@ -69,10 +69,10 @@ public class JinaAIEmbeddingsResponseEntityTests extends ESTestCase {
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
-        assertThat(parsedResults, instanceOf(DenseEmbeddingFloatResults.class));
+        assertThat(parsedResults, instanceOf(LegacyDenseEmbeddingFloatResults.class));
         assertThat(
-            ((DenseEmbeddingFloatResults) parsedResults).embeddings(),
-            is(List.of(new DenseEmbeddingFloatResults.Embedding(new float[] { 0.014539449F, -0.015288644F })))
+            ((LegacyDenseEmbeddingFloatResults) parsedResults).embeddings(),
+            is(List.of(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.014539449F, -0.015288644F })))
         );
     }
 
@@ -123,13 +123,13 @@ public class JinaAIEmbeddingsResponseEntityTests extends ESTestCase {
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
-        assertThat(parsedResults, instanceOf(DenseEmbeddingFloatResults.class));
+        assertThat(parsedResults, instanceOf(LegacyDenseEmbeddingFloatResults.class));
         assertThat(
-            ((DenseEmbeddingFloatResults) parsedResults).embeddings(),
+            ((LegacyDenseEmbeddingFloatResults) parsedResults).embeddings(),
             is(
                 List.of(
-                    new DenseEmbeddingFloatResults.Embedding(new float[] { 0.014539449F, -0.015288644F }),
-                    new DenseEmbeddingFloatResults.Embedding(new float[] { 0.0123F, -0.0123F })
+                    new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.014539449F, -0.015288644F }),
+                    new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.0123F, -0.0123F })
                 )
             )
         );
@@ -363,8 +363,12 @@ public class JinaAIEmbeddingsResponseEntityTests extends ESTestCase {
         );
 
         assertThat(
-            ((DenseEmbeddingBitResults) parsedResults).embeddings(),
-            is(List.of(new DenseEmbeddingByteResults.Embedding(new byte[] { (byte) -55, (byte) 74, (byte) 101, (byte) 67, (byte) 83 })))
+            ((LegacyDenseEmbeddingBitResults) parsedResults).embeddings(),
+            is(
+                List.of(
+                    new LegacyDenseEmbeddingByteResults.Embedding(new byte[] { (byte) -55, (byte) 74, (byte) 101, (byte) 67, (byte) 83 })
+                )
+            )
         );
     }
 
@@ -411,8 +415,12 @@ public class JinaAIEmbeddingsResponseEntityTests extends ESTestCase {
         );
 
         assertThat(
-            ((DenseEmbeddingBitResults) parsedResults).embeddings(),
-            is(List.of(new DenseEmbeddingByteResults.Embedding(new byte[] { (byte) -55, (byte) 74, (byte) 101, (byte) 67, (byte) 83 })))
+            ((LegacyDenseEmbeddingBitResults) parsedResults).embeddings(),
+            is(
+                List.of(
+                    new LegacyDenseEmbeddingByteResults.Embedding(new byte[] { (byte) -55, (byte) 74, (byte) 101, (byte) 67, (byte) 83 })
+                )
+            )
         );
     }
 
@@ -504,7 +512,7 @@ public class JinaAIEmbeddingsResponseEntityTests extends ESTestCase {
                 }
             }""";
 
-        DenseEmbeddingFloatResults parsedResults = (DenseEmbeddingFloatResults) JinaAIEmbeddingsResponseEntity.fromResponse(
+        LegacyDenseEmbeddingFloatResults parsedResults = (LegacyDenseEmbeddingFloatResults) JinaAIEmbeddingsResponseEntity.fromResponse(
             JinaAIEmbeddingsRequestTests.createRequest(
                 List.of("abc"),
                 InputTypeTests.randomWithNull(),
@@ -525,9 +533,9 @@ public class JinaAIEmbeddingsResponseEntityTests extends ESTestCase {
             parsedResults.embeddings(),
             is(
                 List.of(
-                    new DenseEmbeddingFloatResults.Embedding(new float[] { -0.9F, 0.5F, 0.3F }),
-                    new DenseEmbeddingFloatResults.Embedding(new float[] { 0.1F, 0.5F }),
-                    new DenseEmbeddingFloatResults.Embedding(new float[] { 0.5F, 0.5F })
+                    new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { -0.9F, 0.5F, 0.3F }),
+                    new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.1F, 0.5F }),
+                    new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.5F, 0.5F })
                 )
             )
         );

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/llama/LlamaServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/llama/LlamaServiceTests.java
@@ -43,7 +43,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsTests;
 import org.elasticsearch.xpack.core.inference.results.ChunkedInferenceEmbedding;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.UnifiedChatCompletionException;
 import org.elasticsearch.xpack.inference.external.http.HttpClientManager;
 import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSender;
@@ -695,11 +695,11 @@ public class LlamaServiceTests extends AbstractInferenceServiceTests {
                 assertThat(results.get(0), CoreMatchers.instanceOf(ChunkedInferenceEmbedding.class));
                 var floatResult = (ChunkedInferenceEmbedding) results.get(0);
                 assertThat(floatResult.chunks(), hasSize(1));
-                assertThat(floatResult.chunks().get(0).embedding(), Matchers.instanceOf(DenseEmbeddingFloatResults.Embedding.class));
+                assertThat(floatResult.chunks().get(0).embedding(), Matchers.instanceOf(LegacyDenseEmbeddingFloatResults.Embedding.class));
                 assertTrue(
                     Arrays.equals(
                         new float[] { 0.010060793f, -0.0017529363f },
-                        ((DenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values()
+                        ((LegacyDenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values()
                     )
                 );
             }
@@ -707,11 +707,11 @@ public class LlamaServiceTests extends AbstractInferenceServiceTests {
                 assertThat(results.get(1), CoreMatchers.instanceOf(ChunkedInferenceEmbedding.class));
                 var floatResult = (ChunkedInferenceEmbedding) results.get(1);
                 assertThat(floatResult.chunks(), hasSize(1));
-                assertThat(floatResult.chunks().get(0).embedding(), Matchers.instanceOf(DenseEmbeddingFloatResults.Embedding.class));
+                assertThat(floatResult.chunks().get(0).embedding(), Matchers.instanceOf(LegacyDenseEmbeddingFloatResults.Embedding.class));
                 assertTrue(
                     Arrays.equals(
                         new float[] { 0.110060793f, -0.1017529363f },
-                        ((DenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values()
+                        ((LegacyDenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values()
                     )
                 );
             }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/llama/action/LlamaActionCreatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/llama/action/LlamaActionCreatorTests.java
@@ -19,7 +19,7 @@ import org.elasticsearch.test.http.MockWebServer;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResultsTests;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResultsTests;
 import org.elasticsearch.xpack.inference.InputTypeTests;
 import org.elasticsearch.xpack.inference.common.TruncatorTests;
 import org.elasticsearch.xpack.inference.external.http.HttpClientManager;
@@ -100,7 +100,7 @@ public class LlamaActionCreatorTests extends ESTestCase {
 
             assertThat(
                 result.asMap(),
-                is(DenseEmbeddingFloatResultsTests.buildExpectationFloat(List.of(new float[] { -0.0123F, 0.123F })))
+                is(LegacyDenseEmbeddingFloatResultsTests.buildExpectationFloat(List.of(new float[] { -0.0123F, 0.123F })))
             );
 
             assertEmbeddingsRequest();

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/mistral/MistralServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/mistral/MistralServiceTests.java
@@ -41,7 +41,7 @@ import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.results.ChunkedInferenceEmbedding;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.UnifiedChatCompletionException;
 import org.elasticsearch.xpack.inference.ModelConfigurationsTests;
 import org.elasticsearch.xpack.inference.external.http.HttpClientManager;
@@ -1135,11 +1135,11 @@ public class MistralServiceTests extends InferenceServiceTestCase {
                 assertThat(results.get(0), CoreMatchers.instanceOf(ChunkedInferenceEmbedding.class));
                 var floatResult = (ChunkedInferenceEmbedding) results.get(0);
                 assertThat(floatResult.chunks(), hasSize(1));
-                assertThat(floatResult.chunks().get(0).embedding(), Matchers.instanceOf(DenseEmbeddingFloatResults.Embedding.class));
+                assertThat(floatResult.chunks().get(0).embedding(), Matchers.instanceOf(LegacyDenseEmbeddingFloatResults.Embedding.class));
                 assertTrue(
                     Arrays.equals(
                         new float[] { 0.123f, -0.123f },
-                        ((DenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values()
+                        ((LegacyDenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values()
                     )
                 );
             }
@@ -1147,11 +1147,11 @@ public class MistralServiceTests extends InferenceServiceTestCase {
                 assertThat(results.get(1), CoreMatchers.instanceOf(ChunkedInferenceEmbedding.class));
                 var floatResult = (ChunkedInferenceEmbedding) results.get(1);
                 assertThat(floatResult.chunks(), hasSize(1));
-                assertThat(floatResult.chunks().get(0).embedding(), Matchers.instanceOf(DenseEmbeddingFloatResults.Embedding.class));
+                assertThat(floatResult.chunks().get(0).embedding(), Matchers.instanceOf(LegacyDenseEmbeddingFloatResults.Embedding.class));
                 assertTrue(
                     Arrays.equals(
                         new float[] { 0.223f, -0.223f },
-                        ((DenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values()
+                        ((LegacyDenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values()
                     )
                 );
             }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/OpenAiServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/OpenAiServiceTests.java
@@ -44,7 +44,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsTests;
 import org.elasticsearch.xpack.core.inference.results.ChunkedInferenceEmbedding;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.UnifiedChatCompletionException;
 import org.elasticsearch.xpack.inference.external.http.HttpClientManager;
 import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSender;
@@ -84,7 +84,7 @@ import static org.elasticsearch.ExceptionsHelper.unwrapCause;
 import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 import static org.elasticsearch.xcontent.ToXContent.EMPTY_PARAMS;
-import static org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResultsTests.buildExpectationFloat;
+import static org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResultsTests.buildExpectationFloat;
 import static org.elasticsearch.xpack.inference.Utils.getInvalidModel;
 import static org.elasticsearch.xpack.inference.Utils.getRequestConfigMap;
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityExecutors;
@@ -1050,11 +1050,11 @@ public class OpenAiServiceTests extends AbstractInferenceServiceTests {
                 var floatResult = (ChunkedInferenceEmbedding) results.get(0);
                 assertThat(floatResult.chunks(), hasSize(1));
                 assertEquals(new ChunkedInference.TextOffset(0, 1), floatResult.chunks().get(0).offset());
-                assertThat(floatResult.chunks().get(0).embedding(), Matchers.instanceOf(DenseEmbeddingFloatResults.Embedding.class));
+                assertThat(floatResult.chunks().get(0).embedding(), Matchers.instanceOf(LegacyDenseEmbeddingFloatResults.Embedding.class));
                 assertTrue(
                     Arrays.equals(
                         new float[] { 0.123f, -0.123f },
-                        ((DenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values()
+                        ((LegacyDenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values()
                     )
                 );
             }
@@ -1063,11 +1063,11 @@ public class OpenAiServiceTests extends AbstractInferenceServiceTests {
                 var floatResult = (ChunkedInferenceEmbedding) results.get(1);
                 assertThat(floatResult.chunks(), hasSize(1));
                 assertEquals(new ChunkedInference.TextOffset(0, 2), floatResult.chunks().get(0).offset());
-                assertThat(floatResult.chunks().get(0).embedding(), Matchers.instanceOf(DenseEmbeddingFloatResults.Embedding.class));
+                assertThat(floatResult.chunks().get(0).embedding(), Matchers.instanceOf(LegacyDenseEmbeddingFloatResults.Embedding.class));
                 assertTrue(
                     Arrays.equals(
                         new float[] { 0.223f, -0.223f },
-                        ((DenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values()
+                        ((LegacyDenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values()
                     )
                 );
             }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/action/OpenAiActionCreatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/action/OpenAiActionCreatorTests.java
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.inference.results.ChatCompletionResultsTests.buildExpectationCompletion;
-import static org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResultsTests.buildExpectationFloat;
+import static org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResultsTests.buildExpectationFloat;
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityExecutors;
 import static org.elasticsearch.xpack.inference.Utils.mockClusterServiceEmpty;
 import static org.elasticsearch.xpack.inference.external.http.Utils.entityAsMap;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/action/OpenAiEmbeddingsActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/action/OpenAiEmbeddingsActionTests.java
@@ -40,7 +40,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResultsTests.buildExpectationFloat;
+import static org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResultsTests.buildExpectationFloat;
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityExecutors;
 import static org.elasticsearch.xpack.inference.Utils.mockClusterServiceEmpty;
 import static org.elasticsearch.xpack.inference.external.action.ActionUtils.constructFailedToSendRequestMessage;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/response/OpenAiEmbeddingsResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/response/OpenAiEmbeddingsResponseEntityTests.java
@@ -10,7 +10,7 @@ package org.elasticsearch.xpack.inference.services.openai.response;
 import org.apache.http.HttpResponse;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentParseException;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.request.Request;
 
@@ -45,14 +45,14 @@ public class OpenAiEmbeddingsResponseEntityTests extends ESTestCase {
             }
             """;
 
-        DenseEmbeddingFloatResults parsedResults = OpenAiEmbeddingsResponseEntity.fromResponse(
+        LegacyDenseEmbeddingFloatResults parsedResults = OpenAiEmbeddingsResponseEntity.fromResponse(
             mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
         assertThat(
             parsedResults.embeddings(),
-            is(List.of(new DenseEmbeddingFloatResults.Embedding(new float[] { 0.014539449F, -0.015288644F })))
+            is(List.of(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.014539449F, -0.015288644F })))
         );
     }
 
@@ -86,7 +86,7 @@ public class OpenAiEmbeddingsResponseEntityTests extends ESTestCase {
             }
             """;
 
-        DenseEmbeddingFloatResults parsedResults = OpenAiEmbeddingsResponseEntity.fromResponse(
+        LegacyDenseEmbeddingFloatResults parsedResults = OpenAiEmbeddingsResponseEntity.fromResponse(
             mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
@@ -95,8 +95,8 @@ public class OpenAiEmbeddingsResponseEntityTests extends ESTestCase {
             parsedResults.embeddings(),
             is(
                 List.of(
-                    new DenseEmbeddingFloatResults.Embedding(new float[] { 0.014539449F, -0.015288644F }),
-                    new DenseEmbeddingFloatResults.Embedding(new float[] { 0.0123F, -0.0123F })
+                    new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.014539449F, -0.015288644F }),
+                    new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.0123F, -0.0123F })
                 )
             )
         );
@@ -254,12 +254,12 @@ public class OpenAiEmbeddingsResponseEntityTests extends ESTestCase {
             }
             """;
 
-        DenseEmbeddingFloatResults parsedResults = OpenAiEmbeddingsResponseEntity.fromResponse(
+        LegacyDenseEmbeddingFloatResults parsedResults = OpenAiEmbeddingsResponseEntity.fromResponse(
             mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
-        assertThat(parsedResults.embeddings(), is(List.of(new DenseEmbeddingFloatResults.Embedding(new float[] { 1.0F }))));
+        assertThat(parsedResults.embeddings(), is(List.of(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 1.0F }))));
     }
 
     public void testFromResponse_SucceedsWhenEmbeddingValueIsLong() throws IOException {
@@ -283,12 +283,12 @@ public class OpenAiEmbeddingsResponseEntityTests extends ESTestCase {
             }
             """;
 
-        DenseEmbeddingFloatResults parsedResults = OpenAiEmbeddingsResponseEntity.fromResponse(
+        LegacyDenseEmbeddingFloatResults parsedResults = OpenAiEmbeddingsResponseEntity.fromResponse(
             mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
-        assertThat(parsedResults.embeddings(), is(List.of(new DenseEmbeddingFloatResults.Embedding(new float[] { 4.0294965E10F }))));
+        assertThat(parsedResults.embeddings(), is(List.of(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 4.0294965E10F }))));
     }
 
     public void testFromResponse_FailsWhenEmbeddingValueIsAnObject() {
@@ -365,7 +365,7 @@ public class OpenAiEmbeddingsResponseEntityTests extends ESTestCase {
                 }
             }""";
 
-        DenseEmbeddingFloatResults parsedResults = OpenAiEmbeddingsResponseEntity.fromResponse(
+        LegacyDenseEmbeddingFloatResults parsedResults = OpenAiEmbeddingsResponseEntity.fromResponse(
             mock(Request.class),
             new HttpResult(mock(HttpResponse.class), response.getBytes(StandardCharsets.UTF_8))
         );
@@ -374,9 +374,9 @@ public class OpenAiEmbeddingsResponseEntityTests extends ESTestCase {
             parsedResults.embeddings(),
             is(
                 List.of(
-                    new DenseEmbeddingFloatResults.Embedding(new float[] { -0.9F, 0.5F, 0.3F }),
-                    new DenseEmbeddingFloatResults.Embedding(new float[] { 0.1F, 0.5F }),
-                    new DenseEmbeddingFloatResults.Embedding(new float[] { 0.5F, 0.5F })
+                    new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { -0.9F, 0.5F, 0.3F }),
+                    new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.1F, 0.5F }),
+                    new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.5F, 0.5F })
                 )
             )
         );

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/sagemaker/SageMakerServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/sagemaker/SageMakerServiceTests.java
@@ -30,7 +30,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.inference.chunking.WordBoundaryChunkingSettings;
 import org.elasticsearch.xpack.core.inference.results.ChunkedInferenceError;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResultsTests;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResultsTests;
 import org.elasticsearch.xpack.inference.InferencePlugin;
 import org.elasticsearch.xpack.inference.common.amazon.AwsSecretSettings;
 import org.elasticsearch.xpack.inference.services.InferenceServiceTestCase;
@@ -449,7 +449,7 @@ public class SageMakerServiceTests extends InferenceServiceTestCase {
         var model = mockModelForChunking();
 
         SageMakerSchema schema = mock();
-        when(schema.response(any(), any(), any())).thenReturn(DenseEmbeddingFloatResultsTests.createRandomResults());
+        when(schema.response(any(), any(), any())).thenReturn(LegacyDenseEmbeddingFloatResultsTests.createRandomResults());
         when(schemas.schemaFor(model)).thenReturn(schema);
         mockInvoke();
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/sagemaker/schema/elastic/ElasticTextEmbeddingPayloadTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/sagemaker/schema/elastic/ElasticTextEmbeddingPayloadTests.java
@@ -9,8 +9,8 @@ package org.elasticsearch.xpack.inference.services.sagemaker.schema.elastic;
 
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.inference.TaskType;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingByteResults;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingByteResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.services.sagemaker.model.SageMakerModel;
 import org.elasticsearch.xpack.inference.services.sagemaker.schema.SageMakerStoredServiceSchema;
 
@@ -66,8 +66,8 @@ public class ElasticTextEmbeddingPayloadTests extends ElasticPayloadTestCase<Ela
 
         assertThat(bitResults.embeddings().size(), is(1));
         var embedding = bitResults.embeddings().get(0);
-        assertThat(embedding, isA(DenseEmbeddingByteResults.Embedding.class));
-        assertThat(((DenseEmbeddingByteResults.Embedding) embedding).values(), is(new byte[] { 23 }));
+        assertThat(embedding, isA(LegacyDenseEmbeddingByteResults.Embedding.class));
+        assertThat(((LegacyDenseEmbeddingByteResults.Embedding) embedding).values(), is(new byte[] { 23 }));
     }
 
     public void testByteResponse() throws Exception {
@@ -87,8 +87,8 @@ public class ElasticTextEmbeddingPayloadTests extends ElasticPayloadTestCase<Ela
 
         assertThat(byteResults.embeddings().size(), is(1));
         var embedding = byteResults.embeddings().get(0);
-        assertThat(embedding, isA(DenseEmbeddingByteResults.Embedding.class));
-        assertThat(((DenseEmbeddingByteResults.Embedding) embedding).values(), is(new byte[] { 23 }));
+        assertThat(embedding, isA(LegacyDenseEmbeddingByteResults.Embedding.class));
+        assertThat(((LegacyDenseEmbeddingByteResults.Embedding) embedding).values(), is(new byte[] { 23 }));
     }
 
     public void testFloatResponse() throws Exception {
@@ -108,7 +108,7 @@ public class ElasticTextEmbeddingPayloadTests extends ElasticPayloadTestCase<Ela
 
         assertThat(byteResults.embeddings().size(), is(1));
         var embedding = byteResults.embeddings().get(0);
-        assertThat(embedding, isA(DenseEmbeddingFloatResults.Embedding.class));
-        assertThat(((DenseEmbeddingFloatResults.Embedding) embedding).values(), is(new float[] { 0.1F }));
+        assertThat(embedding, isA(LegacyDenseEmbeddingFloatResults.Embedding.class));
+        assertThat(((LegacyDenseEmbeddingFloatResults.Embedding) embedding).values(), is(new float[] { 0.1F }));
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/sagemaker/schema/openai/OpenAiTextEmbeddingPayloadTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/sagemaker/schema/openai/OpenAiTextEmbeddingPayloadTests.java
@@ -12,7 +12,7 @@ import software.amazon.awssdk.services.sagemakerruntime.model.InvokeEndpointResp
 
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.TaskType;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.services.sagemaker.SageMakerInferenceRequest;
 import org.elasticsearch.xpack.inference.services.sagemaker.model.SageMakerModel;
 import org.elasticsearch.xpack.inference.services.sagemaker.schema.SageMakerSchemaPayloadTestCase;
@@ -149,7 +149,7 @@ public class OpenAiTextEmbeddingPayloadTests extends SageMakerSchemaPayloadTestC
 
         assertThat(
             denseEmbeddingFloatResults.embeddings(),
-            is(List.of(new DenseEmbeddingFloatResults.Embedding(new float[] { 0.014539449F, -0.015288644F })))
+            is(List.of(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.014539449F, -0.015288644F })))
         );
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/validation/DenseEmbeddingModelValidatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/validation/DenseEmbeddingModelValidatorTests.java
@@ -17,9 +17,9 @@ import org.elasticsearch.inference.Model;
 import org.elasticsearch.inference.ServiceSettings;
 import org.elasticsearch.inference.validation.ServiceIntegrationValidator;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingByteResults;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingByteResultsTests;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingByteResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingByteResultsTests;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResultsTests;
 import org.elasticsearch.xpack.inference.EmptyTaskSettingsTests;
 import org.elasticsearch.xpack.inference.ModelConfigurationsTests;
@@ -113,7 +113,7 @@ public class DenseEmbeddingModelValidatorTests extends ESTestCase {
     }
 
     public void testValidate_RetrievingEmbeddingSizeThrowsIllegalStateException() {
-        DenseEmbeddingFloatResults results = new DenseEmbeddingFloatResults(List.of());
+        LegacyDenseEmbeddingFloatResults results = new LegacyDenseEmbeddingFloatResults(List.of());
 
         when(mockServiceSettings.dimensionsSetByUser()).thenReturn(true);
         when(mockServiceSettings.dimensions()).thenReturn(randomNonNegativeInt());
@@ -129,7 +129,7 @@ public class DenseEmbeddingModelValidatorTests extends ESTestCase {
     }
 
     public void testValidate_DimensionsSetByUserDoNotEqualEmbeddingSize() {
-        DenseEmbeddingByteResults results = DenseEmbeddingByteResultsTests.createRandomResults();
+        LegacyDenseEmbeddingByteResults results = LegacyDenseEmbeddingByteResultsTests.createRandomResults();
         int embeddingSize = results.getFirstEmbeddingSize();
         int dimensions = randomValueOtherThan(embeddingSize, ESTestCase::randomNonNegativeInt);
 
@@ -168,7 +168,7 @@ public class DenseEmbeddingModelValidatorTests extends ESTestCase {
     }
 
     private void mockSuccessfulValidation(Boolean dimensionsSetByUser) {
-        DenseEmbeddingByteResults results = DenseEmbeddingByteResultsTests.createRandomResults();
+        LegacyDenseEmbeddingByteResults results = LegacyDenseEmbeddingByteResultsTests.createRandomResults();
         when(mockModel.getConfigurations()).thenReturn(ModelConfigurationsTests.createRandomInstance());
         when(mockModel.getTaskSettings()).thenReturn(EmptyTaskSettingsTests.createRandom());
         when(mockServiceSettings.dimensionsSetByUser()).thenReturn(dimensionsSetByUser);

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/voyageai/VoyageAIServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/voyageai/VoyageAIServiceTests.java
@@ -37,7 +37,7 @@ import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
 import org.elasticsearch.xpack.core.inference.results.ChunkedInferenceEmbedding;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.external.http.HttpClientManager;
 import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSender;
 import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSenderTests;
@@ -65,7 +65,7 @@ import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 import static org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsTests.createRandomChunkingSettings;
 import static org.elasticsearch.xpack.core.inference.chunking.ChunkingSettingsTests.createRandomChunkingSettingsMap;
-import static org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResultsTests.buildExpectationFloat;
+import static org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResultsTests.buildExpectationFloat;
 import static org.elasticsearch.xpack.inference.Utils.getInvalidModel;
 import static org.elasticsearch.xpack.inference.Utils.getPersistedConfigMap;
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityExecutors;
@@ -1654,10 +1654,13 @@ public class VoyageAIServiceTests extends InferenceServiceTestCase {
                 var floatResult = (ChunkedInferenceEmbedding) results.getFirst();
                 assertThat(floatResult.chunks(), hasSize(1));
                 assertEquals(new ChunkedInference.TextOffset(0, 1), floatResult.chunks().getFirst().offset());
-                assertThat(floatResult.chunks().get(0).embedding(), CoreMatchers.instanceOf(DenseEmbeddingFloatResults.Embedding.class));
+                assertThat(
+                    floatResult.chunks().get(0).embedding(),
+                    CoreMatchers.instanceOf(LegacyDenseEmbeddingFloatResults.Embedding.class)
+                );
                 assertArrayEquals(
                     new float[] { 0.123f, -0.123f },
-                    ((DenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values(),
+                    ((LegacyDenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values(),
                     0.0f
                 );
             }
@@ -1668,11 +1671,11 @@ public class VoyageAIServiceTests extends InferenceServiceTestCase {
                 assertEquals(new ChunkedInference.TextOffset(0, 2), floatResult.chunks().getFirst().offset());
                 assertThat(
                     floatResult.chunks().getFirst().embedding(),
-                    CoreMatchers.instanceOf(DenseEmbeddingFloatResults.Embedding.class)
+                    CoreMatchers.instanceOf(LegacyDenseEmbeddingFloatResults.Embedding.class)
                 );
                 assertArrayEquals(
                     new float[] { 0.223f, -0.223f },
-                    ((DenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values(),
+                    ((LegacyDenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values(),
                     0.0f
                 );
             }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/voyageai/action/VoyageAIActionCreatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/voyageai/action/VoyageAIActionCreatorTests.java
@@ -37,7 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import static org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResultsTests.buildExpectationFloat;
+import static org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResultsTests.buildExpectationFloat;
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityExecutors;
 import static org.elasticsearch.xpack.inference.Utils.mockClusterServiceEmpty;
 import static org.elasticsearch.xpack.inference.external.http.Utils.entityAsMap;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/voyageai/action/VoyageAIEmbeddingsActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/voyageai/action/VoyageAIEmbeddingsActionTests.java
@@ -46,9 +46,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import static org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResultsTests.buildExpectationBinary;
-import static org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResultsTests.buildExpectationByte;
-import static org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResultsTests.buildExpectationFloat;
+import static org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingBitResultsTests.buildExpectationBinary;
+import static org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingByteResultsTests.buildExpectationByte;
+import static org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResultsTests.buildExpectationFloat;
 import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityExecutors;
 import static org.elasticsearch.xpack.inference.Utils.mockClusterServiceEmpty;
 import static org.elasticsearch.xpack.inference.external.action.ActionUtils.constructFailedToSendRequestMessage;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/voyageai/response/VoyageAIEmbeddingsResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/voyageai/response/VoyageAIEmbeddingsResponseEntityTests.java
@@ -11,7 +11,7 @@ import org.apache.http.HttpResponse;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentParseException;
-import org.elasticsearch.xpack.core.inference.results.DenseEmbeddingFloatResults;
+import org.elasticsearch.xpack.core.inference.results.LegacyDenseEmbeddingFloatResults;
 import org.elasticsearch.xpack.inference.InputTypeTests;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.services.voyageai.request.VoyageAIEmbeddingsRequest;
@@ -60,8 +60,8 @@ public class VoyageAIEmbeddingsResponseEntityTests extends ESTestCase {
         );
 
         assertThat(
-            ((DenseEmbeddingFloatResults) parsedResults).embeddings(),
-            is(List.of(new DenseEmbeddingFloatResults.Embedding(new float[] { 0.014539449F, -0.015288644F })))
+            ((LegacyDenseEmbeddingFloatResults) parsedResults).embeddings(),
+            is(List.of(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.014539449F, -0.015288644F })))
         );
     }
 
@@ -106,11 +106,11 @@ public class VoyageAIEmbeddingsResponseEntityTests extends ESTestCase {
         );
 
         assertThat(
-            ((DenseEmbeddingFloatResults) parsedResults).embeddings(),
+            ((LegacyDenseEmbeddingFloatResults) parsedResults).embeddings(),
             is(
                 List.of(
-                    new DenseEmbeddingFloatResults.Embedding(new float[] { 0.014539449F, -0.015288644F }),
-                    new DenseEmbeddingFloatResults.Embedding(new float[] { 0.0123F, -0.0123F })
+                    new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.014539449F, -0.015288644F }),
+                    new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.0123F, -0.0123F })
                 )
             )
         );
@@ -299,8 +299,8 @@ public class VoyageAIEmbeddingsResponseEntityTests extends ESTestCase {
         );
 
         assertThat(
-            ((DenseEmbeddingFloatResults) parsedResults).embeddings(),
-            is(List.of(new DenseEmbeddingFloatResults.Embedding(new float[] { 1.0F })))
+            ((LegacyDenseEmbeddingFloatResults) parsedResults).embeddings(),
+            is(List.of(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 1.0F })))
         );
     }
 
@@ -336,8 +336,8 @@ public class VoyageAIEmbeddingsResponseEntityTests extends ESTestCase {
         );
 
         assertThat(
-            ((DenseEmbeddingFloatResults) parsedResults).embeddings(),
-            is(List.of(new DenseEmbeddingFloatResults.Embedding(new float[] { 4.0294965E10F })))
+            ((LegacyDenseEmbeddingFloatResults) parsedResults).embeddings(),
+            is(List.of(new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 4.0294965E10F })))
         );
     }
 
@@ -427,15 +427,15 @@ public class VoyageAIEmbeddingsResponseEntityTests extends ESTestCase {
             new HttpResult(mock(HttpResponse.class), response.getBytes(StandardCharsets.UTF_8))
         );
 
-        assertThat(parsedResults, instanceOf(DenseEmbeddingFloatResults.class));
+        assertThat(parsedResults, instanceOf(LegacyDenseEmbeddingFloatResults.class));
 
         assertThat(
-            ((DenseEmbeddingFloatResults) parsedResults).embeddings(),
+            ((LegacyDenseEmbeddingFloatResults) parsedResults).embeddings(),
             is(
                 List.of(
-                    new DenseEmbeddingFloatResults.Embedding(new float[] { -0.9F, 0.5F, 0.3F }),
-                    new DenseEmbeddingFloatResults.Embedding(new float[] { 0.1F, 0.5F }),
-                    new DenseEmbeddingFloatResults.Embedding(new float[] { 0.5F, 0.5F })
+                    new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { -0.9F, 0.5F, 0.3F }),
+                    new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.1F, 0.5F }),
+                    new LegacyDenseEmbeddingFloatResults.Embedding(new float[] { 0.5F, 0.5F })
                 )
             )
         );


### PR DESCRIPTION
The existing DenseEmbeddingResults implementations produce an array named "text_embedding" (with _bits or _bytes suffixes for the DenseEmbeddingBitResults and DenseEmbeddingByteResults implementations), which is not suitable for multimodal embeddings results, which may be generated from text, images or other data formats.

This PR renames the existing DenseEmbedding\*Results classes to LegacyDenseEmbedding\*Results, marks them as deprecated for removal, and introduces a new set of DenseEmbedding\*Results classes that are functionally identical to the Legacy\* classes, but name the results array "embeddings" instead of "text_embedding", making them suitable for both existing text embedding and planned multimodal embedding use cases. Since changing the array name for existing tasks is a breaking change, none of the uses of the Legacy\* classes are removed in this PR, with the migration to use the new classes for the text embedding task type being left until the next major release.

This PR is split into two commits to make it easier to review. The first commit contains any actually substantive changes, and the second contains the results of renaming the DenseEmbedding\*Results classes to LegacyDenseEmbedding\*Results. Git got a bit confused about the combination of renaming existing classes and the introduction of new classes with the same name as the old classes, so the diff marks the renamed Legacy\* classes as being new files and the new non-Legacy classes as being modified.