### PR TITLE
[9.2] Add validation to DER parser for seq len (#138683)

### DIFF
--- a/libs/ssl-config/src/main/java/org/elasticsearch/common/ssl/DerParser.java
+++ b/libs/ssl-config/src/main/java/org/elasticsearch/common/ssl/DerParser.java
@@ -138,7 +138,12 @@ public final class DerParser {
         int n = derInputStream.read(bytes);
         if (n < num) throw new IOException("Invalid DER: length too short");
 
-        return new BigInteger(1, bytes).intValue();
+        int len = new BigInteger(1, bytes).intValue();
+        if (len < 0) {
+            throw new IOException("Invalid DER: length larger than max-int");
+        }
+
+        return len;
     }
 
     /**

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/pki/RdnFieldExtractorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/pki/RdnFieldExtractorTests.java
@@ -88,6 +88,19 @@ public class RdnFieldExtractorTests extends ESTestCase {
         assertThat(result, is(nullValue()));
     }
 
+    public void testSeqLengthOutOfSignedIntRange() {
+        byte[] malformedBytes = {
+            (byte) 48,   // SEQUENCE
+            (byte) 0x84, // Length byte indicating (1) long form with (2) 4 data bytes
+            (byte) 0xFF,
+            (byte) 0xFF,
+            (byte) 0xFF,
+            (byte) 0xFF };
+
+        String result = RdnFieldExtractor.extract(malformedBytes, OID_CN);
+        assertThat(result, is(nullValue()));
+    }
+
     public void testExtractWithSpecialCharacters() {
         assertExtractions("CN=Test\\, User, OU=R\\+D, O=Elastic\\\\Co", Map.of(OID_CN, "Test, User", OID_OU, "R+D", OID_O, "Elastic\\Co"));
     }


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Add validation to DER parser for seq len (#138683)