### PR TITLE
Add the projectId to the ScriptCache.CacheKey equals and hashCode methods

### DIFF
--- a/server/src/main/java/org/elasticsearch/script/ScriptCache.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptCache.java
@@ -86,7 +86,7 @@ public class ScriptCache {
         Map<String, String> options
     ) {
         String lang = scriptEngine.getType();
-        CacheKey cacheKey = new CacheKey(lang, projectId, idOrCode, context.name, options);
+        CacheKey cacheKey = new CacheKey(projectId, lang, idOrCode, context.name, options);
 
         // Relying on computeIfAbsent to avoid multiple threads from compiling the same script
         try {
@@ -205,15 +205,15 @@ public class ScriptCache {
     }
 
     private static final class CacheKey {
-        final String lang;
         final ProjectId projectId;
+        final String lang;
         final String idOrCode;
         final String context;
         final Map<String, String> options;
 
-        private CacheKey(String lang, ProjectId projectId, String idOrCode, String context, Map<String, String> options) {
-            this.lang = lang;
+        private CacheKey(ProjectId projectId, String lang, String idOrCode, String context, Map<String, String> options) {
             this.projectId = projectId;
+            this.lang = lang;
             this.idOrCode = idOrCode;
             this.context = context;
             this.options = options;
@@ -224,8 +224,8 @@ public class ScriptCache {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             CacheKey cacheKey = (CacheKey) o;
-            return Objects.equals(lang, cacheKey.lang)
-                && Objects.equals(projectId, cacheKey.projectId)
+            return Objects.equals(projectId, cacheKey.projectId)
+                && Objects.equals(lang, cacheKey.lang)
                 && Objects.equals(idOrCode, cacheKey.idOrCode)
                 && Objects.equals(context, cacheKey.context)
                 && Objects.equals(options, cacheKey.options);

--- a/server/src/main/java/org/elasticsearch/script/ScriptCache.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptCache.java
@@ -225,6 +225,7 @@ public class ScriptCache {
             if (o == null || getClass() != o.getClass()) return false;
             CacheKey cacheKey = (CacheKey) o;
             return Objects.equals(lang, cacheKey.lang)
+                && Objects.equals(projectId, cacheKey.projectId)
                 && Objects.equals(idOrCode, cacheKey.idOrCode)
                 && Objects.equals(context, cacheKey.context)
                 && Objects.equals(options, cacheKey.options);
@@ -232,7 +233,7 @@ public class ScriptCache {
 
         @Override
         public int hashCode() {
-            return Objects.hash(lang, idOrCode, context, options);
+            return Objects.hash(lang, projectId, idOrCode, context, options);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/script/ScriptCache.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptCache.java
@@ -233,7 +233,7 @@ public class ScriptCache {
 
         @Override
         public int hashCode() {
-            return Objects.hash(lang, projectId, idOrCode, context, options);
+            return Objects.hash(projectId, lang, idOrCode, context, options);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/script/ScriptCache.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptCache.java
@@ -73,7 +73,7 @@ public class ScriptCache {
         this.rate = maxCompilationRate;
         this.compilesAllowedPerNano = ((double) rate.count) / rate.time.nanos();
         this.scriptMetrics = new ScriptMetrics(timeProvider);
-        this.tokenBucketState = new AtomicReference<TokenBucketState>(new TokenBucketState(this.rate.count));
+        this.tokenBucketState = new AtomicReference<>(new TokenBucketState(this.rate.count));
     }
 
     <FactoryType> FactoryType compile(
@@ -90,7 +90,7 @@ public class ScriptCache {
 
         // Relying on computeIfAbsent to avoid multiple threads from compiling the same script
         try {
-            return context.factoryClazz.cast(cache.computeIfAbsent(cacheKey, key -> {
+            return context.factoryClazz.cast(cache.computeIfAbsent(cacheKey, ignored -> {
                 // Either an un-cached inline script or indexed script
                 // If the script type is inline the name will be the same as the code for identification in exceptions
                 // but give the script engine the chance to be better, give it separate name + source code
@@ -144,7 +144,7 @@ public class ScriptCache {
     /**
      * Check whether there have been too many compilations within the last minute, throwing a circuit breaking exception if so.
      * This is a variant of the token bucket algorithm: https://en.wikipedia.org/wiki/Token_bucket
-     *
+     * <p>
      * It can be thought of as a bucket with water, every time the bucket is checked, water is added proportional to the amount of time that
      * elapsed since the last time it was checked. If there is enough water, some is removed and the request is allowed. If there is not
      * enough water the request is denied. Just like a normal bucket, if water is added that overflows the bucket, the extra water/capacity


### PR DESCRIPTION
The ScriptCache.CacheKey has a reference to the projectId, but it isn't using it when calculating equals and hashCode. I figured that should be fixed.

Arguably this is a `>bug`, but since it's a bug that cannot be exercised in Elasticsearch at present, I'm going with `>non-issue`. Also for that reason, I'm not backporting it beyond `main`. Let me know if you object to either of those decisions, I'm not firm on any of it. 🤷