### PR TITLE
Unmute and fix exponential_histogram.LoadFiltered CSV test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -445,9 +445,6 @@ tests:
 - class: org.elasticsearch.xpack.inference.action.filter.ShardBulkInferenceActionFilterBasicLicenseIT
   method: testLicenseInvalidForInference {p0=false}
   issue: https://github.com/elastic/elasticsearch/issues/137691
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  method: test {csv-spec:exponential_histogram.LoadFiltered}
-  issue: https://github.com/elastic/elasticsearch/issues/137727
 - class: org.elasticsearch.xpack.inference.InferenceRestIT
   method: test {p0=inference/70_text_similarity_rank_retriever/Text similarity reranker with min_score zero includes all docs}
   issue: https://github.com/elastic/elasticsearch/issues/137732

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/exponential_histogram.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/exponential_histogram.csv-spec
@@ -1,5 +1,5 @@
 loadFiltered
-required_capability: exponential_histogram
+required_capability: exponential_histogram_topn
 
 FROM exp_histo_sample | WHERE STARTS_WITH(instance, "dummy") | SORT instance | KEEP instance, responseTime
 ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1548,6 +1548,12 @@ public class EsqlCapabilities {
         EXPONENTIAL_HISTOGRAM(EXPONENTIAL_HISTOGRAM_FEATURE_FLAG),
 
         /**
+         * Support for exponential_histogram type in TOPN
+         */
+        EXPONENTIAL_HISTOGRAM_TOPN(EXPONENTIAL_HISTOGRAM_FEATURE_FLAG),
+
+
+        /**
          * Create new block when filtering OrdinalBytesRefBlock
          */
         FIX_FILTER_ORDINALS,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1552,7 +1552,6 @@ public class EsqlCapabilities {
          */
         EXPONENTIAL_HISTOGRAM_TOPN(EXPONENTIAL_HISTOGRAM_FEATURE_FLAG),
 
-
         /**
          * Create new block when filtering OrdinalBytesRefBlock
          */


### PR DESCRIPTION
Closes #137727.

There was an occasional failure of the bwc tests with the following cause:
```
[2025-11-07T08:11:41,491][ERROR][o.e.b.ElasticsearchUncaughtExceptionHandler] [test-cluster-2] fatal error in thread [elasticsearch[test-cluster-2][esql_worker][T#4]], exiting java.lang.AssertionError: No value extractor for [EXPONENTIAL_HISTOGRAM] |  
-- | --
at org.elasticsearch.compute.operator.topn.ValueExtractor.extractorFor(ValueExtractor.java:57) |  
at org.elasticsearch.compute.operator.topn.TopNOperator$RowFiller.<init>(TopNOperator.java:180) |  
at org.elasticsearch.compute.operator.topn.TopNOperator.addInput(TopNOperator.java:401) |  
at org.elasticsearch.compute.operator.Driver.runSingleLoopIteration(Driver.java:294) |  
at org.elasticsearch.compute.operator.Driver.run(Driver.java:191) |  
at org.elasticsearch.compute.operator.Driver$1.doRun(Driver.java:428) |  
at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:27) |  
at org.elasticsearch.compute.operator.DriverScheduler$1.doRun(DriverScheduler.java:57) |  
at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:27) |  
at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.common.util.concurrent.TimedRunnable.doRun(TimedRunnable.java:35) |  
at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:1076) |  
at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:27) |  
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090) |  
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614) |  
at java.base/java.lang.Thread.run(Thread.java:1474)
```

I think this happened for the following reason:
In #133393 I added the new ES|QL exponential_histogram type alongside with a capability named `exponential_histogram`.
In follow-up PRs I then only later added support for TopN (#137313) and CSV tests (#137619).

The CSV tests required the `exponential_histogram`, which means we had some snapshot versions with that capability, but without TopN support. I wasn't aware that when running BWC tests, we have the feature flags on the older versions we test against enabled, which would produce this failure.

This PR fixes this by adding a new capability, making the test depend on that and unmutes the test.
