### PR TITLE
Fixes 'applies_to' syntax on the semantic_text field type page

### DIFF
--- a/docs/reference/elasticsearch/mapping-reference/semantic-text.md
+++ b/docs/reference/elasticsearch/mapping-reference/semantic-text.md
@@ -168,7 +168,7 @@ PUT my-index-000003
 ### Using ELSER on EIS
 
 ```{applies_to}
-stack: preview 9.1 ga 9.2
+stack: preview 9.1, ga 9.2
 deployment:
   self: unavailable
 serverless: ga


### PR DESCRIPTION
This PR fixes an 'applies_to' syntax on the 'semantic_text field type' page.
