### PR TITLE
[8.19] Fix for GET /_migration/deprecations doesn't check deprecated affix settings correctly (#137976)

### DIFF
--- a/docs/changelog/137976.yaml
+++ b/docs/changelog/137976.yaml
@@ -1,0 +1,7 @@
+pr: 137976
+summary: Fix for GET /_migration/deprecations doesn't check deprecated affix settings
+  correctly
+area: Infra/Core
+type: bug
+issues:
+ - 137008

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -141,22 +141,30 @@ public class NodeDeprecationChecks {
         String additionalDetailMessage,
         DeprecationIssue.Level deprecationLevel
     ) {
-        if (removedSetting.exists(clusterSettings) == false && removedSetting.exists(nodeSettings) == false) {
+        boolean existsInClusterSettings = removedSetting.exists(clusterSettings);
+        boolean existsInNodeSettings = removedSetting.exists(nodeSettings);
+        if (existsInClusterSettings == false && existsInNodeSettings == false) {
             return null;
         }
         final String removedSettingKey = removedSetting.getKey();
         // read setting to force the deprecation warning
-        if (removedSetting.exists(clusterSettings)) {
-            removedSetting.get(clusterSettings);
+        Settings settings;
+        if (existsInClusterSettings) {
+            settings = clusterSettings;
         } else {
-            removedSetting.get(nodeSettings);
+            settings = nodeSettings;
+        }
+        if (removedSetting instanceof Setting.AffixSetting<?> affixSetting) {
+            affixSetting.getAsMap(settings);
+        } else {
+            removedSetting.get(settings);
         }
 
         final String message = String.format(Locale.ROOT, "Setting [%s] is deprecated", removedSettingKey);
         final String details = additionalDetailMessage == null
             ? String.format(Locale.ROOT, "Remove the [%s] setting.", removedSettingKey)
             : String.format(Locale.ROOT, "Remove the [%s] setting. %s", removedSettingKey, additionalDetailMessage);
-        boolean canAutoRemoveSetting = removedSetting.exists(clusterSettings) && removedSetting.exists(nodeSettings) == false;
+        boolean canAutoRemoveSetting = existsInClusterSettings && existsInNodeSettings == false;
         Map<String, Object> meta = createMetaMapForRemovableSettings(canAutoRemoveSetting, removedSettingKey);
         return new DeprecationIssue(deprecationLevel, message, url, details, false, meta);
     }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecksTests.java
@@ -78,6 +78,48 @@ public class NodeDeprecationChecksTests extends ESTestCase {
         assertThat(issue.getUrl(), equalTo("https://removed-setting.example.com"));
     }
 
+    public void testRemovedAffixSetting() {
+        final Settings clusterSettings = Settings.EMPTY;
+        final Settings nodeSettings = Settings.builder().put("node.removed_setting.a.value", "value").build();
+        final Setting<?> removedSetting = Setting.affixKeySetting(
+            "node.removed_setting.",
+            "value",
+            key -> Setting.simpleString(key, Setting.Property.NodeScope)
+        );
+        final DeprecationIssue issue = NodeDeprecationChecks.checkRemovedSetting(
+            clusterSettings,
+            nodeSettings,
+            removedSetting,
+            "https://removed-setting.example.com",
+            "Some detail.",
+            DeprecationIssue.Level.CRITICAL
+        );
+        assertThat(issue, not(nullValue()));
+        assertThat(issue.getLevel(), equalTo(DeprecationIssue.Level.CRITICAL));
+        assertThat(issue.getMessage(), equalTo("Setting [node.removed_setting.*.value] is deprecated"));
+        assertThat(issue.getDetails(), equalTo("Remove the [node.removed_setting.*.value] setting. Some detail."));
+        assertThat(issue.getUrl(), equalTo("https://removed-setting.example.com"));
+    }
+
+    public void testRemovedGroupSetting() {
+        final Settings clusterSettings = Settings.EMPTY;
+        final Settings nodeSettings = Settings.builder().put("node.removed_setting.v", "value").build();
+        final Setting<?> removedSetting = Setting.groupSetting("node.removed_setting.", Setting.Property.NodeScope);
+        final DeprecationIssue issue = NodeDeprecationChecks.checkRemovedSetting(
+            clusterSettings,
+            nodeSettings,
+            removedSetting,
+            "https://removed-setting.example.com",
+            "Some detail.",
+            DeprecationIssue.Level.CRITICAL
+        );
+        assertThat(issue, not(nullValue()));
+        assertThat(issue.getLevel(), equalTo(DeprecationIssue.Level.CRITICAL));
+        assertThat(issue.getMessage(), equalTo("Setting [node.removed_setting.] is deprecated"));
+        assertThat(issue.getDetails(), equalTo("Remove the [node.removed_setting.] setting. Some detail."));
+        assertThat(issue.getUrl(), equalTo("https://removed-setting.example.com"));
+    }
+
     public void testMultipleRemovedSettings() {
         final Settings clusterSettings = Settings.EMPTY;
         final Settings nodeSettings = Settings.builder()


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Fix for GET /_migration/deprecations doesn't check deprecated affix settings correctly (#137976)