### PR TITLE
Return `ETag` from S3 fixture `GetObject` API

### DIFF
--- a/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpHandler.java
+++ b/test/fixtures/s3-fixture/src/main/java/fixture/s3/S3HttpHandler.java
@@ -418,6 +418,11 @@ public class S3HttpHandler implements HttpHandler {
         }
     }
 
+    /**
+     * Etags are opaque identifiers for the contents of an object.
+     *
+     * @see <a href="https://en.wikipedia.org/wiki/HTTP_ETag">HTTP ETag on Wikipedia</a>.
+     */
     public static String getEtagFromContents(BytesReference blobContents) {
         return '"' + SHA_256_ETAG_PREFIX + MessageDigests.toHexString(MessageDigests.digest(blobContents, MessageDigests.sha256())) + '"';
     }

--- a/test/fixtures/s3-fixture/src/test/java/fixture/s3/S3HttpHandlerTests.java
+++ b/test/fixtures/s3-fixture/src/test/java/fixture/s3/S3HttpHandlerTests.java
@@ -488,6 +488,20 @@ public class S3HttpHandlerTests extends ESTestCase {
         return multipartUploadTask;
     }
 
+    public void testGetETagFromContents() {
+        // empty-string value from Wikipedia, see also org.elasticsearch.common.hash.MessageDigestsTests.testSha256
+        assertETag("", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+        assertETag("The quick brown fox jumps over the lazy dog", "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592");
+        assertETag("The quick brown fox jumps over the lazy cog", "e4c4d8f3bf76b692de791a173e05321150f7a345b46484fe427f6acc7ecc81be");
+    }
+
+    private static void assertETag(String input, String expectedHash) {
+        assertEquals(
+            "\"es-test-sha-256-" + expectedHash + '"',
+            S3HttpHandler.getEtagFromContents(new BytesArray(input.getBytes(StandardCharsets.UTF_8)))
+        );
+    }
+
     private static class TestWriteTask {
         final BytesReference body;
         final Runnable consumer;


### PR DESCRIPTION
AWS S3 uses the `ETag` header to identify the object contents in various
API responses. `S3HttpHandler` doesn't today return this header from its
`GetObject` API, and its APIs which do return an `ETag` do not properly
conform to its spec (particularly, they are not surrounded by `"`
characters). This commit adds the missing response header to the
`GetObject` API, fixes its format, and uses SHA256 rather than MD5 to
compute the result.