### PR TITLE
[8.19] Reserved state removal

### DIFF
--- a/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedClusterStateService.java
@@ -196,7 +196,7 @@ public class ReservedClusterStateService {
 
         LinkedHashSet<String> orderedHandlers;
         try {
-            orderedHandlers = orderedStateHandlers(reservedState.keySet());
+            orderedHandlers = ReservedStateUpdateTask.orderedStateHandlers(reservedState.keySet(), handlers);
         } catch (Exception e) {
             ErrorState errorState = new ErrorState(
                 namespace,
@@ -356,62 +356,6 @@ public class ReservedClusterStateService {
         }
 
         return errors;
-    }
-
-    /**
-     * Returns an ordered set ({@link LinkedHashSet}) of the cluster state handlers that need to
-     * execute for a given list of handler names supplied through the {@link ReservedStateChunk}.
-     * @param handlerNames Names of handlers found in the {@link ReservedStateChunk}
-     */
-    LinkedHashSet<String> orderedStateHandlers(Set<String> handlerNames) {
-        LinkedHashSet<String> orderedHandlers = new LinkedHashSet<>();
-        LinkedHashSet<String> dependencyStack = new LinkedHashSet<>();
-
-        for (String key : handlerNames) {
-            addStateHandler(key, handlerNames, orderedHandlers, dependencyStack);
-        }
-
-        return orderedHandlers;
-    }
-
-    private void addStateHandler(String key, Set<String> keys, LinkedHashSet<String> ordered, LinkedHashSet<String> visited) {
-        if (visited.contains(key)) {
-            StringBuilder msg = new StringBuilder("Cycle found in settings dependencies: ");
-            visited.forEach(s -> {
-                msg.append(s);
-                msg.append(" -> ");
-            });
-            msg.append(key);
-            throw new IllegalStateException(msg.toString());
-        }
-
-        if (ordered.contains(key)) {
-            // already added by another dependent handler
-            return;
-        }
-
-        visited.add(key);
-        ReservedClusterStateHandler<?> handler = handlers.get(key);
-
-        if (handler == null) {
-            throw new IllegalStateException("Unknown handler type: " + key);
-        }
-
-        for (String dependency : handler.dependencies()) {
-            if (keys.contains(dependency) == false) {
-                throw new IllegalStateException("Missing handler dependency definition: " + key + " -> " + dependency);
-            }
-            addStateHandler(dependency, keys, ordered, visited);
-        }
-
-        for (String dependency : handler.optionalDependencies()) {
-            if (keys.contains(dependency)) {
-                addStateHandler(dependency, keys, ordered, visited);
-            }
-        }
-
-        visited.remove(key);
-        ordered.add(key);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedStateUpdateTask.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedStateUpdateTask.java
@@ -27,6 +27,7 @@ import org.elasticsearch.reservedstate.TransformState;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -49,16 +50,20 @@ public class ReservedStateUpdateTask implements ClusterStateTaskListener {
     private final ReservedStateChunk stateChunk;
     private final ReservedStateVersionCheck versionCheck;
     private final Map<String, ReservedClusterStateHandler<?>> handlers;
-    private final Collection<String> orderedHandlers;
+    private final Collection<String> updateSequence;
     private final Consumer<ErrorState> errorReporter;
     private final ActionListener<ActionResponse.Empty> listener;
 
+    /**
+     * @param updateSequence the names of handlers corresponding to configuration sections present in the source,
+     *                       in the order they should be processed according to their dependencies.
+     */
     public ReservedStateUpdateTask(
         String namespace,
         ReservedStateChunk stateChunk,
         ReservedStateVersionCheck versionCheck,
         Map<String, ReservedClusterStateHandler<?>> handlers,
-        Collection<String> orderedHandlers,
+        Collection<String> updateSequence,
         Consumer<ErrorState> errorReporter,
         ActionListener<ActionResponse.Empty> listener
     ) {
@@ -66,9 +71,19 @@ public class ReservedStateUpdateTask implements ClusterStateTaskListener {
         this.stateChunk = stateChunk;
         this.versionCheck = versionCheck;
         this.handlers = handlers;
-        this.orderedHandlers = orderedHandlers;
+        this.updateSequence = updateSequence;
         this.errorReporter = errorReporter;
         this.listener = listener;
+
+        // We can't assert the order here, even if we'd like to, because in general,
+        // there is not necessarily one unique correct order.
+        // But we can at least assert that updateSequence has the right elements.
+        assert Set.copyOf(updateSequence).equals(stateChunk.state().keySet())
+            : "updateSequence is supposed to be computed from stateChunk.state().keySet(): "
+                + updateSequence
+                + " vs "
+                + stateChunk.state().keySet();
+
     }
 
     @Override
@@ -91,6 +106,7 @@ public class ReservedStateUpdateTask implements ClusterStateTaskListener {
         ReservedStateMetadata existingMetadata = currentState.metadata().reservedStateMetadata().get(namespace);
         Map<String, Object> reservedState = stateChunk.state();
         ReservedStateVersion reservedStateVersion = stateChunk.metadata();
+        var reservedStateMetadata = currentState.getMetadata().reservedStateMetadata().get(namespace);
 
         if (checkMetadataVersion(namespace, existingMetadata, reservedStateVersion, versionCheck) == false) {
             return currentState;
@@ -100,8 +116,9 @@ public class ReservedStateUpdateTask implements ClusterStateTaskListener {
         List<String> errors = new ArrayList<>();
 
         ClusterState state = currentState;
-        // Transform the cluster state first
-        for (var handlerName : orderedHandlers) {
+
+        // First apply the updates to transform the cluster state
+        for (var handlerName : updateSequence) {
             ReservedClusterStateHandler<?> handler = handlers.get(handlerName);
             try {
                 Set<String> existingKeys = keysForHandler(existingMetadata, handlerName);
@@ -112,6 +129,9 @@ public class ReservedStateUpdateTask implements ClusterStateTaskListener {
                 errors.add(format("Error processing %s state change: %s", handler.name(), stackTrace(e)));
             }
         }
+
+        // Now, any existing handler not listed in updateSequence must have been removed.
+        // TODO: Removal logic
 
         checkAndThrowOnError(errors, reservedStateVersion, versionCheck);
 
@@ -212,6 +232,72 @@ public class ReservedStateUpdateTask implements ClusterStateTaskListener {
             )
         );
         return false;
+    }
+
+    /**
+     * Returns an ordered set ({@link LinkedHashSet}) of the cluster state handlers that need to
+     * execute for a given list of handler names supplied through the {@link ReservedStateChunk}.
+     *
+     * @param handlerNames Names of handlers found in the {@link ReservedStateChunk}
+     */
+    static LinkedHashSet<String> orderedStateHandlers(
+        Collection<String> handlerNames,
+        Map<String, ReservedClusterStateHandler<?>> handlers
+    ) {
+        LinkedHashSet<String> orderedHandlers = new LinkedHashSet<>();
+
+        for (String key : handlerNames) {
+            addStateHandler(handlers, key, handlerNames, orderedHandlers, new LinkedHashSet<String>());
+        }
+
+        assert Set.copyOf(handlerNames).equals(orderedHandlers);
+        return orderedHandlers;
+    }
+
+    private static void addStateHandler(
+        Map<String, ReservedClusterStateHandler<?>> handlers,
+        String key,
+        Collection<String> keys,
+        LinkedHashSet<String> ordered,
+        LinkedHashSet<String> inProgress
+    ) {
+        if (inProgress.contains(key)) {
+            StringBuilder msg = new StringBuilder("Cycle found in settings dependencies: ");
+            inProgress.forEach(s -> {
+                msg.append(s);
+                msg.append(" -> ");
+            });
+            msg.append(key);
+            throw new IllegalStateException(msg.toString());
+        }
+
+        if (ordered.contains(key)) {
+            // already added by another dependent handler
+            return;
+        }
+
+        inProgress.add(key);
+        ReservedClusterStateHandler<?> handler = handlers.get(key);
+
+        if (handler == null) {
+            throw new IllegalStateException("Unknown handler type: " + key);
+        }
+
+        for (String dependency : handler.dependencies()) {
+            if (keys.contains(dependency) == false) {
+                throw new IllegalStateException("Missing handler dependency definition: " + key + " -> " + dependency);
+            }
+            addStateHandler(handlers, dependency, keys, ordered, inProgress);
+        }
+
+        for (String dependency : handler.optionalDependencies()) {
+            if (keys.contains(dependency)) {
+                addStateHandler(handlers, dependency, keys, ordered, inProgress);
+            }
+        }
+
+        inProgress.remove(key);
+        ordered.add(key);
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/reservedstate/service/ReservedClusterStateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/reservedstate/service/ReservedClusterStateServiceTests.java
@@ -38,6 +38,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -239,6 +240,138 @@ public class ReservedClusterStateServiceTests extends ESTestCase {
             updatedState.metadata().reservedStateMetadata(),
             equalTo(Map.of("namespace", new ReservedStateMetadata("namespace", ReservedStateMetadata.EMPTY_VERSION, Map.of(), null)))
         );
+    }
+
+    public void testTransformAndRemoveGetCalled() throws Exception {
+        // TODO: Ought to do this for project state updates too.
+
+        // This records the calls made to the handler
+        ArrayList<Operation> operations = new ArrayList<>();
+        var handler = new TestStateHandler("test_cluster_state_handler") {
+            @Override
+            public TransformState transform(Object sourceObj, TransformState prevState) throws Exception {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> source = (Map<String, Object>) sourceObj;
+                operations.add(new Operation.Transform(source, prevState.keys()));
+                return new TransformState(prevState.state(), source.keySet());
+            }
+
+            @Override
+            public ClusterState remove(TransformState prevState) {
+                operations.add(new Operation.Remove(prevState.keys()));
+                return prevState.state();
+            }
+        };
+
+        ClusterState state1 = ClusterState.EMPTY_STATE;
+
+        // 1. Add our section to the reserved state chunk
+        ReservedStateChunk initialStateChunk = new ReservedStateChunk(
+            Map.of("test_handler_name", Map.of("key1", "value1")),
+            new ReservedStateVersion(1L, Version.CURRENT)
+        );
+        ReservedStateUpdateTask addTask = new ReservedStateUpdateTask(
+            "test_namespace",
+            initialStateChunk,
+            ReservedStateVersionCheck.HIGHER_VERSION_ONLY,
+            Map.of("test_handler_name", handler),
+            List.copyOf(initialStateChunk.state().keySet()),
+            Assert::assertNull,
+            ActionListener.noop()
+        );
+        ClusterState state2 = addTask.execute(state1);
+
+        assertEquals(List.of(new Operation.Transform(Map.of("key1", "value1"), Set.of())), operations);
+        var expected2 = Map.of(
+            "test_namespace",
+            new ReservedStateMetadata(
+                "test_namespace",
+                initialStateChunk.metadata().version(),
+                Map.of("test_handler_name", new ReservedStateHandlerMetadata("test_handler_name", Set.of("key1"))),
+                null
+            )
+        );
+        assertEquals("Our section of the reserved state has been added", expected2, state2.metadata().reservedStateMetadata());
+
+        operations.clear();
+
+        // 2. Change our section of the reserved state
+        ReservedStateChunk changedStateChunk = new ReservedStateChunk(
+            Map.of("test_handler_name", Map.of("key2", "value2")),
+            new ReservedStateVersion(2L, Version.CURRENT)
+        );
+        ReservedStateUpdateTask changeTask = new ReservedStateUpdateTask(
+            "test_namespace",
+            changedStateChunk,
+            ReservedStateVersionCheck.HIGHER_VERSION_ONLY,
+            Map.of("test_handler_name", handler),
+            List.copyOf(changedStateChunk.state().keySet()),
+            Assert::assertNull,
+            ActionListener.noop()
+        );
+        ClusterState state3 = changeTask.execute(state2);
+
+        assertEquals(List.of(new Operation.Transform(Map.of("key2", "value2"), Set.of("key1"))), operations);
+        var expected3 = Map.of(
+            "test_namespace",
+            new ReservedStateMetadata(
+                "test_namespace",
+                changedStateChunk.metadata().version(),
+                Map.of("test_handler_name", new ReservedStateHandlerMetadata("test_handler_name", Set.of("key2"))),
+                null
+            )
+        );
+        assertEquals("Our section of the removed state is updated", expected3, state3.metadata().reservedStateMetadata());
+
+        operations.clear();
+
+        // 3. Remove our section of the state chunk
+        ReservedStateChunk removedStateChunk = new ReservedStateChunk(Map.of(), new ReservedStateVersion(3L, Version.CURRENT));
+        ReservedStateUpdateTask removeTask = new ReservedStateUpdateTask(
+            "test_namespace",
+            removedStateChunk,
+            ReservedStateVersionCheck.HIGHER_VERSION_ONLY,
+            Map.of("test_handler_name", handler),
+            List.copyOf(removedStateChunk.state().keySet()),
+            Assert::assertNull,
+            ActionListener.noop()
+        );
+        var state4 = removeTask.execute(state3);
+
+        assertEquals(List.of(new Operation.Remove(Set.of("key2"))), operations);
+        var expected4 = Map.of(
+            "test_namespace",
+            new ReservedStateMetadata("test_namespace", removedStateChunk.metadata().version(), Map.of(), null)
+        );
+        assertEquals("Our section of the removed state is gone", expected4, state4.metadata().reservedStateMetadata());
+
+        operations.clear();
+
+        // 4. Resubmit without our section and make sure it's a no-op
+        ReservedStateChunk stillGoneStateChunk = new ReservedStateChunk(Map.of(), new ReservedStateVersion(4L, Version.CURRENT));
+        ReservedStateUpdateTask noopTask = new ReservedStateUpdateTask(
+            "test_namespace",
+            stillGoneStateChunk,
+            ReservedStateVersionCheck.HIGHER_VERSION_ONLY,
+            Map.of("test_handler_name", handler),
+            List.copyOf(stillGoneStateChunk.state().keySet()),
+            Assert::assertNull,
+            ActionListener.noop()
+        );
+        var state5 = noopTask.execute(state4);
+
+        assertEquals(List.of(), operations);
+        var expected5 = Map.of(
+            "test_namespace",
+            new ReservedStateMetadata("test_namespace", stillGoneStateChunk.metadata().version(), Map.of(), null)
+        );
+        assertEquals("Our section of the removed state is still gone", expected5, state5.metadata().reservedStateMetadata());
+    }
+
+    private sealed interface Operation {
+        record Transform(Object source, Set<String> prevKeys) implements Operation {}
+
+        record Remove(Set<String> prevKeys) implements Operation {}
     }
 
     public void testUpdateStateTasks() throws Exception {

--- a/server/src/test/java/org/elasticsearch/reservedstate/service/ReservedStateUpdateTaskTests.java
+++ b/server/src/test/java/org/elasticsearch/reservedstate/service/ReservedStateUpdateTaskTests.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.reservedstate.service;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -25,7 +26,7 @@ public class ReservedStateUpdateTaskTests extends ESTestCase {
     public void testBlockedClusterState() {
         var task = new ReservedStateUpdateTask(
             "dummy",
-            null,
+            new ReservedStateChunk(Map.of(), new ReservedStateVersion(1L, Version.CURRENT)),
             ReservedStateVersionCheck.HIGHER_VERSION_ONLY,
             Map.of(),
             List.of(),


### PR DESCRIPTION
Backporting some logic from #136721 missed in #137919.

I've made some effort to make this code look like the v9 code, but there are two hurdles here:
- v9 separates cluster vs project reserved state, where v8 does not, so reserved state handling is naturally simpler in v8
- v8 builds with Java 17 so it can't used `SequencedCollection`