### PR TITLE
[OTEL] rename deployment.environment to deployment.environment.name

### DIFF
--- a/x-pack/plugin/otel-data/src/main/resources/component-templates/semconv-resource-to-ecs@mappings.yaml
+++ b/x-pack/plugin/otel-data/src/main/resources/component-templates/semconv-resource-to-ecs@mappings.yaml
@@ -23,7 +23,7 @@ template:
               service.instance.id:
                 type: keyword
                 ignore_above: 1024
-              deployment.environment:
+              deployment.environment.name:
                 type: keyword
                 ignore_above: 1024
               cloud.platform:
@@ -103,7 +103,7 @@ template:
         path: resource.attributes.service.instance.id
       service.environment:
         type: alias
-        path: resource.attributes.deployment.environment
+        path: resource.attributes.deployment.environment.name
       cloud.service.name:
         type: alias
         path: resource.attributes.cloud.platform


### PR DESCRIPTION
**Premise**

The [semconv 1.27 (released on 2nd August 2024)](https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.27.0) renamed the semconv field `deployment.environment` to `deployment.environment.name`.

**Actual Change**

In this **BREAKING CHANGE** commit we adopt the new semantic convention introduced with version 1.27. Read more in the related disscussion:

https://github.com/elastic/opentelemetry/issues/489

**Related issues**

@theletterf already created PRs to adjust the documentation of the EDOT SDK, but the changes do have effect if we also change the actual component templates.


- https://github.com/elastic/opentelemetry/issues/489
- [Rename attribute elastic-otel-php#309](https://github.com/elastic/elastic-otel-php/pull/309)
- [Rename attribute elastic-otel-java#887](https://github.com/elastic/elastic-otel-java/pull/887) and https://github.com/elastic/elastic-otel-java/pull/885
- [Rename attribute elastic-otel-node#1171](https://github.com/elastic/elastic-otel-node/pull/1171)
- [Rename attribute elastic-otel-python#427](https://github.com/elastic/elastic-otel-python/pull/427)
