### PR TITLE
Add histogram as a metric type of an exponential histogram

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesParams.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesParams.java
@@ -36,6 +36,7 @@ public final class TimeSeriesParams {
     public enum MetricType {
         GAUGE(new String[] { "max", "min", "value_count", "sum" }),
         COUNTER(new String[] { "last_value" }),
+        HISTOGRAM(new String[] {}, false),
         POSITION(new String[] {}, false);
 
         private final String[] supportedAggs;

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/FieldValueFetcher.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/FieldValueFetcher.java
@@ -72,6 +72,7 @@ class FieldValueFetcher {
             return switch (fieldType.getMetricType()) {
                 case GAUGE -> MetricFieldProducer.createFieldProducerForGauge(name(), samplingMethod);
                 case COUNTER -> MetricFieldProducer.createFieldProducerForCounter(name());
+                case HISTOGRAM -> throw new IllegalArgumentException("Unsupported metric type [histogram] for downsampling, coming soon");
                 // TODO: Support POSITION in downsampling
                 case POSITION -> throw new IllegalArgumentException("Unsupported metric type [position] for down-sampling");
             };

--- a/x-pack/plugin/mapper-exponential-histogram/build.gradle
+++ b/x-pack/plugin/mapper-exponential-histogram/build.gradle
@@ -20,7 +20,7 @@ base {
 
 restResources {
   restApi {
-    include 'bulk', 'search'
+    include 'bulk', 'search', 'indices', 'cluster'
   }
 }
 dependencies {

--- a/x-pack/plugin/mapper-exponential-histogram/src/test/java/org/elasticsearch/xpack/exponentialhistogram/ExponentialHistogramFieldMapperTests.java
+++ b/x-pack/plugin/mapper-exponential-histogram/src/test/java/org/elasticsearch/xpack/exponentialhistogram/ExponentialHistogramFieldMapperTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.DocumentParsingException;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MapperTestCase;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.SourceToParse;
@@ -740,6 +741,42 @@ public class ExponentialHistogramFieldMapperTests extends MapperTestCase {
                     }
                 }
             }
+        }
+    }
+
+    public void testMetricType() throws IOException {
+        // Test default setting
+        MapperService mapperService = createMapperService(fieldMapping(this::minimalMapping));
+        ExponentialHistogramFieldMapper.ExponentialHistogramFieldType ft =
+            (ExponentialHistogramFieldMapper.ExponentialHistogramFieldType) mapperService.fieldType("field");
+        assertNull(ft.getMetricType());
+
+        assertMetricType("histogram", ExponentialHistogramFieldMapper.ExponentialHistogramFieldType::getMetricType);
+
+        {
+            String unsupportedMetricTypes = randomFrom("counter", "gauge", "position");
+            // Test invalid metric type for this field type
+            Exception e = expectThrows(MapperParsingException.class, () -> createMapperService(fieldMapping(b -> {
+                minimalMapping(b);
+                b.field("time_series_metric", unsupportedMetricTypes);
+            })));
+            assertThat(
+                e.getCause().getMessage(),
+                containsString(
+                    "Unknown value [" + unsupportedMetricTypes + "] for field [time_series_metric] - accepted values are [histogram]"
+                )
+            );
+        }
+        {
+            // Test invalid metric type
+            Exception e = expectThrows(MapperParsingException.class, () -> createMapperService(fieldMapping(b -> {
+                minimalMapping(b);
+                b.field("time_series_metric", "unknown");
+            })));
+            assertThat(
+                e.getCause().getMessage(),
+                containsString("Unknown value [unknown] for field [time_series_metric] - accepted values are [histogram]")
+            );
         }
     }
 

--- a/x-pack/plugin/mapper-exponential-histogram/src/test/java/org/elasticsearch/xpack/exponentialhistogram/aggregations/bucket/histogram/ExponentialHistogramBackedHistogramAggregatorTests.java
+++ b/x-pack/plugin/mapper-exponential-histogram/src/test/java/org/elasticsearch/xpack/exponentialhistogram/aggregations/bucket/histogram/ExponentialHistogramBackedHistogramAggregatorTests.java
@@ -194,7 +194,7 @@ public class ExponentialHistogramBackedHistogramAggregatorTests extends Exponent
     }
 
     private MappedFieldType defaultFieldType(String fieldName) {
-        return new ExponentialHistogramFieldMapper.ExponentialHistogramFieldType(fieldName, Collections.emptyMap());
+        return new ExponentialHistogramFieldMapper.ExponentialHistogramFieldType(fieldName, Collections.emptyMap(), null);
     }
 
     private Map<Double, Long> computeExpectedHistogram(List<ExponentialHistogram> histograms, double interval, double offset) {

--- a/x-pack/plugin/mapper-exponential-histogram/src/test/java/org/elasticsearch/xpack/exponentialhistogram/aggregations/metrics/ExponentialHistogramAvgAggregatorTests.java
+++ b/x-pack/plugin/mapper-exponential-histogram/src/test/java/org/elasticsearch/xpack/exponentialhistogram/aggregations/metrics/ExponentialHistogramAvgAggregatorTests.java
@@ -109,7 +109,7 @@ public class ExponentialHistogramAvgAggregatorTests extends ExponentialHistogram
 
     private void testCase(Query query, CheckedConsumer<RandomIndexWriter, IOException> buildIndex, Consumer<InternalAvg> verify)
         throws IOException {
-        var fieldType = new ExponentialHistogramFieldMapper.ExponentialHistogramFieldType(FIELD_NAME, Collections.emptyMap());
+        var fieldType = new ExponentialHistogramFieldMapper.ExponentialHistogramFieldType(FIELD_NAME, Collections.emptyMap(), null);
         AggregationBuilder aggregationBuilder = createAggBuilderForTypeTest(fieldType, FIELD_NAME);
         testCase(buildIndex, verify, new AggTestConfig(aggregationBuilder, fieldType).withQuery(query));
     }

--- a/x-pack/plugin/mapper-exponential-histogram/src/test/java/org/elasticsearch/xpack/exponentialhistogram/aggregations/metrics/ExponentialHistogramSumAggregatorTests.java
+++ b/x-pack/plugin/mapper-exponential-histogram/src/test/java/org/elasticsearch/xpack/exponentialhistogram/aggregations/metrics/ExponentialHistogramSumAggregatorTests.java
@@ -96,7 +96,7 @@ public class ExponentialHistogramSumAggregatorTests extends ExponentialHistogram
 
     private void testCase(Query query, CheckedConsumer<RandomIndexWriter, IOException> buildIndex, Consumer<Sum> verify)
         throws IOException {
-        var fieldType = new ExponentialHistogramFieldMapper.ExponentialHistogramFieldType(FIELD_NAME, Collections.emptyMap());
+        var fieldType = new ExponentialHistogramFieldMapper.ExponentialHistogramFieldType(FIELD_NAME, Collections.emptyMap(), null);
         AggregationBuilder aggregationBuilder = createAggBuilderForTypeTest(fieldType, FIELD_NAME);
         testCase(buildIndex, verify, new AggTestConfig(aggregationBuilder, fieldType).withQuery(query));
     }

--- a/x-pack/plugin/mapper-exponential-histogram/src/test/java/org/elasticsearch/xpack/exponentialhistogram/aggregations/metrics/ExponentialHistogramValueCountAggregatorTests.java
+++ b/x-pack/plugin/mapper-exponential-histogram/src/test/java/org/elasticsearch/xpack/exponentialhistogram/aggregations/metrics/ExponentialHistogramValueCountAggregatorTests.java
@@ -96,7 +96,7 @@ public class ExponentialHistogramValueCountAggregatorTests extends ExponentialHi
 
     private void testCase(Query query, CheckedConsumer<RandomIndexWriter, IOException> buildIndex, Consumer<InternalValueCount> verify)
         throws IOException {
-        var fieldType = new ExponentialHistogramFieldMapper.ExponentialHistogramFieldType(FIELD_NAME, Collections.emptyMap());
+        var fieldType = new ExponentialHistogramFieldMapper.ExponentialHistogramFieldType(FIELD_NAME, Collections.emptyMap(), null);
         AggregationBuilder aggregationBuilder = createAggBuilderForTypeTest(fieldType, FIELD_NAME);
         testCase(buildIndex, verify, new AggTestConfig(aggregationBuilder, fieldType).withQuery(query));
     }

--- a/x-pack/plugin/mapper-exponential-histogram/src/yamlRestTest/resources/rest-api-spec/test/50_time_series_metric.yml
+++ b/x-pack/plugin/mapper-exponential-histogram/src/yamlRestTest/resources/rest-api-spec/test/50_time_series_metric.yml
@@ -66,3 +66,39 @@
   - match: { my-templated-index.mappings.properties.my_histogram.time_series_metric: histogram }
   - match: { my-templated-index.mappings.properties.my_counter.type: long }
   - match: { my-templated-index.mappings.properties.my_counter.time_series_metric: counter }
+
+---
+"Exponential histogram cannot be a gauge":
+  - do:
+      catch: /Unknown value \[gauge\] for field \[time_series_metric\] - accepted values are \[histogram\]/
+      indices.create:
+        index: invalid_exponential_histogram_metric
+        body:
+          settings:
+            index:
+              mapping:
+                source:
+                  mode: synthetic
+          mappings:
+            properties:
+              my_metric:
+                type: exponential_histogram
+                time_series_metric: gauge
+
+---
+"Exponential histogram cannot be a counter":
+  - do:
+      catch: /Unknown value \[counter\] for field \[time_series_metric\] - accepted values are \[histogram\]/
+      indices.create:
+        index: invalid_exponential_histogram_metric
+        body:
+          settings:
+            index:
+              mapping:
+                source:
+                  mode: synthetic
+          mappings:
+            properties:
+              my_metric:
+                type: exponential_histogram
+                time_series_metric: counter

--- a/x-pack/plugin/mapper-exponential-histogram/src/yamlRestTest/resources/rest-api-spec/test/50_time_series_metric.yml
+++ b/x-pack/plugin/mapper-exponential-histogram/src/yamlRestTest/resources/rest-api-spec/test/50_time_series_metric.yml
@@ -1,0 +1,68 @@
+# TODO we need to add "requires capability" when the feature flag is removed
+---
+"Create time series metric with exponential histogram":
+  - do:
+      indices.create:
+        index: test_exponential_histogram_metric
+        body:
+          settings:
+            index:
+              mapping:
+                source:
+                  mode: synthetic
+          mappings:
+            properties:
+              my_metric:
+                type: exponential_histogram
+                time_series_metric: histogram
+  - is_true: shards_acknowledged
+
+  - do:
+      indices.get_mapping:
+        index: test_exponential_histogram_metric
+  - match: { test_exponential_histogram_metric.mappings.properties.my_metric.type: exponential_histogram }
+  - match: { test_exponential_histogram_metric.mappings.properties.my_metric.time_series_metric: histogram }
+
+---
+"Merging templates with time series metric":
+  - do:
+      cluster.put_component_template:
+        name: metric-histogram
+        body:
+          template:
+            mappings:
+              properties:
+                my_histogram:
+                  type: exponential_histogram
+                  time_series_metric: histogram
+
+
+  - is_true: acknowledged
+
+  - do:
+      indices.put_index_template:
+        name: only-histogram
+        body:
+          index_patterns: [ my-templated-index ]
+          composed_of: [ metric-histogram ]
+          template:
+            mappings:
+              properties:
+                my_counter:
+                  type: long
+                  time_series_metric: counter
+
+  - is_true: acknowledged
+
+  - do:
+      indices.create:
+        index: my-templated-index
+  - is_true: shards_acknowledged
+
+  - do:
+      indices.get_mapping:
+        index: my-templated-index
+  - match: { my-templated-index.mappings.properties.my_histogram.type: exponential_histogram }
+  - match: { my-templated-index.mappings.properties.my_histogram.time_series_metric: histogram }
+  - match: { my-templated-index.mappings.properties.my_counter.type: long }
+  - match: { my-templated-index.mappings.properties.my_counter.time_series_metric: counter }


### PR DESCRIPTION
This PR introduces the `time_series_metric` parameter to the `exponential_histogram` mapper to allow a user to define it as a metric.

Furthermore, we introduce a new non scalar time series metric: `histogram`. Currently, the `histogram` metric type is not protected by a feature flag but it's only used by the `exponential_histogram` type which is behind a feature flag.


Resolves: https://github.com/elastic/elasticsearch/issues/138161