### PR TITLE
[9.2] Don't call start() when reading test cluster ports files (#138062)

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalClusterHandle.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalClusterHandle.java
@@ -118,8 +118,11 @@ public class DefaultLocalClusterHandle implements LocalClusterHandle {
 
     @Override
     public String getHttpAddresses() {
-        start();
-        return execute(() -> nodes.parallelStream().map(Node::getHttpAddress).collect(Collectors.joining(",")));
+        if (started.get()) {
+            return execute(() -> nodes.parallelStream().map(Node::getHttpAddress).collect(Collectors.joining(",")));
+        } else {
+            throw new IllegalStateException("Elasticsearch cluster [" + name + "] has not been started.");
+        }
     }
 
     @Override
@@ -129,8 +132,12 @@ public class DefaultLocalClusterHandle implements LocalClusterHandle {
 
     @Override
     public String getTransportEndpoints() {
-        start();
-        return execute(() -> nodes.parallelStream().map(Node::getTransportEndpoint).collect(Collectors.joining(",")));
+        if (started.get()) {
+            return execute(() -> nodes.parallelStream().map(Node::getTransportEndpoint).collect(Collectors.joining(",")));
+        } else {
+            throw new IllegalStateException("Elasticsearch cluster [" + name + "] has not been started.");
+        }
+
     }
 
     @Override
@@ -153,8 +160,11 @@ public class DefaultLocalClusterHandle implements LocalClusterHandle {
 
     @Override
     public String getRemoteClusterServerEndpoints() {
-        start();
-        return execute(() -> nodes.parallelStream().map(Node::getRemoteClusterServerEndpoint).collect(Collectors.joining(",")));
+        if (started.get()) {
+            return execute(() -> nodes.parallelStream().map(Node::getRemoteClusterServerEndpoint).collect(Collectors.joining(",")));
+        } else {
+            throw new IllegalStateException("Elasticsearch cluster [" + name + "] has not been started.");
+        }
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Don't call start() when reading test cluster ports files (#138062)