### PR TITLE
Minor fixes for APM tracing

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/MockApmServer.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/MockApmServer.java
@@ -114,8 +114,26 @@ public class MockApmServer {
     }
 
     class RootHandler implements HttpHandler {
+        // checked by APM agent to identify the APM server version to adjust its behavior accordingly
+        private static final String FAKE_VERSION = """
+            {
+              "build_date": "2021-12-18T19:59:06Z",
+              "build_sha": "24fe620eeff5a19e2133c940c7e5ce1ceddb1445",
+              "publish_ready": true,
+              "version": "9.0.0"
+            }
+            """;
+
         public void handle(HttpExchange t) {
             try {
+                if ("GET".equals(t.getRequestMethod()) && "/".equals(t.getRequestURI().getPath())) {
+                    t.sendResponseHeaders(200, FAKE_VERSION.length());
+                    try (OutputStream os = t.getResponseBody()) {
+                        os.write(FAKE_VERSION.getBytes());
+                    }
+                    return;
+                }
+
                 InputStream body = t.getRequestBody();
                 if (metricFilter == null && transactionFilter == null) {
                     logRequestBody(body);

--- a/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/tracing/APMTracerTests.java
+++ b/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/tracing/APMTracerTests.java
@@ -109,9 +109,7 @@ public class APMTracerTests extends ESTestCase {
         apmTracer.startTrace(traceContext, TRACEABLE1, "name1_discard", null);
 
         assertThat(traceContext.getTransient(Task.APM_TRACE_CONTEXT), nullValue());
-        // the root span (transaction) is tracked
-        assertThat(apmTracer.getSpans(), aMapWithSize(1));
-        assertThat(apmTracer.getSpans(), hasKey(TRACEABLE1.getSpanId()));
+        assertThat(apmTracer.getSpans(), anEmptyMap());
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/tasks/TaskManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/tasks/TaskManagerTests.java
@@ -287,8 +287,8 @@ public class TaskManagerTests extends ESTestCase {
         final Tracer mockTracer = mock(Tracer.class);
         final TaskManager taskManager = new TaskManager(Settings.EMPTY, threadPool, Set.of(), mockTracer);
 
-        // fake a parent APM trace context
-        threadPool.getThreadContext().putTransient(Task.PARENT_APM_TRACE_CONTEXT, null);
+        // fake an APM trace context
+        threadPool.getThreadContext().putTransient(Task.APM_TRACE_CONTEXT, new Object());
         final boolean hasParentTask = randomBoolean();
         final TaskId parentTask = hasParentTask ? new TaskId("parentNode", 1) : TaskId.EMPTY_TASK_ID;
 
@@ -408,8 +408,8 @@ public class TaskManagerTests extends ESTestCase {
         final Tracer mockTracer = mock(Tracer.class);
         final TaskManager taskManager = new TaskManager(Settings.EMPTY, threadPool, Set.of(), mockTracer);
 
-        // fake a parent APM trace context
-        threadPool.getThreadContext().putTransient(Task.PARENT_APM_TRACE_CONTEXT, null);
+        // fake an APM trace context
+        threadPool.getThreadContext().putTransient(Task.APM_TRACE_CONTEXT, new Object());
 
         final Task task = taskManager.registerAndExecute(
             "testType",


### PR DESCRIPTION
If running a recent version of APM server, it's not necessary to track an unsampled root span (aka transaction) to report a correct duration. APM agent only reports these for old servers < v8.

Cleanup parent trace headers if not tracing (recording), to avoid any further unnecessary attempts to create spans that are immediately discarded. This might be due to sampling or exceeding max transaction spans when `span.isRecording()` returns `false`. This allows us to set `transaction_max_spans = 0` without additional tracing overhead.

Relates to ES-13389
