### PR TITLE
Reduce the number of clauses used in interval query tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/query/IntervalQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/IntervalQueryBuilderTests.java
@@ -111,7 +111,7 @@ public class IntervalQueryBuilderTests extends AbstractQueryTestCase<IntervalQue
     }
 
     static IntervalsSourceProvider.Combine createRandomCombine(int depth, boolean useScripts) {
-        int count = randomInt(5) + 1;
+        int count = randomInt(4) + 1;
         List<IntervalsSourceProvider> subSources = createRandomSourceList(depth, useScripts, count);
         boolean ordered = randomBoolean();
         int maxGaps = randomInt(5) - 1;


### PR DESCRIPTION
Fixes #137950

The number of clauses here was over the limit accepted by the disjunction rewriter, so reduce the number of clauses slightly.