### PR TITLE
Block centroid tests in mixed clusters with 8.15

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial.csv-spec
@@ -550,6 +550,7 @@ POINT (42.97109629958868 14.7552534006536)    | 1
 
 centroidFromAirportsAfterIntersectsCompoundPredicateNoDocValues
 required_capability: st_intersects
+required_capability: spatial_distance_pushdown_enhancements
 
 FROM airports_no_doc_values
 | WHERE scalerank == 9 AND ST_INTERSECTS(location, TO_GEOSHAPE("POLYGON((42 14, 43 14, 43 15, 42 15, 42 14))")) AND country == "Yemen"
@@ -562,6 +563,7 @@ POINT (42.97109629958868 14.7552534006536)    | 1
 
 centroidFromAirportsAfterIntersectsCompoundPredicateNotIndexedNorDocValues
 required_capability: st_intersects
+required_capability: spatial_distance_pushdown_enhancements
 
 FROM airports_not_indexed_nor_doc_values
 | WHERE scalerank == 9 AND ST_INTERSECTS(location, TO_GEOSHAPE("POLYGON((42 14, 43 14, 43 15, 42 15, 42 14))")) AND country == "Yemen"
@@ -574,6 +576,7 @@ POINT (42.97109629958868 14.7552534006536)    | 1
 
 centroidFromAirportsAfterIntersectsCompoundPredicateNotIndexed
 required_capability: st_intersects
+required_capability: spatial_distance_pushdown_enhancements
 
 FROM airports_not_indexed
 | WHERE scalerank == 9 AND ST_INTERSECTS(location, TO_GEOSHAPE("POLYGON((42 14, 43 14, 43 15, 42 15, 42 14))")) AND country == "Yemen"


### PR DESCRIPTION
In 8.16 there was an important fix to the rule for planning doc-values reading of spatial fields for aggregations. This fix did not go back to 8.15 and 8.14, and so any later version that has a mixed cluster with these older versions cannot run queries that perform spatial aggregations when the field does not have doc values. The newer versions will correctly block the doc-values loading, but the older version will still attempt to do this, causing a mismatch of block type, as seen in the issue at #116945 and #137334

The choice of `spatial_distance_pushdown_enhancements` is not an exact match for the change that fixed this issue, but the goal here is primarily to block tests in 8.14 and 8.15, and this capability was introduced in 8.16, and is conceptually related to the change that actually fixed this in 8.16.

The actual fix for 8.15 can be seen in https://github.com/elastic/elasticsearch/pull/138437, but that will never get merged, because no further 8.15 releases will be made.

Fixes #116945
Fixes #137334