### PR TITLE
[DiskBBQ] Fix Computation of DocsPerCentroid

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQVectorsReader.java
@@ -123,7 +123,7 @@ public class ESNextDiskBBQVectorsReader extends IVFVectorsReader {
         float approximateDocsPerCentroid = approximateCost / numCentroids;
         if (approximateDocsPerCentroid <= 1.25) {
             // TODO: we need to make this call to build the iterator, otherwise accept docs breaks all together
-            approximateDocsPerCentroid = acceptDocs.cost();
+            approximateDocsPerCentroid = (float) acceptDocs.cost() / numCentroids;
         }
         final int bitsRequired = DirectWriter.bitsRequired(numCentroids);
         final long sizeLookup = directWriterSizeOnDisk(values.size(), bitsRequired);


### PR DESCRIPTION
This commit fixes the computation of docs per centroid added in https://github.com/elastic/elasticsearch/pull/138127.