### PR TITLE
Fixing get data stream API when data stream index mode has been changed to time_series

### DIFF
--- a/docs/changelog/137852.yaml
+++ b/docs/changelog/137852.yaml
@@ -1,5 +1,5 @@
 pr: 137852
-summary: Fixing geta data stream API when data stream index mode has been changed
+summary: Fixing get data stream API when data stream index mode has been changed
   to `time_series`
 area: Data streams
 type: bug

--- a/docs/changelog/137852.yaml
+++ b/docs/changelog/137852.yaml
@@ -1,0 +1,6 @@
+pr: 137852
+summary: Fixing geta data stream API when data stream index mode has been changed
+  to `time_series`
+area: Data streams
+type: bug
+issues: []

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/280_data_stream_mappings-timeseries.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/280_data_stream_mappings-timeseries.yml
@@ -322,3 +322,267 @@
   - match: { data_streams.0.effective_mappings: null }
   - set: { data_streams.0.indices.0.index_name: oldIndexName }
   - set: { data_streams.0.indices.1.index_name: newIndexName }
+
+---
+"Test change data stream from standard to time_series with no routing_path":
+  # This test makes sure that if we change the index mode of a data stream from standard to time_series without a
+  # configured routing_path, the get data stream and get data stream mappings APIs do not blow up before or after
+  # rollover.
+  - do:
+      indices.put_index_template:
+        name: my-template
+        body:
+          index_patterns: [ test-data-stream-* ]
+          data_stream: { }
+          template:
+            settings:
+              number_of_replicas: 0
+            mappings:
+              properties:
+                field1:
+                  type: keyword
+
+  - do:
+      indices.create_data_stream:
+        name: test-data-stream-1
+
+  - do:
+      indices.put_index_template:
+        name: my-template
+        body:
+          index_patterns: [ test-data-stream-* ]
+          data_stream: { }
+          template:
+            settings:
+              number_of_replicas: 0
+              mode: time_series
+            mappings:
+              properties:
+                field1:
+                  type: keyword
+                  time_series_dimension: true
+
+  - do:
+      cluster.health:
+        index: "test-data-stream-1"
+        wait_for_status: green
+
+  - do:
+      indices.get_data_stream_mappings:
+        name: test-data-stream-1
+  - match: { data_streams.0.name: test-data-stream-1 }
+  - match: { data_streams.0.mappings: {} }
+  - length: { data_streams.0.effective_mappings.properties: 2 }
+
+  - do:
+      indices.get_data_stream:
+        name: test-data-stream-1
+  - match: { data_streams.0.name: test-data-stream-1 }
+  - match: { data_streams.0.mappings: {} }
+  - match: { data_streams.0.effective_mappings: null }
+
+  - do:
+      indices.rollover:
+        alias: "test-data-stream-1"
+
+  - do:
+      cluster.health:
+        index: "test-data-stream-1"
+        wait_for_status: green
+
+  - do:
+      indices.get_data_stream_mappings:
+        name: test-data-stream-1
+  - match: { data_streams.0.name: test-data-stream-1 }
+  - length: { data_streams.0.effective_mappings.properties: 2 }
+  - match: { data_streams.0.effective_mappings.properties.field1.type: "keyword" }
+
+  - do:
+      indices.get_data_stream:
+        name: test-data-stream-1
+  - match: { data_streams.0.name: test-data-stream-1 }
+  - match: { data_streams.0.mappings: { } }
+  - match: { data_streams.0.effective_mappings: null }
+  - set: { data_streams.0.indices.0.index_name: oldIndexName }
+  - set: { data_streams.0.indices.1.index_name: newIndexName }
+
+---
+"Test change data stream from time_series to standard with no routing_path":
+  # This test makes sure that if we change the index mode of a data stream from time_series without a configured
+  # routing_path to standard, the get data stream and get data stream mappings APIs do not blow up before or after
+  # rollover.
+  - do:
+      indices.put_index_template:
+        name: my-template
+        body:
+          index_patterns: [ my-data-stream-* ]
+          data_stream: { }
+          template:
+            settings:
+              number_of_replicas: 0
+              mode: time_series
+            mappings:
+              properties:
+                field1:
+                  type: keyword
+                  time_series_dimension: true
+
+  - do:
+      indices.create_data_stream:
+        name: my-data-stream-1
+
+  - do:
+      cluster.health:
+        index: "my-data-stream-1"
+        wait_for_status: green
+
+  - do:
+      indices.get_data_stream_mappings:
+        name: my-data-stream-1
+  - match: { data_streams.0.name: my-data-stream-1 }
+  - match: { data_streams.0.mappings: {} }
+  - length: { data_streams.0.effective_mappings.properties: 2 }
+
+  - do:
+      indices.get_data_stream:
+        name: my-data-stream-1
+  - match: { data_streams.0.name: my-data-stream-1 }
+  - match: { data_streams.0.mappings: {} }
+  - match: { data_streams.0.effective_mappings: null }
+
+  - do:
+      indices.put_index_template:
+        name: my-template
+        body:
+          index_patterns: [ my-data-stream-* ]
+          data_stream: { }
+          template:
+            settings:
+              number_of_replicas: 0
+            mappings:
+              properties:
+                field1:
+                  type: keyword
+
+  - do:
+      indices.get_data_stream_mappings:
+        name: my-data-stream-1
+  - match: { data_streams.0.name: my-data-stream-1 }
+  - match: { data_streams.0.mappings: {} }
+  - length: { data_streams.0.effective_mappings.properties: 2 }
+
+  - do:
+      indices.get_data_stream:
+        name: my-data-stream-1
+  - match: { data_streams.0.name: my-data-stream-1 }
+  - match: { data_streams.0.mappings: {} }
+  - match: { data_streams.0.effective_mappings: null }
+
+  - do:
+      indices.rollover:
+        alias: "my-data-stream-1"
+
+  - do:
+      cluster.health:
+        index: "my-data-stream-1"
+        wait_for_status: green
+
+  - do:
+      indices.get_data_stream_mappings:
+        name: my-data-stream-1
+  - match: { data_streams.0.name: my-data-stream-1 }
+  - length: { data_streams.0.effective_mappings.properties: 2 }
+  - match: { data_streams.0.effective_mappings.properties.field1.type: "keyword" }
+
+  - do:
+      indices.get_data_stream:
+        name: my-data-stream-1
+  - match: { data_streams.0.name: my-data-stream-1 }
+  - match: { data_streams.0.mappings: { } }
+  - match: { data_streams.0.effective_mappings: null }
+  - set: { data_streams.0.indices.0.index_name: oldIndexName }
+  - set: { data_streams.0.indices.1.index_name: newIndexName }
+
+---
+"Test change data stream from standard to time_series with routing_path":
+  # This test makes sure that if we change the index mode of a data stream from standard to time_series with a
+  # configured routing_path, the get data stream and get data stream mappings APIs do not blow up before or after
+  # rollover.
+  - do:
+      indices.put_index_template:
+        name: my-template
+        body:
+          index_patterns: [ test-data-stream-* ]
+          data_stream: { }
+          template:
+            settings:
+              number_of_replicas: 0
+            mappings:
+              properties:
+                field1:
+                  type: keyword
+
+  - do:
+      indices.create_data_stream:
+        name: test-data-stream-1
+
+  - do:
+      indices.put_index_template:
+        name: my-template
+        body:
+          index_patterns: [ test-data-stream-* ]
+          data_stream: { }
+          template:
+            settings:
+              number_of_replicas: 0
+              routing_path: field1
+              mode: time_series
+            mappings:
+              properties:
+                field1:
+                  type: keyword
+                  time_series_dimension: true
+
+  - do:
+      cluster.health:
+        index: "test-data-stream-1"
+        wait_for_status: green
+
+  - do:
+      indices.get_data_stream_mappings:
+        name: test-data-stream-1
+  - match: { data_streams.0.name: test-data-stream-1 }
+  - match: { data_streams.0.mappings: {} }
+  - length: { data_streams.0.effective_mappings.properties: 2 }
+
+  - do:
+      indices.get_data_stream:
+        name: test-data-stream-1
+  - match: { data_streams.0.name: test-data-stream-1 }
+  - match: { data_streams.0.mappings: {} }
+  - match: { data_streams.0.effective_mappings: null }
+
+  - do:
+      indices.rollover:
+        alias: "test-data-stream-1"
+
+  - do:
+      cluster.health:
+        index: "test-data-stream-1"
+        wait_for_status: green
+
+  - do:
+      indices.get_data_stream_mappings:
+        name: test-data-stream-1
+  - match: { data_streams.0.name: test-data-stream-1 }
+  - length: { data_streams.0.effective_mappings.properties: 2 }
+  - match: { data_streams.0.effective_mappings.properties.field1.type: "keyword" }
+
+  - do:
+      indices.get_data_stream:
+        name: test-data-stream-1
+  - match: { data_streams.0.name: test-data-stream-1 }
+  - match: { data_streams.0.mappings: { } }
+  - match: { data_streams.0.effective_mappings: null }
+  - set: { data_streams.0.indices.0.index_name: oldIndexName }
+  - set: { data_streams.0.indices.1.index_name: newIndexName }


