### PR TITLE
[Entitlements] Forbidden paths

### DIFF
--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/FileCheckActions.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/FileCheckActions.java
@@ -591,6 +591,42 @@ class FileCheckActions {
         Files.createFile(file);
     }
 
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
+    static void readAccessForbiddenJvmOptionsFile(Environment environment) throws IOException {
+        var file = environment.configDir().resolve("jvm.options");
+        Files.readAllBytes(file);
+    }
+
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
+    static void readAccessForbiddenElasticsearchYmlFile(Environment environment) throws IOException {
+        var file = environment.configDir().resolve("elasticsearch.yml");
+        Files.readAllBytes(file);
+    }
+
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
+    static void readAccessForbiddenJvmOptionsDirectory(Environment environment) throws IOException {
+        var file = environment.configDir().resolve("jvm.options.d");
+        Files.isDirectory(file);
+    }
+
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
+    static void writeAccessForbiddenJvmOptionsFile(Environment environment) throws IOException {
+        var file = environment.configDir().resolve("jvm.options");
+        Files.newBufferedWriter(file).close();
+    }
+
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
+    static void writeAccessForbiddenElasticsearchYmlFile(Environment environment) throws IOException {
+        var file = environment.configDir().resolve("elasticsearch.yml");
+        Files.newBufferedWriter(file).close();
+    }
+
+    @EntitlementTest(expectedAccess = ALWAYS_DENIED)
+    static void writerAccessForbiddenJvmOptionsDirectory(Environment environment) throws IOException {
+        var file = environment.configDir().resolve("jvm.options.d").resolve("foo");
+        Files.newBufferedWriter(file).close();
+    }
+
     @EntitlementTest(expectedAccess = ALWAYS_ALLOWED)
     static void readAccessSourcePath() throws URISyntaxException {
         var sourcePath = Paths.get(EntitlementTestPlugin.class.getProtectionDomain().getCodeSource().getLocation().toURI());

--- a/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/RestEntitlementsCheckAction.java
+++ b/libs/entitlement/qa/entitlement-test-plugin/src/main/java/org/elasticsearch/entitlement/qa/test/RestEntitlementsCheckAction.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 
 import static java.util.Map.entry;
 import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAccess.ALWAYS_ALLOWED;
+import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAccess.ALWAYS_DENIED;
 import static org.elasticsearch.entitlement.qa.test.EntitlementTest.ExpectedAccess.PLUGINS;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
@@ -150,6 +151,14 @@ public class RestEntitlementsCheckAction extends BaseRestHandler {
         return checkActions.entrySet()
             .stream()
             .filter(kv -> kv.getValue().expectedAccess().equals(ALWAYS_ALLOWED))
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toSet());
+    }
+
+    public static Set<String> getAlwaysDeniedCheckActions() {
+        return checkActions.entrySet()
+            .stream()
+            .filter(kv -> kv.getValue().expectedAccess().equals(ALWAYS_DENIED))
             .map(Map.Entry::getKey)
             .collect(Collectors.toSet());
     }

--- a/libs/entitlement/qa/src/javaRestTest/java/org/elasticsearch/entitlement/qa/AbstractEntitlementsIT.java
+++ b/libs/entitlement/qa/src/javaRestTest/java/org/elasticsearch/entitlement/qa/AbstractEntitlementsIT.java
@@ -46,7 +46,11 @@ public abstract class AbstractEntitlementsIT extends ESRestTestCase {
                     Map.of("path", tempDir.resolve("read_dir"), "mode", "read"),
                     Map.of("path", tempDir.resolve("read_write_dir"), "mode", "read_write"),
                     Map.of("path", tempDir.resolve("read_file"), "mode", "read"),
-                    Map.of("path", tempDir.resolve("read_write_file"), "mode", "read_write")
+                    Map.of("path", tempDir.resolve("read_write_file"), "mode", "read_write"),
+                    // Try to grant explicit access to forbidden files (and test this is not possible in any case)
+                    Map.of("relative_path", "jvm.options.d", "relative_to", "config", "mode", "read_write"),
+                    Map.of("relative_path", "jvm.options", "relative_to", "config", "mode", "read_write"),
+                    Map.of("relative_path", "elasticsearch.yml", "relative_to", "config", "mode", "read_write")
                 )
             )
         );

