### PR TITLE
[ML] When using CCM, EIS authorization header should use ApiKey instead of Bearer

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/RequestUtils.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/RequestUtils.java
@@ -29,6 +29,14 @@ public class RequestUtils {
         return "Bearer " + apiKey;
     }
 
+    public static Header createApiKeyHeader(SecureString apiKey) {
+        return new BasicHeader(HttpHeaders.AUTHORIZATION, apiKey(apiKey.toString()));
+    }
+
+    public static String apiKey(String apiKey) {
+        return "ApiKey " + apiKey;
+    }
+
     public static URI buildUri(URI accountUri, String service, CheckedSupplier<URI, URISyntaxException> uriBuilder) {
         try {
             return accountUri == null ? uriBuilder.get() : accountUri;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/RequestUtils.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/RequestUtils.java
@@ -29,7 +29,7 @@ public class RequestUtils {
         return "Bearer " + apiKey;
     }
 
-    public static Header createApiKeyHeader(SecureString apiKey) {
+    public static Header createAuthApiKeyHeader(SecureString apiKey) {
         return new BasicHeader(HttpHeaders.AUTHORIZATION, apiKey(apiKey.toString()));
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ccm/CCMAuthenticationApplierFactory.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ccm/CCMAuthenticationApplierFactory.java
@@ -17,7 +17,7 @@ import org.elasticsearch.rest.RestStatus;
 import java.util.Objects;
 import java.util.function.Function;
 
-import static org.elasticsearch.xpack.inference.external.request.RequestUtils.createApiKeyHeader;
+import static org.elasticsearch.xpack.inference.external.request.RequestUtils.createAuthApiKeyHeader;
 import static org.elasticsearch.xpack.inference.rest.Paths.INFERENCE_CCM_PATH;
 
 /**
@@ -70,7 +70,7 @@ public class CCMAuthenticationApplierFactory {
 
         @Override
         public HttpRequestBase apply(HttpRequestBase request) {
-            request.setHeader(createApiKeyHeader(apiKey));
+            request.setHeader(createAuthApiKeyHeader(apiKey));
             return request;
         }
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ccm/CCMAuthenticationApplierFactory.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ccm/CCMAuthenticationApplierFactory.java
@@ -17,7 +17,7 @@ import org.elasticsearch.rest.RestStatus;
 import java.util.Objects;
 import java.util.function.Function;
 
-import static org.elasticsearch.xpack.inference.external.request.RequestUtils.createAuthBearerHeader;
+import static org.elasticsearch.xpack.inference.external.request.RequestUtils.createApiKeyHeader;
 import static org.elasticsearch.xpack.inference.rest.Paths.INFERENCE_CCM_PATH;
 
 /**
@@ -70,7 +70,7 @@ public class CCMAuthenticationApplierFactory {
 
         @Override
         public HttpRequestBase apply(HttpRequestBase request) {
-            request.setHeader(createAuthBearerHeader(apiKey));
+            request.setHeader(createApiKeyHeader(apiKey));
             return request;
         }
     }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/request/RequestUtilsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/request/RequestUtilsTests.java
@@ -10,19 +10,37 @@ package org.elasticsearch.xpack.inference.external.request;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.test.ESTestCase;
 
+import static org.elasticsearch.xpack.inference.external.request.RequestUtils.apiKey;
 import static org.elasticsearch.xpack.inference.external.request.RequestUtils.bearerToken;
+import static org.elasticsearch.xpack.inference.external.request.RequestUtils.createAuthApiKeyHeader;
 import static org.elasticsearch.xpack.inference.external.request.RequestUtils.createAuthBearerHeader;
 import static org.hamcrest.Matchers.is;
 
 public class RequestUtilsTests extends ESTestCase {
-    public void testCreateAuthBearerHeader() {
-        var header = createAuthBearerHeader(new SecureString("abc".toCharArray()));
+    private static final String SECRET = "abc";
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final String APIKEY_PREFIX = "ApiKey ";
+    private static final String AUTHORIZATION_HEADER = "Authorization";
 
-        assertThat(header.getName(), is("Authorization"));
-        assertThat(header.getValue(), is("Bearer abc"));
+    public void testCreateAuthBearerHeader() {
+        var header = createAuthBearerHeader(new SecureString(SECRET.toCharArray()));
+
+        assertThat(header.getName(), is(AUTHORIZATION_HEADER));
+        assertThat(header.getValue(), is(BEARER_PREFIX + SECRET));
     }
 
     public void testBearerToken() {
-        assertThat(bearerToken("abc"), is("Bearer abc"));
+        assertThat(bearerToken(SECRET), is(BEARER_PREFIX + SECRET));
+    }
+
+    public void testCreateAuthApiKeyHeader() {
+        var header = createAuthApiKeyHeader(new SecureString(SECRET.toCharArray()));
+
+        assertThat(header.getName(), is(AUTHORIZATION_HEADER));
+        assertThat(header.getValue(), is(APIKEY_PREFIX + SECRET));
+    }
+
+    public void testApiKey() {
+        assertThat(apiKey(SECRET), is(APIKEY_PREFIX + SECRET));
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/request/elastic/ElasticInferenceServiceRerankRequestTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/request/elastic/ElasticInferenceServiceRerankRequestTests.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import java.util.List;
 
 import static org.elasticsearch.xpack.inference.external.http.Utils.entityAsMap;
-import static org.elasticsearch.xpack.inference.external.request.RequestUtils.bearerToken;
+import static org.elasticsearch.xpack.inference.external.request.RequestUtils.apiKey;
 import static org.elasticsearch.xpack.inference.services.elastic.request.ElasticInferenceServiceRequestTests.randomElasticInferenceServiceRequestMetadata;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.instanceOf;
@@ -99,7 +99,7 @@ public class ElasticInferenceServiceRerankRequestTests extends ESTestCase {
         assertThat(httpPost.getLastHeader(Task.TRACE_STATE).getValue(), is(traceState));
         var headers = httpPost.getHeaders(HttpHeaders.AUTHORIZATION);
         assertThat(headers.length, is(1));
-        assertThat(headers[0].getValue(), is(bearerToken(secret)));
+        assertThat(headers[0].getValue(), is(apiKey(secret)));
     }
 
     private ElasticInferenceServiceRerankRequest createRequest(

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/action/ElasticInferenceServiceActionCreatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/action/ElasticInferenceServiceActionCreatorTests.java
@@ -52,7 +52,7 @@ import static org.elasticsearch.xpack.inference.external.http.Utils.entityAsMap;
 import static org.elasticsearch.xpack.inference.external.http.Utils.getUrl;
 import static org.elasticsearch.xpack.inference.external.http.retry.RetrySettingsTests.buildSettingsWithRetryFields;
 import static org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSenderTests.createSender;
-import static org.elasticsearch.xpack.inference.external.request.RequestUtils.bearerToken;
+import static org.elasticsearch.xpack.inference.external.request.RequestUtils.apiKey;
 import static org.elasticsearch.xpack.inference.services.ServiceComponentsTests.createWithEmptySettings;
 import static org.elasticsearch.xpack.inference.services.elastic.ccm.CCMAuthenticationApplierFactoryTests.createApplierFactory;
 import static org.elasticsearch.xpack.inference.services.elastic.ccm.CCMAuthenticationApplierFactoryTests.createNoopApplierFactory;
@@ -208,7 +208,7 @@ public class ElasticInferenceServiceActionCreatorTests extends ESTestCase {
 
     private static void assertHeadersWithAuth(List<MockRequest> requests, String secret) {
         var request = assertSingleRequestSent(requests);
-        assertThat(request.getHeader(HttpHeaders.AUTHORIZATION), equalTo(bearerToken(secret)));
+        assertThat(request.getHeader(HttpHeaders.AUTHORIZATION), equalTo(apiKey(secret)));
     }
 
     private static MockRequest assertSingleRequestSent(List<MockRequest> requests) {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/authorization/ElasticInferenceServiceAuthorizationRequestHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/authorization/ElasticInferenceServiceAuthorizationRequestHandlerTests.java
@@ -41,7 +41,7 @@ import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityExecutors;
 import static org.elasticsearch.xpack.inference.Utils.mockClusterServiceEmpty;
 import static org.elasticsearch.xpack.inference.external.http.Utils.getUrl;
 import static org.elasticsearch.xpack.inference.external.http.retry.RetryingHttpSender.MAX_RETIES;
-import static org.elasticsearch.xpack.inference.external.request.RequestUtils.bearerToken;
+import static org.elasticsearch.xpack.inference.external.request.RequestUtils.apiKey;
 import static org.elasticsearch.xpack.inference.services.SenderServiceTests.createMockSender;
 import static org.elasticsearch.xpack.inference.services.elastic.ccm.CCMAuthenticationApplierFactoryTests.createApplierFactory;
 import static org.elasticsearch.xpack.inference.services.elastic.ccm.CCMAuthenticationApplierFactoryTests.createNoopApplierFactory;
@@ -266,7 +266,7 @@ public class ElasticInferenceServiceAuthorizationRequestHandlerTests extends EST
 
     private static void assertAuthHeader(List<MockRequest> requests, String secret) {
         assertThat(requests.size(), is(1));
-        assertThat(requests.get(0).getHeader(HttpHeaders.AUTHORIZATION), is(bearerToken(secret)));
+        assertThat(requests.get(0).getHeader(HttpHeaders.AUTHORIZATION), is(apiKey(secret)));
     }
 
     public void testGetAuthorization_OnResponseCalledOnce() throws IOException {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ccm/CCMAuthenticationApplierFactoryTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ccm/CCMAuthenticationApplierFactoryTests.java
@@ -16,7 +16,7 @@ import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 
-import static org.elasticsearch.xpack.inference.external.request.RequestUtils.bearerToken;
+import static org.elasticsearch.xpack.inference.external.request.RequestUtils.apiKey;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
@@ -61,7 +61,7 @@ public class CCMAuthenticationApplierFactoryTests extends ESTestCase {
         var applier = new CCMAuthenticationApplierFactory.AuthenticationHeaderApplier(secret);
         var request = new HttpGet("http://localhost");
         applier.apply(request);
-        assertThat(request.getFirstHeader(HttpHeaders.AUTHORIZATION).getValue(), is(bearerToken(secret)));
+        assertThat(request.getFirstHeader(HttpHeaders.AUTHORIZATION).getValue(), is(apiKey(secret)));
     }
 
     public void testGetAuthenticationApplier_ReturnsNoopWhenConfiguringCCMIsDisabled() {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceDenseTextEmbeddingsRequestTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceDenseTextEmbeddingsRequestTests.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 import static org.elasticsearch.xpack.inference.InferencePlugin.X_ELASTIC_PRODUCT_USE_CASE_HTTP_HEADER;
 import static org.elasticsearch.xpack.inference.external.http.Utils.entityAsMap;
-import static org.elasticsearch.xpack.inference.external.request.RequestUtils.bearerToken;
+import static org.elasticsearch.xpack.inference.external.request.RequestUtils.apiKey;
 import static org.elasticsearch.xpack.inference.services.elastic.request.ElasticInferenceServiceRequestTests.randomElasticInferenceServiceRequestMetadata;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.equalTo;
@@ -200,7 +200,7 @@ public class ElasticInferenceServiceDenseTextEmbeddingsRequestTests extends ESTe
 
             var headers = httpPost.getHeaders(HttpHeaders.AUTHORIZATION);
             assertThat(headers.length, is(1));
-            assertThat(headers[0].getValue(), is(bearerToken(secret)));
+            assertThat(headers[0].getValue(), is(apiKey(secret)));
         }
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceRequestTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceRequestTests.java
@@ -20,7 +20,7 @@ import java.net.URI;
 
 import static org.elasticsearch.xpack.inference.InferencePlugin.X_ELASTIC_ES_VERSION;
 import static org.elasticsearch.xpack.inference.InferencePlugin.X_ELASTIC_PRODUCT_USE_CASE_HTTP_HEADER;
-import static org.elasticsearch.xpack.inference.external.request.RequestUtils.bearerToken;
+import static org.elasticsearch.xpack.inference.external.request.RequestUtils.apiKey;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
@@ -36,7 +36,7 @@ public class ElasticInferenceServiceRequestTests extends ESTestCase {
         var httpRequest = elasticInferenceServiceRequestWrapper.createHttpRequest();
 
         assertThat(httpRequest.httpRequestBase().getHeaders(HttpHeaders.AUTHORIZATION).length, equalTo(1));
-        assertThat(httpRequest.httpRequestBase().getFirstHeader(HttpHeaders.AUTHORIZATION).getValue(), is(bearerToken(secret)));
+        assertThat(httpRequest.httpRequestBase().getFirstHeader(HttpHeaders.AUTHORIZATION).getValue(), is(apiKey(secret)));
     }
 
     public void testElasticInferenceServiceRequestSubclasses_Decorate_HttpRequest_WithProductOrigin() {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceSparseEmbeddingsRequestTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/request/ElasticInferenceServiceSparseEmbeddingsRequestTests.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 import static org.elasticsearch.xpack.inference.InferencePlugin.X_ELASTIC_PRODUCT_USE_CASE_HTTP_HEADER;
 import static org.elasticsearch.xpack.inference.external.http.Utils.entityAsMap;
-import static org.elasticsearch.xpack.inference.external.request.RequestUtils.bearerToken;
+import static org.elasticsearch.xpack.inference.external.request.RequestUtils.apiKey;
 import static org.elasticsearch.xpack.inference.services.elastic.request.ElasticInferenceServiceRequestTests.randomElasticInferenceServiceRequestMetadata;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.equalTo;
@@ -152,7 +152,7 @@ public class ElasticInferenceServiceSparseEmbeddingsRequestTests extends ESTestC
 
             var headers = httpPost.getHeaders(HttpHeaders.AUTHORIZATION);
             assertThat(headers.length, is(1));
-            assertThat(headers[0].getValue(), is(bearerToken(secret)));
+            assertThat(headers[0].getValue(), is(apiKey(secret)));
         }
     }
 


### PR DESCRIPTION
This PR switches the EIS requests to use `ApiKey <secret>` instead of `Bearer <secret>`