### PR TITLE
Round sum and avg in exponential_histogram CSV tests

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/exponential_histogram.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/exponential_histogram.csv-spec
@@ -22,16 +22,16 @@ required_capability: exponential_histogram_pre_tech_preview_v2
 FROM exp_histo_sample 
  | EVAL instance = CASE(STARTS_WITH(instance, "dummy"), "dummy-grouped", instance)
  | STATS min = MIN(responseTime), max = MAX(responseTime), median = MEDIAN(responseTime), p75 = PERCENTILE(responseTime,75), sum = SUM(responseTime), avg = AVG(responseTime) BY instance
- | EVAL median = ROUND(median, 7), p75 = ROUND(p75, 7) // rounding to avoid floating point precision issues
+ | EVAL median = ROUND(median, 7), p75 = ROUND(p75, 7), sum = ROUND(sum, 7), avg = ROUND(avg, 7) // rounding to avoid floating point precision issues
  | KEEP instance, min, max, median, p75, sum, avg
  | SORT instance
 ;
 
-instance:keyword | min:double | max:double | median:double | p75:double | sum:double         | avg:double
-dummy-grouped    | -100.0     | 50.0       | 0.0           | 8.3457089  | -7550.0            | -15.0398406374502
-instance-0       | 2.4E-4     | 6.786232   | 0.0211404     | 0.2608237  | 1472.744209        | 0.1665811796176903
-instance-1       | 2.17E-4    | 3.190723   | 6.469E-4      | 0.0016068  | 36.198484          | 0.011137995076923077
-instance-2       | 2.2E-4     | 2.744054   | 6.469E-4      | 0.0016068  | 27.706021000000003 | 0.008197047633136096
+instance:keyword | min:double | max:double | median:double | p75:double | sum:double  | avg:double
+dummy-grouped    | -100.0     | 50.0       | 0.0           | 8.3457089  | -7550.0     | -15.0398406
+instance-0       | 2.4E-4     | 6.786232   | 0.0211404     | 0.2608237  | 1472.744209 | 0.1665812
+instance-1       | 2.17E-4    | 3.190723   | 6.469E-4      | 0.0016068  | 36.198484   | 0.011138
+instance-2       | 2.2E-4     | 2.744054   | 6.469E-4      | 0.0016068  | 27.706021   | 0.008197
 ;
 
 
@@ -45,12 +45,12 @@ FROM exp_histo_sample
          p75 = PERCENTILE(responseTime,75) WHERE instance == "instance-0",
          sum = SUM(responseTime) WHERE instance == "instance-1",
          avg = AVG(responseTime) WHERE instance == "instance-2"
- | EVAL median = ROUND(median, 7), p75 = ROUND(p75, 7) // rounding to avoid floating point precision issues
+ | EVAL median = ROUND(median, 7), p75 = ROUND(p75, 7), sum = ROUND(sum, 7), avg = ROUND(avg, 7) // rounding to avoid floating point precision issues
  | KEEP min, max, median, p75, sum, avg
 ;
 
 min:double | max:double | median:double | p75:double | sum:double | avg:double
-2.4E-4     | 3.190723   | 6.469E-4      | 0.2608237  | 36.198484  | 0.008197047633136096
+2.4E-4     | 3.190723   | 6.469E-4      | 0.2608237  | 36.198484  | 0.008197
 ;
 
 
@@ -59,8 +59,8 @@ required_capability: exponential_histogram_pre_tech_preview_v2
 
 FROM exp_histo_sample 
  | INLINE STATS min = MIN(responseTime), max = MAX(responseTime), median = MEDIAN(responseTime), p75 = PERCENTILE(responseTime,75), sum = SUM(responseTime), avg = AVG(responseTime)  BY instance
- | EVAL median = ROUND(median, 7), p75 = ROUND(p75, 7) // rounding to avoid floating point precision issues
- | KEEP instance, min, max, median, p75, sum , avg
+ | EVAL median = ROUND(median, 7), p75 = ROUND(p75, 7), sum = ROUND(sum, 7), avg = ROUND(avg, 7) // rounding to avoid floating point precision issues
+ | KEEP instance, min, max, median, p75, sum, avg
  | SORT instance
  | Limit 15
 ;
@@ -69,18 +69,18 @@ instance:keyword          | min:double | max:double | median:double | p75:double
 dummy-empty               | null       | null       | null          | null        | null        | null
 dummy-full                | -100.0     | 50.0       | -21.3333333   | 10.6666667  | -3775.0     | -25.0
 dummy-negative_only       | -50.0      | -1.0       | -24.5830421   | -12.8729318 | -1275.0     | -25.5
-dummy-no_zero_bucket      | -100.0     | 50.0       | -21.3333333   | 10.6666667  | -3775.0     | -25.166666666666668
+dummy-no_zero_bucket      | -100.0     | 50.0       | -21.3333333   | 10.6666667  | -3775.0     | -25.1666667
 dummy-positive_only       | 1.0        | 50.0       | 24.5830421    | 34.7656715  | 1275.0      | 25.5
 dummy-zero_count_only     | 0.0        | 0.0        | 0.0           | 0.0         | 0.0         | 0.0
 dummy-zero_threshold_only | null       | null       | null          | null        | null        | null
