### PR TITLE
Remove dead code in WithinSeriesAggregate

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/WithinSeriesAggregate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/WithinSeriesAggregate.java
@@ -7,20 +7,11 @@
 
 package org.elasticsearch.xpack.esql.plan.logical.promql;
 
-import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
-import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
-import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
-import org.elasticsearch.xpack.esql.core.expression.function.Function;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
-import org.elasticsearch.xpack.esql.core.type.DataType;
-import org.elasticsearch.xpack.esql.expression.promql.function.PromqlFunctionRegistry;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
-import org.elasticsearch.xpack.esql.plan.logical.SurrogateLogicalPlan;
-import org.elasticsearch.xpack.esql.plan.logical.TimeSeriesAggregate;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -51,7 +42,7 @@ import java.util.List;
  *   avg_over_time(cpu_usage[1h])
  *     → TimeSeriesAggregate(groupBy: _tsid, agg: AvgOverTime(value))
  */
-public class WithinSeriesAggregate extends PromqlFunctionCall implements SurrogateLogicalPlan {
+public class WithinSeriesAggregate extends PromqlFunctionCall {
 
     public WithinSeriesAggregate(Source source, LogicalPlan child, String functionName, List<Expression> parameters) {
         super(source, child, functionName, parameters);
@@ -65,34 +56,6 @@ public class WithinSeriesAggregate extends PromqlFunctionCall implements Surroga
     @Override
     public WithinSeriesAggregate replaceChild(LogicalPlan newChild) {
         return new WithinSeriesAggregate(source(), newChild, functionName(), parameters());
-    }
-
-    @Override
-    public LogicalPlan surrogate() {
-        LogicalPlan childPlan = child();
-
-        ReferenceAttribute timestampField = new ReferenceAttribute(source(), "@timestamp", DataType.DATETIME);
-        ReferenceAttribute valueField = new ReferenceAttribute(source(), "value", DataType.DOUBLE);
-        ReferenceAttribute tsidField = new ReferenceAttribute(source(), "_tsid", DataType.KEYWORD);
-
-        List<Expression> functionParams = new ArrayList<>();
-        functionParams.add(valueField);
-        functionParams.add(timestampField);
-        functionParams.addAll(parameters());
-
-        Function esqlFunction = PromqlFunctionRegistry.INSTANCE.buildEsqlFunction(functionName(), source(), functionParams);
-
-        String internalName = functionName() + "_$result";
-        Alias functionAlias = new Alias(source(), internalName, esqlFunction);
-
-        List<Expression> groupings = new ArrayList<>();
-        groupings.add(tsidField);
-
-        List<NamedExpression> aggregates = new ArrayList<>();
-        aggregates.add(functionAlias);
-        aggregates.add(tsidField);
-
-        return new TimeSeriesAggregate(source(), childPlan, groupings, aggregates, null);
     }
 
     // @Override


### PR DESCRIPTION
I'm relatively certain that this is dead code/a leftover. The translation should happen consistently either in the `TranslatePromqlToTimeSeriesAggregate` optimizer rule or via surrogates. But mixing both doesn't seem to make sense.