### PR TITLE
Re-enable doc value skippers on host.name

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -465,7 +465,7 @@ public final class KeywordFieldMapper extends FieldMapper {
 
         private boolean shouldUseHostnameSkipper(final String fullFieldName) {
             return hasDocValues.get()
-                && indexSettings.useDocValuesSkipper()
+                && IndexSettings.USE_DOC_VALUES_SKIPPER.get(indexSettings.getSettings())
                 && indexSettings.getIndexVersionCreated().onOrAfter(IndexVersions.SKIPPERS_ENABLED_BY_DEFAULT)
                 && IndexMode.LOGSDB.equals(indexSettings.getMode())
                 && HOST_NAME.equals(fullFieldName)

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -969,6 +969,7 @@ public class KeywordFieldMapperTests extends MapperTestCase {
 
         final KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("host.name");
         assertTrue(mapper.fieldType().indexType().hasDocValuesSkipper());
+        assertFalse(mapper.fieldType().indexType().hasTerms());
     }
 
     public void testFieldTypeDefault_StandardMode() throws IOException {
@@ -1020,6 +1021,7 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         final KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("host.name");
         assertTrue(mapper.fieldType().hasDocValues());
         assertTrue(mapper.fieldType().indexType().hasDocValuesSkipper());
+        assertFalse(mapper.fieldType().indexType().hasTerms());
     }
 
     public void testFieldTypeDefault_ConfiguredIndexedWithoutSettingOverride() throws IOException {
@@ -1037,6 +1039,7 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         final KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("host.name");
         assertTrue(mapper.fieldType().hasDocValues());
         assertTrue(mapper.fieldType().indexType().hasDocValuesSkipper());
+        assertFalse(mapper.fieldType().indexType().hasTerms());
     }
 
     public void testFieldTypeDefault_ConfiguredDocValues() throws IOException {
@@ -1054,6 +1057,7 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         final KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("host.name");
         assertTrue(mapper.fieldType().hasDocValues());
         assertTrue(mapper.fieldType().indexType().hasDocValuesSkipper());
+        assertFalse(mapper.fieldType().indexType().hasTerms());
     }
 
     public void testFieldTypeDefault_LogsDbMode_NonSortField() throws IOException {
@@ -1089,6 +1093,7 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         final KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("host.name");
         assertTrue(mapper.fieldType().hasDocValues());
         assertTrue(mapper.fieldType().indexType().hasDocValuesSkipper());
+        assertFalse(mapper.fieldType().indexType().hasTerms());
     }
 
     public void testFieldTypeDefault_IndexedFalseDocValuesFalse() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -968,12 +968,7 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         }));
 
         final KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("host.name");
-        if (mapperService.getIndexSettings().useDocValuesSkipper()) {
-            assertTrue(mapper.fieldType().indexType().hasDocValuesSkipper());
-        } else {
-            assertFalse(mapper.fieldType().indexType().hasDocValuesSkipper());
-            assertTrue(mapper.fieldType().indexType().hasTerms());
-        }
+        assertTrue(mapper.fieldType().indexType().hasDocValuesSkipper());
     }
 
     public void testFieldTypeDefault_StandardMode() throws IOException {
@@ -1024,12 +1019,7 @@ public class KeywordFieldMapperTests extends MapperTestCase {
 
         final KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("host.name");
         assertTrue(mapper.fieldType().hasDocValues());
-        if (mapperService.getIndexSettings().useDocValuesSkipper()) {
-            assertTrue(mapper.fieldType().indexType().hasDocValuesSkipper());
-        } else {
-            assertFalse(mapper.fieldType().indexType().hasDocValuesSkipper());
-            assertTrue(mapper.fieldType().indexType().hasTerms());
-        }
+        assertTrue(mapper.fieldType().indexType().hasDocValuesSkipper());
     }
 
     public void testFieldTypeDefault_ConfiguredIndexedWithoutSettingOverride() throws IOException {
@@ -1046,12 +1036,7 @@ public class KeywordFieldMapperTests extends MapperTestCase {
 
         final KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("host.name");
         assertTrue(mapper.fieldType().hasDocValues());
-        if (mapperService.getIndexSettings().useDocValuesSkipper()) {
-            assertTrue(mapper.fieldType().indexType().hasDocValuesSkipper());
-        } else {
-            assertFalse(mapper.fieldType().indexType().hasDocValuesSkipper());
-            assertTrue(mapper.fieldType().indexType().hasTerms());
-        }
+        assertTrue(mapper.fieldType().indexType().hasDocValuesSkipper());
     }
 
     public void testFieldTypeDefault_ConfiguredDocValues() throws IOException {
@@ -1068,12 +1053,7 @@ public class KeywordFieldMapperTests extends MapperTestCase {
 
         final KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("host.name");
         assertTrue(mapper.fieldType().hasDocValues());
-        if (mapperService.getIndexSettings().useDocValuesSkipper()) {
-            assertTrue(mapper.fieldType().indexType().hasDocValuesSkipper());
-        } else {
-            assertFalse(mapper.fieldType().indexType().hasDocValuesSkipper());
-            assertTrue(mapper.fieldType().indexType().hasTerms());
-        }
+        assertTrue(mapper.fieldType().indexType().hasDocValuesSkipper());
     }
 
     public void testFieldTypeDefault_LogsDbMode_NonSortField() throws IOException {
@@ -1108,12 +1088,7 @@ public class KeywordFieldMapperTests extends MapperTestCase {
 
         final KeywordFieldMapper mapper = (KeywordFieldMapper) mapperService.documentMapper().mappers().getMapper("host.name");
         assertTrue(mapper.fieldType().hasDocValues());
-        if (mapperService.getIndexSettings().useDocValuesSkipper()) {
-            assertTrue(mapper.fieldType().indexType().hasDocValuesSkipper());
-        } else {
-            assertFalse(mapper.fieldType().indexType().hasDocValuesSkipper());
-            assertTrue(mapper.fieldType().indexType().hasOnlyDocValues());
-        }
+        assertTrue(mapper.fieldType().indexType().hasDocValuesSkipper());
     }
 
     public void testFieldTypeDefault_IndexedFalseDocValuesFalse() throws IOException {


### PR DESCRIPTION
This PR removes the feature flag from the check to enable doc value skippers on `host.name`.

Relates to #138250