### PR TITLE
Disable filter-by-filter for time-series indices

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
@@ -16,6 +16,7 @@ import org.elasticsearch.TransportVersion;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.RemoteException;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -57,6 +58,7 @@ import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.RoutingPathFields;
 import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.search.SearchService;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileUtils;
@@ -399,6 +401,11 @@ public final class EsqlTestUtils {
         @Override
         public boolean canUseEqualityOnSyntheticSourceDelegate(FieldName name, String value) {
             return false;
+        }
+
+        @Override
+        public Map<ShardId, IndexMetadata> targetShards() {
+            return Map.of();
         }
     }
 

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/TimeSeriesIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/TimeSeriesIT.java
@@ -576,24 +576,27 @@ public class TimeSeriesIT extends AbstractEsqlIntegTestCase {
                 List<DriverProfile> dataProfiles = profile.drivers().stream().filter(d -> d.description().equals("data")).toList();
                 assertThat(dataProfiles, hasSize(1));
                 List<OperatorStatus> ops = dataProfiles.get(0).operators();
-                assertThat(ops, hasSize(8));
+                assertThat(ops, hasSize(9));
                 assertThat(ops.get(0).operator(), containsString("LuceneSourceOperator"));
                 assertThat(ops.get(0).status(), Matchers.instanceOf(LuceneSourceOperator.Status.class));
                 LuceneSourceOperator.Status status = (LuceneSourceOperator.Status) ops.get(0).status();
                 assertThat(status.processedShards().size(), Matchers.lessThanOrEqualTo(3));
-                assertThat(ops.get(1).operator(), containsString("EvalOperator"));
+                // read _timestamp
+                assertThat(ops.get(1).operator(), containsString("ValuesSourceReaderOperator"));
+                // round _timestamp
+                assertThat(ops.get(2).operator(), containsString("EvalOperator"));
                 // read _tisd, cpu
-                assertThat(ops.get(2).operator(), containsString("ValuesSourceReaderOperator"));
-                var readMetrics = (ValuesSourceReaderOperatorStatus) ops.get(2).status();
+                assertThat(ops.get(3).operator(), containsString("ValuesSourceReaderOperator"));
+                var readMetrics = (ValuesSourceReaderOperatorStatus) ops.get(3).status();
                 assertThat(
                     readMetrics.readersBuilt().keySet(),
                     equalTo(
                         Set.of("_tsid:column_at_a_time:BytesRefsFromOrds.Singleton", "cpu:column_at_a_time:DoublesFromDocValues.Singleton")
                     )
                 );
-                assertThat(ops.get(3).operator(), containsString("TimeSeriesAggregationOperator"));
-                assertThat(ops.get(4).operator(), containsString("ValuesSourceReaderOperator"));
-                var readDimensions = (ValuesSourceReaderOperatorStatus) ops.get(4).status();
+                assertThat(ops.get(4).operator(), containsString("TimeSeriesAggregationOperator"));
+                assertThat(ops.get(5).operator(), containsString("ValuesSourceReaderOperator"));
+                var readDimensions = (ValuesSourceReaderOperatorStatus) ops.get(5).status();
                 assertThat(readDimensions.readersBuilt(), aMapWithSize(1));
                 assertThat(
                     Iterables.get(readDimensions.readersBuilt().keySet(), 0),
@@ -601,9 +604,9 @@ public class TimeSeriesIT extends AbstractEsqlIntegTestCase {
                         equalTo("cluster:column_at_a_time:BytesRefsFromOrds.Singleton")
                     )
                 );
-                assertThat(ops.get(5).operator(), containsString("EvalOperator"));
-                assertThat(ops.get(6).operator(), containsString("ProjectOperator"));
-                assertThat(ops.get(7).operator(), containsString("ExchangeSinkOperator"));
+                assertThat(ops.get(6).operator(), containsString("EvalOperator"));
+                assertThat(ops.get(7).operator(), containsString("ProjectOperator"));
+                assertThat(ops.get(8).operator(), containsString("ExchangeSinkOperator"));
             }
         }
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/stats/SearchContextStats.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/stats/SearchContextStats.java
@@ -21,6 +21,8 @@ import org.apache.lucene.index.Terms;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.NumericUtils;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.index.mapper.ConstantFieldType;
 import org.elasticsearch.index.mapper.DocCountFieldMapper.DocCountFieldType;
 import org.elasticsearch.index.mapper.IdFieldMapper;
@@ -30,6 +32,7 @@ import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
 import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute.FieldName;
@@ -497,5 +500,16 @@ public class SearchContextStats implements SearchStats {
         } catch (IOException ex) {
             throw new EsqlIllegalArgumentException("Cannot access data storage", ex);
         }
