### PR TITLE
Ensure IndicesOptions are mutated for GetInferenceFieldsActionRequest…

### DIFF
--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/GetInferenceFieldsActionRequestTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/GetInferenceFieldsActionRequestTests.java
@@ -90,7 +90,13 @@ public class GetInferenceFieldsActionRequestTests extends AbstractBWCWireSeriali
                 instance.resolveWildcards(),
                 instance.useDefaultFields(),
                 instance.getQuery(),
-                randomValueOtherThan(instance.getIndicesOptions(), GetInferenceFieldsActionRequestTests::randomIndicesOptions)
+                randomValueOtherThan(instance.getIndicesOptions(), () -> {
+                    IndicesOptions newOptions = randomIndicesOptions();
+                    while (instance.getIndicesOptions() == IndicesOptions.DEFAULT && newOptions == null) {
+                        newOptions = randomIndicesOptions();
+                    }
+                    return newOptions;
+                })
             );
             default -> throw new AssertionError("Invalid value");
         };


### PR DESCRIPTION
…Tests

When `IndicesOptions` are mutated, we may produce `null`. The request constructor sets indices options to the default ones when the argument is `null`. Thus, if the original instance had the default `IndicesOptions` to begin with, we will end up with a mutation that is identical.

This fixes this by generating a new random `IndicesOptions` object in the case above.

Closed #138134
