### PR TITLE
Ignore new Locales used in tests ES SQL (#138360)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -5,30 +5,6 @@ tests:
 - class: org.elasticsearch.packaging.test.PackagesSecurityAutoConfigurationTests
   method: test20SecurityNotAutoConfiguredOnReInstallation
   issue: https://github.com/elastic/elasticsearch/issues/112635
-- class: org.elasticsearch.xpack.sql.qa.single_node.JdbcSqlSpecIT
-  method: test {case-functions.testSelectInsertWithLcaseAndLengthWithOrderBy}
-  issue: https://github.com/elastic/elasticsearch/issues/112642
-- class: org.elasticsearch.xpack.sql.qa.single_node.JdbcSqlSpecIT
-  method: test {case-functions.testUcaseInline1}
-  issue: https://github.com/elastic/elasticsearch/issues/112641
-- class: org.elasticsearch.xpack.sql.qa.single_node.JdbcSqlSpecIT
-  method: test {case-functions.testUpperCasingTheSecondLetterFromTheRightFromFirstName}
-  issue: https://github.com/elastic/elasticsearch/issues/112640
-- class: org.elasticsearch.xpack.sql.qa.single_node.JdbcSqlSpecIT
-  method: test {case-functions.testUcaseInline3}
-  issue: https://github.com/elastic/elasticsearch/issues/112643
-- class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT
-  method: test {case-functions.testUcaseInline1}
-  issue: https://github.com/elastic/elasticsearch/issues/112641
-- class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT
-  method: test {case-functions.testUcaseInline3}
-  issue: https://github.com/elastic/elasticsearch/issues/112643
-- class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT
-  method: test {case-functions.testUpperCasingTheSecondLetterFromTheRightFromFirstName}
-  issue: https://github.com/elastic/elasticsearch/issues/112640
-- class: org.elasticsearch.xpack.sql.qa.security.JdbcSqlSpecIT
-  method: test {case-functions.testSelectInsertWithLcaseAndLengthWithOrderBy}
-  issue: https://github.com/elastic/elasticsearch/issues/112642
 - class: org.elasticsearch.packaging.test.WindowsServiceTests
   method: test30StartStop
   issue: https://github.com/elastic/elasticsearch/issues/113160

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/SqlSpecTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/SqlSpecTestCase.java
@@ -86,7 +86,17 @@ public abstract class SqlSpecTestCase extends SpecBaseIntegrationTestCase {
     protected final void doTest() throws Throwable {
         // we skip the tests in case of these locales because ES-SQL is Locale-insensitive for now
         // while H2 does take the Locale into consideration
-        String[] h2IncompatibleLocales = new String[] { "tr", "az", "tr-TR", "tr-CY", "az-Latn", "az-Cyrl", "az-Latn-AZ", "az-Cyrl-AZ" };
+        String[] h2IncompatibleLocales = new String[] {
+            "tr",
+            "az",
+            "tr-TR",
+            "tr-CY",
+            "az-Latn",
+            "az-Cyrl",
+            "az-Latn-AZ",
+            "az-Cyrl-AZ",
+            "tr-Latn-TR",
+            "az-AZ" };
         boolean goodLocale = Arrays.stream(h2IncompatibleLocales)
             .anyMatch((l) -> Locale.getDefault().equals(new Locale.Builder().setLanguageTag(l).build())) == false;
         if (fileName.startsWith("case-functions")) {

--- a/x-pack/plugin/sql/qa/server/src/main/resources/case-functions.sql-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/case-functions.sql-spec
@@ -1,7 +1,13 @@
 // To mute tests follow example in file: example.sql-spec
 
+// For anyone reaching this file in the future coming from CI failures related to uppercasing/lowercasing tests:
+// For example: Different result for column [upper], entry [1] expected:< ELAST[İ]C > but was:< ELAST[I]C >
+// Go to SqlSpecTestCase.doTest() method and look for h2IncompatibleLocales and add the faulty Locale there,
+// after you double check that the issue is indeed related to that specific Locale.
+
 // Next 4 SELECTs in this file are related to https://github.com/elastic/elasticsearch/issues/32589
 // H2 is Locale sensitive, while ES-SQL is not (so far)
+
 selectInsertWithLcaseAndLengthWithOrderBy
 SELECT "first_name" origFN, "last_name" origLN, INSERT(UCASE("first_name"),LENGTH("first_name")+1,123,LCASE("last_name")) modified FROM "test_emp" WHERE ASCII("first_name")=65 ORDER BY "first_name" ASC, "last_name" ASC LIMIT 10;
 


### PR DESCRIPTION
These locales are probably "new" and should have been added to the list of ignored ones for that specific test file. The main reason is that ES SQL is Locale-insensitive, while H2 (the database we compare the results with) is Locale sensitive.

Fixes https://github.com/elastic/elasticsearch/issues/112640 
Fixes https://github.com/elastic/elasticsearch/issues/112641 
Fixes https://github.com/elastic/elasticsearch/issues/112642 
Fixes https://github.com/elastic/elasticsearch/issues/112643 
Fixes https://github.com/elastic/elasticsearch/issues/112746

(cherry picked from commit f569ef3b5bc896fec9c8a24873a8ee648d6f41ce)