### PR TITLE
[8.18] Fix dependency reporting (#136209)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/util/DependenciesUtils.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/util/DependenciesUtils.java
@@ -9,13 +9,17 @@
 
 package org.elasticsearch.gradle.internal.util;
 
+import com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin;
+
 import org.gradle.api.artifacts.ArtifactView;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ResolvableDependencies;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.specs.AndSpec;
 import org.gradle.api.specs.Spec;
 
@@ -38,7 +42,7 @@ public class DependenciesUtils {
     public static ArtifactView createNonTransitiveArtifactsView(Configuration configuration, Spec<ComponentIdentifier> componentFilter) {
         ResolvableDependencies incoming = configuration.getIncoming();
         return incoming.artifactView(viewConfiguration -> {
-            Set<ComponentIdentifier> firstLevelDependencyComponents = incoming.getResolutionResult()
+            Provider<Set<ComponentIdentifier>> firstLevelDependencyComponents = incoming.getResolutionResult()
                 .getRootComponent()
                 .map(
                     rootComponent -> rootComponent.getDependencies()
@@ -48,11 +52,36 @@ public class DependenciesUtils {
                         .filter(dependency -> dependency.getSelected() instanceof ResolvedComponentResult)
                         .map(dependency -> dependency.getSelected().getId())
                         .collect(Collectors.toSet())
-                )
-                .get();
+                );
             viewConfiguration.componentFilter(
-                new AndSpec<>(identifier -> firstLevelDependencyComponents.contains(identifier), componentFilter)
+                new AndSpec<>(identifier -> firstLevelDependencyComponents.get().contains(identifier), componentFilter)
             );
         });
+    }
+
+    /**
+     * This method gives us an artifact view of a configuration that filters out all
+     * project dependencies that are not shadowed jars.
+     * Basically a thirdparty only view of the dependency tree.
+     */
+    public static FileCollection thirdPartyDependenciesView(Configuration configuration) {
+        ResolvableDependencies incoming = configuration.getIncoming();
+        return incoming.artifactView(v -> {
+            // resolve componentIdentifier for all shadowed project dependencies
+            Provider<Set<ComponentIdentifier>> shadowedDependencies = incoming.getResolutionResult()
+                .getRootComponent()
+                .map(
+                    root -> root.getDependencies()
+                        .stream()
+                        .filter(dep -> dep instanceof ResolvedDependencyResult)
+                        .map(dep -> (ResolvedDependencyResult) dep)
+                        .filter(dep -> dep.getResolvedVariant().getDisplayName() == ShadowBasePlugin.SHADOW)
+                        .filter(dep -> dep.getSelected() instanceof ResolvedComponentResult)
+                        .map(dep -> dep.getSelected().getId())
+                        .collect(Collectors.toSet())
+                );
+            // filter out project dependencies if they are not a shadowed dependency
+            v.componentFilter(i -> (i instanceof ProjectComponentIdentifier == false || shadowedDependencies.get().contains(i)));
+        }).getFiles();
     }
 }

--- a/x-pack/plugin/inference/build.gradle
+++ b/x-pack/plugin/inference/build.gradle
@@ -8,6 +8,8 @@ import org.elasticsearch.gradle.internal.info.BuildParams
 
 import org.elasticsearch.gradle.internal.AbstractDependenciesTask
 
+import org.elasticsearch.gradle.internal.AbstractDependenciesTask
+
 apply plugin: 'elasticsearch.internal-es-plugin'
 apply plugin: 'elasticsearch.internal-cluster-test'
 apply plugin: 'elasticsearch.internal-yaml-rest-test'


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Fix dependency reporting (#136209)](https://github.com/elastic/elasticsearch/pull/136209)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)