### PR TITLE
[9.2] fix: add missing vector_similarity_support in InferenceFeatures (#138644)

### DIFF
--- a/docs/changelog/138644.yaml
+++ b/docs/changelog/138644.yaml
@@ -1,0 +1,5 @@
+pr: 138644
+summary: "Fix: add missing `vector_similarity_support` in InferenceFeatures"
+area: Search
+type: bug
+issues: []

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -542,14 +542,6 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/117249
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   issue: https://github.com/elastic/elasticsearch/issues/138649
-  methods:
-    - test {p0=index/92_metrics_auto_subobjects/Metrics object indexing}
-    - test {p0=index/92_metrics_auto_subobjects/Root without subobjects with synthetic source}
-    - test {p0=index/92_metrics_auto_subobjects/Metrics object indexing with synthetic source}
-    - test {p0=indices.put_index_template/15_composition/Composable index templates that include subobjects: auto at root}
-    - test {p0=search/330_fetch_fields/Test with subobjects: auto}
-    - test {p0=indices.put_index_template/15_composition/Composable index templates that include subobjects: auto on arbitrary field}
-    - test {p0=index/92_metrics_auto_subobjects/Root with metrics}
 
 # Examples:
 #

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -542,6 +542,25 @@ tests:
   issue: https://github.com/elastic/elasticsearch/issues/117249
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   issue: https://github.com/elastic/elasticsearch/issues/138649
+  method: test {p0=index/92_metrics_auto_subobjects/Metrics object indexing}
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  issue: https://github.com/elastic/elasticsearch/issues/138649
+  method: test {p0=index/92_metrics_auto_subobjects/Root without subobjects with synthetic source}
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  issue: https://github.com/elastic/elasticsearch/issues/138649
+  method: test {p0=index/92_metrics_auto_subobjects/Metrics object indexing with synthetic source}
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  issue: https://github.com/elastic/elasticsearch/issues/138649
+  method: "test {p0=indices.put_index_template/15_composition/Composable index templates that include subobjects: auto at root}"
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  issue: https://github.com/elastic/elasticsearch/issues/138649
+  method: "test {p0=search/330_fetch_fields/Test with subobjects: auto}"
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  issue: https://github.com/elastic/elasticsearch/issues/138649
+  method: "test {p0=indices.put_index_template/15_composition/Composable index templates that include subobjects: auto on arbitrary field}"
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  issue: https://github.com/elastic/elasticsearch/issues/138649
+  method: test {p0=index/92_metrics_auto_subobjects/Root with metrics}
 
 # Examples:
 #

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -540,6 +540,16 @@ tests:
 - class: org.elasticsearch.versioning.ConcurrentSeqNoVersioningIT
   method: testSeqNoCASLinearizability
   issue: https://github.com/elastic/elasticsearch/issues/117249
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  issue: https://github.com/elastic/elasticsearch/issues/138649
+  methods:
+    - test {p0=index/92_metrics_auto_subobjects/Metrics object indexing}
+    - test {p0=index/92_metrics_auto_subobjects/Root without subobjects with synthetic source}
+    - test {p0=index/92_metrics_auto_subobjects/Metrics object indexing with synthetic source}
+    - test {p0=indices.put_index_template/15_composition/Composable index templates that include subobjects: auto at root}
+    - test {p0=search/330_fetch_fields/Test with subobjects: auto}
+    - test {p0=indices.put_index_template/15_composition/Composable index templates that include subobjects: auto on arbitrary field}
+    - test {p0=index/92_metrics_auto_subobjects/Root with metrics}
 
 # Examples:
 #

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceFeatures.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceFeatures.java
@@ -40,6 +40,9 @@ public class InferenceFeatures implements FeatureSpecification {
     private static final NodeFeature SEMANTIC_TEXT_HIGHLIGHTER_DISKBBQ_SIMILARITY_SUPPORT = new NodeFeature(
         "semantic_text.highlighter.bbq_and_similarity_support"
     );
+    private static final NodeFeature SEMANTIC_TEXT_HIGHLIGHTER_VECTOR_SIMILARITY_SUPPORT = new NodeFeature(
+        "semantic_text.highlighter.vector_similarity_support"
+    );
     private static final NodeFeature TEST_RERANKING_SERVICE_PARSE_TEXT_AS_SCORE = new NodeFeature(
         "test_reranking_service.parse_text_as_score"
     );
@@ -97,6 +100,7 @@ public class InferenceFeatures implements FeatureSpecification {
                 SEMANTIC_TEXT_SPARSE_VECTOR_INDEX_OPTIONS,
                 SEMANTIC_TEXT_FIELDS_CHUNKS_FORMAT,
                 SEMANTIC_TEXT_HIGHLIGHTER_DISKBBQ_SIMILARITY_SUPPORT,
+                SEMANTIC_TEXT_HIGHLIGHTER_VECTOR_SIMILARITY_SUPPORT,
                 SemanticQueryBuilder.SEMANTIC_QUERY_MULTIPLE_INFERENCE_IDS,
                 SemanticQueryBuilder.SEMANTIC_QUERY_FILTER_FIELD_CAPS_FIX,
                 InterceptedInferenceQueryBuilder.NEW_SEMANTIC_QUERY_INTERCEPTORS,


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->
<!--
- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
-->
This is an lternative to https://github.com/elastic/elasticsearch/pull/138665 muting only specific tests.

This will backport the following commits from main to 9.2:

https://github.com/elastic/elasticsearch/pull/138644

It will additionally temporarily disabling tests to unblock this PR. The tests will be fixed in https://github.com/elastic/elasticsearch/pull/138640. 
[CI] Failures Issue: https://github.com/elastic/elasticsearch/issues/138649


Adding the missing InferenceFeature that is causing 9.2 `bwc` tests to fail.
Newer versions must have a strict superset of the features of earlier versions, otherwise it might cause issues in upgrade tests.