### PR TITLE
[ES-13503] Adding new version pin for testcontainers to our repo to allow us to …

### DIFF
--- a/gradle/build.versions.toml
+++ b/gradle/build.versions.toml
@@ -4,6 +4,7 @@ jackson = "2.15.0"
 junit5 = "5.12.1"
 spock = "2.3-groovy-4.0"
 nmcp = "0.1.5"
+testcontainers = "2.0.2"
 
 [libraries]
 ant = "org.apache.ant:ant:1.10.12"


### PR DESCRIPTION
Testing to see if updating testconainers in gradle.toml verison to 2.0.2 resolves our docker issue as per this github issue:
https://github.com/testcontainers/testcontainers-java/issues/11212