### PR TITLE
[8.19] Extend timeout in `IngestGeoIpClientYamlTestSuiteIT` (#138610)

### DIFF
--- a/modules/ingest-geoip/src/yamlRestTest/java/org/elasticsearch/ingest/geoip/IngestGeoIpClientYamlTestSuiteIT.java
+++ b/modules/ingest-geoip/src/yamlRestTest/java/org/elasticsearch/ingest/geoip/IngestGeoIpClientYamlTestSuiteIT.java
@@ -32,6 +32,7 @@ import org.junit.rules.TestRule;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
@@ -92,7 +93,9 @@ public class IngestGeoIpClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase 
                 databaseNames,
                 containsInAnyOrder("GeoLite2-City.mmdb", "GeoLite2-Country.mmdb", "GeoLite2-ASN.mmdb", "MyCustomGeoLite2-City.mmdb")
             );
-        });
+            // Downloading all four databases may take some time, so we set a longer timeout here.
+            // If 20 seconds prove insufficient, we should first investigate whether we can speed up the database downloader.
+        }, 20, TimeUnit.SECONDS);
     }
 
     /**


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Extend timeout in `IngestGeoIpClientYamlTestSuiteIT` (#138610)](https://github.com/elastic/elasticsearch/pull/138610)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)