### PR TITLE
Add applies_to label to logsdb message default sort setting

### DIFF
--- a/docs/reference/elasticsearch/mapping-reference/pattern-text.md
+++ b/docs/reference/elasticsearch/mapping-reference/pattern-text.md
@@ -72,7 +72,11 @@ PUT logs
 }
 ```
 
-### Default sorting for LogsDB {applies_to}`stack: preview 9.3`
+### Default sorting for LogsDB
+```{applies_to}
+serverless: preview
+stack: preview 9.3
+```
 This sorting is not applied by default, but can be enabled for the `message` field of LogsDB indices (assuming it is of type `pattern_text`) by setting the index setting `index.logsdb.default_sort_on_message_template` to `true`.
 This will cause the index to be sorted by `host.name` (if present), then `message.template_id`, and finally by `@timestamp`.
 

--- a/docs/reference/elasticsearch/mapping-reference/pattern-text.md
+++ b/docs/reference/elasticsearch/mapping-reference/pattern-text.md
@@ -46,8 +46,8 @@ In both cases, all queries return a constant score of 1.0.
 
 ## Index sorting for improved compression
 The compression provided by `pattern_text` can be significantly improved if the index is sorted by the `template_id` field.
-This sorting is not applied by default, but can be enabled for the `message` field of LogsDB indices (assuming it is of type `pattern_text`) by setting the index setting `index.logsdb.default_sort_on_message_template` to `true`.
-This will cause the index to be sorted by `host.name` (if present), then `message.template_id`, and finally by `@timestamp`.
+
+### Custom sorting
 If the index is not LogsDB or the `pattern_text` field is named something other than `message`, index sorting can still be manually applied as shown in the following example.
 
 ```console
@@ -65,6 +65,32 @@ PUT logs
         "type": "date"
       },
       "notice": {
+        "type": "pattern_text"
+      }
+    }
+  }
+}
+```
+
+### Default sorting for LogsDB {applies_to}`stack: preview 9.3`
+This sorting is not applied by default, but can be enabled for the `message` field of LogsDB indices (assuming it is of type `pattern_text`) by setting the index setting `index.logsdb.default_sort_on_message_template` to `true`.
+This will cause the index to be sorted by `host.name` (if present), then `message.template_id`, and finally by `@timestamp`.
+
+```console
+PUT logs
+{
+  "settings": {
+    "index": {
+      "mode": "logsdb",
+      "logsdb.default_sort_on_message_template": true
+    }
+  },
+  "mappings": {
+    "properties": {
+      "@timestamp": {
+        "type": "date"
+      },
+      "message": {
         "type": "pattern_text"
       }
     }

--- a/docs/reference/elasticsearch/mapping-reference/pattern-text.md
+++ b/docs/reference/elasticsearch/mapping-reference/pattern-text.md
@@ -47,6 +47,16 @@ In both cases, all queries return a constant score of 1.0.
 ## Index sorting for improved compression
 The compression provided by `pattern_text` can be significantly improved if the index is sorted by the `template_id` field.
 
+
+### Default sorting for LogsDB
+```{applies_to}
+serverless: preview
+stack: preview 9.3
+```
+This index sorting is not applied by default, but can be enabled for the `message` field of LogsDB indices (assuming it is of type `pattern_text`) by setting the index setting `index.logsdb.default_sort_on_message_template` to `true`.
+This will cause the index to be sorted by `host.name` (if present), then `message.template_id`, and finally by `@timestamp`.
+
+
 ### Custom sorting
 If the index is not LogsDB or the `pattern_text` field is named something other than `message`, index sorting can still be manually applied as shown in the following example.
 
@@ -72,35 +82,6 @@ PUT logs
 }
 ```
 
-### Default sorting for LogsDB
-```{applies_to}
-serverless: preview
-stack: preview 9.3
-```
-This sorting is not applied by default, but can be enabled for the `message` field of LogsDB indices (assuming it is of type `pattern_text`) by setting the index setting `index.logsdb.default_sort_on_message_template` to `true`.
-This will cause the index to be sorted by `host.name` (if present), then `message.template_id`, and finally by `@timestamp`.
-
-```console
-PUT logs
-{
-  "settings": {
-    "index": {
-      "mode": "logsdb",
-      "logsdb.default_sort_on_message_template": true
-    }
-  },
-  "mappings": {
-    "properties": {
-      "@timestamp": {
-        "type": "date"
-      },
-      "message": {
-        "type": "pattern_text"
-      }
-    }
-  }
-}
-```
 
 
 ## Parameters for pattern text fields [pattern-text-params]


### PR DESCRIPTION
This PR updates the docs for `index.logsdb.default_sort_on_message_template` to indicate that it is a preview feature in stack release 9.3.