### PR TITLE
Set CPS index options only when not using PIT

### DIFF
--- a/docs/changelog/137728.yaml
+++ b/docs/changelog/137728.yaml
@@ -1,0 +1,5 @@
+pr: 137728
+summary: Set CPS index options only when not using PIT
+area: CCS
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -245,7 +245,7 @@ public class RestSearchAction extends BaseRestHandler {
         searchRequest.routing(request.param("routing"));
         searchRequest.preference(request.param("preference"));
         IndicesOptions indicesOptions = IndicesOptions.fromRequest(request, searchRequest.indicesOptions());
-        if (crossProjectEnabled && searchRequest.allowsCrossProject()) {
+        if (crossProjectEnabled && searchRequest.allowsCrossProject() && searchRequest.pointInTimeBuilder() == null) {
             indicesOptions = IndicesOptions.builder(indicesOptions)
                 .crossProjectModeOptions(new IndicesOptions.CrossProjectModeOptions(true))
                 .build();


### PR DESCRIPTION
`PIT` endpoints do not currently support CPS, and their `allowsCrossProject()` method returns `false` anyway. This prevents the Security Action Filter from rewriting the index expressions, and only those indices are used that are provided. However, when the `_search` endpoint is hit with CPS enabled, along with the PIT ID obtained previously by hitting the `_pit`, CPS index options are applied, which causes a validation error when `TransportAction` calls `validate()`.

This PR prevents the CPS index options application when PIT is found in the request's body.