### PR TITLE
[GPU] Change vectors.indexing.use_gpu to be assumed

### DIFF
--- a/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/GPUFeatures.java
+++ b/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/GPUFeatures.java
@@ -14,7 +14,7 @@ import java.util.Set;
 
 public class GPUFeatures implements FeatureSpecification {
 
-    public static final NodeFeature VECTORS_INDEXING_USE_GPU = new NodeFeature("vectors.indexing.use_gpu");
+    public static final NodeFeature VECTORS_INDEXING_USE_GPU = new NodeFeature("vectors.indexing.use_gpu", true);
 
     @Override
     public Set<NodeFeature> getFeatures() {


### PR DESCRIPTION
We would like to exclude the GPU plugin from serverless, to avoid any potential issue, at least provisionally.
In order to do that however we need to "remove" the cluster feature: no plugin, no cluster feature.
This can be done by marking the feature as assumed; this way, after the next release cycle, the feature can be removed. The cluster will act as it is always there, but with no plugin it will effectively not be there.