### PR TITLE
[ML] Disabling CCM by default

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ccm/CCMSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ccm/CCMSettings.java
@@ -14,7 +14,7 @@ import java.util.List;
 public class CCMSettings {
     public static final Setting<Boolean> CCM_SUPPORTED_ENVIRONMENT = Setting.boolSetting(
         "xpack.inference.elastic.ccm_supported_environment",
-        true,
+        false,
         Setting.Property.NodeScope
     );
 


### PR DESCRIPTION
This PR is a temporary fix to help folks using EIS and snapshot builds of ES in ECH.

In snapshot builds of ES CCM is allowed. Because it's allowed causes interactions with EIS to fail because it assumes we need an API.

Once we add the setting to the different environments we can switch this back to `true`.