### PR TITLE
[9.2] Update bundled JDK to 25.0.1 (#137640)

### DIFF
--- a/build-tools-internal/version.properties
+++ b/build-tools-internal/version.properties
@@ -2,7 +2,7 @@ elasticsearch     = 9.2.1
 lucene            = 10.3.1
 
 bundled_jdk_vendor = openjdk
-bundled_jdk = 25+36@bd75d5f9689641da8e1daabeccb5528b
+bundled_jdk = 25.0.1+8@2fbf10d8c78e40bd87641c434705079d
 # optional dependencies
 spatial4j         = 0.7
 jts               = 1.15.0

--- a/docs/changelog/137640.yaml
+++ b/docs/changelog/137640.yaml
@@ -1,0 +1,5 @@
+pr: 137640
+summary: Update bundled JDK to Java 25.0.1+8
+area: Packaging
+type: upgrade
+issues: []


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Update bundled JDK to 25.0.1 (#137640)](https://github.com/elastic/elasticsearch/pull/137640)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)