### PR TITLE
Remove unused code

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
@@ -324,7 +324,8 @@ public final class EsqlTestUtils {
     }
 
     public static EsRelation relation(IndexMode mode) {
-        return new EsRelation(EMPTY, new EsIndex(randomAlphaOfLength(8), emptyMap()), mode);
+        var index = new EsIndex(randomAlphaOfLength(8), emptyMap());
+        return new EsRelation(EMPTY, index.name(), mode, index.indexNameWithModes(), List.of());
     }
 
     /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/EsRelation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/EsRelation.java
@@ -12,19 +12,15 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
-import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.NodeUtils;
 import org.elasticsearch.xpack.esql.core.tree.Source;
-import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.index.EsIndex;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 
@@ -39,10 +35,6 @@ public class EsRelation extends LeafPlan {
     private final IndexMode indexMode;
     private final Map<String, IndexMode> indexNameWithModes;
     private final List<Attribute> attrs;
-
-    public EsRelation(Source source, EsIndex index, IndexMode indexMode) {
-        this(source, index.name(), indexMode, index.indexNameWithModes(), flatten(source, index.mapping()));
-    }
 
     public EsRelation(
         Source source,
@@ -102,35 +94,6 @@ public class EsRelation extends LeafPlan {
     @Override
     protected NodeInfo<EsRelation> info() {
         return NodeInfo.create(this, EsRelation::new, indexPattern, indexMode, indexNameWithModes, attrs);
-    }
-
-    private static List<Attribute> flatten(Source source, Map<String, EsField> mapping) {
-        return flatten(source, mapping, null);
-    }
-
-    private static List<Attribute> flatten(Source source, Map<String, EsField> mapping, FieldAttribute parent) {
-        List<Attribute> list = new ArrayList<>();
-
-        for (Entry<String, EsField> entry : mapping.entrySet()) {
-            String name = entry.getKey();
-            EsField t = entry.getValue();
-
-            if (t != null) {
-                FieldAttribute f = new FieldAttribute(
-                    source,
-                    parent != null ? parent.name() : null,
-                    null,
-                    parent != null ? parent.name() + "." + name : name,
-                    t
-                );
-                list.add(f);
-                // object or nested
-                if (t.getProperties().isEmpty() == false) {
-                    list.addAll(flatten(source, t.getProperties(), f));
-                }
-            }
-        }
-        return list;
     }
 
     public String indexPattern() {


### PR DESCRIPTION
This change removes a constructor as well as a flatten method that were effectively used only in test with empty collections.