### PR TITLE
[9.2] rest-api-spec: fix usage of date type in ML APIs (#137682)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.flush_job.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.flush_job.json
@@ -36,19 +36,19 @@
         "description": "Calculates interim results for the most recent bucket or all buckets within the latency period"
       },
       "start": {
-        "type": "string",
+        "type": "date",
         "description": "When used in conjunction with calc_interim, specifies the range of buckets on which to calculate interim results"
       },
       "end": {
-        "type": "string",
+        "type": "date",
         "description": "When used in conjunction with calc_interim, specifies the range of buckets on which to calculate interim results"
       },
       "advance_time": {
-        "type": "string",
+        "type": "date",
         "description": "Advances time to the given value generating results and updating the model for the advanced interval"
       },
       "skip_time": {
-        "type": "string",
+        "type": "date",
         "description": "Skips time to the given value without generating results or updating the model for the skipped interval"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_buckets.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_buckets.json
@@ -70,12 +70,12 @@
         "description": "specifies a max number of buckets to get"
       },
       "start": {
-        "type": "string",
+        "type": "date",
         "default": "-1",
         "description": "Start time filter for buckets"
       },
       "end": {
-        "type": "string",
+        "type": "date",
         "default": "-1",
         "description": "End time filter for buckets"
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_calendar_events.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_calendar_events.json
@@ -33,7 +33,7 @@
         "description": "Get events for the job. When this option is used calendar_id must be '_all'"
       },
       "start": {
-        "type": "string",
+        "type": "date",
         "description": "Get events after this time"
       },
       "end": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_influencers.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_influencers.json
@@ -48,12 +48,12 @@
         "description": "specifies a max number of influencers to get"
       },
       "start": {
-        "type": "string",
+        "type": "date",
         "default": "-1",
         "description": "start timestamp for the requested influencers"
       },
       "end": {
-        "type": "string",
+        "type": "date",
         "default": "-1",
         "description": "end timestamp for the requested influencers"
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_overall_buckets.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_overall_buckets.json
@@ -51,11 +51,11 @@
         "description": "If true overall buckets that include interim buckets will be excluded"
       },
       "start": {
-        "type": "string",
+        "type": "date",
         "description": "Returns overall buckets with timestamps after this time"
       },
       "end": {
-        "type": "string",
+        "type": "date",
         "description": "Returns overall buckets with timestamps earlier than this time"
       },
       "allow_no_match": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_records.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_records.json
@@ -48,12 +48,12 @@
         "description": "specifies a max number of records to get"
       },
       "start": {
-        "type": "string",
+        "type": "date",
         "default": "-1",
         "description": "Start time filter for records"
       },
       "end": {
-        "type": "string",
+        "type": "date",
         "default": "-1",
         "description": "End time filter for records"
       },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.post_data.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.post_data.json
@@ -33,11 +33,11 @@
     },
     "params": {
       "reset_start": {
-        "type": "string",
+        "type": "date",
         "description": "Optional parameter to specify the start of the bucket resetting range"
       },
       "reset_end": {
-        "type": "string",
+        "type": "date",
         "description": "Optional parameter to specify the end of the bucket resetting range"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.preview_datafeed.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.preview_datafeed.json
@@ -40,11 +40,11 @@
     },
     "params": {
       "start": {
-        "type": "string",
+        "type": "date",
         "description": "The start time from where the datafeed preview should begin"
       },
       "end": {
-        "type": "string",
+        "type": "date",
         "description": "The end time when the datafeed preview should stop"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.start_datafeed.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.start_datafeed.json
@@ -32,11 +32,11 @@
     },
     "params": {
       "start": {
-        "type": "string",
+        "type": "date",
         "description": "The start time from where the datafeed should begin"
       },
       "end": {
-        "type": "string",
+        "type": "date",
         "description": "The end time when the datafeed should stop. When not set, the datafeed continues in real time"
       },
       "timeout": {


### PR DESCRIPTION
Backports the following commits to 9.2:
 - rest-api-spec: fix usage of date type in ML APIs (#137682)