### PR TITLE
Fixes esql class cast bug in STATS at runtime level

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AbstractPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AbstractPhysicalOperationProviders.java
@@ -40,10 +40,8 @@ import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner.PhysicalOperat
 
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -250,7 +248,6 @@ public abstract class AbstractPhysicalOperationProviders implements PhysicalOper
     private static class IntermediateInputs {
         private final List<Attribute> inputAttributes;
         private int nextOffset;
-        private final Map<AggregateFunction, Integer> offsets = new HashMap<>();
 
         IntermediateInputs(AggregateExec aggregateExec) {
             inputAttributes = aggregateExec.child().output();
@@ -259,12 +256,10 @@ public abstract class AbstractPhysicalOperationProviders implements PhysicalOper
 
         List<Attribute> nextInputAttributes(AggregateFunction af, boolean grouping) {
             int intermediateStateSize = AggregateMapper.intermediateStateDesc(af, grouping).size();
-            int offset = offsets.computeIfAbsent(af, unused -> {
-                int v = nextOffset;
-                nextOffset += intermediateStateSize;
-                return v;
-            });
-            return inputAttributes.subList(offset, offset + intermediateStateSize);
+            int endOffset = nextOffset + intermediateStateSize;
+            List<Attribute> attributes = inputAttributes.subList(nextOffset, endOffset);
+            nextOffset = endOffset;
+            return attributes;
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AggregateMapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AggregateMapper.java
@@ -13,7 +13,6 @@ import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
-import org.elasticsearch.xpack.esql.core.expression.AttributeMap;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
@@ -23,9 +22,8 @@ import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
 
-import java.util.HashSet;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Stream;
 
 /**
@@ -42,17 +40,12 @@ public final class AggregateMapper {
     }
 
     private static List<NamedExpression> doMapping(List<? extends NamedExpression> aggregates, boolean grouping) {
-        Set<Expression> seen = new HashSet<>();
-        AttributeMap.Builder<NamedExpression> attrToExpressionsBuilder = AttributeMap.builder();
+        List<NamedExpression> namedExpressions = new ArrayList<>();
         for (NamedExpression agg : aggregates) {
             Expression inner = Alias.unwrap(agg);
-            if (seen.add(inner)) {
-                for (var ne : computeEntryForAgg(agg.name(), inner, grouping)) {
-                    attrToExpressionsBuilder.put(ne.toAttribute(), ne);
-                }
-            }
+            namedExpressions.addAll(computeEntryForAgg(agg.name(), inner, grouping));
         }
-        return attrToExpressionsBuilder.build().values().stream().toList();
+        return namedExpressions;
     }
 
     public static List<IntermediateStateDesc> intermediateStateDesc(AggregateFunction fn, boolean grouping) {


### PR DESCRIPTION
Addresses the runtime side of https://github.com/elastic/elasticsearch/issues/133992 and https://github.com/elastic/elasticsearch/issues/136598. Builds on top of https://github.com/elastic/elasticsearch/pull/137511

Queries like:

```sql
from airports 
rename scalerank AS x 
stats  a = count(x), b = count(x) + count(x), c = count_distinct(x)
```

They should never fail at runtime even if the plan was not optimal for repeated aggregations.

Closes #138653 