### PR DESCRIPTION
This fixes an edge case introduced by #137407. If a data stream is created with the standard `index_mode`, and then the template changes the mode to `time_series` without a `routing_path` and the data stream is not rolled over, then the get data stream API and the get data stream mappings API will fail with errors mentioning something like `failed to apply settings java.lang.IllegalArgumentException: [index.mode=time_series] requires a non-empty [index.routing_path]`. Below is an example stack trace:
```
[2025-11-10T12:51:39,973][WARN ][o.e.c.s.IndexScopedSettings] [runTask-0] [.ds-quickstart-2-2025.11.10-000001] failed to apply settings java.lang.IllegalArgumentException: [index.mode=time_series] requires a non-empty [index.routing_path]
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.index.IndexMode$2.validateWithOtherSettings(IndexMode.java:156)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.index.IndexSettings$3.validate(IndexSettings.java:751)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.index.IndexSettings$3.validate(IndexSettings.java:745)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.common.settings.Setting.get(Setting.java:589)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.common.settings.Setting.get(Setting.java:561)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.index.mapper.MapperService.lambda$static$0(MapperService.java:134)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.common.settings.Setting.innerGetRaw(Setting.java:657)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.common.settings.Setting.getRaw(Setting.java:632)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.common.settings.Setting$Updater.hasChanged(Setting.java:1317)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.common.settings.AbstractScopedSettings$SettingUpdater.updater(AbstractScopedSettings.java:683)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.common.settings.AbstractScopedSettings.applySettings(AbstractScopedSettings.java:168)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.index.IndexSettings.updateIndexMetadata(IndexSettings.java:1495)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.cluster.metadata.DataStream.lambda$getEffectiveMappings$1(DataStream.java:520)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.indices.IndicesService.withTempIndexService(IndicesService.java:773)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.cluster.metadata.DataStream.getEffectiveMappings(DataStream.java:495)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.cluster.metadata.MetadataDataStreamsService.getEffectiveSettings(MetadataDataStreamsService.java:612)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.cluster.metadata.MetadataDataStreamsService.getEffectiveSettings(MetadataDataStreamsService.java:593)
        at org.elasticsearch.datastreams@9.3.0-SNAPSHOT/org.elasticsearch.datastreams.action.TransportGetDataStreamsAction.innerOperation(TransportGetDataStreamsAction.java:283)
        at org.elasticsearch.datastreams@9.3.0-SNAPSHOT/org.elasticsearch.datastreams.action.TransportGetDataStreamsAction.localClusterStateOperation(TransportGetDataStreamsAction.java:179)
        at org.elasticsearch.datastreams@9.3.0-SNAPSHOT/org.elasticsearch.datastreams.action.TransportGetDataStreamsAction.localClusterStateOperation(TransportGetDataStreamsAction.java:72)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.action.support.local.TransportLocalProjectMetadataAction.localClusterStateOperation(TransportLocalProjectMetadataAction.java:59)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.action.support.local.TransportLocalClusterStateAction.lambda$innerDoExecute$0(TransportLocalClusterStateAction.java:92)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.action.ActionRunnable$4.doRun(ActionRunnable.java:101)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:1076)
        at org.elasticsearch.server@9.3.0-SNAPSHOT/org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:27)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
        at java.base/java.lang.Thread.run(Thread.java:1474)
```