### PR TITLE
Fix NodesReloadSecureSettingsResponseTests

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/reload/NodesReloadSecureSettingsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/reload/NodesReloadSecureSettingsResponse.java
@@ -92,7 +92,7 @@ public class NodesReloadSecureSettingsResponse extends BaseNodesResponse<NodesRe
 
     public static class NodeResponse extends BaseNodeResponse {
 
-        private static final TransportVersion KEYSTORE_DETAILS = TransportVersion.fromName(
+        public static final TransportVersion KEYSTORE_DETAILS = TransportVersion.fromName(
             "keystore_details_in_reload_secure_settings_response"
         );
 

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/reload/NodesReloadSecureSettingsResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/reload/NodesReloadSecureSettingsResponseTests.java
@@ -98,7 +98,7 @@ public class NodesReloadSecureSettingsResponseTests extends ESTestCase {
             assertNotNull(readNr.reloadException());
             assertEquals(nr.reloadException().getMessage(), readNr.reloadException().getMessage());
         }
-        if (version.equals(TransportVersion.current())) {
+        if (version.supports(NodesReloadSecureSettingsResponse.NodeResponse.KEYSTORE_DETAILS)) {
             assertArrayEquals(nr.secureSettingNames(), readNr.secureSettingNames());
             assertEquals(nr.keystorePath(), readNr.keystorePath());
             assertEquals(nr.keystoreDigest(), readNr.keystoreDigest());


### PR DESCRIPTION
The test is going to fail once somebody introduces a new transport version.
This change updates it to check for supported version rather than strict equality.