### PR TITLE
[9.2] Do not pack non-dimension fields in TS (#138929)

### DIFF
--- a/docs/changelog/138929.yaml
+++ b/docs/changelog/138929.yaml
@@ -1,0 +1,5 @@
+pr: 138929
+summary: Do not pack non-dimension fields in TS
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/TimeSeriesIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/TimeSeriesIT.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import static org.elasticsearch.index.mapper.DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER;
 import static org.hamcrest.Matchers.closeTo;

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/TimeSeriesIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/TimeSeriesIT.java
@@ -9,14 +9,18 @@ package org.elasticsearch.xpack.esql.action;
 
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Randomness;
+import org.elasticsearch.common.Rounding;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.iterable.Iterables;
+import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.compute.lucene.LuceneSliceQueue;
 import org.elasticsearch.compute.lucene.LuceneSourceOperator;
 import org.elasticsearch.compute.operator.DriverProfile;
 import org.elasticsearch.compute.operator.OperatorStatus;
 import org.elasticsearch.compute.operator.TimeSeriesAggregationOperator;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.xpack.esql.EsqlTestUtils;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
@@ -24,6 +28,7 @@ import org.hamcrest.Matchers;
 import org.junit.Before;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -49,6 +54,8 @@ public class TimeSeriesIT extends AbstractEsqlIntegTestCase {
             .setMapping(
                 "@timestamp",
                 "type=date",
+                "project",
+                "type=keyword",
                 "host",
                 "type=keyword,time_series_dimension=true",
                 "cpu",
@@ -58,7 +65,15 @@ public class TimeSeriesIT extends AbstractEsqlIntegTestCase {
         run("TS empty_index | LIMIT 1").close();
     }
 
-    record Doc(String host, String cluster, long timestamp, int requestCount, double cpu, ByteSizeValue memory) {}
+    record Doc(
+        Collection<String> project,
+        String host,
+        String cluster,
+        long timestamp,
+        int requestCount,
+        double cpu,
+        ByteSizeValue memory
+    ) {}
 
     final List<Doc> docs = new ArrayList<>();
 
@@ -94,6 +109,8 @@ public class TimeSeriesIT extends AbstractEsqlIntegTestCase {
             .setMapping(
                 "@timestamp",
                 "type=date",
+                "project",
+                "type=keyword",
                 "host",
                 "type=keyword,time_series_dimension=true",
                 "cluster",
@@ -114,6 +131,7 @@ public class TimeSeriesIT extends AbstractEsqlIntegTestCase {
         int numDocs = between(20, 100);
         docs.clear();
         Map<String, Integer> requestCounts = new HashMap<>();
+        List<String> allProjects = List.of("project-1", "project-2", "project-3");
         for (int i = 0; i < numDocs; i++) {
             List<String> hosts = randomSubsetOf(between(1, hostToClusters.size()), hostToClusters.keySet());
             timestamp += between(1, 10) * 1000L;
@@ -127,7 +145,8 @@ public class TimeSeriesIT extends AbstractEsqlIntegTestCase {
                 });
                 int cpu = randomIntBetween(0, 100);
                 ByteSizeValue memory = ByteSizeValue.ofBytes(randomIntBetween(1024, 1024 * 1024));
-                docs.add(new Doc(host, hostToClusters.get(host), timestamp, requestCount, cpu, memory));
+                List<String> projects = randomSubsetOf(between(1, 3), allProjects);
+                docs.add(new Doc(projects, host, hostToClusters.get(host), timestamp, requestCount, cpu, memory));
             }
         }
         Randomness.shuffle(docs);
@@ -136,6 +155,8 @@ public class TimeSeriesIT extends AbstractEsqlIntegTestCase {
                 .setSource(
                     "@timestamp",
                     doc.timestamp,
+                    "project",
+                    doc.project,
                     "host",
                     doc.host,
                     "cluster",
@@ -646,7 +667,8 @@ public class TimeSeriesIT extends AbstractEsqlIntegTestCase {
             });
             int cpu = randomIntBetween(0, 100);
             ByteSizeValue memory = ByteSizeValue.ofBytes(randomIntBetween(1024, 1024 * 1024));
-            sparseDocs.add(new Doc(host, hostToClusters.get(host), timestamp, requestCount, cpu, memory));
+            String project = randomFrom("project-1", "project-2", "project-3");
+            sparseDocs.add(new Doc(List.of(project), host, hostToClusters.get(host), timestamp, requestCount, cpu, memory));
         }
 
         Randomness.shuffle(sparseDocs);
@@ -700,6 +722,138 @@ public class TimeSeriesIT extends AbstractEsqlIntegTestCase {
             assertThat(values, hasSize(1));
             assertThat(values.getFirst().get(0), Matchers.notNullValue());
             assertThat(values.getFirst().get(1), Matchers.notNullValue());
+        }
+    }
+
+    public void testGroupByProject() {
+        record TimeSeries(String cluster, String host) {
+
+        }
+        record Sample(int count, double sum) {
+
+        }
+        Map<TimeSeries, Tuple<Sample, Set<String>>> buckets = new HashMap<>();
+        for (Doc doc : docs) {
+            TimeSeries timeSeries = new TimeSeries(doc.cluster, doc.host);
+            buckets.compute(timeSeries, (k, v) -> {
+                if (v == null) {
+                    return Tuple.tuple(new Sample(1, doc.cpu), Set.copyOf(doc.project));
+                } else {
+                    Set<String> projects = Sets.union(v.v2(), Sets.newHashSet(doc.project));
+                    return Tuple.tuple(new Sample(v.v1().count + 1, v.v1().sum + doc.cpu), projects);
+                }
+            });
+        }
+        try (var resp = run("TS host* | STATS avg(avg_over_time(cpu)) BY project")) {
+            Map<String, Integer> countPerProject = new HashMap<>();
+            Map<String, Double> sumOfAvgPerProject = new HashMap<>();
+            for (var e : buckets.entrySet()) {
+                Sample sample = e.getValue().v1();
+                for (String project : e.getValue().v2()) {
+                    countPerProject.merge(project, 1, Integer::sum);
+                    sumOfAvgPerProject.merge(project, sample.sum / sample.count, Double::sum);
+                }
+            }
+            List<List<Object>> rows = EsqlTestUtils.getValuesList(resp);
+            assertThat(rows, hasSize(sumOfAvgPerProject.size()));
+            for (List<Object> r : rows) {
+                String project = (String) r.get(1);
+                double actualAvg = (Double) r.get(0);
+                double expectedAvg = sumOfAvgPerProject.get(project) / countPerProject.get(project);
+                assertThat(actualAvg, closeTo(expectedAvg, 0.5));
+            }
+        }
+        try (var resp = run("TS host* | STATS avg(avg_over_time(cpu)) BY project, cluster")) {
+            record Key(String project, String cluster) {
+
+            }
+            Map<Key, Integer> countPerProject = new HashMap<>();
+            Map<Key, Double> sumOfAvgPerProject = new HashMap<>();
+            for (var e : buckets.entrySet()) {
+                Sample sample = e.getValue().v1();
+                for (String project : e.getValue().v2()) {
+                    Key key = new Key(project, e.getKey().cluster);
+                    countPerProject.merge(key, 1, Integer::sum);
+                    sumOfAvgPerProject.merge(key, sample.sum / sample.count, Double::sum);
+                }
+            }
+            List<List<Object>> rows = EsqlTestUtils.getValuesList(resp);
+            assertThat(rows, hasSize(sumOfAvgPerProject.size()));
+            for (List<Object> r : rows) {
+                Key key = new Key((String) r.get(1), (String) r.get(2));
+                double actualAvg = (Double) r.get(0);
+                double expectedAvg = sumOfAvgPerProject.get(key) / countPerProject.get(key);
+                assertThat(actualAvg, closeTo(expectedAvg, 0.5));
+            }
+        }
+    }
+
+    public void testGroupByProjectAndTBucket() {
+        record TimeSeries(String cluster, String host, String tbucket) {
+
+        }
+        record Sample(int count, double sum) {
+
+        }
+        Map<TimeSeries, Tuple<Sample, Set<String>>> buckets = new HashMap<>();
+        var rounding = new Rounding.Builder(TimeValue.timeValueMillis(TimeValue.timeValueMinutes(1).millis())).build().prepareForUnknown();
+        for (Doc doc : docs) {
+            var tbucket = DEFAULT_DATE_TIME_FORMATTER.formatMillis(rounding.round(doc.timestamp));
+            TimeSeries timeSeries = new TimeSeries(doc.cluster, doc.host, tbucket);
+            buckets.compute(timeSeries, (k, v) -> {
+                if (v == null) {
+                    return Tuple.tuple(new Sample(1, doc.cpu), Set.copyOf(doc.project));
+                } else {
+                    Set<String> projects = Sets.union(v.v2(), Sets.newHashSet(doc.project));
+                    return Tuple.tuple(new Sample(v.v1().count + 1, v.v1().sum + doc.cpu), projects);
+                }
+            });
+        }
+        try (var resp = run("TS host* | STATS avg(avg_over_time(cpu)) BY project, tbucket(1minute)")) {
+            record Key(String project, String tbucket) {
+
+            }
+            Map<Key, Integer> countPerProject = new HashMap<>();
+            Map<Key, Double> sumOfAvgPerProject = new HashMap<>();
+            for (var e : buckets.entrySet()) {
+                Sample sample = e.getValue().v1();
+                for (String project : e.getValue().v2()) {
+                    Key key = new Key(project, e.getKey().tbucket);
+                    countPerProject.merge(key, 1, Integer::sum);
+                    sumOfAvgPerProject.merge(key, sample.sum / sample.count, Double::sum);
+                }
+            }
+            List<List<Object>> rows = EsqlTestUtils.getValuesList(resp);
+            assertThat(rows, hasSize(sumOfAvgPerProject.size()));
+            for (List<Object> r : rows) {
+                Key key = new Key((String) r.get(1), (String) r.get(2));
+                double actualAvg = (Double) r.get(0);
+                double expectedAvg = sumOfAvgPerProject.get(key) / countPerProject.get(key);
+                assertThat(actualAvg, closeTo(expectedAvg, 0.5));
+            }
+        }
+        try (var resp = run("TS host* | STATS avg(avg_over_time(cpu)) BY  tbucket(1minute), project, cluster")) {
+            record Key(String project, String cluster, String tbucket) {
+
+            }
+            Map<Key, Integer> countPerProject = new HashMap<>();
+            Map<Key, Double> sumOfAvgPerProject = new HashMap<>();
+            for (var e : buckets.entrySet()) {
+                Sample sample = e.getValue().v1();
+                for (String project : e.getValue().v2()) {
+                    Key key = new Key(project, e.getKey().cluster, e.getKey().tbucket);
+                    countPerProject.merge(key, 1, Integer::sum);
+                    sumOfAvgPerProject.merge(key, sample.sum / sample.count, Double::sum);
+                }
+            }
+            List<List<Object>> rows = EsqlTestUtils.getValuesList(resp);
+            assertThat(rows, hasSize(sumOfAvgPerProject.size()));
+            for (List<Object> r : rows) {
+                Key key = new Key((String) r.get(2), (String) r.get(3), (String) r.get(1));
+                double actualAvg = (Double) r.get(0);
+                double expectedAvg = sumOfAvgPerProject.get(key) / countPerProject.get(key);
+                assertThat(actualAvg, closeTo(expectedAvg, 0.5));
+            }
         }
     }
 


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Do not pack non-dimension fields in TS (#138929)