### PR TITLE
Don't call start() when reading test cluster ports files

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalClusterHandle.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalClusterHandle.java
@@ -118,8 +118,11 @@ public class DefaultLocalClusterHandle implements LocalClusterHandle {
 
     @Override
     public String getHttpAddresses() {
-        start();
-        return execute(() -> nodes.parallelStream().map(Node::getHttpAddress).collect(Collectors.joining(",")));
+        if (started.get()) {
+            return execute(() -> nodes.parallelStream().map(Node::getHttpAddress).collect(Collectors.joining(",")));
+        } else {
+            throw new IllegalStateException("Elasticsearch cluster [" + name + "] has not been started.");
+        }
     }
 
     @Override
@@ -129,8 +132,12 @@ public class DefaultLocalClusterHandle implements LocalClusterHandle {
 
     @Override
     public String getTransportEndpoints() {
-        start();
-        return execute(() -> nodes.parallelStream().map(Node::getTransportEndpoint).collect(Collectors.joining(",")));
+        if (started.get()) {
+            return execute(() -> nodes.parallelStream().map(Node::getTransportEndpoint).collect(Collectors.joining(",")));
+        } else {
+            throw new IllegalStateException("Elasticsearch cluster [" + name + "] has not been started.");
+        }
+
     }
 
     @Override
@@ -153,8 +160,11 @@ public class DefaultLocalClusterHandle implements LocalClusterHandle {
 
     @Override
     public String getRemoteClusterServerEndpoints() {
-        start();
-        return execute(() -> nodes.parallelStream().map(Node::getRemoteClusterServerEndpoint).collect(Collectors.joining(",")));
+        if (started.get()) {
+            return execute(() -> nodes.parallelStream().map(Node::getRemoteClusterServerEndpoint).collect(Collectors.joining(",")));
+        } else {
+            throw new IllegalStateException("Elasticsearch cluster [" + name + "] has not been started.");
+        }
     }
 
     @Override


### PR DESCRIPTION
Calling methods on test clusters like `getHttpAddresses()` would previously call the `start()` method on the cluster, which blocks on verifying that the cluster is "ready". This can add unnecessary overhead to tests to validate the status of the cluster which has already been started. If for some reason we attempt to call these methods on an unstarted cluster, throw an exception instead.

See https://github.com/elastic/elasticsearch/issues/137379#issuecomment-3529589018