### PR TITLE
[9.2] Serverless filtering create from (#137850)

### DIFF
--- a/docs/changelog/137850.yaml
+++ b/docs/changelog/137850.yaml
@@ -1,0 +1,5 @@
+pr: 137850
+summary: Serverless filtering create from
+area: Indices APIs
+type: bug
+issues: []


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Serverless filtering create from (#137850)