### PR TITLE
[9.2] OTLP: return correct response type for partial successes (#137718)

### DIFF
--- a/docs/changelog/137718.yaml
+++ b/docs/changelog/137718.yaml
@@ -1,0 +1,5 @@
+pr: 137718
+summary: "OTLP: return correct response type for partial successes"
+area: TSDB
+type: bug
+issues: []

--- a/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/DataPointGroupingContext.java
+++ b/x-pack/plugin/otel-data/src/main/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/DataPointGroupingContext.java
@@ -119,8 +119,23 @@ public class DataPointGroupingContext {
         return ignoredDataPoints;
     }
 
-    public String getIgnoredDataPointsMessage() {
-        return ignoredDataPointMessages.isEmpty() ? "" : String.join("\n", ignoredDataPointMessages);
+    public String getIgnoredDataPointsMessage(int limit) {
+        if (ignoredDataPointMessages.isEmpty()) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append("Ignored ").append(ignoredDataPoints).append(" data points due to the following reasons:\n");
+        int count = 0;
+        for (String message : ignoredDataPointMessages) {
+            sb.append(" - ").append(message).append("\n");
+            count++;
+            if (count >= limit) {
+                sb.append(" - ... and more\n");
+                break;
+            }
+        }
+        return sb.toString();
+
     }
 
     private ResourceGroup getOrCreateResourceGroup(ResourceMetrics resourceMetrics) {

--- a/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/OTLPMetricsTransportActionTests.java
+++ b/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/OTLPMetricsTransportActionTests.java
@@ -37,6 +37,7 @@ import java.util.function.Consumer;
 import static org.elasticsearch.xpack.oteldata.otlp.OtlpUtils.keyValue;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -76,12 +77,13 @@ public class OTLPMetricsTransportActionTests extends ESTestCase {
 
     public void test429() throws Exception {
         BulkItemResponse[] bulkItemResponses = new BulkItemResponse[] {
-            failureResponse(RestStatus.TOO_MANY_REQUESTS, "too many requests"),
+            failureResponse("metrics-generic.otel-default", RestStatus.TOO_MANY_REQUESTS, "too many requests"),
             successResponse() };
         MetricsResponse response = executeRequest(createMetricsRequest(createMetric()), new BulkResponse(bulkItemResponses, 0));
 
         assertThat(response.getStatus(), equalTo(RestStatus.TOO_MANY_REQUESTS));
-        ExportMetricsPartialSuccess metricsServiceResponse = ExportMetricsPartialSuccess.parseFrom(response.getResponse().array());
+        ExportMetricsPartialSuccess metricsServiceResponse = ExportMetricsServiceResponse.parseFrom(response.getResponse().array())
+            .getPartialSuccess();
         assertThat(
             metricsServiceResponse.getRejectedDataPoints(),
             equalTo(Arrays.stream(bulkItemResponses).filter(BulkItemResponse::isFailed).count())
@@ -92,13 +94,25 @@ public class OTLPMetricsTransportActionTests extends ESTestCase {
     public void testPartialSuccess() throws Exception {
         MetricsResponse response = executeRequest(
             createMetricsRequest(createMetric()),
-            new BulkResponse(new BulkItemResponse[] { failureResponse(RestStatus.BAD_REQUEST, "bad request") }, 0)
+            new BulkResponse(
+                new BulkItemResponse[] {
+                    failureResponse("metrics-generic.otel-default", RestStatus.BAD_REQUEST, "bad request 1"),
+                    failureResponse("metrics-generic.otel-default", RestStatus.BAD_REQUEST, "bad request 2"),
+                    failureResponse("metrics-hostmetricsreceiver.otel-default", RestStatus.BAD_REQUEST, "bad request 3"),
+                    failureResponse("metrics-generic.otel-default", RestStatus.INTERNAL_SERVER_ERROR, "internal server error") },
+                0
+            )
         );
 
         assertThat(response.getStatus(), equalTo(RestStatus.OK));
-        ExportMetricsPartialSuccess metricsServiceResponse = ExportMetricsPartialSuccess.parseFrom(response.getResponse().array());
+        ExportMetricsPartialSuccess metricsServiceResponse = ExportMetricsServiceResponse.parseFrom(response.getResponse().array())
+            .getPartialSuccess();
         assertThat(metricsServiceResponse.getRejectedDataPoints(), equalTo(1L));
-        assertThat(metricsServiceResponse.getErrorMessage(), containsString("bad request"));
+        // the error message contains only one message per unique index and error status
+        assertThat(metricsServiceResponse.getErrorMessage(), containsString("bad request 1"));
+        assertThat(metricsServiceResponse.getErrorMessage(), not(containsString("bad request  2")));
+        assertThat(metricsServiceResponse.getErrorMessage(), containsString("bad request 3"));
+        assertThat(metricsServiceResponse.getErrorMessage(), containsString("internal server error"));
     }
 
     public void testBulkError() throws Exception {
@@ -113,7 +127,8 @@ public class OTLPMetricsTransportActionTests extends ESTestCase {
         MetricsResponse response = executeRequest(createMetricsRequest(createMetric()), exception);
 
         assertThat(response.getStatus(), equalTo(restStatus));
-        ExportMetricsPartialSuccess metricsServiceResponse = ExportMetricsPartialSuccess.parseFrom(response.getResponse().array());
+        ExportMetricsPartialSuccess metricsServiceResponse = ExportMetricsServiceResponse.parseFrom(response.getResponse().array())
+            .getPartialSuccess();
         assertThat(metricsServiceResponse.getRejectedDataPoints(), equalTo(1L));
         assertThat(metricsServiceResponse.getErrorMessage(), equalTo(exception.getMessage()));
     }
@@ -172,11 +187,11 @@ public class OTLPMetricsTransportActionTests extends ESTestCase {
         return BulkItemResponse.success(-1, DocWriteRequest.OpType.CREATE, mock(DocWriteResponse.class));
     }
 
-    private static BulkItemResponse failureResponse(RestStatus restStatus, String failureMessage) {
+    private static BulkItemResponse failureResponse(String index, RestStatus restStatus, String failureMessage) {
         return BulkItemResponse.failure(
             -1,
             DocWriteRequest.OpType.CREATE,
-            new BulkItemResponse.Failure("index", "id", new RuntimeException(failureMessage), restStatus)
+            new BulkItemResponse.Failure(index, "id", new RuntimeException(failureMessage), restStatus)
         );
     }
 

--- a/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/DataPointGroupingContextTests.java
+++ b/x-pack/plugin/otel-data/src/test/java/org/elasticsearch/xpack/oteldata/otlp/datapoint/DataPointGroupingContextTests.java
@@ -74,7 +74,7 @@ public class DataPointGroupingContextTests extends ESTestCase {
         context.groupDataPoints(metricsRequest);
         assertEquals(6, context.totalDataPoints());
         assertEquals(0, context.getIgnoredDataPoints());
-        assertEquals("", context.getIgnoredDataPointsMessage());
+        assertEquals("", context.getIgnoredDataPointsMessage(10));
 
         AtomicInteger groupCount = new AtomicInteger(0);
         context.consume(dataPointGroup -> groupCount.incrementAndGet());
@@ -96,7 +96,7 @@ public class DataPointGroupingContextTests extends ESTestCase {
         context.groupDataPoints(metricsRequest);
         assertEquals(2, context.totalDataPoints());
         assertEquals(0, context.getIgnoredDataPoints());
-        assertEquals("", context.getIgnoredDataPointsMessage());
+        assertEquals("", context.getIgnoredDataPointsMessage(10));
 
         AtomicInteger groupCount = new AtomicInteger(0);
         List<String> targetIndexes = new ArrayList<>();
@@ -119,7 +119,7 @@ public class DataPointGroupingContextTests extends ESTestCase {
         context.groupDataPoints(metricsRequest);
         assertEquals(2, context.totalDataPoints());
         assertEquals(0, context.getIgnoredDataPoints());
-        assertEquals("", context.getIgnoredDataPointsMessage());
+        assertEquals("", context.getIgnoredDataPointsMessage(10));
 
         AtomicInteger groupCount = new AtomicInteger(0);
         context.consume(dataPointGroup -> groupCount.incrementAndGet());
@@ -136,7 +136,7 @@ public class DataPointGroupingContextTests extends ESTestCase {
         context.groupDataPoints(metricsRequest);
         assertEquals(2, context.totalDataPoints());
         assertEquals(1, context.getIgnoredDataPoints());
-        assertThat(context.getIgnoredDataPointsMessage(), containsString("Duplicate metric name 'system.cpu.usage' for timestamp"));
+        assertThat(context.getIgnoredDataPointsMessage(10), containsString("Duplicate metric name 'system.cpu.usage' for timestamp"));
 
         AtomicInteger groupCount = new AtomicInteger(0);
         context.consume(dataPointGroup -> groupCount.incrementAndGet());
@@ -184,7 +184,7 @@ public class DataPointGroupingContextTests extends ESTestCase {
         context.groupDataPoints(ExportMetricsServiceRequest.newBuilder().addAllResourceMetrics(List.of(resource1, resource2)).build());
         assertEquals(2, context.totalDataPoints());
         assertEquals(0, context.getIgnoredDataPoints());
-        assertEquals("", context.getIgnoredDataPointsMessage());
+        assertEquals("", context.getIgnoredDataPointsMessage(10));
 
         AtomicInteger groupCount = new AtomicInteger(0);
         context.consume(dataPointGroup -> groupCount.incrementAndGet());
@@ -216,7 +216,7 @@ public class DataPointGroupingContextTests extends ESTestCase {
         context.groupDataPoints(ExportMetricsServiceRequest.newBuilder().addAllResourceMetrics(List.of(resource1, resource2)).build());
         assertEquals(2, context.totalDataPoints());
         assertEquals(0, context.getIgnoredDataPoints());
-        assertEquals("", context.getIgnoredDataPointsMessage());
+        assertEquals("", context.getIgnoredDataPointsMessage(10));
 
         AtomicInteger groupCount = new AtomicInteger(0);
         context.consume(dataPointGroup -> groupCount.incrementAndGet());
@@ -234,7 +234,7 @@ public class DataPointGroupingContextTests extends ESTestCase {
         context.groupDataPoints(metricsRequest);
         assertEquals(2, context.totalDataPoints());
         assertEquals(0, context.getIgnoredDataPoints());
-        assertEquals("", context.getIgnoredDataPointsMessage());
+        assertEquals("", context.getIgnoredDataPointsMessage(10));
 
         AtomicInteger groupCount = new AtomicInteger(0);
         context.consume(dataPointGroup -> groupCount.incrementAndGet());
@@ -256,7 +256,7 @@ public class DataPointGroupingContextTests extends ESTestCase {
         context.groupDataPoints(metricsRequest);
         assertEquals(2, context.totalDataPoints());
         assertEquals(0, context.getIgnoredDataPoints());
-        assertEquals("", context.getIgnoredDataPointsMessage());
+        assertEquals("", context.getIgnoredDataPointsMessage(10));
 
         AtomicInteger groupCount = new AtomicInteger(0);
         context.consume(dataPointGroup -> groupCount.incrementAndGet());
@@ -280,7 +280,7 @@ public class DataPointGroupingContextTests extends ESTestCase {
         context.groupDataPoints(ExportMetricsServiceRequest.newBuilder().addAllResourceMetrics(List.of(resource)).build());
         assertEquals(1, context.totalDataPoints());
         assertEquals(0, context.getIgnoredDataPoints());
-        assertEquals("", context.getIgnoredDataPointsMessage());
+        assertEquals("", context.getIgnoredDataPointsMessage(10));
 
         List<String> targetIndexes = new ArrayList<>();
         context.consume(dataPointGroup -> targetIndexes.add(dataPointGroup.targetIndex().index()));
@@ -303,7 +303,7 @@ public class DataPointGroupingContextTests extends ESTestCase {
         context.groupDataPoints(ExportMetricsServiceRequest.newBuilder().addAllResourceMetrics(List.of(resource)).build());
         assertEquals(1, context.totalDataPoints());
         assertEquals(0, context.getIgnoredDataPoints());
-        assertEquals("", context.getIgnoredDataPointsMessage());
+        assertEquals("", context.getIgnoredDataPointsMessage(10));
 
         List<String> targetIndexes = new ArrayList<>();
         context.consume(dataPointGroup -> targetIndexes.add(dataPointGroup.targetIndex().index()));


### PR DESCRIPTION
Backports the following commits to 9.2:
 - OTLP: return correct response type for partial successes (#137718)