### PR TITLE
SQL: add project_routing option

### DIFF
--- a/docs/changelog/138718.yaml
+++ b/docs/changelog/138718.yaml
@@ -1,0 +1,5 @@
+pr: 138718
+summary: Add `project_routing` option
+area: SQL
+type: enhancement
+issues: []

--- a/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/AbstractSqlQueryRequest.java
+++ b/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/AbstractSqlQueryRequest.java
@@ -58,6 +58,7 @@ import static org.elasticsearch.xpack.sql.action.Protocol.QUERY_NAME;
 import static org.elasticsearch.xpack.sql.action.Protocol.REQUEST_TIMEOUT_NAME;
 import static org.elasticsearch.xpack.sql.action.Protocol.TIME_ZONE_NAME;
 import static org.elasticsearch.xpack.sql.action.Protocol.VERSION_NAME;
+import static org.elasticsearch.xpack.sql.proto.CoreProtocol.PROJECT_ROUTING_NAME;
 
 /**
  * Base class for requests that contain sql queries (Query and Translate)
@@ -91,6 +92,7 @@ public abstract class AbstractSqlQueryRequest extends AbstractSqlRequest impleme
     private QueryBuilder filter = null;
     private List<SqlTypedParamValue> params = emptyList();
     private Map<String, Object> runtimeMappings = emptyMap();
+    private String projectRouting;
 
     static final ParseField QUERY = new ParseField(QUERY_NAME);
     static final ParseField CURSOR = new ParseField(CURSOR_NAME);
@@ -104,6 +106,7 @@ public abstract class AbstractSqlQueryRequest extends AbstractSqlRequest impleme
     static final ParseField MODE = new ParseField(MODE_NAME);
     static final ParseField CLIENT_ID = new ParseField(CLIENT_ID_NAME);
     static final ParseField VERSION = new ParseField(VERSION_NAME);
+    static final ParseField PROJECT_ROUTING = new ParseField(PROJECT_ROUTING_NAME);
 
     public AbstractSqlQueryRequest() {
         super();
@@ -155,6 +158,7 @@ public abstract class AbstractSqlQueryRequest extends AbstractSqlRequest impleme
         );
         parser.declareObject(AbstractSqlQueryRequest::filter, (p, c) -> AbstractQueryBuilder.parseTopLevelQuery(p), FILTER);
         parser.declareObject(AbstractSqlQueryRequest::runtimeMappings, (p, c) -> p.map(), SearchSourceBuilder.RUNTIME_MAPPINGS_FIELD);
+        parser.declareString(AbstractSqlQueryRequest::projectRouting, PROJECT_ROUTING);
         return parser;
     }
 
@@ -421,6 +425,14 @@ public abstract class AbstractSqlQueryRequest extends AbstractSqlRequest impleme
     public AbstractSqlQueryRequest runtimeMappings(Map<String, Object> runtimeMappings) {
         this.runtimeMappings = runtimeMappings;
         return this;
+    }
+
+    public String projectRouting() {
+        return projectRouting;
+    }
+
+    public void projectRouting(String projectRouting) {
+        this.projectRouting = projectRouting;
     }
 
     public AbstractSqlQueryRequest(StreamInput in) throws IOException {

--- a/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlTranslateRequestBuilder.java
+++ b/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlTranslateRequestBuilder.java
@@ -68,4 +68,9 @@ public class SqlTranslateRequestBuilder extends ActionRequestBuilder<SqlTranslat
         request.zoneId(zoneId);
         return this;
     }
+
+    public SqlTranslateRequestBuilder projectRouting(String projectRouting) {
+        request.projectRouting(projectRouting);
+        return this;
+    }
 }

--- a/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/CoreProtocol.java
+++ b/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/CoreProtocol.java
@@ -36,6 +36,7 @@ public class CoreProtocol {
     public static final String INDEX_INCLUDE_FROZEN_NAME = "index_include_frozen";
     public static final String RUNTIME_MAPPINGS_NAME = "runtime_mappings";
     public static final String ALLOW_PARTIAL_SEARCH_RESULTS_NAME = "allow_partial_search_results";
+    public static final String PROJECT_ROUTING_NAME = "project_routing";
     // async
     public static final String WAIT_FOR_COMPLETION_TIMEOUT_NAME = "wait_for_completion_timeout";
     public static final String KEEP_ON_COMPLETION_NAME = "keep_on_completion";

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/SqlPlugin.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/SqlPlugin.java
@@ -123,7 +123,7 @@ public class SqlPlugin extends Plugin implements ActionPlugin {
 
         return Arrays.asList(
             new RestSqlQueryAction(settings),
-            new RestSqlTranslateAction(),
+            new RestSqlTranslateAction(settings),
             new RestSqlClearCursorAction(),
             new RestSqlStatsAction(),
             new RestSqlAsyncGetResultsAction(),

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlQueryAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlQueryAction.java
@@ -155,7 +155,8 @@ public final class TransportSqlQueryAction extends HandledTransportAction<SqlQue
             request.indexIncludeFrozen(),
             new TaskId(clusterService.localNode().getId(), task.getId()),
             task,
-            request.allowPartialSearchResults()
+            request.allowPartialSearchResults(),
+            request.projectRouting()
         );
 
         if (Strings.hasText(request.cursor()) == false) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlTranslateAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlTranslateAction.java
@@ -78,7 +78,8 @@ public class TransportSqlTranslateAction extends HandledTransportAction<SqlTrans
             Protocol.INDEX_INCLUDE_FROZEN,
             null,
             null,
-            Protocol.ALLOW_PARTIAL_SEARCH_RESULTS
+            Protocol.ALLOW_PARTIAL_SEARCH_RESULTS,
+            request.projectRouting()
         );
 
         planExecutor.searchSource(

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/SqlConfiguration.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/SqlConfiguration.java
@@ -43,6 +43,7 @@ public class SqlConfiguration extends org.elasticsearch.xpack.ql.session.Configu
     @Nullable
     private final Map<String, Object> runtimeMappings;
     private final boolean allowPartialSearchResults;
+    private final String projectRouting;
 
     public SqlConfiguration(
         ZoneId zi,
@@ -61,7 +62,8 @@ public class SqlConfiguration extends org.elasticsearch.xpack.ql.session.Configu
         boolean includeFrozen,
         @Nullable TaskId taskId,
         @Nullable SqlQueryTask task,
-        boolean allowPartialSearchResults
+        boolean allowPartialSearchResults,
+        String projectRouting
     ) {
         super(zi, username, clusterName);
 
@@ -79,6 +81,7 @@ public class SqlConfiguration extends org.elasticsearch.xpack.ql.session.Configu
         this.taskId = taskId;
         this.task = task;
         this.allowPartialSearchResults = allowPartialSearchResults;
+        this.projectRouting = projectRouting;
     }
 
     public String catalog() {
@@ -135,5 +138,9 @@ public class SqlConfiguration extends org.elasticsearch.xpack.ql.session.Configu
 
     public boolean allowPartialSearchResults() {
         return allowPartialSearchResults;
+    }
+
+    public String projectRouting() {
+        return projectRouting;
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/SqlTestUtils.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/SqlTestUtils.java
@@ -59,7 +59,8 @@ public final class SqlTestUtils {
         false,
         null,
         null,
-        false
+        false,
+        null
     );
 
     public static SqlConfiguration randomConfiguration(ZoneId providedZoneId, SqlVersion sqlVersion) {
@@ -82,7 +83,8 @@ public final class SqlTestUtils {
             randomBoolean(),
             new TaskId(randomAlphaOfLength(10), taskId),
             randomTask(taskId, mode, sqlVersion),
-            randomBoolean()
+            randomBoolean(),
+            null
         );
     }
 

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/DatabaseFunctionTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/DatabaseFunctionTests.java
@@ -46,7 +46,8 @@ public class DatabaseFunctionTests extends ESTestCase {
             randomBoolean(),
             null,
             null,
-            randomBoolean()
+            randomBoolean(),
+            null
         );
         Analyzer analyzer = analyzer(sqlConfig, IndexResolution.valid(test));
 

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/UserFunctionTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/UserFunctionTests.java
@@ -45,7 +45,8 @@ public class UserFunctionTests extends ESTestCase {
             randomBoolean(),
             null,
             null,
-            randomBoolean()
+            randomBoolean(),
+            null
         );
         Analyzer analyzer = analyzer(sqlConfig, IndexResolution.valid(test));
 

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysColumnsTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysColumnsTests.java
@@ -303,7 +303,8 @@ public class SysColumnsTests extends ESTestCase {
             false,
             null,
             null,
-            false
+            false,
+            null
         );
         Tuple<Command, SqlSession> tuple = sql(sql, emptyList(), config, MAPPING1);
 
@@ -350,7 +351,8 @@ public class SysColumnsTests extends ESTestCase {
             false,
             null,
             null,
-            false
+            false,
+            null
         );
         Tuple<Command, SqlSession> tuple = sql(sql, params, config, mapping);
 

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTablesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTablesTests.java
@@ -74,7 +74,8 @@ public class SysTablesTests extends ESTestCase {
         true,
         null,
         null,
-        false
+        false,
+        null
     );
 
     //

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTypesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTypesTests.java
@@ -65,7 +65,8 @@ public class SysTypesTests extends ESTestCase {
             false,
             null,
             null,
-            false
+            false,
+            null
         );
         EsIndex test = new EsIndex("test", SqlTypesTests.loadMapping("mapping-multi-field-with-nested.json", true));
         Analyzer analyzer = analyzer(configuration, IndexResolution.valid(test));


### PR DESCRIPTION
Adding `project_routing` both as a request parameter and as a request body parameter (json).
The parameter is allowed only when CPS is enabled.

It will follow the typical priority rules for _search, ie. the request parameter will have precedence.

This is only the syntactical part, it still has to be wired into field_caps and underlying search.