### PR TITLE
Add IdLoader.create(MapperService) method

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/IdLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IdLoader.java
@@ -59,9 +59,9 @@ public sealed interface IdLoader permits IdLoader.TsIdLoader, IdLoader.StoredIdL
                     }
                 }
             }
-            return IdLoader.createTsIdLoader(indexRouting, routingPaths, indexSettings.useTimeSeriesSyntheticId());
+            return createTsIdLoader(indexRouting, routingPaths, indexSettings.useTimeSeriesSyntheticId());
         } else {
-            return IdLoader.fromLeafStoredFieldLoader();
+            return fromLeafStoredFieldLoader();
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/IdLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IdLoader.java
@@ -18,15 +18,52 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.routing.IndexRouting;
 import org.elasticsearch.cluster.routing.RoutingHashBuilder;
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.fieldvisitor.LeafStoredFieldLoader;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * Responsible for loading the _id from stored fields or for TSDB synthesizing the _id from the routing, _tsid and @timestamp fields.
  */
 public sealed interface IdLoader permits IdLoader.TsIdLoader, IdLoader.StoredIdLoader {
+
+    /**
+     * @return returns an {@link IdLoader} instance to load the value of the _id field.
+     */
+    static IdLoader create(MapperService mapperService) {
+        var indexSettings = mapperService.getIndexSettings();
+        if (indexSettings.getMode() == IndexMode.TIME_SERIES) {
+            IndexRouting.ExtractFromSource.ForRoutingPath indexRouting = null;
+            List<String> routingPaths = null;
+            if (indexSettings.getIndexVersionCreated().before(IndexVersions.TIME_SERIES_ROUTING_HASH_IN_ID)) {
+                indexRouting = (IndexRouting.ExtractFromSource.ForRoutingPath) indexSettings.getIndexRouting();
+                routingPaths = indexSettings.getIndexMetadata().getRoutingPaths();
+                for (String routingField : routingPaths) {
+                    if (routingField.contains("*")) {
+                        // In case the routing fields include path matches, find any matches and add them as distinct fields
+                        // to the routing path.
+                        Set<String> matchingRoutingPaths = new TreeSet<>(routingPaths);
+                        for (Mapper mapper : mapperService.mappingLookup().fieldMappers()) {
+                            if (mapper instanceof KeywordFieldMapper && indexRouting.matchesField(mapper.fullPath())) {
+                                matchingRoutingPaths.add(mapper.fullPath());
+                            }
+                        }
+                        routingPaths = new ArrayList<>(matchingRoutingPaths);
+                        break;
+                    }
+                }
+            }
+            return IdLoader.createTsIdLoader(indexRouting, routingPaths, indexSettings.useTimeSeriesSyntheticId());
+        } else {
+            return IdLoader.fromLeafStoredFieldLoader();
+        }
+    }
 
     /**
      * @return returns an {@link IdLoader} instance the loads the _id from stored field.

--- a/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
@@ -23,16 +23,13 @@ import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchType;
-import org.elasticsearch.cluster.routing.IndexRouting;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.IndexSettings;
-import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.fielddata.FieldDataContext;
@@ -40,9 +37,7 @@ import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.index.fielddata.IndexOrdinalsFieldData;
 import org.elasticsearch.index.mapper.IdLoader;
-import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.NestedLookup;
 import org.elasticsearch.index.mapper.SourceLoader;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
@@ -88,8 +83,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.function.LongSupplier;
@@ -950,30 +943,6 @@ final class DefaultSearchContext extends SearchContext {
 
     @Override
     public IdLoader newIdLoader() {
-        if (indexService.getIndexSettings().getMode() == IndexMode.TIME_SERIES) {
-            IndexRouting.ExtractFromSource.ForRoutingPath indexRouting = null;
-            List<String> routingPaths = null;
-            if (indexService.getIndexSettings().getIndexVersionCreated().before(IndexVersions.TIME_SERIES_ROUTING_HASH_IN_ID)) {
-                indexRouting = (IndexRouting.ExtractFromSource.ForRoutingPath) indexService.getIndexSettings().getIndexRouting();
-                routingPaths = indexService.getMetadata().getRoutingPaths();
-                for (String routingField : routingPaths) {
-                    if (routingField.contains("*")) {
-                        // In case the routing fields include path matches, find any matches and add them as distinct fields
-                        // to the routing path.
-                        Set<String> matchingRoutingPaths = new TreeSet<>(routingPaths);
-                        for (Mapper mapper : indexService.mapperService().mappingLookup().fieldMappers()) {
-                            if (mapper instanceof KeywordFieldMapper && indexRouting.matchesField(mapper.fullPath())) {
-                                matchingRoutingPaths.add(mapper.fullPath());
-                            }
-                        }
-                        routingPaths = new ArrayList<>(matchingRoutingPaths);
-                        break;
-                    }
-                }
-            }
-            return IdLoader.createTsIdLoader(indexRouting, routingPaths, indexService.getIndexSettings().useTimeSeriesSyntheticId());
-        } else {
-            return IdLoader.fromLeafStoredFieldLoader();
-        }
+        return IdLoader.create(indexService.mapperService());
     }
 }


### PR DESCRIPTION
`IdLoader` provides two static methods to create a new instance to load the `_id` field from the store field value or to synthetize the `_id` from other fields.

The appropriate type of instance to use is dictated by the index version, mode and mappings in `DefaultSearchContext`. In order to make `IdLoader` reusable in other places (like LuceneChangesSnapshot), this change adds a new static `create(MapperService)` method that contains the logic to define which instance type to use.