### PR TITLE
Returning correct index mode from get data streams api

### DIFF
--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportGetDataStreamsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportGetDataStreamsAction.java
@@ -224,6 +224,12 @@ public class TransportGetDataStreamsAction extends TransportLocalProjectMetadata
                 indexMode = Enum.valueOf(IndexMode.class, rawMode.toUpperCase(Locale.ROOT));
             }
         }
+        if (indexMode == null) {
+            String rawMode = settings.get(IndexSettings.MODE.getKey());
+            if (rawMode != null) {
+                indexMode = Enum.valueOf(IndexMode.class, rawMode.toUpperCase(Locale.ROOT));
+            }
+        }
         return indexMode;
     }
 

--- a/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/15_default.yml
+++ b/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/15_default.yml
@@ -1,0 +1,19 @@
+'default index mode':
+  - requires:
+      test_runner_features: [ capabilities ]
+      capabilities:
+        - method: PUT
+          path: /{index}
+          capabilities: [ logsdb_index_mode ]
+      reason: "Support for 'logsdb' index mode capability required"
+
+  - do:
+      indices.create_data_stream:
+        name: logs-test-1
+
+  - do:
+      indices.get_data_stream:
+        name: logs-test-1
+
+  - match: { data_streams.0.indices.0.index_mode: logsdb}
+  - match: { data_streams.0.index_mode: logsdb}


### PR DESCRIPTION
This bug was caused by https://github.com/elastic/elasticsearch/pull/137407. Since getEffectiveSettings() [now pulls in IndexSettingProviders](https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataDataStreamsService.java#L619), [the settings passed to `TransportGetDataStreamsAction::resolveMode`](https://github.com/elastic/elasticsearch/blob/main/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportGetDataStreamsAction.java#L277) already had the correct index mode set. This means that `LogsdbIndexModeSettingsProvider::provideAdditionalSettings` [did _not_ put the index mode into its additional settings](https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/LogsdbIndexModeSettingsProvider.java#L131) and so [resolveMode did not find it](https://github.com/elastic/elasticsearch/blob/main/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportGetDataStreamsAction.java#L222).