### PR TITLE
[9.2] [ES-13486] Skipping ES builds on non supported jdk versions (#138262)

### DIFF
--- a/.buildkite/pipelines/periodic.template.yml
+++ b/.buildkite/pipelines/periodic.template.yml
@@ -92,8 +92,7 @@ steps:
           setup:
             ES_RUNTIME_JAVA:
               - openjdk21
-              - openjdk23
-              - openjdk24
+              - openjdk25
             GRADLE_TASK:
               - checkPart1
               - checkPart2
@@ -118,7 +117,7 @@ steps:
           setup:
             ES_RUNTIME_JAVA:
               - openjdk21
-              - openjdk23
+              - openjdk25
             BWC_VERSION: $BWC_LIST
         agents:
           provider: gcp

--- a/.buildkite/pipelines/periodic.yml
+++ b/.buildkite/pipelines/periodic.yml
@@ -530,8 +530,7 @@ steps:
           setup:
             ES_RUNTIME_JAVA:
               - openjdk21
-              - openjdk23
-              - openjdk24
+              - openjdk25
             GRADLE_TASK:
               - checkPart1
               - checkPart2
@@ -556,7 +555,7 @@ steps:
           setup:
             ES_RUNTIME_JAVA:
               - openjdk21
-              - openjdk23
+              - openjdk25
             BWC_VERSION: ["8.19.8", "9.1.8", "9.2.2"]
         agents:
           provider: gcp


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[ES-13486] Skipping ES builds on non supported jdk versions (#138262)](https://github.com/elastic/elasticsearch/pull/138262)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

[ES-13486]: https://elasticco.atlassian.net/browse/ES-13486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