### PR TITLE
ES|QL: Add missing decay function validations

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/score/Decay.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/score/Decay.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
 import org.elasticsearch.compute.operator.EvalOperator;
@@ -45,11 +46,13 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.common.logging.LoggerMessageFormat.format;
 import static org.elasticsearch.xpack.esql.common.Failure.fail;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.FIRST;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.FOURTH;
@@ -61,6 +64,7 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.DOUBLE;
 import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
 import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
 import static org.elasticsearch.xpack.esql.core.type.DataType.LONG;
+import static org.elasticsearch.xpack.esql.core.type.DataType.NULL;
 import static org.elasticsearch.xpack.esql.core.type.DataType.TEXT;
 import static org.elasticsearch.xpack.esql.core.type.DataType.TIME_DURATION;
 import static org.elasticsearch.xpack.esql.core.type.DataType.isDateNanos;
@@ -212,8 +216,9 @@ public class Decay extends EsqlScalarFunction implements OptionalArgument, PostO
             return new TypeResolution("Unresolved children");
         }
 
-        return validateValue().and(() -> validateOriginAndScale(value.dataType()))
-            .and(() -> Options.resolveWithMultipleDataTypesAllowed(options, source(), FOURTH, ALLOWED_OPTIONS));
+        return validateValue().and(() -> Options.resolveWithMultipleDataTypesAllowed(options, source(), FOURTH, ALLOWED_OPTIONS))
+            .and(() -> validateOriginScaleAndOffset(value.dataType()))
+            .and(this::validateTypeOption);
     }
 
     private TypeResolution validateValue() {
@@ -222,32 +227,98 @@ public class Decay extends EsqlScalarFunction implements OptionalArgument, PostO
         );
     }
 
