### PR TITLE
[9.2] Fix for GET /_migration/deprecations doesn't check deprecated affix settings correctly (#137976)

### DIFF
--- a/docs/changelog/137976.yaml
+++ b/docs/changelog/137976.yaml
@@ -1,0 +1,7 @@
+pr: 137976
+summary: Fix for GET /_migration/deprecations doesn't check deprecated affix settings
+  correctly
+area: Infra/Core
+type: bug
+issues:
+ - 137008

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -77,6 +77,48 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         assertThat(issue.getUrl(), equalTo("https://removed-setting.example.com"));
     }
 
+    public void testRemovedAffixSetting() {
+        final Settings clusterSettings = Settings.EMPTY;
+        final Settings nodeSettings = Settings.builder().put("node.removed_setting.a.value", "value").build();
+        final Setting<?> removedSetting = Setting.affixKeySetting(
+            "node.removed_setting.",
+            "value",
+            key -> Setting.simpleString(key, Setting.Property.NodeScope)
+        );
+        final DeprecationIssue issue = NodeDeprecationChecks.checkRemovedSetting(
+            clusterSettings,
+            nodeSettings,
+            removedSetting,
+            "https://removed-setting.example.com",
+            "Some detail.",
+            DeprecationIssue.Level.CRITICAL
+        );
+        assertThat(issue, not(nullValue()));
+        assertThat(issue.getLevel(), equalTo(DeprecationIssue.Level.CRITICAL));
+        assertThat(issue.getMessage(), equalTo("Setting [node.removed_setting.*.value] is deprecated"));
+        assertThat(issue.getDetails(), equalTo("Remove the [node.removed_setting.*.value] setting. Some detail."));
+        assertThat(issue.getUrl(), equalTo("https://removed-setting.example.com"));
+    }
+
+    public void testRemovedGroupSetting() {
+        final Settings clusterSettings = Settings.EMPTY;
+        final Settings nodeSettings = Settings.builder().put("node.removed_setting.v", "value").build();
+        final Setting<?> removedSetting = Setting.groupSetting("node.removed_setting.", Setting.Property.NodeScope);
+        final DeprecationIssue issue = NodeDeprecationChecks.checkRemovedSetting(
+            clusterSettings,
+            nodeSettings,
+            removedSetting,
+            "https://removed-setting.example.com",
+            "Some detail.",
+            DeprecationIssue.Level.CRITICAL
+        );
+        assertThat(issue, not(nullValue()));
+        assertThat(issue.getLevel(), equalTo(DeprecationIssue.Level.CRITICAL));
+        assertThat(issue.getMessage(), equalTo("Setting [node.removed_setting.] is deprecated"));
+        assertThat(issue.getDetails(), equalTo("Remove the [node.removed_setting.] setting. Some detail."));
+        assertThat(issue.getUrl(), equalTo("https://removed-setting.example.com"));
+    }
+
     public void testMultipleRemovedSettings() {
         final Settings clusterSettings = Settings.EMPTY;
         final Settings nodeSettings = Settings.builder()


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Fix for GET /_migration/deprecations doesn't check deprecated affix settings correctly (#137976)