### PR TITLE
Fix `IndicesRequestIT.testIndicesStats`

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -429,9 +429,6 @@ tests:
 - class: org.elasticsearch.xpack.ilm.CCRIndexLifecycleIT
   method: testTsdbLeaderIndexRolloverAndSyncAfterWaitUntilEndTime {targetCluster=FOLLOWER}
   issue: https://github.com/elastic/elasticsearch/issues/137565
-- class: org.elasticsearch.action.IndicesRequestIT
-  method: testIndicesStats
-  issue: https://github.com/elastic/elasticsearch/issues/137594
 - class: org.elasticsearch.xpack.esql.vector.VectorSimilarityFunctionsIT
   method: testTopNSimilarityBetweenConstantVectorAndField {functionName=v_l2_norm
     similarityFunction=org.elasticsearch.xpack.esql.expression.function.vector.L2Norm$1@5b068087 elementType=byte}

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/IndicesRequestIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/IndicesRequestIT.java
@@ -131,6 +131,7 @@ public class IndicesRequestIT extends ESIntegTestCase {
             // InternalClusterInfoService sends IndicesStatsRequest periodically which messes with this test
             // this setting disables it...
             .put("cluster.routing.allocation.disk.threshold_enabled", false)
+            .put("cluster.routing.allocation.write_load_decider.enabled", "disabled")
             .build();
     }
 


### PR DESCRIPTION
Explanation:
- We have a infrequent test failure for a test which asserts the expected inter-node transport requests are made on a given request to the cluster
- `InternalClusterInfoService.java` (ICIS) aids allocation decisions by making index stats requests, by default every 30 seconds, if either disk-threshold allocation decider or write-load decider are enabled
- in the unlikely scenario ICIS write-load decider makes index stats requests during the test, it will fail
- I've made this failure deterministic by [doing the following](https://github.com/elastic/elasticsearch/issues/137594#issuecomment-3504247885)
- I've `git bisected` to indicate [this PR](https://github.com/elastic/elasticsearch/pull/135246) is the one where the failures start
- All test failures in CI are after this was merged
- There's an existing comment right above my change that also suggests it's a problem with ICIS
- The test is only muted in `main`, but the issue should also be present in `9.2`, i'll open a manual PR to get rid of the issue in `9.2`

Closes #137594