### PR TITLE
[9.1] GET /_migration/deprecations doesn't check disk watermarks against correct settings values (#138115)

### DIFF
--- a/docs/changelog/138115.yaml
+++ b/docs/changelog/138115.yaml
@@ -1,0 +1,7 @@
+pr: 138115
+summary: GET /_migration/deprecations doesn't check disk watermarks against correct
+  settings values
+area: Infra/Core
+type: bug
+issues:
+ - 137005

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdSettings.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdSettings.java
@@ -487,6 +487,12 @@ public class DiskThresholdSettings implements Writeable {
         return getFreeBytesThreshold(total, lowStageWatermark, lowStageMaxHeadroom);
     }
 
+    public static ByteSizeValue getFreeBytesThresholdLowStage(ByteSizeValue total, ClusterSettings clusterSettings) {
+        var lowStageWatermark = clusterSettings.get(CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING);
+        var lowStageMaxHeadroom = clusterSettings.get(CLUSTER_ROUTING_ALLOCATION_LOW_DISK_MAX_HEADROOM_SETTING);
+        return getFreeBytesThreshold(total, lowStageWatermark, lowStageMaxHeadroom);
+    }
+
     public ByteSizeValue getFreeBytesThresholdHighStage(ByteSizeValue total) {
         return getFreeBytesThreshold(total, highStageWatermark, highStageMaxHeadroom);
     }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecker.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecker.java
@@ -52,7 +52,7 @@ public class NodeDeprecationChecker {
                         .collect(Collectors.toList());
                     logger.warn("nodes failed to run deprecation checks: {}", failedNodeIds);
                     for (FailedNodeException failure : response.failures()) {
-                        logger.debug("node {} failed to run deprecation checks: {}", failure.nodeId(), failure);
+                        logger.atWarn().withThrowable(failure).log("node {} failed to run deprecation checks", failure.nodeId());
                     }
                 }
                 l.onResponse(reduceToDeprecationIssues(response));

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckAction.java
@@ -11,19 +11,13 @@ import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.admin.cluster.node.info.PluginsAndModules;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.nodes.TransportNodesAction;
-import org.elasticsearch.cluster.ClusterInfo;
-import org.elasticsearch.cluster.ClusterInfoService;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.DiskUsage;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.regex.Regex;
-import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.plugins.PluginsService;
@@ -35,10 +29,7 @@ import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.Objects;
-
-import static org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING;
 
 public class TransportNodeDeprecationCheckAction extends TransportNodesAction<
     NodesDeprecationCheckRequest,
@@ -50,7 +41,6 @@ public class TransportNodeDeprecationCheckAction extends TransportNodesAction<
     private final Settings settings;
     private final XPackLicenseState licenseState;
     private final PluginsService pluginsService;
-    private final ClusterInfoService clusterInfoService;
     private volatile List<String> skipTheseDeprecations;
 
     @Inject
@@ -61,8 +51,7 @@ public class TransportNodeDeprecationCheckAction extends TransportNodesAction<
         ClusterService clusterService,
         TransportService transportService,
         PluginsService pluginsService,
