### PR TITLE
[9.1] Unmute #129533 (#130752)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -287,9 +287,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
   method: test {knn-function.KnnSearchWithKOption SYNC}
   issue: https://github.com/elastic/elasticsearch/issues/129512
-- class: org.elasticsearch.upgrades.IndexingIT
-  method: testIndexing
-  issue: https://github.com/elastic/elasticsearch/issues/129533
 - class: org.elasticsearch.upgrades.QueryableBuiltInRolesUpgradeIT
   method: testBuiltInRolesSyncedOnClusterUpgrade
   issue: https://github.com/elastic/elasticsearch/issues/129534


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Unmute #129533 (#130752)](https://github.com/elastic/elasticsearch/pull/130752)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

Closes #129533