### PR TITLE
[9.1] Serverless filtering create from (#137850)

### DIFF
--- a/docs/changelog/137850.yaml
+++ b/docs/changelog/137850.yaml
@@ -1,0 +1,5 @@
+pr: 137850
+summary: Serverless filtering create from
+area: Indices APIs
+type: bug
+issues: []

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/CreateIndexFromSourceTransportAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/CreateIndexFromSourceTransportAction.java
@@ -17,7 +17,6 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.IndexScopedSettings;

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/CreateIndexFromSourceTransportAction.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/action/CreateIndexFromSourceTransportAction.java
@@ -16,6 +16,8 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.IndexScopedSettings;
@@ -154,6 +156,7 @@ public class CreateIndexFromSourceTransportAction extends HandledTransportAction
     private Settings filterSettings(IndexMetadata sourceIndex) {
         Settings sourceSettings = sourceIndex.getSettings();
         final Settings.Builder builder = Settings.builder();
+        final boolean isServerless = DiscoveryNode.isStateless(clusterService.getSettings());
         for (final String key : sourceSettings.keySet()) {
             final Setting<?> setting = indexScopedSettings.get(key);
             if (setting == null) {
@@ -167,6 +170,9 @@ public class CreateIndexFromSourceTransportAction extends HandledTransportAction
                 continue;
             }
             if (setting.getProperties().contains(Setting.Property.IndexSettingDeprecatedInV7AndRemovedInV8)) {
+                continue;
+            }
+            if (isServerless && setting.isServerlessPublic() == false) {
                 continue;
             }
             if (SPECIFIC_SETTINGS_TO_REMOVE.contains(key)) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Serverless filtering create from (#137850)](https://github.com/elastic/elasticsearch/pull/137850)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)