### PR TITLE
[ES|QL] Fix capabilities on tsdb yaml tests

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_tsdb.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_tsdb.yml
@@ -291,7 +291,7 @@ from doc with aggregate_metric_double:
         - method: POST
           path: /_query
           parameters: []
-          capabilities: [aggregate_metric_double, dense_vector_agg_metric_double_if_version]
+          capabilities: [aggregate_metric_double_v0, dense_vector_agg_metric_double_if_version]
       reason: "Support for aggregate_metric_double"
   - do:
       allowed_warnings_regex:
@@ -320,7 +320,7 @@ stats on aggregate_metric_double:
         - method: POST
           path: /_query
           parameters: []
-          capabilities: [aggregate_metric_double, dense_vector_agg_metric_double_if_version]
+          capabilities: [aggregate_metric_double_v0, dense_vector_agg_metric_double_if_version]
       reason: "Support for aggregate_metric_double"
   - do:
       allowed_warnings_regex:
@@ -351,7 +351,7 @@ grouping stats on aggregate_metric_double:
         - method: POST
           path: /_query
           parameters: []
-          capabilities: [aggregate_metric_double, dense_vector_agg_metric_double_if_version]
+          capabilities: [aggregate_metric_double_v0, dense_vector_agg_metric_double_if_version]
       reason: "Support for aggregate_metric_double"
   - do:
       allowed_warnings_regex:
@@ -392,7 +392,7 @@ sorting with aggregate_metric_double with partial submetrics:
         - method: POST
           path: /_query
           parameters: []
-          capabilities: [aggregate_metric_double_sorting, dense_vector_agg_metric_double_if_version]
+          capabilities: [aggregate_metric_double_v0, dense_vector_agg_metric_double_if_version]
       reason: "Support for sorting when aggregate_metric_double present"
   - do:
       allowed_warnings_regex:
@@ -424,7 +424,7 @@ aggregate_metric_double unsortable:
         - method: POST
           path: /_query
           parameters: []
-          capabilities: [aggregate_metric_double_sorting, dense_vector_agg_metric_double_if_version]
+          capabilities: [aggregate_metric_double_v0, dense_vector_agg_metric_double_if_version]
       reason: "Support for sorting when aggregate_metric_double present"
   - do:
       catch: /cannot sort on aggregate_metric_double/
@@ -440,7 +440,7 @@ stats on aggregate_metric_double with partial submetrics:
         - method: POST
           path: /_query
           parameters: []
-          capabilities: [aggregate_metric_double_partial_submetrics, dense_vector_agg_metric_double_if_version]
+          capabilities: [aggregate_metric_double_v0, dense_vector_agg_metric_double_if_version]
       reason: "Support for partial submetrics in aggregate_metric_double"
   - do:
       allowed_warnings_regex:
@@ -480,7 +480,7 @@ stats on aggregate_metric_double missing min and max:
         - method: POST
           path: /_query
           parameters: [ ]
-          capabilities: [ aggregate_metric_double_partial_submetrics, dense_vector_agg_metric_double_if_version ]
+          capabilities: [ aggregate_metric_double_v0, dense_vector_agg_metric_double_if_version ]
       reason: "Support for partial submetrics in aggregate_metric_double"
   - do:
       allowed_warnings_regex:
@@ -512,7 +512,7 @@ render aggregate_metric_double when missing min and max:
         - method: POST
           path: /_query
           parameters: [ ]
-          capabilities: [ aggregate_metric_double_rendering, dense_vector_agg_metric_double_if_version ]
+          capabilities: [ aggregate_metric_double_v0, dense_vector_agg_metric_double_if_version ]
       reason: "Support for rendering aggregate_metric_doubles"
   - do:
       allowed_warnings_regex:
@@ -536,7 +536,7 @@ render aggregate_metric_double when missing value:
         - method: POST
           path: /_query
           parameters: [ ]
-          capabilities: [ aggregate_metric_double_rendering, dense_vector_agg_metric_double_if_version ]
+          capabilities: [ aggregate_metric_double_v0, dense_vector_agg_metric_double_if_version ]
       reason: "Support for rendering aggregate_metric_doubles"
   - do:
       allowed_warnings_regex:
@@ -560,7 +560,7 @@ to_string aggregate_metric_double:
         - method: POST
           path: /_query
           parameters: [ ]
-          capabilities: [ aggregate_metric_double_rendering, dense_vector_agg_metric_double_if_version ]
+          capabilities: [ aggregate_metric_double_v0, dense_vector_agg_metric_double_if_version ]
       reason: "Support for rendering aggregate_metric_doubles"
   - do:
       allowed_warnings_regex:
@@ -583,7 +583,7 @@ from index pattern unsupported counter:
         - method: POST
           path: /_query
           parameters: []
