### PR TITLE
[9.1] rest-api-spec: remove typed monitoring.bulk endpoint (#138229)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/monitoring.bulk.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/monitoring.bulk.json
@@ -22,27 +22,6 @@
             "POST",
             "PUT"
           ]
-        },
-        {
-          "path": "/_monitoring/{type}/bulk",
-          "methods": [
-            "POST",
-            "PUT"
-          ],
-          "parts": {
-            "type": {
-              "type": "string",
-              "description": "Default document type for items which don't provide one",
-              "deprecated": {
-                "version": "7.0.0",
-                "description": "Specifying types in urls has been deprecated"
-              }
-            }
-          },
-          "deprecated": {
-            "version": "7.0.0",
-            "description": "Specifying types in urls has been deprecated"
-          }
         }
       ]
     },


### PR DESCRIPTION
Backports the following commits to 9.1:
 - rest-api-spec: remove typed monitoring.bulk endpoint (#138229)