### PR TITLE
Reject mappings that (eventually) set dimension and metric in the same field

### DIFF
--- a/docs/changelog/138308.yaml
+++ b/docs/changelog/138308.yaml
@@ -1,0 +1,5 @@
+pr: 138308
+summary: Reject mappings that (eventually) set dimension and metric in the same field
+area: Mapping
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -2316,6 +2316,17 @@ public class NumberFieldMapper extends FieldMapper {
                 TimeSeriesParams.TIME_SERIES_DIMENSION_PARAM + " can't be configured in nested field [" + fullPath() + "]"
             );
         }
+        if (dimension && metricType != null) {
+            throw new IllegalArgumentException(
+                "["
+                    + TimeSeriesParams.TIME_SERIES_DIMENSION_PARAM
+                    + "] and ["
+                    + TimeSeriesParams.TIME_SERIES_METRIC_PARAM
+                    + "] cannot be set in conjunction with each other ["
+                    + fullPath()
+                    + "]"
+            );
+        }
     }
 
     private SourceLoader.SyntheticFieldLoader docValuesSyntheticFieldLoader() {

--- a/server/src/test/java/org/elasticsearch/index/mapper/PassThroughObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/PassThroughObjectMapperTests.java
@@ -265,4 +265,20 @@ public class PassThroughObjectMapperTests extends MapperServiceTestCase {
         );
         assertThat(e.getMessage(), containsString("Pass-through object [bar] has a conflicting param [priority=1] with object [foo]"));
     }
+
+    public void testTimeSeriesDimensionAndMetricConflict() throws IOException {
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> createMapperService(mapping(b -> {
+            b.startObject("labels").field("type", "passthrough").field("priority", "0").field("time_series_dimension", "true");
+            {
+                b.startObject("properties");
+                b.startObject("dim").field("type", "long").field("time_series_metric", "counter").endObject();
+                b.endObject();
+            }
+            b.endObject();
+        })));
+        assertThat(
+            e.getMessage(),
+            containsString("[time_series_dimension] and [time_series_metric] cannot be set in conjunction with each other [labels.dim]")
+        );
+    }
 }


### PR DESCRIPTION
In this PR we add a check that will reject the following mapping:
```
PUT my-index-2
{
  "mappings": {
    "properties": {
      "attributes": {
          "type": "passthrough",
          "time_series_dimension": true,
          "priority": 20,
          "properties": {
            "attributes.kube_job_status_active": {
              "type": "double",
              "time_series_metric": "gauge"
            }
          }
      }
    }
  }
}
```

This mapping was rejected when assertions were enabled, but on production environments it was not checked properly. 

The problem is that we were checking that a field cannot be both a dimension and a metric during parsing. When the mapping is first parsed the `attributes.kube_job_status_active` does not explicitly list `"time_series_dimension": true` so it passes the check, then during building the mappers we do add it but we do not recheck it then.

Now we check this when we build a `NumberFieldMapper`.

Fixes: https://github.com/elastic/elasticsearch/issues/138044