### PR TITLE
[9.2] Fix StringIndexOutOfBoundsException in COMPLETION command when options are omitted. (#138363)

### DIFF
--- a/docs/changelog/138363.yaml
+++ b/docs/changelog/138363.yaml
@@ -1,0 +1,6 @@
+pr: 138363
+summary: Fix StringIndexOutOfBoundsException in COMPLETION command when options are omitted.
+area: ES|QL
+type: bug
+issues:
+ - 138361

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
@@ -1029,16 +1029,20 @@ public class LogicalPlanBuilder extends ExpressionBuilder {
     }
 
     private Completion applyCompletionOptions(Completion completion, EsqlBaseParser.CommandNamedParametersContext ctx) {
-        MapExpression optionsExpresion = visitCommandNamedParameters(ctx);
+        MapExpression optionsExpression = ctx == null ? null : visitCommandNamedParameters(ctx);
 
-        if (optionsExpresion == null || optionsExpresion.containsKey(Completion.INFERENCE_ID_OPTION_NAME) == false) {
+        if (optionsExpression == null || optionsExpression.containsKey(Completion.INFERENCE_ID_OPTION_NAME) == false) {
             // Having a mandatory named parameter for inference_id is an antipattern, but it will be optional in the future when we have a
             // default LLM. It is better to keep inference_id as a named parameter and relax the syntax when it will become optional than
             // completely change the syntax in the future.
-            throw new ParsingException(source(ctx), "Missing mandatory option [{}] in COMPLETION", Completion.INFERENCE_ID_OPTION_NAME);
+            throw new ParsingException(
+                completion.source(),
+                "Missing mandatory option [{}] in COMPLETION",
+                Completion.INFERENCE_ID_OPTION_NAME
+            );
         }
 
-        Map<String, Expression> optionsMap = visitCommandNamedParameters(ctx).keyFoldedMap();
+        Map<String, Expression> optionsMap = optionsExpression.keyFoldedMap();
 
         Expression inferenceId = optionsMap.remove(Completion.INFERENCE_ID_OPTION_NAME);
         if (inferenceId != null) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
@@ -4111,13 +4111,13 @@ public class StatementParserTests extends AbstractStatementParserTests {
     }
 
     public void testCompletionMissingOptions() {
-        expectError("FROM foo* | COMPLETION targetField = prompt", "line 1:44: Missing mandatory option [inference_id] in COMPLETION");
+        expectError("FROM foo* | COMPLETION targetField = prompt", "line 1:13: Missing mandatory option [inference_id] in COMPLETION");
     }
 
     public void testCompletionEmptyOptions() {
         expectError(
             "FROM foo* | COMPLETION targetField = prompt WITH { }",
-            "line 1:45: Missing mandatory option [inference_id] in COMPLETION"
+            "line 1:13: Missing mandatory option [inference_id] in COMPLETION"
         );
     }
 


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Fix StringIndexOutOfBoundsException in COMPLETION command when options are omitted. (#138363)