### PR TITLE
Correct seed data NodesReloadSecureSettingsResponseTests.

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/reload/NodesReloadSecureSettingsResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/reload/NodesReloadSecureSettingsResponseTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.test.ESTestCase;
@@ -33,7 +34,7 @@ public class NodesReloadSecureSettingsResponseTests extends ESTestCase {
 
         TransportVersion target = NodesReloadSecureSettingsResponse.NodeResponse.KEYSTORE_DETAILS;
         TransportVersion previous = TransportVersionUtils.getPreviousVersion(target);
-        TransportVersion future = TransportVersionUtils.randomVersionBetween(new Random(), target, null);
+        TransportVersion future = TransportVersionUtils.randomVersionBetween(Randomness.get(), target, null);
 
         TransportVersion[] versions = { target, previous, future };
         Exception[] exceptions = { null, new ElasticsearchException("test error") };

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/reload/NodesReloadSecureSettingsResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/reload/NodesReloadSecureSettingsResponseTests.java
@@ -15,7 +15,6 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
-import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.test.ESTestCase;
@@ -33,9 +32,11 @@ public class NodesReloadSecureSettingsResponseTests extends ESTestCase {
 
         TransportVersion target = NodesReloadSecureSettingsResponse.NodeResponse.KEYSTORE_DETAILS;
         TransportVersion previous = TransportVersionUtils.getPreviousVersion(target);
-        TransportVersion future = TransportVersionUtils.randomVersionBetween(Randomness.get(), target, null);
+        TransportVersion higher = TransportVersionUtils.allReleasedVersions().higher(target);
 
-        TransportVersion[] versions = { target, previous, future };
+        TransportVersion[] versions = higher != null
+            ? new TransportVersion[] { target, previous, higher }
+            : new TransportVersion[] { target, previous };
         Exception[] exceptions = { null, new ElasticsearchException("test error") };
         String[][] settingNamesCases = { null, {}, { "setting1", "setting2" } };
         String[] paths = { null, "/keystore" };

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/reload/NodesReloadSecureSettingsResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/reload/NodesReloadSecureSettingsResponseTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.test.TransportVersionUtils;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 
 public class NodesReloadSecureSettingsResponseTests extends ESTestCase {
 
@@ -30,8 +31,11 @@ public class NodesReloadSecureSettingsResponseTests extends ESTestCase {
     public static List<Object[]> parameters() {
         List<Object[]> parameters = new ArrayList<>();
 
-        TransportVersion current = NodesReloadSecureSettingsResponse.NodeResponse.KEYSTORE_DETAILS;
-        TransportVersion[] versions = { current, TransportVersionUtils.getPreviousVersion(current) };
+        TransportVersion target = NodesReloadSecureSettingsResponse.NodeResponse.KEYSTORE_DETAILS;
+        TransportVersion previous = TransportVersionUtils.getPreviousVersion(target);
+        TransportVersion future = TransportVersionUtils.randomVersionBetween(new Random(), target, null);
+
+        TransportVersion[] versions = { target, previous, future };
         Exception[] exceptions = { null, new ElasticsearchException("test error") };
         String[][] settingNamesCases = { null, {}, { "setting1", "setting2" } };
         String[] paths = { null, "/keystore" };

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/reload/NodesReloadSecureSettingsResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/reload/NodesReloadSecureSettingsResponseTests.java
@@ -24,7 +24,6 @@ import org.elasticsearch.test.TransportVersionUtils;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 
 public class NodesReloadSecureSettingsResponseTests extends ESTestCase {
 

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/reload/NodesReloadSecureSettingsResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/reload/NodesReloadSecureSettingsResponseTests.java
@@ -30,7 +30,7 @@ public class NodesReloadSecureSettingsResponseTests extends ESTestCase {
     public static List<Object[]> parameters() {
         List<Object[]> parameters = new ArrayList<>();
 
-        TransportVersion current = TransportVersion.current();
+        TransportVersion current = NodesReloadSecureSettingsResponse.NodeResponse.KEYSTORE_DETAILS;
         TransportVersion[] versions = { current, TransportVersionUtils.getPreviousVersion(current) };
         Exception[] exceptions = { null, new ElasticsearchException("test error") };
         String[][] settingNamesCases = { null, {}, { "setting1", "setting2" } };


### PR DESCRIPTION
This change fixes the seed data for test `NodesReloadSecureSettingsResponseTests`.

The intent is to guarantee that the test always runs with seed data that contains both the _target_ transport version and
the previous one.

It's a follow-up to the test fix by @idegtiarenko here https://github.com/elastic/elasticsearch/pull/138408.