### PR TITLE
Fixing _rollup/data performance for a large number of indices

### DIFF
--- a/docs/changelog/138305.yaml
+++ b/docs/changelog/138305.yaml
@@ -1,0 +1,5 @@
+pr: 138305
+summary: Fixing _rollup/data performance for a large number of indices
+area: Rollup
+type: bug
+issues: []

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportGetRollupIndexCapsAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportGetRollupIndexCapsAction.java
@@ -29,6 +29,8 @@ import org.elasticsearch.xpack.core.rollup.action.RollupJobCaps;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -86,11 +88,11 @@ public class TransportGetRollupIndexCapsAction extends HandledTransportAction<
         Transports.assertNotTransportThread("retrieving rollup job index caps may be expensive");
         final var project = projectResolver.getProjectMetadata(clusterService.state());
         String[] indices = resolver.concreteIndexNames(project, request.indicesOptions(), request);
-        Map<String, RollableIndexCaps> allCaps = getCapsByRollupIndex(Arrays.asList(indices), project.indices());
+        Map<String, RollableIndexCaps> allCaps = getCapsByRollupIndex(new HashSet<>(Arrays.asList(indices)), project.indices());
         listener.onResponse(new GetRollupIndexCapsAction.Response(allCaps));
     }
 
-    static Map<String, RollableIndexCaps> getCapsByRollupIndex(List<String> resolvedIndexNames, Map<String, IndexMetadata> indices) {
+    static Map<String, RollableIndexCaps> getCapsByRollupIndex(Collection<String> resolvedIndexNames, Map<String, IndexMetadata> indices) {
         Map<String, List<RollupJobCaps>> allCaps = new TreeMap<>();
 
         indices.entrySet().stream().filter(entry -> resolvedIndexNames.contains(entry.getKey())).forEach(entry -> {


### PR DESCRIPTION
This avoids performing an N^2 loop through indices when we call `GET /*/_rollup/data`. This can save a few seconds per call for clusters with a very large number of indices.