### PR TITLE
Remove transport version constant V_8_18_0 (#138844)

### DIFF
--- a/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/AddIndexBlockRollingUpgradeIT.java
+++ b/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/AddIndexBlockRollingUpgradeIT.java
@@ -13,7 +13,7 @@ import io.netty.handler.codec.http.HttpMethod;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 
-import org.elasticsearch.TransportVersions;
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -39,7 +39,7 @@ public class AddIndexBlockRollingUpgradeIT extends AbstractRollingUpgradeTestCas
         } else if (isMixedCluster()) {
             blockWrites();
             // this is used both for upgrading from 9.0.0 to current and from 8.18 to current.
-            if (minimumTransportVersion().supports(TransportVersions.V_8_18_0) == false) {
+            if (minimumTransportVersion().supports(TransportVersion.fromId(8840000)) == false) {
                 assertNull(verifiedSettingValue());
             } else {
                 assertThat(verifiedSettingValue(), Matchers.equalTo("true"));

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -97,7 +97,6 @@ public class TransportVersions {
     public static final TransportVersion INITIAL_ELASTICSEARCH_8_17_3 = def(8_797_0_03);
     public static final TransportVersion INITIAL_ELASTICSEARCH_8_17_4 = def(8_797_0_04);
     public static final TransportVersion INITIAL_ELASTICSEARCH_8_17_5 = def(8_797_0_05);
-    public static final TransportVersion V_8_18_0 = def(8_840_0_00);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodeResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodeResponse.java
@@ -52,11 +52,7 @@ public class ClusterStatsNodeResponse extends BaseNodeResponse {
             repositoryUsageStats = RepositoryUsageStats.EMPTY;
             searchCcsMetrics = new CCSTelemetrySnapshot();
         }
-        if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            esqlCcsMetrics = new CCSTelemetrySnapshot(in);
-        } else {
-            esqlCcsMetrics = new CCSTelemetrySnapshot();
-        }
+        esqlCcsMetrics = new CCSTelemetrySnapshot(in);
     }
 
     public ClusterStatsNodeResponse(
@@ -131,9 +127,7 @@ public class ClusterStatsNodeResponse extends BaseNodeResponse {
             repositoryUsageStats.writeTo(out);
             searchCcsMetrics.writeTo(out);
         } // else just drop these stats, ok for bwc
-        if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            esqlCcsMetrics.writeTo(out);
-        }
+        esqlCcsMetrics.writeTo(out);
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/MappingStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/MappingStats.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.action.admin.cluster.stats;
 
-import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
@@ -270,9 +269,7 @@ public final class MappingStats implements ToXContentFragment, Writeable {
         fieldTypeStats = in.readCollectionAsImmutableList(FieldStats::new);
         runtimeFieldStats = in.readCollectionAsImmutableList(RuntimeFieldStats::new);
         var transportVersion = in.getTransportVersion();
-        sourceModeUsageCount = canReadOrWriteSourceModeTelemetry(transportVersion)
-            ? in.readImmutableMap(StreamInput::readString, StreamInput::readVInt)
-            : Map.of();
+        sourceModeUsageCount = in.readImmutableMap(StreamInput::readString, StreamInput::readVInt);
     }
 
     @Override
@@ -284,14 +281,7 @@ public final class MappingStats implements ToXContentFragment, Writeable {
         }
         out.writeCollection(fieldTypeStats);
         out.writeCollection(runtimeFieldStats);
-        var transportVersion = out.getTransportVersion();
-        if (canReadOrWriteSourceModeTelemetry(transportVersion)) {
-            out.writeMap(sourceModeUsageCount, StreamOutput::writeVInt);
-        }
-    }
-
-    private static boolean canReadOrWriteSourceModeTelemetry(TransportVersion version) {
-        return version.isPatchFrom(TransportVersions.V_8_17_0) || version.supports(TransportVersions.V_8_18_0);
+        out.writeMap(sourceModeUsageCount, StreamOutput::writeVInt);
     }
 
     private static OptionalLong ofNullable(Long l) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/readonly/AddIndexBlockRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/readonly/AddIndexBlockRequest.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.action.admin.indices.readonly;
 
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -40,11 +39,7 @@ public class AddIndexBlockRequest extends AcknowledgedRequest<AddIndexBlockReque
         indices = in.readStringArray();
         indicesOptions = IndicesOptions.readIndicesOptions(in);
         block = APIBlock.readFrom(in);
-        if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            markVerified = in.readBoolean();
-        } else {
-            markVerified = false;
-        }
+        markVerified = in.readBoolean();
     }
 
     /**
@@ -132,9 +127,7 @@ public class AddIndexBlockRequest extends AcknowledgedRequest<AddIndexBlockReque
         out.writeStringArray(indices);
         indicesOptions.writeIndicesOptions(out);
         block.writeTo(out);
-        if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            out.writeBoolean(markVerified);
-        }
+        out.writeBoolean(markVerified);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/readonly/TransportVerifyShardIndexBlockAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/readonly/TransportVerifyShardIndexBlockAction.java
@@ -8,7 +8,6 @@
  */
 package org.elasticsearch.action.admin.indices.readonly;
 
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.admin.indices.flush.FlushRequest;
@@ -181,11 +180,7 @@ public class TransportVerifyShardIndexBlockAction extends TransportReplicationAc
         ShardRequest(StreamInput in) throws IOException {
             super(in);
             clusterBlock = new ClusterBlock(in);
-            if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-                phase1 = in.readBoolean();
-            } else {
-                phase1 = true; // does not matter, not verified anyway
-            }
+            phase1 = in.readBoolean();
         }
 
         public ShardRequest(final ShardId shardId, final ClusterBlock clusterBlock, boolean phase1, final TaskId parentTaskId) {
@@ -204,9 +199,7 @@ public class TransportVerifyShardIndexBlockAction extends TransportReplicationAc
         public void writeTo(final StreamOutput out) throws IOException {
             super.writeTo(out);
             clusterBlock.writeTo(out);
-            if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-                out.writeBoolean(phase1);
-            }
+            out.writeBoolean(phase1);
         }
 
         public ClusterBlock clusterBlock() {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveClusterActionRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveClusterActionRequest.java
@@ -84,14 +84,9 @@ public class ResolveClusterActionRequest extends LegacyActionRequest implements 
         this.names = in.readStringArray();
         this.indicesOptions = IndicesOptions.readIndicesOptions(in);
         this.localIndicesRequested = localIndicesPresent(names);
-        if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            this.clusterInfoOnly = in.readBoolean();
-            this.isQueryingCluster = in.readBoolean();
-            this.timeout = in.readOptionalTimeValue();
-        } else {
-            this.clusterInfoOnly = false;
-            this.isQueryingCluster = false;
-        }
+        this.clusterInfoOnly = in.readBoolean();
+        this.isQueryingCluster = in.readBoolean();
+        this.timeout = in.readOptionalTimeValue();
     }
 
     @Override
@@ -102,11 +97,9 @@ public class ResolveClusterActionRequest extends LegacyActionRequest implements 
         }
         out.writeStringArray(names);
         indicesOptions.writeIndicesOptions(out);
-        if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            out.writeBoolean(clusterInfoOnly);
-            out.writeBoolean(isQueryingCluster);
-            out.writeOptionalTimeValue(timeout);
-        }
+        out.writeBoolean(clusterInfoOnly);
+        out.writeBoolean(isQueryingCluster);
+        out.writeOptionalTimeValue(timeout);
     }
 
     static String createVersionErrorMessage(TransportVersion versionFound) {

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
@@ -105,9 +105,7 @@ public class BulkRequest extends LegacyActionRequest
         } else {
             incrementalState = BulkRequest.IncrementalState.EMPTY;
         }
-        if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            includeSourceOnError = in.readBoolean();
-        } // else default value is true
+        includeSourceOnError = in.readBoolean();
     }
 
     public BulkRequest(@Nullable String globalIndex) {
@@ -471,9 +469,7 @@ public class BulkRequest extends LegacyActionRequest
         if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_16_0)) {
             incrementalState.writeTo(out);
         }
-        if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            out.writeBoolean(includeSourceOnError);
-        }
+        out.writeBoolean(includeSourceOnError);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/datastreams/GetDataStreamAction.java
+++ b/server/src/main/java/org/elasticsearch/action/datastreams/GetDataStreamAction.java
@@ -337,9 +337,7 @@ public class GetDataStreamAction extends ActionType<GetDataStreamAction.Response
             @Override
             public void writeTo(StreamOutput out) throws IOException {
                 dataStream.writeTo(out);
-                if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-                    out.writeBoolean(failureStoreEffectivelyEnabled);
-                }
+                out.writeBoolean(failureStoreEffectivelyEnabled);
                 dataStreamStatus.writeTo(out);
                 out.writeOptionalString(indexTemplate);
                 out.writeOptionalString(ilmPolicyName);

--- a/server/src/main/java/org/elasticsearch/action/index/IndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/index/IndexRequest.java
@@ -213,9 +213,7 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
             }
         }
 
-        if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            includeSourceOnError = in.readBoolean();
-        } // else default value is true
+        includeSourceOnError = in.readBoolean();
     }
 
     public IndexRequest() {
@@ -812,9 +810,8 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
                 out.writeBoolean(false); // obsolete originatesFromUpdateByDoc
             }
         }
-        if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            out.writeBoolean(includeSourceOnError);
-        }
+
+        out.writeBoolean(includeSourceOnError);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/ingest/SimulateIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/SimulateIndexResponse.java
@@ -49,11 +49,7 @@ public class SimulateIndexResponse extends IndexResponse {
         } else {
             this.exception = null;
         }
-        if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            this.ignoredFields = in.readStringCollectionAsList();
-        } else {
-            this.ignoredFields = List.of();
-        }
+        this.ignoredFields = in.readStringCollectionAsList();
     }
 
     @SuppressWarnings("this-escape")
@@ -124,9 +120,7 @@ public class SimulateIndexResponse extends IndexResponse {
         if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_15_0)) {
             out.writeException(exception);
         }
-        if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            out.writeStringCollection(ignoredFields);
-        }
+        out.writeStringCollection(ignoredFields);
     }
 
     public Exception getException() {

--- a/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
+++ b/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
@@ -879,15 +879,10 @@ public record IndicesOptions(
         }
         // Until the feature flag is removed we access the field directly from the gatekeeper options.
         if (gatekeeperOptions().allowSelectors()) {
-            if (out.getTransportVersion().supports(TransportVersions.V_8_14_0)
-                && out.getTransportVersion().supports(TransportVersions.V_8_18_0) == false) {
-                backwardsCompatibleOptions.add(Option.ALLOW_FAILURE_INDICES);
-            } else if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-                backwardsCompatibleOptions.add(Option.ALLOW_SELECTORS);
-            }
+            backwardsCompatibleOptions.add(Option.ALLOW_SELECTORS);
         }
 
