### PR TITLE
EQL: accept project_routing as query parameter

### DIFF
--- a/docs/changelog/138559.yaml
+++ b/docs/changelog/138559.yaml
@@ -1,0 +1,5 @@
+pr: 138559
+summary: Accept `project_routing` as query parameter
+area: EQL
+type: enhancement
+issues: []

--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/EqlRestTestCase.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/EqlRestTestCase.java
@@ -61,7 +61,10 @@ public abstract class EqlRestTestCase extends RemoteClusterAwareEqlRestTestCase 
             """, validQuery), "query malformed, empty clause found" },
         { String.format(Locale.ROOT, """
             {"query": "%s", "max_samples_per_key": 0}
-            """, validQuery), "max_samples_per_key must be greater than 0" } };
+            """, validQuery), "max_samples_per_key must be greater than 0" },
+        { String.format(Locale.ROOT, """
+            {"query": "%s", "project_routing": "foo"}
+            """, validQuery), "[project_routing] is only allowed when cross-project search is enabled" } };
 
     public void testBadRequests() throws Exception {
         createIndex(defaultValidationIndexName, (String) null);

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
@@ -90,6 +90,7 @@ public class EqlSearchRequest extends LegacyActionRequest implements IndicesRequ
     static final String KEY_MAX_SAMPLES_PER_KEY = "max_samples_per_key";
     static final String KEY_ALLOW_PARTIAL_SEARCH_RESULTS = "allow_partial_search_results";
     static final String KEY_ALLOW_PARTIAL_SEQUENCE_RESULTS = "allow_partial_sequence_results";
+    static final String KEY_PROJECT_ROUTING = "project_routing";
 
     static final ParseField FILTER = new ParseField(KEY_FILTER);
     static final ParseField TIMESTAMP_FIELD = new ParseField(KEY_TIMESTAMP_FIELD);
@@ -106,6 +107,7 @@ public class EqlSearchRequest extends LegacyActionRequest implements IndicesRequ
     static final ParseField MAX_SAMPLES_PER_KEY = new ParseField(KEY_MAX_SAMPLES_PER_KEY);
     static final ParseField ALLOW_PARTIAL_SEARCH_RESULTS = new ParseField(KEY_ALLOW_PARTIAL_SEARCH_RESULTS);
     static final ParseField ALLOW_PARTIAL_SEQUENCE_RESULTS = new ParseField(KEY_ALLOW_PARTIAL_SEQUENCE_RESULTS);
+    static final ParseField PROJECT_ROUTING = new ParseField(KEY_PROJECT_ROUTING);
 
     private static final ObjectParser<EqlSearchRequest, Void> PARSER = objectParser(EqlSearchRequest::new);
 
@@ -301,6 +303,7 @@ public class EqlSearchRequest extends LegacyActionRequest implements IndicesRequ
         parser.declareInt(EqlSearchRequest::maxSamplesPerKey, MAX_SAMPLES_PER_KEY);
         parser.declareBoolean(EqlSearchRequest::allowPartialSearchResults, ALLOW_PARTIAL_SEARCH_RESULTS);
         parser.declareBoolean(EqlSearchRequest::allowPartialSequenceResults, ALLOW_PARTIAL_SEQUENCE_RESULTS);
+        parser.declareString(EqlSearchRequest::projectRouting, PROJECT_ROUTING);
         return parser;
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/RestEqlSearchAction.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/RestEqlSearchAction.java
@@ -29,6 +29,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.eql.action.EqlSearchAction;
 import org.elasticsearch.xpack.eql.action.EqlSearchRequest;
 import org.elasticsearch.xpack.eql.action.EqlSearchResponse;
+import org.elasticsearch.xpack.ql.InvalidArgumentException;
 
 import java.io.IOException;
 import java.util.List;
@@ -88,6 +89,9 @@ public class RestEqlSearchAction extends BaseRestHandler {
                 request.paramAsBoolean("allow_partial_sequence_results", eqlRequest.allowPartialSequenceResults())
             );
             eqlRequest.projectRouting(request.param("project_routing", eqlRequest.getProjectRouting()));
+            if (crossProjectEnabled == false && eqlRequest.getProjectRouting() != null) {
+                throw new InvalidArgumentException("[project_routing] is only allowed when cross-project search is enabled");
+            }
         }
 
         return channel -> {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/RestEqlSearchAction.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/RestEqlSearchAction.java
@@ -87,6 +87,7 @@ public class RestEqlSearchAction extends BaseRestHandler {
             eqlRequest.allowPartialSequenceResults(
                 request.paramAsBoolean("allow_partial_sequence_results", eqlRequest.allowPartialSequenceResults())
             );
+            eqlRequest.projectRouting(request.param("project_routing", eqlRequest.getProjectRouting()));
         }
 
         return channel -> {

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlRequestParserTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlRequestParserTests.java
@@ -68,6 +68,7 @@ public class EqlRequestParserTests extends ESTestCase {
               "timestamp_field": "tsf",
               "event_category_field": "etf",
               "size": "101",
+              "project_routing": "_alias:_origin",
               "query": "file where user != 'SYSTEM' by file_path"
             }""", EqlSearchRequest::fromXContent);
         assertArrayEquals(new String[] { "endgame-*" }, request.indices());
@@ -81,6 +82,7 @@ public class EqlRequestParserTests extends ESTestCase {
         assertEquals(101, request.size());
         assertEquals(1000, request.fetchSize());
         assertEquals("file where user != 'SYSTEM' by file_path", request.query());
+        assertEquals("_alias:_origin", request.getProjectRouting());
     }
 
     private EqlSearchRequest generateRequest(String index, String json, Function<XContentParser, EqlSearchRequest> fromXContent)

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlSearchRequestTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlSearchRequestTests.java
@@ -81,6 +81,7 @@ public class EqlSearchRequestTests extends AbstractBWCSerializationTestCase<EqlS
                 .keepOnCompletion(randomBoolean())
                 .allowPartialSearchResults(randomBoolean())
                 .allowPartialSequenceResults(randomBoolean())
+                .projectRouting(randomAlphaOfLength(10))
                 .fetchFields(randomFetchFields)
                 .runtimeMappings(randomRuntimeMappings())
                 .resultPosition(randomFrom("tail", "head"))
@@ -143,6 +144,7 @@ public class EqlSearchRequestTests extends AbstractBWCSerializationTestCase<EqlS
         mutatedInstance.allowPartialSequenceResults(
             version.supports(TransportVersions.V_8_18_0) ? instance.allowPartialSequenceResults() : false
         );
+        mutatedInstance.projectRouting(instance.getProjectRouting());
 
         return mutatedInstance;
     }


### PR DESCRIPTION
For consistency with other EQL parameters, we'll allow `project_routing` to be defined both as a query parameter and as a request body parameter.

Also adding some validation, to avoid the usage of project_routing in non-cps scenarios