### PR TITLE
Removes EnsureNoPostingsFormat

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdPostingsFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdPostingsFormat.java
@@ -12,7 +12,9 @@ package org.elasticsearch.index.codec.tsdb;
 import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.codecs.FieldsConsumer;
 import org.apache.lucene.codecs.FieldsProducer;
+import org.apache.lucene.codecs.NormsProducer;
 import org.apache.lucene.codecs.PostingsFormat;
+import org.apache.lucene.index.Fields;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.elasticsearch.core.IOUtils;
@@ -57,7 +59,24 @@ public class TSDBSyntheticIdPostingsFormat extends PostingsFormat {
 
     @Override
     public FieldsConsumer fieldsConsumer(SegmentWriteState state) throws IOException {
-        assert false : "this should never be called";
-        throw new UnsupportedOperationException();
+        return new FieldsConsumer() {
+            @Override
+            public void write(Fields fields, NormsProducer norms) {
+                // Segments flushed to disk should never have terms produced for the synthetic _id field
+                if (state.context.flushInfo() != null) {
+                    for (var field : fields) {
+                        if (SYNTHETIC_ID.equalsIgnoreCase(field)) {
+                            var message = "Field [" + SYNTHETIC_ID + "] has terms produced during indexing";
+                            assert false : message;
+                            throw new IllegalArgumentException(message);
+                        }
+                    }
+                }
+            }
+
+            @Override
+            public void close() {
+            }
+        };
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdPostingsFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdPostingsFormat.java
@@ -75,8 +75,7 @@ public class TSDBSyntheticIdPostingsFormat extends PostingsFormat {
             }
 
             @Override
-            public void close() {
-            }
+            public void close() {}
         };
     }
 }


### PR DESCRIPTION
This change removes the `EnsureNoPostingsFormat` to avoid an additional format wrapper and adjust the assertion and exception thrown to allow the method `write(Fields fields, NormsProducer norms)` to be called for merges.