-    private TypeResolution validateOriginAndScale(DataType valueType) {
+    private TypeResolution validateOriginScaleAndOffset(DataType valueType) {
         if (isSpatialPoint(valueType)) {
             boolean isGeoPoint = isGeoPoint(valueType);
 
-            return validateOriginAndScale(
+            return validateOriginScaleAndOffset(
                 DataType::isSpatialPoint,
                 "spatial point",
+                isGeoPoint ? DataType::isString : DataType::isNumeric,
+                isGeoPoint ? "keyword or text" : "numeric",
                 isGeoPoint ? DataType::isString : DataType::isNumeric,
                 isGeoPoint ? "keyword or text" : "numeric"
             );
         } else if (isMillisOrNanos(valueType)) {
-            return validateOriginAndScale(DataType::isMillisOrNanos, "datetime or date_nanos", DataType::isTimeDuration, "time_duration");
+            return validateOriginScaleAndOffset(
+                DataType::isMillisOrNanos,
+                "datetime or date_nanos",
+                DataType::isTimeDuration,
+                "time_duration",
+                DataType::isTimeDuration,
+                "time_duration"
+            );
         } else {
-            return validateOriginAndScale(DataType::isNumeric, "numeric", DataType::isNumeric, "numeric");
+            return validateOriginScaleAndOffset(
+                DataType::isNumeric,
+                "numeric",
+                DataType::isNumeric,
+                "numeric",
+                DataType::isNumeric,
+                "numeric"
+            );
         }
     }
 
-    private TypeResolution validateOriginAndScale(
+    private TypeResolution validateOriginScaleAndOffset(
         Predicate<DataType> originPredicate,
         String originDesc,
         Predicate<DataType> scalePredicate,
-        String scaleDesc
+        String scaleDesc,
+        Predicate<DataType> offsetPredicate,
+        String offsetDesc
     ) {
+        if (options != null) {
+            Expression offset = ((MapExpression) options).keyFoldedMap().get(OFFSET);
+            if (offset != null && offset.dataType() != NULL && offsetPredicate.test((offset).dataType()) == false) {
+                return new TypeResolution(
+                    format(null, "{} option has invalid type, expected [{}], found [{}]", OFFSET, offsetDesc, offset.dataType().typeName())
+                );
+            }
+        }
+
         return isNotNull(origin, sourceText(), SECOND).and(isType(origin, originPredicate, sourceText(), SECOND, originDesc))
             .and(isNotNull(scale, sourceText(), THIRD))
             .and(isType(scale, scalePredicate, sourceText(), THIRD, scaleDesc));
+    }
+
+    private TypeResolution validateTypeOption() {
+        if (options == null) {
+            return TypeResolution.TYPE_RESOLVED;
+        }
+
+        Expression decayType = ((MapExpression) options).keyFoldedMap().get(TYPE);
+
+        if (decayType == null || decayType.dataType() == NULL) {
+            return TypeResolution.TYPE_RESOLVED;
+        }
+
+        if (decayType.dataType() != KEYWORD) {
+            return new TypeResolution(
+                format(
+                    null,
+                    "{} option has invalid type, expected [{}], found [{}]",
+                    TYPE,
+                    KEYWORD.typeName(),
+                    decayType.dataType().typeName()
+                )
+            );
+        }
+
+        String decayTypeName = BytesRefs.toString(decayType.fold(FoldContext.small())).toLowerCase(Locale.ROOT);
+
+        if (DecayFunction.BY_NAME.containsKey(decayTypeName) == false) {
+            return new TypeResolution(
+                format(
+                    null,
+                    "{} option has invalid value, expected one of [gauss, linear, exp], found [{}]",
+                    TYPE,
+                    decayType.source().text()
+                )
+            );
+        }
+
+        return TypeResolution.TYPE_RESOLVED;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -2638,7 +2638,7 @@ public class VerifierTests extends ESTestCase {
         }
     }
 
-    public void testDecayFunctionNullArgs() {
+    public void testDecayArgs() {
         assumeTrue("Decay function not enabled", EsqlCapabilities.Cap.DECAY_FUNCTION.isEnabled());
 
         // First arg cannot be null
@@ -2668,6 +2668,49 @@ public class VerifierTests extends ESTestCase {
             error(
                 "row value = 10, origin = 10\n"
                     + "| eval decay_result = decay(value, origin, null, {\"offset\": 0, \"decay\": 0.5, \"type\": \"linear\"})"
+            )
+        );
+
+        // Offset value type
+        assertEquals(
+            "2:23: offset option has invalid type, expected [numeric], found [keyword]",
+            error(
+                "row value = 10, origin = 10, scale = 1\n"
+                    + "| eval decay_result = decay(value, origin, scale, {\"offset\": \"aaa\", \"decay\": 0.5, \"type\": \"linear\"})"
+            )
+        );
+
+        assertEquals(
+            "1:118: offset option has invalid type, expected [time_duration], found [keyword]",
+            error(
+                "row value =  TO_DATETIME(\"2023-01-01T00:00:00Z\"), origin =  TO_DATETIME(\"2023-01-01T00:00:00Z\")"
+                    + "| eval decay_result = decay(value, origin, 24 hours, {\"offset\": \"aaa\", \"decay\": 0.5, \"type\": \"linear\"})"
+            )
+        );
+
+        assertEquals(
+            "1:110: offset option has invalid type, expected [numeric], found [keyword]",
+            error(
+                "row value =  TO_CARTESIANPOINT(\"POINT(10 0)\"), origin = TO_CARTESIANPOINT(\"POINT(0 0)\")"
+                    + "| eval decay_result = decay(value, origin, 10.0, {\"offset\": \"aaa\", \"decay\": 0.5, \"type\": \"linear\"})"
+            )
+        );
+
+        // Type option value
+        assertEquals(
+            "2:23: Invalid option [type] in "
+                + "[decay(value, origin, scale, {\"offset\": 1, \"decay\": 0.5, \"type\": 123})], allowed types [[KEYWORD]]",
+            error(
+                "row value = 10, origin = 10, scale = 1\n"
+                    + "| eval decay_result = decay(value, origin, scale, {\"offset\": 1, \"decay\": 0.5, \"type\": 123})"
+            )
+        );
+
+        assertEquals(
+            "2:23: type option has invalid value, expected one of [gauss, linear, exp], found [\"foobar\"]",
+            error(
+                "row value = 10, origin = 10, scale = 1\n"
+                    + "| eval decay_result = decay(value, origin, scale, {\"offset\": 1, \"decay\": 0.5, \"type\": \"foobar\"})"
             )
         );
     }


### PR DESCRIPTION
closes https://github.com/elastic/elasticsearch/issues/134789

Adds validations for the `type` and `offset` options.
The last missing piece before we take this out of snapshot.