### PR TITLE
[9.2] Extend timeout in `IngestGeoIpClientYamlTestSuiteIT` (#138610)

### DIFF
--- a/modules/ingest-geoip/src/yamlRestTest/java/org/elasticsearch/ingest/geoip/IngestGeoIpClientYamlTestSuiteIT.java
+++ b/modules/ingest-geoip/src/yamlRestTest/java/org/elasticsearch/ingest/geoip/IngestGeoIpClientYamlTestSuiteIT.java
@@ -38,6 +38,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
@@ -158,7 +159,9 @@ public class IngestGeoIpClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase 
 
             // ensure that the extra config database has been set up, too:
             assertThat(node.get("config_databases"), equalTo(List.of("asn.mmdb")));
-        });
+            // Downloading all four databases may take some time, so we set a longer timeout here.
+            // If 20 seconds prove insufficient, we should first investigate whether we can speed up the database downloader.
+        }, 20, TimeUnit.SECONDS);
     }
 
     @SuppressForbidden(reason = "fixtures use java.io.File based APIs")


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Extend timeout in `IngestGeoIpClientYamlTestSuiteIT` (#138610)](https://github.com/elastic/elasticsearch/pull/138610)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)