### PR TITLE
Logging SLM failures due to master node change at INFO level

### DIFF
--- a/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTask.java
+++ b/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTask.java
@@ -593,7 +593,7 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
         public void onFailure(Exception e) {
             logger.log(
                 e instanceof NotMasterException ? Level.INFO : Level.ERROR,
-                String.format(
+                format(
                     "failed to record snapshot policy execution status [%s] for snapshot [%s] in policy [%s]",
                     exception.isPresent() ? "failure" : "success",
                     snapshotId.getName(),

--- a/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTask.java
+++ b/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTask.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.slm;
 
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
@@ -19,6 +20,7 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.OriginSettingClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
+import org.elasticsearch.cluster.NotMasterException;
 import org.elasticsearch.cluster.ProjectState;
 import org.elasticsearch.cluster.SnapshotsInProgress;
 import org.elasticsearch.cluster.metadata.ProjectId;
@@ -589,11 +591,14 @@ public class SnapshotLifecycleTask implements SchedulerEngine.Listener {
 
         @Override
         public void onFailure(Exception e) {
-            logger.error(
-                "failed to record snapshot policy execution status [{}] for snapshot [{}] in policy [{}]: {}",
-                exception.isPresent() ? "failure" : "success",
-                snapshotId.getName(),
-                policyName,
+            logger.log(
+                e instanceof NotMasterException ? Level.INFO : Level.ERROR,
+                String.format(
+                    "failed to record snapshot policy execution status [%s] for snapshot [%s] in policy [%s]",
+                    exception.isPresent() ? "failure" : "success",
+                    snapshotId.getName(),
+                    policyName
+                ),
                 e
             );
         }


### PR DESCRIPTION
Looking through production logs, I see tons of error-level messages like:
```
failed to record snapshot policy execution status [failure] for snapshot [cloud-snapshot-2025.11.07--z6apgzsq_ayllg2rhf3hg] in policy [obs-policy]: org.elasticsearch.cluster.NotMasterException: no longer master
```
These are not errors, in that if this node is no longer the master node we do not expect it to be making snapshots. This changes these to INFO level.