### PR TITLE
rest-api-spec: fix cluster.get_component_template name part

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_component_template.json
@@ -26,8 +26,8 @@
           ],
           "parts": {
             "name": {
-              "type": "list",
-              "description": "The comma separated names of the component templates"
+              "type": "string",
+              "description": "The name of the component template. Wildcard (`*`) expressions are supported."
             }
           }
         }


### PR DESCRIPTION
In `GET /_component_template/{name}` queries, the name is just a name, comma-separated values are not accepted, only wildcard expressions. I've tested it manually: `GET _component_template/synthetics*` returns many templates, while `GET _component_template/synthetics@mappings,synthetics-mappings` fails with `"component template matching [synthetics@mappings,synthetics-mappings] not found"`. Source code:

* [name is read in RestGetComponentTemplateAction](https://github.com/elastic/elasticsearch/blob/14f5892ad658df85029d2853e5fd033476101d3f/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetComponentTemplateAction.java#L55)
* [It is then stored in a Nullable String](https://github.com/elastic/elasticsearch/blob/14f5892ad658df85029d2853e5fd033476101d3f/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetComponentTemplateAction.java#L53-L54)