--- a/libs/entitlement/qa/src/javaRestTest/java/org/elasticsearch/entitlement/qa/EntitlementsAlwaysDeniedIT.java
+++ b/libs/entitlement/qa/src/javaRestTest/java/org/elasticsearch/entitlement/qa/EntitlementsAlwaysDeniedIT.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlement.qa;
+
+import com.carrotsearch.randomizedtesting.annotations.Name;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.elasticsearch.entitlement.qa.test.RestEntitlementsCheckAction;
+import org.junit.ClassRule;
+
+/**
+ * Actions denied even when we allow them via explicit entitlements
+ */
+public class EntitlementsAlwaysDeniedIT extends AbstractEntitlementsIT {
+
+    @ClassRule
+    public static EntitlementsTestRule testRule = new EntitlementsTestRule(true, ALLOWED_TEST_ENTITLEMENTS);
+
+    public EntitlementsAlwaysDeniedIT(@Name("actionName") String actionName) {
+        super(actionName, false);
+    }
+
+    @ParametersFactory
+    public static Iterable<Object[]> data() {
+        return RestEntitlementsCheckAction.getAlwaysDeniedCheckActions().stream().map(action -> new Object[] { action }).toList();
+    }
+
+    @Override
+    protected String getTestRestCluster() {
+        return testRule.cluster.getHttpAddresses();
+    }
+}

