### PR TITLE
Add support for RDN attribute name matching to PKI realm.

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/pki/PkiRealmSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/pki/PkiRealmSettings.java
@@ -29,6 +29,12 @@ public final class PkiRealmSettings {
         key -> new Setting<>(key, DEFAULT_USERNAME_PATTERN, s -> Pattern.compile(s, Pattern.CASE_INSENSITIVE), Setting.Property.NodeScope)
     );
 
+    public static final Setting.AffixSetting<String> USERNAME_RDN_NAME_SETTING = Setting.affixKeySetting(
+        RealmSettings.realmSettingPrefix(TYPE),
+        "username_rdn_name",
+        key -> Setting.simpleString(key, Setting.Property.NodeScope)
+    );
+
     private static final TimeValue DEFAULT_TTL = TimeValue.timeValueMinutes(20);
     public static final Setting.AffixSetting<TimeValue> CACHE_TTL_SETTING = Setting.affixKeySetting(
         RealmSettings.realmSettingPrefix(TYPE),
@@ -75,6 +81,7 @@ public final class PkiRealmSettings {
     public static Set<Setting.AffixSetting<?>> getSettings() {
         Set<Setting.AffixSetting<?>> settings = new HashSet<>();
         settings.add(USERNAME_PATTERN_SETTING);
+        settings.add(USERNAME_RDN_NAME_SETTING);
         settings.add(CACHE_TTL_SETTING);
         settings.add(CACHE_MAX_USERS_SETTING);
         settings.add(DELEGATION_ENABLED_SETTING);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/pki/PkiRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/pki/PkiRealm.java
@@ -8,9 +8,7 @@ package org.elasticsearch.xpack.security.authc.pki;
 
 import com.unboundid.ldap.sdk.Attribute;
 import com.unboundid.ldap.sdk.DN;
-
 import com.unboundid.ldap.sdk.LDAPException;
-
 import com.unboundid.ldap.sdk.RDN;
 
 import org.apache.logging.log4j.Logger;


### PR DESCRIPTION
This change adds configuration options to the PKI Realm for principal extraction from the client certificate based on a relative distinguished name (RDN) attribute value.

The following Elasticsearch YAML configuration options is included:
* `username_rdn_name` - the RDN attribute name to use, e.g. `CN`

The implementation is based on text parsing of the RFC 2253 formatted text of the X500 distinguished name using the UnboundID LDAP SDK library.

Caveat: this approach only supports standard LDAP attribute types, such as `CN`, `O`, `OU`, `UID`, etc.

Non-LDAP extensions, such as `EMAILADDRESS`, and custom OIDs are not supported.

Examples:

| DN | Name | Value |
| :--- | :--- | :--- |
| `CN=John Doe, OU=Security Team, OU=Engineering, O=Elastic` | `CN` | `John Doe` |
| `UID=abc123, OU=Security Team, OU=Engineering, O=Elastic` | `UID` | `abc123` |
| `UID=abc123, OU=Security Team, OU=Engineering, O=Elastic` | `CN` | - |