### PR TITLE
Test utility for `BytesReference` equality

### DIFF
--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ClientScrollableHitSourceTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ClientScrollableHitSourceTests.java
@@ -50,6 +50,7 @@ import java.util.function.Function;
 import java.util.stream.IntStream;
 
 import static org.apache.lucene.tests.util.TestUtil.randomSimpleString;
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.elasticsearch.core.TimeValue.timeValueSeconds;
 import static org.hamcrest.Matchers.instanceOf;
 
@@ -174,7 +175,7 @@ public class ClientScrollableHitSourceTests extends ESTestCase {
     private void assertSameHits(List<? extends ScrollableHitSource.Hit> actual, SearchHit[] expected) {
         assertEquals(actual.size(), expected.length);
         for (int i = 0; i < actual.size(); ++i) {
-            assertEquals(actual.get(i).getSource(), expected[i].getSourceRef());
+            assertThat(expected[i].getSourceRef(), equalBytes(actual.get(i).getSource()));
             assertEquals(actual.get(i).getIndex(), expected[i].getIndex());
             assertEquals(actual.get(i).getVersion(), expected[i].getVersion());
             assertEquals(actual.get(i).getPrimaryTerm(), expected[i].getPrimaryTerm());

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/RoundTripTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/RoundTripTests.java
@@ -38,6 +38,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import static org.apache.lucene.tests.util.TestUtil.randomSimpleString;
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 
 /**
  * Round trip tests for all {@link Writeable} things declared in this plugin.
@@ -144,7 +145,7 @@ public class RoundTripTests extends ESTestCase {
             assertNotNull(tripped.getRemoteInfo());
             assertEquals(request.getRemoteInfo().getScheme(), tripped.getRemoteInfo().getScheme());
             assertEquals(request.getRemoteInfo().getHost(), tripped.getRemoteInfo().getHost());
-            assertEquals(request.getRemoteInfo().getQuery(), tripped.getRemoteInfo().getQuery());
+            assertThat(tripped.getRemoteInfo().getQuery(), equalBytes(request.getRemoteInfo().getQuery()));
             assertEquals(request.getRemoteInfo().getUsername(), tripped.getRemoteInfo().getUsername());
             assertEquals(request.getRemoteInfo().getPassword(), tripped.getRemoteInfo().getPassword());
             assertEquals(request.getRemoteInfo().getHeaders(), tripped.getRemoteInfo().getHeaders());

--- a/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
+++ b/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
@@ -59,6 +59,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.elasticsearch.common.io.Streams.readFully;
 import static org.elasticsearch.repositories.blobstore.BlobStoreTestUtil.randomPurpose;
 import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSettings.CREDENTIALS_FILE_SETTING;
@@ -219,7 +220,7 @@ public class GoogleCloudStorageBlobStoreRepositoryTests extends ESMockAPIBasedRe
             container.writeBlob(randomPurpose(), key, new BytesArray(initialValue), true);
 
             BytesReference reference = readFully(container.readBlob(randomPurpose(), key));
-            assertEquals(new BytesArray(initialValue), reference);
+            assertThat(reference, equalBytes(new BytesArray(initialValue)));
 
             container.deleteBlobsIgnoringIfNotExists(randomPurpose(), Iterators.single(key));
         }

--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerRetriesTests.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerRetriesTests.java
@@ -79,6 +79,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static fixture.gcs.TestUtils.createServiceAccount;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.elasticsearch.common.io.Streams.readFully;
 import static org.elasticsearch.repositories.blobstore.BlobStoreTestUtil.randomPurpose;
 import static org.elasticsearch.repositories.blobstore.ESBlobStoreRepositoryIntegTestCase.randomBytes;
@@ -582,7 +583,7 @@ public class GoogleCloudStorageBlobContainerRetriesTests extends AbstractBlobCon
         final OptionalBytesReference updateResult = safeAwait(
             l -> container.compareAndExchangeRegister(randomPurpose(), key, new BytesArray(data), new BytesArray(updatedData), l)
         );
-        assertEquals(new BytesArray(data), updateResult.bytesReference());
+        assertThat(updateResult.bytesReference(), equalBytes(new BytesArray(data)));
 
         assertEquals(0, requestHandlers.size());
         container.delete(randomPurpose());
@@ -601,7 +602,7 @@ public class GoogleCloudStorageBlobContainerRetriesTests extends AbstractBlobCon
         container.writeBlob(randomPurpose(), key, new BytesArray(initialValue), true);
 
         BytesReference reference = readFully(container.readBlob(randomPurpose(), key));
-        assertEquals(new BytesArray(initialValue), reference);
+        assertThat(reference, equalBytes(new BytesArray(initialValue)));
 
         try (InputStream inputStream = container.readBlob(randomPurpose(), key)) {
             // Trigger the first chunk to load

--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerStatsTests.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerStatsTests.java
@@ -50,6 +50,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.elasticsearch.repositories.blobstore.BlobStoreTestUtil.randomPurpose;
 import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSettings.APPLICATION_NAME_SETTING;
 import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSettings.CONNECT_TIMEOUT_SETTING;
@@ -138,7 +139,7 @@ public class GoogleCloudStorageBlobContainerStatsTests extends ESTestCase {
         final StatsMap wantStats = new StatsMap(purpose);
         assertStatsEquals(wantStats.add(INSERT, 1), store.stats());
         try (InputStream is = container.readBlob(purpose, blobName)) {
-            assertEquals(blobContents, Streams.readFully(is));
+            assertThat(Streams.readFully(is), equalBytes(blobContents));
         }
         assertStatsEquals(wantStats.add(GET, 1), store.stats());
     }
@@ -164,7 +165,7 @@ public class GoogleCloudStorageBlobContainerStatsTests extends ESTestCase {
         assertStatsEquals(wantStats.add(INSERT, 1, totalRequests), store.stats());
 
         try (InputStream is = container.readBlob(purpose, blobName)) {
-            assertEquals(blobContents, Streams.readFully(is));
+            assertThat(Streams.readFully(is), equalBytes(blobContents));
         }
         assertStatsEquals(wantStats.add(GET, 1), store.stats());
     }

--- a/modules/repository-s3/qa/third-party/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryThirdPartyTests.java
+++ b/modules/repository-s3/qa/third-party/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryThirdPartyTests.java
@@ -49,6 +49,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.elasticsearch.repositories.blobstore.BlobStoreTestUtil.randomPurpose;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.blankOrNullString;
@@ -194,7 +195,7 @@ public class S3RepositoryThirdPartyTests extends AbstractThirdPartyRepositoryTes
                 assertTrue(testHarness.tryCompareAndSet(BytesArray.EMPTY, bytes1));
 
                 // show we're looking at the right blob
-                assertEquals(bytes1, testHarness.readRegister());
+                assertThat(testHarness.readRegister(), equalBytes(bytes1));
                 assertArrayEquals(
                     bytes1.array(),
                     client.getObject(GetObjectRequest.builder().bucket(bucketName).key(registerBlobPath).build()).readAllBytes()
@@ -217,7 +218,7 @@ public class S3RepositoryThirdPartyTests extends AbstractThirdPartyRepositoryTes
                 timeOffsetMillis.addAndGet(blobStore.getCompareAndExchangeTimeToLive().millis() - Math.min(0, age));
                 assertTrue(testHarness.tryCompareAndSet(bytes1, bytes2));
                 assertThat(testHarness.listMultipartUploads(), hasSize(0));
-                assertEquals(bytes2, testHarness.readRegister());
+                assertThat(testHarness.readRegister(), equalBytes(bytes2));
             } finally {
                 blobContainer.delete(randomPurpose());
             }

--- a/modules/rest-root/src/test/java/org/elasticsearch/rest/root/RestMainActionTests.java
+++ b/modules/rest-root/src/test/java/org/elasticsearch/rest/root/RestMainActionTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.xcontent.json.JsonXContent;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 
@@ -95,6 +96,6 @@ public class RestMainActionTests extends ESTestCase {
         }
         mainResponse.toXContent(responseBuilder, ToXContent.EMPTY_PARAMS);
         BytesReference xcontentBytes = BytesReference.bytes(responseBuilder);
-        assertEquals(xcontentBytes, response.content());
+        assertThat(response.content(), equalBytes(xcontentBytes));
     }
 }

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpPipeliningHandlerTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpPipeliningHandlerTests.java
@@ -72,6 +72,7 @@ import java.util.stream.IntStream;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -548,7 +549,7 @@ public class Netty4HttpPipeliningHandlerTests extends ESTestCase {
     }
 
     private static void assertContentAtIndexEquals(List<Object> messagesSeen, int index, BytesReference single) {
-        assertEquals(Netty4Utils.toBytesReference(((ByteBufHolder) messagesSeen.get(index)).content()), single);
+        assertThat(single, equalBytes(Netty4Utils.toBytesReference(((ByteBufHolder) messagesSeen.get(index)).content())));
     }
 
     private static void assertDoneWithClosedChannel(ChannelPromise chunkedWritePromise) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/get/GetActionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/get/GetActionIT.java
@@ -60,6 +60,7 @@ import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
 import static java.util.Collections.singleton;
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
@@ -1026,9 +1027,9 @@ public class GetActionIT extends ESIntegTestCase {
         assertTrue(lucene1.isExists());
         assertTrue(lucene2.isExists());
         assertTrue(lucene3.isExists());
-        assertThat(translog1.getSourceAsBytesRef(), equalTo(lucene1.getSourceAsBytesRef()));
-        assertThat(translog2.getSourceAsBytesRef(), equalTo(lucene2.getSourceAsBytesRef()));
-        assertThat(translog3.getSourceAsBytesRef(), equalTo(lucene3.getSourceAsBytesRef()));
+        assertThat(translog1.getSourceAsBytesRef(), equalBytes(lucene1.getSourceAsBytesRef()));
+        assertThat(translog2.getSourceAsBytesRef(), equalBytes(lucene2.getSourceAsBytesRef()));
+        assertThat(translog3.getSourceAsBytesRef(), equalBytes(lucene3.getSourceAsBytesRef()));
     }
 
     private void assertGetFieldsAlwaysWorks(String index, String docId, String[] fields) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fields/SearchFieldsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fields/SearchFieldsIT.java
@@ -59,6 +59,7 @@ import java.util.function.Supplier;
 
 import static java.util.Collections.singleton;
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.elasticsearch.common.util.set.Sets.newHashSet;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
@@ -664,7 +665,7 @@ public class SearchFieldsIT extends ESIntegTestCase {
                 assertThat(searchHit.getFields().get("boolean_field").getValue(), equalTo((Object) Boolean.TRUE));
                 assertThat(
                     searchHit.getFields().get("binary_field").getValue(),
-                    equalTo(new BytesArray("testing text".getBytes(StandardCharsets.UTF_8)))
+                    equalBytes(new BytesArray("testing text".getBytes(StandardCharsets.UTF_8)))
                 );
             }
         );

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsResponseTests.java
@@ -22,6 +22,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
+
 public class GetFieldMappingsResponseTests extends AbstractWireSerializingTestCase<GetFieldMappingsResponse> {
 
     public void testManualSerialization() throws IOException {
@@ -36,7 +38,7 @@ public class GetFieldMappingsResponseTests extends AbstractWireSerializingTestCa
                 GetFieldMappingsResponse serialized = new GetFieldMappingsResponse(in);
                 FieldMappingMetadata metadata = serialized.fieldMappings("index", "field");
                 assertNotNull(metadata);
-                assertEquals(new BytesArray("{}"), metadata.source());
+                assertThat(metadata.source(), equalBytes(new BytesArray("{}")));
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/action/bulk/BulkRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/BulkRequestTests.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.elasticsearch.test.StreamsUtils.copyToStringFromClasspath;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
@@ -52,9 +53,9 @@ public class BulkRequestTests extends ESTestCase {
         BulkRequest bulkRequest = new BulkRequest();
         bulkRequest.add(bulkAction.getBytes(StandardCharsets.UTF_8), 0, bulkAction.length(), null, XContentType.JSON);
         assertThat(bulkRequest.numberOfActions(), equalTo(3));
-        assertThat(((IndexRequest) bulkRequest.requests().get(0)).source(), equalTo(new BytesArray("{ \"field1\" : \"value1\" }")));
+        assertThat(((IndexRequest) bulkRequest.requests().get(0)).source(), equalBytes(new BytesArray("{ \"field1\" : \"value1\" }")));
         assertThat(bulkRequest.requests().get(1), instanceOf(DeleteRequest.class));
-        assertThat(((IndexRequest) bulkRequest.requests().get(2)).source(), equalTo(new BytesArray("{ \"field1\" : \"value3\" }")));
+        assertThat(((IndexRequest) bulkRequest.requests().get(2)).source(), equalBytes(new BytesArray("{ \"field1\" : \"value3\" }")));
     }
 
     public void testSimpleBulkWithCarriageReturn() throws Exception {
@@ -65,7 +66,7 @@ public class BulkRequestTests extends ESTestCase {
         BulkRequest bulkRequest = new BulkRequest();
         bulkRequest.add(bulkAction.getBytes(StandardCharsets.UTF_8), 0, bulkAction.length(), null, XContentType.JSON);
         assertThat(bulkRequest.numberOfActions(), equalTo(1));
-        assertThat(((IndexRequest) bulkRequest.requests().get(0)).source(), equalTo(new BytesArray("{ \"field1\" : \"value1\" }")));
+        assertThat(((IndexRequest) bulkRequest.requests().get(0)).source(), equalBytes(new BytesArray("{ \"field1\" : \"value1\" }")));
         Map<String, Object> sourceMap = XContentHelper.convertToMap(
             ((IndexRequest) bulkRequest.requests().get(0)).source(),
             false,

--- a/server/src/test/java/org/elasticsearch/action/index/IndexRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/index/IndexRequestTests.java
@@ -48,6 +48,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
@@ -199,7 +200,7 @@ public class IndexRequestTests extends ESTestCase {
         StreamInput in = StreamInput.wrap(out.bytes().toBytesRef().bytes);
         IndexRequest serialized = new IndexRequest(in);
         assertEquals(XContentType.JSON, serialized.getContentType());
-        assertEquals(new BytesArray("{}"), serialized.source());
+        assertThat(serialized.source(), equalBytes(new BytesArray("{}")));
         assertEquals(isRequireAlias, serialized.isRequireAlias());
         assertThat(serialized.getDynamicTemplates(), equalTo(dynamicTemplates));
     }

--- a/server/src/test/java/org/elasticsearch/action/ingest/PutPipelineRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/ingest/PutPipelineRequestTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.elasticsearch.ingest.IngestPipelineTestUtils.putJsonPipelineRequest;
 
 public class PutPipelineRequestTests extends ESTestCase {
@@ -61,6 +62,6 @@ public class PutPipelineRequestTests extends ESTestCase {
         );
         XContentBuilder requestBuilder = XContentBuilder.builder(xContentType.xContent());
         BytesReference actualRequestBody = BytesReference.bytes(request.toXContent(requestBuilder, ToXContent.EMPTY_PARAMS));
-        assertEquals(BytesReference.bytes(pipelineBuilder), actualRequestBody);
+        assertThat(actualRequestBody, equalBytes(BytesReference.bytes(pipelineBuilder)));
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/termvectors/TermVectorsUnitTests.java
+++ b/server/src/test/java/org/elasticsearch/action/termvectors/TermVectorsUnitTests.java
@@ -48,6 +48,7 @@ import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.hamcrest.Matchers.equalTo;
 
 public class TermVectorsUnitTests extends ESTestCase {
@@ -239,7 +240,7 @@ public class TermVectorsUnitTests extends ESTestCase {
             assertThat(request.termStatistics(), equalTo(req2.termStatistics()));
             assertThat(request.preference(), equalTo(pref));
             assertThat(request.routing(), equalTo(null));
-            assertEquals(new BytesArray("{}"), request.doc());
+            assertThat(request.doc(), equalBytes(new BytesArray("{}")));
             assertEquals(XContentType.JSON, request.xContentType());
         }
     }

--- a/server/src/test/java/org/elasticsearch/common/blobstore/RetryingInputStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/common/blobstore/RetryingInputStreamTests.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.hamcrest.Matchers.empty;
 
 public class RetryingInputStreamTests extends ESTestCase {
@@ -45,7 +46,7 @@ public class RetryingInputStreamTests extends ESTestCase {
         byte[] results = copyToBytes(new RetryingInputStream(services, randomRetryingPurpose()) {
         });
         assertEquals(resourceBytes.length(), results.length);
-        assertEquals(resourceBytes, new BytesArray(results));
+        assertThat(new BytesArray(results), equalBytes(resourceBytes));
         assertEquals(retryableFailures + 1, services.getAttempts());
         assertEquals(Stream.generate(() -> "read").limit(retryableFailures).toList(), services.getRetryStarted());
     }
@@ -106,7 +107,7 @@ public class RetryingInputStreamTests extends ESTestCase {
 
         byte[] result = copyToBytes(new RetryingInputStream(services, OperationPurpose.INDICES) {
         });
-        assertEquals(resourceBytes, new BytesArray(result));
+        assertThat(new BytesArray(result), equalBytes(resourceBytes));
         assertEquals(numberOfFailures + 1, services.getAttempts());
         assertEquals(Stream.generate(() -> "read").limit(numberOfFailures).toList(), services.getRetryStarted());
     }

--- a/server/src/test/java/org/elasticsearch/common/blobstore/fs/FsBlobContainerTests.java
+++ b/server/src/test/java/org/elasticsearch/common/blobstore/fs/FsBlobContainerTests.java
@@ -49,6 +49,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
+import static org.elasticsearch.common.io.Streams.readFully;
 import static org.elasticsearch.repositories.blobstore.BlobStoreTestUtil.randomNonDataPurpose;
 import static org.elasticsearch.repositories.blobstore.BlobStoreTestUtil.randomPurpose;
 import static org.hamcrest.Matchers.containsString;
@@ -196,7 +198,7 @@ public class FsBlobContainerTests extends ESTestCase {
 
         for (int i = 0; i < 5; i++) {
             switch (between(1, 4)) {
-                case 1 -> assertEquals(expectedValue.get(), getBytesAsync(l -> container.getRegister(randomPurpose(), key, l)));
+                case 1 -> assertThat(getBytesAsync(l -> container.getRegister(randomPurpose(), key, l)), equalBytes(expectedValue.get()));
                 case 2 -> assertFalse(
                     getAsync(
                         l -> container.compareAndSetRegister(
@@ -208,8 +210,7 @@ public class FsBlobContainerTests extends ESTestCase {
                         )
                     )
                 );
-                case 3 -> assertEquals(
-                    expectedValue.get(),
+                case 3 -> assertThat(
                     getBytesAsync(
                         l -> container.compareAndExchangeRegister(
                             randomPurpose(),
@@ -218,7 +219,8 @@ public class FsBlobContainerTests extends ESTestCase {
                             new BytesArray(randomByteArrayOfLength(8)),
                             l
                         )
-                    )
+                    ),
+                    equalBytes(expectedValue.get())
                 );
                 case 4 -> {
                     /* no-op */
@@ -229,9 +231,9 @@ public class FsBlobContainerTests extends ESTestCase {
             if (randomBoolean()) {
                 assertTrue(getAsync(l -> container.compareAndSetRegister(randomPurpose(), key, expectedValue.get(), newValue, l)));
             } else {
-                assertEquals(
-                    expectedValue.get(),
-                    getBytesAsync(l -> container.compareAndExchangeRegister(randomPurpose(), key, expectedValue.get(), newValue, l))
+                assertThat(
+                    getBytesAsync(l -> container.compareAndExchangeRegister(randomPurpose(), key, expectedValue.get(), newValue, l)),
+                    equalBytes(expectedValue.get())
                 );
             }
             expectedValue.set(newValue);
@@ -278,7 +280,7 @@ public class FsBlobContainerTests extends ESTestCase {
                             l -> container.compareAndExchangeRegister(p, uncontendedKey, startValue, finalValue, l)
                         );
                         // NB calling .bytesReference() asserts that the result is present, there was no contention
-                        assertEquals(startValue, result.bytesReference());
+                        assertThat(result.bytesReference(), equalBytes(startValue));
                     }
                     // other threads try and do contended writes, which may fail and need retrying
                     : () -> {
@@ -313,9 +315,9 @@ public class FsBlobContainerTests extends ESTestCase {
         }
 
         for (var key : new String[] { contendedKey, uncontendedKey }) {
-            assertEquals(
-                finalValue,
-                safeAwait((ActionListener<OptionalBytesReference> l) -> container.getRegister(p, key, l)).bytesReference()
+            assertThat(
+                safeAwait((ActionListener<OptionalBytesReference> l) -> container.getRegister(p, key, l)).bytesReference(),
+                equalBytes(finalValue)
             );
         }
     }
@@ -362,7 +364,7 @@ public class FsBlobContainerTests extends ESTestCase {
         } else {
             container.writeBlobAtomic(randomNonDataPurpose(), blobName, blobData.streamInput(), blobData.length(), false);
         }
-        assertEquals(blobData, Streams.readFully(container.readBlob(randomPurpose(), blobName)));
+        assertThat(readFully(container.readBlob(randomPurpose(), blobName)), equalBytes(blobData));
         expectThrows(
             FileAlreadyExistsException.class,
             () -> container.writeBlobAtomic(
@@ -398,8 +400,8 @@ public class FsBlobContainerTests extends ESTestCase {
 
         var sourceContents = Streams.readFully(sourceContainer.readBlob(randomPurpose(), sourceBlobName));
         var targetContents = Streams.readFully(destinationContainer.readBlob(randomPurpose(), blobName));
-        assertEquals(sourceContents, targetContents);
-        assertEquals(contents, targetContents);
+        assertThat(targetContents, equalBytes(sourceContents));
+        assertThat(targetContents, equalBytes(contents));
     }
 
     static class MockFileSystemProvider extends FilterFileSystemProvider {

--- a/server/src/test/java/org/elasticsearch/common/blobstore/support/BlobContainerUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/blobstore/support/BlobContainerUtilsTests.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import static org.elasticsearch.common.blobstore.support.BlobContainerUtils.MAX_REGISTER_CONTENT_LENGTH;
 import static org.elasticsearch.common.blobstore.support.BlobContainerUtils.ensureValidRegisterContent;
 import static org.elasticsearch.common.blobstore.support.BlobContainerUtils.getRegisterUsingConsistentRead;
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 
 public class BlobContainerUtilsTests extends ESTestCase {
 
@@ -28,7 +29,7 @@ public class BlobContainerUtilsTests extends ESTestCase {
 
     public void testGetRegisterUsingConsistentRead() throws IOException {
         final var content = randomBytesReference(between(0, MAX_REGISTER_CONTENT_LENGTH));
-        assertEquals(content, getRegisterUsingConsistentRead(content.streamInput(), "", ""));
+        assertThat(getRegisterUsingConsistentRead(content.streamInput(), "", ""), equalBytes(content));
 
         final var invalidContent = randomBytesReference(MAX_REGISTER_CONTENT_LENGTH + 1);
         expectThrows(IllegalStateException.class, () -> getRegisterUsingConsistentRead(invalidContent.streamInput(), "", ""));

--- a/server/src/test/java/org/elasticsearch/common/bytes/CompositeBytesReferenceTests.java
+++ b/server/src/test/java/org/elasticsearch/common/bytes/CompositeBytesReferenceTests.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.hamcrest.Matchers.equalTo;
 
 public class CompositeBytesReferenceTests extends AbstractBytesReferenceTestCase {
@@ -98,7 +99,7 @@ public class CompositeBytesReferenceTests extends AbstractBytesReferenceTestCase
 
         int offset = 0;
         for (BytesReference reference : referenceList) {
-            assertEquals(reference, ref.slice(offset, reference.length()));
+            assertThat(ref.slice(offset, reference.length()), equalBytes(reference));
             int probes = randomIntBetween(Math.min(10, reference.length()), reference.length());
             for (int i = 0; i < probes; i++) {
                 int index = randomIntBetween(0, reference.length() - 1);
@@ -108,12 +109,12 @@ public class CompositeBytesReferenceTests extends AbstractBytesReferenceTestCase
         }
 
         BytesArray array = new BytesArray(builder.toBytesRef());
-        assertEquals(array, ref);
+        assertThat(ref, equalBytes(array));
         assertEquals(array.hashCode(), ref.hashCode());
 
         BytesStreamOutput output = new BytesStreamOutput();
         ref.writeTo(output);
-        assertEquals(array, output.bytes());
+        assertThat(output.bytes(), equalBytes(array));
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/common/bytes/PagedBytesReferenceTests.java
+++ b/server/src/test/java/org/elasticsearch/common/bytes/PagedBytesReferenceTests.java
@@ -15,6 +15,8 @@ import org.hamcrest.Matchers;
 
 import java.io.IOException;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
+
 public class PagedBytesReferenceTests extends AbstractBytesReferenceTestCase {
 
     @Override
@@ -121,7 +123,7 @@ public class PagedBytesReferenceTests extends AbstractBytesReferenceTestCase {
         // get refs & compare
         BytesReference pbr = BytesReference.fromByteArray(ba1, length);
         BytesReference pbr2 = BytesReference.fromByteArray(ba2, length);
-        assertEquals(pbr, pbr2);
+        assertThat(pbr2, equalBytes(pbr));
         int offsetToFlip = randomIntBetween(0, length - 1);
         int value = ~Byte.toUnsignedInt(ba1.get(offsetToFlip));
         ba2.set(offsetToFlip, (byte) value);

--- a/server/src/test/java/org/elasticsearch/common/compress/DeflateCompressTests.java
+++ b/server/src/test/java/org/elasticsearch/common/compress/DeflateCompressTests.java
@@ -26,6 +26,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Random;
 import java.util.zip.ZipException;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
@@ -319,7 +320,7 @@ public class DeflateCompressTests extends ESTestCase {
                 }
             } else {
                 var uncompressed = compressor.uncompress(compressed);
-                assertEquals(original, uncompressed);
+                assertThat(uncompressed, equalBytes(original));
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/common/compress/DeflateCompressedXContentTests.java
+++ b/server/src/test/java/org/elasticsearch/common/compress/DeflateCompressedXContentTests.java
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Random;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 
@@ -33,7 +34,7 @@ public class DeflateCompressedXContentTests extends ESTestCase {
 
     private void assertEquals(CompressedXContent s1, CompressedXContent s2) {
         Assert.assertEquals(s1, s2);
-        assertEquals(s1.uncompressed(), s2.uncompressed());
+        assertThat(s2.uncompressed(), equalBytes(s1.uncompressed()));
         assertEquals(s1.hashCode(), s2.hashCode());
     }
 

--- a/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamOutputTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamOutputTests.java
@@ -15,6 +15,8 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
+
 public class BytesStreamOutputTests extends ESTestCase {
 
     private BytesStreamOutput stream;
@@ -28,7 +30,7 @@ public class BytesStreamOutputTests extends ESTestCase {
     public void testDefaultConstructor() {
         assertEquals(0, stream.size());
         assertEquals(0, stream.position());
-        assertEquals(BytesArray.EMPTY, stream.bytes());
+        assertThat(stream.bytes(), equalBytes(BytesArray.EMPTY));
     }
 
     public void testConstructorWithExpectedSize() {

--- a/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
@@ -40,6 +40,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
@@ -327,8 +328,8 @@ public class BytesStreamsTests extends ESTestCase {
         assertThat(in.readString(), equalTo("goodbye"));
         assertThat(in.readGenericValue(), equalTo((Object) BytesRefs.toBytesRef("bytesref")));
         assertThat(in.readStringArray(), equalTo(new String[] { "a", "b", "cat" }));
-        assertThat(in.readBytesReference(), equalTo(new BytesArray("test")));
-        assertThat(in.readOptionalBytesReference(), equalTo(new BytesArray("test")));
+        assertThat(in.readBytesReference(), equalBytes(new BytesArray("test")));
+        assertThat(in.readOptionalBytesReference(), equalBytes(new BytesArray("test")));
         assertNull(in.readOptionalDouble());
         assertThat(in.readOptionalDouble(), closeTo(1.2, 0.0001));
         assertEquals(ZoneId.of("CET"), in.readZoneId());
@@ -679,7 +680,7 @@ public class BytesStreamsTests extends ESTestCase {
             output.writeMapWithConsistentOrder(map);
             reverseMapOutput.writeMapWithConsistentOrder(reverseMap);
 
-            assertEquals(output.bytes(), reverseMapOutput.bytes());
+            assertThat(reverseMapOutput.bytes(), equalBytes(output.bytes()));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutputTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutputTests.java
@@ -46,6 +46,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
@@ -368,8 +369,8 @@ public class RecyclerBytesStreamOutputTests extends ESTestCase {
         assertThat(in.readString(), equalTo("goodbye"));
         assertThat(in.readGenericValue(), equalTo((Object) BytesRefs.toBytesRef("bytesref")));
         assertThat(in.readStringArray(), equalTo(new String[] { "a", "b", "cat" }));
-        assertThat(in.readBytesReference(), equalTo(new BytesArray("test")));
-        assertThat(in.readOptionalBytesReference(), equalTo(new BytesArray("test")));
+        assertThat(in.readBytesReference(), equalBytes(new BytesArray("test")));
+        assertThat(in.readOptionalBytesReference(), equalBytes(new BytesArray("test")));
         assertNull(in.readOptionalDouble());
         assertThat(in.readOptionalDouble(), closeTo(1.2, 0.0001));
         assertEquals(ZoneId.of("CET"), in.readZoneId());
@@ -776,7 +777,7 @@ public class RecyclerBytesStreamOutputTests extends ESTestCase {
             output.writeMapWithConsistentOrder(map);
             reverseMapOutput.writeMapWithConsistentOrder(reverseMap);
 
-            assertEquals(output.bytes(), reverseMapOutput.bytes());
+            assertThat(reverseMapOutput.bytes(), equalBytes(output.bytes()));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/common/logging/ChunkedLoggingStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/ChunkedLoggingStreamTests.java
@@ -23,6 +23,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.stream.IntStream;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
+
 public class ChunkedLoggingStreamTests extends ESTestCase {
 
     public static final Logger logger = LogManager.getLogger(ChunkedLoggingStreamTests.class);
@@ -56,14 +58,11 @@ public class ChunkedLoggingStreamTests extends ESTestCase {
         final var bytes = randomByteArrayOfLength(between(0, 10000));
         final var level = randomFrom(Level.DEBUG, Level.INFO, Level.WARN, Level.ERROR);
         final var referenceDocs = randomFrom(ReferenceDocs.values());
-        assertEquals(
-            new BytesArray(bytes),
-            ChunkedLoggingStreamTestUtils.getDecodedLoggedBody(logger, level, "prefix", referenceDocs, () -> {
-                try (var stream = ChunkedLoggingStream.create(logger, level, "prefix", referenceDocs)) {
-                    writeRandomly(stream, bytes);
-                }
-            })
-        );
+        assertThat(ChunkedLoggingStreamTestUtils.getDecodedLoggedBody(logger, level, "prefix", referenceDocs, () -> {
+            try (var stream = ChunkedLoggingStream.create(logger, level, "prefix", referenceDocs)) {
+                writeRandomly(stream, bytes);
+            }
+        }), equalBytes(new BytesArray(bytes)));
     }
 
     private static void writeRandomly(OutputStream stream, byte[] bytes) throws IOException {

--- a/server/src/test/java/org/elasticsearch/http/HttpTracerTests.java
+++ b/server/src/test/java/org/elasticsearch/http/HttpTracerTests.java
@@ -29,6 +29,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
+
 public class HttpTracerTests extends ESTestCase {
 
     // these loggers are named in the docs so must not be changed without due care
@@ -96,15 +98,15 @@ public class HttpTracerTests extends ESTestCase {
             .withContent(responseBody, null)
             .build();
 
-        assertEquals(
-            responseBody,
+        assertThat(
             ChunkedLoggingStreamTestUtils.getDecodedLoggedBody(
                 LogManager.getLogger(HTTP_BODY_TRACER_LOGGER),
                 Level.TRACE,
                 "[" + request.getRequestId() + "] request body",
                 ReferenceDocs.HTTP_TRACER,
                 () -> assertNotNull(tracer.maybeLogRequest(request, null))
-            )
+            ),
+            equalBytes(responseBody)
         );
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/XContentDataHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/XContentDataHelperTests.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.hamcrest.Matchers.equalTo;
 
 public class XContentDataHelperTests extends ESTestCase {
@@ -143,7 +144,7 @@ public class XContentDataHelperTests extends ESTestCase {
         XContentDataHelper.decodeAndWrite(decoded, encoded);
         var decodedBytes = BytesReference.bytes(builder);
 
-        assertEquals(originalBytes, decodedBytes);
+        assertThat(decodedBytes, equalBytes(originalBytes));
     }
 
     public void testObject() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/query/InnerHitBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/InnerHitBuilderTests.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import static java.util.Collections.emptyList;
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.elasticsearch.test.EqualsHashCodeTestUtils.checkEqualsAndHashCode;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
@@ -105,7 +106,7 @@ public class InnerHitBuilderTests extends ESTestCase {
             BytesStreamOutput out2 = new BytesStreamOutput();
             original.writeTo(out1);
             deserialized.writeTo(out2);
-            assertEquals(out1.bytes(), out2.bytes());
+            assertThat(out2.bytes(), equalBytes(out1.bytes()));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/translog/TranslogHeaderWriterTests.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TranslogHeaderWriterTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.transport.BytesRefRecycler;
 import java.io.IOException;
 import java.util.zip.CRC32;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
@@ -206,7 +207,7 @@ public class TranslogHeaderWriterTests extends ESTestCase {
         serialized.writeToTranslogBuffer(operationOutput);
 
         BytesReference actualWithSize = operationOutput.bytes();
-        assertThat(actualWithSize.slice(4 + offset, actualWithSize.length() - offset - 4), equalTo(expectedWithoutSize));
+        assertThat(actualWithSize.slice(4 + offset, actualWithSize.length() - offset - 4), equalBytes(expectedWithoutSize));
     }
 
     private static void operationMatches(

--- a/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -124,6 +124,7 @@ import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.elasticsearch.common.util.BigArrays.NON_RECYCLING_INSTANCE;
 import static org.elasticsearch.index.translog.SnapshotMatchers.containsOperationsInAnyOrder;
 import static org.elasticsearch.index.translog.TranslogOperationsUtils.indexOp;
@@ -875,7 +876,7 @@ public class TranslogTests extends ESTestCase {
                         Translog.Index expIndexOp = (Translog.Index) expectedOp;
                         assertEquals(expIndexOp.uid(), indexOp.uid());
                         assertEquals(expIndexOp.routing(), indexOp.routing());
-                        assertEquals(expIndexOp.source(), indexOp.source());
+                        assertThat(indexOp.source(), equalBytes(expIndexOp.source()));
                         assertEquals(expIndexOp.version(), indexOp.version());
                     }
                     case DELETE -> {

--- a/server/src/test/java/org/elasticsearch/rest/ChunkedRestResponseBodyPartTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/ChunkedRestResponseBodyPartTests.java
@@ -31,6 +31,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
+
 public class ChunkedRestResponseBodyPartTests extends ESTestCase {
 
     public void testEncodesChunkedXContentCorrectly() throws IOException {
@@ -67,7 +69,7 @@ public class ChunkedRestResponseBodyPartTests extends ESTestCase {
         }
         assertTrue(firstBodyPart.isLastPart());
 
-        assertEquals(bytesDirect, CompositeBytesReference.of(refsGenerated.toArray(new BytesReference[0])));
+        assertThat(CompositeBytesReference.of(refsGenerated.toArray(new BytesReference[0])), equalBytes(bytesDirect));
     }
 
     public void testFromTextChunks() throws IOException {
@@ -88,7 +90,7 @@ public class ChunkedRestResponseBodyPartTests extends ESTestCase {
                 writer.write(chunk);
             }
             writer.flush();
-            assertEquals(new BytesArray(outputStream.toByteArray()), chunkedBytes);
+            assertThat(chunkedBytes, equalBytes(new BytesArray(outputStream.toByteArray())));
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/rest/RestContentAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestContentAggregatorTests.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.stream.IntStream.range;
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.elasticsearch.rest.RestContentAggregator.aggregate;
 
 public class RestContentAggregatorTests extends ESTestCase {
@@ -78,7 +79,7 @@ public class RestContentAggregatorTests extends ESTestCase {
 
         var aggregated = aggregatedRef.get();
         var expectedBytes = CompositeBytesReference.of(streamChunks.toArray(new ReleasableBytesReference[0]));
-        assertEquals(expectedBytes, aggregated.content());
+        assertThat(aggregated.content(), equalBytes(expectedBytes));
         aggregated.content().close();
     }
 

--- a/server/src/test/java/org/elasticsearch/rest/RestRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestRequestTests.java
@@ -34,6 +34,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.elasticsearch.rest.RestRequest.OPERATOR_REQUEST;
 import static org.elasticsearch.rest.RestRequest.SERVERLESS_REQUEST;
 import static org.hamcrest.Matchers.containsString;
@@ -174,16 +175,16 @@ public class RestRequestTests extends ESTestCase {
     public void testContentOrSourceParam() {
         Exception e = expectThrows(ElasticsearchParseException.class, () -> contentRestRequest("", emptyMap()).contentOrSourceParam());
         assertEquals("request body or source parameter is required", e.getMessage());
-        assertEquals(new BytesArray("stuff"), contentRestRequest("stuff", emptyMap()).contentOrSourceParam().v2());
-        assertEquals(
-            new BytesArray("stuff"),
-            contentRestRequest("stuff", Map.of("source", "stuff2", "source_content_type", "application/json")).contentOrSourceParam().v2()
+        assertThat(contentRestRequest("stuff", emptyMap()).contentOrSourceParam().v2(), equalBytes(new BytesArray("stuff")));
+        assertThat(
+            contentRestRequest("stuff", Map.of("source", "stuff2", "source_content_type", "application/json")).contentOrSourceParam().v2(),
+            equalBytes(new BytesArray("stuff"))
         );
-        assertEquals(
-            new BytesArray("{\"foo\": \"stuff\"}"),
+        assertThat(
             contentRestRequest("", Map.of("source", "{\"foo\": \"stuff\"}", "source_content_type", "application/json"))
                 .contentOrSourceParam()
-                .v2()
+                .v2(),
+            equalBytes(new BytesArray("{\"foo\": \"stuff\"}"))
         );
         e = expectThrows(ValidationException.class, () -> contentRestRequest("", Map.of("source", "stuff2")).contentOrSourceParam());
         assertThat(e.getMessage(), containsString("source and source_content_type parameters are required"));
@@ -290,10 +291,10 @@ public class RestRequestTests extends ESTestCase {
     public void testRequiredContent() {
         Exception e = expectThrows(ElasticsearchParseException.class, () -> contentRestRequest("", emptyMap()).requiredContent());
         assertEquals("request body is required", e.getMessage());
-        assertEquals(new BytesArray("stuff"), contentRestRequest("stuff", emptyMap()).requiredContent());
-        assertEquals(
-            new BytesArray("stuff"),
-            contentRestRequest("stuff", Map.of("source", "stuff2", "source_content_type", "application/json")).requiredContent()
+        assertThat(contentRestRequest("stuff", emptyMap()).requiredContent(), equalBytes(new BytesArray("stuff")));
+        assertThat(
+            contentRestRequest("stuff", Map.of("source", "stuff2", "source_content_type", "application/json")).requiredContent(),
+            equalBytes(new BytesArray("stuff"))
         );
         e = expectThrows(
             ElasticsearchParseException.class,

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestGetSourceActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestGetSourceActionTests.java
@@ -26,6 +26,7 @@ import org.junit.Before;
 import org.mockito.Mockito;
 
 import static java.util.Collections.emptyMap;
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
 import static org.elasticsearch.rest.RestStatus.OK;
 import static org.hamcrest.Matchers.equalTo;
@@ -63,7 +64,7 @@ public final class RestGetSourceActionTests extends RestActionTestCase {
 
         assertThat(restResponse.status(), equalTo(OK));
         assertThat(restResponse.contentType(), equalTo("application/json"));// dropping charset as it was not on a request
-        assertThat(restResponse.content(), equalTo(new BytesArray("{\"foo\": \"bar\"}")));
+        assertThat(restResponse.content(), equalBytes(new BytesArray("{\"foo\": \"bar\"}")));
     }
 
     public void testRestGetSourceActionWithMissingDocument() {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DoubleBoundsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DoubleBoundsTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.hamcrest.Matchers.equalTo;
 
 public class DoubleBoundsTests extends ESTestCase {
@@ -66,7 +67,7 @@ public class DoubleBoundsTests extends ESTestCase {
             readBytes = out.bytes();
         }
 
-        assertEquals(origBytes, readBytes);
+        assertThat(readBytes, equalBytes(origBytes));
     }
 
     public void testXContentRoundTrip() throws Exception {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/LongBoundsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/LongBoundsTests.java
@@ -28,6 +28,7 @@ import java.util.function.LongSupplier;
 
 import static java.lang.Math.max;
 import static java.lang.Math.min;
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.hamcrest.Matchers.equalTo;
 
 public class LongBoundsTests extends ESTestCase {
@@ -137,7 +138,7 @@ public class LongBoundsTests extends ESTestCase {
             readBytes = out.bytes();
         }
 
-        assertEquals(origBytes, readBytes);
+        assertThat(readBytes, equalBytes(origBytes));
     }
 
     public void testXContentRoundTrip() throws Exception {

--- a/server/src/test/java/org/elasticsearch/search/internal/ShardSearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/search/internal/ShardSearchRequestTests.java
@@ -49,6 +49,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.elasticsearch.index.query.AbstractQueryBuilder.parseTopLevelQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.hamcrest.Matchers.containsString;
@@ -186,7 +187,7 @@ public class ShardSearchRequestTests extends AbstractSearchTestCase {
         assertEquals(orig.searchType(), copy.searchType());
         assertEquals(orig.shardId(), copy.shardId());
         assertEquals(orig.numberOfShards(), copy.numberOfShards());
-        assertEquals(orig.cacheKey(null), copy.cacheKey(null));
+        assertThat(copy.cacheKey(null), equalBytes(orig.cacheKey(null)));
         assertNotSame(orig, copy);
         assertEquals(orig.getAliasFilter(), copy.getAliasFilter());
         assertEquals(orig.indexBoost(), copy.indexBoost(), 0.0f);

--- a/server/src/test/java/org/elasticsearch/transport/OutboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/OutboundHandlerTests.java
@@ -52,6 +52,7 @@ import java.util.function.LongSupplier;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -131,7 +132,7 @@ public class OutboundHandlerTests extends ESTestCase {
             assertSame(e, exception.get());
         }
 
-        assertEquals(bytesArray, reference);
+        assertThat(reference, equalBytes(bytesArray));
     }
 
     public void testSendRequest() throws IOException {

--- a/test/fixtures/gcs-fixture/src/test/java/fixture/gcs/MultipartUploadTests.java
+++ b/test/fixtures/gcs-fixture/src/test/java/fixture/gcs/MultipartUploadTests.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.Arrays;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 
 public class MultipartUploadTests extends ESTestCase {
 
@@ -63,7 +64,7 @@ public class MultipartUploadTests extends ESTestCase {
             var delimitedContent = DelimitedContent.randomContent();
             var inputStream = delimitedContent.toBytesReference().streamInput();
             var readBytes = MultipartUpload.readUntilDelimiter(inputStream, delimitedContent.delimiter);
-            assertEquals(new BytesArray(delimitedContent.before), readBytes);
+            assertThat(readBytes, equalBytes(new BytesArray(delimitedContent.before)));
             var readRemaining = inputStream.readAllBytes();
             assertArrayEquals(delimitedContent.after, readRemaining);
         }

--- a/test/framework/src/main/java/org/elasticsearch/common/bytes/AbstractBytesReferenceTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/bytes/AbstractBytesReferenceTestCase.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.hamcrest.Matchers.greaterThan;
 
 public abstract class AbstractBytesReferenceTestCase extends ESTestCase {
@@ -508,13 +509,13 @@ public abstract class AbstractBytesReferenceTestCase extends ESTestCase {
         BytesReference copy = bytesReference.slice(0, bytesReference.length());
 
         // get refs & compare
-        assertEquals(copy, bytesReference);
+        assertThat(bytesReference, equalBytes(copy));
         int sliceFrom = randomIntBetween(0, bytesReference.length());
         int sliceLength = randomIntBetween(0, bytesReference.length() - sliceFrom);
-        assertEquals(copy.slice(sliceFrom, sliceLength), bytesReference.slice(sliceFrom, sliceLength));
+        assertThat(bytesReference.slice(sliceFrom, sliceLength), equalBytes(copy.slice(sliceFrom, sliceLength)));
 
         BytesRef bytesRef = BytesRef.deepCopyOf(copy.toBytesRef());
-        assertEquals(new BytesArray(bytesRef), copy);
+        assertThat(copy, equalBytes(new BytesArray(bytesRef)));
 
         int offsetToFlip = randomIntBetween(0, bytesRef.length - 1);
         int value = ~Byte.toUnsignedInt(bytesRef.bytes[bytesRef.offset + offsetToFlip]);
@@ -625,13 +626,13 @@ public abstract class AbstractBytesReferenceTestCase extends ESTestCase {
 
         final BytesArray b1 = new BytesArray(array1, offset1, len);
         final BytesArray b2 = new BytesArray(array2, offset2, len);
-        assertEquals(b1, b2);
+        assertThat(b2, equalBytes(b1));
         assertEquals(Arrays.hashCode(BytesReference.toBytes(b1)), b1.hashCode());
         assertEquals(Arrays.hashCode(BytesReference.toBytes(b2)), b2.hashCode());
 
         // test same instance
-        assertEquals(b1, b1);
-        assertEquals(b2, b2);
+        assertThat(b1, equalBytes(b1));
+        assertThat(b2, equalBytes(b2));
 
         if (len > 0) {
             // test different length
@@ -714,7 +715,7 @@ public abstract class AbstractBytesReferenceTestCase extends ESTestCase {
                 }
                 boolean sliceRight = randomBoolean();
                 BytesReference right = sliceRight ? input2.readSlicedBytesReference() : input2.readBytesReference();
-                assertEquals(left, right);
+                assertThat(right, equalBytes(left));
                 if (sliceRight && bytesReference.hasArray()) {
                     assertSame(right.array(), right.array());
                 }

--- a/test/framework/src/main/java/org/elasticsearch/common/bytes/BytesReferenceTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/bytes/BytesReferenceTestUtils.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.common.bytes;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Strings;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public enum BytesReferenceTestUtils {
+    ;
+
+    /**
+     * Like {@link Matchers#equalTo} except it reports the contents of the respective {@link BytesReference} instances on mismatch.
+     */
+    public static Matcher<BytesReference> equalBytes(BytesReference expected) {
+        return new BaseMatcher<>() {
+            @Override
+            public boolean matches(Object actual) {
+                return Objects.equals(expected, actual);
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                if (expected == null) {
+                    description.appendValue(null);
+                } else {
+                    appendBytesReferenceDescription(expected, description);
+                }
+            }
+
+            private void appendBytesReferenceDescription(BytesReference bytesReference, Description description) {
+                final var stringBuilder = new StringBuilder("BytesReference[");
+                final var iterator = bytesReference.iterator();
+                BytesRef bytesRef;
+                boolean first = true;
+                try {
+                    while ((bytesRef = iterator.next()) != null) {
+                        for (int i = 0; i < bytesRef.length; i++) {
+                            if (first) {
+                                first = false;
+                            } else {
+                                stringBuilder.append(' ');
+                            }
+                            stringBuilder.append(Strings.format("%02x", bytesRef.bytes[bytesRef.offset + i]));
+                        }
+                    }
+                    description.appendText(stringBuilder.append(']').toString());
+                } catch (IOException e) {
+                    throw new AssertionError("no IO happens here", e);
+                }
+            }
+
+            @Override
+            public void describeMismatch(Object item, Description description) {
+                description.appendText("was ");
+                if (item instanceof BytesReference bytesReference) {
+                    appendBytesReferenceDescription(bytesReference, description);
+                } else {
+                    description.appendValue(item);
+                }
+            }
+        };
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -142,6 +142,7 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.shuffle;
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.elasticsearch.index.engine.Engine.Operation.Origin.PEER_RECOVERY;
 import static org.elasticsearch.index.engine.Engine.Operation.Origin.PRIMARY;
 import static org.elasticsearch.index.engine.Engine.Operation.Origin.REPLICA;
@@ -1434,7 +1435,7 @@ public abstract class EngineTestCase extends ESTestCase {
                         translogOperationAsserter.assertSameIndexOperation((Translog.Index) luceneOp, (Translog.Index) translogOp)
                     );
                 } else {
-                    assertThat(((Translog.Index) luceneOp).source(), equalTo(((Translog.Index) translogOp).source()));
+                    assertThat(((Translog.Index) luceneOp).source(), equalBytes(((Translog.Index) translogOp).source()));
                 }
             }
         }

--- a/test/framework/src/main/java/org/elasticsearch/repositories/AbstractThirdPartyRepositoryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/AbstractThirdPartyRepositoryTestCase.java
@@ -45,6 +45,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.function.Predicate;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.elasticsearch.repositories.blobstore.BlobStoreRepository.METADATA_PREFIX;
 import static org.elasticsearch.repositories.blobstore.BlobStoreRepository.SNAPSHOT_PREFIX;
 import static org.elasticsearch.repositories.blobstore.BlobStoreTestUtil.randomNonDataPurpose;
@@ -299,7 +300,7 @@ public abstract class AbstractThirdPartyRepositoryTestCase extends ESSingleNodeT
         });
 
         {
-            assertThat("Exact Range", readBlob(repository, blobName, 0L, blobBytes.length()), equalTo(blobBytes));
+            assertThat("Exact Range", readBlob(repository, blobName, 0L, blobBytes.length()), equalBytes(blobBytes));
         }
         {
             int position = randomIntBetween(0, blobBytes.length() - 1);
@@ -307,7 +308,7 @@ public abstract class AbstractThirdPartyRepositoryTestCase extends ESSingleNodeT
             assertThat(
                 "Random Range: " + position + '-' + (position + length),
                 readBlob(repository, blobName, position, length),
-                equalTo(blobBytes.slice(position, length))
+                equalBytes(blobBytes.slice(position, length))
             );
         }
         {
@@ -316,7 +317,7 @@ public abstract class AbstractThirdPartyRepositoryTestCase extends ESSingleNodeT
             assertThat(
                 "Random Larger Range: " + position + '-' + (position + length),
                 readBlob(repository, blobName, position, length),
-                equalTo(blobBytes.slice(position, Math.toIntExact(Math.min(length, blobBytes.length() - position))))
+                equalBytes(blobBytes.slice(position, Math.toIntExact(Math.min(length, blobBytes.length() - position))))
             );
         }
     }
@@ -386,7 +387,7 @@ public abstract class AbstractThirdPartyRepositoryTestCase extends ESSingleNodeT
             return null;
         });
 
-        assertEquals(overwriteBlobBytes, readBlob(repository, blobName, 0, overwriteBlobBytes.length()));
+        assertThat(readBlob(repository, blobName, 0, overwriteBlobBytes.length()), equalBytes(overwriteBlobBytes));
 
         // throw exception if failIfAlreadyExists is set to true
         executeOnBlobStore(repository, blobStore -> {

--- a/test/framework/src/test/java/org/elasticsearch/common/bytes/BytesReferenceTestUtilsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/common/bytes/BytesReferenceTestUtilsTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.common.bytes;
+
+import org.elasticsearch.test.ESTestCase;
+import org.hamcrest.StringDescription;
+
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
+
+public class BytesReferenceTestUtilsTests extends ESTestCase {
+    public void testEqualBytes() {
+        final var expectedBytes = randomBoolean()
+            ? new BytesArray(new byte[] { 0, 1, 2, 3, 99 })
+            : CompositeBytesReference.of(new BytesArray(new byte[] { 0, 1 }), new BytesArray(new byte[] { 2, 3, 99 }));
+
+        final var matcher = equalBytes(expectedBytes);
+        assertTrue(matcher.matches(expectedBytes));
+        assertTrue(matcher.matches(new BytesArray(BytesReference.toBytes(expectedBytes))));
+        assertTrue(matcher.matches(CompositeBytesReference.of(expectedBytes.slice(0, 3), expectedBytes.slice(3, 2))));
+        assertFalse(matcher.matches(randomBytesReference(5)));
+
+        final var description = new StringDescription();
+        matcher.describeTo(description);
+        assertEquals("BytesReference[00 01 02 03 63]", description.toString());
+
+        final var nullMismatchDescription = new StringDescription();
+        matcher.describeMismatch(null, nullMismatchDescription);
+        assertEquals("was null", nullMismatchDescription.toString());
+
+        final var unequalMismatchDescription = new StringDescription();
+        matcher.describeMismatch(new BytesArray(new byte[] { 0, 1, 2, 3, 15 }), unequalMismatchDescription);
+        assertEquals("was BytesReference[00 01 02 03 0f]", unequalMismatchDescription.toString());
+
+        final var nullMatcher = equalBytes(null);
+        assertTrue(nullMatcher.matches(null));
+        assertFalse(nullMatcher.matches(randomBytesReference(5)));
+
+        final var nullMatcherDescription = new StringDescription();
+        nullMatcher.describeTo(nullMatcherDescription);
+        assertEquals("null", nullMatcherDescription.toString());
+    }
+}

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/action/GetAutoscalingCapacityActionResponseTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/action/GetAutoscalingCapacityActionResponseTests.java
@@ -13,7 +13,6 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.autoscaling.AutoscalingTestCase;
 import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingDeciderResults;
-import org.hamcrest.Matchers;
 
 import java.io.IOException;
 import java.util.Map;
@@ -22,6 +21,8 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 
 public class GetAutoscalingCapacityActionResponseTests extends AutoscalingTestCase {
 
@@ -50,6 +51,6 @@ public class GetAutoscalingCapacityActionResponseTests extends AutoscalingTestCa
         expected.endObject();
         expected.endObject();
         BytesReference expectedBytes = BytesReference.bytes(expected);
-        assertThat(responseBytes, Matchers.equalTo(expectedBytes));
+        assertThat(responseBytes, equalBytes(expectedBytes));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTests.java
@@ -44,6 +44,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static java.util.Map.entry;
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.elasticsearch.xpack.core.security.authc.Authentication.VERSION_API_KEY_ROLES_AS_BYTES;
 import static org.elasticsearch.xpack.core.security.authc.AuthenticationTestHelper.randomCloudApiKeyAuthentication;
 import static org.elasticsearch.xpack.core.security.authc.AuthenticationTestHelper.randomCrossClusterAccessSubjectInfo;
@@ -1262,7 +1263,7 @@ public class AuthenticationTests extends ESTestCase {
         );
 
         // check null value
-        assertThat(null, equalTo(Authentication.maybeRemoveRemoteIndicesFromRoleDescriptors(null)));
+        assertThat(null, equalBytes(Authentication.maybeRemoveRemoteIndicesFromRoleDescriptors(null)));
 
         // and an empty map
         final BytesReference empty = randomBoolean() ? new BytesArray("""

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/SubjectTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/SubjectTests.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.elasticsearch.xpack.core.security.authc.AuthenticationField.API_KEY_LIMITED_ROLE_DESCRIPTORS_KEY;
 import static org.elasticsearch.xpack.core.security.authc.AuthenticationField.API_KEY_REALM_NAME;
 import static org.elasticsearch.xpack.core.security.authc.AuthenticationField.API_KEY_REALM_TYPE;
@@ -358,7 +359,7 @@ public class SubjectTests extends ESTestCase {
         final List<RoleReference> roleReferences = roleReferenceIntersection.getRoleReferences();
         assertThat(roleReferences, contains(isA(ApiKeyRoleReference.class), isA(ApiKeyRoleReference.class)));
         final ApiKeyRoleReference limitedByRoleReference = (ApiKeyRoleReference) roleReferences.get(1);
-        assertThat(limitedByRoleReference.getRoleDescriptorsBytes(), equalTo(FLEET_SERVER_ROLE_DESCRIPTOR_BYTES_V_7_14));
+        assertThat(limitedByRoleReference.getRoleDescriptorsBytes(), equalBytes(FLEET_SERVER_ROLE_DESCRIPTOR_BYTES_V_7_14));
     }
 
     private AnonymousUser getAnonymousUser() {

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/search/PITAwareQueryClientTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/search/PITAwareQueryClientTests.java
@@ -68,6 +68,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static org.elasticsearch.action.ActionListener.wrap;
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.elasticsearch.index.query.QueryBuilders.idsQuery;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
@@ -219,7 +220,7 @@ public class PITAwareQueryClientTests extends ESTestCase {
                 listener.onResponse((Response) response);
             } else if (request instanceof ClosePointInTimeRequest closePIT) {
                 assertTrue(openedPIT);
-                assertEquals(pitId, closePIT.getId());
+                assertThat(closePIT.getId(), equalBytes(pitId));
 
                 openedPIT = false;
                 ClosePointInTimeResponse response = new ClosePointInTimeResponse(true, 1);
@@ -229,7 +230,7 @@ public class PITAwareQueryClientTests extends ESTestCase {
                 searchRequestsRemainingCount--;
                 assertTrue(searchRequestsRemainingCount >= 0);
 
-                assertEquals(pitId, searchRequest.source().pointInTimeBuilder().getEncodedId());
+                assertThat(searchRequest.source().pointInTimeBuilder().getEncodedId(), equalBytes(pitId));
                 assertEquals(0, searchRequest.indices().length); // no indices set in the search request
                 assertEquals(1, searchRequest.source().subSearches().size());
 

--- a/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/saml/support/SamlAuthenticationStateTests.java
+++ b/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/saml/support/SamlAuthenticationStateTests.java
@@ -23,6 +23,7 @@ import org.opensaml.saml.saml2.core.NameID;
 import java.io.IOException;
 import java.util.List;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.hamcrest.Matchers.equalTo;
 
 public class SamlAuthenticationStateTests extends IdpSamlTestCase {
@@ -81,7 +82,7 @@ public class SamlAuthenticationStateTests extends IdpSamlTestCase {
             assertThat(obj2, equalTo(obj1));
 
             final BytesReference bytes2 = XContentHelper.toXContent(obj2, xContentType, humanReadable);
-            assertThat(bytes2, equalTo(bytes1));
+            assertThat(bytes2, equalBytes(bytes1));
 
             return obj2;
         }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilterTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilterTests.java
@@ -88,6 +88,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.elasticsearch.index.IndexingPressure.MAX_COORDINATING_BYTES;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.awaitLatch;
@@ -767,7 +768,7 @@ public class ShardBulkInferenceActionFilterTests extends ESTestCase {
 
                 IndexRequest doc1IndexRequest = getIndexRequestOrNull(doc1Request.request());
                 assertThat(doc1IndexRequest, notNullValue());
-                assertThat(doc1IndexRequest.source(), equalTo(BytesReference.bytes(doc1Source)));
+                assertThat(doc1IndexRequest.source(), equalBytes(BytesReference.bytes(doc1Source)));
 
                 IndexingPressure.Coordinating coordinatingIndexingPressure = indexingPressure.getCoordinating();
                 assertThat(coordinatingIndexingPressure, notNullValue());
@@ -851,7 +852,7 @@ public class ShardBulkInferenceActionFilterTests extends ESTestCase {
 
                 IndexRequest doc1IndexRequest = getIndexRequestOrNull(doc1Request.request());
                 assertThat(doc1IndexRequest, notNullValue());
-                assertThat(doc1IndexRequest.source(), equalTo(BytesReference.bytes(doc1Source)));
+                assertThat(doc1IndexRequest.source(), equalBytes(BytesReference.bytes(doc1Source)));
 
                 IndexingPressure.Coordinating coordinatingIndexingPressure = indexingPressure.getCoordinating();
                 assertThat(coordinatingIndexingPressure, notNullValue());
@@ -964,7 +965,7 @@ public class ShardBulkInferenceActionFilterTests extends ESTestCase {
 
                 IndexRequest doc2IndexRequest = getIndexRequestOrNull(doc2Request.request());
                 assertThat(doc2IndexRequest, notNullValue());
-                assertThat(doc2IndexRequest.source(), equalTo(BytesReference.bytes(doc2Source)));
+                assertThat(doc2IndexRequest.source(), equalBytes(BytesReference.bytes(doc2Source)));
 
                 IndexingPressure.Coordinating coordinatingIndexingPressure = indexingPressure.getCoordinating();
                 assertThat(coordinatingIndexingPressure, notNullValue());

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/ChunkedTrainedModelPersisterIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/ChunkedTrainedModelPersisterIT.java
@@ -58,6 +58,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.startsWith;
@@ -143,7 +144,7 @@ public class ChunkedTrainedModelPersisterIT extends MlSingleNodeTestCase {
 
         TrainedModelConfig storedConfig = getTrainedModelFuture.actionGet();
 
-        assertThat(storedConfig.getCompressedDefinition(), equalTo(compressedDefinition));
+        assertThat(storedConfig.getCompressedDefinition(), equalBytes(compressedDefinition));
         assertThat(storedConfig.getEstimatedOperations(), equalTo((long) modelSizeInfo.numOperations()));
         assertThat(storedConfig.getModelSize(), equalTo(modelSizeInfo.ramBytesUsed()));
         assertThat(storedConfig.getMetadata(), hasKey("total_feature_importance"));
@@ -219,7 +220,7 @@ public class ChunkedTrainedModelPersisterIT extends MlSingleNodeTestCase {
         trainedModelProvider.getTrainedModel(inferenceModelId, GetTrainedModelsAction.Includes.all(), null, getTrainedModelFuture);
 
         TrainedModelConfig storedConfig = getTrainedModelFuture.actionGet();
-        assertThat(storedConfig.getCompressedDefinition(), equalTo(compressedDefinition));
+        assertThat(storedConfig.getCompressedDefinition(), equalBytes(compressedDefinition));
         assertThat(storedConfig.getEstimatedOperations(), equalTo((long) modelSizeInfo.numOperations()));
         assertThat(storedConfig.getModelSize(), equalTo(modelSizeInfo.ramBytesUsed()));
         assertThat(storedConfig.getMetadata(), hasKey("total_feature_importance"));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobTests.java
@@ -67,6 +67,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.elasticsearch.xpack.ml.MachineLearning.DELAYED_DATA_CHECK_FREQ;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -389,7 +390,7 @@ public class DatafeedJobTests extends ESTestCase {
             IndexRequest indexRequest = (IndexRequest) bulkRequest.requests().get(0);
             assertThat(indexRequest.index(), equalTo(AnnotationIndex.WRITE_ALIAS_NAME));
             assertThat(indexRequest.id(), equalTo(annotationDocId));
-            assertThat(indexRequest.source(), equalTo(expectedSource));
+            assertThat(indexRequest.source(), equalBytes(expectedSource));
             assertThat(indexRequest.opType(), equalTo(DocWriteRequest.OpType.INDEX));
         }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/action/MonitoringBulkDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/action/MonitoringBulkDocTests.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.elasticsearch.test.EqualsHashCodeTestUtils.checkEqualsAndHashCode;
 import static org.elasticsearch.xpack.monitoring.MonitoringTestUtils.randomMonitoringBulkDoc;
 import static org.hamcrest.Matchers.equalTo;
@@ -74,7 +75,7 @@ public class MonitoringBulkDocTests extends ESTestCase {
         assertThat(document.getId(), equalTo(id));
         assertThat(document.getTimestamp(), equalTo(timestamp));
         assertThat(document.getIntervalMillis(), equalTo(interval));
-        assertThat(document.getSource(), equalTo(source));
+        assertThat(document.getSource(), equalBytes(source));
         assertThat(document.getXContentType(), equalTo(xContentType));
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/action/MonitoringBulkRequestTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/action/MonitoringBulkRequestTests.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
@@ -134,7 +135,7 @@ public class MonitoringBulkRequestTests extends ESTestCase {
             assertThat(bulkDoc.getId(), equalTo(ids[count]));
             assertThat(bulkDoc.getTimestamp(), equalTo(timestamp));
             assertThat(bulkDoc.getIntervalMillis(), equalTo(interval));
-            assertThat(bulkDoc.getSource(), equalTo(sources[count]));
+            assertThat(bulkDoc.getSource(), equalBytes(sources[count]));
             assertThat(bulkDoc.getXContentType(), equalTo(xContentType));
             ++count;
         }

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/BytesReferenceMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/BytesReferenceMonitoringDocTests.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.elasticsearch.test.EqualsHashCodeTestUtils.checkEqualsAndHashCode;
 import static org.elasticsearch.xpack.core.monitoring.MonitoredSystem.KIBANA;
 import static org.hamcrest.Matchers.equalTo;
@@ -62,7 +63,7 @@ public class BytesReferenceMonitoringDocTests extends BaseMonitoringDocTestCase<
         assertThat(document.getId(), equalTo(id));
 
         assertThat(document.getXContentType(), equalTo(xContentType));
-        assertThat(document.getSource(), equalTo(source));
+        assertThat(document.getSource(), equalBytes(source));
     }
 
     public void testConstructorMonitoredSystemMustNotBeNull() {

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/RetrySearchIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/RetrySearchIntegTests.java
@@ -38,6 +38,7 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
@@ -139,7 +140,7 @@ public class RetrySearchIntegTests extends BaseSearchableSnapshotsIntegTestCase 
         SetOnce<BytesReference> updatedPit = new SetOnce<>();
         try {
             assertNoFailuresAndResponse(prepareSearch().setPointInTime(new PointInTimeBuilder(pitId)), resp -> {
-                assertThat(resp.pointInTimeId(), equalTo(pitId));
+                assertThat(resp.pointInTimeId(), equalBytes(pitId));
                 assertHitCount(resp, docCount);
             });
             final Set<String> allocatedNodes = internalCluster().nodesInclude(indexName);
@@ -176,7 +177,7 @@ public class RetrySearchIntegTests extends BaseSearchableSnapshotsIntegTestCase 
                     .setAllowPartialSearchResults(randomBoolean())  // partial results should not matter here
                     .setPointInTime(new PointInTimeBuilder(updatedPit.get()).setKeepAlive(TimeValue.timeValueMinutes(2))),
                 resp -> {
-                    assertThat(resp.pointInTimeId(), equalTo(updatedPit.get()));
+                    assertThat(resp.pointInTimeId(), equalBytes(updatedPit.get()));
                     assertHitCount(resp, docCount);
                 }
             );
@@ -208,7 +209,7 @@ public class RetrySearchIntegTests extends BaseSearchableSnapshotsIntegTestCase 
 
         try {
             assertNoFailuresAndResponse(prepareSearch().setPointInTime(new PointInTimeBuilder(pitId)), resp -> {
-                assertThat(resp.pointInTimeId(), equalTo(pitId));
+                assertThat(resp.pointInTimeId(), equalBytes(pitId));
                 assertHitCount(resp, docCount);
             });
 
@@ -226,7 +227,7 @@ public class RetrySearchIntegTests extends BaseSearchableSnapshotsIntegTestCase 
                     .setAllowPartialSearchResults(true)
                     .setPointInTime(new PointInTimeBuilder(pitId)),
                 resp -> {
-                    assertThat(resp.pointInTimeId(), equalTo(pitId));
+                    assertThat(resp.pointInTimeId(), equalBytes(pitId));
                     assertHitCount(resp, docCount);
                 }
             );

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStoreTests.java
@@ -85,6 +85,7 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.elasticsearch.common.util.set.Sets.newHashSet;
 import static org.elasticsearch.search.SearchService.ALLOW_EXPENSIVE_QUERIES;
 import static org.elasticsearch.test.ActionListenerUtils.anyActionListener;
@@ -702,7 +703,7 @@ public class NativePrivilegeStoreTests extends ESTestCase {
             assertThat(request.indices(), arrayContaining(SecuritySystemIndices.SECURITY_MAIN_ALIAS));
             assertThat(request.id(), equalTo("application-privilege_" + privilege.getApplication() + ":" + privilege.getName()));
             final XContentBuilder builder = privilege.toXContent(XContentBuilder.builder(XContentType.JSON.xContent()), true);
-            assertThat(request.source(), equalTo(BytesReference.bytes(builder)));
+            assertThat(request.source(), equalBytes(BytesReference.bytes(builder)));
             final boolean created = privilege.getName().equals("user") == false;
             responses[i] = BulkItemResponse.success(
                 i,

--- a/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/analyze/RepositoryAnalysisSuccessIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/analyze/RepositoryAnalysisSuccessIT.java
@@ -61,6 +61,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.elasticsearch.indices.recovery.RecoverySettings.INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING;
 import static org.elasticsearch.repositories.blobstore.BlobStoreRepository.MAX_RESTORE_BYTES_PER_SEC;
 import static org.elasticsearch.repositories.blobstore.BlobStoreRepository.MAX_SNAPSHOT_BYTES_PER_SEC;
@@ -594,7 +595,7 @@ public class RepositoryAnalysisSuccessIT extends AbstractSnapshotIntegTestCase {
                         contendedRegisterValue = updatedValue;
                     }
                 } else {
-                    assertEquals(expected, witness); // uncontended writes always succeed
+                    assertThat(witness, equalBytes(expected)); // uncontended writes always succeed
                     assertNotEquals(expected, updated); // uncontended register sees only updates
                     if (updated.length() != 0) {
                         final var updatedValue = longFromBytes(updated);

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/CancellationTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/CancellationTests.java
@@ -52,6 +52,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.Collections.singletonMap;
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -192,7 +193,7 @@ public class CancellationTests extends ESTestCase {
         doAnswer((Answer<Void>) invocation -> {
             @SuppressWarnings("unchecked")
             SearchRequest request = (SearchRequest) invocation.getArguments()[1];
-            assertEquals(pitId, request.pointInTimeBuilder().getEncodedId());
+            assertThat(request.pointInTimeBuilder().getEncodedId(), equalBytes(pitId));
             TaskId parentTask = request.getParentTask();
             assertNotNull(parentTask);
             assertEquals(task.getId(), parentTask.getId());
@@ -206,7 +207,7 @@ public class CancellationTests extends ESTestCase {
         // Emulation of close pit
         doAnswer(invocation -> {
             ClosePointInTimeRequest request = (ClosePointInTimeRequest) invocation.getArguments()[1];
-            assertEquals(pitId, request.getId());
+            assertThat(request.getId(), equalBytes(pitId));
 
             @SuppressWarnings("unchecked")
             ActionListener<ClosePointInTimeResponse> listener = (ActionListener<ClosePointInTimeResponse>) invocation.getArguments()[2];

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexerTests.java
@@ -87,6 +87,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.IntStream;
 
+import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -189,7 +190,7 @@ public class ClientTransformIndexerTests extends ESTestCase {
             );
 
             this.<SearchResponse>assertAsync(listener -> indexer.doNextSearch(0, listener), response -> {
-                assertEquals(new BytesArray("the_pit_id+"), response.pointInTimeId());
+                assertThat(response.pointInTimeId(), equalBytes(new BytesArray("the_pit_id+")));
             });
 
             assertEquals(1L, client.getPitContextCounter());
@@ -202,15 +203,15 @@ public class ClientTransformIndexerTests extends ESTestCase {
             assertEquals(0L, client.getPitContextCounter());
 
             this.<SearchResponse>assertAsync(listener -> indexer.doNextSearch(0, listener), response -> {
-                assertEquals(new BytesArray("the_pit_id+"), response.pointInTimeId());
+                assertThat(response.pointInTimeId(), equalBytes(new BytesArray("the_pit_id+")));
             });
 
             this.<SearchResponse>assertAsync(listener -> indexer.doNextSearch(0, listener), response -> {
-                assertEquals(new BytesArray("the_pit_id++"), response.pointInTimeId());
+                assertThat(response.pointInTimeId(), equalBytes(new BytesArray("the_pit_id++")));
             });
 
             this.<SearchResponse>assertAsync(listener -> indexer.doNextSearch(0, listener), response -> {
-                assertEquals(new BytesArray("the_pit_id+++"), response.pointInTimeId());
+                assertThat(response.pointInTimeId(), equalBytes(new BytesArray("the_pit_id+++")));
             });
 
             assertEquals(1L, client.getPitContextCounter());
@@ -219,7 +220,7 @@ public class ClientTransformIndexerTests extends ESTestCase {
             assertEquals(0L, client.getPitContextCounter());
 
             this.<SearchResponse>assertAsync(listener -> indexer.doNextSearch(0, listener), response -> {
-                assertEquals(new BytesArray("the_pit_id+"), response.pointInTimeId());
+                assertThat(response.pointInTimeId(), equalBytes(new BytesArray("the_pit_id+")));
             });
 
             var paceCounter = new AtomicInteger(0);
@@ -229,15 +230,15 @@ public class ClientTransformIndexerTests extends ESTestCase {
             assertEquals(0L, client.getPitContextCounter());
 
             this.<SearchResponse>assertAsync(listener -> indexer.doNextSearch(0, listener), response -> {
-                assertEquals(new BytesArray("the_pit_id+"), response.pointInTimeId());
+                assertThat(response.pointInTimeId(), equalBytes(new BytesArray("the_pit_id+")));
             });
 
             this.<SearchResponse>assertAsync(listener -> indexer.doNextSearch(0, listener), response -> {
-                assertEquals(new BytesArray("the_pit_id++"), response.pointInTimeId());
+                assertThat(response.pointInTimeId(), equalBytes(new BytesArray("the_pit_id++")));
             });
 
             this.<SearchResponse>assertAsync(listener -> indexer.doNextSearch(0, listener), response -> {
-                assertEquals(new BytesArray("the_pit_id+++"), response.pointInTimeId());
+                assertThat(response.pointInTimeId(), equalBytes(new BytesArray("the_pit_id+++")));
             });
 
             assertEquals(1L, client.getPitContextCounter());
@@ -380,7 +381,7 @@ public class ClientTransformIndexerTests extends ESTestCase {
 
             this.<SearchResponse>assertAsync(listener -> indexer.doNextSearch(0, listener), response -> {
                 if (pitEnabled) {
-                    assertEquals(new BytesArray("the_pit_id+"), response.pointInTimeId());
+                    assertThat(response.pointInTimeId(), equalBytes(new BytesArray("the_pit_id+")));
                 } else {
                     assertNull(response.pointInTimeId());
                 }
@@ -393,7 +394,7 @@ public class ClientTransformIndexerTests extends ESTestCase {
                 if (pitEnabled) {
                     assertNull(response.pointInTimeId());
                 } else {
-                    assertEquals(new BytesArray("the_pit_id+"), response.pointInTimeId());
+                    assertThat(response.pointInTimeId(), equalBytes(new BytesArray("the_pit_id+")));
                 }
             });
         }


### PR DESCRIPTION
Today if you assert two `BytesReference` objects are equal, and they
aren't, then the test output is unhelpful because `BytesReference`
instances do not include their contents in their default string
representations. This commit introduces a new matcher specifically for
testing `BytesReference` instances for equality which generates more
useful output.