### PR TITLE
Ignore abort-on-cleanup failure in S3 repo

### DIFF
--- a/docs/changelog/138569.yaml
+++ b/docs/changelog/138569.yaml
@@ -1,0 +1,5 @@
+pr: 138569
+summary: Ignore abort-on-cleanup failure in S3 repo
+area: Snapshot/Restore
+type: bug
+issues: []


### PR DESCRIPTION
If a `CompleteMultipartUpload` request fails then we attempt to clean up
by calling the `AbortMultipartUpload` API. This cleanup may also fail,
and a failure here will supersede the original failure. The cleanup is
really a best-effort thing so we should ignore failures. In particular
if the `CompleteMultipartUpload` has an `If-None-Match` precondition
then this may fail with a `409 Conflict` and in that case the upload no
longer exists, so we would expect the `AbortMultipartUpload` call to
fail with a 404.

This commit extends `S3HttpHandler` to respond with both 412 and 409s on
precondition failures, cleaning up the upload on a 409 but not a 412,
triggering the unwanted failure path in some tests, and adds exception
handling to deal with it.