### PR TITLE
[9.2] [ML] Fix casting in RegressionIT test (#136743)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -597,9 +597,6 @@ tests:
 - class: org.elasticsearch.datastreams.DataStreamIndexSettingsProviderTests
   method: testGetAdditionalIndexSettings
   issue: https://github.com/elastic/elasticsearch/issues/135972
-- class: org.elasticsearch.xpack.ml.integration.RegressionIT
-  method: testAliasFields
-  issue: https://github.com/elastic/elasticsearch/issues/137377
 - class: org.elasticsearch.upgrades.SearchStatesIT
   method: testCanMatch
   issue: https://github.com/elastic/elasticsearch/issues/137687

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
@@ -630,8 +630,8 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
                 assertThat(resultsObject.containsKey(predictionField), is(true));
                 assertThat(resultsObject.containsKey("is_training"), is(true));
 
-                int featureValue = (int) destDoc.get("field_1");
-                double predictionValue = (double) resultsObject.get(predictionField);
+                int featureValue = ((Number) destDoc.get("field_1")).intValue();
+                double predictionValue = ((Number) resultsObject.get(predictionField)).doubleValue();
                 predictionErrorSum += Math.abs(predictionValue - 2 * featureValue);
             }
             // We assert on the mean prediction error in order to reduce the probability


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[ML] Fix casting in RegressionIT test (#136743)](https://github.com/elastic/elasticsearch/pull/136743)


Closes #137377

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)