### PR TITLE
Fix AggregateMetricDoubleArrayBlock serialization bwc bug

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AggregateMetricDoubleArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AggregateMetricDoubleArrayBlock.java
@@ -16,6 +16,7 @@ import org.elasticsearch.core.Releasables;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.function.IntFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -238,12 +239,35 @@ public final class AggregateMetricDoubleArrayBlock extends AbstractNonThreadSafe
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        for (Block block : List.of(minBlock, maxBlock, sumBlock, countBlock)) {
-            if (out.getTransportVersion().supports(WRITE_TYPED_BLOCK)) {
+        if (out.getTransportVersion().supports(WRITE_TYPED_BLOCK)) {
+            for (Block block : List.of(minBlock, maxBlock, sumBlock, countBlock)) {
                 Block.writeTypedBlock(block, out);
-            } else {
-                block.writeTo(out);
             }
+        } else {
+            // We can't serialize ConstantNullBlock instances for BWC reasons,
+            // so we replace them with non-constant null blocks here
+            for (DoubleBlock block : List.of(minBlock, maxBlock, sumBlock)) {
+                try (Block notConstantNull = replaceConstantNullBlock(block, blockFactory()::newDoubleBlockBuilder)) {
+                    notConstantNull.writeTo(out);
+                }
+            }
+            try (Block notConstantNull = replaceConstantNullBlock(countBlock, blockFactory()::newIntBlockBuilder)) {
+                notConstantNull.writeTo(out);
+            }
+        }
+    }
+
+    private Block replaceConstantNullBlock(Block block, IntFunction<Builder> builderProducer) {
+        if (block instanceof ConstantNullBlock) {
+            try (var builder = builderProducer.apply(block.getPositionCount())) {
+                for (int i = 0; i < block.getPositionCount(); i++) {
+                    builder.appendNull();
+                }
+                return builder.build();
+            }
+        } else {
+            block.incRef();
+            return block;
         }
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockSerializationTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockSerializationTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.core.Releasables;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.test.EqualsHashCodeTestUtils;
 import org.elasticsearch.test.TransportVersionUtils;
+import org.elasticsearch.xpack.esql.core.type.DataType;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -492,15 +493,12 @@ public class BlockSerializationTests extends SerializationTestCase {
                     origBlock,
                     TransportVersionUtils.randomVersionBetween(
                         random(),
-                        AggregateMetricDoubleArrayBlock.WRITE_TYPED_BLOCK,
+                        DataType.DataTypesTransportVersions.ESQL_AGGREGATE_METRIC_DOUBLE_CREATED_VERSION,
                         TransportVersion.current()
                     )
                 )
             ) {
-                assertThat(deserBlock.minBlock(), equalTo(minBlock));
-                assertThat(deserBlock.minBlock(), equalTo(minBlock));
-                assertThat(deserBlock.minBlock(), equalTo(minBlock));
-                assertThat(deserBlock.minBlock(), equalTo(minBlock));
+                assertThat(deserBlock, equalTo(origBlock));
                 EqualsHashCodeTestUtils.checkEqualsAndHashCode(deserBlock, unused -> deserBlock);
             }
         }


### PR DESCRIPTION
Fixes a backwards-compatibility problem introduced (or rather not fully fixed) with https://github.com/elastic/elasticsearch/pull/138539.

The problem is that we could serialize via `ConstantNullBlock.writeTo`, build would try to deserialize as `DoubleBlock.readFrom`.
This PR adds a reproducer by ensuring the problematic transport versions are covered by the existing serialization unit test.
I ran the test locally with 10k iteration, now it passes correctly.