### PR TITLE
[9.1] rest-api-spec: fix cluster.get_component_template name part (#138284)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_component_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.get_component_template.json
@@ -26,8 +26,8 @@
           ],
           "parts": {
             "name": {
-              "type": "list",
-              "description": "The comma separated names of the component templates"
+              "type": "string",
+              "description": "The name of the component template. Wildcard (`*`) expressions are supported."
             }
           }
         }


### PR DESCRIPTION
Backports the following commits to 9.1:
 - rest-api-spec: fix cluster.get_component_template name part (#138284)