### PR TITLE
rest-api-spec: fix indices APIs around sampling

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_sample_configuration.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_sample_configuration.json
@@ -1,7 +1,7 @@
 {
   "indices.delete_sample_configuration": {
     "documentation": {
-      "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-delete-sample-configuration",
+      "url": "https://www.elastic.co/docs/api/doc/elasticsearch#TODO",
       "description": "Delete sampling configuration for an index or data stream"
     },
     "stability": "experimental",
@@ -34,10 +34,12 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for connection to master node"
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for the request"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_all_sample_configuration.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_all_sample_configuration.json
@@ -1,7 +1,7 @@
 {
   "indices.get_all_sample_configuration": {
     "documentation": {
-      "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-get-all-sample-configuration",
+      "url": "https://www.elastic.co/docs/api/doc/elasticsearch#TODO",
       "description": "Get sampling configurations for all indices and data streams"
     },
     "stability": "experimental",
@@ -25,6 +25,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for connection to master node"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_sample.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_sample.json
@@ -1,11 +1,12 @@
 {
   "indices.get_sample": {
     "documentation": {
-      "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-get-sample",
+      "url": "https://www.elastic.co/docs/api/doc/elasticsearch#TODO",
       "description": "Get random sample of ingested data"
     },
     "stability": "experimental",
-    "visibility": "public",
+    "visibility": "feature_flag",
+    "feature_flag": "random_sampling",
     "headers": {
       "accept": [
         "application/json"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_sample_configuration.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_sample_configuration.json
@@ -1,7 +1,7 @@
 {
   "indices.get_sample_configuration": {
     "documentation": {
-      "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-get-sample-configuration",
+      "url": "https://www.elastic.co/docs/api/doc/elasticsearch#TODO",
       "description": "Get sampling configuration for an index or data stream"
     },
     "stability": "experimental",
@@ -31,6 +31,7 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for connection to master node"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_sample_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_sample_stats.json
@@ -1,11 +1,12 @@
 {
   "indices.get_sample_stats": {
     "documentation": {
-      "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-get-sample",
+      "url": "https://www.elastic.co/docs/api/doc/elasticsearch#TODO",
       "description": "Get stats about a random sample of ingested data"
     },
     "stability": "experimental",
-    "visibility": "public",
+    "visibility": "feature_flag",
+    "feature_flag": "random_sampling",
     "headers": {
       "accept": [
         "application/json"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_sample_configuration.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_sample_configuration.json
@@ -1,7 +1,7 @@
 {
   "indices.put_sample_configuration": {
     "documentation": {
-      "url": "https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-put-sample-configuration",
+      "url": "https://www.elastic.co/docs/api/doc/elasticsearch#TODO",
       "description": "Configure sampling for an index or data stream"
     },
     "stability": "experimental",
@@ -34,10 +34,12 @@
     "params": {
       "master_timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for connection to master node"
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for the request"
       }
     },


### PR DESCRIPTION
We agreed to use `https://www.elastic.co/docs/api/doc/elasticsearch#TODO` for unreleased APIs for now.

Relates https://github.com/elastic/elasticsearch-specification/pull/5668 as I'm trying to eliminate the differnces between rest-api-spec and the Elasticsearch specification.