### PR TITLE
Make it possible to use projectRouting as a builder

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlQueryRequest.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlQueryRequest.java
@@ -323,8 +323,9 @@ public class EsqlQueryRequest extends org.elasticsearch.xpack.core.esql.action.E
         this.acceptedPragmaRisks = accepted;
     }
 
-    public void projectRouting(String projectRouting) {
+    public EsqlQueryRequest projectRouting(String projectRouting) {
         this.projectRouting = projectRouting;
+        return this;
     }
 
     public String projectRouting() {


### PR DESCRIPTION
Similar to most of the other setters in EsqlQueryRequest, this makes `projectRouting` return current request instance so that it could be used as part of the request chain/builder:
`syncEsqlQueryRequest("FROM *").projectRouting(..).includeExecutionMetadata(true)`