### PR TITLE
[ML] Basic licence check for EIS not required

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceLicenceCheck.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceLicenceCheck.java
@@ -13,19 +13,21 @@ import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.xpack.core.XPackField;
 import org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceService;
 
-import static org.elasticsearch.xpack.inference.InferencePlugin.EIS_INFERENCE_FEATURE;
 import static org.elasticsearch.xpack.inference.InferencePlugin.INFERENCE_API_FEATURE;
 
 public class InferenceLicenceCheck {
 
     private InferenceLicenceCheck() {}
 
+    /**
+     * Is the Inference service compliant with the current license.
+     * @param serviceName The Inference service name
+     * @param licenseState The current license state
+     * @return True if the licence is sufficient
+     */
     public static boolean isServiceLicenced(String serviceName, XPackLicenseState licenseState) {
-        if (ElasticInferenceService.NAME.equals(serviceName)) {
-            return EIS_INFERENCE_FEATURE.check(licenseState);
-        } else {
-            return INFERENCE_API_FEATURE.check(licenseState);
-        }
+        // EIS is always available.
+        return ElasticInferenceService.NAME.equals(serviceName) || INFERENCE_API_FEATURE.check(licenseState);
     }
 
     public static ElasticsearchSecurityException complianceException(String serviceName) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
@@ -214,12 +214,6 @@ public class InferencePlugin extends Plugin
         License.OperationMode.ENTERPRISE
     );
 
