### PR TITLE
Speed up LeafCollector#setScorer in TopHitsAggregator

### DIFF
--- a/docs/changelog/138883.yaml
+++ b/docs/changelog/138883.yaml
@@ -1,0 +1,5 @@
+pr: 138883
+summary: Speed up `LeafCollector#setScorer` in `TopHitsAggregator`
+area: Search
+type: bug
+issues: []


### PR DESCRIPTION
This is a fix for a performance bug reported in this [discuss](https://discuss.elastic.co/t/re-massive-performance-drop-for-certain-queries-in-es9-compared-to-es8) issue. 

In lucene 10.3 there was [this change](https://github.com/apache/lucene/pull/14976) to speed up must not queries. The change has the side effect that we might be calling `LeafCollector#setScorer` many more times than before. This is probably ok because it is expected to be a cheap method.

TopHitsAggregator contains an implementation of `LeafCollector#setScorer` that can be expensive if the aggregator is part of a multi-bucket aggregator. Whenever we set the scorer we are looping over all buckets to set the scorer. 

Therefore, this commit proposes to introduce a wrapper for the Scorable that is shared by all the buckets so we only need to change it in one place when present. 