-        ActionFilters actionFilters,
-        ClusterInfoService clusterInfoService
+        ActionFilters actionFilters
     ) {
         super(
             NodesDeprecationCheckAction.NAME,
@@ -75,7 +64,6 @@ public class TransportNodeDeprecationCheckAction extends TransportNodesAction<
         this.settings = settings;
         this.pluginsService = pluginsService;
         this.licenseState = licenseState;
-        this.clusterInfoService = clusterInfoService;
         skipTheseDeprecations = TransportDeprecationInfoAction.SKIP_DEPRECATIONS_SETTING.get(settings);
         // Safe to register this here because it happens synchronously before the cluster service is started:
         clusterService.getClusterSettings()
@@ -135,55 +123,6 @@ public class TransportNodeDeprecationCheckAction extends TransportNodesAction<
             .map(c -> c.apply(filteredNodeSettings, pluginsService.info(), filteredClusterState, licenseState))
             .filter(Objects::nonNull)
             .toList();
-        DeprecationIssue watermarkIssue = checkDiskLowWatermark(
-            filteredNodeSettings,
-            filteredClusterState.metadata().settings(),
-            clusterInfoService.getClusterInfo(),
-            clusterService.getClusterSettings(),
-            transportService.getLocalNode().getId()
-        );
-        if (watermarkIssue != null) {
-            issues.add(watermarkIssue);
-        }
         return new NodesDeprecationCheckAction.NodeResponse(transportService.getLocalNode(), issues);
-    }
-
-    static DeprecationIssue checkDiskLowWatermark(
-        Settings nodeSettings,
-        Settings dynamicSettings,
-        ClusterInfo clusterInfo,
-        ClusterSettings clusterSettings,
-        String nodeId
-    ) {
-        DiskUsage usage = clusterInfo.getNodeMostAvailableDiskUsages().get(nodeId);
-        if (usage != null) {
-            long freeBytes = usage.freeBytes();
-            long totalBytes = usage.totalBytes();
-            if (exceedsLowWatermark(nodeSettings, clusterSettings, freeBytes, totalBytes)
-                || exceedsLowWatermark(dynamicSettings, clusterSettings, freeBytes, totalBytes)) {
-                return new DeprecationIssue(
-                    DeprecationIssue.Level.CRITICAL,
-                    "Disk usage exceeds low watermark",
-                    "https://ela.st/es-deprecation-7-disk-watermark-exceeded",
-                    String.format(
-                        Locale.ROOT,
-                        "Disk usage exceeds low watermark, which will prevent reindexing indices during upgrade. Get disk usage on "
-                            + "all nodes below the value specified in %s",
-                        CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING.getKey()
-                    ),
-                    false,
-                    null
-                );
-            }
-        }
-        return null;
-    }
-
-    private static boolean exceedsLowWatermark(Settings settingsToCheck, ClusterSettings clusterSettings, long freeBytes, long totalBytes) {
-        DiskThresholdSettings diskThresholdSettings = new DiskThresholdSettings(settingsToCheck, clusterSettings);
-        if (freeBytes < diskThresholdSettings.getFreeBytesThresholdLowStage(ByteSizeValue.ofBytes(totalBytes)).getBytes()) {
-            return true;
-        }
-        return false;
     }
 }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationCheckerTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/IndexDeprecationCheckerTests.java
@@ -51,8 +51,9 @@ public class IndexDeprecationCheckerTests extends ESTestCase {
     private static final IndexVersion OLD_VERSION = IndexVersion.fromId(7170099);
     private final IndexNameExpressionResolver indexNameExpressionResolver = TestIndexNameExpressionResolver.newInstance();
     private final IndexDeprecationChecker checker = new IndexDeprecationChecker(indexNameExpressionResolver);
-    private final TransportDeprecationInfoAction.PrecomputedData emptyPrecomputedData =
-        new TransportDeprecationInfoAction.PrecomputedData();
+    private final TransportDeprecationInfoAction.PrecomputedData emptyPrecomputedData = new TransportDeprecationInfoAction.PrecomputedData(
+        null
+    );
     private final IndexMetadata.State indexMetdataState;
 
     public IndexDeprecationCheckerTests(@Name("indexMetadataState") IndexMetadata.State indexMetdataState) {
@@ -793,7 +794,7 @@ public class IndexDeprecationCheckerTests extends ESTestCase {
                 );
             }
         }
