### PR TITLE
[9.2] ES|QL: do not calculate query plan diff when not needed (#137721)

### DIFF
--- a/docs/changelog/137721.yaml
+++ b/docs/changelog/137721.yaml
@@ -1,0 +1,5 @@
+pr: 137721
+summary: Do not calculate query plan diff when not needed
+area: ES|QL
+type: enhancement
+issues: []

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
@@ -371,7 +371,12 @@ public class EsqlSession {
                 );
                 // TODO: INLINE STATS can we do better here and further optimize the plan AFTER one of the subplans executed?
                 newLogicalPlan.setOptimized();
-                LOGGER.trace("Main plan change after previous subplan execution:\n{}", NodeUtils.diffString(optimizedPlan, newLogicalPlan));
+                if (LOGGER.isTraceEnabled()) {
+                    LOGGER.trace(
+                        "Main plan change after previous subplan execution:\n{}",
+                        NodeUtils.diffString(optimizedPlan, newLogicalPlan)
+                    );
+                }
 
                 // look for the next inlinejoin plan
                 var newSubPlan = firstSubPlan(newLogicalPlan, subPlansResults);


### PR DESCRIPTION
Backports the following commits to 9.2:
 - ES|QL: do not calculate query plan diff when not needed (#137721)