### PR TITLE
ES|QL: Fix generative tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -432,9 +432,6 @@ tests:
 - class: org.elasticsearch.test.rest.yaml.CcsCommonYamlTestSuiteIT
   method: test {p0=search/160_exists_query/Test exists query on mapped byte field with no doc values}
   issue: https://github.com/elastic/elasticsearch/issues/138452
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/138454
 - class: org.elasticsearch.test.rest.yaml.RcsCcsCommonYamlTestSuiteIT
   method: test {p0=search/160_exists_query/Test exists query on geo_point field in empty index}
   issue: https://github.com/elastic/elasticsearch/issues/138461

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
@@ -59,6 +59,7 @@ public abstract class GenerativeRestTest extends ESRestTestCase implements Query
         "The field names are too complex to process", // field_caps problem
         "must be \\[any type except counter types\\]", // TODO refine the generation of count()
         "INLINE STATS cannot be used after an explicit or implicit LIMIT command",
+        "sub-plan execution results too large",  // INLINE STATS limitations
 
         // Awaiting fixes for query failure
         "Unknown column \\[<all-fields-projected>\\]", // https://github.com/elastic/elasticsearch/issues/121741,


### PR DESCRIPTION
Adding an exclusion for failures due to large sub-plans (not supported)

Fixes: https://github.com/elastic/elasticsearch/issues/138454