### PR TITLE
[Test] Fix TSDBIndexingIT.testDynamicDimensions and more

### DIFF
--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/TSDBIndexingIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/TSDBIndexingIT.java
@@ -596,9 +596,7 @@ public class TSDBIndexingIT extends ESSingleNodeTestCase {
         putTemplateRequest.indexTemplate(
             ComposableIndexTemplate.builder()
                 .indexPatterns(List.of(dataStreamName, reindexedDataStreamName))
-                .template(
-                    new Template(templateSettings.build(), new CompressedXContent(MAPPING_TEMPLATE), null)
-                )
+                .template(new Template(templateSettings.build(), new CompressedXContent(MAPPING_TEMPLATE), null))
                 .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate(false, false))
                 .build()
         );
@@ -741,37 +739,31 @@ public class TSDBIndexingIT extends ESSingleNodeTestCase {
         putTemplateRequest.indexTemplate(
             ComposableIndexTemplate.builder()
                 .indexPatterns(List.of(dataStreamName))
-                .template(
-                    new Template(
-                        templateSettings.build(),
-                        new CompressedXContent("""
-                                {
-                              "_doc": {
-                                "dynamic_templates": [
-                                  {
-                                    "labels": {
-                                      "match_mapping_type": "string",
-                                      "mapping": {
-                                        "type": "keyword",
-                                        "time_series_dimension": true
-                                      }
-                                    }
-                                  }
-                                ],
-                                "properties": {
-                                  "@timestamp": {
-                                    "type": "date"
-                                  },
-                                  "metricset": {
-                                    "type": "keyword",
-                                    "time_series_dimension": true
-                                  }
-                                }
+                .template(new Template(templateSettings.build(), new CompressedXContent("""
+                        {
+                      "_doc": {
+                        "dynamic_templates": [
+                          {
+                            "labels": {
+                              "match_mapping_type": "string",
+                              "mapping": {
+                                "type": "keyword",
+                                "time_series_dimension": true
                               }
-                            }"""),
-                        null
-                    )
-                )
+                            }
+                          }
+                        ],
+                        "properties": {
+                          "@timestamp": {
+                            "type": "date"
+                          },
+                          "metricset": {
+                            "type": "keyword",
+                            "time_series_dimension": true
+                          }
+                        }
+                      }
+                    }"""), null))
                 .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate(false, false))
                 .build()
         );
@@ -813,37 +805,31 @@ public class TSDBIndexingIT extends ESSingleNodeTestCase {
         putTemplateRequest.indexTemplate(
             ComposableIndexTemplate.builder()
                 .indexPatterns(List.of(dataStreamName))
-                .template(
-                    new Template(
-                        templateSettings.build(),
-                        new CompressedXContent("""
+                .template(new Template(templateSettings.build(), new CompressedXContent("""
 
-                                {
-                              "_doc": {
-                                "dynamic_templates": [
-                                  {
-                                    "label": {
-                                      "mapping": {
-                                        "type": "keyword",
-                                        "time_series_dimension": true
-                                      }
-                                    }
-                                  }
-                                ],
-                                "properties": {
-                                  "@timestamp": {
-                                    "type": "date"
-                                  },
-                                  "metricset": {
-                                    "type": "keyword",
-                                    "time_series_dimension": true
-                                  }
-                                }
+                        {
+                      "_doc": {
+                        "dynamic_templates": [
+                          {
+                            "label": {
+                              "mapping": {
+                                "type": "keyword",
+                                "time_series_dimension": true
                               }
-                            }"""),
-                        null
-                    )
-                )
+                            }
+                          }
+                        ],
+                        "properties": {
+                          "@timestamp": {
+                            "type": "date"
+                          },
+                          "metricset": {
+                            "type": "keyword",
+                            "time_series_dimension": true
+                          }
+                        }
+                      }
+                    }"""), null))
                 .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate(false, false))
                 .build()
         );

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/TSDBIndexingIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/TSDBIndexingIT.java
@@ -588,19 +588,16 @@ public class TSDBIndexingIT extends ESSingleNodeTestCase {
     public void testReindexing() throws Exception {
         String dataStreamName = "my-ds";
         String reindexedDataStreamName = "my-reindexed-ds";
+        var templateSettings = Settings.builder().put("index.mode", "time_series");
+        if (IndexSettings.TSDB_SYNTHETIC_ID_FEATURE_FLAG && randomBoolean()) {
+            templateSettings.put(IndexSettings.USE_SYNTHETIC_ID.getKey(), true);
+        }
         var putTemplateRequest = new TransportPutComposableIndexTemplateAction.Request("id");
         putTemplateRequest.indexTemplate(
             ComposableIndexTemplate.builder()
                 .indexPatterns(List.of(dataStreamName, reindexedDataStreamName))
                 .template(
-                    new Template(
-                        Settings.builder()
-                            .put("index.mode", "time_series")
-                            .put(IndexSettings.USE_SYNTHETIC_ID.getKey(), IndexSettings.TSDB_SYNTHETIC_ID_FEATURE_FLAG && randomBoolean())
-                            .build(),
-                        new CompressedXContent(MAPPING_TEMPLATE),
-                        null
-                    )
+                    new Template(templateSettings.build(), new CompressedXContent(MAPPING_TEMPLATE), null)
                 )
                 .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate(false, false))
                 .build()
@@ -650,20 +647,16 @@ public class TSDBIndexingIT extends ESSingleNodeTestCase {
         String dataStreamName = "my-ds";
         var putTemplateRequest = new TransportPutComposableIndexTemplateAction.Request("id");
         boolean indexDimensionsTsidStrategyEnabled = randomBoolean();
+        var templateSettings = Settings.builder()
+            .put("index.mode", "time_series")
+            .put("index.dimensions_tsid_strategy_enabled", indexDimensionsTsidStrategyEnabled);
+        if (IndexSettings.TSDB_SYNTHETIC_ID_FEATURE_FLAG && randomBoolean()) {
+            templateSettings.put(IndexSettings.USE_SYNTHETIC_ID.getKey(), true);
+        }
         putTemplateRequest.indexTemplate(
             ComposableIndexTemplate.builder()
                 .indexPatterns(List.of(dataStreamName))
-                .template(
-                    new Template(
-                        Settings.builder()
-                            .put("index.mode", "time_series")
-                            .put("index.dimensions_tsid_strategy_enabled", indexDimensionsTsidStrategyEnabled)
-                            .put(IndexSettings.USE_SYNTHETIC_ID.getKey(), IndexSettings.TSDB_SYNTHETIC_ID_FEATURE_FLAG && randomBoolean())
-                            .build(),
-                        new CompressedXContent(MAPPING_TEMPLATE),
-                        null
-                    )
-                )
+                .template(new Template(templateSettings.build(), new CompressedXContent(MAPPING_TEMPLATE), null))
                 .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate(false, false))
                 .build()
         );
@@ -740,16 +733,17 @@ public class TSDBIndexingIT extends ESSingleNodeTestCase {
 
     public void testDynamicStringDimensions() throws Exception {
         String dataStreamName = "my-ds";
+        var templateSettings = Settings.builder().put("index.mode", "time_series");
+        if (IndexSettings.TSDB_SYNTHETIC_ID_FEATURE_FLAG && randomBoolean()) {
+            templateSettings.put(IndexSettings.USE_SYNTHETIC_ID.getKey(), true);
+        }
         var putTemplateRequest = new TransportPutComposableIndexTemplateAction.Request("id");
         putTemplateRequest.indexTemplate(
             ComposableIndexTemplate.builder()
                 .indexPatterns(List.of(dataStreamName))
                 .template(
                     new Template(
-                        Settings.builder()
-                            .put("index.mode", "time_series")
-                            .put(IndexSettings.USE_SYNTHETIC_ID.getKey(), IndexSettings.TSDB_SYNTHETIC_ID_FEATURE_FLAG && randomBoolean())
-                            .build(),
+                        templateSettings.build(),
                         new CompressedXContent("""
                                 {
                               "_doc": {
@@ -811,16 +805,17 @@ public class TSDBIndexingIT extends ESSingleNodeTestCase {
 
     public void testDynamicDimensions() throws Exception {
         String dataStreamName = "my-ds";
+        var templateSettings = Settings.builder().put("index.mode", "time_series");
+        if (IndexSettings.TSDB_SYNTHETIC_ID_FEATURE_FLAG && randomBoolean()) {
+            templateSettings.put(IndexSettings.USE_SYNTHETIC_ID.getKey(), true);
+        }
         var putTemplateRequest = new TransportPutComposableIndexTemplateAction.Request("id");
         putTemplateRequest.indexTemplate(
             ComposableIndexTemplate.builder()
                 .indexPatterns(List.of(dataStreamName))
                 .template(
                     new Template(
-                        Settings.builder()
-                            .put("index.mode", "time_series")
-                            .put(IndexSettings.USE_SYNTHETIC_ID.getKey(), IndexSettings.TSDB_SYNTHETIC_ID_FEATURE_FLAG && randomBoolean())
-                            .build(),
+                        templateSettings.build(),
                         new CompressedXContent("""
 
                                 {

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -466,9 +466,6 @@ tests:
 - class: org.elasticsearch.index.mapper.LongSyntheticSourceNativeArrayIntegrationTests
   method: testSynthesizeArrayRandom
   issue: https://github.com/elastic/elasticsearch/issues/138819
-- class: org.elasticsearch.datastreams.TSDBIndexingIT
-  method: testDynamicDimensions
-  issue: https://github.com/elastic/elasticsearch/issues/138815
 - class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
   issue: https://github.com/elastic/elasticsearch/issues/138796
 


### PR DESCRIPTION
The `index.mapping.use_synthetic_id` is not registered on non-snapshot build so that simply fails the template creation. I adjusted some tests but forgot to adjust all other tests in the class. This is now done.

Closes #138815