### PR TITLE
[8.19] Explicitly disable Mustache partials (#138944)

### DIFF
--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomMustacheFactory.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomMustacheFactory.java
@@ -86,7 +86,7 @@ public final class CustomMustacheFactory extends DefaultMustacheFactory {
     }
 
     private CustomMustacheFactory(String mediaType, boolean detectMissingParams) {
-        super();
+        super(resourceName -> null); // we do not resolve templates via files or the classpath, etc.
         setObjectHandler(new CustomReflectionObjectHandler(detectMissingParams));
         this.encoder = createEncoder(mediaType);
     }
@@ -136,6 +136,13 @@ public final class CustomMustacheFactory extends DefaultMustacheFactory {
             } else {
                 list.add(new IterableCode(templateContext, df, mustache, variable));
             }
+        }
+
+        @Override
+        public void partial(TemplateContext tc, String variable, String indent) {
+            // throwing a mustache exception here is important because this gets caught, handled (closing readers, etc),
+            // and re-thrown in the mustache parser itself
+            throw new MustacheException(Strings.format("Cannot expand '%s' because partial templates are not supported", variable));
         }
     }
 

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MustacheTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MustacheTests.java
@@ -455,6 +455,18 @@ public class MustacheTests extends ESTestCase {
         );
     }
 
+    public void testsUnsupportedPartials() {
+        ScriptException e;
+
+        final String script1 = "{{>foobar}}";
+        e = expectThrows(ScriptException.class, () -> compile(script1));
+        assertThat(e.getMessage(), equalTo("Cannot expand 'foobar' because partial templates are not supported"));
+
+        final String script2 = "{{>*foobar}}";
+        e = expectThrows(ScriptException.class, () -> compile(script2));
+        assertThat(e.getMessage(), equalTo("Cannot expand '*foobar' because partial templates are not supported"));
+    }
+
     private void assertScript(String script, Map<String, Object> vars, Matcher<String> matcher) {
         String result = compile(script).newInstance(vars).execute();
         assertThat(result, matcher);

--- a/modules/lang-mustache/src/yamlRestTest/resources/rest-api-spec/test/lang_mustache/20_render_search_template.yml
+++ b/modules/lang-mustache/src/yamlRestTest/resources/rest-api-spec/test/lang_mustache/20_render_search_template.yml
@@ -47,7 +47,7 @@
   - match: { template_output.aggs.my_terms.terms.field: "my_other_field" }
 
   - do:
-      catch: /Improperly.closed.variable.in.query-template/
+      catch: "/Improperly.closed.variable(: my_value)?.in.query-template/"
       render_search_template:
         body: { "source": { "query": { "match": { "text": "{{{my_value}}" } }, "aggs": { "my_terms": { "terms": { "field": "{{my_field}}" } } } }, "params": { "my_value": "bar", "my_field": "field1" } }
 ---
@@ -99,7 +99,7 @@
   - match: { template_output.size: 100 }
 
   - do:
-      catch: /Improperly.closed.variable.in.query-template/
+      catch: "/Improperly.closed.variable(: my_value)?.in.query-template/"
       render_search_template:
         body: { "source": "{ \"query\": { \"match\": { \"text\": \"{{{my_value}}\" } }, \"size\": {{my_size}} }", "params": { "my_value": "bar", "my_size": 100 } }
 


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Explicitly disable Mustache partials (#138944)