### PR TITLE
Add a test that exercises two little known conditional processor paths

### DIFF
--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/210_conditional_processor.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/210_conditional_processor.yml
@@ -221,3 +221,44 @@ teardown:
         index: test
         id: "2"
       catch: missing
+
+---
+"Test conditionals support params and statements":
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        body: >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "set" : {
+                  "if" : {
+                    "source": "def hit = params.success_codes.containsKey(ctx.code); return hit != null && hit == true;",
+                    "params": {
+                      "success_codes" : {
+                        "10": true,
+                        "20": true
+                      }
+                    }
+                  },
+                  "field" : "result",
+                  "value" : "success"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      index:
+        index: test
+        id: "1"
+        pipeline: "my_pipeline"
+        body: { code: "20" }
+
+  - do:
+      get:
+        index: test
+        id: "1"
+  - match: { _source.result: "success" }


### PR DESCRIPTION
These work, and probably have worked forever, but I don't think we document it anywhere. I think it would be useful to have test coverage for these behaviors since they're somewhat obscure.

-----

First, conditionals are commonly seen to have **expressions**. But they can also have **statements**. This can be useful as an optimization. For example, this expression:

```
"if": "ctx.foo?.bar?.baz != null && ctx.foo.bar.baz != 'reject' && ctx.foo.bar.baz != 'failure'"
```

Can be rewritten as these statements:

```
"if": "def baz = ctx.foo?.bar?.baz; return baz != null && baz != 'reject' && baz != 'failure';"
```

The latter approach might be faster than the former (note: you should profile your code, not trust random github PR descriptions) because it descends the `ctx` object tree via chained `Map#get` invocations just once, rather than up to three times.

-----

Second, did you know that `"if"` doesn't have to be a `String`? It can be a map, too! And the map can have `params`. An especially useful application of this trick would be a conditional that's checking a candidate value against a large group of other values, like what one might choose to do [here](https://github.com/elastic/integrations/blob/ef49c6fdeec4e2d86dc915c14ba82567c70f1db0/packages/sophos/data_stream/xg/elasticsearch/ingest_pipeline/antispam.yml#L21-L25).

To my understanding, as written, that example currently compiles down to bytecode that creates an empty `ArrayList`, then adds twelve strings to it (note: the ArrayList is resized from the default capacity of 10 to a capacity of 15 in order to accommodate the 11th string, with the ensuing array copy), and then a linear scan of the `ArrayList` is performed in the `.contains(...)`. And that's all performed for every document that goes through the thus-defined processor.

By way of contrast, this would work similarly in terms of effect, but be much faster (note: assuming flow-style inline maps are supported by whatever is handling the yaml there, otherwise the syntax would be slightly different):

```
- set:
    tag: set_event_kind_23ecd1e1
    field: event.kind
    value: alert
    if: 
     source: 'params.containsKey(ctx.event?.code)'
     params: { "13001":true, "13002":true, "13004":true, "13005":true, "13006":true, "13009":true, "13012":true, "13014":true, "14001":true, "14002":true, "15001":true, "15002":true }
```

This version is admittedly a bit uglier, but since it generates a single static params map of all the values just once at script definition time and then does a fast `containsKey` check on that map, it's quite a bit faster (and allocation-free).

The most ideal version of that might not rely on the set semantics of the map keys, but in the absence of support for constant set collections in painless, this is probably the optimal mix of readable and fast for the state of the current technology.