### PR TITLE
[9.2] Fix `IndicesRequestIT.testIndicesStats`

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/IndicesRequestIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/IndicesRequestIT.java
@@ -131,6 +131,7 @@ public class IndicesRequestIT extends ESIntegTestCase {
             // InternalClusterInfoService sends IndicesStatsRequest periodically which messes with this test
             // this setting disables it...
             .put("cluster.routing.allocation.disk.threshold_enabled", false)
+            .put("cluster.routing.allocation.write_load_decider.enabled", "disabled")
             .build();
     }
 


### PR DESCRIPTION
Manual backport of: https://github.com/elastic/elasticsearch/pull/137825