### PR TITLE
[9.1] Reject mappings that (eventually) set dimension and metric in the same field (#138308)

### DIFF
--- a/docs/changelog/138308.yaml
+++ b/docs/changelog/138308.yaml
@@ -1,0 +1,5 @@
+pr: 138308
+summary: Reject mappings that (eventually) set dimension and metric in the same field
+area: Mapping
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -2271,6 +2271,17 @@ public class NumberFieldMapper extends FieldMapper {
                 TimeSeriesParams.TIME_SERIES_DIMENSION_PARAM + " can't be configured in nested field [" + fullPath() + "]"
             );
         }
+        if (dimension && metricType != null) {
+            throw new IllegalArgumentException(
+                "["
+                    + TimeSeriesParams.TIME_SERIES_DIMENSION_PARAM
+                    + "] and ["
+                    + TimeSeriesParams.TIME_SERIES_METRIC_PARAM
+                    + "] cannot be set in conjunction with each other ["
+                    + fullPath()
+                    + "]"
+            );
+        }
     }
 
     private SourceLoader.SyntheticFieldLoader docValuesSyntheticFieldLoader() {

--- a/server/src/test/java/org/elasticsearch/index/mapper/PassThroughObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/PassThroughObjectMapperTests.java
@@ -215,4 +215,20 @@ public class PassThroughObjectMapperTests extends MapperServiceTestCase {
         );
         assertThat(e.getMessage(), containsString("Pass-through object [bar] has a conflicting param [priority=1] with object [foo]"));
     }
+
+    public void testTimeSeriesDimensionAndMetricConflict() throws IOException {
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> createMapperService(mapping(b -> {
+            b.startObject("labels").field("type", "passthrough").field("priority", "0").field("time_series_dimension", "true");
+            {
+                b.startObject("properties");
+                b.startObject("dim").field("type", "long").field("time_series_metric", "counter").endObject();
+                b.endObject();
+            }
+            b.endObject();
+        })));
+        assertThat(
+            e.getMessage(),
+            containsString("[time_series_dimension] and [time_series_metric] cannot be set in conjunction with each other [labels.dim]")
+        );
+    }
 }


### PR DESCRIPTION
Backports the following commits to 9.1:
 - Reject mappings that (eventually) set dimension and metric in the same field (#138308)