### PR TITLE
[8.19] Break on FieldData when building global ordinals (#108875)

### DIFF
--- a/docs/changelog/108875.yaml
+++ b/docs/changelog/108875.yaml
@@ -1,0 +1,6 @@
+pr: 108875
+summary: Break on `FieldData` when building global ordinals
+area: Aggregations
+type: bug
+issues:
+ - 97075

--- a/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsBuilder.java
@@ -72,7 +72,7 @@ public enum GlobalOrdinalsBuilder {
         }
         final OrdinalMap ordinalMap = OrdinalMap.build(null, termsEnums, weights, PackedInts.DEFAULT);
         final long memorySizeInBytes = ordinalMap.ramBytesUsed();
-        breaker.addWithoutBreaking(memorySizeInBytes);
+        breaker.addEstimateBytesAndMaybeBreak(memorySizeInBytes, "Global Ordinals");
 
         TimeValue took = new TimeValue(System.nanoTime() - startTimeNS, TimeUnit.NANOSECONDS);
         if (logger.isDebugEnabled()) {

--- a/server/src/test/java/org/elasticsearch/index/fielddata/FieldDataCacheTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/FieldDataCacheTests.java
@@ -37,6 +37,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.FieldMaskingReader;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 
 public class FieldDataCacheTests extends ESTestCase {
     private static final ToScriptFieldFactory<SortedSetDocValues> MOCK_TO_SCRIPT_FIELD = (dv, n) -> new DelegateDocValuesField(
@@ -100,7 +101,8 @@ public class FieldDataCacheTests extends ESTestCase {
         iw.close();
         DirectoryReader ir = ElasticsearchDirectoryReader.wrap(DirectoryReader.open(dir), new ShardId("_index", "_na_", 0));
 
-        int[] timesCalled = new int[1];
+        int[] timesCalledForParent = new int[1];
+        long[] timesCalledForFieldData = new long[1];
         SortedSetOrdinalsIndexFieldData sortedSetOrdinalsIndexFieldData = new SortedSetOrdinalsIndexFieldData(
             new DummyAccountingFieldDataCache(),
             "field1",
@@ -113,16 +115,22 @@ public class FieldDataCacheTests extends ESTestCase {
                         @Override
                         public void addEstimateBytesAndMaybeBreak(long bytes, String label) throws CircuitBreakingException {
                             assertThat(label, equalTo("Global Ordinals"));
-                            assertThat(bytes, equalTo(0L));
-                            timesCalled[0]++;
+                            if (bytes == 0) {
+                                timesCalledForParent[0]++;
+                            } else {
+                                assertThat(timesCalledForFieldData[0], equalTo(0L));
+                                assertThat(bytes, greaterThan(0L));
+                                timesCalledForFieldData[0] = bytes;
+                            }
                         }
                     };
                 }
             },
             MOCK_TO_SCRIPT_FIELD
         );
-        sortedSetOrdinalsIndexFieldData.loadGlobal(ir);
-        assertThat(timesCalled[0], equalTo(2));
+        IndexOrdinalsFieldData globalOrdinals = sortedSetOrdinalsIndexFieldData.loadGlobal(ir);
+        assertThat(timesCalledForParent[0], equalTo(2));
+        assertThat(timesCalledForFieldData[0], equalTo(globalOrdinals.getOrdinalMap().ramBytesUsed()));
 
         ir.close();
         dir.close();


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Break on FieldData when building global ordinals (#108875)