### PR TITLE
Disable histogram percentile tests when feature flag is not enabled

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/histogram/HistogramPercentileErrorTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/histogram/HistogramPercentileErrorTests.java
@@ -8,11 +8,13 @@
 package org.elasticsearch.xpack.esql.expression.function.scalar.histogram;
 
 import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.plugin.EsqlCorePlugin;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.ErrorsForCasesWithoutExamplesTestCase;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 import org.hamcrest.Matcher;
+import org.junit.Before;
 
 import java.util.List;
 import java.util.Set;
@@ -20,6 +22,14 @@ import java.util.Set;
 import static org.hamcrest.Matchers.equalTo;
 
 public class HistogramPercentileErrorTests extends ErrorsForCasesWithoutExamplesTestCase {
+
+    @Before
+    public void setup() {
+        assumeTrue(
+            "Only when esql_exponential_histogram feature flag is enabled",
+            EsqlCorePlugin.EXPONENTIAL_HISTOGRAM_FEATURE_FLAG.isEnabled()
+        );
+    }
 
     @Override
     protected List<TestCaseSupplier> cases() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/histogram/HistogramPercentileSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/histogram/HistogramPercentileSerializationTests.java
@@ -7,11 +7,21 @@
 
 package org.elasticsearch.xpack.esql.expression.function.scalar.histogram;
 
+import org.elasticsearch.xpack.esql.core.plugin.EsqlCorePlugin;
 import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+import org.junit.Before;
 
 import java.io.IOException;
 
 public class HistogramPercentileSerializationTests extends AbstractExpressionSerializationTests<HistogramPercentile> {
+
+    @Before
+    public void setup() {
+        assumeTrue(
+            "Only when esql_exponential_histogram feature flag is enabled",
+            EsqlCorePlugin.EXPONENTIAL_HISTOGRAM_FEATURE_FLAG.isEnabled()
+        );
+    }
 
     @Override
     protected HistogramPercentile createTestInstance() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/histogram/HistogramPercentileTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/histogram/HistogramPercentileTests.java
@@ -13,10 +13,12 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import org.elasticsearch.exponentialhistogram.ExponentialHistogram;
 import org.elasticsearch.exponentialhistogram.ExponentialHistogramQuantile;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.plugin.EsqlCorePlugin;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.AbstractScalarFunctionTestCase;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
+import org.junit.Before;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,6 +30,14 @@ import static org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier.
 import static org.hamcrest.Matchers.equalTo;
 
 public class HistogramPercentileTests extends AbstractScalarFunctionTestCase {
+
+    @Before
+    public void setup() {
+        assumeTrue(
+            "Only when esql_exponential_histogram feature flag is enabled",
+            EsqlCorePlugin.EXPONENTIAL_HISTOGRAM_FEATURE_FLAG.isEnabled()
+        );
+    }
 
     public HistogramPercentileTests(@Name("TestCase") Supplier<TestCaseSupplier.TestCase> testCaseSupplier) {
         this.testCase = testCaseSupplier.get();


### PR DESCRIPTION
I once again forgot to disable tests for a feature behind a feature flag on release tests.
Fixes #137693.