### PR TITLE
remove redundant field

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/index/IndexResolution.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/index/IndexResolution.java
@@ -18,22 +18,20 @@ public final class IndexResolution {
 
     /**
      * @param index EsIndex encapsulating requested index expression, resolved mappings and index modes from field-caps.
-     * @param resolvedIndices Set of concrete indices resolved by field-caps. (This information is not always present in the EsIndex).
      * @param failures failures occurred during field-caps.
      * @return valid IndexResolution
      */
-    public static IndexResolution valid(EsIndex index, Set<String> resolvedIndices, Map<String, List<FieldCapabilitiesFailure>> failures) {
+    public static IndexResolution valid(EsIndex index, Map<String, List<FieldCapabilitiesFailure>> failures) {
         Objects.requireNonNull(index, "index must not be null if it was found");
-        Objects.requireNonNull(resolvedIndices, "resolvedIndices must not be null");
         Objects.requireNonNull(failures, "failures must not be null");
-        return new IndexResolution(index, null, resolvedIndices, failures);
+        return new IndexResolution(index, null, failures);
     }
 
     /**
      * Use this method only if the set of concrete resolved indices is the same as EsIndex#concreteIndices().
      */
     public static IndexResolution valid(EsIndex index) {
-        return valid(index, index.concreteIndices(), Map.of());
+        return valid(index, Map.of());
     }
 
     public static IndexResolution empty(String indexPattern) {
@@ -42,7 +40,7 @@ public final class IndexResolution {
 
     public static IndexResolution invalid(String invalid) {
         Objects.requireNonNull(invalid, "invalid must not be null to signal that the index is invalid");
-        return new IndexResolution(null, invalid, Set.of(), Map.of());
+        return new IndexResolution(null, invalid, Map.of());
     }
 
     public static IndexResolution notFound(String name) {
@@ -53,21 +51,12 @@ public final class IndexResolution {
     private final EsIndex index;
     @Nullable
     private final String invalid;
-
-    // all indices found by field-caps
-    private final Set<String> resolvedIndices;
     // map from cluster alias to failures that occurred during field-caps.
     private final Map<String, List<FieldCapabilitiesFailure>> failures;
 
-    private IndexResolution(
-        EsIndex index,
-        @Nullable String invalid,
-        Set<String> resolvedIndices,
-        Map<String, List<FieldCapabilitiesFailure>> failures
-    ) {
+    private IndexResolution(EsIndex index, @Nullable String invalid, Map<String, List<FieldCapabilitiesFailure>> failures) {
         this.index = index;
         this.invalid = invalid;
-        this.resolvedIndices = resolvedIndices;
         this.failures = failures;
     }
 
@@ -101,44 +90,24 @@ public final class IndexResolution {
         return failures;
     }
 
-    /**
-     * @return all indices found by field-caps (regardless of whether they had any mappings)
-     */
-    public Set<String> resolvedIndices() {
-        return resolvedIndices;
-    }
-
     @Override
     public boolean equals(Object obj) {
         if (obj == null || obj.getClass() != getClass()) {
             return false;
         }
         IndexResolution other = (IndexResolution) obj;
-        return Objects.equals(index, other.index)
-            && Objects.equals(invalid, other.invalid)
-            && Objects.equals(resolvedIndices, other.resolvedIndices)
-            && Objects.equals(failures, other.failures);
+        return Objects.equals(index, other.index) && Objects.equals(invalid, other.invalid) && Objects.equals(failures, other.failures);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(index, invalid, resolvedIndices, failures);
+        return Objects.hash(index, invalid, failures);
     }
 
     @Override
     public String toString() {
         return invalid != null
             ? invalid
-            : "IndexResolution{"
-                + "index="
-                + index
-                + ", invalid='"
-                + invalid
-                + '\''
-                + ", resolvedIndices="
-                + resolvedIndices
-                + ", unavailableClusters="
-                + failures
-                + '}';
+            : "IndexResolution{" + "index=" + index + ", invalid='" + invalid + "', unavailableClusters=" + failures + '}';
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlCCSUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlCCSUtils.java
@@ -197,7 +197,7 @@ public class EsqlCCSUtils {
         // NOTE: we assume that updateExecutionInfoWithUnavailableClusters() was already run and took care of unavailable clusters.
         final Set<String> clustersWithNoMatchingIndices = executionInfo.getRunningClusterAliases().collect(toSet());
         for (IndexResolution indexResolution : indexResolutions) {
-            for (String indexName : indexResolution.resolvedIndices()) {
+            for (String indexName : indexResolution.get().concreteIndices()) {
                 clustersWithNoMatchingIndices.remove(RemoteClusterAware.parseClusterAlias(indexName));
             }
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/IndexResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/IndexResolver.java
@@ -274,7 +274,7 @@ public class IndexResolver {
         // errors.
         var index = new EsIndex(indexPattern, rootFields, allEmpty ? Map.of() : concreteIndices, partiallyUnmappedFields);
         var failures = EsqlCCSUtils.groupFailuresPerCluster(fieldsInfo.caps.getFailures());
-        return IndexResolution.valid(index, concreteIndices.keySet(), failures);
+        return IndexResolution.valid(index, failures);
     }
 
     private record IndexFieldCapabilitiesWithSourceHash(List<IndexFieldCapabilities> fieldCapabilities, String indexMappingHash) {}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/EsqlCCSUtilsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/EsqlCCSUtilsTests.java
@@ -222,7 +222,7 @@ public class EsqlCCSUtilsTests extends ESTestCase {
                 )
             );
 
-            IndexResolution indexResolution = IndexResolution.valid(esIndex, esIndex.concreteIndices(), Map.of());
+            IndexResolution indexResolution = IndexResolution.valid(esIndex, Map.of());
 
             EsqlCCSUtils.updateExecutionInfoWithClustersWithNoMatchingIndices(executionInfo, Set.of(indexResolution));
 
@@ -265,7 +265,7 @@ public class EsqlCCSUtilsTests extends ESTestCase {
                     IndexMode.STANDARD
                 )
             );
-            IndexResolution indexResolution = IndexResolution.valid(esIndex, esIndex.concreteIndices(), Map.of());
+            IndexResolution indexResolution = IndexResolution.valid(esIndex, Map.of());
 
             EsqlCCSUtils.updateExecutionInfoWithClustersWithNoMatchingIndices(executionInfo, Set.of(indexResolution));
 
@@ -307,7 +307,7 @@ public class EsqlCCSUtilsTests extends ESTestCase {
             // remote1 is unavailable
             var failure = new FieldCapabilitiesFailure(new String[] { "logs-a" }, new NoSeedNodeLeftException("unable to connect"));
             var failures = Map.of(REMOTE1_ALIAS, List.of(failure));
-            IndexResolution indexResolution = IndexResolution.valid(esIndex, esIndex.concreteIndices(), failures);
+            IndexResolution indexResolution = IndexResolution.valid(esIndex, failures);
 
             EsqlCCSUtils.updateExecutionInfoWithClustersWithNoMatchingIndices(executionInfo, Set.of(indexResolution));
 
@@ -349,7 +349,7 @@ public class EsqlCCSUtilsTests extends ESTestCase {
 
             var failure = new FieldCapabilitiesFailure(new String[] { "logs-a" }, new NoSeedNodeLeftException("unable to connect"));
             var failures = Map.of(REMOTE1_ALIAS, List.of(failure));
-            IndexResolution indexResolution = IndexResolution.valid(esIndex, esIndex.concreteIndices(), failures);
+            IndexResolution indexResolution = IndexResolution.valid(esIndex, failures);
             EsqlCCSUtils.updateExecutionInfoWithClustersWithNoMatchingIndices(executionInfo, Set.of(indexResolution));
 
             EsqlExecutionInfo.Cluster localCluster = executionInfo.getCluster(LOCAL_CLUSTER_ALIAS);
@@ -397,7 +397,7 @@ public class EsqlCCSUtilsTests extends ESTestCase {
             // remote1 is unavailable
             var failure = new FieldCapabilitiesFailure(new String[] { "logs-a" }, new NoSeedNodeLeftException("unable to connect"));
             var failures = Map.of(REMOTE1_ALIAS, List.of(failure));
-            IndexResolution indexResolution = IndexResolution.valid(esIndex, esIndex.concreteIndices(), failures);
+            IndexResolution indexResolution = IndexResolution.valid(esIndex, failures);
 
             EsqlCCSUtils.updateExecutionInfoWithClustersWithNoMatchingIndices(executionInfo, Set.of(indexResolution));
 


### PR DESCRIPTION
This change removes `org.elasticsearch.xpack.esql.index.IndexResolution#resolvedIndices` as it is duplicating `IndexResolution#index#concreteIndices()`