### PR TITLE
Move `host.name` skipper checks out from feature flag

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -462,7 +462,7 @@ public final class KeywordFieldMapper extends FieldMapper {
 
         private boolean shouldUseHostnameSkipper(final String fullFieldName) {
             return hasDocValues.get()
-                && indexSettings.useDocValuesSkipper()
+                && IndexSettings.USE_DOC_VALUES_SKIPPER.get(indexSettings.getSettings())
                 && indexSettings.getIndexVersionCreated().onOrAfter(IndexVersions.SKIPPERS_ENABLED_BY_DEFAULT)
                 && IndexMode.LOGSDB.equals(indexSettings.getMode())
                 && HOST_NAME.equals(fullFieldName)


### PR DESCRIPTION
#173348 inadvertently changed the `host.name` skipper checks on keyword field mapper to take into account the `doc_values_skipper` feature flag, where before they were looking directly at index settings.  This changed index structures without adding a new index version.

This commit changes the check back to its previous behaviour.