### PR TITLE
[9.2] Improving performance of get data streams API by avoiding getting effective mappings (#138948)

### DIFF
--- a/docs/changelog/138948.yaml
+++ b/docs/changelog/138948.yaml
@@ -1,0 +1,6 @@
+pr: 138948
+summary: Improving performance of get data streams API by avoiding getting effective
+  mappings
+area: Data streams
+type: bug
+issues: []

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportGetDataStreamsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportGetDataStreamsAction.java
@@ -32,6 +32,7 @@ import org.elasticsearch.cluster.metadata.DataStreamGlobalRetentionSettings;
 import org.elasticsearch.cluster.metadata.DataStreamLifecycle;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.MetadataCreateDataStreamService;
 import org.elasticsearch.cluster.metadata.MetadataDataStreamsService;
 import org.elasticsearch.cluster.metadata.MetadataIndexTemplateService;
 import org.elasticsearch.cluster.metadata.ProjectMetadata;
@@ -278,12 +279,21 @@ public class TransportGetDataStreamsAction extends TransportLocalProjectMetadata
             } else {
                 indexTemplate = MetadataIndexTemplateService.findV2Template(state.metadata(), dataStream.getName(), false);
                 if (indexTemplate != null) {
-                    final Settings settings;
-                    try {
-                        settings = metadataDataStreamsService.getEffectiveSettings(state.metadata(), dataStream);
-                    } catch (IOException e) {
-                        throw new RuntimeException("Failed to get effective settings for data stream: " + dataStream.getName(), e);
-                    }
+                    /*
+                     * Here we intentionally avoid the full MetadataDataStreamService::getEffectiveSettings and instead do a shortcut that
+                     * does not merge all mappings together in order to fetch the settings from additional settings providers. The reason
+                     * is that this code can be called fairly frequently, and we do not need that information here -- we get settings from
+                     * additional settings providers below in resolveMode, and those settings do not require any information from mappings.
+                     */
+                    ComposableIndexTemplate template = MetadataCreateDataStreamService.lookupTemplateForDataStream(
+                        dataStream.getName(),
+                        state.metadata()
+                    );
+                    Settings templateSettings = MetadataIndexTemplateService.resolveSettings(
+                        template,
+                        state.metadata().componentTemplates()
+                    );
+                    final Settings settings = templateSettings.merge(dataStream.getSettings());
                     ilmPolicyName = settings.get(IndexMetadata.LIFECYCLE_NAME);
                     if (indexMode == null && state.metadata().templatesV2().get(indexTemplate) != null) {
                         try {

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/280_data_stream_mappings-timeseries.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/280_data_stream_mappings-timeseries.yml
@@ -39,6 +39,7 @@
   - match: { data_streams.0.name: my-data-stream-1 }
   - match: { data_streams.0.mappings: {} }
   - match: { data_streams.0.effective_mappings: null }
+  - match: { data_streams.0.index_mode: time_series }
 
   - do:
       indices.put_data_stream_mappings:
@@ -78,6 +79,7 @@
   - match: { data_streams.0.name: my-data-stream-1 }
   - match: { data_streams.0.mappings.properties.name.type: "keyword" }
   - match: { data_streams.0.effective_mappings: null }
+  - match: { data_streams.0.index_mode: time_series }
   - set: { data_streams.0.indices.0.index_name: oldIndexName }
   - set: { data_streams.0.indices.1.index_name: newIndexName }
 
@@ -141,6 +143,7 @@
   - match: { data_streams.0.name: my-component-only-data-stream-1 }
   - match: { data_streams.0.mappings: {} }
   - match: { data_streams.0.effective_mappings: null }
+  - match: { data_streams.0.index_mode: time_series }
 
   - do:
       indices.put_data_stream_mappings:
@@ -202,6 +205,7 @@
   - match: { data_streams.0.effective_mappings: null }
   - set: { data_streams.0.indices.0.index_name: oldIndexName }
   - set: { data_streams.0.indices.1.index_name: newIndexName }
+  - match: { data_streams.0.index_mode: time_series }
 
   - do:
       indices.get_mapping:
@@ -269,6 +273,7 @@
   - match: { data_streams.0.name: my-data-stream-1 }
   - match: { data_streams.0.mappings: {} }
   - match: { data_streams.0.effective_mappings: null }
+  - match: { data_streams.0.index_mode: time_series }
 
   - do:
       indices.put_index_template:
@@ -297,6 +302,7 @@
   - match: { data_streams.0.name: my-data-stream-1 }
   - match: { data_streams.0.mappings: {} }
   - match: { data_streams.0.effective_mappings: null }
+  - match: { data_streams.0.index_mode: time_series }
 
   - do:
       indices.rollover:
@@ -320,6 +326,7 @@
   - match: { data_streams.0.name: my-data-stream-1 }
   - match: { data_streams.0.mappings: { } }
   - match: { data_streams.0.effective_mappings: null }
+  - match: { data_streams.0.index_mode: standard }
   - set: { data_streams.0.indices.0.index_name: oldIndexName }
   - set: { data_streams.0.indices.1.index_name: newIndexName }
 
@@ -380,6 +387,7 @@
   - match: { data_streams.0.name: test-data-stream-1 }
   - match: { data_streams.0.mappings: {} }
   - match: { data_streams.0.effective_mappings: null }
+  - match: { data_streams.0.index_mode: time_series }
 
   - do:
       indices.rollover:
@@ -403,6 +411,7 @@
   - match: { data_streams.0.name: test-data-stream-1 }
   - match: { data_streams.0.mappings: { } }
   - match: { data_streams.0.effective_mappings: null }
+  - match: { data_streams.0.index_mode: time_series }
   - set: { data_streams.0.indices.0.index_name: oldIndexName }
   - set: { data_streams.0.indices.1.index_name: newIndexName }
 
@@ -449,6 +458,7 @@
   - match: { data_streams.0.name: my-data-stream-1 }
   - match: { data_streams.0.mappings: {} }
   - match: { data_streams.0.effective_mappings: null }
+  - match: { data_streams.0.index_mode: time_series }
 
   - do:
       indices.put_index_template:
@@ -477,6 +487,7 @@
   - match: { data_streams.0.name: my-data-stream-1 }
   - match: { data_streams.0.mappings: {} }
   - match: { data_streams.0.effective_mappings: null }
+  - match: { data_streams.0.index_mode: time_series }
 
   - do:
       indices.rollover:
@@ -500,6 +511,7 @@
   - match: { data_streams.0.name: my-data-stream-1 }
   - match: { data_streams.0.mappings: { } }
   - match: { data_streams.0.effective_mappings: null }
+  - match: { data_streams.0.index_mode: standard }
   - set: { data_streams.0.indices.0.index_name: oldIndexName }
   - set: { data_streams.0.indices.1.index_name: newIndexName }
 
@@ -561,6 +573,7 @@
   - match: { data_streams.0.name: test-data-stream-1 }
   - match: { data_streams.0.mappings: {} }
   - match: { data_streams.0.effective_mappings: null }
+  - match: { data_streams.0.index_mode: time_series }
 
   - do:
       indices.rollover:
@@ -584,5 +597,6 @@
   - match: { data_streams.0.name: test-data-stream-1 }
   - match: { data_streams.0.mappings: { } }
   - match: { data_streams.0.effective_mappings: null }
+  - match: { data_streams.0.index_mode: time_series }
   - set: { data_streams.0.indices.0.index_name: oldIndexName }
   - set: { data_streams.0.indices.1.index_name: newIndexName }


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Improving performance of get data streams API by avoiding getting effective mappings (#138948)