### PR TITLE
ES|QL: do not calculate query plan diff when not needed

### DIFF
--- a/docs/changelog/137721.yaml
+++ b/docs/changelog/137721.yaml
@@ -1,0 +1,5 @@
+pr: 137721
+summary: Do not calculate query plan diff when not needed
+area: ES|QL
+type: enhancement
+issues: []

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
@@ -379,7 +379,12 @@ public class EsqlSession {
                 );
                 // TODO: INLINE STATS can we do better here and further optimize the plan AFTER one of the subplans executed?
                 newLogicalPlan.setOptimized();
-                LOGGER.trace("Main plan change after previous subplan execution:\n{}", NodeUtils.diffString(optimizedPlan, newLogicalPlan));
+                if (LOGGER.isTraceEnabled()) {
+                    LOGGER.trace(
+                        "Main plan change after previous subplan execution:\n{}",
+                        NodeUtils.diffString(optimizedPlan, newLogicalPlan)
+                    );
+                }
 
                 // look for the next inlinejoin plan
                 var newSubPlan = firstSubPlan(newLogicalPlan, subPlansResults);


### PR DESCRIPTION
Calculate the query plan diff only when log trace is enabled.
This will save significant memory and computation time for complex execution plans