### PR TITLE
[9.2] Extend reflection to retrieve vector values from DefaultFlatVectorScorer$FloatScoringSupplier too (#138503)

### DIFF
--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/SystemJvmOptions.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/SystemJvmOptions.java
@@ -62,6 +62,7 @@ final class SystemJvmOptions {
                 "-Dio.netty.recycler.maxCapacityPerThread=0",
                 // Needed to get access to raw vectors from Lucene scorers
                 "--add-opens=org.apache.lucene.core/org.apache.lucene.codecs.lucene99=org.elasticsearch.server",
+                "--add-opens=org.apache.lucene.core/org.apache.lucene.codecs.hnsw=org.elasticsearch.server",
                 "--add-opens=org.apache.lucene.core/org.apache.lucene.internal.vectorization=org.elasticsearch.server",
                 // log4j 2
                 "-Dlog4j.shutdownHookEnabled=false",

--- a/libs/gpu-codec/src/main/java/org/elasticsearch/gpu/codec/ES92GpuHnswVectorsWriter.java
+++ b/libs/gpu-codec/src/main/java/org/elasticsearch/gpu/codec/ES92GpuHnswVectorsWriter.java
@@ -620,7 +620,7 @@ final class ES92GpuHnswVectorsWriter extends KnnVectorsWriter {
                 }
             }
         } else {
-            logger.warn("Cannot get merged raw vectors from scorer.");
+            logger.warn("Cannot get merged raw vectors from scorer. Performances will be degraded.");
             var byteVectorValues = getMergedByteVectorValues(fieldInfo, mergeState);
 
             // TODO: revert to CuVSMatrix.deviceBuilder when cuvs has fixed the multiple copies problem

--- a/x-pack/plugin/gpu/src/yamlRestTest/java/org/elasticsearch/xpack/gpu/GPUClientYamlTestSuiteIT.java
+++ b/x-pack/plugin/gpu/src/yamlRestTest/java/org/elasticsearch/xpack/gpu/GPUClientYamlTestSuiteIT.java
@@ -33,6 +33,7 @@ public class GPUClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
             .setting("xpack.security.enabled", "false")
             // Needed to get access to raw vectors from Lucene scorers
             .jvmArg("--add-opens=org.apache.lucene.core/org.apache.lucene.codecs.lucene99=org.elasticsearch.server")
+            .jvmArg("--add-opens=org.apache.lucene.core/org.apache.lucene.codecs.hnsw=org.elasticsearch.server")
             .jvmArg("--add-opens=org.apache.lucene.core/org.apache.lucene.internal.vectorization=org.elasticsearch.server");
 
         var libraryPath = System.getenv("LD_LIBRARY_PATH");


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Extend reflection to retrieve vector values from DefaultFlatVectorScorer$FloatScoringSupplier too (#138503)