### PR TITLE
ESQL: Mute mixed yaml rest tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -466,6 +466,8 @@ tests:
 - class: org.elasticsearch.index.mapper.LongSyntheticSourceNativeArrayIntegrationTests
   method: testSynthesizeArrayRandom
   issue: https://github.com/elastic/elasticsearch/issues/138819
+- class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
+  issue: https://github.com/elastic/elasticsearch/issues/138796
 
 # Examples:
 #


### PR DESCRIPTION
Due to https://github.com/elastic/elasticsearch/issues/138796, the mixed yaml rest tests currently don't pass against 9.2.2.