### PR TITLE
Close data node consumer on listener completion

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -152,9 +152,6 @@ tests:
 - class: org.elasticsearch.action.RejectionActionIT
   method: testSimulatedSearchRejectionLoad
   issue: https://github.com/elastic/elasticsearch/issues/125901
-- class: org.elasticsearch.search.basic.SearchWithRandomDisconnectsIT
-  method: testSearchWithRandomDisconnects
-  issue: https://github.com/elastic/elasticsearch/issues/122707
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=transform/transforms_reset/Test force reseting a running transform}
   issue: https://github.com/elastic/elasticsearch/issues/126240

--- a/server/src/main/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncAction.java
@@ -882,10 +882,7 @@ public class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<S
                 listener.onFailure(e);
                 return;
             }
-            ActionListener.respondAndRelease(
-                listener,
-                new BytesTransportResponse(out.moveToBytesReference(), out.getTransportVersion())
-            );
+            ActionListener.respondAndRelease(listener, new BytesTransportResponse(out.moveToBytesReference(), out.getTransportVersion()));
         }
 
         // Writes the "successful" response (see NodeQueryResponse for the corresponding read logic)
@@ -1008,10 +1005,7 @@ public class SearchQueryThenFetchAsyncAction extends AbstractSearchAsyncAction<S
                     out.close();
                 }
             }
-            ActionListener.respondAndRelease(
-                listener,
-                new BytesTransportResponse(out.moveToBytesReference(), out.getTransportVersion())
-            );
+            ActionListener.respondAndRelease(listener, new BytesTransportResponse(out.moveToBytesReference(), out.getTransportVersion()));
         }
 
         private void maybeFreeContext(


### PR DESCRIPTION
Resolves #122707.

Currently, we close the consumer (therefore decRef-ing all consumed shard results) once all shards in the batched query request are complete. I found that SearchWithRandomDisconnectsIT often causes the batched request to complete before all shards are done, leading to the leak with QuerySearchResults sitting in an un-closed consumer (to reproduce this locally, just run the suite with `@Repeat(iterations = 100)`).

I think we should mirror what is done on the coord node side - tie the consumer to the request listener (see AbstractSearchAsyncAction).