### PR TITLE
[9.2] Fix DatafeedJobsIT.testDatafeedTimingStats_DatafeedRecreated (#137856)

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedJobsIT.java
@@ -250,7 +250,7 @@ public class DatafeedJobsIT extends MlNativeAutodetectIntegTestCase {
 
             putDatafeed(datafeedConfig);
             // Datafeed did not do anything yet, hence search_count is equal to 0.
-            assertDatafeedStats(datafeedId, DatafeedState.STOPPED, job.getId(), equalTo(0L));
+            assertBusy(() -> assertDatafeedStats(datafeedId, DatafeedState.STOPPED, job.getId(), equalTo(0L)));
             startDatafeed(datafeedId, 0L, now.toEpochMilli());
 
             // First, wait for data processing to complete
@@ -263,7 +263,14 @@ public class DatafeedJobsIT extends MlNativeAutodetectIntegTestCase {
                 TimeUnit.SECONDS
             );
 
-            deleteDatafeed(datafeedId);
+            DeleteDatafeedAction.Request request = new DeleteDatafeedAction.Request(datafeedId);
+            assertBusy(() -> {
+                try {
+                    client().execute(DeleteDatafeedAction.INSTANCE, request).actionGet();
+                } catch (Exception e) {
+                    throw new AssertionError("Datafeed could not be deleted", e);
+                }
+            });
             waitUntilJobIsClosed(job.getId());
         };
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Fix DatafeedJobsIT.testDatafeedTimingStats_DatafeedRecreated (#137856)](https://github.com/elastic/elasticsearch/pull/137856)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)