### PR TITLE
[9.2] Mark snapshot version of protobuf gradle plugin non changeable (#138241)

### DIFF
--- a/x-pack/plugin/otel-data/build.gradle
+++ b/x-pack/plugin/otel-data/build.gradle
@@ -12,7 +12,9 @@ buildscript {
     maven { url = "https://jitpack.io" }
   }
   dependencies {
-    classpath 'com.github.google:protobuf-gradle-plugin:PR786-SNAPSHOT'
+    classpath('com.github.google:protobuf-gradle-plugin:PR786-SNAPSHOT') {
+      changing = false
+    }
   }
 }
 


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Mark snapshot version of protobuf gradle plugin non changeable (#138241)