-          capabilities: [aggregate_metric_double_partial_submetrics, dense_vector_agg_metric_double_if_version]
+          capabilities: [aggregate_metric_double_v0, dense_vector_agg_metric_double_if_version]
       reason: "Support for partial submetrics in aggregate_metric_double"
   - do:
       allowed_warnings_regex:
@@ -675,7 +675,7 @@ to_aggregate_metric_double with multi_values:
         - method: POST
           path: /_query
           parameters: [ ]
-          capabilities: [ aggregate_metric_double_convert_to ]
+          capabilities: [ aggregate_metric_double_v0 ]
       reason: "Support for to_aggregate_metric_double function"
 
   - do:
@@ -725,7 +725,7 @@ avg of aggregate_metric_double:
         - method: POST
           path: /_query
           parameters: []
-          capabilities: [aggregate_metric_double_avg, dense_vector_agg_metric_double_if_version]
+          capabilities: [aggregate_metric_double_v0, dense_vector_agg_metric_double_if_version]
       reason: "support avg aggregations with aggregate metric double"
 
   - do:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/46_downsample.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/46_downsample.yml
@@ -83,7 +83,7 @@ setup:
         - method: POST
           path: /_query
           parameters: []
-          capabilities: [aggregate_metric_double, dense_vector_agg_metric_double_if_version]
+          capabilities: [aggregate_metric_double_v0, dense_vector_agg_metric_double_if_version]
       reason: "Support for aggregate_metric_double"
   - do:
       indices.downsample:
@@ -125,7 +125,7 @@ setup:
         - method: POST
           path: /_query
           parameters: []
-          capabilities: [aggregate_metric_double_rendering, dense_vector_agg_metric_double_if_version]
+          capabilities: [aggregate_metric_double_v0, dense_vector_agg_metric_double_if_version]
       reason: "Support for rendering aggregate_metric_doubles"
   - do:
       indices.downsample:
@@ -155,7 +155,7 @@ setup:
         - method: POST
           path: /_query
           parameters: []
-          capabilities: [aggregate_metric_double_convert_to, dense_vector_agg_metric_double_if_version]
+          capabilities: [aggregate_metric_double_v0, dense_vector_agg_metric_double_if_version]
       reason: "Support for to_aggregate_metric_double function"
 
   - do:
@@ -260,7 +260,7 @@ setup:
         - method: POST
           path: /_query
           parameters: []
-          capabilities: [metrics_capability, aggregate_metric_double_implicit_casting_in_aggs, dense_vector_agg_metric_double_if_version]
+          capabilities: [aggregate_metric_double_v0, dense_vector_agg_metric_double_if_version]
       reason: "Support for casting aggregate metric double implicitly when present in aggregations"
 
   - do:
@@ -367,7 +367,7 @@ setup:
   - length: {values.0: 1}
   - match: {columns.0.name: "max"}
   - match: {columns.0.type: "double"}
-  - match: {values.0.0: 803685.0}
+  - match: {values.0.0: 800479.0}
 
 ---
 "Over time functions from downsampled and non-downsampled indices simultaneously, no grouping":
@@ -377,7 +377,7 @@ setup:
         - method: POST
           path: /_query
           parameters: []
-          capabilities: [metrics_command, aggregate_metric_double_implicit_casting_in_aggs, dense_vector_agg_metric_double_if_version]
+          capabilities: [aggregate_metric_double_v0, dense_vector_agg_metric_double_if_version]
       reason: "Support for casting aggregate metric double implicitly when present in aggregations"
 
   - do:
@@ -499,7 +499,7 @@ setup:
         - method: POST
           path: /_query
           parameters: []
-          capabilities: [metrics_command, aggregate_metric_double_implicit_casting_in_aggs]
+          capabilities: [aggregate_metric_double_v0]
       reason: "Support for casting aggregate metric double implicitly when present in aggregations"
 
   - do:
@@ -638,7 +638,7 @@ setup:
         - method: POST
           path: /_query
           parameters: []
-          capabilities: [aggregate_metric_double_sorting_fixed]
+          capabilities: [aggregate_metric_double_v0]
       reason: "Fix sorting for rows comprised of docs from multiple indices where agg metric is missing from some"
 
   - do:
@@ -705,7 +705,7 @@ setup:
         - method: POST
           path: /_query
           parameters: []
-          capabilities: [aggregate_metric_double_mv_expand, dense_vector_agg_metric_double_if_version]
+          capabilities: [aggregate_metric_double_v0, dense_vector_agg_metric_double_if_version]
       reason: "Have MV_EXPAND not error out when applied to aggregate_metric_doubles (is a no-op)"
 
   - do:


### PR DESCRIPTION
The capabilities for these tests were overwritten to use capabilities
that no longer exist, thereby causing these tests to stop getting run.
This commit fixes that.