### PR TITLE
Adding applies_to tags for unavailable Serverless

### DIFF
--- a/docs/reference/aggregations/search-aggregations-metrics-scripted-metric-aggregation.md
+++ b/docs/reference/aggregations/search-aggregations-metrics-scripted-metric-aggregation.md
@@ -2,6 +2,11 @@
 navigation_title: "Scripted metric"
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-scripted-metric-aggregation.html
+applies_to:
+  stack: ga
+  serverless: unavailable
+products:
+  - id: elasticsearch
 ---
 
 # Scripted metric aggregation [search-aggregations-metrics-scripted-metric-aggregation]


### PR DESCRIPTION
Part of [#1198](https://github.com/elastic/docs-content/issues/1198)

Adding the Serverless unavailable tags, as per [Elasticsearch table](https://www.elastic.co/docs/deploy-manage/deploy/elastic-cloud/differences-from-other-elasticsearch-offerings#elasticsearch) in the comparison doc.
