### PR TITLE
[Docs] Adding minor clarification

### DIFF
--- a/docs/reference/elasticsearch/configuration-reference/snapshot-restore-settings.md
+++ b/docs/reference/elasticsearch/configuration-reference/snapshot-restore-settings.md
@@ -49,6 +49,6 @@ $$$slm-health-failed-snapshot-warn-threshold$$$
 $$$repositories-url-allowed$$$
 
 `repositories.url.allowed_urls` ![logo cloud](https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg "Supported on Elastic Cloud Hosted")
-:   ([Static](docs-content://deploy-manage/stack-settings.md#static-cluster-setting)) Specifies the [read-only URL repositories](docs-content://deploy-manage/tools/snapshot-and-restore/read-only-url-repository.md) that snapshots can be restored from.
+:   ([Static](docs-content://deploy-manage/stack-settings.md#static-cluster-setting)) Specifies the [read-only URL repositories](docs-content://deploy-manage/tools/snapshot-and-restore/read-only-url-repository.md) that snapshots can be restored from. The default value is an empty list.
 
 


### PR DESCRIPTION
Fixes [#1422](https://github.com/elastic/docs-content/issues/1422) and states that the default value is an empty list.


The default seems to be set [here](https://github.com/elastic/elasticsearch/blob/fa8c7711d8be7e552a314b9c3c08096e2758358a/modules/repository-url/src/main/java/org/elasticsearch/repositories/url/URLRepository.java#L67-L77).