+    }
+
+    @Override
+    public Map<ShardId, IndexMetadata> targetShards() {
+        Map<ShardId, IndexMetadata> shards = Maps.newHashMapWithExpectedSize(contexts.size());
+        for (SearchExecutionContext context : contexts) {
+            IndexMetadata indexMetadata = context.getIndexSettings().getIndexMetadata();
+            ShardId shardId = new ShardId(context.index(), context.getShardId());
+            shards.putIfAbsent(shardId, indexMetadata);
+        }
+        return shards;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/stats/SearchStats.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/stats/SearchStats.java
@@ -8,9 +8,13 @@
 package org.elasticsearch.xpack.esql.stats;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute.FieldName;
+
+import java.util.Map;
 
 /**
  * Interface for determining information about fields in the index.
@@ -60,6 +64,11 @@ public interface SearchStats {
     default MappedFieldType fieldType(FieldName name) {
         return null;
     }
+
+    /**
+     * Returns the target shards and their index metadata.
+     */
+    Map<ShardId, IndexMetadata> targetShards();
 
     /**
      * When there are no search stats available, for example when there are no search contexts, we have static results.
@@ -129,6 +138,11 @@ public interface SearchStats {
         public boolean canUseEqualityOnSyntheticSourceDelegate(FieldName name, String value) {
             return false;
         }
+
+        @Override
+        public Map<ShardId, IndexMetadata> targetShards() {
+            return Map.of();
+        }
     }
 
     /**
@@ -197,6 +211,11 @@ public interface SearchStats {
 
         @Override
         public boolean canUseEqualityOnSyntheticSourceDelegate(FieldName name, String value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Map<ShardId, IndexMetadata> targetShards() {
             throw new UnsupportedOperationException();
         }
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/AbstractLocalPhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/AbstractLocalPhysicalPlanOptimizerTests.java
@@ -55,7 +55,7 @@ public class AbstractLocalPhysicalPlanOptimizerTests extends MapperServiceTestCa
     protected TestPlannerOptimizer plannerOptimizer;
     protected TestPlannerOptimizer plannerOptimizerDateDateNanosUnionTypes;
     protected TestPlannerOptimizer plannerOptimizerTimeSeries;
-    private Analyzer timeSeriesAnalyzer;
+    protected Analyzer timeSeriesAnalyzer;
 
     private static final String PARAM_FORMATTING = "%1$s";
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/SubstituteRoundToTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/SubstituteRoundToTests.java
@@ -7,14 +7,22 @@
 
 package org.elasticsearch.xpack.esql.optimizer.rules.physical.local;
 
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.MatchQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.RangeQueryBuilder;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.EsqlTestUtils;
 import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
@@ -902,6 +910,51 @@ public class SubstituteRoundToTests extends AbstractLocalPhysicalPlanOptimizerTe
         assertThat(statsQueryExec.stat(), is(instanceOf(EsStatsQueryExec.ByStat.class)));
         EsStatsQueryExec.ByStat byStat = (EsStatsQueryExec.ByStat) statsQueryExec.stat();
         assertThat(byStat.queryBuilderAndTags(), is(not(empty())));
+    }
+
+    public void testRoundToWithTimeSeriesIndices() {
+        Map<String, Object> minValue = Map.of(
+            "@timestamp",
+            DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseMillis("2023-10-20T12:15:03.360Z")
+        );
+        Map<String, Object> maxValue = Map.of(
+            "@timestamp",
+            DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseMillis("2023-10-20T14:55:01.543Z")
+        );
+        SearchStats searchStats = new EsqlTestUtils.TestSearchStatsWithMinMax(minValue, maxValue) {
+            @Override
+            public Map<ShardId, IndexMetadata> targetShards() {
+                var indexMetadata = IndexMetadata.builder("test_index")
+                    .settings(
+                        ESTestCase.indexSettings(IndexVersion.current(), 1, 1)
+                            .put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES.name())
+                    )
+                    .build();
+                return Map.of(new ShardId(new Index("id", "n/a"), 1), indexMetadata);
+            }
+        };
+        // enable filter-by-filter for rate aggregations
+        {
+            String q = """
+                TS k8s
+                | STATS max(rate(network.total_bytes_in)) BY cluster, BUCKET(@timestamp, 1 hour)
+                | LIMIT 10
+                """;
+            PhysicalPlan plan = plannerOptimizerTimeSeries.plan(q, searchStats, timeSeriesAnalyzer);
+            int queryAndTags = plainQueryAndTags(plan);
+            assertThat(queryAndTags, equalTo(4));
+        }
+        // disable filter-by-filter for non-rate aggregations
+        {
+            String q = """
+                TS k8s
+                | STATS max(avg_over_time(network.bytes_in)) BY cluster, BUCKET(@timestamp, 1 hour)
+                | LIMIT 10
+                """;
+            PhysicalPlan plan = plannerOptimizerTimeSeries.plan(q, searchStats, timeSeriesAnalyzer);
+            int queryAndTags = plainQueryAndTags(plan);
+            assertThat(queryAndTags, equalTo(1));
+        }
     }
 
     private static SearchStats searchStats() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/stats/DisabledSearchStats.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/stats/DisabledSearchStats.java
@@ -8,9 +8,13 @@
 package org.elasticsearch.xpack.esql.stats;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.blockloader.BlockLoaderFunctionConfig;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute.FieldName;
+
+import java.util.Map;
 
 public class DisabledSearchStats implements SearchStats {
 
@@ -78,5 +82,10 @@ public class DisabledSearchStats implements SearchStats {
     @Override
     public boolean canUseEqualityOnSyntheticSourceDelegate(FieldName name, String value) {
         return false;
+    }
+
+    @Override
+    public Map<ShardId, IndexMetadata> targetShards() {
+        return Map.of();
     }
 }


### PR DESCRIPTION
Time-series indices are sorted by _tsid, then timestamp. Replacing round_to causes fragmentation, leading to reading many small chunks of data. It is more efficient to query sequentially and apply round_to on the timestamp field (we can even push round_to to the field loading).

For example, with 1,000 tsids over 90 minutes (tbucket=1m), replacing round_to would generate 90 queries. Each query necessitates 1,000 seeks, resulting in decompression and partial reads of many doc-value blocks.

`avg_avgot_memory_by_host_5m` reduced from 70ms to 40ms

However, if the EsQueryExec index mode is time-series (e.g., rate), we should continue to replace round_to with QueryAndTags when possible, as we currently lack a method to partition the data for increased parallelism.

Follow-up:

For rate aggregations, I plan to implement a hybrid approach using larger ranges. For the example above, instead of generating 90 sub-queries for a 90-minute range, we would generate 9 queries with 10-minute ranges. This will increase parallelism while minimizing seek/reading overhead.
