### PR TITLE
[8.19] [IRONSCALES] - Fix Cannot execute ILM policy delete step (#138094)

### DIFF
--- a/docs/changelog/138094.yaml
+++ b/docs/changelog/138094.yaml
@@ -1,0 +1,6 @@
+pr: 138094
+summary: "[IRONSCALES] Add `manage`, `create_index`, `read`, `index`, `write`, `delete`, permission for third party agent indices `kibana_system`"
+area: Authorization
+type: enhancement
+issues:
+  - 138093

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -502,7 +502,7 @@ class KibanaOwnedReservedRoleDescriptors {
                         TransportDeleteIndexAction.TYPE.name()
                     )
                     .build(),
-                // For ExtraHop, QualysGAV, SentinelOne, Island Browser and Cyera specific actions.
+                // For ExtraHop, QualysGAV, SentinelOne, Island Browser, Cyera and IRONSCALES specific actions.
                 // Kibana reads, writes and manages this index
                 // for configured ILM policies.
                 RoleDescriptor.IndicesPrivileges.builder()
@@ -515,7 +515,8 @@ class KibanaOwnedReservedRoleDescriptors {
                         "logs-island_browser.device-*",
                         "logs-cyera.classification-*",
                         "logs-cyera.issue-*",
-                        "logs-cyera.datastore-*"
+                        "logs-cyera.datastore-*",
+                        "logs-ironscales.incident-*"
                     )
                     .privileges(
                         "manage",

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1896,7 +1896,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
             assertThat(kibanaRole.indices().allowedIndicesMatcher(RolloverAction.NAME).test(indexAbstraction), is(true));
         });
 
-        // Tests for third-party agent indices (ExtraHop, QualysGAV, SentinelOne, Island Browser, Cyera) that `kibana_system`
+        // Tests for third-party agent indices (ExtraHop, QualysGAV, SentinelOne, Island Browser, Cyera, IRONSCALES) that `kibana_system`
         // has full management access to
         // This includes read, write, create, delete, and all ILM-related management actions.
         Arrays.asList(
@@ -1908,7 +1908,8 @@ public class ReservedRolesStoreTests extends ESTestCase {
             "logs-island_browser.device-" + randomAlphaOfLength(randomIntBetween(1, 10)),
             "logs-cyera.classification-" + randomAlphaOfLength(randomIntBetween(1, 10)),
             "logs-cyera.issue-" + randomAlphaOfLength(randomIntBetween(1, 10)),
-            "logs-cyera.datastore-" + randomAlphaOfLength(randomIntBetween(1, 10))
+            "logs-cyera.datastore-" + randomAlphaOfLength(randomIntBetween(1, 10)),
+            "logs-ironscales.incident-" + randomAlphaOfLength(randomIntBetween(1, 10))
         ).forEach((index_qualys_extra_hop) -> {
             final IndexAbstraction indexAbstraction = mockIndexAbstraction(index_qualys_extra_hop);
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:

- https://github.com/elastic/elasticsearch/pull/138094

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)