-        if (out.getTransportVersion().supports(TransportVersions.V_8_18_0) && gatekeeperOptions.includeFailureIndices()) {
+        if (gatekeeperOptions.includeFailureIndices()) {
             backwardsCompatibleOptions.add(Option.INCLUDE_FAILURE_INDICES);
         }
         out.writeEnumSet(backwardsCompatibleOptions);
@@ -907,15 +902,6 @@ public record IndicesOptions(
             out.writeBoolean(true);
             out.writeBoolean(false);
         }
-        if (out.getTransportVersion().supports(TransportVersions.V_8_16_0)
-            && out.getTransportVersion().supports(TransportVersions.V_8_18_0) == false) {
-            if (out.getTransportVersion().before(TransportVersions.V_8_17_0)) {
-                out.writeVInt(1); // Enum set sized 1
-                out.writeVInt(0); // ordinal 0 (::data selector)
-            } else {
-                out.writeByte((byte) 0); // ordinal 0 (::data selector)
-            }
-        }
     }
 
     public static IndicesOptions readIndicesOptions(StreamInput in) throws IOException {
@@ -925,19 +911,8 @@ public record IndicesOptions(
             options.contains(Option.ALLOW_EMPTY_WILDCARD_EXPRESSIONS),
             options.contains(Option.EXCLUDE_ALIASES)
         );
-        boolean allowSelectors = true;
-        if (in.getTransportVersion().supports(TransportVersions.V_8_14_0)
-            && in.getTransportVersion().supports(TransportVersions.V_8_18_0) == false) {
-            // We've effectively replaced the allow failure indices setting with allow selectors. If it is configured on an older version
-            // then use its value for allow selectors.
-            allowSelectors = options.contains(Option.ALLOW_FAILURE_INDICES);
-        } else if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            allowSelectors = options.contains(Option.ALLOW_SELECTORS);
-        }
-        boolean includeFailureIndices = false;
-        if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            includeFailureIndices = options.contains(Option.INCLUDE_FAILURE_INDICES);
-        }
+        boolean allowSelectors = options.contains(Option.ALLOW_SELECTORS);
+        boolean includeFailureIndices = options.contains(Option.INCLUDE_FAILURE_INDICES);
         GatekeeperOptions gatekeeperOptions = GatekeeperOptions.builder()
             .allowClosedIndices(options.contains(Option.ERROR_WHEN_CLOSED_INDICES) == false)
             .allowAliasToMultipleIndices(options.contains(Option.ERROR_WHEN_ALIASES_TO_MULTIPLE_INDICES) == false)
@@ -949,18 +924,6 @@ public record IndicesOptions(
             // Reading from an older node, which will be sending two booleans that we must read out and ignore.
             in.readBoolean();
             in.readBoolean();
-        }
-        if (in.getTransportVersion().supports(TransportVersions.V_8_16_0)
-            && in.getTransportVersion().supports(TransportVersions.V_8_18_0) == false) {
-            // Reading from an older node, which will be sending either an enum set or a single byte that needs to be read out and ignored.
-            if (in.getTransportVersion().before(TransportVersions.V_8_17_0)) {
-                int size = in.readVInt();
-                for (int i = 0; i < size; i++) {
-                    in.readVInt();
-                }
-            } else {
-                in.readByte();
-            }
         }
         return new IndicesOptions(
             options.contains(Option.ALLOW_UNAVAILABLE_CONCRETE_TARGETS)

--- a/server/src/main/java/org/elasticsearch/cluster/block/ClusterBlock.java
+++ b/server/src/main/java/org/elasticsearch/cluster/block/ClusterBlock.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.cluster.block;
 
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -144,12 +143,7 @@ public class ClusterBlock implements Writeable, ToXContentFragment {
         out.writeVInt(id);
         out.writeOptionalString(uuid);
         out.writeString(description);
-        if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            out.writeEnumSet(levels);
-        } else {
-            // do not send ClusterBlockLevel.REFRESH to old nodes
-            out.writeEnumSet(filterLevels(levels, level -> ClusterBlockLevel.REFRESH.equals(level) == false));
-        }
+        out.writeEnumSet(levels);
         out.writeBoolean(retryable);
         out.writeBoolean(disableStatePersistence);
         RestStatus.writeTo(out, status);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplate.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplate.java
@@ -514,10 +514,6 @@ public class ComposableIndexTemplate implements SimpleDiffable<ComposableIndexTe
                 boolean value = in.readBoolean();
                 assert value == false : "expected false, because this used to be an optional enum that never got set";
             }