-        TransportDeprecationInfoAction.PrecomputedData precomputedData = new TransportDeprecationInfoAction.PrecomputedData();
+        TransportDeprecationInfoAction.PrecomputedData precomputedData = new TransportDeprecationInfoAction.PrecomputedData(null);
         precomputedData.setOnceTransformConfigs(transforms);
         return precomputedData;
     }

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoActionTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoActionTests.java
@@ -8,9 +8,17 @@ package org.elasticsearch.xpack.deprecation;
 
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.cluster.ClusterInfo;
+import org.elasticsearch.cluster.ClusterInfoService;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.DiskUsage;
 import org.elasticsearch.cluster.metadata.ComponentTemplate;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.DataStream;
@@ -20,19 +28,31 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.indices.TestIndexNameExpressionResolver;
+import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.client.NoOpNodeClient;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
+import org.elasticsearch.xpack.core.transform.action.GetTransformAction;
 import org.hamcrest.core.IsEqual;
 import org.junit.Assert;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -45,11 +65,14 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.elasticsearch.common.settings.ClusterSettings.BUILT_IN_CLUSTER_SETTINGS;
 import static org.elasticsearch.xpack.deprecation.DeprecationInfoAction.Response.RESERVED_NAMES;
 import static org.elasticsearch.xpack.deprecation.DeprecationInfoActionResponseTests.createTestDeprecationIssue;
+import static org.elasticsearch.xpack.deprecation.TransportDeprecationInfoAction.SKIP_DEPRECATIONS_SETTING;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -114,7 +137,7 @@ public class TransportDeprecationInfoActionTests extends ESTestCase {
         List<DeprecationIssue> nodeDeprecationIssues = nodeIssueFound ? List.of(foundIssue) : List.of();
 
         DeprecationInfoAction.Request request = new DeprecationInfoAction.Request(randomTimeValue(), Strings.EMPTY_ARRAY);
-        TransportDeprecationInfoAction.PrecomputedData precomputedData = new TransportDeprecationInfoAction.PrecomputedData();
+        TransportDeprecationInfoAction.PrecomputedData precomputedData = new TransportDeprecationInfoAction.PrecomputedData(null);
         precomputedData.setOnceTransformConfigs(List.of());
         precomputedData.setOncePluginIssues(Map.of());
         precomputedData.setOnceNodeSettingsIssues(nodeDeprecationIssues);
@@ -234,7 +257,7 @@ public class TransportDeprecationInfoActionTests extends ESTestCase {
             });
             return Map.of();
         }));
-        TransportDeprecationInfoAction.PrecomputedData precomputedData = new TransportDeprecationInfoAction.PrecomputedData();
+        TransportDeprecationInfoAction.PrecomputedData precomputedData = new TransportDeprecationInfoAction.PrecomputedData(null);
         precomputedData.setOnceTransformConfigs(List.of());
         precomputedData.setOncePluginIssues(Map.of());
         precomputedData.setOnceNodeSettingsIssues(List.of());
@@ -337,6 +360,171 @@ public class TransportDeprecationInfoActionTests extends ESTestCase {
         );
         Exception exception = expectThrows(Exception.class, future::actionGet);
         assertThat(exception.getCause().getMessage(), containsString("boom"));
