### PR TITLE
[8.19] Fix default value for some settings when filtered (#137652)

### DIFF
--- a/docs/changelog/137652.yaml
+++ b/docs/changelog/137652.yaml
@@ -1,0 +1,6 @@
+pr: 137652
+summary: Fix default value for some settings when filtered
+area: Infra/Settings
+type: bug
+issues:
+ - 136333

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsIT.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.action.admin.indices.settings.get;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.LambdaMatchers;
+
+import java.util.Map;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.equalTo;
+
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE)
+public class GetSettingsIT extends ESIntegTestCase {
+    public void testGetDefaultValueWhenDependentOnOtherSettings() {
+        final String indexName = "test-index-1";
+
+        Settings expectedSettings = Settings.builder()
+            .put("index.mapping.source.mode", "SYNTHETIC")
+            .put("index.mapping.total_fields.ignore_dynamic_beyond_limit", true)
+            .put("index.recovery.use_synthetic_source", true)
+            .put("index.use_time_series_doc_values_format", true)
+            .put("index.mapping.ignore_above", 8191)
+            .putList("index.sort.field", "@timestamp")
+            .putList("index.sort.order", "desc")
+            .putList("index.sort.mode", "max")
+            .putList("index.sort.missing", "_last")
+            .build();
+
+        assertAcked(prepareCreate(indexName).setSettings(Settings.builder().put("index.mode", "logsdb")).get());
+        GetSettingsResponse unfilteredResponse = indicesAdmin().getSettings(
+            new GetSettingsRequest(TEST_REQUEST_TIMEOUT).indices(indexName).includeDefaults(true)
+        ).actionGet();
+        for (String key : expectedSettings.keySet()) {
+            assertThat(unfilteredResponse.getSetting(indexName, key), equalTo(expectedSettings.get(key)));
+            GetSettingsResponse filteredResponse = indicesAdmin().getSettings(
+                new GetSettingsRequest(TEST_REQUEST_TIMEOUT).indices(indexName).includeDefaults(true).names(key)
+            ).actionGet();
+
+            var expectedFilteredSettingsMap = Map.of(indexName, expectedSettings.filter(key::equals));
+            assertThat(
+                filteredResponse,
+                LambdaMatchers.transformedMatch(GetSettingsResponse::getIndexToDefaultSettings, equalTo(expectedFilteredSettingsMap))
+            );
+        }
+
+    }
+}

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsIT.java
@@ -27,12 +27,7 @@ public class GetSettingsIT extends ESIntegTestCase {
             .put("index.mapping.source.mode", "SYNTHETIC")
             .put("index.mapping.total_fields.ignore_dynamic_beyond_limit", true)
             .put("index.recovery.use_synthetic_source", true)
-            .put("index.use_time_series_doc_values_format", true)
             .put("index.mapping.ignore_above", 8191)
-            .putList("index.sort.field", "@timestamp")
-            .putList("index.sort.order", "desc")
-            .putList("index.sort.mode", "max")
-            .putList("index.sort.missing", "_last")
             .build();
 
         assertAcked(prepareCreate(indexName).setSettings(Settings.builder().put("index.mode", "logsdb")).get());

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsIT.java
@@ -37,12 +37,12 @@ public class GetSettingsIT extends ESIntegTestCase {
 
         assertAcked(prepareCreate(indexName).setSettings(Settings.builder().put("index.mode", "logsdb")).get());
         GetSettingsResponse unfilteredResponse = indicesAdmin().getSettings(
-            new GetSettingsRequest(TEST_REQUEST_TIMEOUT).indices(indexName).includeDefaults(true)
+            new GetSettingsRequest().indices(indexName).includeDefaults(true)
         ).actionGet();
         for (String key : expectedSettings.keySet()) {
             assertThat(unfilteredResponse.getSetting(indexName, key), equalTo(expectedSettings.get(key)));
             GetSettingsResponse filteredResponse = indicesAdmin().getSettings(
-                new GetSettingsRequest(TEST_REQUEST_TIMEOUT).indices(indexName).includeDefaults(true).names(key)
+                new GetSettingsRequest().indices(indexName).includeDefaults(true).names(key)
             ).actionGet();
 
             var expectedFilteredSettingsMap = Map.of(indexName, expectedSettings.filter(key::equals));

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/TransportGetSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/TransportGetSettingsAction.java
@@ -106,7 +106,7 @@ public class TransportGetSettingsAction extends TransportMasterNodeReadAction<Ge
 
             indexToSettings.put(concreteIndex.getName(), indexSettings);
             if (indexToDefaultSettings != null) {
-                Settings defaultSettings = settingsFilter.filter(indexScopedSettings.diff(indexSettings, Settings.EMPTY));
+                Settings defaultSettings = settingsFilter.filter(indexScopedSettings.diff(indexMetadata.getSettings(), Settings.EMPTY));
                 if (isFilteredRequest(request)) {
                     defaultSettings = defaultSettings.filter(k -> Regex.simpleMatch(request.names(), k));
                 }

--- a/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/10_setting.yml
+++ b/x-pack/plugin/logsdb/src/yamlRestTest/resources/rest-api-spec/test/10_setting.yml
@@ -1,5 +1,4 @@
----
-synthetic_source_keep defaults:
+setup:
   - requires:
       test_runner_features: [ capabilities ]
       capabilities:
@@ -8,6 +7,8 @@ synthetic_source_keep defaults:
           capabilities: [ logsdb_index_mode ]
       reason: "Support for 'logsdb' index mode capability required"
 
+---
+synthetic_source_keep defaults:
   - do:
       indices.create:
         index: test1
@@ -37,3 +38,38 @@ synthetic_source_keep defaults:
   - is_true: test2
   - is_false: test2.settings.index.mode
   - match: { test2.defaults.index.mapping.synthetic_source_keep: "none" }
+
+---
+total_fields.ignore_dynamic_beyond_limit defaults:
+  - do:
+      indices.put_index_template:
+        name: template-foo
+        body:
+          index_patterns: ["ds-foo*"]
+          data_stream: {}
+          priority: 700
+          template:
+            settings:
+              index.mode: logsdb
+
+  - do:
+      indices.create_data_stream:
+        name: ds-foo
+
+  - do:
+      indices.get_data_stream:
+        name: ds-foo
+  - set: { data_streams.0.indices.0.index_name: backing_index }
+
+  - do:
+      indices.get_settings:
+        index: ds-foo
+        include_defaults: true
+  - match: { .$backing_index.defaults.index.mapping.total_fields.ignore_dynamic_beyond_limit: "true" }
+
+  - do:
+      indices.get_settings:
+        index: ds-foo
+        name: index.mapping.total_fields.ignore_dynamic_beyond_limit
+        include_defaults: true
+  - match: { .$backing_index.defaults.index.mapping.total_fields.ignore_dynamic_beyond_limit: "true" }


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Fix default value for some settings when filtered (#137652)