### PR TITLE
Disk usage don't include synthetic _id postings

### DIFF
--- a/docs/changelog/138745.yaml
+++ b/docs/changelog/138745.yaml
@@ -1,0 +1,5 @@
+pr: 138745
+summary: Disk usage don't include synthetic `_id` postings
+area: Distributed
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzer.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzer.java
@@ -372,6 +372,7 @@ final class IndexDiskUsageAnalyzer {
             if (SyntheticIdField.hasSyntheticIdAttributes(field.attributes())) {
                 // Synthetic _id field doesn't have an inverted index stored on disk,
                 // but it pretends to have one on the read path by setting IndexOptions.DOCS
+                assert SyntheticIdField.NAME.equals(field.getName()) : "Expected only synthetic id fields to have synthetic id attribute";
                 continue;
             }
             // It's expensive to look up every term and visit every document of the postings lists of all terms.

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzer.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzer.java
@@ -56,6 +56,7 @@ import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.index.codec.postings.ES812PostingsFormat;
+import org.elasticsearch.index.mapper.SyntheticIdField;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.store.LuceneFilesExtensions;
 
@@ -366,6 +367,11 @@ final class IndexDiskUsageAnalyzer {
             directory.resetBytesRead();
             final Terms terms = postingsReader.terms(field.name);
             if (terms == null) {
+                continue;
+            }
+            if (SyntheticIdField.hasSyntheticIdAttributes(field.attributes())) {
+                // Synthetic _id field doesn't have an inverted index stored on disk,
+                // but it pretends to have one on the read path by setting IndexOptions.DOCS
                 continue;
             }
             // It's expensive to look up every term and visit every document of the postings lists of all terms.


### PR DESCRIPTION
Synthetic `_id` fields doesn't have an inverted index, but will pretend to have it on the read path by injecting `IndexOptions.DOCS` on the `_id` field. We short circuit `IndexDiskUsageAnalyzer` if we see a synthetic `_id` field.