### PR TITLE
[8.19] [ML] Bump anomalies index template version (#138097)

### DIFF
--- a/docs/changelog/138097.yaml
+++ b/docs/changelog/138097.yaml
@@ -1,0 +1,5 @@
+pr: 138097
+summary: Bump anomalies index template version to install latest
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistry.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistry.java
@@ -40,9 +40,10 @@ public class MlIndexTemplateRegistry extends IndexTemplateRegistry {
      * the state index has no mappings - its template basically just says
      * this - hence there's no mappings version for the state index. Please
      * add a comment with a reason each time the base number is incremented.
-     * 10000001: TODO - reason
+     *
+     * 10000001: ".reindexed-v7-ml-anomalies-*" added to ml-anomalies index pattern
      */
-    public static final int ML_INDEX_TEMPLATE_VERSION = 10000000 + AnomalyDetectorsIndex.RESULTS_INDEX_MAPPINGS_VERSION
+    public static final int ML_INDEX_TEMPLATE_VERSION = 10000001 + AnomalyDetectorsIndex.RESULTS_INDEX_MAPPINGS_VERSION
         + NotificationsIndex.NOTIFICATIONS_INDEX_MAPPINGS_VERSION + MlStatsIndex.STATS_INDEX_MAPPINGS_VERSION
         + NotificationsIndex.NOTIFICATIONS_INDEX_TEMPLATE_VERSION;
 

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlMappingsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlMappingsUpgradeIT.java
@@ -25,6 +25,7 @@ import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -82,6 +83,14 @@ public class MlMappingsUpgradeIT extends AbstractUpgradeTestCase {
                 assertLegacyIndicesRollover();
                 assertAnomalyIndicesRollover();
                 assertNotificationsIndexAliasCreated();
+                assertBusy(
+                    () -> IndexMappingTemplateAsserter.assertTemplateVersionAndPattern(
+                        client(),
+                        ".ml-anomalies-",
+                        10000005,
+                        List.of(".ml-anomalies-*", ".reindexed-v7-ml-anomalies-*")
+                    )
+                );
                 break;
             default:
                 throw new UnsupportedOperationException("Unknown cluster type [" + CLUSTER_TYPE + "]");

--- a/x-pack/qa/src/main/java/org/elasticsearch/xpack/test/rest/IndexMappingTemplateAsserter.java
+++ b/x-pack/qa/src/main/java/org/elasticsearch/xpack/test/rest/IndexMappingTemplateAsserter.java
@@ -120,7 +120,7 @@ public class IndexMappingTemplateAsserter {
             "index_templates",
             "index_template",
             "version"
-        )).getFirst();
+        )).get(0);
         assertEquals(version, templateVersion.intValue());
 
         var templateIndexPatterns = ((List<String>) XContentMapValues.extractValue(


### PR DESCRIPTION
Backports the following commits to 8.19:
 - [ML] Bump anomalies index template version (#138097)