### PR TITLE
[9.2] [Test] Fix NodeShutdownIT testStalledShardMigrationProperlyDetected (#138150)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -555,9 +555,6 @@ tests:
 - class: org.elasticsearch.xpack.inference.InferenceRestIT
   method: test {p0=inference/70_text_similarity_rank_retriever/Text similarity reranker with min_score zero includes all docs}
   issue: https://github.com/elastic/elasticsearch/issues/137732
-- class: org.elasticsearch.xpack.shutdown.NodeShutdownIT
-  method: testStalledShardMigrationProperlyDetected
-  issue: https://github.com/elastic/elasticsearch/issues/115697
 
 # Examples:
 #

--- a/x-pack/plugin/shutdown/qa/multi-node/build.gradle
+++ b/x-pack/plugin/shutdown/qa/multi-node/build.gradle
@@ -11,4 +11,5 @@ testClusters.configureEach {
   testDistribution = 'DEFAULT'
   numberOfNodes = 4
   readinessEnabled = true
+  systemProperty 'es.queryable_built_in_roles_enabled', 'false'
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[Test] Fix NodeShutdownIT testStalledShardMigrationProperlyDetected (#138150)](https://github.com/elastic/elasticsearch/pull/138150)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)