### PR TITLE
[9.1] [ML] Fix casting in RegressionIT test (#136743)

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
@@ -630,8 +630,8 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
                 assertThat(resultsObject.containsKey(predictionField), is(true));
                 assertThat(resultsObject.containsKey("is_training"), is(true));
 
-                int featureValue = (int) destDoc.get("field_1");
-                double predictionValue = (double) resultsObject.get(predictionField);
+                int featureValue = ((Number) destDoc.get("field_1")).intValue();
+                double predictionValue = ((Number) resultsObject.get(predictionField)).doubleValue();
                 predictionErrorSum += Math.abs(predictionValue - 2 * featureValue);
             }
             // We assert on the mean prediction error in order to reduce the probability


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[ML] Fix casting in RegressionIT test (#136743)](https://github.com/elastic/elasticsearch/pull/136743)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)