### PR TITLE
Fix race condition in JwtRealmAuthenticateTests#testJwkUpdatesByReloadWithFile

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -414,9 +414,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.RevertModelSnapshotIT
   method: testRevertModelSnapshot_DeleteInterveningResults
   issue: https://github.com/elastic/elasticsearch/issues/132349
-- class: org.elasticsearch.xpack.security.authc.jwt.JwtRealmAuthenticateTests
-  method: testJwkUpdatesByReloadWithFile
-  issue: https://github.com/elastic/elasticsearch/issues/138397
 - class: org.elasticsearch.smoketest.MlWithSecurityIT
   method: test {yaml=ml/start_data_frame_analytics/Test start classification analysis when the dependent variable cardinality is too low}
   issue: https://github.com/elastic/elasticsearch/issues/138409

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/jwt/JwtRealmAuthenticateTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/jwt/JwtRealmAuthenticateTests.java
@@ -286,7 +286,7 @@ public class JwtRealmAuthenticateTests extends JwtRealmTestCase {
             1, // audiencesRange
             1, // usersRange
             1, // rolesRange
-            1, // jwtCacheSizeRange
+            0, // jwtCacheSizeRange (disabled cache)
             httpsServer, // createHttpsServer,
             true
         );


### PR DESCRIPTION
There was a race condition in the test `JwtRealmAuthenticateTests#testJwkUpdatesByReloadWithFile`.

This test verifies PKC JWK set background reloading behavior in the JWT realm. It involves (1) a background thread in JWT realm that polls the JWKS file and (2) the foreground test thread that attempt to authenticate repeatedly.

The foreground test thread also checks the JWT cache without proper locking or synchronization. The can result in concurrent modification to the JWT cache and the NPE below.

The solution is simply to disable the JWT cache for this test. It isn't relevant to the test.

```
java.lang.NullPointerException: Cannot read field "after" because "this.next" is null
at __randomizedtesting.SeedInfo.seed([4F100CD9E675577:DA439805A8AA5B64]:0) |  
-- | --
  | at org.elasticsearch.common.cache.Cache$CacheIterator.next(Cache.java:722) |  
  | at org.elasticsearch.common.cache.Cache$1.next(Cache.java:636) |  
  | at org.elasticsearch.xpack.security.authc.jwt.JwtRealmTestCase.doMultipleAuthcAuthzAndVerifySuccess(JwtRealmTestCase.java:494) |  
  | at org.elasticsearch.xpack.security.authc.jwt.JwtRealmAuthenticateTests.lambda$awaitAuthenticationSuccess$3(JwtRealmAuthenticateTests.java:331) |  
  | at org.elasticsearch.test.ESTestCase.waitUntil(ESTestCase.java:1661) |  
  | at org.elasticsearch.xpack.security.authc.jwt.JwtRealmAuthenticateTests.awaitAuthenticationSuccess(JwtRealmAuthenticateTests.java:329) |  
  | at org.elasticsearch.xpack.security.authc.jwt.JwtRealmAuthenticateTests.doTestJwkUpdatesByReload(JwtRealmAuthenticateTests.java:308) |  
  | at org.elasticsearch.xpack.security.authc.jwt.JwtRealmAuthenticateTests.testJwkUpdatesByReloadWithFile(JwtRealmAuthenticateTests.java:274)
```