-instance-0                | 2.4E-4     | 6.786232   | 0.0211404     | 0.2608237   | 1472.744209 | 0.1665811796176903
-instance-0                | 2.4E-4     | 6.786232   | 0.0211404     | 0.2608237   | 1472.744209 | 0.1665811796176903
-instance-0                | 2.4E-4     | 6.786232   | 0.0211404     | 0.2608237   | 1472.744209 | 0.1665811796176903
-instance-0                | 2.4E-4     | 6.786232   | 0.0211404     | 0.2608237   | 1472.744209 | 0.1665811796176903
-instance-0                | 2.4E-4     | 6.786232   | 0.0211404     | 0.2608237   | 1472.744209 | 0.1665811796176903
-instance-0                | 2.4E-4     | 6.786232   | 0.0211404     | 0.2608237   | 1472.744209 | 0.1665811796176903
-instance-0                | 2.4E-4     | 6.786232   | 0.0211404     | 0.2608237   | 1472.744209 | 0.1665811796176903
-instance-0                | 2.4E-4     | 6.786232   | 0.0211404     | 0.2608237   | 1472.744209 | 0.1665811796176903
+instance-0                | 2.4E-4     | 6.786232   | 0.0211404     | 0.2608237   | 1472.744209 | 0.1665812
+instance-0                | 2.4E-4     | 6.786232   | 0.0211404     | 0.2608237   | 1472.744209 | 0.1665812
+instance-0                | 2.4E-4     | 6.786232   | 0.0211404     | 0.2608237   | 1472.744209 | 0.1665812
+instance-0                | 2.4E-4     | 6.786232   | 0.0211404     | 0.2608237   | 1472.744209 | 0.1665812
+instance-0                | 2.4E-4     | 6.786232   | 0.0211404     | 0.2608237   | 1472.744209 | 0.1665812
+instance-0                | 2.4E-4     | 6.786232   | 0.0211404     | 0.2608237   | 1472.744209 | 0.1665812
+instance-0                | 2.4E-4     | 6.786232   | 0.0211404     | 0.2608237   | 1472.744209 | 0.1665812
+instance-0                | 2.4E-4     | 6.786232   | 0.0211404     | 0.2608237   | 1472.744209 | 0.1665812
 ;
 
 
@@ -207,12 +207,12 @@ ungroupedAvg
 required_capability: exponential_histogram_pre_tech_preview_v2
 
 FROM exp_histo_sample | WHERE NOT STARTS_WITH(instance, "dummy") 
- | STATS avg = AVG(responseTime)
+ | STATS avg = ROUND(AVG(responseTime), 7) // rounding to avoid floating point precision issues
  | KEEP avg
 ;
 
 avg:double 
-0.09932445956951716
+0.0993245
 ;
 
 
@@ -220,15 +220,15 @@ groupedAvg
 required_capability: exponential_histogram_pre_tech_preview_v2
 
 FROM exp_histo_sample | WHERE NOT STARTS_WITH(instance, "dummy") 
- | STATS avg = AVG(responseTime) BY instance
+ | STATS avg = ROUND(AVG(responseTime), 7) BY instance // rounding to avoid floating point precision issues
  | KEEP instance, avg
  | SORT instance
 ;
 
 instance:keyword | avg:double
-instance-0       | 0.1665811796176903
-instance-1       | 0.011137995076923077
-instance-2       | 0.008197047633136096
+instance-0       | 0.1665812
+instance-1       | 0.011138
+instance-2       | 0.008197
 ;
 
 
@@ -236,7 +236,7 @@ avgOnEmptyHistogram
 required_capability: exponential_histogram_pre_tech_preview_v2
 
 FROM exp_histo_sample | WHERE instance == "dummy-empty"
- | STATS  avg = AVG(responseTime)
+ | STATS avg = AVG(responseTime)
  | KEEP avg
 ;
 
@@ -249,7 +249,7 @@ ungroupedSum
 required_capability: exponential_histogram_pre_tech_preview_v2
 
 FROM exp_histo_sample | WHERE NOT STARTS_WITH(instance, "dummy") 
- | STATS sum = SUM(responseTime)
+ | STATS sum = ROUND(SUM(responseTime), 7) // rounding to avoid floating point precision issues
  | KEEP sum
 ;
 
@@ -262,7 +262,7 @@ groupedSum
 required_capability: exponential_histogram_pre_tech_preview_v2
 
 FROM exp_histo_sample | WHERE NOT STARTS_WITH(instance, "dummy") 
- | STATS sum = SUM(responseTime) BY instance
+ | STATS sum = ROUND(SUM(responseTime), 7) BY instance // rounding to avoid floating point precision issues
  | KEEP instance, sum
  | SORT instance
 ;
@@ -270,5 +270,5 @@ FROM exp_histo_sample | WHERE NOT STARTS_WITH(instance, "dummy")
 instance:keyword | sum:double
 instance-0       | 1472.744209
 instance-1       | 36.198484
-instance-2       | 27.706021000000003
+instance-2       | 27.706021
 ;


### PR DESCRIPTION
Adds rounding to the `SUM` and `AVG` computations in the CSV tests for exponential_histograms.
SUM and AVG are only deterministic when the order of inputs is always the same. Therefore, when running as unit tests the tests have always been passing, but occasionally have failed when running as integration tests.
