### PR TITLE
Remove duplicate `path.repo` setting in `AbstractIndexCompatibilityTestCase`

### DIFF
--- a/qa/lucene-index-compatibility/src/javaRestTest/java/org/elasticsearch/lucene/AbstractIndexCompatibilityTestCase.java
+++ b/qa/lucene-index-compatibility/src/javaRestTest/java/org/elasticsearch/lucene/AbstractIndexCompatibilityTestCase.java
@@ -77,7 +77,6 @@ public abstract class AbstractIndexCompatibilityTestCase extends ESRestTestCase 
         .setting("path.repo", () -> REPOSITORY_PATH.getRoot().getPath())
         .setting("xpack.security.enabled", "false")
         .setting("xpack.ml.enabled", "false")
-        .setting("path.repo", () -> REPOSITORY_PATH.getRoot().getPath())
         .apply(() -> clusterConfig)
         .build();
 


### PR DESCRIPTION
The `static ElasticsearchCluster cluster` initialization method chain had a duplicate line:
`.setting("path.repo", () -> REPOSITORY_PATH.getRoot().getPath())`.

Saw this while looking into a `RollingUpgradeDeprecatedSettingsIT` failure.
