### PR TITLE
Add tier_preference and node.role columns to _cat/shards API

### DIFF
--- a/docs/changelog/138322.yaml
+++ b/docs/changelog/138322.yaml
@@ -1,0 +1,6 @@
+pr: 138322
+summary: Add tier_preference and node.role columns to _cat/shards API
+area: CAT APIs
+type: enhancement
+issues:
+  - 136895

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
@@ -262,6 +262,15 @@ public class RestShardsAction extends AbstractCatAction {
             "alias:svc,sparseVectorCount;default:false;text-align:right;desc:number of indexed sparse vectors in shard"
         );
 
+        table.addCell(
+            "tier_preference",
+            "alias:tp,tierPreference;default:false;desc:index tier preference for shard allocation"
+        );
+        table.addCell(
+            "node.role",
+            "alias:r,role,nodeRole;default:false;desc:node roles"
+        );
+
         table.endHeaders();
         return table;
     }
@@ -430,6 +439,22 @@ public class RestShardsAction extends AbstractCatAction {
 
             table.addCell(getOrNull(commonStats, CommonStats::getDenseVectorStats, DenseVectorStats::getValueCount));
             table.addCell(getOrNull(commonStats, CommonStats::getSparseVectorStats, SparseVectorStats::getValueCount));
+
+            // Add tier_preference from index settings
+            String tierPreference = state.getState()
+                .metadata()
+                .index(shard.index())
+                .getSettings()
+                .get("index.routing.allocation.include._tier_preference");
+            table.addCell(tierPreference);
+
+            // Add node.role abbreviation
+            if (shard.assignedToNode()) {
+                String nodeRoles = state.getState().nodes().get(shard.currentNodeId()).getRoleAbbreviationString();
+                table.addCell(nodeRoles);
+            } else {
+                table.addCell(null);
+            }
 
             table.endRow();
         }


### PR DESCRIPTION
This enhancement adds two new columns to the _cat/shards API to facilitate troubleshooting of ILM-related shard allocation issues:

- tier_preference: Shows the index.routing.allocation.include._tier_preference setting for the shard's index
-  node.role: Displays node roles in abbreviated format (similar to _cat/nodes)

These columns help diagnose shards stuck during tier migrations (hot -> warm -> cold) by providing a consolidated view of tier preferences and node roles.

Closes #136895