### PR TITLE
[ML] Fix for flaky sparse_vector_search test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -46,9 +46,6 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=transform/transforms_start_stop/Test start/stop/start transform}
   issue: https://github.com/elastic/elasticsearch/issues/119508
-- class: org.elasticsearch.smoketest.MlWithSecurityIT
-  method: test {yaml=ml/sparse_vector_search/Test sparse_vector search with query vector and pruning config}
-  issue: https://github.com/elastic/elasticsearch/issues/119548
 - class: org.elasticsearch.multi_cluster.MultiClusterYamlTestSuiteIT
   issue: https://github.com/elastic/elasticsearch/issues/119983
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/sparse_vector_search.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/sparse_vector_search.yml
@@ -251,7 +251,7 @@ teardown:
               field: ml.tokens
               query_vector:
                 the: 0.5
-                comforter: 2.0
+                comforter: 3.0
                 smells: 1.0
                 bad: 1.0
               prune: true
@@ -261,7 +261,7 @@ teardown:
                 only_score_pruned_tokens: false
 
   - match: { hits.total.value: 3 }
-  - match: { hits.hits.0._score: 4 }
+  - match: { hits.hits.0._score: 6 }
 
 ---
 "Test sparse_vector search with query vector and pruning config with only score pruned tokens":


### PR DESCRIPTION
Tweak params in "sparse_vector_search/Test sparse_vector search with query vector and pruning config" yaml rest test for more deterministic outcome. The test has now been unmuted.

Tested with

```
for (( i=0; i<100; ++i )); do echo $i; ./gradlew ":x-pack:plugin:ml:qa:ml-with-security:yamlRestTest" --tests "org.elasticsearch.smoketest.MlWithSecurityIT.test {yaml=ml/sparse_vector_search/Test sparse_vector search with query vector and pruning config}"; if [ $? != 0 ]; then echo "test failed"; break; fi ; done
```

with no failures.

Fixes #119548
