### PR TITLE
Use Wrapped Action Listeners in ShardBulkInferenceActionFilter

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilter.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilter.java
@@ -325,61 +325,55 @@ public class ShardBulkInferenceActionFilter implements MappedActionFilter {
             final Releasable onFinish
         ) {
             if (inferenceProvider == null) {
-                ActionListener<UnparsedModel> modelLoadingListener = new ActionListener<>() {
-                    @Override
-                    public void onResponse(UnparsedModel unparsedModel) {
-                        var service = inferenceServiceRegistry.getService(unparsedModel.service());
-                        if (service.isEmpty() == false) {
-                            var provider = new InferenceProvider(
-                                service.get(),
-                                service.get()
-                                    .parsePersistedConfigWithSecrets(
-                                        inferenceId,
-                                        unparsedModel.taskType(),
-                                        unparsedModel.settings(),
-                                        unparsedModel.secrets()
-                                    )
-                            );
-                            executeChunkedInferenceAsync(inferenceId, provider, requests, onFinish);
-                        } else {
-                            try (onFinish) {
-                                for (FieldInferenceRequest request : requests) {
-                                    inferenceResults.get(request.bulkItemIndex).failures.add(
-                                        new ResourceNotFoundException(
-                                            "Inference service [{}] not found for field [{}]",
-                                            unparsedModel.service(),
-                                            request.field
-                                        )
-                                    );
-                                }
-                            }
-                        }
-                    }
-
-                    @Override
-                    public void onFailure(Exception exc) {
+                ActionListener<UnparsedModel> modelLoadingListener = ActionListener.wrap(unparsedModel -> {
+                    var service = inferenceServiceRegistry.getService(unparsedModel.service());
+                    if (service.isEmpty() == false) {
+                        var provider = new InferenceProvider(
+                            service.get(),
+                            service.get()
+                                .parsePersistedConfigWithSecrets(
+                                    inferenceId,
+                                    unparsedModel.taskType(),
+                                    unparsedModel.settings(),
+                                    unparsedModel.secrets()
+                                )
+                        );
+                        executeChunkedInferenceAsync(inferenceId, provider, requests, onFinish);
+                    } else {
                         try (onFinish) {
                             for (FieldInferenceRequest request : requests) {
-                                Exception failure;
-                                if (ExceptionsHelper.unwrap(exc, ResourceNotFoundException.class) instanceof ResourceNotFoundException) {
-                                    failure = new ResourceNotFoundException(
-                                        "Inference id [{}] not found for field [{}]",
-                                        inferenceId,
+                                inferenceResults.get(request.bulkItemIndex).failures.add(
+                                    new ResourceNotFoundException(
+                                        "Inference service [{}] not found for field [{}]",
+                                        unparsedModel.service(),
                                         request.field
-                                    );
-                                } else {
-                                    failure = new InferenceException(
-                                        "Error loading inference for inference id [{}] on field [{}]",
-                                        exc,
-                                        inferenceId,
-                                        request.field
-                                    );
-                                }
-                                inferenceResults.get(request.bulkItemIndex).failures.add(failure);
+                                    )
+                                );
                             }
                         }
                     }
-                };
+                }, exc -> {
+                    try (onFinish) {
+                        for (FieldInferenceRequest request : requests) {
+                            Exception failure;
+                            if (ExceptionsHelper.unwrap(exc, ResourceNotFoundException.class) instanceof ResourceNotFoundException) {
+                                failure = new ResourceNotFoundException(
+                                    "Inference id [{}] not found for field [{}]",
+                                    inferenceId,
+                                    request.field
+                                );
+                            } else {
+                                failure = new InferenceException(
+                                    "Error loading inference for inference id [{}] on field [{}]",
+                                    exc,
+                                    inferenceId,
+                                    request.field
+                                );
+                            }
+                            inferenceResults.get(request.bulkItemIndex).failures.add(failure);
+                        }
+                    }
+                });
                 modelRegistry.getModelWithSecrets(inferenceId, modelLoadingListener);
                 return;
             }
@@ -398,65 +392,59 @@ public class ShardBulkInferenceActionFilter implements MappedActionFilter {
                 .map(r -> new ChunkInferenceInput(new InferenceString(r.input, TEXT), r.chunkingSettings))
                 .collect(Collectors.toList());
 
-            ActionListener<List<ChunkedInference>> completionListener = new ActionListener<>() {
-
-                @Override
-                public void onResponse(List<ChunkedInference> results) {
-                    try (onFinish) {
-                        var requestsIterator = requests.iterator();
-                        int success = 0;
-                        for (ChunkedInference result : results) {
-                            var request = requestsIterator.next();
-                            var acc = inferenceResults.get(request.bulkItemIndex);
-                            if (result instanceof ChunkedInferenceError error) {
-                                recordRequestCountMetrics(inferenceProvider.model, 1, error.exception());
-                                acc.addFailure(
-                                    new InferenceException(
-                                        "Exception when running inference id [{}] on field [{}]",
-                                        error.exception(),
-                                        inferenceProvider.model.getInferenceEntityId(),
-                                        request.field
-                                    )
-                                );
-                            } else {
-                                success++;
-                                acc.addOrUpdateResponse(
-                                    new FieldInferenceResponse(
-                                        request.field(),
-                                        request.sourceField(),
-                                        useLegacyFormat ? request.input() : null,
-                                        request.inputOrder(),
-                                        request.offsetAdjustment(),
-                                        inferenceProvider.model,
-                                        result
-                                    )
-                                );
-                            }
-                        }
-                        if (success > 0) {
-                            recordRequestCountMetrics(inferenceProvider.model, success, null);
-                        }
-                    }
-                }
-
-                @Override
-                public void onFailure(Exception exc) {
-                    try (onFinish) {
-                        recordRequestCountMetrics(inferenceProvider.model, requests.size(), exc);
-                        for (FieldInferenceRequest request : requests) {
-                            addInferenceResponseFailure(
-                                request.bulkItemIndex,
+            ActionListener<List<ChunkedInference>> completionListener = ActionListener.wrap(results -> {
+                try (onFinish) {
+                    var requestsIterator = requests.iterator();
+                    int success = 0;
+                    for (ChunkedInference result : results) {
+                        var request = requestsIterator.next();
+                        var acc = inferenceResults.get(request.bulkItemIndex);
+                        if (result instanceof ChunkedInferenceError error) {
+                            recordRequestCountMetrics(inferenceProvider.model, 1, error.exception());
+                            acc.addFailure(
                                 new InferenceException(
                                     "Exception when running inference id [{}] on field [{}]",
-                                    exc,
+                                    error.exception(),
                                     inferenceProvider.model.getInferenceEntityId(),
                                     request.field
                                 )
                             );
+                        } else {
+                            success++;
+                            acc.addOrUpdateResponse(
+                                new FieldInferenceResponse(
+                                    request.field(),
+                                    request.sourceField(),
+                                    useLegacyFormat ? request.input() : null,
+                                    request.inputOrder(),
+                                    request.offsetAdjustment(),
+                                    inferenceProvider.model,
+                                    result
+                                )
+                            );
                         }
                     }
+                    if (success > 0) {
+                        recordRequestCountMetrics(inferenceProvider.model, success, null);
+                    }
                 }
-            };
+            }, exc -> {
+                try (onFinish) {
+                    recordRequestCountMetrics(inferenceProvider.model, requests.size(), exc);
+                    for (FieldInferenceRequest request : requests) {
+                        addInferenceResponseFailure(
+                            request.bulkItemIndex,
+                            new InferenceException(
+                                "Exception when running inference id [{}] on field [{}]",
+                                exc,
+                                inferenceProvider.model.getInferenceEntityId(),
+                                request.field
+                            )
+                        );
+                    }
+                }
+            });
+
             inferenceProvider.service()
                 .chunkedInfer(
                     inferenceProvider.model(),

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilter.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilter.java
@@ -379,7 +379,7 @@ public class ShardBulkInferenceActionFilter implements MappedActionFilter {
 
                         if (ExceptionsHelper.status(exc).getStatus() >= 500) {
                             List<String> fields = requests.stream().map(FieldInferenceRequest::field).distinct().toList();
-                            logger.warn("Error loading inference for inference id [" + inferenceId + "] on fields " + fields, exc);
+                            logger.error("Error loading inference for inference id [" + inferenceId + "] on fields " + fields, exc);
                         }
                     }
                 });
@@ -454,7 +454,7 @@ public class ShardBulkInferenceActionFilter implements MappedActionFilter {
 
                     if (ExceptionsHelper.status(exc).getStatus() >= 500) {
                         List<String> fields = requests.stream().map(FieldInferenceRequest::field).distinct().toList();
-                        logger.warn(
+                        logger.error(
                             "Exception when running inference id ["
                                 + inferenceProvider.model.getInferenceEntityId()
                                 + "] on fields "


### PR DESCRIPTION
Use wrapped action listeners in `ShardBulkInferenceActionFilter` to ensure that any exceptions thrown during `onResponse` handling are reported.