### PR TITLE
[9.1] Improved validation message for unknown archived settings (#138810)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/ReferenceDocs.java
+++ b/server/src/main/java/org/elasticsearch/common/ReferenceDocs.java
@@ -85,6 +85,7 @@ public enum ReferenceDocs {
     SECURE_SETTINGS,
     CLUSTER_SHARD_LIMIT,
     DELETE_INDEX_BLOCK,
+    ARCHIVED_SETTINGS,
     // this comment keeps the ';' on the next line so every entry above has a trailing ',' which makes the diff for adding new links cleaner
     ;
 

--- a/server/src/main/resources/org/elasticsearch/common/reference-docs-links.txt
+++ b/server/src/main/resources/org/elasticsearch/common/reference-docs-links.txt
@@ -47,3 +47,4 @@ ALLOCATION_EXPLAIN_MAX_RETRY                                    troubleshoot/ela
 SECURE_SETTINGS                                                 deploy-manage/security/secure-settings
 CLUSTER_SHARD_LIMIT                                             reference/elasticsearch/configuration-reference/miscellaneous-cluster-settings#cluster-shard-limit
 DELETE_INDEX_BLOCK                                              api/doc/elasticsearch/operation/operation-indices-remove-block
+ARCHIVED_SETTINGS                                               deploy-manage/upgrade/deployment-or-cluster/archived-settings

--- a/server/src/test/java/org/elasticsearch/common/settings/ScopedSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/ScopedSettingsTests.java
@@ -335,6 +335,23 @@ public class ScopedSettingsTests extends ESTestCase {
         assertThat(e3.getMessage(), equalTo("too long"));
     }
 
+    public void testValidateArchivedSetting() {
+        IndexScopedSettings settings = new IndexScopedSettings(Settings.EMPTY, IndexScopedSettings.BUILT_IN_INDEX_SETTINGS);
+        final IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> settings.validate(Settings.builder().put("archived.index.store.type", "boom").build(), false)
+        );
+        assertThat(
+            e.getMessage(),
+            equalTo(
+                "unknown setting [archived.index.store.type] was archived after upgrading, and must be removed."
+                    + " See [https://www.elastic.co/docs/deploy-manage/upgrade/deployment-or-cluster/archived-settings?version=master] "
+                    + "for details."
+            )
+        );
+
+    }
+
     public void testTupleAffixUpdateConsumer() {
         String prefix = randomAlphaOfLength(3) + "foo.";
         String intSuffix = randomAlphaOfLength(3);

--- a/server/src/test/java/org/elasticsearch/common/settings/ScopedSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/ScopedSettingsTests.java
@@ -345,7 +345,7 @@ public class ScopedSettingsTests extends ESTestCase {
             e.getMessage(),
             equalTo(
                 "unknown setting [archived.index.store.type] was archived after upgrading, and must be removed."
-                    + " See [https://www.elastic.co/docs/deploy-manage/upgrade/deployment-or-cluster/archived-settings?version=master] "
+                    + " See [https://www.elastic.co/docs/deploy-manage/upgrade/deployment-or-cluster/archived-settings?version=9.1] "
                     + "for details."
             )
         );


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Improved validation message for unknown archived settings (#138810)](https://github.com/elastic/elasticsearch/pull/138810)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)