### PR TITLE
[Build] Update InternalTestArtifact plugin to reference unique artifacts

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -239,7 +239,7 @@ similar to how the Gradle build-in `java-test-fixtures` plugin works.
 ```
 dependencies {
   testImplementation(project(":fixture-providing-project')) {
-    requireCapabilities("org.elasticsearch.gradle:fixture-providing-project-test-artifacts")
+    requireCapabilities(${project(":fixture-providing-project').group}:fixture-providing-project-test-artifacts")
   }
 }
 ```

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalTestArtifactExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalTestArtifactExtension.java
@@ -34,7 +34,7 @@ public class InternalTestArtifactExtension {
         JavaPluginExtension javaPluginExtension = project.getExtensions().getByType(JavaPluginExtension.class);
         javaPluginExtension.registerFeature(name + "Artifacts", featureSpec -> {
             featureSpec.usingSourceSet(sourceSet);
-            featureSpec.capability("org.elasticsearch.gradle", project.getName() + "-" + sourceSet.getName() + "-artifacts", "1.0");
+            featureSpec.capability(project.getGroup().toString(), project.getName() + "-" + sourceSet.getName() + "-artifacts", "1.0");
             // This feature is only used internally in the
             // elasticsearch build so we do not need any publication.
             featureSpec.disablePublication();

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ tasks.named('zipAggregation').configure {
 ext.testArtifact = { p, String name = "test" ->
   def projectDependency = p.dependencies.create(p)
   projectDependency.capabilities {
-    requireCapabilities("org.elasticsearch.gradle:${projectDependency.name}-${name}-artifacts")
+    requireCapabilities("${p.group}:${projectDependency.name}-${name}-artifacts")
   };
 }
 

--- a/test/external-modules/esql-heap-attack/build.gradle
+++ b/test/external-modules/esql-heap-attack/build.gradle
@@ -11,8 +11,6 @@ apply plugin: 'elasticsearch.internal-java-rest-test'
 // Necessary to use tests in Serverless
 apply plugin: 'elasticsearch.internal-test-artifact'
 
-group = 'org.elasticsearch.plugin'
-
 esplugin {
   description = 'A test module that can trigger out of memory'
   classname ='org.elasticsearch.test.esql.heap_attack.HeapAttackPlugin'


### PR DESCRIPTION
This ensures that we can reference multiple test artfiacts of the same type (e.g. javaRestTest) by taking the group name of the referencing project into account for the referenced capability