### PR TITLE
[9.2] Fix ThreadPoolTests#testDetailedUtilizationMetric (#138393)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/TaskExecutionTimeTrackingEsThreadPoolExecutor.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/TaskExecutionTimeTrackingEsThreadPoolExecutor.java
@@ -57,8 +57,8 @@ public final class TaskExecutionTimeTrackingEsThreadPoolExecutor extends EsThrea
         ALLOCATION,
     }
 
-    private volatile UtilizationTracker apmUtilizationTracker = new UtilizationTracker();
-    private volatile UtilizationTracker allocationUtilizationTracker = new UtilizationTracker();
+    private final UtilizationTracker apmUtilizationTracker = new UtilizationTracker();
+    private final UtilizationTracker allocationUtilizationTracker = new UtilizationTracker();
 
     TaskExecutionTimeTrackingEsThreadPoolExecutor(
         String name,

--- a/server/src/test/java/org/elasticsearch/threadpool/ThreadPoolTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/ThreadPoolTests.java
@@ -533,10 +533,12 @@ public class ThreadPoolTests extends ESTestCase {
             });
             safeAwait(barrier);
             safeGet(future);
-            final long maxDurationNanos = System.nanoTime() - beforeStartNanos;
-
             // Wait for TaskExecutionTimeTrackingEsThreadPoolExecutor#afterExecute to run
             assertBusy(() -> assertThat(executor.getTotalTaskExecutionTime(), greaterThan(0L)));
+            // When you call submit, the TimedRunnable wraps the FutureTask, so safeGet can return before the duration of
+            // the task is calculated. Waiting for totalTaskExecutionTime to be updated ensures maxDurationNanos is greater
+            // than the actual duration.
+            final long maxDurationNanos = System.nanoTime() - beforeStartNanos;
 
             final long beforeMetricsCollectedNanos = System.nanoTime();
             meterRegistry.getRecorder().collect();


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Fix ThreadPoolTests#testDetailedUtilizationMetric (#138393)