### PR TITLE
[9.1] Fix ThreadPoolTests#testDetailedUtilizationMetric (#138393)

### DIFF
--- a/server/src/test/java/org/elasticsearch/threadpool/ThreadPoolTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/ThreadPoolTests.java
@@ -528,10 +528,12 @@ public class ThreadPoolTests extends ESTestCase {
             });
             safeAwait(barrier);
             safeGet(future);
-            final long maxDurationNanos = System.nanoTime() - beforeStartNanos;
-
             // Wait for TaskExecutionTimeTrackingEsThreadPoolExecutor#afterExecute to run
             assertBusy(() -> assertThat(executor.getTotalTaskExecutionTime(), greaterThan(0L)));
+            // When you call submit, the TimedRunnable wraps the FutureTask, so safeGet can return before the duration of
+            // the task is calculated. Waiting for totalTaskExecutionTime to be updated ensures maxDurationNanos is greater
+            // than the actual duration.
+            final long maxDurationNanos = System.nanoTime() - beforeStartNanos;
 
             final long beforeMetricsCollectedNanos = System.nanoTime();
             meterRegistry.getRecorder().collect();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Fix ThreadPoolTests#testDetailedUtilizationMetric (#138393)](https://github.com/elastic/elasticsearch/pull/138393)

<!--- Backport version: 10.0.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)