### PR TITLE
Add `toString()` for `RemoteConnectionInfo` and `ModeInfo` impls

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/ProxyConnectionStrategy.java
+++ b/server/src/main/java/org/elasticsearch/transport/ProxyConnectionStrategy.java
@@ -305,5 +305,15 @@ public class ProxyConnectionStrategy extends RemoteConnectionStrategy {
         public int hashCode() {
             return Objects.hash(address, serverName, maxSocketConnections, numSocketsConnected);
         }
+
+        @Override
+        public String toString() {
+            return "ProxyModeInfo{" +
+                "address='" + address + '\'' +
+                ", serverName='" + serverName + '\'' +
+                ", maxSocketConnections=" + maxSocketConnections +
+                ", numSocketsConnected=" + numSocketsConnected +
+                '}';
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/transport/ProxyConnectionStrategy.java
+++ b/server/src/main/java/org/elasticsearch/transport/ProxyConnectionStrategy.java
@@ -308,12 +308,18 @@ public class ProxyConnectionStrategy extends RemoteConnectionStrategy {
 
         @Override
         public String toString() {
-            return "ProxyModeInfo{" +
-                "address='" + address + '\'' +
-                ", serverName='" + serverName + '\'' +
-                ", maxSocketConnections=" + maxSocketConnections +
-                ", numSocketsConnected=" + numSocketsConnected +
-                '}';
+            return "ProxyModeInfo{"
+                + "address='"
+                + address
+                + '\''
+                + ", serverName='"
+                + serverName
+                + '\''
+                + ", maxSocketConnections="
+                + maxSocketConnections
+                + ", numSocketsConnected="
+                + numSocketsConnected
+                + '}';
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/transport/RemoteConnectionInfo.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteConnectionInfo.java
@@ -121,6 +121,17 @@ public final class RemoteConnectionInfo implements ToXContentFragment, Writeable
         return Objects.hash(modeInfo, initialConnectionTimeout, clusterAlias, skipUnavailable, hasClusterCredentials);
     }
 
+    @Override
+    public String toString() {
+        return "RemoteConnectionInfo{" +
+            "modeInfo=" + modeInfo +
+            ", initialConnectionTimeout=" + initialConnectionTimeout +
+            ", clusterAlias='" + clusterAlias + '\'' +
+            ", skipUnavailable=" + skipUnavailable +
+            ", hasClusterCredentials=" + hasClusterCredentials +
+            '}';
+    }
+
     public interface ModeInfo extends ToXContentFragment, Writeable {
 
         boolean isConnected();

--- a/server/src/main/java/org/elasticsearch/transport/RemoteConnectionInfo.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteConnectionInfo.java
@@ -123,13 +123,19 @@ public final class RemoteConnectionInfo implements ToXContentFragment, Writeable
 
     @Override
     public String toString() {
-        return "RemoteConnectionInfo{" +
-            "modeInfo=" + modeInfo +
-            ", initialConnectionTimeout=" + initialConnectionTimeout +
-            ", clusterAlias='" + clusterAlias + '\'' +
-            ", skipUnavailable=" + skipUnavailable +
-            ", hasClusterCredentials=" + hasClusterCredentials +
-            '}';
+        return "RemoteConnectionInfo{"
+            + "modeInfo="
+            + modeInfo
+            + ", initialConnectionTimeout="
+            + initialConnectionTimeout
+            + ", clusterAlias='"
+            + clusterAlias
+            + '\''
+            + ", skipUnavailable="
+            + skipUnavailable
+            + ", hasClusterCredentials="
+            + hasClusterCredentials
+            + '}';
     }
 
     public interface ModeInfo extends ToXContentFragment, Writeable {

--- a/server/src/main/java/org/elasticsearch/transport/SniffConnectionStrategy.java
+++ b/server/src/main/java/org/elasticsearch/transport/SniffConnectionStrategy.java
@@ -540,11 +540,14 @@ public class SniffConnectionStrategy extends RemoteConnectionStrategy {
 
         @Override
         public String toString() {
-            return "SniffModeInfo{" +
-                "seedNodes=" + seedNodes +
-                ", maxConnectionsPerCluster=" + maxConnectionsPerCluster +
-                ", numNodesConnected=" + numNodesConnected +
-                '}';
+            return "SniffModeInfo{"
+                + "seedNodes="
+                + seedNodes
+                + ", maxConnectionsPerCluster="
+                + maxConnectionsPerCluster
+                + ", numNodesConnected="
+                + numNodesConnected
+                + '}';
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/transport/SniffConnectionStrategy.java
+++ b/server/src/main/java/org/elasticsearch/transport/SniffConnectionStrategy.java
@@ -537,5 +537,14 @@ public class SniffConnectionStrategy extends RemoteConnectionStrategy {
         public int hashCode() {
             return Objects.hash(seedNodes, maxConnectionsPerCluster, numNodesConnected);
         }
+
+        @Override
+        public String toString() {
+            return "SniffModeInfo{" +
+                "seedNodes=" + seedNodes +
+                ", maxConnectionsPerCluster=" + maxConnectionsPerCluster +
+                ", numNodesConnected=" + numNodesConnected +
+                '}';
+        }
     }
 }


### PR DESCRIPTION
Adds generated `toString()` methods for `RemoteConnectionInfo` and the `ModeInfo` implementations to support debugging of assertions.

Relates: ES-13292