### PR TITLE
Fix lambda parameter description

### DIFF
--- a/docs/reference/elasticsearch/rest-apis/retrievers/diversify-retriever.md
+++ b/docs/reference/elasticsearch/rest-apis/retrievers/diversify-retriever.md
@@ -54,7 +54,7 @@ The ordering of results returned from the inner retriever is preserved.
 `lambda`
 :   (Required for `mmr`, float)
 
-    A value between 0.0 and 1.0 that controls how similarity is calculated during diversification. Higher values weight comparisons between field values more heavily, lower values weight the query vector more heavily.
+    A value between 0.0 and 1.0 that controls how similarity is calculated during diversification. Higher values weight the similarity to the query_vector more heavily, lower values weight the diversity more heavily.
 
 `size`
 :   (Optional, only if `mmr` is used, integer)


### PR DESCRIPTION
Lower and higher value descriptions are switched. 

`float mmr = (context.getLambda() * querySimilarityScore) - ((1 - context.getLambda()) * highestMMRScore);`
`1.0` would result in `querySimilarityScore` 

Also added more user friendly wording - most users most likely don't understand how mmr works and what "comparisons between field values" means, so I just replaced it with "diversity"