### PR TITLE
[ML] Fix DatafeedJobsIT.testDatafeedTimingStats_DatafeedRecreated

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -402,9 +402,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.optimizer.rules.logical.HoistRemoteEnrichTopNTests
   method: testTopNSortExpressionWithinRemoteEnrichAliasing
   issue: https://github.com/elastic/elasticsearch/issues/136957
-- class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
-  method: testDatafeedTimingStats_DatafeedRecreated
-  issue: https://github.com/elastic/elasticsearch/issues/137207
 - class: org.elasticsearch.xpack.inference.DefaultEndPointsIT
   method: testMultipleInferencesTriggeringDownloadAndDeploy
   issue: https://github.com/elastic/elasticsearch/issues/117208

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsIT.java
@@ -250,7 +250,7 @@ public class DatafeedJobsIT extends MlNativeAutodetectIntegTestCase {
 
             putDatafeed(datafeedConfig);
             // Datafeed did not do anything yet, hence search_count is equal to 0.
-            assertDatafeedStats(datafeedId, DatafeedState.STOPPED, job.getId(), equalTo(0L));
+            assertBusy(() -> assertDatafeedStats(datafeedId, DatafeedState.STOPPED, job.getId(), equalTo(0L)));
             startDatafeed(datafeedId, 0L, now.toEpochMilli());
 
             // First, wait for data processing to complete
@@ -263,7 +263,14 @@ public class DatafeedJobsIT extends MlNativeAutodetectIntegTestCase {
                 TimeUnit.SECONDS
             );
 
-            deleteDatafeed(datafeedId);
+            DeleteDatafeedAction.Request request = new DeleteDatafeedAction.Request(datafeedId);
+            assertBusy(() -> {
+                try {
+                    client().execute(DeleteDatafeedAction.INSTANCE, request).actionGet();
+                } catch (Exception e) {
+                    throw new AssertionError("Datafeed could not be deleted", e);
+                }
+            });
             waitUntilJobIsClosed(job.getId());
         };
 


### PR DESCRIPTION
This commit fixes two separate issues in the test.

Firstly, the assertion that search_count stats should be equal to zero may fail the second time the openAndRunJob runnable is invoked if the stats haven't been updated since the previous datafeed with the same ID was deleted. Wrapping the assertion in an assertBusy() call prevents this.

Secondly, deleting the datafeed may fail if the master node which processes the delete datafeed action hasn't finished updating its state to reflect the fact that the datafeed has been stopped yet, but the node that processes the datafeed stats request has. Wrapping the datafeed deletion in an assertBusy() call allows it to be retried if this race condition is encountered.

Closes #137207

To verify the fix for the second issue, I first modified `assertBusy()` to poll every 5ms instead of using an exponential backoff, which made it much easier to hit the race condition that causes the failure. This change resulted in increasing the failure rate of the test to ~40%. After adding the `assertBusy()` call around the datafeed deletion request, no failures were observed in 100 repeats of the test.