### PR TITLE
Log a warning if an empty shutting down node doesn't leave the cluster

### DIFF
--- a/docs/changelog/138842.yaml
+++ b/docs/changelog/138842.yaml
@@ -1,5 +1,0 @@
-pr: 138842
-summary: Log a warning if an empty shutting down node doesn't leave the cluster
-area: "Distributed, Autoscaling"
-type: enhancement
-issues: []

--- a/docs/changelog/138842.yaml
+++ b/docs/changelog/138842.yaml
@@ -1,5 +1,5 @@
 pr: 138842
 summary: Log a warning if an empty shutting down node doesn't leave the cluster
 area: "Distributed, Autoscaling"
-type: bug
+type: enhancement
 issues: []

--- a/docs/changelog/138842.yaml
+++ b/docs/changelog/138842.yaml
@@ -1,0 +1,5 @@
+pr: 138842
+summary: Log a warning if an empty shutting down node doesn't leave the cluster
+area: "Distributed, Autoscaling"
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoverySourceService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoverySourceService.java
@@ -134,6 +134,10 @@ public class PeerRecoverySourceService extends AbstractLifecycleComponent implem
         }
     }
 
+    public void addEmptyListener(ActionListener<Void> listener) {
+        ongoingRecoveries.addEmptyListener(listener);
+    }
+
     private void recover(StartRecoveryRequest request, Task task, ActionListener<RecoveryResponse> listener) {
         PeerRecoverySourceClusterStateDelay.ensureClusterStateVersion(
             request.clusterStateVersion(),
@@ -305,6 +309,11 @@ public class PeerRecoverySourceService extends AbstractLifecycleComponent implem
                 emptyListeners.add(future);
             }
             FutureUtils.get(future);
+        }
+
+        public void addEmptyListener(ActionListener<Void> listener) {
+            assert emptyListeners != null;
+            emptyListeners.add(listener);
         }
 
         private final class ShardRecoveryContext {


### PR DESCRIPTION
Relates ES-12189

The idea here is add a ActionListener<Void> into PeerRecoverySourceService during the shutdown phase. This actionListener can either send a precise signal all recoveries are completed. 

If IngestMetricsService receive such signals , then maybeAdjustIngestLoadsForRelocationLoad() can account for shutdown more precisely. 