+    }
+
+    public void testCheckDiskLowWatermark() {
+        Settings settingsWithLowWatermark = Settings.builder().put("cluster.routing.allocation.disk.watermark.low", "10%").build();
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, BUILT_IN_CLUSTER_SETTINGS);
+        String nodeId1 = "123";
+        String nodeId2 = "124";
+        String nodeId3 = "125";
+        long totalBytesOnMachine = 100;
+        long totalBytesFree = 70;
+        ClusterInfo clusterInfo = new ClusterInfo(
+            Map.of(),
+            Map.of(
+                nodeId1,
+                new DiskUsage(nodeId1, "", "", totalBytesOnMachine, totalBytesFree),
+                nodeId2,
+                new DiskUsage(nodeId2, "", "", totalBytesOnMachine, totalBytesFree),
+                nodeId3,
+                new DiskUsage(nodeId2, "", "", totalBytesOnMachine, totalBytesOnMachine)
+            ),
+            Map.of(),
+            Map.of(),
+            Map.of(),
+            Map.of(),
+            Map.of()
+        );
+        DiscoveryNode node1 = mock(DiscoveryNode.class);
+        when(node1.getId()).thenReturn(nodeId1);
+        when(node1.getName()).thenReturn("node1");
+        DiscoveryNodes discoveryNodes = mock(DiscoveryNodes.class);
+        when(discoveryNodes.get(nodeId1)).thenReturn(node1);
+        DiscoveryNode node2 = mock(DiscoveryNode.class);
+        when(node2.getId()).thenReturn(nodeId2);
+        when(node2.getName()).thenReturn("node2");
+        when(discoveryNodes.get(nodeId2)).thenReturn(node2);
+        DiscoveryNode node3 = mock(DiscoveryNode.class);
+        when(node3.getId()).thenReturn(nodeId3);
+        when(node3.getName()).thenReturn("node3");
+        when(discoveryNodes.get(nodeId3)).thenReturn(node3);
+
+        clusterSettings.applySettings(settingsWithLowWatermark);
+        DeprecationIssue issue = TransportDeprecationInfoAction.checkDiskLowWatermark(clusterSettings, clusterInfo, discoveryNodes);
+        assertNotNull(issue);
+        assertEquals("Disk usage exceeds low watermark", issue.getMessage());
+
+        // Making sure there's no warning when we clear out the cluster settings:
+        clusterSettings.applySettings(Settings.EMPTY);
+        issue = TransportDeprecationInfoAction.checkDiskLowWatermark(clusterSettings, clusterInfo, discoveryNodes);
+        assertNull(issue);
+
+        // And make sure there is a warning when the setting is in the node settings but not the cluster settings:
+        clusterSettings = new ClusterSettings(settingsWithLowWatermark, BUILT_IN_CLUSTER_SETTINGS);
+        issue = TransportDeprecationInfoAction.checkDiskLowWatermark(clusterSettings, clusterInfo, discoveryNodes);
+        assertNotNull(issue);
+        assertEquals("Disk usage exceeds low watermark", issue.getMessage());
+        assertThat(issue.getDetails(), containsString("(nodes impacted: [node1, node2])"));
+    }
+
+    public void testMasterOperation() throws InterruptedException {
+        try (TestThreadPool threadPool = new TestThreadPool("TransportDeprecationInfoActionTests")) {
+            ClusterService clusterService = mock(ClusterService.class);
+
+            String nodeId = "node1";
+            DiscoveryNode node1 = mock(DiscoveryNode.class);
+            when(node1.getId()).thenReturn(nodeId);
+            when(node1.getName()).thenReturn(nodeId);
+            DiscoveryNodes discoveryNodes = mock(DiscoveryNodes.class);
+            when(discoveryNodes.get(nodeId)).thenReturn(node1);
+
+            ClusterState state = mock(ClusterState.class);
+            when(state.nodes()).thenReturn(discoveryNodes);
+            when(state.metadata()).thenReturn(Metadata.EMPTY_METADATA);
+            when(clusterService.state()).thenReturn(state);
+
+            ClusterInfoService clusterInfoService = mock(ClusterInfoService.class);
+
+            NodeClient client = new NoOpNodeClient(threadPool) {
+                @SuppressWarnings("unchecked")
+                @Override
+                public <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
+                    ActionType<Response> action,
+                    Request request,
+                    ActionListener<Response> listener
+                ) {
+                    switch (action.name()) {
+                        case NodesDeprecationCheckAction.NAME:
+                            NodesDeprecationCheckAction.NodeResponse nodeResponse = new NodesDeprecationCheckAction.NodeResponse(
+                                node1,
+                                List.of(
+                                    new DeprecationIssue(DeprecationIssue.Level.WARNING, "Node issue", "http://url", "details", false, null)
+                                )
+                            );
+                            NodesDeprecationCheckResponse nodesResponse = new NodesDeprecationCheckResponse(
+                                ClusterName.DEFAULT,
+                                List.of(nodeResponse),
+                                Collections.emptyList()
+                            );
+                            listener.onResponse((Response) nodesResponse);
+                            break;
+                        case GetTransformAction.NAME:
+                            listener.onResponse((Response) new GetTransformAction.Response(List.of(), 0, List.of()));
+                            break;
+                        default:
+                    }
+                }
+            };
+
+            // Disable ML to avoid MlDeprecationChecker making calls
+            Settings settings = Settings.builder().put("xpack.ml.enabled", false).build();
+            ClusterSettings clusterSettings = new ClusterSettings(
+                settings,
+                Set.copyOf(CollectionUtils.appendToCopy(BUILT_IN_CLUSTER_SETTINGS, SKIP_DEPRECATIONS_SETTING))
+            );
+            when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+            when(clusterService.getClusterName()).thenReturn(ClusterName.DEFAULT);
+
+            IndexNameExpressionResolver indexNameExpressionResolver = mock(IndexNameExpressionResolver.class);
+            when(indexNameExpressionResolver.concreteIndexNames(any(ClusterState.class), any())).thenReturn(new String[0]);
+            TransportDeprecationInfoAction action = new TransportDeprecationInfoAction(
+                settings,
+                mock(TransportService.class),
+                clusterService,
+                threadPool,
+                mock(ActionFilters.class),
+                indexNameExpressionResolver,
+                client,
+                NamedXContentRegistry.EMPTY,
+                clusterInfoService
+            );
+
+            DiskUsage diskUsage = new DiskUsage(nodeId, "node1", "/data", 100L, 0L);
+            ClusterInfo clusterInfo = mock(ClusterInfo.class);
+            when(clusterInfo.getNodeMostAvailableDiskUsages()).thenReturn(Map.of(nodeId, diskUsage));
+            when(clusterInfoService.getClusterInfo()).thenReturn(clusterInfo);
+
+            action.masterOperation(mock(Task.class), new DeprecationInfoAction.Request(TimeValue.MAX_VALUE), state, new ActionListener<>() {
+                @Override
+                public void onResponse(DeprecationInfoAction.Response response) {
+                    List<DeprecationIssue> nodeSettingsIssues = response.getNodeSettingsIssues();
+                    assertThat(nodeSettingsIssues, hasSize(2));
+
+                    DeprecationIssue nodeIssue = nodeSettingsIssues.stream()
+                        .filter(i -> i.getMessage().equals("Node issue"))
+                        .findFirst()
+                        .orElseThrow();
+
+                    DeprecationIssue diskIssue = nodeSettingsIssues.stream()
+                        .filter(i -> i.getMessage().equals("Disk usage exceeds low watermark"))
+                        .findFirst()
+                        .orElseThrow();
+
+                    assertThat(nodeIssue.getLevel(), equalTo(DeprecationIssue.Level.WARNING));
+                    assertThat(nodeIssue.getUrl(), equalTo("http://url"));
+                    assertThat(nodeIssue.getDetails(), containsString("(nodes impacted: [node1])"));
+
+                    assertThat(diskIssue.getLevel(), equalTo(DeprecationIssue.Level.CRITICAL));
+                    assertThat(diskIssue.getDetails(), containsString("(nodes impacted: [node1])"));
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    fail("Test failed with exception: " + e.getMessage());
+                }
+            });
+        }
     }
 
     private static ResourceDeprecationChecker createResourceChecker(

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckActionTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckActionTests.java
@@ -9,11 +9,8 @@ package org.elasticsearch.xpack.deprecation;
 
 import org.elasticsearch.action.admin.cluster.node.info.PluginsAndModules;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.cluster.ClusterInfo;
-import org.elasticsearch.cluster.ClusterInfoService;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.DiskUsage;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -32,7 +29,6 @@ import org.junit.Before;
 import org.mockito.Mockito;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -85,9 +81,6 @@ public class TransportNodeDeprecationCheckActionTests extends ESTestCase {
         when(transportService.getLocalNode()).thenReturn(node);
         PluginsService pluginsService = Mockito.mock(PluginsService.class);
         ActionFilters actionFilters = Mockito.mock(ActionFilters.class);
-        ClusterInfoService clusterInfoService = Mockito.mock(ClusterInfoService.class);
-        ClusterInfo clusterInfo = ClusterInfo.EMPTY;
-        when(clusterInfoService.getClusterInfo()).thenReturn(clusterInfo);
         TransportNodeDeprecationCheckAction transportNodeDeprecationCheckAction = new TransportNodeDeprecationCheckAction(
             nodeSettings,
             threadPool,
@@ -95,8 +88,7 @@ public class TransportNodeDeprecationCheckActionTests extends ESTestCase {
             clusterService,
             transportService,
             pluginsService,
-            actionFilters,
-            clusterInfoService
+            actionFilters
         );
         NodesDeprecationCheckAction.NodeRequest nodeRequest = null;
         AtomicReference<Settings> visibleNodeSettings = new AtomicReference<>();
@@ -155,58 +147,5 @@ public class TransportNodeDeprecationCheckActionTests extends ESTestCase {
             Settings.builder().put("some.bad.dynamic.property", "someValue1").build(),
             visibleClusterStateMetadataSettings.get()
         );
-    }
-
-    public void testCheckDiskLowWatermark() {
-        Settings nodeSettings = Settings.EMPTY;
-        Settings.Builder settingsBuilder = Settings.builder();
-        settingsBuilder.put("cluster.routing.allocation.disk.watermark.low", "10%");
-        Settings settingsWithLowWatermark = settingsBuilder.build();
-        Settings dynamicSettings = settingsWithLowWatermark;
-        ClusterSettings clusterSettings = new ClusterSettings(nodeSettings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        String nodeId = "123";
-        long totalBytesOnMachine = 100;
-        long totalBytesFree = 70;
-        ClusterInfo clusterInfo = new ClusterInfo(
-            Map.of(),
-            Map.of(nodeId, new DiskUsage(nodeId, "", "", totalBytesOnMachine, totalBytesFree)),
-            Map.of(),
-            Map.of(),
-            Map.of(),
-            Map.of(),
-            Map.of()
-        );
-        DeprecationIssue issue = TransportNodeDeprecationCheckAction.checkDiskLowWatermark(
-            nodeSettings,
-            dynamicSettings,
-            clusterInfo,
-            clusterSettings,
-            nodeId
-        );
-        assertNotNull(issue);
-        assertEquals("Disk usage exceeds low watermark", issue.getMessage());
-
-        // Making sure there's no warning when we clear out the cluster settings:
-        dynamicSettings = Settings.EMPTY;
-        issue = TransportNodeDeprecationCheckAction.checkDiskLowWatermark(
-            nodeSettings,
-            dynamicSettings,
-            clusterInfo,
-            clusterSettings,
-            nodeId
-        );
-        assertNull(issue);
-
-        // And make sure there is a warning when the setting is in the node settings but not the cluster settings:
-        nodeSettings = settingsWithLowWatermark;
-        issue = TransportNodeDeprecationCheckAction.checkDiskLowWatermark(
-            nodeSettings,
-            dynamicSettings,
-            clusterInfo,
-            clusterSettings,
-            nodeId
-        );
-        assertNotNull(issue);
-        assertEquals("Disk usage exceeds low watermark", issue.getMessage());
     }
 }


### PR DESCRIPTION
Backports the following commits to 9.1 with small corrections:

GET /_migration/deprecations doesn't check disk watermarks against correct settings values (https://github.com/elastic/elasticsearch/pull/138115)