### PR TITLE
[9.2] [GPU] Add license check to the x-pack plugin (#138491)

### DIFF
--- a/x-pack/plugin/gpu/src/internalClusterTest/java/org/elasticsearch/xpack/gpu/GPUIndexIT.java
+++ b/x-pack/plugin/gpu/src/internalClusterTest/java/org/elasticsearch/xpack/gpu/GPUIndexIT.java
@@ -35,9 +35,16 @@ import static org.hamcrest.Matchers.containsString;
 @LuceneTestCase.SuppressCodecs("*") // use our custom codec
 public class GPUIndexIT extends ESIntegTestCase {
 
+    public static class TestGPUPlugin extends GPUPlugin {
+        @Override
+        protected boolean isGpuIndexingFeatureAllowed() {
+            return true;
+        }
+    }
+
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return List.of(GPUPlugin.class);
+        return List.of(TestGPUPlugin.class);
     }
 
     @BeforeClass

--- a/x-pack/plugin/gpu/src/main/java/module-info.java
+++ b/x-pack/plugin/gpu/src/main/java/module-info.java
@@ -13,6 +13,7 @@ module org.elasticsearch.xpack.gpu {
     requires org.elasticsearch.server;
     requires org.elasticsearch.base;
     requires org.elasticsearch.gpu;
+    requires org.elasticsearch.xcore;
 
     provides org.elasticsearch.features.FeatureSpecification with org.elasticsearch.xpack.gpu.GPUFeatures;
 }

--- a/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/GPUPlugin.java
+++ b/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/GPUPlugin.java
@@ -15,14 +15,18 @@ import org.elasticsearch.gpu.codec.ES92GpuHnswSQVectorsFormat;
 import org.elasticsearch.gpu.codec.ES92GpuHnswVectorsFormat;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.index.mapper.vectors.VectorsFormatProvider;
+import org.elasticsearch.license.License;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.internal.InternalVectorFormatProviderPlugin;
+import org.elasticsearch.xpack.core.XPackPlugin;
 
 import java.util.List;
 
 public class GPUPlugin extends Plugin implements InternalVectorFormatProviderPlugin {
 
     public static final FeatureFlag GPU_FORMAT = new FeatureFlag("gpu_vectors_indexing");
+
+    private static final License.OperationMode MINIMUM_ALLOWED_LICENSE = License.OperationMode.ENTERPRISE;
 
     /**
      * An enum for the tri-state value of the `index.vectors.indexing.use_gpu` setting.
@@ -59,6 +63,12 @@ public class GPUPlugin extends Plugin implements InternalVectorFormatProviderPlu
         }
     }
 
+    // Allow tests to override the license state
+    protected boolean isGpuIndexingFeatureAllowed() {
+        var licenseState = XPackPlugin.getSharedLicenseState();
+        return licenseState != null && licenseState.isAllowedByLicense(MINIMUM_ALLOWED_LICENSE);
+    }
+
     @Override
     public VectorsFormatProvider getVectorsFormatProvider() {
         return (indexSettings, indexOptions, similarity) -> {
@@ -75,9 +85,19 @@ public class GPUPlugin extends Plugin implements InternalVectorFormatProviderPlu
                             "[index.vectors.indexing.use_gpu] was set to [true], but GPU resources are not accessible on the node."
                         );
                     }
+                    if (isGpuIndexingFeatureAllowed() == false) {
+                        throw new IllegalArgumentException(
+                            "[index.vectors.indexing.use_gpu] was set to [true], but GPU indexing is a ["
+                                + MINIMUM_ALLOWED_LICENSE
+                                + "] level feature"
+                        );
+                    }
                     return getVectorsFormat(indexOptions, similarity);
                 }
-                if (gpuMode == GpuMode.AUTO && vectorIndexTypeSupported(indexOptions.getType()) && GPUSupport.isSupported()) {
+                if (gpuMode == GpuMode.AUTO
+                    && vectorIndexTypeSupported(indexOptions.getType())
+                    && GPUSupport.isSupported()
+                    && isGpuIndexingFeatureAllowed()) {
                     return getVectorsFormat(indexOptions, similarity);
                 }
             }

--- a/x-pack/plugin/gpu/src/test/java/org/elasticsearch/xpack/gpu/GPUDenseVectorFieldMapperTests.java
+++ b/x-pack/plugin/gpu/src/test/java/org/elasticsearch/xpack/gpu/GPUDenseVectorFieldMapperTests.java
@@ -34,7 +34,12 @@ public class GPUDenseVectorFieldMapperTests extends DenseVectorFieldMapperTests 
 
     @Override
     protected Collection<Plugin> getPlugins() {
-        var plugin = new GPUPlugin();
+        var plugin = new GPUPlugin() {
+            @Override
+            protected boolean isGpuIndexingFeatureAllowed() {
+                return true;
+            }
+        };
         return Collections.singletonList(plugin);
     }
 


### PR DESCRIPTION
Backports the following commits to 9.2:
 - [GPU] Add license check to the x-pack plugin (#138491)