### PR TITLE
[DiskBBQ] avoid EsAcceptDocs bug by calling cost before building iterator

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQVectorsReader.java
@@ -120,7 +120,11 @@ public class ESNextDiskBBQVectorsReader extends IVFVectorsReader {
         float visitRatio
     ) throws IOException {
         final FieldEntry fieldEntry = fields.get(fieldInfo.number);
-        final float approximateDocsPerCentroid = approximateCost / numCentroids;
+        float approximateDocsPerCentroid = approximateCost / numCentroids;
+        if (approximateDocsPerCentroid <= 1.25) {
+            // TODO: we need to make this call to build the iterator, otherwise accept docs breaks all together
+            approximateDocsPerCentroid = acceptDocs.cost();
+        }
         final int bitsRequired = DirectWriter.bitsRequired(numCentroids);
         final long sizeLookup = directWriterSizeOnDisk(values.size(), bitsRequired);
         final long fp = centroids.getFilePointer();


### PR DESCRIPTION
 Nightly benchmarks are failing with the following error:

```
Caused by: java.lang.IllegalStateException: This operation only works with an unpositioned iterator, got current position = 2147483647
        Suppressed: java.lang.IllegalStateException: This operation only works with an unpositioned iterator, got current position = 2147483647
```

This happens whenever we call `EsAcceptDocs#iterator` and then `EsAcceptDocs#bits` and the underlaying structure is not a bitset. 

More over if you try the combination `EsAcceptDocs#bits` and then `EsAcceptDocs#iterator` you get a different error:

```
 Exception in thread "main" java.lang.IllegalArgumentException: cost must be >= 0, got -1
        at org.apache.lucene.util.BitSetIterator.<init>(BitSetIterator.java:61)
```

Therefore in order to run those two methods you need to call `EsAcceptDocs#cost`. I am hacking this in this PR so we can get some nightly benchmarks data points.