### PR TITLE
[8.19] [ES-13486] Skipping ES builds on non supported jdk versions (#138262)

### DIFF
--- a/.buildkite/pipelines/periodic.template.yml
+++ b/.buildkite/pipelines/periodic.template.yml
@@ -93,7 +93,7 @@ steps:
               - adoptopenjdk17
               - openjdk21
               - openjdk22
-              - openjdk23
+              - openjdk25
             GRADLE_TASK:
               - checkPart1
               - checkPart2
@@ -121,7 +121,7 @@ steps:
               - adoptopenjdk17
               - openjdk21
               - openjdk22
-              - openjdk23
+              - openjdk25
             BWC_VERSION: $BWC_LIST
         agents:
           provider: gcp

--- a/.buildkite/pipelines/periodic.yml
+++ b/.buildkite/pipelines/periodic.yml
@@ -816,7 +816,7 @@ steps:
               - adoptopenjdk17
               - openjdk21
               - openjdk22
-              - openjdk23
+              - openjdk25
             GRADLE_TASK:
               - checkPart1
               - checkPart2
@@ -844,7 +844,7 @@ steps:
               - adoptopenjdk17
               - openjdk21
               - openjdk22
-              - openjdk23
+              - openjdk25
             BWC_VERSION: ["7.17.30", "8.19.8"]
         agents:
           provider: gcp


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[ES-13486] Skipping ES builds on non supported jdk versions (#138262)](https://github.com/elastic/elasticsearch/pull/138262)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

[ES-13486]: https://elasticco.atlassian.net/browse/ES-13486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