-    public static final LicensedFeature.Momentary EIS_INFERENCE_FEATURE = LicensedFeature.momentary(
-        "inference",
-        "Elastic Inference Service",
-        License.OperationMode.BASIC
-    );
-
     public static final String X_ELASTIC_PRODUCT_USE_CASE_HTTP_HEADER = "X-elastic-product-use-case";
     public static final String X_ELASTIC_ES_VERSION = "X-elastic-es-version";
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/InferenceLicenceCheckTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/InferenceLicenceCheckTests.java
@@ -16,18 +16,18 @@ import static org.hamcrest.Matchers.containsString;
 import static org.mockito.Mockito.when;
 
 public class InferenceLicenceCheckTests extends ESTestCase {
-    public void testIsServiceLicenced_WithElasticInferenceService_WhenLicensed() {
+    public void testIsServiceLicenced_WithElasticInferenceService_BasicLicence() {
         var licenseState = MockLicenseState.createMock();
-        when(licenseState.isAllowed(InferencePlugin.EIS_INFERENCE_FEATURE)).thenReturn(true);
+        when(licenseState.isAllowed(InferencePlugin.INFERENCE_API_FEATURE)).thenReturn(false);
 
         assertTrue(InferenceLicenceCheck.isServiceLicenced(ElasticInferenceService.NAME, licenseState));
     }
 
-    public void testIsServiceLicenced_WithElasticInferenceService_WhenNotLicensed() {
+    public void testIsServiceLicenced_WithElasticInferenceService_EntLicensed() {
         var licenseState = MockLicenseState.createMock();
-        when(licenseState.isAllowed(InferencePlugin.EIS_INFERENCE_FEATURE)).thenReturn(false);
+        when(licenseState.isAllowed(InferencePlugin.INFERENCE_API_FEATURE)).thenReturn(true);
 
-        assertFalse(InferenceLicenceCheck.isServiceLicenced(ElasticInferenceService.NAME, licenseState));
+        assertTrue(InferenceLicenceCheck.isServiceLicenced(ElasticInferenceService.NAME, licenseState));
     }
 
     public void testIsServiceLicenced_WithOtherService_WhenLicensed() {
@@ -46,7 +46,6 @@ public class InferenceLicenceCheckTests extends ESTestCase {
 
     public void testIsServiceLicenced_WithMultipleServices() {
         var licenseState = MockLicenseState.createMock();
-        when(licenseState.isAllowed(InferencePlugin.EIS_INFERENCE_FEATURE)).thenReturn(true);
         when(licenseState.isAllowed(InferencePlugin.INFERENCE_API_FEATURE)).thenReturn(false);
 
         // Elastic Inference Service should be licensed

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilterTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilterTests.java
@@ -41,7 +41,6 @@ import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexingPressure;
 import org.elasticsearch.index.mapper.InferenceMetadataFieldsMapper;
-import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.inference.ChunkInferenceInput;
 import org.elasticsearch.inference.ChunkedInference;
@@ -49,7 +48,6 @@ import org.elasticsearch.inference.InferenceService;
 import org.elasticsearch.inference.InferenceServiceRegistry;
 import org.elasticsearch.inference.MinimalServiceSettings;
 import org.elasticsearch.inference.Model;
-import org.elasticsearch.inference.SimilarityMeasure;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.inference.UnparsedModel;
 import org.elasticsearch.inference.telemetry.InferenceStats;
@@ -71,7 +69,6 @@ import org.elasticsearch.xpack.inference.InferencePlugin;
 import org.elasticsearch.xpack.inference.mapper.SemanticTextField;
 import org.elasticsearch.xpack.inference.model.TestModel;
 import org.elasticsearch.xpack.inference.registry.ModelRegistry;
-import org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceService;
 import org.junit.After;
 import org.junit.Before;
 import org.mockito.stubbing.Answer;
@@ -183,62 +180,6 @@ public class ShardBulkInferenceActionFilterTests extends ESTestCase {
         StaticModel model = StaticModel.createRandomInstance();
         var licenseState = MockLicenseState.createMock();
         when(licenseState.isAllowed(InferencePlugin.INFERENCE_API_FEATURE)).thenReturn(false);
-        ShardBulkInferenceActionFilter filter = createFilter(
-            threadPool,
-            Map.of(model.getInferenceEntityId(), model),
-            NOOP_INDEXING_PRESSURE,
-            useLegacyFormat,
-            licenseState,
-            inferenceStats
-        );
-        CountDownLatch chainExecuted = new CountDownLatch(1);
-        ActionFilterChain actionFilterChain = (task, action, request, listener) -> {
-            try {
-                BulkShardRequest bulkShardRequest = (BulkShardRequest) request;
-                assertThat(bulkShardRequest.items().length, equalTo(1));
-
-                BulkItemResponse.Failure failure = bulkShardRequest.items()[0].getPrimaryResponse().getFailure();
-                assertNotNull(failure);
-                assertThat(failure.getCause(), instanceOf(ElasticsearchSecurityException.class));
-                assertThat(
-                    failure.getMessage(),
-                    containsString(org.elasticsearch.core.Strings.format("current license is non-compliant for [%s]", XPackField.INFERENCE))
-                );
-            } finally {
-                chainExecuted.countDown();
-            }
-
-        };
-        ActionListener actionListener = mock(ActionListener.class);
-        Task task = mock(Task.class);
-
-        Map<String, InferenceFieldMetadata> inferenceFieldMap = Map.of(
-            "obj.field1",
-            new InferenceFieldMetadata("obj.field1", model.getInferenceEntityId(), new String[] { "obj.field1" }, null)
-        );
-        BulkItemRequest[] items = new BulkItemRequest[1];
-        items[0] = new BulkItemRequest(0, new IndexRequest("test").source("obj.field1", "Test"));
-        BulkShardRequest request = new BulkShardRequest(new ShardId("test", "test", 0), WriteRequest.RefreshPolicy.NONE, items);
-        request.setInferenceFieldMap(inferenceFieldMap);
-
-        filter.apply(task, TransportShardBulkAction.ACTION_NAME, request, actionListener, actionFilterChain);
-        awaitLatch(chainExecuted, 10, TimeUnit.SECONDS);
-    }
-
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    public void testLicenseInvalidForEis() throws InterruptedException {
-        final InferenceStats inferenceStats = InferenceStatsTests.mockInferenceStats();
-        StaticModel model = new StaticModel(
-            randomAlphanumericOfLength(5),
-            TaskType.TEXT_EMBEDDING,
-            ElasticInferenceService.NAME,
-            new TestModel.TestServiceSettings("foo", 128, SimilarityMeasure.COSINE, DenseVectorFieldMapper.ElementType.BYTE),
-            new TestModel.TestTaskSettings(randomInt(3)),
-            new TestModel.TestSecretSettings(randomAlphaOfLength(4))
-        );
-
-        var licenseState = MockLicenseState.createMock();
-        when(licenseState.isAllowed(InferencePlugin.EIS_INFERENCE_FEATURE)).thenReturn(false);
         ShardBulkInferenceActionFilter filter = createFilter(
             threadPool,
             Map.of(model.getInferenceEntityId(), model),


### PR DESCRIPTION
#137434 made the Elastic Inference Service available with a basic licence. Reviewing the code basic licences are not checked as it is freely available. This follow up removes the licence feature for EIS