### PR TITLE
[8.19] Add User Profile Size Limit Enforced During Profile Updates (#137712)

### DIFF
--- a/docs/changelog/137712.yaml
+++ b/docs/changelog/137712.yaml
@@ -1,0 +1,5 @@
+pr: 137712
+summary: Add User Profile Size Limit Enforced During Profile Updates
+area: Security
+type: bug
+issues: []

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -1474,6 +1474,7 @@ public class Security extends Plugin
         settingsList.add(TokenService.TOKEN_EXPIRATION);
         settingsList.add(TokenService.DELETE_INTERVAL);
         settingsList.add(TokenService.DELETE_TIMEOUT);
+        settingsList.add(ProfileService.MAX_SIZE_SETTING);
         settingsList.addAll(SSLConfigurationSettings.getProfileSettings());
         settingsList.add(ApiKeyService.STORED_HASH_ALGO_SETTING);
         settingsList.add(ApiKeyService.DELETE_TIMEOUT);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/profile/ProfileService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/profile/ProfileService.java
@@ -116,7 +116,7 @@ public class ProfileService {
 
     public static final Setting<ByteSizeValue> MAX_SIZE_SETTING = Setting.byteSizeSetting(
         "xpack.security.profile.max_size",
-        ByteSizeValue.of(10, ByteSizeUnit.MB), // default: 10 MB
+        ByteSizeValue.ofMb(10), // default: 10 MB
         ByteSizeValue.ZERO, // minimum: 0 bytes
         ByteSizeValue.ofBytes(Integer.MAX_VALUE),
         Setting.Property.NodeScope

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/profile/ProfileService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/profile/ProfileService.java
@@ -42,7 +42,6 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.XContentHelper;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/profile/ProfileService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/profile/ProfileService.java
@@ -40,7 +40,10 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.lucene.Lucene;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.TimeValue;
@@ -110,6 +113,15 @@ import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SEC
 import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SECURITY_PROFILE_ORIGIN_FEATURE;
 
 public class ProfileService {
+
+    public static final Setting<ByteSizeValue> MAX_SIZE_SETTING = Setting.byteSizeSetting(
+        "xpack.security.profile.max_size",
+        ByteSizeValue.of(10, ByteSizeUnit.MB), // default: 10 MB
+        ByteSizeValue.ZERO, // minimum: 0 bytes
+        ByteSizeValue.ofBytes(Integer.MAX_VALUE),
+        Setting.Property.NodeScope
+    );
+
     private static final Logger logger = LogManager.getLogger(ProfileService.class);
     private static final String DOC_ID_PREFIX = "profile_";
     private static final BackoffPolicy DEFAULT_BACKOFF = BackoffPolicy.exponentialBackoff();
@@ -124,6 +136,7 @@ public class ProfileService {
     private final FeatureService featureService;
     private final Function<String, DomainConfig> domainConfigLookup;
     private final Function<RealmConfig.RealmIdentifier, Authentication.RealmRef> realmRefLookup;
+    private final ByteSizeValue maxProfileSize;
 
     public ProfileService(
         Settings settings,
@@ -142,6 +155,7 @@ public class ProfileService {
         this.featureService = featureService;
         this.domainConfigLookup = realms::getDomainConfig;
         this.realmRefLookup = realms::getRealmRef;
+        this.maxProfileSize = MAX_SIZE_SETTING.get(settings);
     }
 
     public void getProfiles(List<String> uids, Set<String> dataKeys, ActionListener<ResultsAndErrors<Profile>> listener) {
@@ -256,10 +270,59 @@ public class ProfileService {
             return;
         }
 
-        doUpdate(
-            buildUpdateRequest(request.getUid(), builder, request.getRefreshPolicy(), request.getIfPrimaryTerm(), request.getIfSeqNo()),
-            listener.map(updateResponse -> AcknowledgedResponse.TRUE)
-        );
+        getVersionedDocument(request.getUid(), ActionListener.wrap(doc -> {
+            validateProfileSize(doc, request, maxProfileSize);
+
+            doUpdate(
+                buildUpdateRequest(request.getUid(), builder, request.getRefreshPolicy(), request.getIfPrimaryTerm(), request.getIfSeqNo()),
+                listener.map(updateResponse -> AcknowledgedResponse.TRUE)
+            );
+        }, listener::onFailure));
+    }
+
+    static void validateProfileSize(VersionedDocument doc, UpdateProfileDataRequest request, ByteSizeValue limit) {
+        if (doc == null) {
+            return;
+        }
+        Map<String, Object> labels = combineMaps(doc.doc.labels(), request.getLabels());
+        Map<String, Object> data = combineMaps(mapFromBytesReference(doc.doc.applicationData()), request.getData());
+        ByteSizeValue actualSize = ByteSizeValue.ofBytes(serializationSize(labels) + serializationSize(data));
+        if (actualSize.compareTo(limit) > 0) {
+            throw new ElasticsearchStatusException(
+                Strings.format(
+                    "cannot update profile [%s] because the combined profile size of [%s] exceeds the maximum of [%s]",
+                    request.getUid(),
+                    actualSize,
+                    limit
+                ),
+                RestStatus.BAD_REQUEST
+            );
+        }
+    }
+
+    static Map<String, Object> combineMaps(Map<String, Object> src, Map<String, Object> update) {
+        Map<String, Object> result = new HashMap<>(); // ensure mutable outer source map for update below
+        if (src != null) {
+            result.putAll(src);
+        }
+        XContentHelper.update(result, update, false);
+        return result;
+    }
+
+    static Map<String, Object> mapFromBytesReference(BytesReference bytesRef) {
+        if (bytesRef == null || bytesRef.length() == 0) {
+            return Map.of();
+        }
+        return XContentHelper.convertToMap(bytesRef, false, XContentType.JSON).v2();
+    }
+
+    static int serializationSize(Map<String, Object> map) {
+        try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
+            builder.value(map);
+            return BytesReference.bytes(builder).length();
+        } catch (IOException e) {
+            throw new ElasticsearchException("Error occurred computing serialization size", e); // I/O error should never happen here
+        }
     }
 
     public void suggestProfile(SuggestProfilesRequest request, TaskId parentTaskId, ActionListener<SuggestProfilesResponse> listener) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/profile/ProfileServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/profile/ProfileServiceTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.action.search.TransportMultiSearchAction;
 import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.update.TransportUpdateAction;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.action.update.UpdateRequestBuilder;
@@ -44,6 +45,7 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.hash.MessageDigests;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.set.Sets;
@@ -76,6 +78,7 @@ import org.elasticsearch.xpack.core.security.action.profile.Profile;
 import org.elasticsearch.xpack.core.security.action.profile.SuggestProfilesRequest;
 import org.elasticsearch.xpack.core.security.action.profile.SuggestProfilesRequestTests;
 import org.elasticsearch.xpack.core.security.action.profile.SuggestProfilesResponse;
+import org.elasticsearch.xpack.core.security.action.profile.UpdateProfileDataRequest;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationTestHelper;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationTests;
@@ -94,7 +97,10 @@ import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -1392,6 +1398,54 @@ public class ProfileServiceTests extends ESTestCase {
         PlainActionFuture<Collection<String>> finalListener = listener;
         ExecutionException e = expectThrows(ExecutionException.class, () -> finalListener.get());
         assertThat(e.getMessage(), containsString("test unavailable"));
+    }
+
+    public void testSerializationSize() {
+        assertThat(ProfileService.serializationSize(Map.of()), is(2));
+        assertThat(ProfileService.serializationSize(Map.of("foo", "bar")), is(13));
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> ProfileService.serializationSize(Map.of("bad", new ByteArrayInputStream(new byte[0])))
+        );
+    }
+
+    public void testMapFromBytesReference() {
+        assertThat(ProfileService.mapFromBytesReference(null), is(Map.of()));
+        assertThat(ProfileService.mapFromBytesReference(BytesReference.fromByteBuffer(ByteBuffer.allocate(0))), is(Map.of()));
+        assertThat(ProfileService.mapFromBytesReference(newBytesReference("{}")), is(Map.of()));
+        assertThat(ProfileService.mapFromBytesReference(newBytesReference("{\"foo\":\"bar\"}")), is(Map.of("foo", "bar")));
+    }
+
+    public void testCombineMaps() {
+        assertThat(ProfileService.combineMaps(null, Map.of("a", 1)), is(Map.of("a", 1)));
+        assertThat(
+            ProfileService.combineMaps(new HashMap<>(Map.of("a", 1, "b", 2)), Map.of("b", 3, "c", 4)),
+            is(Map.of("a", 1, "b", 3, "c", 4))
+        );
+        assertThat(
+            ProfileService.combineMaps(new HashMap<>(Map.of("a", new HashMap<>(Map.of("b", "c")))), Map.of("a", Map.of("d", "e"))),
+            is(Map.of("a", Map.of("b", "c", "d", "e")))
+        );
+    }
+
+    public void testValidateProfileSize() {
+        var pd = new ProfileDocument("uid", true, 0L, null, Map.of(), newBytesReference("{}"));
+        var vd = new ProfileService.VersionedDocument(pd, 1L, 1L);
+        var up = new UpdateProfileDataRequest(
+            "uid",
+            Map.of("key", "value"),
+            Map.of("key", "value"),
+            1L,
+            1L,
+            WriteRequest.RefreshPolicy.NONE
+        );
+        assertThrows(ElasticsearchException.class, () -> ProfileService.validateProfileSize(vd, up, ByteSizeValue.ZERO));
+        ProfileService.validateProfileSize(vd, up, ByteSizeValue.ofBytes(100));
+        ProfileService.validateProfileSize(null, up, ByteSizeValue.ZERO);
+    }
+
+    private static BytesReference newBytesReference(String str) {
+        return BytesReference.fromByteBuffer(ByteBuffer.wrap(str.getBytes(StandardCharsets.UTF_8)));
     }
 
     record SampleDocumentParameter(String uid, String username, List<String> roles, long lastSynchronized) {}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Add User Profile Size Limit Enforced During Profile Updates (#137712)](https://github.com/elastic/elasticsearch/pull/137712)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)