### PR TITLE
Add DenseDoubleValues and DenseLongValues

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/fielddata/DenseLongValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/DenseLongValues.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.fielddata;
+
+import org.apache.lucene.search.LongValues;
+
+import java.io.IOException;
+
+/**
+ * LongValues implementation that is guaranteed to have a value
+ * for every document in a reader
+ */
+public abstract class DenseLongValues extends LongValues {
+
+    @Override
+    public final boolean advanceExact(int doc) throws IOException {
+        doAdvanceExact(doc);
+        return true;
+    }
+
+    protected abstract void doAdvanceExact(int doc) throws IOException;
+}

--- a/server/src/main/java/org/elasticsearch/index/fielddata/FieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/FieldData.java
@@ -614,19 +614,18 @@ public enum FieldData {
      * document, returns the same value as {@code values} if there is a value
      * for the current document and {@code missing} otherwise.
      */
-    public static LongValues replaceMissing(LongValues values, long missing) {
-        return new LongValues() {
+    public static DenseLongValues replaceMissing(LongValues values, long missing) {
+        return new DenseLongValues() {
 
             private long value;
 
             @Override
-            public boolean advanceExact(int target) throws IOException {
+            public void doAdvanceExact(int target) throws IOException {
                 if (values.advanceExact(target)) {
                     value = values.longValue();
                 } else {
                     value = missing;
                 }
-                return true;
             }
 
             @Override
@@ -641,19 +640,18 @@ public enum FieldData {
      * document, returns the same value as {@code values} if there is a value
      * for the current document and {@code missing} otherwise.
      */
-    public static NumericDoubleValues replaceMissing(NumericDoubleValues values, double missing) {
-        return new NumericDoubleValues() {
+    public static DenseDoubleValues replaceMissing(NumericDoubleValues values, double missing) {
+        return new DenseDoubleValues() {
 
             private double value;
 
             @Override
-            public boolean advanceExact(int target) throws IOException {
+            public void doAdvanceExact(int target) throws IOException {
                 if (values.advanceExact(target)) {
                     value = values.doubleValue();
                 } else {
                     value = missing;
                 }
-                return true;
             }
 
             @Override

--- a/server/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/DoubleValuesComparatorSource.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/DoubleValuesComparatorSource.java
@@ -21,10 +21,10 @@ import org.apache.lucene.search.comparators.DoubleComparator;
 import org.apache.lucene.util.BitSet;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.fielddata.DenseDoubleValues;
 import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
-import org.elasticsearch.index.fielddata.NumericDoubleValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.MultiValueMode;
@@ -59,7 +59,7 @@ public class DoubleValuesComparatorSource extends IndexFieldData.XFieldComparato
         return indexFieldData.load(context).getDoubleValues();
     }
 
-    private NumericDoubleValues getNumericDocValues(LeafReaderContext context, double missingValue) throws IOException {
+    private DenseDoubleValues getDenseDoubleValues(LeafReaderContext context, double missingValue) throws IOException {
         final SortedNumericDoubleValues values = getValues(context);
         if (nested == null) {
             return FieldData.replaceMissing(sortMode.select(values), missingValue);
@@ -80,14 +80,17 @@ public class DoubleValuesComparatorSource extends IndexFieldData.XFieldComparato
         final double dMissingValue = (Double) missingObject(missingValue, reversed);
         // NOTE: it's important to pass null as a missing value in the constructor so that
         // the comparator doesn't check docsWithField since we replace missing values in select()
-        // TODO we can re-enable pruning here if we allow NumericDoubleValues to expose an iterator
-        return new DoubleComparator(numHits, fieldname, null, reversed, Pruning.NONE) {
+        return new DoubleComparator(numHits, fieldname, null, reversed, enableSkipping) {
             @Override
             public LeafFieldComparator getLeafComparator(LeafReaderContext context) throws IOException {
                 return new DoubleLeafComparator(context) {
                     @Override
                     protected NumericDocValues getNumericDocValues(LeafReaderContext context, String field) throws IOException {
-                        return DoubleValuesComparatorSource.this.getNumericDocValues(context, dMissingValue).getRawDoubleValues();
+                        return DenseDoubleValues.asNumericDocValues(
+                            getDenseDoubleValues(context, dMissingValue),
+                            context.reader().maxDoc(),
+                            Double::doubleToRawLongBits
+                        );
                     }
 
                     @Override
@@ -113,7 +116,7 @@ public class DoubleValuesComparatorSource extends IndexFieldData.XFieldComparato
             @Override
             public Leaf forLeaf(LeafReaderContext ctx) throws IOException {
                 return new Leaf(ctx) {
-                    private final NumericDoubleValues docValues = getNumericDocValues(ctx, dMissingValue);
+                    private final DenseDoubleValues docValues = getDenseDoubleValues(ctx, dMissingValue);
                     private double docValue;
 
                     @Override

--- a/server/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/FloatValuesComparatorSource.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/FloatValuesComparatorSource.java
@@ -20,10 +20,10 @@ import org.apache.lucene.search.comparators.FloatComparator;
 import org.apache.lucene.util.BitSet;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.fielddata.DenseDoubleValues;
 import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
-import org.elasticsearch.index.fielddata.NumericDoubleValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.MultiValueMode;
@@ -54,7 +54,7 @@ public class FloatValuesComparatorSource extends IndexFieldData.XFieldComparator
         return SortField.Type.FLOAT;
     }
 
-    NumericDoubleValues getNumericDocValues(LeafReaderContext context, double missingValue) throws IOException {
+    DenseDoubleValues getDenseDoubleValues(LeafReaderContext context, double missingValue) throws IOException {
         final SortedNumericDoubleValues values = indexFieldData.load(context).getDoubleValues();
         if (nested == null) {
             return FieldData.replaceMissing(sortMode.select(values), missingValue);
@@ -73,14 +73,17 @@ public class FloatValuesComparatorSource extends IndexFieldData.XFieldComparator
         final float fMissingValue = (Float) missingObject(missingValue, reversed);
         // NOTE: it's important to pass null as a missing value in the constructor so that
         // the comparator doesn't check docsWithField since we replace missing values in select()
-        // TODO we can re-enable pruning here if we allow NumericDoubleValues to expose an iterator
-        return new FloatComparator(numHits, fieldname, null, reversed, Pruning.NONE) {
+        return new FloatComparator(numHits, fieldname, null, reversed, enableSkipping) {
             @Override
             public LeafFieldComparator getLeafComparator(LeafReaderContext context) throws IOException {
                 return new FloatLeafComparator(context) {
                     @Override
                     protected NumericDocValues getNumericDocValues(LeafReaderContext context, String field) throws IOException {
-                        return FloatValuesComparatorSource.this.getNumericDocValues(context, fMissingValue).getRawFloatValues();
+                        return DenseDoubleValues.asNumericDocValues(
+                            getDenseDoubleValues(context, fMissingValue),
+                            context.reader().maxDoc(),
+                            v -> Float.floatToRawIntBits((float) v)
+                        );
                     }
                 };
             }
@@ -106,7 +109,7 @@ public class FloatValuesComparatorSource extends IndexFieldData.XFieldComparator
             @Override
             public Leaf forLeaf(LeafReaderContext ctx) throws IOException {
                 return new Leaf(ctx) {
-                    private final NumericDoubleValues docValues = getNumericDocValues(ctx, dMissingValue);
+                    private final DenseDoubleValues docValues = getDenseDoubleValues(ctx, dMissingValue);
                     private float docValue;
 
                     @Override

--- a/server/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/LongValuesComparatorSource.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/fieldcomparator/LongValuesComparatorSource.java
@@ -22,6 +22,7 @@ import org.apache.lucene.util.BitSet;
 import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.fielddata.DenseLongValues;
 import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
@@ -88,7 +89,7 @@ public class LongValuesComparatorSource extends IndexFieldData.XFieldComparatorS
         return converter != null ? converter.apply(values) : values;
     }
 
-    LongValues getLongValues(LeafReaderContext context, long missingValue) throws IOException {
+    DenseLongValues getLongValues(LeafReaderContext context, long missingValue) throws IOException {
         final SortedNumericLongValues values = loadDocValues(context);
         if (nested == null) {
             return FieldData.replaceMissing(sortMode.select(values), missingValue);
@@ -201,7 +202,7 @@ public class LongValuesComparatorSource extends IndexFieldData.XFieldComparatorS
         return super.missingObject(missingValue, reversed);
     }
 
-    protected static NumericDocValues wrap(LongValues longValues, int maxDoc) {
+    protected static NumericDocValues wrap(DenseLongValues longValues, int maxDoc) {
         return new NumericDocValues() {
 
             int doc = -1;

--- a/server/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/functionscore/DecayFunctionBuilder.java
@@ -10,6 +10,7 @@
 package org.elasticsearch.index.query.functionscore;
 
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.DoubleValues;
 import org.apache.lucene.search.Explanation;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.ParsingException;
@@ -31,7 +32,6 @@ import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.index.fielddata.MultiGeoPointValues;
-import org.elasticsearch.index.fielddata.NumericDoubleValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.index.fielddata.SortingNumericDoubleValues;
 import org.elasticsearch.index.mapper.DateFieldMapper;
@@ -391,7 +391,7 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
         }
 
         @Override
-        protected NumericDoubleValues distance(LeafReaderContext context) {
+        protected DoubleValues distance(LeafReaderContext context) {
             final MultiGeoPointValues geoPointValues = fieldData.load(context).getPointValues();
             return FieldData.replaceMissing(mode.select(new SortingNumericDoubleValues() {
                 @Override
@@ -484,7 +484,7 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
         }
 
         @Override
-        protected NumericDoubleValues distance(LeafReaderContext context) {
+        protected DoubleValues distance(LeafReaderContext context) {
             final SortedNumericDoubleValues doubleValues = fieldData.load(context).getDoubleValues();
             return FieldData.replaceMissing(mode.select(new SortingNumericDoubleValues() {
                 @Override
@@ -585,11 +585,11 @@ public abstract class DecayFunctionBuilder<DFB extends DecayFunctionBuilder<DFB>
          * guaranteed that the value actually exists. If it does not, we assume
          * the user handles this case in the query and return 0.
          * */
-        protected abstract NumericDoubleValues distance(LeafReaderContext context);
+        protected abstract DoubleValues distance(LeafReaderContext context);
 
         @Override
         public final LeafScoreFunction getLeafScoreFunction(final LeafReaderContext ctx) {
-            final NumericDoubleValues distance = distance(ctx);
+            final DoubleValues distance = distance(ctx);
             return new LeafScoreFunction() {
 
                 @Override

--- a/server/src/test/java/org/elasticsearch/index/fielddata/FieldDataTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/FieldDataTests.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.index.fielddata;
 
+import org.apache.lucene.search.DoubleValues;
 import org.apache.lucene.search.LongValues;
 import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.test.ESTestCase;
@@ -181,7 +182,7 @@ public class FieldDataTests extends ESTestCase {
 
     public void testReplaceMissingDoubles() throws IOException {
         final NumericDoubleValues values = asNumericDoubleValues(null, 1.3, 1.2, null, 1.5, null);
-        final NumericDoubleValues replaced = FieldData.replaceMissing(values, 1.4);
+        final DoubleValues replaced = FieldData.replaceMissing(values, 1.4);
 
         assertTrue(replaced.advanceExact(0));
         assertEquals(1.4, replaced.doubleValue(), 0d);

--- a/server/src/test/java/org/elasticsearch/index/mapper/HalfFloatFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/HalfFloatFieldMapperTests.java
@@ -79,7 +79,7 @@ public class HalfFloatFieldMapperTests extends NumberFieldMapperTests {
     protected List<SortShortcutSupport> getSortShortcutSupport() {
         return List.of(
             // TODO enable pruning here
-            new SortShortcutSupport(this::minimalMapping, this::writeField, false),
+            new SortShortcutSupport(this::minimalMapping, this::writeField, true),
             new SortShortcutSupport(IndexVersion.fromId(5000099), this::minimalMapping, this::writeField, false)
         );
     }

--- a/server/src/test/java/org/elasticsearch/search/MultiValueModeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/MultiValueModeTests.java
@@ -13,6 +13,7 @@ import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.search.DoubleValues;
 import org.apache.lucene.search.LongValues;
 import org.apache.lucene.util.BitSetIterator;
 import org.apache.lucene.util.BytesRef;
@@ -386,7 +387,7 @@ public class MultiValueModeTests extends ESTestCase {
         }
     }
 
-    private void verifyDoubleValueCanCalledMoreThanOnce(NumericDoubleValues values, double expected) throws IOException {
+    private void verifyDoubleValueCanCalledMoreThanOnce(DoubleValues values, double expected) throws IOException {
         for (int j = 0, numCall = randomIntBetween(1, 10); j < numCall; j++) {
             assertTrue(Double.compare(values.doubleValue(), expected) == 0);
         }
@@ -406,13 +407,7 @@ public class MultiValueModeTests extends ESTestCase {
                 MultiValueMode.SUM,
                 MultiValueMode.AVG }) {
                 SortedNumericDoubleValues values = supplier.get();
-                final NumericDoubleValues selected = mode.select(
-                    values,
-                    missingValue,
-                    rootDocs,
-                    new BitSetIterator(innerDocs, 0L),
-                    maxChildren
-                );
+                final DoubleValues selected = mode.select(values, missingValue, rootDocs, new BitSetIterator(innerDocs, 0L), maxChildren);
                 int prevRoot = -1;
                 for (int root = rootDocs.nextSetBit(0); root != -1; root = root + 1 < maxDoc ? rootDocs.nextSetBit(root + 1) : -1) {
                     assertTrue(selected.advanceExact(root));


### PR DESCRIPTION
These are extensions of DoubleValues and LongValues that are guaranteed 
to have values for every document, which means they can also be used for 
iteration.  This allows us to re-enable pruning on sorts that use them as sources 
for comparators.