### PR TITLE
[9.2] Pass ES version in EIS inference request header (#137643)

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
@@ -204,6 +204,7 @@ public class InferencePlugin extends Plugin
     );
 
     public static final String X_ELASTIC_PRODUCT_USE_CASE_HTTP_HEADER = "X-elastic-product-use-case";
+    public static final String X_ELASTIC_ES_VERSION = "X-elastic-es-version";
 
     public static final String NAME = "inference";
     public static final String UTILITY_THREAD_POOL_NAME = "inference_utility";

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceRequest.java
@@ -8,13 +8,14 @@
 package org.elasticsearch.xpack.inference.services.elastic.request;
 
 import org.apache.http.client.methods.HttpRequestBase;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.xpack.inference.external.request.HttpRequest;
 import org.elasticsearch.xpack.inference.external.request.Request;
 
-import java.util.Objects;
-
+import static org.elasticsearch.xpack.inference.InferencePlugin.X_ELASTIC_ES_VERSION;
 import static org.elasticsearch.xpack.inference.InferencePlugin.X_ELASTIC_PRODUCT_USE_CASE_HTTP_HEADER;
 
 public abstract class ElasticInferenceServiceRequest implements Request {
@@ -36,13 +37,18 @@ public abstract class ElasticInferenceServiceRequest implements Request {
 
         var productOrigin = metadata.productOrigin();
         var productUseCase = metadata.productUseCase();
+        var esVersion = metadata.esVersion();
 
-        if (Objects.nonNull(productOrigin) && productOrigin.isEmpty() == false) {
-            request.setHeader(Task.X_ELASTIC_PRODUCT_ORIGIN_HTTP_HEADER, metadata.productOrigin());
+        if (Strings.isNullOrEmpty(productOrigin) == false) {
+            request.setHeader(Task.X_ELASTIC_PRODUCT_ORIGIN_HTTP_HEADER, productOrigin);
         }
 
-        if (Objects.nonNull(productUseCase) && productUseCase.isEmpty() == false) {
-            request.addHeader(X_ELASTIC_PRODUCT_USE_CASE_HTTP_HEADER, metadata.productUseCase());
+        if (Strings.isNullOrEmpty(productUseCase) == false) {
+            request.addHeader(X_ELASTIC_PRODUCT_USE_CASE_HTTP_HEADER, productUseCase);
+        }
+
+        if (Strings.isNullOrEmpty(esVersion) == false) {
+            request.addHeader(X_ELASTIC_ES_VERSION, esVersion);
         }
 
         return new HttpRequest(request, getInferenceEntityId());
@@ -55,7 +61,8 @@ public abstract class ElasticInferenceServiceRequest implements Request {
         // 'X-Elastic-Product-Use-Case' is Elastic Inference Service specific and is therefore not propagated through the ES-wide Task.
         return new ElasticInferenceServiceRequestMetadata(
             context.getHeader(Task.X_ELASTIC_PRODUCT_ORIGIN_HTTP_HEADER),
-            context.getHeader(X_ELASTIC_PRODUCT_USE_CASE_HTTP_HEADER)
+            context.getHeader(X_ELASTIC_PRODUCT_USE_CASE_HTTP_HEADER),
+            Version.CURRENT.toString()
         );
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceRequestMetadata.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceRequestMetadata.java
@@ -12,4 +12,4 @@ package org.elasticsearch.xpack.inference.services.elastic.request;
  * @param productOrigin - product origin of the inference request (usually a whole system like "kibana", "logstash" etc.)
  * @param productUseCase - product use case of the inference request (more granular view on a user flow like "security ai assistant" etc.)
  */
-public record ElasticInferenceServiceRequestMetadata(String productOrigin, String productUseCase) {}
+public record ElasticInferenceServiceRequestMetadata(String productOrigin, String productUseCase, String esVersion) {}

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceDenseTextEmbeddingsRequestTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceDenseTextEmbeddingsRequestTests.java
@@ -157,7 +157,7 @@ public class ElasticInferenceServiceDenseTextEmbeddingsRequestTests extends ESTe
                 ElasticInferenceServiceDenseTextEmbeddingsModelTests.createModel(url, modelId),
                 List.of(input),
                 new TraceContext(randomAlphaOfLength(10), randomAlphaOfLength(10)),
-                new ElasticInferenceServiceRequestMetadata("my-product-origin", "my-product-use-case-from-metadata"),
+                new ElasticInferenceServiceRequestMetadata("my-product-origin", "my-product-use-case-from-metadata", "1.2.3"),
                 inputType
             );
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceRequestTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceRequestTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xpack.inference.external.request.Request;
 
 import java.net.URI;
 
+import static org.elasticsearch.xpack.inference.InferencePlugin.X_ELASTIC_ES_VERSION;
 import static org.elasticsearch.xpack.inference.InferencePlugin.X_ELASTIC_PRODUCT_USE_CASE_HTTP_HEADER;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -23,7 +24,7 @@ public class ElasticInferenceServiceRequestTests extends ESTestCase {
     public void testElasticInferenceServiceRequestSubclasses_Decorate_HttpRequest_WithProductOrigin() {
         var productOrigin = "elastic";
         var elasticInferenceServiceRequestWrapper = getDummyElasticInferenceServiceRequest(
-            new ElasticInferenceServiceRequestMetadata(productOrigin, null)
+            new ElasticInferenceServiceRequestMetadata(productOrigin, null, null)
         );
         var httpRequest = elasticInferenceServiceRequestWrapper.createHttpRequest();
         var productOriginHeader = httpRequest.httpRequestBase().getFirstHeader(Task.X_ELASTIC_PRODUCT_ORIGIN_HTTP_HEADER);
@@ -36,7 +37,7 @@ public class ElasticInferenceServiceRequestTests extends ESTestCase {
     public void testElasticInferenceServiceRequestSubclasses_Decorate_HttpRequest_WithProductUseCase() {
         var productUseCase = "ai assistant";
         var elasticInferenceServiceRequestWrapper = getDummyElasticInferenceServiceRequest(
-            new ElasticInferenceServiceRequestMetadata(null, productUseCase)
+            new ElasticInferenceServiceRequestMetadata(null, productUseCase, null)
         );
         var httpRequest = elasticInferenceServiceRequestWrapper.createHttpRequest();
         var productUseCaseHeader = httpRequest.httpRequestBase().getFirstHeader(X_ELASTIC_PRODUCT_USE_CASE_HTTP_HEADER);
@@ -44,6 +45,19 @@ public class ElasticInferenceServiceRequestTests extends ESTestCase {
         // Make sure the product use case header only exists once
         assertThat(httpRequest.httpRequestBase().getHeaders(X_ELASTIC_PRODUCT_USE_CASE_HTTP_HEADER).length, equalTo(1));
         assertThat(productUseCaseHeader.getValue(), equalTo(productUseCase));
+    }
+
+    public void testElasticInferenceServiceRequestSubclasses_Decorate_HttpRequest_WithEsVersion() {
+        var esVersion = "1.2.3";
+        var elasticInferenceServiceRequestWrapper = getDummyElasticInferenceServiceRequest(
+            new ElasticInferenceServiceRequestMetadata(null, null, esVersion)
+        );
+        var httpRequest = elasticInferenceServiceRequestWrapper.createHttpRequest();
+        var productUseCaseHeader = httpRequest.httpRequestBase().getFirstHeader(X_ELASTIC_ES_VERSION);
+
+        // Make sure the product use case header only exists once
+        assertThat(httpRequest.httpRequestBase().getHeaders(X_ELASTIC_ES_VERSION).length, equalTo(1));
+        assertThat(productUseCaseHeader.getValue(), equalTo(esVersion));
     }
 
     private static ElasticInferenceServiceRequest getDummyElasticInferenceServiceRequest(
@@ -79,6 +93,7 @@ public class ElasticInferenceServiceRequestTests extends ESTestCase {
 
     public static ElasticInferenceServiceRequestMetadata randomElasticInferenceServiceRequestMetadata() {
         return new ElasticInferenceServiceRequestMetadata(
+            randomFrom(new String[] { null, randomAlphaOfLength(10) }),
             randomFrom(new String[] { null, randomAlphaOfLength(10) }),
             randomFrom(new String[] { null, randomAlphaOfLength(10) })
         );

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceSparseEmbeddingsRequestTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceSparseEmbeddingsRequestTests.java
@@ -109,7 +109,7 @@ public class ElasticInferenceServiceSparseEmbeddingsRequestTests extends ESTestC
                 new Truncator.TruncationResult(List.of(input), new boolean[] { false }),
                 ElasticInferenceServiceSparseEmbeddingsModelTests.createModel(url, modelId),
                 new TraceContext(randomAlphaOfLength(10), randomAlphaOfLength(10)),
-                new ElasticInferenceServiceRequestMetadata("my-product-origin", "my-product-use-case-from-metadata"),
+                new ElasticInferenceServiceRequestMetadata("my-product-origin", "my-product-use-case-from-metadata", "1.2.3"),
                 inputType
             );
 


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Pass ES version in EIS inference request header (#137643)