### PR TITLE
[9.2] Fix Bug in RankDocRetrieverBuilder when `from` is set to Default (-1) (#137637)

### DIFF
--- a/docs/changelog/137637.yaml
+++ b/docs/changelog/137637.yaml
@@ -1,0 +1,5 @@
+pr: 137637
+summary: Fix Bug in `RankDocRetrieverBuilder` when `from` is set to Default (-1)
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/retriever/RankDocsRetrieverBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/RankDocsRetrieverBuilder.java
@@ -13,6 +13,7 @@ import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.index.query.RankDocsQueryBuilder;
+import org.elasticsearch.search.SearchService;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.rank.RankDoc;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -135,6 +136,11 @@ public class RankDocsRetrieverBuilder extends RetrieverBuilder {
         if (sourceHasMinScore()) {
             searchSourceBuilder.minScore(this.minScore == null ? Float.MIN_VALUE : this.minScore);
         }
+
+        if (searchSourceBuilder.from() < 0) {
+            searchSourceBuilder.from(SearchService.DEFAULT_FROM);
+        }
+
         if (searchSourceBuilder.size() + searchSourceBuilder.from() > rankDocResults.length) {
             searchSourceBuilder.size(Math.max(0, rankDocResults.length - searchSourceBuilder.from()));
         }

--- a/server/src/test/java/org/elasticsearch/search/retriever/RankDocsRetrieverBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/retriever/RankDocsRetrieverBuilderTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.index.query.RandomQueryBuilder;
 import org.elasticsearch.index.query.RankDocsQueryBuilder;
 import org.elasticsearch.index.query.Rewriteable;
+import org.elasticsearch.search.SearchService;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.rank.RankDoc;
@@ -124,6 +125,9 @@ public class RankDocsRetrieverBuilderTests extends ESTestCase {
             }
         }
         assertNull(source.postFilter());
+
+        // the default `from` is -1, when `extractToSearchSourceBuilder` is run, it should modify this to the default
+        assertEquals(SearchService.DEFAULT_FROM, source.from());
     }
 
     public void testTopDocsQuery() throws IOException {

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/70_text_similarity_rank_retriever.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/70_text_similarity_rank_retriever.yml
@@ -398,7 +398,7 @@ setup:
               rank_window_size: 10
               inference_id: my-rerank-model
               inference_text: "How often does the moon hide the sun?"
-              field: inference_text_field
+              field: text
           size: 10
 
   - match: { hits.total.value: 1 }
@@ -477,7 +477,7 @@ setup:
               rank_window_size: 10
               inference_id: my-rerank-model
               inference_text: "How often does the moon hide the sun?"
-              field: inference_text_field
+              field: text
               min_score: 0
           size: 10
 


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Fix Bug in RankDocRetrieverBuilder when `from` is set to Default (-1) (#137637)