### PR TITLE
[9.2] Add node scoped vectors.indexing.use_gpu setting (#138738)

### DIFF
--- a/docs/changelog/138738.yaml
+++ b/docs/changelog/138738.yaml
@@ -1,0 +1,5 @@
+pr: 138738
+summary: Add node scoped `vectors.indexing.use_gpu` setting
+area: Vector Search
+type: enhancement
+issues: []

--- a/x-pack/plugin/gpu/src/internalClusterTest/java/org/elasticsearch/xpack/gpu/GPUPluginInitializationWithGPUIT.java
+++ b/x-pack/plugin/gpu/src/internalClusterTest/java/org/elasticsearch/xpack/gpu/GPUPluginInitializationWithGPUIT.java
@@ -24,9 +24,6 @@ import java.util.Collection;
 import java.util.List;
 
 import static org.elasticsearch.xpack.gpu.TestVectorsFormatUtils.randomGPUSupportedSimilarity;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.startsWith;
 
 public class GPUPluginInitializationWithGPUIT extends ESIntegTestCase {
 
@@ -47,11 +44,12 @@ public class GPUPluginInitializationWithGPUIT extends ESIntegTestCase {
     }
 
     private static boolean isGpuIndexingFeatureAllowed = true;
+    private static GPUPlugin.GpuMode gpuMode = GPUPlugin.GpuMode.AUTO;
 
     public static class TestGPUPlugin extends GPUPlugin {
 
         public TestGPUPlugin() {
-            super();
+            super(Settings.builder().put("vectors.indexing.use_gpu", gpuMode.name()).build());
         }
 
         @Override
@@ -63,6 +61,7 @@ public class GPUPluginInitializationWithGPUIT extends ESIntegTestCase {
     @After
     public void reset() {
         isGpuIndexingFeatureAllowed = true;
+        gpuMode = GPUPlugin.GpuMode.AUTO;
     }
 
     @Override
@@ -70,6 +69,7 @@ public class GPUPluginInitializationWithGPUIT extends ESIntegTestCase {
         return List.of(TestGPUPlugin.class);
     }
 
+    // Feature flag disabled tests
     public void testFFOff() {
         assumeFalse("GPU_FORMAT feature flag disabled", GPUPlugin.GPU_FORMAT.isEnabled());
 
@@ -80,43 +80,15 @@ public class GPUPluginInitializationWithGPUIT extends ESIntegTestCase {
         assertNull(format);
     }
 
-    public void testFFOffIndexSettingNotSupported() {
-        assumeFalse("GPU_FORMAT feature flag disabled", GPUPlugin.GPU_FORMAT.isEnabled());
-        IllegalArgumentException exception = expectThrows(
-            IllegalArgumentException.class,
-            () -> createIndex(
-                "index1",
-                Settings.builder().put(GPUPlugin.VECTORS_INDEXING_USE_GPU_SETTING.getKey(), GPUPlugin.GpuMode.TRUE).build()
-            )
-        );
-        assertThat(exception.getMessage(), containsString("unknown setting [index.vectors.indexing.use_gpu]"));
-    }
-
-    public void testFFOffGPUFormatNull() {
-        assumeFalse("GPU_FORMAT feature flag disabled", GPUPlugin.GPU_FORMAT.isEnabled());
-
-        GPUPlugin gpuPlugin = internalCluster().getInstance(TestGPUPlugin.class);
-        VectorsFormatProvider vectorsFormatProvider = gpuPlugin.getVectorsFormatProvider();
-
-        createIndex("index1", Settings.EMPTY);
-        IndexSettings settings = getIndexSettings();
-        final var indexOptions = DenseVectorFieldTypeTests.randomGpuSupportedIndexOptions();
-
-        var format = vectorsFormatProvider.getKnnVectorsFormat(
-            settings,
-            indexOptions,
-            randomGPUSupportedSimilarity(indexOptions.getType())
-        );
-        assertNull(format);
-    }
-
-    public void testIndexSettingOnIndexAllSupported() {
+    // AUTO mode tests
+    public void testAutoModeSupportedVectorType() {
+        gpuMode = GPUPlugin.GpuMode.AUTO;
         assumeTrue("GPU_FORMAT feature flag enabled", GPUPlugin.GPU_FORMAT.isEnabled());
 
         GPUPlugin gpuPlugin = internalCluster().getInstance(TestGPUPlugin.class);
         VectorsFormatProvider vectorsFormatProvider = gpuPlugin.getVectorsFormatProvider();
 
-        createIndex("index1", Settings.builder().put(GPUPlugin.VECTORS_INDEXING_USE_GPU_SETTING.getKey(), GPUPlugin.GpuMode.TRUE).build());
+        createIndex("index1");
         IndexSettings settings = getIndexSettings();
         final var indexOptions = DenseVectorFieldTypeTests.randomGpuSupportedIndexOptions();
 
@@ -128,51 +100,54 @@ public class GPUPluginInitializationWithGPUIT extends ESIntegTestCase {
         assertNotNull(format);
     }
 
-    public void testIndexSettingOnIndexTypeNotSupportedThrows() {
+    public void testAutoModeUnsupportedVectorType() {
+        gpuMode = GPUPlugin.GpuMode.AUTO;
         assumeTrue("GPU_FORMAT feature flag enabled", GPUPlugin.GPU_FORMAT.isEnabled());
 
         GPUPlugin gpuPlugin = internalCluster().getInstance(TestGPUPlugin.class);
         VectorsFormatProvider vectorsFormatProvider = gpuPlugin.getVectorsFormatProvider();
 
-        createIndex("index1", Settings.builder().put(GPUPlugin.VECTORS_INDEXING_USE_GPU_SETTING.getKey(), GPUPlugin.GpuMode.TRUE).build());
+        createIndex("index1");
         IndexSettings settings = getIndexSettings();
         final var indexOptions = DenseVectorFieldTypeTests.randomFlatIndexOptions();
 
-        var ex = expectThrows(
-            IllegalArgumentException.class,
-            () -> vectorsFormatProvider.getKnnVectorsFormat(settings, indexOptions, randomGPUSupportedSimilarity(indexOptions.getType()))
+        var format = vectorsFormatProvider.getKnnVectorsFormat(
+            settings,
+            indexOptions,
+            randomGPUSupportedSimilarity(indexOptions.getType())
         );
-        assertThat(ex.getMessage(), startsWith("[index.vectors.indexing.use_gpu] doesn't support [index_options.type] of"));
+        assertNull(format);
     }
 
-    public void testIndexSettingOnIndexLicenseNotSupportedThrows() {
-        assumeTrue("GPU_FORMAT feature flag enabled", GPUPlugin.GPU_FORMAT.isEnabled());
+    public void testAutoModeLicenseNotSupported() {
+        gpuMode = GPUPlugin.GpuMode.AUTO;
         isGpuIndexingFeatureAllowed = false;
+        assumeTrue("GPU_FORMAT feature flag enabled", GPUPlugin.GPU_FORMAT.isEnabled());
 
         GPUPlugin gpuPlugin = internalCluster().getInstance(TestGPUPlugin.class);
         VectorsFormatProvider vectorsFormatProvider = gpuPlugin.getVectorsFormatProvider();
 
-        createIndex("index1", Settings.builder().put(GPUPlugin.VECTORS_INDEXING_USE_GPU_SETTING.getKey(), GPUPlugin.GpuMode.TRUE).build());
+        createIndex("index1");
         IndexSettings settings = getIndexSettings();
         final var indexOptions = DenseVectorFieldTypeTests.randomGpuSupportedIndexOptions();
 
-        var ex = expectThrows(
-            IllegalArgumentException.class,
-            () -> vectorsFormatProvider.getKnnVectorsFormat(settings, indexOptions, randomGPUSupportedSimilarity(indexOptions.getType()))
+        var format = vectorsFormatProvider.getKnnVectorsFormat(
+            settings,
+            indexOptions,
+            randomGPUSupportedSimilarity(indexOptions.getType())
         );
-        assertThat(
-            ex.getMessage(),
-            equalTo("[index.vectors.indexing.use_gpu] was set to [true], but GPU indexing is a [ENTERPRISE] level feature")
-        );
+        assertNull(format);
     }
 
-    public void testIndexSettingAutoAllSupported() {
+    // TRUE mode tests
+    public void testTrueModeSupportedVectorType() {
+        gpuMode = GPUPlugin.GpuMode.TRUE;
         assumeTrue("GPU_FORMAT feature flag enabled", GPUPlugin.GPU_FORMAT.isEnabled());
 
         GPUPlugin gpuPlugin = internalCluster().getInstance(TestGPUPlugin.class);
         VectorsFormatProvider vectorsFormatProvider = gpuPlugin.getVectorsFormatProvider();
 
-        createIndex("index1", Settings.builder().put(GPUPlugin.VECTORS_INDEXING_USE_GPU_SETTING.getKey(), GPUPlugin.GpuMode.AUTO).build());
+        createIndex("index1");
         IndexSettings settings = getIndexSettings();
         final var indexOptions = DenseVectorFieldTypeTests.randomGpuSupportedIndexOptions();
 
@@ -184,32 +159,14 @@ public class GPUPluginInitializationWithGPUIT extends ESIntegTestCase {
         assertNotNull(format);
     }
 
-    public void testIndexSettingAutoLicenseNotSupported() {
-        assumeTrue("GPU_FORMAT feature flag enabled", GPUPlugin.GPU_FORMAT.isEnabled());
-        isGpuIndexingFeatureAllowed = false;
-
-        GPUPlugin gpuPlugin = internalCluster().getInstance(TestGPUPlugin.class);
-        VectorsFormatProvider vectorsFormatProvider = gpuPlugin.getVectorsFormatProvider();
-
-        createIndex("index1", Settings.builder().put(GPUPlugin.VECTORS_INDEXING_USE_GPU_SETTING.getKey(), GPUPlugin.GpuMode.AUTO).build());
-        IndexSettings settings = getIndexSettings();
-        final var indexOptions = DenseVectorFieldTypeTests.randomGpuSupportedIndexOptions();
-
-        var format = vectorsFormatProvider.getKnnVectorsFormat(
-            settings,
-            indexOptions,
-            randomGPUSupportedSimilarity(indexOptions.getType())
-        );
-        assertNull(format);
-    }
-
-    public void testIndexSettingAutoIndexTypeNotSupported() {
+    public void testTrueModeUnsupportedVectorType() {
+        gpuMode = GPUPlugin.GpuMode.TRUE;
         assumeTrue("GPU_FORMAT feature flag enabled", GPUPlugin.GPU_FORMAT.isEnabled());
 
         GPUPlugin gpuPlugin = internalCluster().getInstance(TestGPUPlugin.class);
         VectorsFormatProvider vectorsFormatProvider = gpuPlugin.getVectorsFormatProvider();
 
-        createIndex("index1", Settings.builder().put(GPUPlugin.VECTORS_INDEXING_USE_GPU_SETTING.getKey(), GPUPlugin.GpuMode.AUTO).build());
+        createIndex("index1");
         IndexSettings settings = getIndexSettings();
         final var indexOptions = DenseVectorFieldTypeTests.randomFlatIndexOptions();
 
@@ -221,13 +178,35 @@ public class GPUPluginInitializationWithGPUIT extends ESIntegTestCase {
         assertNull(format);
     }
 
-    public void testIndexSettingOff() {
+    public void testTrueModeLicenseNotSupported() {
+        gpuMode = GPUPlugin.GpuMode.TRUE;
+        isGpuIndexingFeatureAllowed = false;
         assumeTrue("GPU_FORMAT feature flag enabled", GPUPlugin.GPU_FORMAT.isEnabled());
 
         GPUPlugin gpuPlugin = internalCluster().getInstance(TestGPUPlugin.class);
         VectorsFormatProvider vectorsFormatProvider = gpuPlugin.getVectorsFormatProvider();
 
-        createIndex("index1", Settings.builder().put(GPUPlugin.VECTORS_INDEXING_USE_GPU_SETTING.getKey(), GPUPlugin.GpuMode.FALSE).build());
+        createIndex("index1");
+        IndexSettings settings = getIndexSettings();
+        final var indexOptions = DenseVectorFieldTypeTests.randomGpuSupportedIndexOptions();
+
+        var format = vectorsFormatProvider.getKnnVectorsFormat(
+            settings,
+            indexOptions,
+            randomGPUSupportedSimilarity(indexOptions.getType())
+        );
+        assertNull(format);
+    }
+
+    // FALSE mode tests
+    public void testFalseModeNeverUsesGpu() {
+        gpuMode = GPUPlugin.GpuMode.FALSE;
+        assumeTrue("GPU_FORMAT feature flag enabled", GPUPlugin.GPU_FORMAT.isEnabled());
+
+        GPUPlugin gpuPlugin = internalCluster().getInstance(TestGPUPlugin.class);
+        VectorsFormatProvider vectorsFormatProvider = gpuPlugin.getVectorsFormatProvider();
+
+        createIndex("index1");
         IndexSettings settings = getIndexSettings();
         final var indexOptions = DenseVectorFieldTypeTests.randomGpuSupportedIndexOptions();
 
@@ -252,4 +231,5 @@ public class GPUPluginInitializationWithGPUIT extends ESIntegTestCase {
         assertNotNull(settings);
         return settings;
     }
+
 }

--- a/x-pack/plugin/gpu/src/internalClusterTest/java/org/elasticsearch/xpack/gpu/GPUPluginInitializationWithoutGPUIT.java
+++ b/x-pack/plugin/gpu/src/internalClusterTest/java/org/elasticsearch/xpack/gpu/GPUPluginInitializationWithoutGPUIT.java
@@ -20,8 +20,6 @@ import java.util.Collection;
 import java.util.List;
 
 import static org.elasticsearch.xpack.gpu.TestVectorsFormatUtils.randomGPUSupportedSimilarity;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
 
 public class GPUPluginInitializationWithoutGPUIT extends ESIntegTestCase {
 
@@ -29,63 +27,38 @@ public class GPUPluginInitializationWithoutGPUIT extends ESIntegTestCase {
         TestCuVSServiceProvider.mockedGPUInfoProvider = p -> new TestCuVSServiceProvider.TestGPUInfoProvider(List.of());
     }
 
+    public static class TestGPUPlugin extends GPUPlugin {
+        public TestGPUPlugin() {
+            super(Settings.EMPTY);
+        }
+    }
+
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return List.of(GPUPlugin.class);
+        return List.of(TestGPUPlugin.class);
     }
 
     public void testFFOff() {
         assumeFalse("GPU_FORMAT feature flag disabled", GPUPlugin.GPU_FORMAT.isEnabled());
 
-        GPUPlugin gpuPlugin = internalCluster().getInstance(GPUPlugin.class);
+        TestGPUPlugin gpuPlugin = internalCluster().getInstance(TestGPUPlugin.class);
         VectorsFormatProvider vectorsFormatProvider = gpuPlugin.getVectorsFormatProvider();
 
         var format = vectorsFormatProvider.getKnnVectorsFormat(null, null, null);
         assertNull(format);
     }
 
-    public void testFFOffIndexSettingNotSupported() {
-        assumeFalse("GPU_FORMAT feature flag disabled", GPUPlugin.GPU_FORMAT.isEnabled());
-        IllegalArgumentException exception = expectThrows(
-            IllegalArgumentException.class,
-            () -> createIndex(
-                "index1",
-                Settings.builder().put(GPUPlugin.VECTORS_INDEXING_USE_GPU_SETTING.getKey(), GPUPlugin.GpuMode.TRUE).build()
-            )
-        );
-        assertThat(exception.getMessage(), containsString("unknown setting [index.vectors.indexing.use_gpu]"));
-    }
-
-    public void testIndexSettingOnGPUNotSupportedThrows() {
+    public void testAutoModeWithoutGPU() {
         assumeTrue("GPU_FORMAT feature flag enabled", GPUPlugin.GPU_FORMAT.isEnabled());
 
-        GPUPlugin gpuPlugin = internalCluster().getInstance(GPUPlugin.class);
+        TestGPUPlugin gpuPlugin = internalCluster().getInstance(TestGPUPlugin.class);
         VectorsFormatProvider vectorsFormatProvider = gpuPlugin.getVectorsFormatProvider();
 
-        createIndex("index1", Settings.builder().put(GPUPlugin.VECTORS_INDEXING_USE_GPU_SETTING.getKey(), GPUPlugin.GpuMode.TRUE).build());
+        createIndex("index1");
         IndexSettings settings = getIndexSettings();
         final var indexOptions = DenseVectorFieldTypeTests.randomGpuSupportedIndexOptions();
 
-        var ex = expectThrows(
-            IllegalArgumentException.class,
-            () -> vectorsFormatProvider.getKnnVectorsFormat(settings, indexOptions, randomGPUSupportedSimilarity(indexOptions.getType()))
-        );
-        assertThat(
-            ex.getMessage(),
-            equalTo("[index.vectors.indexing.use_gpu] was set to [true], but GPU resources are not accessible on the node.")
-        );
-    }
-
-    public void testIndexSettingAutoGPUNotSupported() {
-        assumeTrue("GPU_FORMAT feature flag enabled", GPUPlugin.GPU_FORMAT.isEnabled());
-
-        GPUPlugin gpuPlugin = internalCluster().getInstance(GPUPlugin.class);
-        VectorsFormatProvider vectorsFormatProvider = gpuPlugin.getVectorsFormatProvider();
-
-        createIndex("index1", Settings.builder().put(GPUPlugin.VECTORS_INDEXING_USE_GPU_SETTING.getKey(), GPUPlugin.GpuMode.AUTO).build());
-        IndexSettings settings = getIndexSettings();
-        final var indexOptions = DenseVectorFieldTypeTests.randomGpuSupportedIndexOptions();
-
+        // With AUTO mode (default) and no GPU, should return null (fallback to CPU)
         var format = vectorsFormatProvider.getKnnVectorsFormat(
             settings,
             indexOptions,

--- a/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/GPUPlugin.java
+++ b/x-pack/plugin/gpu/src/main/java/org/elasticsearch/xpack/gpu/GPUPlugin.java
@@ -8,7 +8,11 @@
 package org.elasticsearch.xpack.gpu;
 
 import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.elasticsearch.bootstrap.BootstrapCheck;
+import org.elasticsearch.bootstrap.BootstrapContext;
+import org.elasticsearch.common.ReferenceDocs;
 import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.FeatureFlag;
 import org.elasticsearch.gpu.GPUSupport;
 import org.elasticsearch.gpu.codec.ES92GpuHnswSQVectorsFormat;
@@ -28,8 +32,14 @@ public class GPUPlugin extends Plugin implements InternalVectorFormatProviderPlu
 
     private static final License.OperationMode MINIMUM_ALLOWED_LICENSE = License.OperationMode.ENTERPRISE;
 
+    private final GpuMode gpuMode;
+
+    public GPUPlugin(Settings settings) {
+        this.gpuMode = VECTORS_INDEXING_USE_GPU_NODE_SETTING.get(settings);
+    }
+
     /**
-     * An enum for the tri-state value of the `index.vectors.indexing.use_gpu` setting.
+     * An enum for the tri-state value of the `vectors.indexing.use_gpu` setting.
      */
     public enum GpuMode {
         TRUE,
@@ -38,26 +48,25 @@ public class GPUPlugin extends Plugin implements InternalVectorFormatProviderPlu
     }
 
     /**
-     * Setting to control whether to use GPU for vectors indexing.
-     * Currently only applicable for index_options.type: hnsw.
+     * Node-level setting to control whether to use GPU for vectors indexing across the node.
+     * This is a static, node-scoped setting.
      *
-     * If unset or "auto", an automatic decision is made based on the presence of GPU, necessary libraries, vectors' index type.
+     * If unset or "auto", an automatic decision is made based on the presence of GPU and necessary libraries.
      * If set to <code>true</code>, GPU must be used for vectors indexing, and if GPU or necessary libraries are not available,
-     * an exception will be thrown.
+     * the node will refuse to start and throw an exception.
      * If set to <code>false</code>, GPU will not be used for vectors indexing.
      */
-    public static final Setting<GpuMode> VECTORS_INDEXING_USE_GPU_SETTING = Setting.enumSetting(
+    public static final Setting<GpuMode> VECTORS_INDEXING_USE_GPU_NODE_SETTING = Setting.enumSetting(
         GpuMode.class,
-        "index.vectors.indexing.use_gpu",
+        "vectors.indexing.use_gpu",
         GpuMode.AUTO,
-        Setting.Property.IndexScope,
-        Setting.Property.Dynamic
+        Setting.Property.NodeScope
     );
 
     @Override
     public List<Setting<?>> getSettings() {
         if (GPU_FORMAT.isEnabled()) {
-            return List.of(VECTORS_INDEXING_USE_GPU_SETTING);
+            return List.of(VECTORS_INDEXING_USE_GPU_NODE_SETTING);
         } else {
             return List.of();
         }
@@ -70,34 +79,45 @@ public class GPUPlugin extends Plugin implements InternalVectorFormatProviderPlu
     }
 
     @Override
+    public List<BootstrapCheck> getBootstrapChecks() {
+        if (GPU_FORMAT.isEnabled()) {
+            return List.of(new GpuModeBootstrapCheck());
+        } else {
+            return List.of();
+        }
+    }
+
+    /**
+     * Bootstrap check to ensure GPU is available when vectors.indexing.use_gpu is set to true.
+     * Refuses to start the node if GPU support is required but not available.
+     */
+    static class GpuModeBootstrapCheck implements BootstrapCheck {
+        @Override
+        public BootstrapCheckResult check(BootstrapContext context) {
+            Settings settings = context.settings();
+            GpuMode gpuMode = VECTORS_INDEXING_USE_GPU_NODE_SETTING.get(settings);
+
+            if (gpuMode == GpuMode.TRUE && GPUSupport.isSupported() == false) {
+                return BootstrapCheckResult.failure(
+                    "vectors.indexing.use_gpu is set to [true], but GPU resources are not accessible on this node. Check logs for details."
+                );
+            }
+
+            return BootstrapCheckResult.success();
+        }
+
+        @Override
+        public ReferenceDocs referenceDocs() {
+            return ReferenceDocs.BOOTSTRAP_CHECKS;
+        }
+    }
+
+    @Override
     public VectorsFormatProvider getVectorsFormatProvider() {
         return (indexSettings, indexOptions, similarity) -> {
-            if (GPU_FORMAT.isEnabled()) {
-                GpuMode gpuMode = indexSettings.getValue(VECTORS_INDEXING_USE_GPU_SETTING);
-                if (gpuMode == GpuMode.TRUE) {
-                    if (vectorIndexTypeSupported(indexOptions.getType()) == false) {
-                        throw new IllegalArgumentException(
-                            "[index.vectors.indexing.use_gpu] doesn't support [index_options.type] of [" + indexOptions.getType() + "]."
-                        );
-                    }
-                    if (GPUSupport.isSupported() == false) {
-                        throw new IllegalArgumentException(
-                            "[index.vectors.indexing.use_gpu] was set to [true], but GPU resources are not accessible on the node."
-                        );
-                    }
-                    if (isGpuIndexingFeatureAllowed() == false) {
-                        throw new IllegalArgumentException(
-                            "[index.vectors.indexing.use_gpu] was set to [true], but GPU indexing is a ["
-                                + MINIMUM_ALLOWED_LICENSE
-                                + "] level feature"
-                        );
-                    }
-                    return getVectorsFormat(indexOptions, similarity);
-                }
-                if (gpuMode == GpuMode.AUTO
-                    && vectorIndexTypeSupported(indexOptions.getType())
-                    && GPUSupport.isSupported()
-                    && isGpuIndexingFeatureAllowed()) {
+            if (GPU_FORMAT.isEnabled() && isGpuIndexingFeatureAllowed()) {
+                if ((gpuMode == GpuMode.TRUE || (gpuMode == GpuMode.AUTO && GPUSupport.isSupported()))
+                    && vectorIndexTypeSupported(indexOptions.getType())) {
                     return getVectorsFormat(indexOptions, similarity);
                 }
             }

--- a/x-pack/plugin/gpu/src/test/java/org/elasticsearch/xpack/gpu/GPUDenseVectorFieldMapperTests.java
+++ b/x-pack/plugin/gpu/src/test/java/org/elasticsearch/xpack/gpu/GPUDenseVectorFieldMapperTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.gpu;
 
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.gpu.GPUSupport;
 import org.elasticsearch.index.codec.CodecService;
@@ -34,7 +35,7 @@ public class GPUDenseVectorFieldMapperTests extends DenseVectorFieldMapperTests 
 
     @Override
     protected Collection<Plugin> getPlugins() {
-        var plugin = new GPUPlugin() {
+        var plugin = new GPUPlugin(Settings.EMPTY) {
             @Override
             protected boolean isGpuIndexingFeatureAllowed() {
                 return true;

--- a/x-pack/plugin/gpu/src/test/java/org/elasticsearch/xpack/gpu/GPUPluginBootstrapCheckTests.java
+++ b/x-pack/plugin/gpu/src/test/java/org/elasticsearch/xpack/gpu/GPUPluginBootstrapCheckTests.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.gpu;
+
+import org.elasticsearch.bootstrap.BootstrapContext;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.gpu.GPUSupport;
+import org.elasticsearch.test.AbstractBootstrapCheckTestCase;
+
+import static org.hamcrest.Matchers.containsString;
+
+public class GPUPluginBootstrapCheckTests extends AbstractBootstrapCheckTestCase {
+
+    public void testNodeSettingTrueWithoutGPUFails() {
+        assumeTrue("GPU_FORMAT feature flag enabled", GPUPlugin.GPU_FORMAT.isEnabled());
+        assumeFalse("GPU not supported on this environment", GPUSupport.isSupported());
+
+        Settings settings = Settings.builder()
+            .put(GPUPlugin.VECTORS_INDEXING_USE_GPU_NODE_SETTING.getKey(), GPUPlugin.GpuMode.TRUE)
+            .build();
+
+        BootstrapContext context = createTestContext(settings, Metadata.EMPTY_METADATA);
+        var check = new GPUPlugin.GpuModeBootstrapCheck();
+
+        var result = check.check(context);
+        assertTrue("Bootstrap check should fail when GPU setting is TRUE but GPU is not supported", result.isFailure());
+        assertThat(
+            result.getMessage(),
+            containsString("vectors.indexing.use_gpu is set to [true], but GPU resources are not accessible on this node")
+        );
+    }
+
+    public void testNodeSettingTrueWithGPUSucceeds() {
+        assumeTrue("GPU_FORMAT feature flag enabled", GPUPlugin.GPU_FORMAT.isEnabled());
+        assumeTrue("GPU supported on this environment", GPUSupport.isSupported());
+
+        Settings settings = Settings.builder()
+            .put(GPUPlugin.VECTORS_INDEXING_USE_GPU_NODE_SETTING.getKey(), GPUPlugin.GpuMode.TRUE)
+            .build();
+
+        BootstrapContext context = createTestContext(settings, Metadata.EMPTY_METADATA);
+        var check = new GPUPlugin.GpuModeBootstrapCheck();
+
+        var result = check.check(context);
+        assertTrue("Bootstrap check should succeed when GPU setting is TRUE and GPU is supported", result.isSuccess());
+    }
+
+    public void testNodeSettingAutoWithoutGPUSucceeds() {
+        assumeTrue("GPU_FORMAT feature flag enabled", GPUPlugin.GPU_FORMAT.isEnabled());
+
+        Settings settings = Settings.builder()
+            .put(GPUPlugin.VECTORS_INDEXING_USE_GPU_NODE_SETTING.getKey(), GPUPlugin.GpuMode.AUTO)
+            .build();
+
+        BootstrapContext context = createTestContext(settings, Metadata.EMPTY_METADATA);
+        var check = new GPUPlugin.GpuModeBootstrapCheck();
+
+        var result = check.check(context);
+        assertTrue("Bootstrap check should succeed when GPU setting is AUTO", result.isSuccess());
+    }
+
+    public void testNodeSettingFalseWithoutGPUSucceeds() {
+        assumeTrue("GPU_FORMAT feature flag enabled", GPUPlugin.GPU_FORMAT.isEnabled());
+
+        Settings settings = Settings.builder()
+            .put(GPUPlugin.VECTORS_INDEXING_USE_GPU_NODE_SETTING.getKey(), GPUPlugin.GpuMode.FALSE)
+            .build();
+
+        BootstrapContext context = createTestContext(settings, Metadata.EMPTY_METADATA);
+        var check = new GPUPlugin.GpuModeBootstrapCheck();
+
+        var result = check.check(context);
+        assertTrue("Bootstrap check should succeed when GPU setting is FALSE", result.isSuccess());
+    }
+
+    public void testNodeSettingDefaultAutoSucceeds() {
+        assumeTrue("GPU_FORMAT feature flag enabled", GPUPlugin.GPU_FORMAT.isEnabled());
+
+        // Don't set the setting - use default (AUTO)
+        Settings settings = Settings.EMPTY;
+
+        BootstrapContext context = createTestContext(settings, Metadata.EMPTY_METADATA);
+        var check = new GPUPlugin.GpuModeBootstrapCheck();
+
+        var result = check.check(context);
+        assertTrue("Bootstrap check should succeed with default setting (AUTO)", result.isSuccess());
+    }
+
+    public void testBootstrapCheckReferenceDocs() {
+        assumeTrue("GPU_FORMAT feature flag enabled", GPUPlugin.GPU_FORMAT.isEnabled());
+
+        var check = new GPUPlugin.GpuModeBootstrapCheck();
+        assertNotNull("referenceDocs should return a non-null value", check.referenceDocs());
+    }
+}

--- a/x-pack/plugin/gpu/src/yamlRestTest/java/org/elasticsearch/xpack/gpu/GPUClientYamlTestSuiteIT.java
+++ b/x-pack/plugin/gpu/src/yamlRestTest/java/org/elasticsearch/xpack/gpu/GPUClientYamlTestSuiteIT.java
@@ -31,6 +31,7 @@ public class GPUClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
             .module("gpu")
             .setting("xpack.license.self_generated.type", "trial")
             .setting("xpack.security.enabled", "false")
+            .setting("vectors.indexing.use_gpu", "true")
             // Needed to get access to raw vectors from Lucene scorers
             .jvmArg("--add-opens=org.apache.lucene.core/org.apache.lucene.codecs.lucene99=org.elasticsearch.server")
             .jvmArg("--add-opens=org.apache.lucene.core/org.apache.lucene.codecs.hnsw=org.elasticsearch.server")

--- a/x-pack/plugin/gpu/src/yamlRestTest/resources/rest-api-spec/test/gpu/10_hnsw.yml
+++ b/x-pack/plugin/gpu/src/yamlRestTest/resources/rest-api-spec/test/gpu/10_hnsw.yml
@@ -5,7 +5,6 @@
       cluster_features: [ "vectors.indexing.use_gpu" ]
       reason: "A cluster should have a GPU plugin to run these tests"
 
-  # creating an index is successful even if the GPU is not available
   - do:
       indices.create:
         index: my_vectors
@@ -20,7 +19,6 @@
                   type: hnsw
           settings:
             index.number_of_shards: 1
-            index.vectors.indexing.use_gpu: true
   - match: { error: null }
 
 

--- a/x-pack/plugin/gpu/src/yamlRestTest/resources/rest-api-spec/test/gpu/20_int8_hnsw.yml
+++ b/x-pack/plugin/gpu/src/yamlRestTest/resources/rest-api-spec/test/gpu/20_int8_hnsw.yml
@@ -5,7 +5,6 @@
       cluster_features: [ "vectors.indexing.use_gpu" ]
       reason: "A cluster should have a GPU plugin to run these tests"
 
-  # creating an index is successful even if the GPU is not available
   - do:
       indices.create:
         index: my_vectors
@@ -20,7 +19,6 @@
                   type: int8_hnsw
           settings:
             index.number_of_shards: 1
-            index.vectors.indexing.use_gpu: true
             index.refresh_interval: -1 # disable automatic refresh to ensure documents are indexed together
   - match: { error: null }
 


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Add node scoped vectors.indexing.use_gpu setting (#138738)