### PR TITLE
[9.2] fix: add missing vector_similarity_support in InferenceFeatures (#138644)

### DIFF
--- a/docs/changelog/138644.yaml
+++ b/docs/changelog/138644.yaml
@@ -1,0 +1,5 @@
+pr: 138644
+summary: "Fix: add missing `vector_similarity_support` in InferenceFeatures"
+area: Search
+type: bug
+issues: []

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -540,6 +540,8 @@ tests:
 - class: org.elasticsearch.versioning.ConcurrentSeqNoVersioningIT
   method: testSeqNoCASLinearizability
   issue: https://github.com/elastic/elasticsearch/issues/117249
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  issue: https://github.com/elastic/elasticsearch/issues/138649
 
 # Examples:
 #

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceFeatures.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceFeatures.java
@@ -40,6 +40,9 @@ public class InferenceFeatures implements FeatureSpecification {
     private static final NodeFeature SEMANTIC_TEXT_HIGHLIGHTER_DISKBBQ_SIMILARITY_SUPPORT = new NodeFeature(
         "semantic_text.highlighter.bbq_and_similarity_support"
     );
+    private static final NodeFeature SEMANTIC_TEXT_HIGHLIGHTER_VECTOR_SIMILARITY_SUPPORT = new NodeFeature(
+        "semantic_text.highlighter.vector_similarity_support"
+    );
     private static final NodeFeature TEST_RERANKING_SERVICE_PARSE_TEXT_AS_SCORE = new NodeFeature(
         "test_reranking_service.parse_text_as_score"
     );
@@ -97,6 +100,7 @@ public class InferenceFeatures implements FeatureSpecification {
                 SEMANTIC_TEXT_SPARSE_VECTOR_INDEX_OPTIONS,
                 SEMANTIC_TEXT_FIELDS_CHUNKS_FORMAT,
                 SEMANTIC_TEXT_HIGHLIGHTER_DISKBBQ_SIMILARITY_SUPPORT,
+                SEMANTIC_TEXT_HIGHLIGHTER_VECTOR_SIMILARITY_SUPPORT,
                 SemanticQueryBuilder.SEMANTIC_QUERY_MULTIPLE_INFERENCE_IDS,
                 SemanticQueryBuilder.SEMANTIC_QUERY_FILTER_FIELD_CAPS_FIX,
                 InterceptedInferenceQueryBuilder.NEW_SEMANTIC_QUERY_INTERCEPTORS,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [fix: add missing vector_similarity_support in InferenceFeatures (#138644)](https://github.com/elastic/elasticsearch/pull/138644)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)