### PR TITLE
Revert "[TEST] Remove newline from json in MappingStatsTests"

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/MappingStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/MappingStatsTests.java
@@ -99,7 +99,7 @@ public class MappingStatsTests extends AbstractWireSerializingTestCase<MappingSt
 
     private static final String SCRIPT_1 = scriptAsJSON("doc['field'] + doc.field + params._source.field");
     private static final String SCRIPT_2 = scriptAsJSON("doc['field']");
-    private static final String SCRIPT_3 = scriptAsJSON("params._source.field + params._source.field + params._source.field");
+    private static final String SCRIPT_3 = scriptAsJSON("params._source.field + params._source.field \n + params._source.field");
     private static final String SCRIPT_4 = scriptAsJSON("params._source.field");
 
     public void testToXContent() {
@@ -114,8 +114,8 @@ public class MappingStatsTests extends AbstractWireSerializingTestCase<MappingSt
               "mappings" : {
                 "total_field_count" : 12,
                 "total_deduplicated_field_count" : 6,
-                "total_deduplicated_mapping_size" : "255b",
-                "total_deduplicated_mapping_size_in_bytes" : 255,
+                "total_deduplicated_mapping_size" : "260b",
+                "total_deduplicated_mapping_size_in_bytes" : 260,
                 "field_types" : [
                   {
                     "name" : "dense_vector",
@@ -159,10 +159,10 @@ public class MappingStatsTests extends AbstractWireSerializingTestCase<MappingSt
                     "lang" : [
                       "painless"
                     ],
-                    "lines_max" : 1,
-                    "lines_total" : 4,
-                    "chars_max" : 66,
-                    "chars_total" : 172,
+                    "lines_max" : 2,
+                    "lines_total" : 6,
+                    "chars_max" : 68,
+                    "chars_total" : 176,
                     "source_max" : 3,
                     "source_total" : 8,
                     "doc_max" : 0,
@@ -203,10 +203,10 @@ public class MappingStatsTests extends AbstractWireSerializingTestCase<MappingSt
                     "lang" : [
                       "painless"
                     ],
-                    "lines_max" : 1,
-                    "lines_total" : 4,
-                    "chars_max" : 66,
-                    "chars_total" : 172,
+                    "lines_max" : 2,
+                    "lines_total" : 6,
+                    "chars_max" : 68,
+                    "chars_total" : 176,
                     "source_max" : 3,
                     "source_total" : 8,
                     "doc_max" : 0,
@@ -246,8 +246,8 @@ public class MappingStatsTests extends AbstractWireSerializingTestCase<MappingSt
               "mappings" : {
                 "total_field_count" : 18,
                 "total_deduplicated_field_count" : 12,
-                "total_deduplicated_mapping_size" : "513b",
-                "total_deduplicated_mapping_size_in_bytes" : 513,
+                "total_deduplicated_mapping_size" : "519b",
+                "total_deduplicated_mapping_size_in_bytes" : 519,
                 "field_types" : [
                   {
                     "name" : "dense_vector",
@@ -291,10 +291,10 @@ public class MappingStatsTests extends AbstractWireSerializingTestCase<MappingSt
                     "lang" : [
                       "painless"
                     ],
-                    "lines_max" : 1,
-                    "lines_total" : 6,
-                    "chars_max" : 66,
-                    "chars_total" : 258,
+                    "lines_max" : 2,
+                    "lines_total" : 9,
+                    "chars_max" : 68,
+                    "chars_total" : 264,
                     "source_max" : 3,
                     "source_total" : 12,
                     "doc_max" : 0,
@@ -335,10 +335,10 @@ public class MappingStatsTests extends AbstractWireSerializingTestCase<MappingSt
                     "lang" : [
                       "painless"
                     ],
-                    "lines_max" : 1,
-                    "lines_total" : 6,
-                    "chars_max" : 66,
-                    "chars_total" : 258,
+                    "lines_max" : 2,
+                    "lines_total" : 9,
+                    "chars_max" : 68,
+                    "chars_total" : 264,
                     "source_max" : 3,
                     "source_total" : 12,
                     "doc_max" : 0,


### PR DESCRIPTION
Reverts elastic/elasticsearch#138428 
Related to #138236

It didn't solve the flakiness issue.