### PR TITLE
Use mock ML model server in yaml tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -86,9 +86,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/120339
 - class: org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeToCharProcessorTests
   issue: https://github.com/elastic/elasticsearch/issues/120575
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=ml/3rd_party_deployment/Test start deployment fails while model download in progress}
-  issue: https://github.com/elastic/elasticsearch/issues/120810
 - class: org.elasticsearch.xpack.security.authc.service.ServiceAccountIT
   method: testAuthenticateShouldNotFallThroughInCaseOfFailure
   issue: https://github.com/elastic/elasticsearch/issues/120902
@@ -113,12 +110,6 @@ tests:
 - class: org.elasticsearch.indices.recovery.IndexRecoveryIT
   method: testSourceThrottling
   issue: https://github.com/elastic/elasticsearch/issues/123680
-- class: org.elasticsearch.smoketest.MlWithSecurityIT
-  method: test {yaml=ml/3rd_party_deployment/Test start deployment fails while model download in progress}
-  issue: https://github.com/elastic/elasticsearch/issues/120814
-- class: org.elasticsearch.smoketest.MlWithSecurityIT
-  method: test {yaml=ml/3rd_party_deployment/Test start and stop multiple deployments}
-  issue: https://github.com/elastic/elasticsearch/issues/124315
 - class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
   method: testDeploymentSurvivesRestart {cluster=OLD}
   issue: https://github.com/elastic/elasticsearch/issues/124160

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -21,6 +21,7 @@ dependencies {
   testImplementation project(xpackModule('core'))
   testImplementation(testArtifact(project(xpackModule('core'))))
   testImplementation(testArtifact(project(":x-pack:plugin:security:qa:service-account"), "javaRestTest"))
+  testImplementation(testArtifact(project(':x-pack:plugin:inference:qa:inference-service-tests'), "javaRestTest"))
   testImplementation project(':test:yaml-rest-runner')
 }
 

--- a/x-pack/plugin/inference/qa/inference-service-tests/build.gradle
+++ b/x-pack/plugin/inference/qa/inference-service-tests/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'elasticsearch.internal-java-rest-test'
+apply plugin: 'elasticsearch.internal-test-artifact'
 
 dependencies {
   javaRestTestImplementation project(path: xpackModule('core'))

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceBaseRestTest.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceBaseRestTest.java
@@ -60,15 +60,7 @@ public class InferenceBaseRestTest extends ESRestTestCase {
 
     @Before
     public void setMlModelRepository() throws IOException {
-        logger.info("setting ML model repository to: {}", mlModelServer.getUrl());
-        var request = new Request("PUT", "/_cluster/settings");
-        request.setJsonEntity(Strings.format("""
-            {
-              "persistent": {
-                "xpack.ml.model_repository": "%s"
-              }
-            }""", mlModelServer.getUrl()));
-        assertOK(client().performRequest(request));
+        assertOK(mlModelServer.setMlModelRepository(client()));
     }
 
     @Override

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceBaseRestTest.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceBaseRestTest.java
@@ -60,7 +60,7 @@ public class InferenceBaseRestTest extends ESRestTestCase {
 
     @Before
     public void setMlModelRepository() throws IOException {
-        assertOK(mlModelServer.setMlModelRepository(client()));
+        assertOK(mlModelServer.setMlModelRepository(adminClient()));
     }
 
     @Override

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/MlModelServer.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/MlModelServer.java
@@ -13,6 +13,10 @@ import com.sun.net.httpserver.HttpServer;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.utils.URIBuilder;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.test.fixture.HttpHeaderParser;
@@ -48,7 +52,19 @@ public class MlModelServer implements TestRule {
 
     private int port;
 
-    public String getUrl() {
+    public Response setMlModelRepository(RestClient restClient) throws IOException {
+        logger.info("setting ML model repository to: {}", getUrl());
+        var request = new Request("PUT", "/_cluster/settings");
+        request.setJsonEntity(Strings.format("""
+            {
+              "persistent": {
+                "xpack.ml.model_repository": "%s"
+              }
+            }""", getUrl()));
+        return restClient.performRequest(request);
+    }
+
+    private String getUrl() {
         return new URIBuilder().setScheme("http").setHost(HOST).setPort(port).toString();
     }
 

--- a/x-pack/plugin/src/test/java/org/elasticsearch/xpack/test/rest/AbstractXPackRestTest.java
+++ b/x-pack/plugin/src/test/java/org/elasticsearch/xpack/test/rest/AbstractXPackRestTest.java
@@ -37,6 +37,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import org.elasticsearch.xpack.inference.MlModelServer;
+import org.junit.ClassRule;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonMap;
@@ -49,6 +51,14 @@ public abstract class AbstractXPackRestTest extends ESClientYamlSuiteTestCase {
         "x_pack_rest_user",
         SecuritySettingsSourceField.TEST_PASSWORD_SECURE_STRING
     );
+
+    @ClassRule
+    public static MlModelServer mlModelServer = new MlModelServer();
+
+    @Before
+    public void setMlModelRepository() throws IOException {
+        assertOK(mlModelServer.setMlModelRepository(client()));
+    }
 
     public AbstractXPackRestTest(ClientYamlTestCandidate testCandidate) {
         super(testCandidate);

--- a/x-pack/plugin/src/test/java/org/elasticsearch/xpack/test/rest/AbstractXPackRestTest.java
+++ b/x-pack/plugin/src/test/java/org/elasticsearch/xpack/test/rest/AbstractXPackRestTest.java
@@ -25,8 +25,10 @@ import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndexFields;
 import org.elasticsearch.xpack.core.ml.notifications.NotificationsIndex;
 import org.elasticsearch.xpack.core.rollup.job.RollupJob;
+import org.elasticsearch.xpack.inference.MlModelServer;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -37,8 +39,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
-import org.elasticsearch.xpack.inference.MlModelServer;
-import org.junit.ClassRule;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonMap;

--- a/x-pack/plugin/src/test/java/org/elasticsearch/xpack/test/rest/AbstractXPackRestTest.java
+++ b/x-pack/plugin/src/test/java/org/elasticsearch/xpack/test/rest/AbstractXPackRestTest.java
@@ -57,7 +57,7 @@ public abstract class AbstractXPackRestTest extends ESClientYamlSuiteTestCase {
 
     @Before
     public void setMlModelRepository() throws IOException {
-        assertOK(mlModelServer.setMlModelRepository(client()));
+        assertOK(mlModelServer.setMlModelRepository(adminClient()));
     }
 
     public AbstractXPackRestTest(ClientYamlTestCandidate testCandidate) {


### PR DESCRIPTION
fixes #120814 #120810 #124315 #128899 

Using https://ml-models.elastic.co/ from the tests will inevitably lead to some failure at some point in time