### PR TITLE
[9.1] Adjust two today()/current_date() tests to create less noise (#138588)

### DIFF
--- a/x-pack/plugin/sql/qa/server/src/main/resources/date.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/date.csv-spec
@@ -38,7 +38,7 @@ SELECT TRUNCATE(YEAR(TODAY() - INTERVAL 50 YEARS) / 1000) AS result;
 
 
 currentDateFilter
-SELECT first_name FROM test_emp WHERE hire_date > CURRENT_DATE() - INTERVAL 45 YEARS ORDER BY first_name ASC LIMIT 10;
+SELECT first_name FROM test_emp WHERE hire_date > DATE_TRUNC('CENTURY', CURRENT_DATE()) - INTERVAL 11 YEARS ORDER BY first_name ASC LIMIT 10;
 
     first_name
 -----------------
@@ -46,12 +46,12 @@ Alejandro
 Amabile
 Anneke
 Anoosh
-Arumugam
 Basil
-Berhard
-Berni
-Bezalel
 Bojan
+Brendon
+Cristinel
+Divier
+Domenick
 ;
 
 currentDateFilterScript

--- a/x-pack/plugin/sql/qa/server/src/main/resources/docs/docs.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/docs/docs.csv-spec
@@ -3345,15 +3345,15 @@ SELECT TODAY() AS result;
 
 filterToday
 // tag::filterToday
-SELECT first_name FROM emp WHERE hire_date > TODAY() - INTERVAL 35 YEARS ORDER BY first_name ASC LIMIT 5;
+SELECT first_name FROM emp WHERE hire_date > DATE_TRUNC('CENTURY', TODAY()) - INTERVAL 11 YEARS ORDER BY first_name ASC LIMIT 5;
 
  first_name
 ------------
 Alejandro
 Amabile
+Anneke
 Anoosh
 Basil
-Cristinel
 // end::filterToday
 ;
 


### PR DESCRIPTION
Backports the following commits to 9.1:
 - Adjust two today()/current_date() tests to create less noise (#138588)