### PR TITLE
Fix and unmute ExponentialHistogramBlockTests.testComponentAccess.

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -420,9 +420,6 @@ tests:
 - class: org.elasticsearch.xpack.security.authc.jwt.JwtRealmAuthenticateTests
   method: testJwkUpdatesByReloadWithFile
   issue: https://github.com/elastic/elasticsearch/issues/138397
-- class: org.elasticsearch.compute.data.ExponentialHistogramBlockTests
-  method: testComponentAccess
-  issue: https://github.com/elastic/elasticsearch/issues/138399
 
 # Examples:
 #

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/ExponentialHistogramBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/ExponentialHistogramBlockTests.java
@@ -95,9 +95,13 @@ public class ExponentialHistogramBlockTests extends ComputeTestCase {
                             }
                         }
                         case SUM -> {
-                            assertThat(componentBlock.getValueCount(i), equalTo(1));
-                            int valueIndex = componentBlock.getFirstValueIndex(i);
-                            assertThat(((DoubleBlock) componentBlock).getDouble(valueIndex), equalTo(histo.sum()));
+                            if (histo.valueCount() == 0) {
+                                assertThat(componentBlock.isNull(i), equalTo(true));
+                            } else {
+                                assertThat(componentBlock.getValueCount(i), equalTo(1));
+                                int valueIndex = componentBlock.getFirstValueIndex(i);
+                                assertThat(((DoubleBlock) componentBlock).getDouble(valueIndex), equalTo(histo.sum()));
+                            }
                         }
                         case COUNT -> {
                             assertThat(componentBlock.getValueCount(i), equalTo(1));


### PR DESCRIPTION
Fixes #138399.
Looks like in #138349 this test slipped through due to randomization.
