### PR TITLE
Fix JinaAI chunkedInfer with late chunking test failure

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -420,9 +420,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.RevertModelSnapshotIT
   method: testRevertModelSnapshot
   issue: https://github.com/elastic/elasticsearch/issues/132733
-- class: org.elasticsearch.xpack.inference.services.jinaai.JinaAIServiceTests
-  method: test_Embedding_ChunkedInfer_LateChunkingEnabled
-  issue: https://github.com/elastic/elasticsearch/issues/138451
 - class: org.elasticsearch.test.rest.yaml.CcsCommonYamlTestSuiteIT
   method: test {p0=search/160_exists_query/Test exists query on mapped byte field with no doc values}
   issue: https://github.com/elastic/elasticsearch/issues/138452

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIServiceTests.java
@@ -1733,27 +1733,7 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
                 }
                 """;
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
-            var responseJson2 = """
-                {
-                    "model": "jina-clip-v2",
-                    "object": "list",
-                    "usage": {
-                        "total_tokens": 5,
-                        "prompt_tokens": 5
-                    },
-                    "data": [
-                        {
-                            "object": "embedding",
-                            "index": 0,
-                            "embedding": [
-                                0.123,
-                                -0.123
-                            ]
-                        }
-                    ]
-                }
-                """;
-            webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson2));
+            webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
         } else {
             var responseJson = """
                 {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIServiceTests.java
@@ -1702,7 +1702,7 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
                 assertEquals(new ChunkedInference.TextOffset(0, 2), floatResult.chunks().get(0).offset());
                 assertThat(floatResult.chunks().get(0).embedding(), Matchers.instanceOf(DenseEmbeddingFloatResults.Embedding.class));
                 assertArrayEquals(
-                    new float[] { 0.223f, -0.223f },
+                    new float[] { 0.123f, -0.123f },
                     ((DenseEmbeddingFloatResults.Embedding) floatResult.chunks().get(0).embedding()).values(),
                     0.0f
                 );
@@ -1746,8 +1746,8 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
                             "object": "embedding",
                             "index": 0,
                             "embedding": [
-                                0.223,
-                                -0.223
+                                0.123,
+                                -0.123
                             ]
                         }
                     ]
@@ -1776,8 +1776,8 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
                             "object": "embedding",
                             "index": 1,
                             "embedding": [
-                                0.223,
-                                -0.223
+                                0.123,
+                                -0.123
                             ]
                         }
                     ]


### PR DESCRIPTION
Closes - https://github.com/elastic/elasticsearch/issues/138451

From the test failure it seems that when late chunking is enabled and we are sending 2 requests to the `MockWebServer`. The `MockWebServer` has two results enqueued which will be returned in FIFO order. On occasions we find that the first request to the `MockWebServer` comes back with the second result. It seems that since we are sending the requests to the `MockWebServer` in parallel, we can occasionally have the second request complete before the first, thus having the results seem out-of-order. This change updates the results to be identical so we don't have to depend on a specific order of requests completing.