--- a/libs/entitlement/qa/src/javaRestTest/java/org/elasticsearch/entitlement/qa/EntitlementsAlwaysDeniedNonModularIT.java
+++ b/libs/entitlement/qa/src/javaRestTest/java/org/elasticsearch/entitlement/qa/EntitlementsAlwaysDeniedNonModularIT.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.entitlement.qa;
+
+import com.carrotsearch.randomizedtesting.annotations.Name;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.elasticsearch.entitlement.qa.test.RestEntitlementsCheckAction;
+import org.junit.ClassRule;
+
+/**
+ * Actions denied even when we allow them via explicit entitlements
+ */
+public class EntitlementsAlwaysDeniedNonModularIT extends AbstractEntitlementsIT {
+
+    @ClassRule
+    public static EntitlementsTestRule testRule = new EntitlementsTestRule(false, ALLOWED_TEST_ENTITLEMENTS);
+
+    public EntitlementsAlwaysDeniedNonModularIT(@Name("actionName") String actionName) {
+        super(actionName, false);
+    }
+
+    @ParametersFactory
+    public static Iterable<Object[]> data() {
+        return RestEntitlementsCheckAction.getAlwaysDeniedCheckActions().stream().map(action -> new Object[] { action }).toList();
+    }
+
+    @Override
+    protected String getTestRestCluster() {
+        return testRule.cluster.getHttpAddresses();
+    }
+}

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/bootstrap/FilesEntitlementsValidation.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/bootstrap/FilesEntitlementsValidation.java
@@ -45,7 +45,7 @@ class FilesEntitlementsValidation {
                     .map(x -> ((FilesEntitlement) x))
                     .findFirst();
                 if (filesEntitlement.isPresent()) {
-                    var fileAccessTree = FileAccessTree.withoutExclusivePaths(filesEntitlement.get(), pathLookup, List.of());
+                    var fileAccessTree = FileAccessTree.withoutExclusivePaths(filesEntitlement.get(), pathLookup, List.of(), List.of());
                     validateReadFilesEntitlements(pluginPolicy.getKey(), scope.moduleName(), fileAccessTree, readAccessForbidden);
                     validateWriteFilesEntitlements(pluginPolicy.getKey(), scope.moduleName(), fileAccessTree, writeAccessForbidden);
                 }

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTree.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTree.java
@@ -90,7 +90,7 @@ import static org.elasticsearch.entitlement.runtime.policy.entitlements.FilesEnt
  * Permission is granted if both:
  * <ul>
  * <li>
- * there is no match in exclusivePaths, and
+ * there is no match in {@link FileAccessTree#forbiddenPaths}, and
  * </li>
  * <li>
  * there is a match in the array corresponding to the desired operation (read or write).
@@ -187,10 +187,11 @@ public final class FileAccessTree {
 
     private final FileAccessTreeComparison comparison;
     /**
-     * lists paths that are forbidden for this component+module because some other component has granted exclusive access to one of its
-     * modules
+     * lists paths that are forbidden for this component+module
+     * A path can be forbidden unconditionally, or because some other component has granted exclusive
+     * access to one of its modules
      */
-    private final String[] exclusivePaths;
+    private final String[] forbiddenPaths;
     /**
      * lists paths for which the component has granted read or read_write access to the module
      */
@@ -200,20 +201,21 @@ public final class FileAccessTree {
      */
     private final String[] writePaths;
 
-    private static String[] buildUpdatedAndSortedExclusivePaths(
+    private static String[] buildFinalSortedForbiddenPaths(
         String componentName,
         String moduleName,
         List<ExclusivePath> exclusivePaths,
+        Collection<String> forbiddenPaths,
         FileAccessTreeComparison comparison
     ) {
-        List<String> updatedExclusivePaths = new ArrayList<>();
+        List<String> finalForbiddenPathList = new ArrayList<>(forbiddenPaths);
         for (ExclusivePath exclusivePath : exclusivePaths) {
             if (exclusivePath.componentName().equals(componentName) == false || exclusivePath.moduleNames().contains(moduleName) == false) {
-                updatedExclusivePaths.add(exclusivePath.path());
+                finalForbiddenPathList.add(exclusivePath.path());
             }
         }
-        updatedExclusivePaths.sort(comparison.pathComparator());
-        return updatedExclusivePaths.toArray(new String[0]);
+        finalForbiddenPathList.sort(comparison.pathComparator());
+        return finalForbiddenPathList.toArray(new String[0]);
     }
 
     FileAccessTree(
@@ -276,14 +278,14 @@ public final class FileAccessTree {
         readPaths.sort(comparison.pathComparator());
         writePaths.sort(comparison.pathComparator());
 
-        this.exclusivePaths = sortedExclusivePaths;
+        this.forbiddenPaths = sortedExclusivePaths;
         this.readPaths = pruneSortedPaths(readPaths, comparison).toArray(new String[0]);
         this.writePaths = pruneSortedPaths(writePaths, comparison).toArray(new String[0]);
 
         logger.debug(
             () -> Strings.format(
-                "Created FileAccessTree with paths: exclusive [%s], read [%s], write [%s]",
-                String.join(",", this.exclusivePaths),
+                "Created FileAccessTree with paths: forbidden [%s], read [%s], write [%s]",
+                String.join(",", this.forbiddenPaths),
                 String.join(",", this.readPaths),
                 String.join(",", this.writePaths)
             )
@@ -313,13 +315,14 @@ public final class FileAccessTree {
         FilesEntitlement filesEntitlement,
         PathLookup pathLookup,
         Collection<Path> componentPaths,
-        List<ExclusivePath> exclusivePaths
+        List<ExclusivePath> exclusivePaths,
+        Collection<String> forbiddenPaths
     ) {
         return new FileAccessTree(
             filesEntitlement,
             pathLookup,
             componentPaths,
-            buildUpdatedAndSortedExclusivePaths(componentName, moduleName, exclusivePaths, DEFAULT_COMPARISON),
+            buildFinalSortedForbiddenPaths(componentName, moduleName, exclusivePaths, forbiddenPaths, DEFAULT_COMPARISON),
             DEFAULT_COMPARISON
         );
     }
@@ -330,9 +333,12 @@ public final class FileAccessTree {
     public static FileAccessTree withoutExclusivePaths(
         FilesEntitlement filesEntitlement,
         PathLookup pathLookup,
+        Collection<String> forbiddenPaths,
         Collection<Path> componentPaths
     ) {
-        return new FileAccessTree(filesEntitlement, pathLookup, componentPaths, new String[0], DEFAULT_COMPARISON);
+        return new FileAccessTree(filesEntitlement, pathLookup, componentPaths,
+            forbiddenPaths.stream().sorted(DEFAULT_COMPARISON.pathComparator()).toArray(String[]::new),
+            DEFAULT_COMPARISON);
     }
 
     public boolean canRead(Path path) {
@@ -368,8 +374,8 @@ public final class FileAccessTree {
             return false;
         }
 
-        int endx = Arrays.binarySearch(exclusivePaths, path, comparison.pathComparator());
-        if (endx < -1 && comparison.isParent(exclusivePaths[-endx - 2], path) || endx >= 0) {
+        int endx = Arrays.binarySearch(forbiddenPaths, path, comparison.pathComparator());
+        if (endx < -1 && comparison.isParent(forbiddenPaths[-endx - 2], path) || endx >= 0) {
             return false;
         }
 

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTree.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTree.java
@@ -336,9 +336,13 @@ public final class FileAccessTree {
         Collection<String> forbiddenPaths,
         Collection<Path> componentPaths
     ) {
-        return new FileAccessTree(filesEntitlement, pathLookup, componentPaths,
+        return new FileAccessTree(
+            filesEntitlement,
+            pathLookup,
+            componentPaths,
             forbiddenPaths.stream().sorted(DEFAULT_COMPARISON.pathComparator()).toArray(String[]::new),
-            DEFAULT_COMPARISON);
+            DEFAULT_COMPARISON
+        );
     }
 
     public boolean canRead(Path path) {

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
@@ -151,7 +151,7 @@ public class PolicyManager {
     }
 
     private FileAccessTree getDefaultFileAccess(Collection<Path> componentPaths) {
-        return FileAccessTree.withoutExclusivePaths(FilesEntitlement.EMPTY, pathLookup, componentPaths);
+        return FileAccessTree.withoutExclusivePaths(FilesEntitlement.EMPTY, pathLookup, forbiddenPaths, componentPaths);
     }
 
     // pkg private for testing
@@ -176,7 +176,7 @@ public class PolicyManager {
             componentName,
             moduleName,
             entitlements.stream().collect(groupingBy(Entitlement::getClass)),
-            FileAccessTree.of(componentName, moduleName, filesEntitlement, pathLookup, componentPaths, exclusivePaths)
+            FileAccessTree.of(componentName, moduleName, filesEntitlement, pathLookup, componentPaths, exclusivePaths, forbiddenPaths)
         );
     }
 
@@ -226,6 +226,22 @@ public class PolicyManager {
      */
     private final List<ExclusivePath> exclusivePaths;
 
+    /**
+     * Paths for which we never want to allow access to, from any component
+     */
+    private final Set<String> forbiddenPaths;
+
+    private static Set<String> createForbiddenPaths(PathLookup pathLookup) {
+        return pathLookup.getBaseDirPaths(PathLookup.BaseDir.CONFIG)
+            .flatMap(baseDir ->
+                Stream.of(
+                    baseDir.resolve("elasticsearch.yml"),
+                    baseDir.resolve("jvm.options"),
+                    baseDir.resolve("jvm.options.d")))
+            .map(FileAccessTree::normalizePath)
+            .collect(Collectors.toSet());
+    }
+
     public PolicyManager(
         Policy serverPolicy,
         List<Entitlement> apmAgentEntitlements,
@@ -260,6 +276,7 @@ public class PolicyManager {
         );
         FileAccessTree.validateExclusivePaths(exclusivePaths, FileAccessTree.DEFAULT_COMPARISON);
         this.exclusivePaths = exclusivePaths;
+        this.forbiddenPaths = createForbiddenPaths(pathLookup);
     }
 
     private static Map<String, List<Entitlement>> buildScopeEntitlementsMap(Policy policy) {

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyManager.java
@@ -233,11 +233,9 @@ public class PolicyManager {
 
     private static Set<String> createForbiddenPaths(PathLookup pathLookup) {
         return pathLookup.getBaseDirPaths(PathLookup.BaseDir.CONFIG)
-            .flatMap(baseDir ->
-                Stream.of(
-                    baseDir.resolve("elasticsearch.yml"),
-                    baseDir.resolve("jvm.options"),
-                    baseDir.resolve("jvm.options.d")))
+            .flatMap(
+                baseDir -> Stream.of(baseDir.resolve("elasticsearch.yml"), baseDir.resolve("jvm.options"), baseDir.resolve("jvm.options.d"))
+            )
             .map(FileAccessTree::normalizePath)
             .collect(Collectors.toSet());
     }

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTreeTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTreeTests.java
@@ -23,10 +23,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.core.PathUtils.getDefaultFileSystem;
 import static org.elasticsearch.entitlement.runtime.policy.FileAccessTree.buildExclusivePathList;
@@ -51,10 +54,6 @@ public class FileAccessTreeTests extends ESTestCase {
         settings = Settings.EMPTY;
     }
 
-    private static Path path(String s) {
-        return root.resolve(s);
-    }
-
     private static final PathLookup TEST_PATH_LOOKUP = new PathLookupImpl(
         Path.of("/home"),
         Path.of("/config"),
@@ -71,13 +70,13 @@ public class FileAccessTreeTests extends ESTestCase {
     );
 
     public void testEmpty() {
-        var tree = accessTree(FilesEntitlement.EMPTY, List.of());
+        var tree = accessTree(FilesEntitlement.EMPTY);
         assertThat(tree.canRead(path("path")), is(false));
         assertThat(tree.canWrite(path("path")), is(false));
     }
 
     public void testRead() {
-        var tree = accessTree(entitlement("foo", "read"), List.of());
+        var tree = accessTree(entitlement("foo", "read"));
         assertThat(tree.canRead(path("foo")), is(true));
         assertThat(tree.canRead(path("foo/subdir")), is(true));
         assertThat(tree.canRead(path("food")), is(false));
@@ -89,7 +88,7 @@ public class FileAccessTreeTests extends ESTestCase {
     }
 
     public void testWrite() {
-        var tree = accessTree(entitlement("foo", "read_write"), List.of());
+        var tree = accessTree(entitlement("foo", "read_write"));
         assertThat(tree.canWrite(path("foo")), is(true));
         assertThat(tree.canWrite(path("foo/subdir")), is(true));
         assertThat(tree.canWrite(path("food")), is(false));
@@ -101,7 +100,7 @@ public class FileAccessTreeTests extends ESTestCase {
     }
 
     public void testTwoPaths() {
-        var tree = accessTree(entitlement("foo", "read", "bar", "read"), List.of());
+        var tree = accessTree(entitlement("foo", "read", "bar", "read"));
         assertThat(tree.canRead(path("a")), is(false));
         assertThat(tree.canRead(path("bar")), is(true));
         assertThat(tree.canRead(path("bar/subdir")), is(true));
@@ -112,7 +111,7 @@ public class FileAccessTreeTests extends ESTestCase {
     }
 
     public void testReadWriteUnderRead() {
-        var tree = accessTree(entitlement("foo", "read", "foo/bar", "read_write"), List.of());
+        var tree = accessTree(entitlement("foo", "read", "foo/bar", "read_write"));
         assertThat(tree.canRead(path("foo")), is(true));
         assertThat(tree.canWrite(path("foo")), is(false));
         assertThat(tree.canRead(path("foo/bar")), is(true));
@@ -122,7 +121,7 @@ public class FileAccessTreeTests extends ESTestCase {
     }
 
     public void testPrunedPaths() {
-        var tree = accessTree(entitlement("foo", "read", "foo/baz", "read", "foo/bar", "read"), List.of());
+        var tree = accessTree(entitlement("foo", "read", "foo/baz", "read", "foo/bar", "read"));
         assertThat(tree.canRead(path("foo")), is(true));
         assertThat(tree.canWrite(path("foo")), is(false));
         assertThat(tree.canRead(path("foo/bar")), is(true));
@@ -133,7 +132,7 @@ public class FileAccessTreeTests extends ESTestCase {
         assertThat(tree.canRead(path("foo/barf")), is(true));
         assertThat(tree.canWrite(path("foo/barf")), is(false));
 
-        tree = accessTree(entitlement("foo", "read", "foo/bar", "read_write"), List.of());
+        tree = accessTree(entitlement("foo", "read", "foo/bar", "read_write"));
         assertThat(tree.canRead(path("foo")), is(true));
         assertThat(tree.canWrite(path("foo")), is(false));
         assertThat(tree.canRead(path("foo/bar")), is(true));
@@ -143,7 +142,7 @@ public class FileAccessTreeTests extends ESTestCase {
     }
 
     public void testPathAndFileWithSamePrefix() {
-        var tree = accessTree(entitlement("foo/bar/", "read", "foo/bar.xml", "read"), List.of());
+        var tree = accessTree(entitlement("foo/bar/", "read", "foo/bar.xml", "read"));
         assertThat(tree.canRead(path("foo")), is(false));
         assertThat(tree.canRead(path("foo/bar")), is(true));
         assertThat(tree.canRead(path("foo/bar/baz")), is(true));
@@ -153,7 +152,7 @@ public class FileAccessTreeTests extends ESTestCase {
 
     public void testReadWithRelativePath() {
         for (var dir : List.of("home")) {
-            var tree = accessTree(entitlement(Map.of("relative_path", "foo", "mode", "read", "relative_to", dir)), List.of());
+            var tree = accessTree(entitlement(Map.of("relative_path", "foo", "mode", "read", "relative_to", dir)));
             assertThat(tree.canRead(path("foo")), is(false));
 
             assertThat(tree.canRead(path("/" + dir + "/foo")), is(true));
@@ -170,7 +169,7 @@ public class FileAccessTreeTests extends ESTestCase {
 
     public void testWriteWithRelativePath() {
         for (var dir : List.of("home")) {
-            var tree = accessTree(entitlement(Map.of("relative_path", "foo", "mode", "read_write", "relative_to", dir)), List.of());
+            var tree = accessTree(entitlement(Map.of("relative_path", "foo", "mode", "read_write", "relative_to", dir)));
             assertThat(tree.canWrite(path("/" + dir + "/foo")), is(true));
             assertThat(tree.canWrite(path("/" + dir + "/foo/subdir")), is(true));
             assertThat(tree.canWrite(path("/" + dir)), is(false));
@@ -185,7 +184,7 @@ public class FileAccessTreeTests extends ESTestCase {
     }
 
     public void testMultipleDataDirs() {
-        var tree = accessTree(entitlement(Map.of("relative_path", "foo", "mode", "read_write", "relative_to", "data")), List.of());
+        var tree = accessTree(entitlement(Map.of("relative_path", "foo", "mode", "read_write", "relative_to", "data")));
         assertThat(tree.canWrite(path("/data1/foo")), is(true));
         assertThat(tree.canWrite(path("/data2/foo")), is(true));
         assertThat(tree.canWrite(path("/data3/foo")), is(false));
@@ -203,7 +202,7 @@ public class FileAccessTreeTests extends ESTestCase {
     }
 
     public void testNormalizePath() {
-        var tree = accessTree(entitlement("foo/../bar", "read"), List.of());
+        var tree = accessTree(entitlement("foo/../bar", "read"));
         assertThat(tree.canRead(path("foo/../bar")), is(true));
         assertThat(tree.canRead(path("foo/../bar/")), is(true));
         assertThat(tree.canRead(path("foo")), is(false));
@@ -219,8 +218,7 @@ public class FileAccessTreeTests extends ESTestCase {
         assertThat(FileAccessTree.normalizePath(Path.of("C:/a/c\\foo.txt")), equalTo("C:\\a\\c\\foo.txt"));
 
         var tree = accessTree(
-            entitlement("C:\\a\\b", "read", "C:/a.xml", "read", "C:/a/b.txt", "read", "C:/a/c\\foo.txt", "read"),
-            List.of()
+            entitlement("C:\\a\\b", "read", "C:/a.xml", "read", "C:/a/b.txt", "read", "C:/a/c\\foo.txt", "read")
         );
 
         assertThat(tree.canRead(Path.of("C:/a.xml")), is(true));
@@ -234,7 +232,7 @@ public class FileAccessTreeTests extends ESTestCase {
     }
 
     public void testNormalizeTrailingSlashes() {
-        var tree = accessTree(entitlement("/trailing/slash/", "read", "/no/trailing/slash", "read"), List.of());
+        var tree = accessTree(entitlement("/trailing/slash/", "read", "/no/trailing/slash", "read"));
         assertThat(tree.canRead(path("/trailing/slash")), is(true));
         assertThat(tree.canRead(path("/trailing/slash/")), is(true));
         assertThat(tree.canRead(path("/trailing/slash.xml")), is(false));
@@ -247,7 +245,7 @@ public class FileAccessTreeTests extends ESTestCase {
 
     public void testForwardSlashes() {
         String sep = getDefaultFileSystem().getSeparator();
-        var tree = accessTree(entitlement("a/b", "read", "m" + sep + "n", "read"), List.of());
+        var tree = accessTree(entitlement("a/b", "read", "m" + sep + "n", "read"));
 
         // Native separators work
         assertThat(tree.canRead(path("a" + sep + "b")), is(true));
@@ -261,7 +259,7 @@ public class FileAccessTreeTests extends ESTestCase {
     public void testJdkAccess() {
         Path jdkDir = Paths.get(System.getProperty("java.home"));
         var confDir = jdkDir.resolve("conf");
-        var tree = accessTree(FilesEntitlement.EMPTY, List.of());
+        var tree = accessTree(FilesEntitlement.EMPTY);
 
         assertThat(tree.canRead(confDir), is(true));
         assertThat(tree.canWrite(confDir), is(false));
@@ -283,7 +281,7 @@ public class FileAccessTreeTests extends ESTestCase {
         Path writeTarget = baseTargetDir.resolve("write_link");
         Files.createSymbolicLink(readTarget, source1Dir);
         Files.createSymbolicLink(writeTarget, source2Dir);
-        var tree = accessTree(entitlement(readTarget.toString(), "read", writeTarget.toString(), "read_write"), List.of());
+        var tree = accessTree(entitlement(readTarget.toString(), "read", writeTarget.toString(), "read_write"));
 
         assertThat(tree.canRead(baseSourceDir), is(false));
         assertThat(tree.canRead(baseTargetDir), is(false));
@@ -300,25 +298,25 @@ public class FileAccessTreeTests extends ESTestCase {
     }
 
     public void testTempDirAccess() {
-        var tree = FileAccessTree.of("test-component", "test-module", FilesEntitlement.EMPTY, TEST_PATH_LOOKUP, List.of(), List.of());
+        var tree = accessTree(FilesEntitlement.EMPTY);
         assertThat(tree.canRead(TEST_PATH_LOOKUP.getBaseDirPaths(TEMP).findFirst().get()), is(true));
         assertThat(tree.canWrite(TEST_PATH_LOOKUP.getBaseDirPaths(TEMP).findFirst().get()), is(true));
     }
 
     public void testConfigDirAccess() {
-        var tree = FileAccessTree.of("test-component", "test-module", FilesEntitlement.EMPTY, TEST_PATH_LOOKUP, List.of(), List.of());
-        assertThat(tree.canRead(TEST_PATH_LOOKUP.getBaseDirPaths(CONFIG).findFirst().get()), is(true));
-        assertThat(tree.canWrite(TEST_PATH_LOOKUP.getBaseDirPaths(CONFIG).findFirst().get()), is(false));
+        var tree = accessTree(FilesEntitlement.EMPTY);
+        assertThat(tree.canRead(configDirPath()), is(true));
+        assertThat(tree.canWrite(configDirPath()), is(false));
     }
 
     public void testBasicExclusiveAccess() {
-        var tree = accessTree(entitlement("foo", "read"), exclusivePaths("test-component", "test-module", "foo"));
+        var tree = accessTree(entitlement("foo", "read"), exclusivePaths("test-component", "test-module", "foo"), List.of());
         assertThat(tree.canRead(path("foo")), is(true));
         assertThat(tree.canWrite(path("foo")), is(false));
-        tree = accessTree(entitlement("foo", "read_write"), exclusivePaths("test-component", "test-module", "foo"));
+        tree = accessTree(entitlement("foo", "read_write"), exclusivePaths("test-component", "test-module", "foo"), List.of());
         assertThat(tree.canRead(path("foo")), is(true));
         assertThat(tree.canWrite(path("foo")), is(true));
-        tree = accessTree(entitlement("foo", "read"), exclusivePaths("test-component", "diff-module", "foo/bar"));
+        tree = accessTree(entitlement("foo", "read"), exclusivePaths("test-component", "diff-module", "foo/bar"), List.of());
         assertThat(tree.canRead(path("foo")), is(true));
         assertThat(tree.canWrite(path("foo")), is(false));
         assertThat(tree.canRead(path("foo/baz")), is(true));
@@ -327,7 +325,8 @@ public class FileAccessTreeTests extends ESTestCase {
         assertThat(tree.canWrite(path("foo/bar")), is(false));
         tree = accessTree(
             entitlement("foo", "read", "foo.xml", "read", "foo/bar.xml", "read_write"),
-            exclusivePaths("test-component", "diff-module", "foo/bar", "foo/baz", "other")
+            exclusivePaths("test-component", "diff-module", "foo/bar", "foo/baz", "other"),
+            List.of()
         );
         assertThat(tree.canRead(path("foo")), is(true));
         assertThat(tree.canWrite(path("foo")), is(false));
@@ -346,21 +345,65 @@ public class FileAccessTreeTests extends ESTestCase {
     }
 
     public void testInvalidExclusiveAccess() {
-        var tree = accessTree(entitlement("a", "read"), exclusivePaths("diff-component", "diff-module", "a/b"));
+        var tree = accessTree(entitlement("a", "read"), exclusivePaths("diff-component", "diff-module", "a/b"), List.of());
         assertThat(tree.canRead(path("a")), is(true));
         assertThat(tree.canWrite(path("a")), is(false));
         assertThat(tree.canRead(path("a/b")), is(false));
         assertThat(tree.canWrite(path("a/b")), is(false));
         assertThat(tree.canRead(path("a/b/c")), is(false));
         assertThat(tree.canWrite(path("a/b/c")), is(false));
-        tree = accessTree(entitlement("a/b", "read"), exclusivePaths("diff-component", "diff-module", "a"));
+        tree = accessTree(entitlement("a/b", "read"), exclusivePaths("diff-component", "diff-module", "a"), List.of());
         assertThat(tree.canRead(path("a")), is(false));
         assertThat(tree.canWrite(path("a")), is(false));
         assertThat(tree.canRead(path("a/b")), is(false));
         assertThat(tree.canWrite(path("a/b")), is(false));
-        tree = accessTree(entitlement("a", "read"), exclusivePaths("diff-component", "diff-module", "a"));
+        tree = accessTree(entitlement("a", "read"), exclusivePaths("diff-component", "diff-module", "a"), List.of());
         assertThat(tree.canRead(path("a")), is(false));
         assertThat(tree.canWrite(path("a")), is(false));
+    }
+
+    public void testForbiddenAccess() {
+        var tree = accessTree(FilesEntitlement.EMPTY, List.of(), pathsInConfigDir("foo"));
+        // Can always read from config
+        assertThat(tree.canRead(configDirPath("bar")), is(true));
+        // Unless forbidden
+        assertThat(tree.canRead(configDirPath("foo")), is(false));
+        assertThat(tree.canWrite(configDirPath("foo")), is(false));
+        tree = accessTree(entitlement("foo", "read_write"), List.of(), paths("foo"));
+        // Forbidden wins over entitlement
+        assertThat(tree.canRead(path("foo")), is(false));
+        assertThat(tree.canWrite(path("foo")), is(false));
+        tree = accessTree(entitlement("foo", "read_write"), exclusivePaths("test-component", "test-module", "foo"), paths("foo"));
+        // Even over exclusive paths
+        assertThat(tree.canRead(path("foo")), is(false));
+        assertThat(tree.canWrite(path("foo")), is(false));
+        tree = accessTree(entitlement("foo", "read"), List.of(), paths("foo/bar"));
+        assertThat(tree.canRead(path("foo")), is(true));
+        assertThat(tree.canWrite(path("foo")), is(false));
+        assertThat(tree.canRead(path("foo/baz")), is(true));
+        assertThat(tree.canWrite(path("foo/baz")), is(false));
+        // Forbidden sub-path
+        assertThat(tree.canRead(path("foo/bar")), is(false));
+        assertThat(tree.canWrite(path("foo/bar")), is(false));
+        tree = accessTree(
+            entitlement("foo", "read", "foo.xml", "read", "foo/bar.xml", "read_write"),
+            List.of(),
+            paths("test-component", "diff-module", "foo/bar", "foo/baz", "other")
+        );
+        assertThat(tree.canRead(path("foo")), is(true));
+        assertThat(tree.canWrite(path("foo")), is(false));
+        assertThat(tree.canRead(path("foo.xml")), is(true));
+        assertThat(tree.canWrite(path("foo.xml")), is(false));
+        assertThat(tree.canRead(path("foo/baz")), is(false));
+        assertThat(tree.canWrite(path("foo/baz")), is(false));
+        assertThat(tree.canRead(path("foo/bar")), is(false));
+        assertThat(tree.canWrite(path("foo/bar")), is(false));
+        assertThat(tree.canRead(path("foo/bar.xml")), is(true));
+        assertThat(tree.canWrite(path("foo/bar.xml")), is(true));
+        assertThat(tree.canRead(path("foo/bar.baz")), is(true));
+        assertThat(tree.canWrite(path("foo/bar.baz")), is(false));
+        assertThat(tree.canRead(path("foo/biz/bar.xml")), is(true));
+        assertThat(tree.canWrite(path("foo/biz/bar.xml")), is(false));
     }
 
     public void testDuplicatePrunedPaths() {
@@ -463,6 +506,7 @@ public class FileAccessTreeTests extends ESTestCase {
             ),
             TEST_PATH_LOOKUP,
             List.of(),
+            List.of(),
             List.of()
         );
 
@@ -489,6 +533,7 @@ public class FileAccessTreeTests extends ESTestCase {
             ),
             TEST_PATH_LOOKUP,
             List.of(),
+            List.of(),
             List.of()
         );
 
@@ -504,8 +549,12 @@ public class FileAccessTreeTests extends ESTestCase {
         assertThat(fileAccessTree.canWrite(Path.of("d:\\foo")), is(false));
     }
 
-    FileAccessTree accessTree(FilesEntitlement entitlement, List<ExclusivePath> exclusivePaths) {
-        return FileAccessTree.of("test-component", "test-module", entitlement, TEST_PATH_LOOKUP, List.of(), exclusivePaths);
+    FileAccessTree accessTree(FilesEntitlement entitlement) {
+        return FileAccessTree.of("test-component", "test-module", entitlement, TEST_PATH_LOOKUP, List.of(), List.of(), List.of());
+    }
+
+    FileAccessTree accessTree(FilesEntitlement entitlement, List<ExclusivePath> exclusivePaths, Collection<String> forbiddenPaths) {
+        return FileAccessTree.of("test-component", "test-module", entitlement, TEST_PATH_LOOKUP, List.of(), exclusivePaths, forbiddenPaths);
     }
 
     static FilesEntitlement entitlement(String... values) {
@@ -523,11 +572,34 @@ public class FileAccessTreeTests extends ESTestCase {
         return FilesEntitlement.build(List.of(value));
     }
 
+    static Path path(String s) {
+        return root.resolve(s);
+    }
+
+    static List<String> paths(String... paths) {
+        return Arrays.stream(paths).map(x -> FileAccessTree.normalizePath(path(x))).toList();
+    }
+
     static List<ExclusivePath> exclusivePaths(String componentName, String moduleName, String... paths) {
         List<ExclusivePath> exclusivePaths = new ArrayList<>();
         for (String path : paths) {
             exclusivePaths.add(new ExclusivePath(componentName, Set.of(moduleName), normalizePath(path(path))));
         }
         return exclusivePaths;
+    }
+
+    static Set<String> pathsInConfigDir(String... files) {
+        return TEST_PATH_LOOKUP.getBaseDirPaths(PathLookup.BaseDir.CONFIG)
+            .flatMap(baseDir -> Arrays.stream(files).map(baseDir::resolve))
+            .map(FileAccessTree::normalizePath)
+            .collect(Collectors.toSet());
+    }
+
+    static Path configDirPath() {
+        return TEST_PATH_LOOKUP.getBaseDirPaths(CONFIG).findFirst().orElseThrow();
+    }
+
+    static Path configDirPath(String file) {
+        return configDirPath().resolve(file);
     }
 }

--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTreeTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/runtime/policy/FileAccessTreeTests.java
@@ -217,9 +217,7 @@ public class FileAccessTreeTests extends ESTestCase {
         assertThat(FileAccessTree.normalizePath(Path.of("C:/a/b.txt")), equalTo("C:\\a\\b.txt"));
         assertThat(FileAccessTree.normalizePath(Path.of("C:/a/c\\foo.txt")), equalTo("C:\\a\\c\\foo.txt"));
 
-        var tree = accessTree(
-            entitlement("C:\\a\\b", "read", "C:/a.xml", "read", "C:/a/b.txt", "read", "C:/a/c\\foo.txt", "read")
-        );
+        var tree = accessTree(entitlement("C:\\a\\b", "read", "C:/a.xml", "read", "C:/a/b.txt", "read", "C:/a/c\\foo.txt", "read"));
 
         assertThat(tree.canRead(Path.of("C:/a.xml")), is(true));
         assertThat(tree.canRead(Path.of("C:\\a.xml")), is(true));


### PR DESCRIPTION
Elasticsearch has a need to protect some special files and paths, guaranteeing that nobody (not even `server` code) could read or write them. 
This PR adds protection for these forbidden paths by leveraging the existing "exclusive access" mechanism.