### PR TITLE
Enforce docker api version for testcontainer usages

### DIFF
--- a/test/fixtures/hdfs-fixture/src/main/java/org/elasticsearch/test/fixtures/hdfs/HdfsFixture.java
+++ b/test/fixtures/hdfs-fixture/src/main/java/org/elasticsearch/test/fixtures/hdfs/HdfsFixture.java
@@ -196,6 +196,7 @@ public class HdfsFixture extends ExternalResource {
             } catch (IOException e) {
                 // Log the exception
                 System.out.println("Attempt " + attempt + " failed with error: " + e.getMessage());
+                e.printStackTrace();
                 // If the maximum number of attempts is reached, rethrow the exception
                 FileUtils.deleteDirectory(baseDir.toFile());
                 if (attempt == maxAttempts) {

--- a/test/fixtures/testcontainer-utils/src/main/java/org/elasticsearch/test/fixtures/testcontainers/DockerEnvironmentAwareTestContainer.java
+++ b/test/fixtures/testcontainer-utils/src/main/java/org/elasticsearch/test/fixtures/testcontainers/DockerEnvironmentAwareTestContainer.java
@@ -34,12 +34,18 @@ public abstract class DockerEnvironmentAwareTestContainer extends GenericContain
     implements
         TestRule,
         CacheableTestFixture {
+
+    static {
+        System.setProperty("api.version", "v1.44"); // set docker api version to avoid version probing which fails in some environments
+    }
+
     protected static final Logger LOGGER = LoggerFactory.getLogger(DockerEnvironmentAwareTestContainer.class);
 
     private static final String DOCKER_ON_LINUX_EXCLUSIONS_FILE = ".ci/dockerOnLinuxExclusions";
 
     private static final boolean CI = Boolean.parseBoolean(System.getProperty("CI", "false"));
     private static final boolean EXCLUDED_OS = isExcludedOs();
+
     private static final boolean DOCKER_PROBING_SUCCESSFUL = isDockerAvailable();
 
     /**


### PR DESCRIPTION
This should fix our test container issues with docker 29+

See https://github.com/testcontainers/testcontainers-java/issues/11212#issuecomment-3520766237