### PR TITLE
[9.2] Returning correct index mode from get data streams api (#137646)

### DIFF
--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportGetDataStreamsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportGetDataStreamsAction.java
@@ -224,6 +224,12 @@ public class TransportGetDataStreamsAction extends TransportLocalProjectMetadata
                 indexMode = Enum.valueOf(IndexMode.class, rawMode.toUpperCase(Locale.ROOT));
             }
         }
+        if (indexMode == null) {
+            String rawMode = settings.get(IndexSettings.MODE.getKey());
+            if (rawMode != null) {
+                indexMode = Enum.valueOf(IndexMode.class, rawMode.toUpperCase(Locale.ROOT));
+            }
+        }
         return indexMode;
     }
 

--- a/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/15_default.yml
+++ b/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/15_default.yml
@@ -1,0 +1,19 @@
+'default index mode':
+  - requires:
+      test_runner_features: [ capabilities ]
+      capabilities:
+        - method: PUT
+          path: /{index}
+          capabilities: [ logsdb_index_mode ]
+      reason: "Support for 'logsdb' index mode capability required"
+
+  - do:
+      indices.create_data_stream:
+        name: logs-test-1
+
+  - do:
+      indices.get_data_stream:
+        name: logs-test-1
+
+  - match: { data_streams.0.indices.0.index_mode: logsdb}
+  - match: { data_streams.0.index_mode: logsdb}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Returning correct index mode from get data streams api (#137646)](https://github.com/elastic/elasticsearch/pull/137646)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)