### PR TITLE
[8.19] Adding workspace var for git safe dir when it is missing (#137893)

### DIFF
--- a/.ci/scripts/packaging-test.sh
+++ b/.ci/scripts/packaging-test.sh
@@ -61,9 +61,14 @@ sudo bash -c 'cat > /etc/sudoers.d/elasticsearch_vars'  << SUDOERS_VARS
 SUDOERS_VARS
 sudo chmod 0440 /etc/sudoers.d/elasticsearch_vars
 
-# Bats tests still use this locationa
+# Bats tests still use this location
 sudo rm -Rf /elasticsearch
 sudo mkdir -p /elasticsearch/qa/ && sudo chown jenkins /elasticsearch/qa/ && ln -s $PWD/qa/vagrant /elasticsearch/qa/
+
+#
+if [[ -z "${WORKSPACE}" ]]; then
+  WORKSPACE=$(pwd)
+fi
 
 # Ensure since we're running as root that we can do git operations in this directory
 # See: https://git-scm.com/docs/git-config/2.35.2#Documentation/git-config.txt-safedirectory


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Adding workspace var for git safe dir when it is missing (#137893)