### PR TITLE
Fix parameter type in ml.get_categories YAML test

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/jobs_get_result_categories.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/jobs_get_result_categories.yml
@@ -128,7 +128,7 @@ setup:
   - do:
       ml.get_categories:
         job_id: "jobs-get-result-categories"
-        category_id: "1"
+        category_id: 1
 
   - length: { categories: 1 }
   - match: { categories.0.job_id: jobs-get-result-categories }


### PR DESCRIPTION
`category_id` is a long, not a string: https://github.com/elastic/elasticsearch/blob/f86f58fbf3ebfb4e54fd711acae8290e3669e835/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/results/RestGetCategoriesAction.java#L53-L55

We noticed this thanks to the Elasticsearch specification CI which validates YAML tests against the Elasticsearch specification types.