### PR TITLE
Fix `ComponentTemplatesFileSettingsIT.testSettingsApplied`

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -423,9 +423,6 @@ tests:
 - class: org.elasticsearch.xpack.inference.DefaultEndPointsIT
   method: testMultipleInferencesTriggeringDownloadAndDeploy
   issue: https://github.com/elastic/elasticsearch/issues/117208
-- class: org.elasticsearch.reservedstate.service.ComponentTemplatesFileSettingsIT
-  method: testSettingsApplied
-  issue: https://github.com/elastic/elasticsearch/issues/137258
 - class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
   method: test {p0=esql/40_tsdb/error on rename timestamp}
   issue: https://github.com/elastic/elasticsearch/issues/137259

--- a/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/ComponentTemplatesFileSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/ComponentTemplatesFileSettingsIT.java
@@ -386,6 +386,7 @@ public class ComponentTemplatesFileSettingsIT extends ESIntegTestCase {
         boolean awaitSuccessful = savedClusterState.await(20, TimeUnit.SECONDS);
         assertTrue(awaitSuccessful);
 
+        awaitMasterNode();
         final ClusterStateResponse clusterStateResponse = clusterAdmin().state(
             new ClusterStateRequest(TEST_REQUEST_TIMEOUT).waitForMetadataVersion(metadataVersion.get())
         ).actionGet();
@@ -532,8 +533,7 @@ public class ComponentTemplatesFileSettingsIT extends ESIntegTestCase {
         writeJSONFile(dataNode, testJSON);
 
         logger.info("--> start master node");
-        final String masterNode = internalCluster().startMasterOnlyNode();
-        awaitMasterNode(internalCluster().getNonMasterNodeName(), masterNode);
+        internalCluster().startMasterOnlyNode();
 
         assertClusterStateSaveOK(savedClusterState.v1(), savedClusterState.v2());
 


### PR DESCRIPTION
This is pretty much a copy of #130869.

Since the cluster state API no longer runs on the master node, we need to wait for the cluster state publication to have finished before retrieving the cluster state.

Fixes #137258