### PR TITLE
Make testTopNSortExpressionWithinRemoteEnrichAliasing not require exact temp name

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -325,9 +325,6 @@ tests:
 - class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
   method: testRemoteClusterOnlyCCSWithFailuresOnAllShards
   issue: https://github.com/elastic/elasticsearch/issues/136894
-- class: org.elasticsearch.xpack.esql.optimizer.rules.logical.HoistRemoteEnrichTopNTests
-  method: testTopNSortExpressionWithinRemoteEnrichAliasing
-  issue: https://github.com/elastic/elasticsearch/issues/136957
 - class: org.elasticsearch.xpack.inference.DefaultEndPointsIT
   method: testMultipleInferencesTriggeringDownloadAndDeploy
   issue: https://github.com/elastic/elasticsearch/issues/117208

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/HoistRemoteEnrichTopNTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/HoistRemoteEnrichTopNTests.java
@@ -252,7 +252,7 @@ public class HoistRemoteEnrichTopNTests extends AbstractLogicalPlanOptimizerTest
         assertFalse(topn.local());
         Order topNOrder = topn.order().get(1);
         NamedExpression expr = as(topNOrder.child(), NamedExpression.class);
-        assertThat(expr.name(), startsWith("$$order_by$1$0"));
+        assertThat(expr.name(), startsWith("$$order_by$1$"));
         var enrich = as(topn.child(), Enrich.class);
         assertThat(enrich.mode(), is(Enrich.Mode.REMOTE));
         var innerTopN = as(enrich.child(), TopN.class);


### PR DESCRIPTION
The temp counter may not be 0 when the test is run. 

Closes https://github.com/elastic/elasticsearch/issues/136957