### PR TITLE
[9.1] [ES-12728] Adding debian-13 support (#137061)

### DIFF
--- a/.buildkite/pipelines/periodic-packaging.template.yml
+++ b/.buildkite/pipelines/periodic-packaging.template.yml
@@ -8,6 +8,7 @@ steps:
           setup:
             image:
               - debian-12
+              - debian-13
               - opensuse-leap-15
               - oraclelinux-8
               - oraclelinux-9

--- a/.buildkite/pipelines/periodic-packaging.yml
+++ b/.buildkite/pipelines/periodic-packaging.yml
@@ -9,6 +9,7 @@ steps:
           setup:
             image:
               - debian-12
+              - debian-13
               - opensuse-leap-15
               - oraclelinux-8
               - oraclelinux-9

--- a/.buildkite/pipelines/periodic-platform-support.yml
+++ b/.buildkite/pipelines/periodic-platform-support.yml
@@ -8,6 +8,7 @@ steps:
           setup:
             image:
               - debian-12
+              - debian-13
               - opensuse-leap-15
               - oraclelinux-8
               - oraclelinux-9

--- a/.buildkite/pipelines/pull-request/packaging-tests-unix.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-unix.yml
@@ -11,6 +11,7 @@ steps:
           setup:
             image:
               - debian-12
+              - debian-13
               - opensuse-leap-15
               - oraclelinux-8
               - oraclelinux-9

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/Packages.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/Packages.java
@@ -232,6 +232,8 @@ public class Packages {
             ).forEach(confFile -> assertThat(confFile, file(File, "root", "root", p644)));
 
             final String sysctlExecutable = (distribution.packaging == Distribution.Packaging.RPM) ? "/usr/sbin/sysctl" : "/sbin/sysctl";
+            // Restarting sysctl so changes to conf get applied
+            sh.run(sysctlExecutable + " --system");
             assertThat(sh.run(sysctlExecutable + " vm.max_map_count").stdout(), containsString("vm.max_map_count = 262144"));
         }
     }


### PR DESCRIPTION
Backports the following commits to 9.1:
 - [ES-12728] Adding debian-13 support (#137061)

[ES-12728]: https://elasticco.atlassian.net/browse/ES-12728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