### PR TITLE
[9.2] Task may be unregistered outside of the trace context in exceptional cases. (#137865)

### DIFF
--- a/server/src/main/java/org/elasticsearch/tasks/TaskManager.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskManager.java
@@ -191,12 +191,6 @@ public class TaskManager implements ClusterStateApplier {
         tracer.startTrace(threadContext, task, task.getAction(), attributes);
     }
 
-    void maybeStopTrace(ThreadContext threadContext, Task task) {
-        if (threadContext.hasTraceContext()) {
-            tracer.stopTrace(task);
-        }
-    }
-
     public <Request extends ActionRequest, Response extends ActionResponse> Task registerAndExecute(
         String type,
         TransportAction<Request, Response> action,
@@ -358,7 +352,7 @@ public class TaskManager implements ClusterStateApplier {
                 return removedTask;
             }
         } finally {
-            maybeStopTrace(threadPool.getThreadContext(), task);
+            tracer.stopTrace(task); // stop trace if started / known by tracer
             for (RemovedTaskListener listener : removedTaskListeners) {
                 listener.onRemoved(task);
             }

--- a/server/src/test/java/org/elasticsearch/tasks/TaskManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/tasks/TaskManagerTests.java
@@ -69,6 +69,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class TaskManagerTests extends ESTestCase {
@@ -311,6 +312,9 @@ public class TaskManagerTests extends ESTestCase {
                 ? Map.of(Tracer.AttributeKeys.TASK_ID, task.getId(), Tracer.AttributeKeys.PARENT_TASK_ID, parentTask.toString())
                 : Map.of(Tracer.AttributeKeys.TASK_ID, task.getId());
             verify(mockTracer).startTrace(any(), eq(task), eq("testAction"), eq(attributes));
+
+            taskManager.unregister(task);
+            verify(mockTracer).stopTrace(task); // always attempt stopping to guard against leaks
         }
     }
 
@@ -393,7 +397,8 @@ public class TaskManagerTests extends ESTestCase {
         // no trace context
 
         taskManager.unregister(task);
-        verifyNoInteractions(mockTracer);
+        verify(mockTracer).stopTrace(task); // always attempt stopping to guard against leaks
+        verifyNoMoreInteractions(mockTracer);
     }
 
     /**
@@ -438,6 +443,7 @@ public class TaskManagerTests extends ESTestCase {
         );
 
         verify(mockTracer).startTrace(any(), eq(task), eq("actionName"), anyMap());
+        verify(mockTracer).stopTrace(task); // always attempt stopping to guard against leaks
     }
 
     /**
@@ -480,7 +486,8 @@ public class TaskManagerTests extends ESTestCase {
             ActionTestUtils.assertNoFailureListener(r -> {})
         );
 
-        verifyNoInteractions(mockTracer);
+        verify(mockTracer).stopTrace(task); // always attempt stopping to guard against leaks
+        verifyNoMoreInteractions(mockTracer);
     }
 
     public void testRegisterWithEnabledDisabledTracing() {


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Task may be unregistered outside of the trace context in exceptional cases. (#137865)