-            if (in.getTransportVersion().supports(DataStream.ADDED_FAILURE_STORE_TRANSPORT_VERSION)
-                && in.getTransportVersion().supports(TransportVersions.V_8_18_0) == false) {
-                in.readBoolean();
-            }
         }
 
         /**
@@ -554,12 +550,6 @@ public class ComposableIndexTemplate implements SimpleDiffable<ComposableIndexTe
             }
             if (out.getTransportVersion().between(TransportVersions.V_8_1_0, TransportVersions.V_8_3_0)) {
                 // See comment in constructor.
-                out.writeBoolean(false);
-            }
-            if (out.getTransportVersion().supports(DataStream.ADDED_FAILURE_STORE_TRANSPORT_VERSION)
-                && out.getTransportVersion().supports(TransportVersions.V_8_18_0) == false) {
-                // Previous versions expect the failure store to be configured via the DataStreamTemplate. We add it here, so we don't break
-                // the serialisation, but we do not care to preserve the value because this feature is still behind a feature flag.
                 out.writeBoolean(false);
             }
         }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -14,7 +14,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.admin.indices.create.CreateIndexClusterStateUpdateRequest;
@@ -136,12 +135,7 @@ public class MetadataCreateIndexService {
 
     @FunctionalInterface
     interface ClusterBlocksTransformer {
-        void apply(
-            ClusterBlocks.Builder clusterBlocks,
-            ProjectId projectId,
-            IndexMetadata indexMetadata,
-            TransportVersion minClusterTransportVersion
-        );
+        void apply(ClusterBlocks.Builder clusterBlocks, ProjectId projectId, IndexMetadata indexMetadata);
     }
 
     private final Settings settings;
@@ -589,7 +583,7 @@ public class MetadataCreateIndexService {
                 blocksTransformerUponIndexCreation,
                 allocationService.getShardRoutingRoleStrategy()
             );
-            assert assertHasRefreshBlock(indexMetadata, updated.projectState(request.projectId()), updated.getMinTransportVersion());
+            assert assertHasRefreshBlock(indexMetadata, updated.projectState(request.projectId()));
             if (request.performReroute()) {
                 updated = allocationService.reroute(
                     updated,
@@ -1440,7 +1434,7 @@ public class MetadataCreateIndexService {
         var blocksBuilder = ClusterBlocks.builder().blocks(currentState.blocks());
         blocksBuilder.updateBlocks(projectId, indexMetadata);
         if (blocksTransformer != null) {
-            blocksTransformer.apply(blocksBuilder, projectId, indexMetadata, currentState.getMinTransportVersion());
+            blocksTransformer.apply(blocksBuilder, projectId, indexMetadata);
         }
 
         var routingTableBuilder = RoutingTable.builder(shardRoutingRoleStrategy, currentState.routingTable(projectId))
@@ -1887,11 +1881,11 @@ public class MetadataCreateIndexService {
 
     static ClusterBlocksTransformer createClusterBlocksTransformerForIndexCreation(Settings settings) {
         if (useRefreshBlock(settings) == false) {
-            return (clusterBlocks, projectId, indexMetadata, minClusterTransportVersion) -> {};
+            return (clusterBlocks, projectId, indexMetadata) -> {};
         }
         logger.debug("applying refresh block on index creation");
-        return (clusterBlocks, projectId, indexMetadata, minClusterTransportVersion) -> {
-            if (applyRefreshBlock(indexMetadata, minClusterTransportVersion)) {
+        return (clusterBlocks, projectId, indexMetadata) -> {
+            if (applyRefreshBlock(indexMetadata)) {
                 // Applies the INDEX_REFRESH_BLOCK to the index. This block will remain in cluster state until an unpromotable shard is
                 // started or a configurable delay is elapsed.
                 clusterBlocks.addIndexBlock(projectId, indexMetadata.getIndex().getName(), IndexMetadata.INDEX_REFRESH_BLOCK);
@@ -1899,17 +1893,16 @@ public class MetadataCreateIndexService {
         };
     }
 
-    private static boolean applyRefreshBlock(IndexMetadata indexMetadata, TransportVersion minClusterTransportVersion) {
+    private static boolean applyRefreshBlock(IndexMetadata indexMetadata) {
         return 0 < indexMetadata.getNumberOfReplicas() // index has replicas
             && indexMetadata.getResizeSourceIndex() == null // index is not a split/shrink index
-            && indexMetadata.getInSyncAllocationIds().values().stream().allMatch(Set::isEmpty) // index is a new index
-            && minClusterTransportVersion.supports(TransportVersions.V_8_18_0);
+            && indexMetadata.getInSyncAllocationIds().values().stream().allMatch(Set::isEmpty); // index is a new index
     }
 
-    private boolean assertHasRefreshBlock(IndexMetadata indexMetadata, ProjectState state, TransportVersion minTransportVersion) {
+    private boolean assertHasRefreshBlock(IndexMetadata indexMetadata, ProjectState state) {
         var hasRefreshBlock = state.blocks()
             .hasIndexBlock(state.projectId(), indexMetadata.getIndex().getName(), IndexMetadata.INDEX_REFRESH_BLOCK);
-        if (useRefreshBlock(settings) == false || applyRefreshBlock(indexMetadata, minTransportVersion) == false) {
+        if (useRefreshBlock(settings) == false || applyRefreshBlock(indexMetadata) == false) {
             assert hasRefreshBlock == false : indexMetadata.getIndex();
         } else {
             assert hasRefreshBlock : indexMetadata.getIndex();

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
@@ -12,7 +12,6 @@ package org.elasticsearch.cluster.metadata;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.admin.indices.close.CloseIndexClusterStateUpdateRequest;
@@ -543,8 +542,7 @@ public class MetadataIndexStateService {
                                             task.request,
                                             blockedIndices,
                                             verifyResults,
-                                            task.request().markVerified()
-                                                && clusterService.state().getMinTransportVersion().supports(TransportVersions.V_8_18_0),
+                                            task.request().markVerified(),
                                             delegate2
                                         ),
                                         null

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/SingleNodeShutdownMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/SingleNodeShutdownMetadata.java
@@ -168,11 +168,7 @@ public class SingleNodeShutdownMetadata implements SimpleDiffable<SingleNodeShut
 
     public SingleNodeShutdownMetadata(StreamInput in) throws IOException {
         this.nodeId = in.readString();
-        if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            this.nodeEphemeralId = in.readOptionalString();
-        } else {
-            this.nodeEphemeralId = null; // empty when talking to old nodes, meaning the persistent node id is the only differentiator
-        }
+        this.nodeEphemeralId = in.readOptionalString();
         this.type = in.readEnum(Type.class);
         this.reason = in.readString();
         this.startedAtMillis = in.readVLong();
@@ -262,9 +258,7 @@ public class SingleNodeShutdownMetadata implements SimpleDiffable<SingleNodeShut
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(nodeId);
-        if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            out.writeOptionalString(nodeEphemeralId);
-        }
+        out.writeOptionalString(nodeEphemeralId);
         if (out.getTransportVersion().before(SIGTERM_ADDED_VERSION) && this.type == Type.SIGTERM) {
             out.writeEnum(SingleNodeShutdownMetadata.Type.REMOVE);
         } else {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Template.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Template.java
@@ -178,12 +178,7 @@ public class Template implements SimpleDiffable<Template>, ToXContentObject {
         } else {
             this.lifecycle = null;
         }
-        if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            dataStreamOptions = ResettableValue.read(in, DataStreamOptions.Template::read);
-        } else {
-            // We default to no data stream options since failure store is behind a feature flag up to this version
-            this.dataStreamOptions = ResettableValue.undefined();
-        }
+        dataStreamOptions = ResettableValue.read(in, DataStreamOptions.Template::read);
     }
 
     @Nullable
@@ -244,9 +239,7 @@ public class Template implements SimpleDiffable<Template>, ToXContentObject {
                 out.writeOptionalWriteable(lifecycle);
             }
         }
-        if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            ResettableValue.write(out, dataStreamOptions, (o, v) -> v.writeTo(o));
-        }
+        ResettableValue.write(out, dataStreamOptions, (o, v) -> v.writeTo(o));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -328,12 +328,7 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
         Version version = Version.readVersion(in);
         IndexVersion minIndexVersion = IndexVersion.readVersion(in);
         IndexVersion minReadOnlyIndexVersion;
-        if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            minReadOnlyIndexVersion = IndexVersion.readVersion(in);
-        } else {
-            minReadOnlyIndexVersion = minIndexVersion;
-
-        }
+        minReadOnlyIndexVersion = IndexVersion.readVersion(in);
         IndexVersion maxIndexVersion = IndexVersion.readVersion(in);
         versionInfo = new VersionInformation(version, minIndexVersion, minReadOnlyIndexVersion, maxIndexVersion);
         if (in.getTransportVersion().onOrAfter(EXTERNAL_ID_VERSION)) {
@@ -370,9 +365,7 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
         });
         Version.writeVersion(versionInfo.nodeVersion(), out);
         IndexVersion.writeVersion(versionInfo.minIndexVersion(), out);
-        if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            IndexVersion.writeVersion(versionInfo.minReadOnlyIndexVersion(), out);
-        }
+        IndexVersion.writeVersion(versionInfo.minReadOnlyIndexVersion(), out);
         IndexVersion.writeVersion(versionInfo.maxIndexVersion(), out);
         if (out.getTransportVersion().onOrAfter(EXTERNAL_ID_VERSION)) {
             out.writeString(externalId);

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexingStats.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexingStats.java
@@ -67,9 +67,7 @@ public class IndexingStats implements Writeable, ToXContentFragment {
             indexTimeInMillis = in.readVLong();
             indexCurrent = in.readVLong();
             indexFailedCount = in.readVLong();
-            if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-                indexFailedDueToVersionConflictCount = in.readVLong();
-            }
+            indexFailedDueToVersionConflictCount = in.readVLong();
             deleteCount = in.readVLong();
             deleteTimeInMillis = in.readVLong();
             deleteCurrent = in.readVLong();
@@ -307,9 +305,7 @@ public class IndexingStats implements Writeable, ToXContentFragment {
             out.writeVLong(indexTimeInMillis);
             out.writeVLong(indexCurrent);
             out.writeVLong(indexFailedCount);
-            if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-                out.writeVLong(indexFailedDueToVersionConflictCount);
-            }
+            out.writeVLong(indexFailedDueToVersionConflictCount);
             out.writeVLong(deleteCount);
             out.writeVLong(deleteTimeInMillis);
             out.writeVLong(deleteCurrent);

--- a/server/src/main/java/org/elasticsearch/index/stats/IndexingPressureStats.java
+++ b/server/src/main/java/org/elasticsearch/index/stats/IndexingPressureStats.java
@@ -95,13 +95,8 @@ public class IndexingPressureStats implements Writeable, ToXContentFragment {
             totalCoordinatingRequests = -1L;
         }
 
-        if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            lowWaterMarkSplits = in.readVLong();
-            highWaterMarkSplits = in.readVLong();
-        } else {
-            lowWaterMarkSplits = -1L;
-            highWaterMarkSplits = -1L;
-        }
+        lowWaterMarkSplits = in.readVLong();
+        highWaterMarkSplits = in.readVLong();
 
         if (in.getTransportVersion().supports(MAX_OPERATION_SIZE_REJECTIONS_ADDED)) {
             largeOpsRejections = in.readVLong();
@@ -193,10 +188,8 @@ public class IndexingPressureStats implements Writeable, ToXContentFragment {
             out.writeVLong(totalCoordinatingRequests);
         }
 
-        if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            out.writeVLong(lowWaterMarkSplits);
-            out.writeVLong(highWaterMarkSplits);
-        }
+        out.writeVLong(lowWaterMarkSplits);
+        out.writeVLong(highWaterMarkSplits);
 
         if (out.getTransportVersion().supports(MAX_OPERATION_SIZE_REJECTIONS_ADDED)) {
             out.writeVLong(largeOpsRejections);

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoryStats.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoryStats.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.repositories;
 
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.blobstore.BlobStoreActionStats;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -32,14 +31,7 @@ public class RepositoryStats implements Writeable {
     }
 
     public RepositoryStats(StreamInput in) throws IOException {
-        if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            this.actionStats = in.readMap(BlobStoreActionStats::new);
-        } else {
-            this.actionStats = in.readMap(si -> {
-                long legacyValue = in.readLong();
-                return new BlobStoreActionStats(legacyValue, legacyValue);
-            });
-        }
+        this.actionStats = in.readMap(BlobStoreActionStats::new);
     }
 
     public RepositoryStats merge(RepositoryStats otherStats) {
@@ -52,11 +44,7 @@ public class RepositoryStats implements Writeable {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            out.writeMap(actionStats, (so, v) -> v.writeTo(so));
-        } else {
-            out.writeMap(actionStats, (so, v) -> so.writeLong(v.requests()));
-        }
+        out.writeMap(actionStats, (so, v) -> v.writeTo(so));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -19,7 +19,6 @@ import org.apache.lucene.search.TopDocs;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.ResolvedIndices;
@@ -597,12 +596,8 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         long taskId,
         ThreadPool threadPool
     ) {
-        final boolean header;
-        if (version.supports(TransportVersions.V_8_18_0) && threadPool.getThreadContext() != null) {
-            header = Boolean.parseBoolean(threadPool.getThreadContext().getHeaderOrDefault("error_trace", "false"));
-        } else {
-            header = true;
-        }
+        final boolean header = threadPool.getThreadContext() == null
+            || Boolean.parseBoolean(threadPool.getThreadContext().getHeaderOrDefault("error_trace", "false"));
         return listener.delegateResponse((l, e) -> {
             org.apache.logging.log4j.util.Supplier<String> messageSupplier = () -> format(
                 "[%s]%s: failed to execute search request for task [%d]",

--- a/server/src/main/java/org/elasticsearch/search/vectors/KnnSearchBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/KnnSearchBuilder.java
@@ -329,11 +329,7 @@ public class KnnSearchBuilder implements Writeable, ToXContentFragment, Rewritea
         if (in.getTransportVersion().onOrAfter(V_8_11_X)) {
             this.innerHitBuilder = in.readOptionalWriteable(InnerHitBuilder::new);
         }
-        if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            this.rescoreVectorBuilder = in.readOptional(RescoreVectorBuilder::new);
-        } else {
-            this.rescoreVectorBuilder = null;
-        }
+        this.rescoreVectorBuilder = in.readOptional(RescoreVectorBuilder::new);
     }
 
     public int k() {
@@ -589,9 +585,7 @@ public class KnnSearchBuilder implements Writeable, ToXContentFragment, Rewritea
         if (out.getTransportVersion().onOrAfter(V_8_11_X)) {
             out.writeOptionalWriteable(innerHitBuilder);
         }
-        if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            out.writeOptionalWriteable(rescoreVectorBuilder);
-        }
+        out.writeOptionalWriteable(rescoreVectorBuilder);
     }
 
     public static class Builder {

--- a/server/src/main/java/org/elasticsearch/search/vectors/KnnVectorQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/KnnVectorQueryBuilder.java
@@ -255,12 +255,7 @@ public class KnnVectorQueryBuilder extends AbstractQueryBuilder<KnnVectorQueryBu
         } else {
             this.queryVectorBuilder = null;
         }
-        if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            this.rescoreVectorBuilder = in.readOptional(RescoreVectorBuilder::new);
-        } else {
-            this.rescoreVectorBuilder = null;
-        }
-
+        this.rescoreVectorBuilder = in.readOptional(RescoreVectorBuilder::new);
         this.queryVectorSupplier = null;
     }
 
@@ -365,9 +360,7 @@ public class KnnVectorQueryBuilder extends AbstractQueryBuilder<KnnVectorQueryBu
         if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_14_0)) {
             out.writeOptionalNamedWriteable(queryVectorBuilder);
         }
-        if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            out.writeOptionalWriteable(rescoreVectorBuilder);
-        }
+        out.writeOptionalWriteable(rescoreVectorBuilder);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/TransportVersionTests.java
+++ b/server/src/test/java/org/elasticsearch/TransportVersionTests.java
@@ -419,7 +419,7 @@ public class TransportVersionTests extends ESTestCase {
             "TransportVersions.java is locked. Generate transport versions with TransportVersion.fromName "
                 + "and generateTransportVersion gradle task",
             TransportVersions.DEFINED_VERSIONS.getLast().id(),
-            equalTo(8_840_0_00)
+            equalTo(8_797_0_05)
         );
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/block/ClusterBlockTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/block/ClusterBlockTests.java
@@ -10,7 +10,6 @@
 package org.elasticsearch.cluster.block;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -23,10 +22,7 @@ import java.util.EnumSet;
 import java.util.Map;
 
 import static java.util.EnumSet.copyOf;
-import static org.elasticsearch.test.TransportVersionUtils.getFirstVersion;
-import static org.elasticsearch.test.TransportVersionUtils.getPreviousVersion;
 import static org.elasticsearch.test.TransportVersionUtils.randomVersion;
-import static org.elasticsearch.test.TransportVersionUtils.randomVersionBetween;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
@@ -40,7 +36,7 @@ public class ClusterBlockTests extends ESTestCase {
         int iterations = randomIntBetween(5, 20);
         for (int i = 0; i < iterations; i++) {
             TransportVersion version = randomVersion(random());
-            ClusterBlock clusterBlock = randomClusterBlock(version);
+            ClusterBlock clusterBlock = randomClusterBlock();
 
             BytesStreamOutput out = new BytesStreamOutput();
             out.setTransportVersion(version);
@@ -54,39 +50,13 @@ public class ClusterBlockTests extends ESTestCase {
         }
     }
 
-    public void testSerializationBwc() throws Exception {
-        var out = new BytesStreamOutput();
-        out.setTransportVersion(randomVersionBetween(random(), getFirstVersion(), getPreviousVersion(TransportVersions.V_8_18_0)));
-
-        var clusterBlock = randomClusterBlock(TransportVersions.V_8_18_0);
-        clusterBlock.writeTo(out);
-
-        var in = out.bytes().streamInput();
-        in.setTransportVersion(randomVersion());
-
-        assertClusterBlockEquals(
-            new ClusterBlock(
-                clusterBlock.id(),
-                clusterBlock.uuid(),
-                clusterBlock.description(),
-                clusterBlock.retryable(),
-                clusterBlock.disableStatePersistence(),
-                clusterBlock.isAllowReleaseResources(),
-                clusterBlock.status(),
-                // ClusterBlockLevel.REFRESH should not be sent over the wire to nodes with version < NEW_REFRESH_CLUSTER_BLOCK
-                ClusterBlock.filterLevels(clusterBlock.levels(), level -> ClusterBlockLevel.REFRESH.equals(level) == false)
-            ),
-            new ClusterBlock(in)
-        );
-    }
-
     public void testToStringDanglingComma() {
-        final ClusterBlock clusterBlock = randomClusterBlock(randomVersion(random()));
+        final ClusterBlock clusterBlock = randomClusterBlock();
         assertThat(clusterBlock.toString(), not(endsWith(",")));
     }
 
     public void testGlobalBlocksCheckedIfNoIndicesSpecified() {
-        ClusterBlock globalBlock = randomClusterBlock(randomVersion(random()));
+        ClusterBlock globalBlock = randomClusterBlock();
         ClusterBlocks clusterBlocks = new ClusterBlocks(Collections.singleton(globalBlock), Map.of());
         ClusterBlockException exception = clusterBlocks.indicesBlockedException(
             randomProjectIdOrDefault(),
@@ -174,9 +144,9 @@ public class ClusterBlockTests extends ESTestCase {
         final ProjectId project2 = randomUniqueProjectId();
         final ClusterBlocks.Builder builder = ClusterBlocks.builder();
         final var project1Index = randomIdentifier();
-        final var indexBlock = randomClusterBlock(randomVersion());
-        final var globalBlock = randomClusterBlock(randomVersion());
-        final var projectGlobalBlock = randomClusterBlock(randomVersion());
+        final var indexBlock = randomClusterBlock();
+        final var globalBlock = randomClusterBlock();
+        final var projectGlobalBlock = randomClusterBlock();
         if (randomBoolean()) {
             builder.addIndexBlock(project1, project1Index, indexBlock);
         }
@@ -191,13 +161,9 @@ public class ClusterBlockTests extends ESTestCase {
         assertTrue(clusterBlocks.indexBlocked(project1, randomFrom(projectGlobalBlock.levels()), project1Index));
     }
 
-    private static ClusterBlock randomClusterBlock(TransportVersion version) {
+    private static ClusterBlock randomClusterBlock() {
         final String uuid = randomBoolean() ? UUIDs.randomBase64UUID() : null;
-        final EnumSet<ClusterBlockLevel> levels = ClusterBlock.filterLevels(
-            EnumSet.allOf(ClusterBlockLevel.class),
-            // Filter out ClusterBlockLevel.REFRESH for versions < TransportVersions.NEW_REFRESH_CLUSTER_BLOCK
-            level -> ClusterBlockLevel.REFRESH.equals(level) == false || version.supports(TransportVersions.V_8_18_0)
-        );
+        final EnumSet<ClusterBlockLevel> levels = EnumSet.allOf(ClusterBlockLevel.class);
         return new ClusterBlock(
             randomInt(),
             uuid,

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -13,7 +13,6 @@ import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.RegExp;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.ResourceAlreadyExistsException;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.admin.indices.create.CreateIndexClusterStateUpdateRequest;
@@ -1630,7 +1629,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
                 TestShardRoutingRoleStrategies.DEFAULT_ROLE_ONLY
             );
 
-            var expectRefreshBlock = 0 < nbReplicas && minTransportVersion.supports(TransportVersions.V_8_18_0);
+            var expectRefreshBlock = 0 < nbReplicas;
             assertThat(updatedClusterState.blocks().indices(projectId), is(aMapWithSize(expectRefreshBlock ? 1 : 0)));
             assertThat(
                 updatedClusterState.blocks().hasIndexBlock(projectId, "test", IndexMetadata.INDEX_REFRESH_BLOCK),
@@ -1661,13 +1660,9 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
                 .settings(settings(IndexVersion.current()))
                 .numberOfShards(1)
                 .numberOfReplicas(randomIntBetween(1, 3))
-                .build(),
-            minTransportVersion
+                .build()
         );
-        assertThat(
-            blocks.hasIndexBlock(projectId, "test", IndexMetadata.INDEX_REFRESH_BLOCK),
-            is(isStateless && useRefreshBlock && minTransportVersion.supports(TransportVersions.V_8_18_0))
-        );
+        assertThat(blocks.hasIndexBlock(projectId, "test", IndexMetadata.INDEX_REFRESH_BLOCK), is(isStateless && useRefreshBlock));
     }
 
     private IndexTemplateMetadata addMatchingTemplate(Consumer<IndexTemplateMetadata.Builder> configurator) {

--- a/server/src/test/java/org/elasticsearch/search/vectors/AbstractKnnVectorQueryBuilderTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/AbstractKnnVectorQueryBuilderTestCase.java
@@ -14,14 +14,9 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.knn.KnnSearchStrategy;
-import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.compress.CompressedXContent;
-import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
@@ -36,7 +31,6 @@ import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.test.AbstractBuilderTestCase;
 import org.elasticsearch.test.AbstractQueryTestCase;
-import org.elasticsearch.test.TransportVersionUtils;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.junit.Before;
@@ -353,95 +347,6 @@ abstract class AbstractKnnVectorQueryBuilderTestCase extends AbstractQueryTestCa
 
         QueryBuilder rewrittenQuery = query.rewrite(context);
         assertThat(rewrittenQuery, instanceOf(MatchNoneQueryBuilder.class));
-    }
-
-    public void testBWCVersionSerializationFilters() throws IOException {
-        KnnVectorQueryBuilder query = createTestQueryBuilder();
-        VectorData vectorData = VectorData.fromFloats(query.queryVector().asFloatVector());
-        KnnVectorQueryBuilder queryNoFilters = new KnnVectorQueryBuilder(
-            query.getFieldName(),
-            vectorData,
-            null,
-            query.numCands(),
-            null,
-            null
-        ).queryName(query.queryName()).boost(query.boost());
-        TransportVersion beforeFilterVersion = TransportVersionUtils.randomVersionBetween(
-            random(),
-            TransportVersions.V_8_0_0,
-            TransportVersions.V_8_1_0
-        );
-        assertBWCSerialization(query, queryNoFilters, beforeFilterVersion);
-    }
-
-    public void testBWCVersionSerializationSimilarity() throws IOException {
-        KnnVectorQueryBuilder query = createTestQueryBuilder();
-        VectorData vectorData = VectorData.fromFloats(query.queryVector().asFloatVector());
-        KnnVectorQueryBuilder queryNoSimilarity = new KnnVectorQueryBuilder(
-            query.getFieldName(),
-            vectorData,
-            null,
-            query.numCands(),
-            null,
-            null
-        ).queryName(query.queryName()).boost(query.boost()).addFilterQueries(query.filterQueries());
-        assertBWCSerialization(query, queryNoSimilarity, TransportVersions.V_8_7_0);
-    }
-
-    public void testBWCVersionSerializationQuery() throws IOException {
-        KnnVectorQueryBuilder query = createTestQueryBuilder();
-        TransportVersion differentQueryVersion = TransportVersionUtils.randomVersionBetween(
-            random(),
-            TransportVersions.V_8_2_0,
-            TransportVersions.V_8_12_0
-        );
-        Float similarity = differentQueryVersion.before(TransportVersions.V_8_8_0) ? null : query.getVectorSimilarity();
-        VectorData vectorData = VectorData.fromFloats(query.queryVector().asFloatVector());
-        KnnVectorQueryBuilder queryOlderVersion = new KnnVectorQueryBuilder(
-            query.getFieldName(),
-            vectorData,
-            null,
-            query.numCands(),
-            null,
-            similarity
-        ).queryName(query.queryName()).boost(query.boost()).addFilterQueries(query.filterQueries());
-        assertBWCSerialization(query, queryOlderVersion, differentQueryVersion);
-    }
-
-    public void testBWCVersionSerializationRescoreVector() throws IOException {
-        KnnVectorQueryBuilder query = createTestQueryBuilder();
-        TransportVersion version = TransportVersionUtils.randomVersionBetween(
-            random(),
-            TransportVersions.V_8_8_1,
-            TransportVersionUtils.getPreviousVersion(TransportVersions.V_8_18_0)
-        );
-        VectorData vectorData = version.onOrAfter(TransportVersions.V_8_14_0)
-            ? query.queryVector()
-            : VectorData.fromFloats(query.queryVector().asFloatVector());
-        Integer k = version.before(TransportVersions.V_8_15_0) ? null : query.k();
-        KnnVectorQueryBuilder queryNoRescoreVector = new KnnVectorQueryBuilder(
-            query.getFieldName(),
-            vectorData,
-            k,
-            query.numCands(),
-            null,
-            query.getVectorSimilarity()
-        ).queryName(query.queryName()).boost(query.boost()).addFilterQueries(query.filterQueries());
-        assertBWCSerialization(query, queryNoRescoreVector, version);
-    }
-
-    private void assertBWCSerialization(QueryBuilder newQuery, QueryBuilder bwcQuery, TransportVersion version) throws IOException {
-        assertSerialization(bwcQuery, version);
-        try (BytesStreamOutput output = new BytesStreamOutput()) {
-            output.setTransportVersion(version);
-            output.writeNamedWriteable(newQuery);
-            try (StreamInput in = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), namedWriteableRegistry())) {
-                in.setTransportVersion(version);
-                KnnVectorQueryBuilder deserializedQuery = (KnnVectorQueryBuilder) in.readNamedWriteable(QueryBuilder.class);
-                assertEquals(bwcQuery, deserializedQuery);
-                assertEquals(bwcQuery.hashCode(), deserializedQuery.hashCode());
-            }
-        }
     }
 
     public void testRewriteForInnerHits() throws IOException {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/application/LogsDBFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/application/LogsDBFeatureSetUsage.java
@@ -35,12 +35,7 @@ public final class LogsDBFeatureSetUsage extends XPackFeatureUsage {
             numDocs = 0;
             sizeInBytes = 0;
         }
-        var transportVersion = input.getTransportVersion();
-        if (transportVersion.isPatchFrom(TransportVersions.V_8_17_0) || transportVersion.supports(TransportVersions.V_8_18_0)) {
-            hasCustomCutoffDate = input.readBoolean();
-        } else {
-            hasCustomCutoffDate = false;
-        }
+        hasCustomCutoffDate = input.readBoolean();
     }
 
     @Override
@@ -52,10 +47,7 @@ public final class LogsDBFeatureSetUsage extends XPackFeatureUsage {
             out.writeVLong(numDocs);
             out.writeVLong(sizeInBytes);
         }
-        var transportVersion = out.getTransportVersion();
-        if (transportVersion.isPatchFrom(TransportVersions.V_8_17_0) || transportVersion.supports(TransportVersions.V_8_18_0)) {
-            out.writeBoolean(hasCustomCutoffDate);
-        }
+        out.writeBoolean(hasCustomCutoffDate);
     }
 
     public LogsDBFeatureSetUsage(

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/datastreams/DataStreamFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/datastreams/DataStreamFeatureSetUsage.java
@@ -134,7 +134,7 @@ public class DataStreamFeatureSetUsage extends XPackFeatureUsage {
                 in.readVLong(),
                 in.readVLong(),
                 in.getTransportVersion().onOrAfter(TransportVersions.V_8_15_0) ? in.readVLong() : 0,
-                in.getTransportVersion().supports(TransportVersions.V_8_18_0) ? in.readVLong() : 0,
+                in.readVLong(),
                 in.getTransportVersion().onOrAfter(TransportVersions.V_8_15_0) ? in.readVLong() : 0,
                 in.getTransportVersion().supports(INTRODUCE_FAILURES_LIFECYCLE) ? in.readVLong() : 0,
                 in.getTransportVersion().supports(INTRODUCE_FAILURES_LIFECYCLE) ? in.readVLong() : 0,
@@ -156,9 +156,7 @@ public class DataStreamFeatureSetUsage extends XPackFeatureUsage {
             out.writeVLong(this.indicesBehindDataStream);
             if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_15_0)) {
                 out.writeVLong(this.failureStoreExplicitlyEnabledDataStreamCount);
-                if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-                    out.writeVLong(failureStoreEffectivelyEnabledDataStreamCount);
-                }
+                out.writeVLong(this.failureStoreEffectivelyEnabledDataStreamCount);
                 out.writeVLong(this.failureStoreIndicesCount);
             }
             if (out.getTransportVersion().supports(INTRODUCE_FAILURES_LIFECYCLE)) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotAction.java
@@ -127,7 +127,7 @@ public class SearchableSnapshotAction implements LifecycleAction {
         this.snapshotRepository = in.readString();
         this.forceMergeIndex = in.readBoolean();
         this.totalShardsPerNode = in.getTransportVersion().onOrAfter(TransportVersions.V_8_16_0) ? in.readOptionalInt() : null;
-        this.replicateFor = in.getTransportVersion().supports(TransportVersions.V_8_18_0) ? in.readOptionalTimeValue() : null;
+        this.replicateFor = in.readOptionalTimeValue();
     }
 
     boolean isForceMergeIndex() {
@@ -473,9 +473,7 @@ public class SearchableSnapshotAction implements LifecycleAction {
         if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_16_0)) {
             out.writeOptionalInt(totalShardsPerNode);
         }
-        if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            out.writeOptionalTimeValue(replicateFor);
-        }
+        out.writeOptionalTimeValue(replicateFor);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/BaseInferenceActionRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/BaseInferenceActionRequest.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.core.inference.action;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.LegacyActionRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -36,14 +35,7 @@ public abstract class BaseInferenceActionRequest extends LegacyActionRequest {
 
     public BaseInferenceActionRequest(StreamInput in) throws IOException {
         super(in);
-        if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            this.hasBeenRerouted = in.readBoolean();
-        } else {
-            // For backwards compatibility, we treat all inference requests coming from ES nodes having
-            // a version pre-node-local-rate-limiting as already rerouted to maintain pre-node-local-rate-limiting behavior.
-            this.hasBeenRerouted = true;
-        }
-
+        this.hasBeenRerouted = in.readBoolean();
         if (in.getTransportVersion().supports(INFERENCE_CONTEXT)) {
             this.context = new InferenceContext(in);
         } else {
@@ -72,10 +64,7 @@ public abstract class BaseInferenceActionRequest extends LegacyActionRequest {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            out.writeBoolean(hasBeenRerouted);
-        }
-
+        out.writeBoolean(hasBeenRerouted);
         if (out.getTransportVersion().supports(INFERENCE_CONTEXT)) {
             context.writeTo(out);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/vectors/TextEmbeddingQueryVectorBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/vectors/TextEmbeddingQueryVectorBuilder.java
@@ -64,11 +64,7 @@ public class TextEmbeddingQueryVectorBuilder implements QueryVectorBuilder {
     }
 
     public TextEmbeddingQueryVectorBuilder(StreamInput in) throws IOException {
-        if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            this.modelId = in.readOptionalString();
-        } else {
-            this.modelId = in.readString();
-        }
+        this.modelId = in.readOptionalString();
         this.modelText = in.readString();
     }
 
@@ -84,11 +80,7 @@ public class TextEmbeddingQueryVectorBuilder implements QueryVectorBuilder {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            out.writeOptionalString(modelId);
-        } else {
-            out.writeString(modelId);
-        }
+        out.writeOptionalString(modelId);
         out.writeString(modelText);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformMetadata.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.core.transform;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.cluster.NamedDiff;
@@ -83,19 +82,13 @@ public class TransformMetadata implements Metadata.ProjectCustom {
 
     public TransformMetadata(StreamInput in) throws IOException {
         this.resetMode = in.readBoolean();
-        if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            this.upgradeMode = in.readBoolean();
-        } else {
-            this.upgradeMode = false;
-        }
+        this.upgradeMode = in.readBoolean();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeBoolean(resetMode);
-        if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            out.writeBoolean(upgradeMode);
-        }
+        out.writeBoolean(upgradeMode);
     }
 
     @Override
@@ -117,12 +110,8 @@ public class TransformMetadata implements Metadata.ProjectCustom {
         }
 
         public TransformMetadataDiff(StreamInput in) throws IOException {
-            resetMode = in.readBoolean();
-            if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-                this.upgradeMode = in.readBoolean();
-            } else {
-                this.upgradeMode = false;
-            }
+            this.resetMode = in.readBoolean();
+            this.upgradeMode = in.readBoolean();
         }
 
         /**
@@ -138,9 +127,7 @@ public class TransformMetadata implements Metadata.ProjectCustom {
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeBoolean(resetMode);
-            if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-                out.writeBoolean(upgradeMode);
-            }
+            out.writeBoolean(upgradeMode);
         }
 
         @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/action/InferenceActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/action/InferenceActionRequestTests.java
@@ -693,11 +693,7 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
                     }
 
         // We always assume that a request has been rerouted, if it came from a node without adaptive rate limiting
-        if (version.supports(TransportVersions.V_8_18_0) == false) {
-            mutated.setHasBeenRerouted(true);
-        } else {
-            mutated.setHasBeenRerouted(instance.hasBeenRerouted());
-        }
+        mutated.setHasBeenRerouted(instance.hasBeenRerouted());
 
         return mutated;
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/action/InferenceActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/action/InferenceActionRequestTests.java
@@ -746,31 +746,6 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
         assertThat(deserializedInstance.getInputType(), is(InputType.UNSPECIFIED));
     }
 
-    public void testWriteTo_WhenVersionIsBeforeAdaptiveRateLimiting_ShouldSetHasBeenReroutedToTrue() throws IOException {
-        var instance = new InferenceAction.Request(
-            TaskType.TEXT_EMBEDDING,
-            "model",
-            null,
-            null,
-            null,
-            List.of("input"),
-            Map.of(),
-            InputType.UNSPECIFIED,
-            InferenceAction.Request.DEFAULT_TIMEOUT,
-            false
-        );
-
-        InferenceAction.Request deserializedInstance = copyWriteable(
-            instance,
-            getNamedWriteableRegistry(),
-            instanceReader(),
-            TransportVersions.V_8_13_0
-        );
-
-        // Verify that hasBeenRerouted is true after deserializing a request coming from an older transport version
-        assertTrue(deserializedInstance.hasBeenRerouted());
-    }
-
     public void testWriteTo_WhenVersionIsBeforeInferenceContext_ShouldSetContextToEmptyContext() throws IOException {
         var instance = new InferenceAction.Request(
             TaskType.TEXT_EMBEDDING,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/action/UnifiedCompletionActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/action/UnifiedCompletionActionRequestTests.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.core.inference.action;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.TimeValue;
@@ -20,7 +19,6 @@ import org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCase;
 import java.io.IOException;
 import java.util.List;
 
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 public class UnifiedCompletionActionRequestTests extends AbstractBWCWireSerializationTestCase<UnifiedCompletionAction.Request> {
@@ -68,43 +66,6 @@ public class UnifiedCompletionActionRequestTests extends AbstractBWCWireSerializ
             TimeValue.timeValueSeconds(10)
         );
         assertNull(request.validate());
-    }
-
-    public void testWriteTo_WhenVersionIsBeforeAdaptiveRateLimiting_ShouldSetHasBeenReroutedToTrue() throws IOException {
-        var instance = new UnifiedCompletionAction.Request(
-            "model",
-            TaskType.ANY,
-            UnifiedCompletionRequest.of(List.of(UnifiedCompletionRequestTests.randomMessage())),
-            TimeValue.timeValueSeconds(10)
-        );
-
-        UnifiedCompletionAction.Request deserializedInstance = copyWriteable(
-            instance,
-            getNamedWriteableRegistry(),
-            instanceReader(),
-            TransportVersions.V_8_17_0
-        );
-
-        // Verify that hasBeenRerouted is true after deserializing a request coming from an older transport version
-        assertTrue(deserializedInstance.hasBeenRerouted());
-    }
-
-    public void testWriteTo_WhenVersionIsBeforeInferenceContext_ShouldSetContextToEmptyContext() throws IOException {
-        var instance = new UnifiedCompletionAction.Request(
-            "model",
-            TaskType.ANY,
-            UnifiedCompletionRequest.of(List.of(UnifiedCompletionRequestTests.randomMessage())),
-            InferenceContext.EMPTY_INSTANCE,
-            TimeValue.timeValueSeconds(10)
-        );
-
-        UnifiedCompletionAction.Request deserializedInstance = copyWriteable(
-            instance,
-            getNamedWriteableRegistry(),
-            instanceReader(),
-            TransportVersions.V_8_18_0
-        );
-        assertThat(deserializedInstance.getContext(), equalTo(InferenceContext.EMPTY_INSTANCE));
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/retriever/RuleQueryRankDoc.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/retriever/RuleQueryRankDoc.java
@@ -40,15 +40,10 @@ public class RuleQueryRankDoc extends RankDoc {
 
     public RuleQueryRankDoc(StreamInput in) throws IOException {
         super(in);
-        if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            List<String> inRulesetIds = in.readOptionalStringCollectionAsList();
-            this.rulesetIds = inRulesetIds == null ? null : Collections.unmodifiableList(inRulesetIds);
-            boolean matchCriteriaExists = in.readBoolean();
-            this.matchCriteria = matchCriteriaExists ? in.readGenericMap() : null;
-        } else {
-            rulesetIds = in.readStringCollectionAsImmutableList();
-            matchCriteria = in.readGenericMap();
-        }
+        List<String> inRulesetIds = in.readOptionalStringCollectionAsList();
+        this.rulesetIds = inRulesetIds == null ? null : Collections.unmodifiableList(inRulesetIds);
+        boolean matchCriteriaExists = in.readBoolean();
+        this.matchCriteria = matchCriteriaExists ? in.readGenericMap() : null;
     }
 
     @Override
@@ -63,15 +58,10 @@ public class RuleQueryRankDoc extends RankDoc {
 
     @Override
     public void doWriteTo(StreamOutput out) throws IOException {
-        if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            out.writeOptionalStringCollection(rulesetIds);
-            out.writeBoolean(matchCriteria != null);
-            if (matchCriteria != null) {
-                out.writeGenericMap(matchCriteria);
-            }
-        } else {
-            out.writeStringCollection(rulesetIds == null ? Collections.emptyList() : rulesetIds);
-            out.writeGenericMap(matchCriteria == null ? Collections.emptyMap() : matchCriteria);
+        out.writeOptionalStringCollection(rulesetIds);
+        out.writeBoolean(matchCriteria != null);
+        if (matchCriteria != null) {
+            out.writeGenericMap(matchCriteria);
         }
     }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
@@ -133,13 +133,8 @@ public class EqlSearchRequest extends LegacyActionRequest implements IndicesRequ
         if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_7_0)) {
             maxSamplesPerKey = in.readInt();
         }
-        if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            allowPartialSearchResults = in.readOptionalBoolean();
-            allowPartialSequenceResults = in.readOptionalBoolean();
-        } else {
-            allowPartialSearchResults = false;
-            allowPartialSequenceResults = false;
-        }
+        allowPartialSearchResults = in.readOptionalBoolean();
+        allowPartialSequenceResults = in.readOptionalBoolean();
     }
 
     @Override
@@ -491,10 +486,8 @@ public class EqlSearchRequest extends LegacyActionRequest implements IndicesRequ
         if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_7_0)) {
             out.writeInt(maxSamplesPerKey);
         }
-        if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            out.writeOptionalBoolean(allowPartialSearchResults);
-            out.writeOptionalBoolean(allowPartialSequenceResults);
-        }
+        out.writeOptionalBoolean(allowPartialSearchResults);
+        out.writeOptionalBoolean(allowPartialSequenceResults);
     }
 
     @Override

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchResponse.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchResponse.java
@@ -127,11 +127,7 @@ public class EqlSearchResponse extends ActionResponse implements ToXContentObjec
         asyncExecutionId = in.readOptionalString();
         isPartial = in.readBoolean();
         isRunning = in.readBoolean();
-        if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            shardFailures = in.readArray(ShardSearchFailure::readShardSearchFailure, ShardSearchFailure[]::new);
-        } else {
-            shardFailures = ShardSearchFailure.EMPTY_ARRAY;
-        }
+        shardFailures = in.readArray(ShardSearchFailure::readShardSearchFailure, ShardSearchFailure[]::new);
     }
 
     public static EqlSearchResponse fromXContent(XContentParser parser) {
@@ -146,9 +142,7 @@ public class EqlSearchResponse extends ActionResponse implements ToXContentObjec
         out.writeOptionalString(asyncExecutionId);
         out.writeBoolean(isPartial);
         out.writeBoolean(isRunning);
-        if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            out.writeArray(shardFailures);
-        }
+        out.writeArray(shardFailures);
     }
 
     @Override

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlSearchRequestTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/action/EqlSearchRequestTests.java
@@ -137,13 +137,8 @@ public class EqlSearchRequestTests extends AbstractBWCSerializationTestCase<EqlS
         mutatedInstance.runtimeMappings(instance.runtimeMappings());
         mutatedInstance.resultPosition(instance.resultPosition());
         mutatedInstance.maxSamplesPerKey(version.onOrAfter(TransportVersions.V_8_7_0) ? instance.maxSamplesPerKey() : 1);
-        mutatedInstance.allowPartialSearchResults(
-            version.supports(TransportVersions.V_8_18_0) ? instance.allowPartialSearchResults() : false
-        );
-        mutatedInstance.allowPartialSequenceResults(
-            version.supports(TransportVersions.V_8_18_0) ? instance.allowPartialSequenceResults() : false
-        );
-
+        mutatedInstance.allowPartialSearchResults(instance.allowPartialSearchResults());
+        mutatedInstance.allowPartialSequenceResults(instance.allowPartialSequenceResults());
         return mutatedInstance;
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneOperator.java
@@ -380,11 +380,7 @@ public abstract class LuceneOperator extends SourceOperator {
             sliceMin = in.readVInt();
             sliceMax = in.readVInt();
             current = in.readVInt();
-            if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-                rowsEmitted = in.readVLong();
-            } else {
-                rowsEmitted = 0;
-            }
+            rowsEmitted = in.readVLong();
             partitioningStrategies = serializeShardPartitioning(in.getTransportVersion())
                 ? in.readMap(LuceneSliceQueue.PartitioningStrategy::readFrom)
                 : Map.of();
@@ -406,9 +402,7 @@ public abstract class LuceneOperator extends SourceOperator {
             out.writeVInt(sliceMin);
             out.writeVInt(sliceMax);
             out.writeVInt(current);
-            if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-                out.writeVLong(rowsEmitted);
-            }
+            out.writeVLong(rowsEmitted);
             if (serializeShardPartitioning(out.getTransportVersion())) {
                 out.writeMap(partitioningStrategies, StreamOutput::writeString, StreamOutput::writeWriteable);
             }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/AbstractPageMappingOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/AbstractPageMappingOperator.java
@@ -130,13 +130,8 @@ public abstract class AbstractPageMappingOperator implements Operator {
         public Status(StreamInput in) throws IOException {
             processNanos = in.getTransportVersion().onOrAfter(TransportVersions.V_8_14_0) ? in.readVLong() : 0;
             pagesProcessed = in.readVInt();
-            if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-                rowsReceived = in.readVLong();
-                rowsEmitted = in.readVLong();
-            } else {
-                rowsReceived = 0;
-                rowsEmitted = 0;
-            }
+            rowsReceived = in.readVLong();
+            rowsEmitted = in.readVLong();
         }
 
         @Override
@@ -145,10 +140,8 @@ public abstract class AbstractPageMappingOperator implements Operator {
                 out.writeVLong(processNanos);
             }
             out.writeVInt(pagesProcessed);
-            if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-                out.writeVLong(rowsReceived);
-                out.writeVLong(rowsEmitted);
-            }
+            out.writeVLong(rowsReceived);
+            out.writeVLong(rowsEmitted);
         }
 
         @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/AbstractPageMappingToIteratorOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/AbstractPageMappingToIteratorOperator.java
@@ -223,13 +223,8 @@ public abstract class AbstractPageMappingToIteratorOperator implements Operator 
             processNanos = in.readVLong();
             pagesReceived = in.readVInt();
             pagesEmitted = in.readVInt();
-            if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-                rowsReceived = in.readVLong();
-                rowsEmitted = in.readVLong();
-            } else {
-                rowsReceived = 0;
-                rowsEmitted = 0;
-            }
+            rowsReceived = in.readVLong();
+            rowsEmitted = in.readVLong();
         }
 
         @Override
@@ -237,10 +232,8 @@ public abstract class AbstractPageMappingToIteratorOperator implements Operator 
             out.writeVLong(processNanos);
             out.writeVInt(pagesReceived);
             out.writeVInt(pagesEmitted);
-            if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-                out.writeVLong(rowsReceived);
-                out.writeVLong(rowsEmitted);
-            }
+            out.writeVLong(rowsReceived);
+            out.writeVLong(rowsEmitted);
         }
 
         @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/AggregationOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/AggregationOperator.java
@@ -247,13 +247,8 @@ public class AggregationOperator implements Operator {
                 aggregationFinishNanos = null;
             }
             pagesProcessed = in.readVInt();
-            if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-                rowsReceived = in.readVLong();
-                rowsEmitted = in.readVLong();
-            } else {
-                rowsReceived = 0;
-                rowsEmitted = 0;
-            }
+            rowsReceived = in.readVLong();
+            rowsEmitted = in.readVLong();
         }
 
         @Override
@@ -263,10 +258,8 @@ public class AggregationOperator implements Operator {
                 out.writeOptionalVLong(aggregationFinishNanos);
             }
             out.writeVInt(pagesProcessed);
-            if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-                out.writeVLong(rowsReceived);
-                out.writeVLong(rowsEmitted);
-            }
+            out.writeVLong(rowsReceived);
+            out.writeVLong(rowsEmitted);
         }
 
         @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/HashAggregationOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/HashAggregationOperator.java
@@ -355,14 +355,8 @@ public class HashAggregationOperator implements Operator {
             hashNanos = in.readVLong();
             aggregationNanos = in.readVLong();
             pagesProcessed = in.readVInt();
-
-            if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-                rowsReceived = in.readVLong();
-                rowsEmitted = in.readVLong();
-            } else {
-                rowsReceived = 0;
-                rowsEmitted = 0;
-            }
+            rowsReceived = in.readVLong();
+            rowsEmitted = in.readVLong();
             if (in.getTransportVersion().supports(ESQL_HASH_OPERATOR_STATUS_OUTPUT_TIME)) {
                 emitNanos = in.readVLong();
             } else {
@@ -375,11 +369,8 @@ public class HashAggregationOperator implements Operator {
             out.writeVLong(hashNanos);
             out.writeVLong(aggregationNanos);
             out.writeVInt(pagesProcessed);
-
-            if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-                out.writeVLong(rowsReceived);
-                out.writeVLong(rowsEmitted);
-            }
+            out.writeVLong(rowsReceived);
+            out.writeVLong(rowsEmitted);
             if (out.getTransportVersion().supports(ESQL_HASH_OPERATOR_STATUS_OUTPUT_TIME)) {
                 out.writeVLong(emitNanos);
             }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/LimitOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/LimitOperator.java
@@ -192,13 +192,8 @@ public class LimitOperator implements Operator {
             limit = in.readVInt();
             limitRemaining = in.readVInt();
             pagesProcessed = in.readVInt();
-            if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-                rowsReceived = in.readVLong();
-                rowsEmitted = in.readVLong();
-            } else {
-                rowsReceived = 0;
-                rowsEmitted = 0;
-            }
+            rowsReceived = in.readVLong();
+            rowsEmitted = in.readVLong();
         }
 
         @Override
@@ -206,10 +201,8 @@ public class LimitOperator implements Operator {
             out.writeVInt(limit);
             out.writeVInt(limitRemaining);
             out.writeVInt(pagesProcessed);
-            if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-                out.writeVLong(rowsReceived);
-                out.writeVLong(rowsEmitted);
-            }
+            out.writeVLong(rowsReceived);
+            out.writeVLong(rowsEmitted);
         }
 
         @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/MvExpandOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/MvExpandOperator.java
@@ -292,13 +292,8 @@ public class MvExpandOperator implements Operator {
             pagesReceived = in.readVInt();
             pagesEmitted = in.readVInt();
             noops = in.readVInt();
-            if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-                rowsReceived = in.readVLong();
-                rowsEmitted = in.readVLong();
-            } else {
-                rowsReceived = 0;
-                rowsEmitted = 0;
-            }
+            rowsReceived = in.readVLong();
+            rowsEmitted = in.readVLong();
         }
 
         @Override
@@ -306,10 +301,8 @@ public class MvExpandOperator implements Operator {
             out.writeVInt(pagesReceived);
             out.writeVInt(pagesEmitted);
             out.writeVInt(noops);
-            if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-                out.writeVLong(rowsReceived);
-                out.writeVLong(rowsEmitted);
-            }
+            out.writeVLong(rowsReceived);
+            out.writeVLong(rowsEmitted);
         }
 
         @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeSinkOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeSinkOperator.java
@@ -114,21 +114,13 @@ public class ExchangeSinkOperator extends SinkOperator {
 
         Status(StreamInput in) throws IOException {
             pagesReceived = in.readVInt();
-
-            if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-                rowsReceived = in.readVLong();
-            } else {
-                rowsReceived = 0;
-            }
+            rowsReceived = in.readVLong();
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeVInt(pagesReceived);
-
-            if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-                out.writeVLong(rowsReceived);
-            }
+            out.writeVLong(rowsReceived);
         }
 
         @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeSourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeSourceOperator.java
@@ -117,22 +117,14 @@ public class ExchangeSourceOperator extends SourceOperator {
         Status(StreamInput in) throws IOException {
             pagesWaiting = in.readVInt();
             pagesEmitted = in.readVInt();
-
-            if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-                rowsEmitted = in.readVLong();
-            } else {
-                rowsEmitted = 0;
-            }
+            rowsEmitted = in.readVLong();
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeVInt(pagesWaiting);
             out.writeVInt(pagesEmitted);
-
-            if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-                out.writeVLong(rowsEmitted);
-            }
+            out.writeVLong(rowsEmitted);
         }
 
         @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/TopNOperatorStatus.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/TopNOperatorStatus.java
@@ -52,17 +52,11 @@ public class TopNOperatorStatus implements Operator.Status {
         this.occupiedRows = in.readVInt();
         this.ramBytesUsed = in.readVLong();
 
-        if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            this.pagesReceived = in.readVInt();
-            this.pagesEmitted = in.readVInt();
-            this.rowsReceived = in.readVLong();
-            this.rowsEmitted = in.readVLong();
-        } else {
-            this.pagesReceived = 0;
-            this.pagesEmitted = 0;
-            this.rowsReceived = 0;
-            this.rowsEmitted = 0;
-        }
+        this.pagesReceived = in.readVInt();
+        this.pagesEmitted = in.readVInt();
+        this.rowsReceived = in.readVLong();
+        this.rowsEmitted = in.readVLong();
+
     }
 
     @Override
@@ -70,12 +64,10 @@ public class TopNOperatorStatus implements Operator.Status {
         out.writeVInt(occupiedRows);
         out.writeVLong(ramBytesUsed);
 
-        if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            out.writeVInt(pagesReceived);
-            out.writeVInt(pagesEmitted);
-            out.writeVLong(rowsReceived);
-            out.writeVLong(rowsEmitted);
-        }
+        out.writeVInt(pagesReceived);
+        out.writeVInt(pagesEmitted);
+        out.writeVLong(rowsReceived);
+        out.writeVLong(rowsEmitted);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlExecutionInfo.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlExecutionInfo.java
@@ -124,11 +124,7 @@ public class EsqlExecutionInfo implements ChunkedToXContentObject, Writeable {
         } else {
             this.includeCCSMetadata = false;
         }
-        if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            this.isPartial = in.readBoolean();
-        } else {
-            this.isPartial = false;
-        }
+        this.isPartial = in.readBoolean();
         this.skipUnavailablePredicate = Predicates.always();
         this.relativeStart = null;
         if (in.getTransportVersion().supports(ESQL_QUERY_PLANNING_DURATION)) {
@@ -148,9 +144,7 @@ public class EsqlExecutionInfo implements ChunkedToXContentObject, Writeable {
         if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_16_0)) {
             out.writeBoolean(includeCCSMetadata);
         }
-        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_18_0)) {
-            out.writeBoolean(isPartial);
-        }
+        out.writeBoolean(isPartial);
         if (out.getTransportVersion().supports(ESQL_QUERY_PLANNING_DURATION)) {
             out.writeOptionalWriteable(overallTimeSpan);
             out.writeOptionalWriteable(planningTimeSpan);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/Kql.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/Kql.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.expression.function.fulltext;
 
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -61,10 +60,7 @@ public class Kql extends FullTextFunction {
     private static Kql readFrom(StreamInput in) throws IOException {
         Source source = Source.readFrom((PlanStreamInput) in);
         Expression query = in.readNamedWriteable(Expression.class);
-        QueryBuilder queryBuilder = null;
-        if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            queryBuilder = in.readOptionalNamedWriteable(QueryBuilder.class);
-        }
+        QueryBuilder queryBuilder = in.readOptionalNamedWriteable(QueryBuilder.class);
         return new Kql(source, query, queryBuilder);
     }
 
@@ -72,9 +68,7 @@ public class Kql extends FullTextFunction {
     public void writeTo(StreamOutput out) throws IOException {
         source().writeTo(out);
         out.writeNamedWriteable(query());
-        if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            out.writeOptionalNamedWriteable(queryBuilder());
-        }
+        out.writeOptionalNamedWriteable(queryBuilder());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/Match.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/Match.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.esql.expression.function.fulltext;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -277,10 +276,7 @@ public class Match extends FullTextFunction implements OptionalArgument, PostAna
         Source source = Source.readFrom((PlanStreamInput) in);
         Expression field = in.readNamedWriteable(Expression.class);
         Expression query = in.readNamedWriteable(Expression.class);
-        QueryBuilder queryBuilder = null;
-        if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            queryBuilder = in.readOptionalNamedWriteable(QueryBuilder.class);
-        }
+        QueryBuilder queryBuilder = in.readOptionalNamedWriteable(QueryBuilder.class);
         return new Match(source, field, query, null, queryBuilder);
     }
 
@@ -290,9 +286,7 @@ public class Match extends FullTextFunction implements OptionalArgument, PostAna
         source().writeTo(out);
         out.writeNamedWriteable(field());
         out.writeNamedWriteable(query());
-        if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            out.writeOptionalNamedWriteable(queryBuilder());
-        }
+        out.writeOptionalNamedWriteable(queryBuilder());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/QueryString.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/QueryString.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.expression.function.fulltext;
 
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -276,10 +275,7 @@ public class QueryString extends FullTextFunction implements OptionalArgument {
     private static QueryString readFrom(StreamInput in) throws IOException {
         Source source = Source.readFrom((PlanStreamInput) in);
         Expression query = in.readNamedWriteable(Expression.class);
-        QueryBuilder queryBuilder = null;
-        if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            queryBuilder = in.readOptionalNamedWriteable(QueryBuilder.class);
-        }
+        QueryBuilder queryBuilder = in.readOptionalNamedWriteable(QueryBuilder.class);
         return new QueryString(source, query, null, queryBuilder);
     }
 
@@ -287,9 +283,7 @@ public class QueryString extends FullTextFunction implements OptionalArgument {
     public void writeTo(StreamOutput out) throws IOException {
         source().writeTo(out);
         out.writeNamedWriteable(query());
-        if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            out.writeOptionalNamedWriteable(queryBuilder());
-        }
+        out.writeOptionalNamedWriteable(queryBuilder());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/Term.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/Term.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.expression.function.fulltext;
 
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -76,10 +75,7 @@ public class Term extends FullTextFunction implements PostAnalysisPlanVerificati
         Source source = Source.readFrom((PlanStreamInput) in);
         Expression field = in.readNamedWriteable(Expression.class);
         Expression query = in.readNamedWriteable(Expression.class);
-        QueryBuilder queryBuilder = null;
-        if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            queryBuilder = in.readOptionalNamedWriteable(QueryBuilder.class);
-        }
+        QueryBuilder queryBuilder = in.readOptionalNamedWriteable(QueryBuilder.class);
         return new Term(source, field, query, queryBuilder);
     }
 
@@ -88,9 +84,7 @@ public class Term extends FullTextFunction implements PostAnalysisPlanVerificati
         source().writeTo(out);
         out.writeNamedWriteable(field());
         out.writeNamedWriteable(query());
-        if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            out.writeOptionalNamedWriteable(queryBuilder());
-        }
+        out.writeOptionalNamedWriteable(queryBuilder());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/FragmentExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/FragmentExec.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.plan.physical;
 
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -53,14 +52,7 @@ public class FragmentExec extends LeafExec implements EstimatesRowSize {
         super(Source.readFrom((PlanStreamInput) in));
         this.fragment = in.readNamedWriteable(LogicalPlan.class);
         this.esFilter = in.readOptionalNamedWriteable(QueryBuilder.class);
-        if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            this.estimatedRowSize = in.readVInt();
-        } else {
-            this.estimatedRowSize = Objects.requireNonNull(in.readOptionalVInt());
-            if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_14_0)) {
-                in.readOptionalNamedWriteable(PhysicalPlan.class); // for old reducer
-            }
-        }
+        this.estimatedRowSize = in.readVInt();
     }
 
     @Override
@@ -68,14 +60,7 @@ public class FragmentExec extends LeafExec implements EstimatesRowSize {
         Source.EMPTY.writeTo(out);
         out.writeNamedWriteable(fragment());
         out.writeOptionalNamedWriteable(esFilter());
-        if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            out.writeVInt(estimatedRowSize);
-        } else {
-            out.writeOptionalVInt(estimatedRowSize());
-            if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_14_0)) {
-                out.writeOptionalNamedWriteable(null);// for old reducer
-            }
-        }
+        out.writeVInt(estimatedRowSize);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeRequest.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/DataNodeRequest.java
@@ -100,11 +100,7 @@ final class DataNodeRequest extends AbstractTransportRequest implements IndicesR
             this.indices = shardIds.stream().map(ShardId::getIndexName).distinct().toArray(String[]::new);
             this.indicesOptions = IndicesOptions.strictSingleIndexNoExpandForbidClosed();
         }
-        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_18_0)) {
-            this.runNodeLevelReduction = in.readBoolean();
-        } else {
-            this.runNodeLevelReduction = false;
-        }
+        this.runNodeLevelReduction = in.readBoolean();
     }
 
     @Override
@@ -122,9 +118,7 @@ final class DataNodeRequest extends AbstractTransportRequest implements IndicesR
             out.writeStringArray(indices);
             indicesOptions.writeIndicesOptions(out);
         }
-        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_18_0)) {
-            out.writeBoolean(runNodeLevelReduction);
-        }
+        out.writeBoolean(runNodeLevelReduction);
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/queries/SemanticQueryBuilder.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/queries/SemanticQueryBuilder.java
@@ -105,11 +105,7 @@ public class SemanticQueryBuilder extends AbstractQueryBuilder<SemanticQueryBuil
         this.inferenceResults = in.readOptionalNamedWriteable(InferenceResults.class);
         this.noInferenceResults = in.readBoolean();
         this.inferenceResultsSupplier = null;
-        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_18_0)) {
-            this.lenient = in.readOptionalBoolean();
-        } else {
-            this.lenient = null;
-        }
+        this.lenient = in.readOptionalBoolean();
     }
 
     @Override
@@ -121,9 +117,7 @@ public class SemanticQueryBuilder extends AbstractQueryBuilder<SemanticQueryBuil
         out.writeString(query);
         out.writeOptionalNamedWriteable(inferenceResults);
         out.writeBoolean(noInferenceResults);
-        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_18_0)) {
-            out.writeOptionalBoolean(lenient);
-        }
+        out.writeOptionalBoolean(lenient);
     }
 
     private SemanticQueryBuilder(

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankDoc.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rank/textsimilarity/TextSimilarityRankDoc.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.inference.rank.textsimilarity;
 
 import org.apache.lucene.search.Explanation;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.rank.RankDoc;
@@ -36,13 +35,8 @@ public class TextSimilarityRankDoc extends RankDoc {
 
     public TextSimilarityRankDoc(StreamInput in) throws IOException {
         super(in);
-        if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            inferenceId = in.readOptionalString();
-            field = in.readOptionalString();
-        } else {
-            inferenceId = in.readString();
-            field = in.readString();
-        }
+        inferenceId = in.readOptionalString();
+        field = in.readOptionalString();
     }
 
     @Override
@@ -63,13 +57,8 @@ public class TextSimilarityRankDoc extends RankDoc {
 
     @Override
     public void doWriteTo(StreamOutput out) throws IOException {
-        if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            out.writeOptionalString(inferenceId);
-            out.writeOptionalString(field);
-        } else {
-            out.writeString(inferenceId == null ? "" : inferenceId);
-            out.writeString(field == null ? "" : field);
-        }
+        out.writeOptionalString(inferenceId);
+        out.writeOptionalString(field);
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/completion/ElasticInferenceServiceCompletionServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/completion/ElasticInferenceServiceCompletionServiceSettings.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.inference.services.elastic.completion;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -85,7 +84,7 @@ public class ElasticInferenceServiceCompletionServiceSettings extends FilteredXC
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {
-        return TransportVersions.V_8_18_0;
+        return TransportVersion.minimumCompatible();
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/rerank/IbmWatsonxRerankServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/rerank/IbmWatsonxRerankServiceSettings.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.inference.services.ibmwatsonx.rerank;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -157,7 +156,7 @@ public class IbmWatsonxRerankServiceSettings extends FilteredXContentObject impl
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {
-        return TransportVersions.V_8_18_0;
+        return TransportVersion.minimumCompatible();
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/rerank/IbmWatsonxRerankTaskSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/rerank/IbmWatsonxRerankTaskSettings.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.inference.services.ibmwatsonx.rerank;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -137,7 +136,7 @@ public class IbmWatsonxRerankTaskSettings implements TaskSettings {
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {
-        return TransportVersions.V_8_18_0;
+        return TransportVersion.minimumCompatible();
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIService.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.inference.services.jinaai;
 
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.util.LazyInitializable;
@@ -335,7 +334,7 @@ public class JinaAIService extends SenderService {
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {
-        return TransportVersions.V_8_18_0;
+        return TransportVersion.minimumCompatible();
     }
 
     public static class Configuration {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIServiceSettings.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.inference.services.jinaai;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -131,7 +130,7 @@ public class JinaAIServiceSettings extends FilteredXContentObject implements Ser
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {
-        return TransportVersions.V_8_18_0;
+        return TransportVersion.minimumCompatible();
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/embeddings/JinaAIEmbeddingsServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/embeddings/JinaAIEmbeddingsServiceSettings.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.inference.services.jinaai.embeddings;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -174,7 +173,7 @@ public class JinaAIEmbeddingsServiceSettings extends FilteredXContentObject impl
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {
-        return TransportVersions.V_8_18_0;
+        return TransportVersion.minimumCompatible();
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/embeddings/JinaAIEmbeddingsTaskSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/embeddings/JinaAIEmbeddingsTaskSettings.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.inference.services.jinaai.embeddings;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -139,7 +138,7 @@ public class JinaAIEmbeddingsTaskSettings implements TaskSettings {
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {
-        return TransportVersions.V_8_18_0;
+        return TransportVersion.minimumCompatible();
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/rerank/JinaAIRerankServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/rerank/JinaAIRerankServiceSettings.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.inference.services.jinaai.rerank;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -90,7 +89,7 @@ public class JinaAIRerankServiceSettings extends FilteredXContentObject implemen
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {
-        return TransportVersions.V_8_18_0;
+        return TransportVersion.minimumCompatible();
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/rerank/JinaAIRerankTaskSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/rerank/JinaAIRerankTaskSettings.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.inference.services.jinaai.rerank;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -118,7 +117,7 @@ public class JinaAIRerankTaskSettings implements TaskSettings {
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {
-        return TransportVersions.V_8_18_0;
+        return TransportVersion.minimumCompatible();
     }
 
     @Override

--- a/x-pack/plugin/kql/src/main/java/org/elasticsearch/xpack/kql/query/KqlQueryBuilder.java
+++ b/x-pack/plugin/kql/src/main/java/org/elasticsearch/xpack/kql/query/KqlQueryBuilder.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.kql.query;
 
 import org.apache.lucene.search.Query;
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -97,7 +96,7 @@ public class KqlQueryBuilder extends AbstractQueryBuilder<KqlQueryBuilder> {
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {
-        return TransportVersions.V_8_18_0;
+        return TransportVersion.minimumCompatible();
     }
 
     public String queryString() {

--- a/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/task/ReindexDataStreamTaskParams.java
+++ b/x-pack/plugin/migrate/src/main/java/org/elasticsearch/xpack/migrate/task/ReindexDataStreamTaskParams.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.migrate.task;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -77,7 +76,7 @@ public record ReindexDataStreamTaskParams(
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {
-        return TransportVersions.V_8_18_0;
+        return TransportVersion.minimumCompatible();
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlAnomaliesIndexUpdate.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlAnomaliesIndexUpdate.java
@@ -11,7 +11,6 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequestBuilder;
@@ -65,7 +64,7 @@ public class MlAnomaliesIndexUpdate implements MlAutoUpdateService.UpdateAction 
     public boolean isMinTransportVersionSupported(TransportVersion minTransportVersion) {
         // Automatic rollover does not require any new features
         // but wait for all nodes to be upgraded anyway
-        return minTransportVersion.supports(TransportVersions.V_8_18_0);
+        return true;
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlIndexRollover.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlIndexRollover.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.ml;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.rollover.RolloverRequest;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -60,7 +59,7 @@ public class MlIndexRollover implements MlAutoUpdateService.UpdateAction {
     public boolean isMinTransportVersionSupported(TransportVersion minTransportVersion) {
         // Wait for all nodes to be upgraded to ensure that the
         // newly created index will be of the latest version.
-        return minTransportVersion.supports(TransportVersions.V_8_18_0);
+        return true;
     }
 
     @Override

--- a/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/linear/LinearRankDoc.java
+++ b/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/linear/LinearRankDoc.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.rank.linear;
 
 import org.apache.lucene.search.Explanation;
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.rank.RankDoc;
@@ -138,6 +137,6 @@ public class LinearRankDoc extends RankDoc {
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {
-        return TransportVersions.V_8_18_0;
+        return TransportVersion.minimumCompatible();
     }
 }

--- a/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/rrf/RRFRankDoc.java
+++ b/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/rrf/RRFRankDoc.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.rank.rrf;
 
 import org.apache.lucene.search.Explanation;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.rank.RankDoc;
@@ -17,8 +16,6 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
-
-import static org.elasticsearch.xpack.rank.rrf.RRFRetrieverBuilder.DEFAULT_RANK_CONSTANT;
 
 /**
  * {@code RRFRankDoc} supports additional ranking information
@@ -66,23 +63,13 @@ public final class RRFRankDoc extends RankDoc {
     public RRFRankDoc(StreamInput in) throws IOException {
         super(in);
         rank = in.readVInt();
-        if (in.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            if (in.readBoolean()) {
-                positions = in.readIntArray();
-            } else {
-                positions = null;
-            }
-            scores = in.readOptionalFloatArray();
-            rankConstant = in.readOptionalVInt();
-        } else {
+        if (in.readBoolean()) {
             positions = in.readIntArray();
-            scores = in.readFloatArray();
-            if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_16_0)) {
-                this.rankConstant = in.readVInt();
-            } else {
-                this.rankConstant = DEFAULT_RANK_CONSTANT;
-            }
+        } else {
+            positions = null;
         }
+        scores = in.readOptionalFloatArray();
+        rankConstant = in.readOptionalVInt();
     }
 
     @Override
@@ -134,22 +121,14 @@ public final class RRFRankDoc extends RankDoc {
     @Override
     public void doWriteTo(StreamOutput out) throws IOException {
         out.writeVInt(rank);
-        if (out.getTransportVersion().supports(TransportVersions.V_8_18_0)) {
-            if (positions != null) {
-                out.writeBoolean(true);
-                out.writeIntArray(positions);
-            } else {
-                out.writeBoolean(false);
-            }
-            out.writeOptionalFloatArray(scores);
-            out.writeOptionalVInt(rankConstant);
+        if (positions != null) {
+            out.writeBoolean(true);
+            out.writeIntArray(positions);
         } else {
-            out.writeIntArray(positions == null ? new int[0] : positions);
-            out.writeFloatArray(scores == null ? new float[0] : scores);
-            if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_16_0)) {
-                out.writeVInt(rankConstant == null ? DEFAULT_RANK_CONSTANT : rankConstant);
-            }
+            out.writeBoolean(false);
         }
+        out.writeOptionalFloatArray(scores);
+        out.writeOptionalVInt(rankConstant);
     }
 
     @Override


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch/pull/138844