### PR TITLE
fix memory limit in testMaybeSample

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -472,9 +472,6 @@ tests:
 - class: org.elasticsearch.xpack.inference.external.http.sender.RequestExecutorServiceTests
   method: testExecute_NotifiesNonRateLimitedTasksOfShutdown
   issue: https://github.com/elastic/elasticsearch/issues/137831
-- class: org.elasticsearch.ingest.SamplingServiceTests
-  method: testMaybeSample
-  issue: https://github.com/elastic/elasticsearch/issues/137871
 - class: org.elasticsearch.xpack.inference.integration.AuthorizationTaskExecutorMultipleNodesIT
   method: testAuthorizationTaskGetsRelocatedToAnotherNode_WhenTheNodeThatIsRunningItShutsDown
   issue: https://github.com/elastic/elasticsearch/issues/137911

--- a/server/src/test/java/org/elasticsearch/ingest/SamplingServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/SamplingServiceTests.java
@@ -71,7 +71,7 @@ public class SamplingServiceTests extends ESTestCase {
             .putCustom(
                 SamplingMetadata.TYPE,
                 new SamplingMetadata(
-                    Map.of(indexName, new SamplingConfiguration(1.0, maxSize, ByteSizeValue.ofKb(100), TimeValue.timeValueDays(3), null))
+                    Map.of(indexName, new SamplingConfiguration(1.0, maxSize, ByteSizeValue.ofKb(500), TimeValue.timeValueDays(3), null))
                 )
             );
         projectMetadata = projectBuilder.build();


### PR DESCRIPTION
The memory limit in testMaybeSample was set too low for certain seeds & size of samples was surpassing the 100kb limit about halfway through, this PR increases that limit to 500kb and unmutes the test.

closes https://github.com/elastic/elasticsearch/issues/137871