### PR TITLE
Increase cluster per neighbour in KMeansLocalTests#testComputeNeighbours

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/codec/vectors/cluster/KMeansLocalTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/vectors/cluster/KMeansLocalTests.java
@@ -154,7 +154,7 @@ public class KMeansLocalTests extends ESTestCase {
                 vectors[i][j] = randomFloat();
             }
         }
-        int clustersPerNeighbour = randomIntBetween(32, 128);
+        int clustersPerNeighbour = randomIntBetween(64, 128);
         NeighborHood[] neighborHoodsGraph = NeighborHood.computeNeighborhoodsGraph(vectors, clustersPerNeighbour);
         NeighborHood[] neighborHoodsBruteForce = NeighborHood.computeNeighborhoodsBruteForce(vectors, clustersPerNeighbour);
         assertEquals(neighborHoodsGraph.length, neighborHoodsBruteForce.length);


### PR DESCRIPTION
Increasing the minimum value allowed ensures better quality on the graph construction.

fixes https://github.com/elastic/elasticsearch/issues/138064