### PR TITLE
Fix testRoleMigration race condition 

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/SecurityIndexRolesMetadataMigrationIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/SecurityIndexRolesMetadataMigrationIT.java
@@ -54,8 +54,9 @@ public class SecurityIndexRolesMetadataMigrationIT extends AbstractUpgradeTestCa
             assertMigratedDocInSecurityIndex(mixed1TestRole, "meta", "test");
             assertMigratedDocInSecurityIndex(mixed2TestRole, "meta", "test");
             assertMigratedDocInSecurityIndex(upgradedTestRole, "meta", "test");
-            // queries all roles by metadata
-            assertAllRoles(client(), "mixed1-test-role", "mixed2-test-role", "old-test-role", "upgraded-test-role");
+            // query all roles by metadata - use assertBusy to handle the case where the node handling the query is not yet aware of the
+            // successful migration
+            assertBusy(() -> assertAllRoles(client(), "mixed1-test-role", "mixed2-test-role", "old-test-role", "upgraded-test-role"));
         }
     }
 
@@ -175,7 +176,13 @@ public class SecurityIndexRolesMetadataMigrationIT extends AbstractUpgradeTestCa
             {"query":{"bool":{"must":[{"exists":{"field":"metadata.meta"}}]}},"sort":["name"]}""";
         Request request = new Request(randomFrom("POST", "GET"), "/_security/_query/role");
         request.setJsonEntity(metadataQuery);
-        Response response = client.performRequest(request);
+        Response response = null;
+        try {
+            response = client.performRequest(request);
+        } catch (ResponseException e) {
+            fail(e);
+        }
+        assertNotNull(response);
         assertOK(response);
         Map<String, Object> responseMap = responseAsMap(response);
         assertThat(responseMap.get("total"), is(roleNames.length));


### PR DESCRIPTION
This replaces: https://github.com/elastic/elasticsearch/pull/138732 

This is intermittent and has only muted tests on 9.1 so far but needs to be backported to 8.19, 9.1 and 9.2. 

Resolves: https://github.com/elastic/elasticsearch/issues/138731

I need to remember to remove the mute in the 9.1 backport. 