### PR TITLE
[9.2] FIX: return builtin CuVSProvider when mock is null in internalClusterTests (#138155)

### DIFF
--- a/x-pack/plugin/gpu/src/internalClusterTest/java/org/elasticsearch/plugin/gpu/TestCuVSServiceProvider.java
+++ b/x-pack/plugin/gpu/src/internalClusterTest/java/org/elasticsearch/plugin/gpu/TestCuVSServiceProvider.java
@@ -25,6 +25,9 @@ public class TestCuVSServiceProvider extends CuVSServiceProvider {
 
     @Override
     public CuVSProvider get(CuVSProvider builtin) {
+        if (mockedGPUInfoProvider == null) {
+            return builtin;
+        }
         return new CuVSProviderDelegate(builtin) {
             @Override
             public GPUInfoProvider gpuInfoProvider() {


### PR DESCRIPTION
Backports the following commits to 9.2:
 - FIX: return builtin CuVSProvider when mock is null in internalClusterTests (#138155)