### PR TITLE
Unmute SearchWithRandomDisconnectsIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -152,9 +152,6 @@ tests:
 - class: org.elasticsearch.action.RejectionActionIT
   method: testSimulatedSearchRejectionLoad
   issue: https://github.com/elastic/elasticsearch/issues/125901
-- class: org.elasticsearch.search.basic.SearchWithRandomDisconnectsIT
-  method: testSearchWithRandomDisconnects
-  issue: https://github.com/elastic/elasticsearch/issues/122707
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=transform/transforms_reset/Test force reseting a running transform}
   issue: https://github.com/elastic/elasticsearch/issues/126240


### PR DESCRIPTION
Resolves #122707.

Thought I needed more to fix this, but appears it was resolved by #136889 (I used to be able to reproduce locally with ~10 iterations, now can't reproduce at all). I thought through it again and am satisfied with the explanation provided: https://github.com/elastic/elasticsearch/issues/122707#issuecomment-3367078143.