### PR TITLE
[DiskBBQ] do not build empty priority queue

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQVectorsReader.java
@@ -324,6 +324,20 @@ public class ESNextDiskBBQVectorsReader extends IVFVectorsReader {
         final NeighborQueue currentParentQueue = new NeighborQueue(maxChildrenSize, true);
         final int bufferSize = (int) Math.min(Math.max(centroidRatio * numCentroids, 1), numCentroids);
         final int numCentroidsFiltered = acceptCentroids == null ? numCentroids : acceptCentroids.cardinality();
+        if (numCentroidsFiltered == 0) {
+            // TODO maybe this makes CentroidIterator polymorphic?
+            return new CentroidIterator() {
+                @Override
+                public boolean hasNext() {
+                    return false;
+                }
+
+                @Override
+                public CentroidOffsetAndLength nextPostingListOffsetAndLength() {
+                    return null;
+                }
+            };
+        }
         final float[] scores = new float[ES92Int7VectorsScorer.BULK_SIZE];
         final NeighborQueue neighborQueue;
         if (acceptCentroids != null && numCentroidsFiltered <= bufferSize) {

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQVectorsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQVectorsFormatTests.java
@@ -29,6 +29,7 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.AcceptDocs;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.KnnCollector;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopKnnCollector;
@@ -382,6 +383,17 @@ public class ESNextDiskBBQVectorsFormatTests extends BaseKnnVectorsFormatTestCas
                     uniqueDocIds.add(topDocs.scoreDocs[i].doc);
                 }
                 assertEquals(matchingDocs, uniqueDocIds.size());
+                // match no docs
+                leafReader.searchNearestVectors(
+                    "f",
+                    vector,
+                    new TopKnnCollector(2, Integer.MAX_VALUE),
+                    AcceptDocs.fromIteratorSupplier(
+                        DocIdSetIterator::empty,
+                        leafReader.getLiveDocs(),
+                        leafReader.maxDoc()
+                    )
+                );
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQVectorsFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQVectorsFormatTests.java
@@ -388,11 +388,7 @@ public class ESNextDiskBBQVectorsFormatTests extends BaseKnnVectorsFormatTestCas
                     "f",
                     vector,
                     new TopKnnCollector(2, Integer.MAX_VALUE),
-                    AcceptDocs.fromIteratorSupplier(
-                        DocIdSetIterator::empty,
-                        leafReader.getLiveDocs(),
-                        leafReader.maxDoc()
-                    )
+                    AcceptDocs.fromIteratorSupplier(DocIdSetIterator::empty, leafReader.getLiveDocs(), leafReader.maxDoc())
                 );
             }
         }


### PR DESCRIPTION
I noticed in some of our internal benchmarks that this cal fail with error:

```
'search_phase_execution_exception', 'maxSize must be > 0 and < 2147483630; got: 0', maxSize must be > 0 and < 2147483630; got: 0)
```

In order to prevent that let's add a fail safe. We should later investigate how we ended up in this situation as I would expect we should bail out earlier.
