### PR TITLE
[9.2] Reapply "Remove references to V8_1_0 transport version (#136239)" (#136560) (#139008)

### DIFF
--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/TimeSeriesAggregationBuilder.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/TimeSeriesAggregationBuilder.java
@@ -10,7 +10,6 @@
 package org.elasticsearch.aggregations.bucket.timeseries;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
@@ -155,6 +154,6 @@ public class TimeSeriesAggregationBuilder extends AbstractAggregationBuilder<Tim
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {
-        return TransportVersions.V_8_1_0;
+        return TransportVersion.minimumCompatible();
     }
 }

--- a/server/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/server/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -1922,7 +1922,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
             org.elasticsearch.cluster.desirednodes.VersionConflictException.class,
             org.elasticsearch.cluster.desirednodes.VersionConflictException::new,
             164,
-            TransportVersions.V_8_1_0
+            UNKNOWN_VERSION_ADDED
         ),
         SNAPSHOT_NAME_ALREADY_IN_USE_EXCEPTION(
             org.elasticsearch.snapshots.SnapshotNameAlreadyInUseException.class,

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -64,7 +64,6 @@ public class TransportVersions {
     public static final TransportVersion V_7_9_0 = def(7_09_00_99);
     public static final TransportVersion V_7_10_0 = def(7_10_00_99);
     public static final TransportVersion V_8_0_0 = def(8_00_00_99);
-    public static final TransportVersion V_8_1_0 = def(8_01_00_99);
     public static final TransportVersion V_8_2_0 = def(8_02_00_99);
     public static final TransportVersion V_8_3_0 = def(8_03_00_99);
     public static final TransportVersion V_8_4_0 = def(8_04_00_99);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponse.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.action.admin.indices.stats;
 
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ClusterStatsLevel;
 import org.elasticsearch.action.admin.indices.stats.IndexStats.IndexStatsBuilder;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
@@ -56,15 +55,10 @@ public class IndicesStatsResponse extends ChunkedBroadcastResponse {
     IndicesStatsResponse(StreamInput in) throws IOException {
         super(in);
         shards = in.readArray(ShardStats::new, ShardStats[]::new);
-        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_1_0)) {
-            // Between 8.1 and INDEX_STATS_ADDITIONAL_FIELDS, we had a different format for the response
-            // where we only had health and state available.
-            indexHealthMap = in.readMap(ClusterHealthStatus::readFrom);
-            indexStateMap = in.readMap(IndexMetadata.State::readFrom);
-        } else {
-            indexHealthMap = Map.of();
-            indexStateMap = Map.of();
-        }
+        // Between 8.1 and INDEX_STATS_ADDITIONAL_FIELDS, we had a different format for the response
+        // where we only had health and state available.
+        indexHealthMap = in.readMap(ClusterHealthStatus::readFrom);
+        indexStateMap = in.readMap(IndexMetadata.State::readFrom);
     }
 
     @FixForMultiProject(description = "we can pass ProjectMetadata here")
@@ -179,10 +173,8 @@ public class IndicesStatsResponse extends ChunkedBroadcastResponse {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeArray(shards);
-        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_1_0)) {
-            out.writeMap(indexHealthMap, StreamOutput::writeWriteable);
-            out.writeMap(indexStateMap, StreamOutput::writeWriteable);
-        }
+        out.writeMap(indexHealthMap, StreamOutput::writeWriteable);
+        out.writeMap(indexStateMap, StreamOutput::writeWriteable);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplate.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplate.java
@@ -547,14 +547,6 @@ public class ComposableIndexTemplate implements SimpleDiffable<ComposableIndexTe
         DataStreamTemplate(StreamInput in) throws IOException {
             hidden = in.readBoolean();
             allowCustomRouting = in.readBoolean();
-            if (in.getTransportVersion().between(TransportVersions.V_8_1_0, TransportVersions.V_8_3_0)) {
-                // Accidentally included index_mode to binary node to node protocol in previous releases.
-                // (index_mode is removed and was part of code based when tsdb was behind a feature flag)
-                // (index_mode was behind a feature in the xcontent parser, so it could never actually used)
-                // (this used to be an optional enum, so just need to (de-)serialize a false boolean value here)
-                boolean value = in.readBoolean();
-                assert value == false : "expected false, because this used to be an optional enum that never got set";
-            }
         }
 
         /**
@@ -587,10 +579,6 @@ public class ComposableIndexTemplate implements SimpleDiffable<ComposableIndexTe
         public void writeTo(StreamOutput out) throws IOException {
             out.writeBoolean(hidden);
             out.writeBoolean(allowCustomRouting);
-            if (out.getTransportVersion().between(TransportVersions.V_8_1_0, TransportVersions.V_8_3_0)) {
-                // See comment in constructor.
-                out.writeBoolean(false);
-            }
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
@@ -300,7 +300,7 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
         var replicated = in.readBoolean();
         var system = in.readBoolean();
         var allowCustomRouting = in.readBoolean();
-        var indexMode = in.getTransportVersion().onOrAfter(TransportVersions.V_8_1_0) ? in.readOptionalEnum(IndexMode.class) : null;
+        var indexMode = in.readOptionalEnum(IndexMode.class);
         var lifecycle = in.getTransportVersion().onOrAfter(TransportVersions.V_8_9_X)
             ? in.readOptionalWriteable(DataStreamLifecycle::new)
             : null;
@@ -1482,9 +1482,7 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
         out.writeBoolean(replicated);
         out.writeBoolean(system);
         out.writeBoolean(allowCustomRouting);
-        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_1_0)) {
-            out.writeOptionalEnum(indexMode);
-        }
+        out.writeOptionalEnum(indexMode);
         if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_9_X)) {
             out.writeOptionalWriteable(lifecycle);
         }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DesiredNodesMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DesiredNodesMetadata.java
@@ -10,7 +10,6 @@
 package org.elasticsearch.cluster.metadata;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.cluster.AbstractNamedDiffable;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.NamedDiff;
@@ -29,7 +28,6 @@ import java.util.Iterator;
 import java.util.Objects;
 
 public class DesiredNodesMetadata extends AbstractNamedDiffable<Metadata.ClusterCustom> implements Metadata.ClusterCustom {
-    private static final TransportVersion MIN_SUPPORTED_VERSION = TransportVersions.V_8_1_0;
     public static final String TYPE = "desired_nodes";
 
     public static final DesiredNodesMetadata EMPTY = new DesiredNodesMetadata((DesiredNodes) null);
@@ -96,7 +94,7 @@ public class DesiredNodesMetadata extends AbstractNamedDiffable<Metadata.Cluster
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {
-        return MIN_SUPPORTED_VERSION;
+        return TransportVersion.minimumCompatible();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/search/stats/FieldUsageStats.java
+++ b/server/src/main/java/org/elasticsearch/index/search/stats/FieldUsageStats.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.index.search.stats;
 
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -211,11 +210,7 @@ public class FieldUsageStats implements ToXContentObject, Writeable {
             payloads = in.readVLong();
             termVectors = in.readVLong();
             points = in.readVLong();
-            if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_1_0)) {
-                knnVectors = in.readVLong();
-            } else {
-                knnVectors = 0;
-            }
+            knnVectors = in.readVLong();
         }
 
         @Override
@@ -233,9 +228,7 @@ public class FieldUsageStats implements ToXContentObject, Writeable {
             out.writeVLong(payloads);
             out.writeVLong(termVectors);
             out.writeVLong(points);
-            if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_1_0)) {
-                out.writeVLong(knnVectors);
-            }
+            out.writeVLong(knnVectors);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/script/ScriptContextStats.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptContextStats.java
@@ -61,16 +61,8 @@ public record ScriptContextStats(
         var compilationLimitTriggered = in.readVLong();
         TimeSeries compilationsHistory;
         TimeSeries cacheEvictionsHistory;
-        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_1_0)) {
-            compilationsHistory = new TimeSeries(in);
-            cacheEvictionsHistory = new TimeSeries(in);
-        } else if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_0_0)) {
-            compilationsHistory = new TimeSeries(in).withTotal(compilations);
-            cacheEvictionsHistory = new TimeSeries(in).withTotal(cacheEvictions);
-        } else {
-            compilationsHistory = new TimeSeries(compilations);
-            cacheEvictionsHistory = new TimeSeries(cacheEvictions);
-        }
+        compilationsHistory = new TimeSeries(in);
+        cacheEvictionsHistory = new TimeSeries(in);
         return new ScriptContextStats(
             context,
             compilations,

--- a/server/src/main/java/org/elasticsearch/script/TimeSeries.java
+++ b/server/src/main/java/org/elasticsearch/script/TimeSeries.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.script;
 
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -59,11 +58,7 @@ public class TimeSeries implements Writeable, ToXContentFragment {
         fiveMinutes = in.readVLong();
         fifteenMinutes = in.readVLong();
         twentyFourHours = in.readVLong();
-        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_1_0)) {
-            total = in.readVLong();
-        } else {
-            total = 0;
-        }
+        total = in.readVLong();
     }
 
     @Override
@@ -80,9 +75,7 @@ public class TimeSeries implements Writeable, ToXContentFragment {
         out.writeVLong(fiveMinutes);
         out.writeVLong(fifteenMinutes);
         out.writeVLong(twentyFourHours);
-        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_1_0)) {
-            out.writeVLong(total);
-        }
+        out.writeVLong(total);
     }
 
     public boolean areTimingsEmpty() {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/prefix/IpPrefixAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/prefix/IpPrefixAggregationBuilder.java
@@ -11,7 +11,6 @@ package org.elasticsearch.search.aggregations.bucket.prefix;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
@@ -68,7 +67,9 @@ public class IpPrefixAggregationBuilder extends ValuesSourceAggregationBuilder<I
     private static final int IPV4_MAX_PREFIX_LENGTH = 32;
     private static final int MIN_PREFIX_LENGTH = 0;
 
-    /** Read from a stream, for internal use only. */
+    /**
+     * Read from a stream, for internal use only.
+     */
     public IpPrefixAggregationBuilder(StreamInput in) throws IOException {
         super(in);
         this.prefixLength = in.readVInt();
@@ -102,7 +103,9 @@ public class IpPrefixAggregationBuilder extends ValuesSourceAggregationBuilder<I
         );
     }
 
-    /** Set the minDocCount on this builder, and return the builder so that calls can be chained. */
+    /**
+     * Set the minDocCount on this builder, and return the builder so that calls can be chained.
+     */
     public IpPrefixAggregationBuilder minDocCount(long minDocCount) {
         if (minDocCount < 1) {
             throwOnInvalidFieldValue(MIN_DOC_COUNT_FIELD.getPreferredName(), 1, Integer.MAX_VALUE, minDocCount);
@@ -115,7 +118,8 @@ public class IpPrefixAggregationBuilder extends ValuesSourceAggregationBuilder<I
      * Set the prefixLength on this builder, and return the builder so that calls can be chained.
      *
      * @throws IllegalArgumentException if prefixLength is negative.
-     * */
+     *
+     */
     public IpPrefixAggregationBuilder prefixLength(int prefixLength) {
         if (prefixLength < MIN_PREFIX_LENGTH) {
             throwOnInvalidFieldValue(
@@ -129,25 +133,33 @@ public class IpPrefixAggregationBuilder extends ValuesSourceAggregationBuilder<I
         return this;
     }
 
-    /** Set the isIpv6 on this builder, and return the builder so that calls can be chained. */
+    /**
+     * Set the isIpv6 on this builder, and return the builder so that calls can be chained.
+     */
     public IpPrefixAggregationBuilder isIpv6(boolean isIpv6) {
         this.isIpv6 = isIpv6;
         return this;
     }
 
-    /** Set the appendPrefixLength on this builder, and return the builder so that calls can be chained. */
+    /**
+     * Set the appendPrefixLength on this builder, and return the builder so that calls can be chained.
+     */
     public IpPrefixAggregationBuilder appendPrefixLength(boolean appendPrefixLength) {
         this.appendPrefixLength = appendPrefixLength;
         return this;
     }
 
-    /** Set the keyed on this builder, and return the builder so that calls can be chained. */
+    /**
+     * Set the keyed on this builder, and return the builder so that calls can be chained.
+     */
     public IpPrefixAggregationBuilder keyed(boolean keyed) {
         this.keyed = keyed;
         return this;
     }
 
-    /** Create a new builder with the given name. */
+    /**
+     * Create a new builder with the given name.
+     */
     public IpPrefixAggregationBuilder(String name) {
         super(name);
     }
@@ -237,13 +249,11 @@ public class IpPrefixAggregationBuilder extends ValuesSourceAggregationBuilder<I
 
     /**
      * @param prefixLength the network prefix length which defines the size of the network.
-     * @param isIpv6 true for an IPv6 netmask, false for an IPv4 netmask.
-     *
+     * @param isIpv6       true for an IPv6 netmask, false for an IPv4 netmask.
      * @return a 16-bytes representation of the subnet with 1s identifying the network
-     *         part and 0s identifying the host part.
-     *
+     * part and 0s identifying the host part.
      * @throws IllegalArgumentException if prefixLength is not in range [0, 128] for an IPv6
-     *         network, or is not in range [0, 32] for an IPv4 network.
+     *                                  network, or is not in range [0, 32] for an IPv4 network.
      */
     public static BytesRef extractNetmask(int prefixLength, boolean isIpv6) {
         if (prefixLength < 0
@@ -312,6 +322,6 @@ public class IpPrefixAggregationBuilder extends ValuesSourceAggregationBuilder<I
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {
-        return TransportVersions.V_8_1_0;
+        return TransportVersion.minimumCompatible();
     }
 }

--- a/server/src/main/java/org/elasticsearch/transport/ActionTransportException.java
+++ b/server/src/main/java/org/elasticsearch/transport/ActionTransportException.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.transport;
 
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.network.NetworkAddress;
@@ -25,10 +24,6 @@ public class ActionTransportException extends TransportException {
 
     public ActionTransportException(StreamInput in) throws IOException {
         super(in);
-        if (in.getTransportVersion().before(TransportVersions.V_8_1_0)) {
-            in.readOptionalWriteable(TransportAddress::new);
-            in.readOptionalString();
-        }
     }
 
     public ActionTransportException(String name, TransportAddress address, String action, Throwable cause) {
@@ -46,10 +41,6 @@ public class ActionTransportException extends TransportException {
     @Override
     protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
         super.writeTo(out, nestedExceptionsWriter);
-        if (out.getTransportVersion().before(TransportVersions.V_8_1_0)) {
-            out.writeMissingWriteable(TransportAddress.class);
-            out.writeMissingString(); // action
-        }
     }
 
     private static String buildMessage(String name, InetSocketAddress address, String action, String msg) {

--- a/server/src/main/java/org/elasticsearch/transport/ConnectTransportException.java
+++ b/server/src/main/java/org/elasticsearch/transport/ConnectTransportException.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.transport;
 
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -37,9 +36,6 @@ public class ConnectTransportException extends ActionTransportException {
 
     public ConnectTransportException(StreamInput in) throws IOException {
         super(in);
-        if (in.getTransportVersion().before(TransportVersions.V_8_1_0)) {
-            in.readOptionalWriteable(DiscoveryNode::new);
-        }
     }
 
     /**
@@ -57,8 +53,5 @@ public class ConnectTransportException extends ActionTransportException {
     @Override
     protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
         super.writeTo(out, nestedExceptionsWriter);
-        if (out.getTransportVersion().before(TransportVersions.V_8_1_0)) {
-            out.writeMissingWriteable(DiscoveryNode.class);
-        }
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleExplainResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleExplainResponse.java
@@ -347,11 +347,7 @@ public class IndexLifecycleExplainResponse implements ToXContentObject, Writeabl
             repositoryName = in.readOptionalString();
             snapshotName = in.readOptionalString();
             shrinkIndexName = in.readOptionalString();
-            if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_1_0)) {
-                indexCreationDate = in.readOptionalLong();
-            } else {
-                indexCreationDate = null;
-            }
+            indexCreationDate = in.readOptionalLong();
             if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_16_0)) {
                 previousStepInfo = in.readOptionalBytesReference();
             } else {
@@ -409,9 +405,7 @@ public class IndexLifecycleExplainResponse implements ToXContentObject, Writeabl
             out.writeOptionalString(repositoryName);
             out.writeOptionalString(snapshotName);
             out.writeOptionalString(shrinkIndexName);
-            if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_1_0)) {
-                out.writeOptionalLong(indexCreationDate);
-            }
+            out.writeOptionalLong(indexCreationDate);
             if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_16_0)) {
                 out.writeOptionalBytesReference(previousStepInfo);
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteTrainedModelAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteTrainedModelAction.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
@@ -40,11 +39,7 @@ public class DeleteTrainedModelAction extends ActionType<AcknowledgedResponse> {
         public Request(StreamInput in) throws IOException {
             super(in);
             id = in.readString();
-            if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_1_0)) {
-                force = in.readBoolean();
-            } else {
-                force = false;
-            }
+            force = in.readBoolean();
         }
 
         public Request(String id) {
@@ -83,9 +78,7 @@ public class DeleteTrainedModelAction extends ActionType<AcknowledgedResponse> {
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             out.writeString(id);
-            if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_1_0)) {
-                out.writeBoolean(force);
-            }
+            out.writeBoolean(force);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedRunningStateAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedRunningStateAction.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.tasks.BaseTasksRequest;
 import org.elasticsearch.action.support.tasks.BaseTasksResponse;
@@ -100,11 +99,7 @@ public class GetDatafeedRunningStateAction extends ActionType<GetDatafeedRunning
             public RunningState(StreamInput in) throws IOException {
                 this.realTimeConfigured = in.readBoolean();
                 this.realTimeRunning = in.readBoolean();
-                if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_1_0)) {
-                    this.searchInterval = in.readOptionalWriteable(SearchInterval::new);
-                } else {
-                    this.searchInterval = null;
-                }
+                this.searchInterval = in.readOptionalWriteable(SearchInterval::new);
             }
 
             @Override
@@ -126,9 +121,7 @@ public class GetDatafeedRunningStateAction extends ActionType<GetDatafeedRunning
             public void writeTo(StreamOutput out) throws IOException {
                 out.writeBoolean(realTimeConfigured);
                 out.writeBoolean(realTimeRunning);
-                if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_1_0)) {
-                    out.writeOptionalWriteable(searchInterval);
-                }
+                out.writeOptionalWriteable(searchInterval);
             }
 
             @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/AssignmentStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/AssignmentStats.java
@@ -163,19 +163,11 @@ public class AssignmentStats implements ToXContentObject, Writeable {
             this.pendingCount = in.readOptionalVInt();
             this.routingState = in.readOptionalWriteable(RoutingStateAndReason::new);
             this.startTime = in.readOptionalInstant();
-            if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_1_0)) {
-                this.threadsPerAllocation = in.readOptionalVInt();
-                this.numberOfAllocations = in.readOptionalVInt();
-                this.errorCount = in.readVInt();
-                this.rejectedExecutionCount = in.readVInt();
-                this.timeoutCount = in.readVInt();
-            } else {
-                this.threadsPerAllocation = null;
-                this.numberOfAllocations = null;
-                this.errorCount = 0;
-                this.rejectedExecutionCount = 0;
-                this.timeoutCount = 0;
-            }
+            this.threadsPerAllocation = in.readOptionalVInt();
+            this.numberOfAllocations = in.readOptionalVInt();
+            this.errorCount = in.readVInt();
+            this.rejectedExecutionCount = in.readVInt();
+            this.timeoutCount = in.readVInt();
             if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_2_0)) {
                 this.peakThroughput = in.readVLong();
                 this.throughputLastPeriod = in.readVLong();
@@ -342,13 +334,11 @@ public class AssignmentStats implements ToXContentObject, Writeable {
             out.writeOptionalVInt(pendingCount);
             out.writeOptionalWriteable(routingState);
             out.writeOptionalInstant(startTime);
-            if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_1_0)) {
-                out.writeOptionalVInt(threadsPerAllocation);
-                out.writeOptionalVInt(numberOfAllocations);
-                out.writeVInt(errorCount);
-                out.writeVInt(rejectedExecutionCount);
-                out.writeVInt(timeoutCount);
-            }
+            out.writeOptionalVInt(threadsPerAllocation);
+            out.writeOptionalVInt(numberOfAllocations);
+            out.writeVInt(errorCount);
+            out.writeVInt(rejectedExecutionCount);
+            out.writeVInt(timeoutCount);
             if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_2_0)) {
                 out.writeVLong(peakThroughput);
                 out.writeVLong(throughputLastPeriod);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/NlpConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/NlpConfigUpdate.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
@@ -84,18 +83,12 @@ public abstract class NlpConfigUpdate implements InferenceConfigUpdate, NamedXCo
     }
 
     public NlpConfigUpdate(StreamInput in) throws IOException {
-        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_1_0)) {
-            tokenizationUpdate = in.readOptionalNamedWriteable(TokenizationUpdate.class);
-        } else {
-            tokenizationUpdate = null;
-        }
+        tokenizationUpdate = in.readOptionalNamedWriteable(TokenizationUpdate.class);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_1_0)) {
-            out.writeOptionalNamedWriteable(tokenizationUpdate);
-        }
+        out.writeOptionalNamedWriteable(tokenizationUpdate);
     }
 
     protected boolean isNoop() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetTransformAction.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.core.transform.action;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.common.ValidationException;
@@ -179,12 +178,8 @@ public class GetTransformAction extends ActionType<GetTransformAction.Response> 
 
         public Response(StreamInput in) throws IOException {
             super(in);
-            if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_1_0)) {
-                if (in.readBoolean()) {
-                    this.errors = in.readCollectionAsList(Error::new);
-                } else {
-                    this.errors = null;
-                }
+            if (in.readBoolean()) {
+                this.errors = in.readCollectionAsList(Error::new);
             } else {
                 this.errors = null;
             }
@@ -240,13 +235,11 @@ public class GetTransformAction extends ActionType<GetTransformAction.Response> 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_1_0)) {
-                if (errors != null) {
-                    out.writeBoolean(true);
-                    out.writeCollection(errors);
-                } else {
-                    out.writeBoolean(false);
-                }
+            if (errors != null) {
+                out.writeBoolean(true);
+                out.writeCollection(errors);
+            } else {
+                out.writeBoolean(false);
             }
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/SettingsConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/SettingsConfig.java
@@ -162,11 +162,7 @@ public class SettingsConfig implements Writeable, ToXContentObject {
         this.alignCheckpoints = in.readOptionalInt();
         this.usePit = in.readOptionalInt();
 
-        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_1_0)) {
-            deduceMappings = in.readOptionalInt();
-        } else {
-            deduceMappings = DEFAULT_DEDUCE_MAPPINGS;
-        }
+        deduceMappings = in.readOptionalInt();
         if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
             numFailureRetries = in.readOptionalInt();
         } else {
@@ -278,9 +274,7 @@ public class SettingsConfig implements Writeable, ToXContentObject {
         out.writeOptionalInt(alignCheckpoints);
         out.writeOptionalInt(usePit);
 
-        if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_1_0)) {
-            out.writeOptionalInt(deduceMappings);
-        }
+        out.writeOptionalInt(deduceMappings);
         if (out.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
             out.writeOptionalInt(numFailureRetries);
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/RolloverActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/RolloverActionTests.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.core.ilm;
 
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.admin.indices.rollover.RolloverConditions;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -16,9 +15,6 @@ import org.elasticsearch.xpack.core.ilm.Step.StepKey;
 
 import java.io.IOException;
 import java.util.List;
-
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.nullValue;
 
 public class RolloverActionTests extends AbstractActionTestCase<RolloverAction> {
 
@@ -145,18 +141,5 @@ public class RolloverActionTests extends AbstractActionTestCase<RolloverAction> 
         assertEquals(fifthStep.getKey(), fourthStep.getNextStepKey());
         assertEquals(conditions, firstStep.getConditions());
         assertEquals(nextStepKey, fifthStep.getNextStepKey());
-    }
-
-    public void testBwcSerializationWithMaxPrimaryShardDocs() throws Exception {
-        // In case of serializing to node with older version, replace maxPrimaryShardDocs with maxDocs.
-        RolloverAction instance = new RolloverAction(null, null, null, null, 1L, null, null, null, null, null);
-        RolloverAction deserializedInstance = copyInstance(instance, TransportVersions.V_8_1_0);
-        assertThat(deserializedInstance.getConditions().getMaxPrimaryShardDocs(), nullValue());
-
-        // But not if maxDocs is also specified:
-        instance = new RolloverAction(null, null, null, 2L, 1L, null, null, null, null, null);
-        deserializedInstance = copyInstance(instance, TransportVersions.V_8_1_0);
-        assertThat(deserializedInstance.getConditions().getMaxPrimaryShardDocs(), nullValue());
-        assertThat(deserializedInstance.getConditions().getMaxDocs(), equalTo(instance.getConditions().getMaxDocs()));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/FillMaskConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/FillMaskConfigUpdateTests.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.xcontent.XContentParser;
@@ -38,9 +37,6 @@ public class FillMaskConfigUpdateTests extends AbstractNlpConfigUpdateTestCase<F
     }
 
     public static FillMaskConfigUpdate mutateForVersion(FillMaskConfigUpdate instance, TransportVersion version) {
-        if (version.before(TransportVersions.V_8_1_0)) {
-            return new FillMaskConfigUpdate(instance.getNumTopClasses(), instance.getResultsField(), null);
-        }
         return instance;
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/NerConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/NerConfigUpdateTests.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.xcontent.XContentParser;
@@ -35,9 +34,6 @@ public class NerConfigUpdateTests extends AbstractNlpConfigUpdateTestCase<NerCon
     }
 
     public static NerConfigUpdate mutateForVersion(NerConfigUpdate instance, TransportVersion version) {
-        if (version.before(TransportVersions.V_8_1_0)) {
-            return new NerConfigUpdate(instance.getResultsField(), null);
-        }
         return instance;
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/PassThroughConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/PassThroughConfigUpdateTests.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.xcontent.XContentParser;
@@ -35,9 +34,6 @@ public class PassThroughConfigUpdateTests extends AbstractNlpConfigUpdateTestCas
     }
 
     public static PassThroughConfigUpdate mutateForVersion(PassThroughConfigUpdate instance, TransportVersion version) {
-        if (version.before(TransportVersions.V_8_1_0)) {
-            return new PassThroughConfigUpdate(instance.getResultsField(), null);
-        }
         return instance;
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/QuestionAnsweringConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/QuestionAnsweringConfigUpdateTests.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.xcontent.XContentParser;
@@ -36,15 +35,6 @@ public class QuestionAnsweringConfigUpdateTests extends AbstractNlpConfigUpdateT
     }
 
     public static QuestionAnsweringConfigUpdate mutateForVersion(QuestionAnsweringConfigUpdate instance, TransportVersion version) {
-        if (version.before(TransportVersions.V_8_1_0)) {
-            return new QuestionAnsweringConfigUpdate(
-                instance.getQuestion(),
-                instance.getNumTopClasses(),
-                instance.getMaxAnswerLength(),
-                instance.getResultsField(),
-                null
-            );
-        }
         return instance;
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextClassificationConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextClassificationConfigUpdateTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.xcontent.XContentParser;
@@ -44,14 +43,6 @@ public class TextClassificationConfigUpdateTests extends AbstractNlpConfigUpdate
     }
 
     public static TextClassificationConfigUpdate mutateForVersion(TextClassificationConfigUpdate instance, TransportVersion version) {
-        if (version.before(TransportVersions.V_8_1_0)) {
-            return new TextClassificationConfigUpdate(
-                instance.getClassificationLabels(),
-                instance.getNumTopClasses(),
-                instance.getResultsField(),
-                null
-            );
-        }
         return instance;
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextEmbeddingConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextEmbeddingConfigUpdateTests.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.xcontent.XContentParser;
@@ -35,9 +34,6 @@ public class TextEmbeddingConfigUpdateTests extends AbstractNlpConfigUpdateTestC
     }
 
     public static TextEmbeddingConfigUpdate mutateForVersion(TextEmbeddingConfigUpdate instance, TransportVersion version) {
-        if (version.before(TransportVersions.V_8_1_0)) {
-            return new TextEmbeddingConfigUpdate(instance.getResultsField(), null);
-        }
         return instance;
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextExpansionConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextExpansionConfigUpdateTests.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.xcontent.XContentParser;
@@ -31,9 +30,6 @@ public class TextExpansionConfigUpdateTests extends AbstractNlpConfigUpdateTestC
     }
 
     public static TextExpansionConfigUpdate mutateForVersion(TextExpansionConfigUpdate instance, TransportVersion version) {
-        if (version.before(TransportVersions.V_8_1_0)) {
-            return new TextExpansionConfigUpdate(instance.getResultsField(), null);
-        }
         return instance;
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextSimilarityConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextSimilarityConfigUpdateTests.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.xcontent.XContentParser;
@@ -41,9 +40,6 @@ public class TextSimilarityConfigUpdateTests extends AbstractNlpConfigUpdateTest
     }
 
     public static TextSimilarityConfigUpdate mutateForVersion(TextSimilarityConfigUpdate instance, TransportVersion version) {
-        if (version.before(TransportVersions.V_8_1_0)) {
-            return new TextSimilarityConfigUpdate(instance.getText(), instance.getResultsField(), null, null);
-        }
         return instance;
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ZeroShotClassificationConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ZeroShotClassificationConfigUpdateTests.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.xcontent.XContentParser;
@@ -38,9 +37,6 @@ public class ZeroShotClassificationConfigUpdateTests extends AbstractNlpConfigUp
         ZeroShotClassificationConfigUpdate instance,
         TransportVersion version
     ) {
-        if (version.before(TransportVersions.V_8_1_0)) {
-            return new ZeroShotClassificationConfigUpdate(instance.getLabels(), instance.getMultiLabel(), instance.getResultsField(), null);
-        }
         return instance;
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/TransportVersionUtilsTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/TransportVersionUtilsTests.java
@@ -22,7 +22,7 @@ public class TransportVersionUtilsTests extends ESTestCase {
 
     private static final Map<String, CompatibilityVersions> transportVersions = Map.of(
         "Alfredo",
-        new CompatibilityVersions(TransportVersions.V_8_1_0, Map.of()),
+        new CompatibilityVersions(TransportVersion.fromId(8010099), Map.of()),
         "Bertram",
         new CompatibilityVersions(TransportVersions.V_8_6_0, Map.of()),
         "Charles",

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexGridAggregationBuilder.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexGridAggregationBuilder.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.spatial.search.aggregations.bucket.geogrid;
 
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.geo.GeoBoundingBox;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
@@ -120,6 +119,6 @@ public final class GeoHexGridAggregationBuilder extends GeoGridAggregationBuilde
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {
-        return TransportVersions.V_8_1_0;
+        return TransportVersion.minimumCompatible();
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/common/io/SqlStreamTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/common/io/SqlStreamTests.java
@@ -9,16 +9,12 @@ package org.elasticsearch.xpack.sql.common.io;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.TransportVersions;
-import org.elasticsearch.common.io.stream.InputStreamStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.sql.SqlIllegalArgumentException;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.List;
 
 import static org.hamcrest.Matchers.containsString;
@@ -66,19 +62,6 @@ public class SqlStreamTests extends ESTestCase {
         );
 
         assertThat(ex.getMessage(), containsString("Unsupported cursor version [7150199], expected [" + TransportVersion.current() + "]"));
-    }
-
-    public void testVersionCanBeReadByOldNodes() throws IOException {
-        TransportVersion version = TransportVersions.V_8_1_0;
-        SqlStreamOutput out = SqlStreamOutput.create(version, randomZone());
-        out.writeString("payload");
-        out.close();
-        String encoded = out.streamAsString();
-
-        byte[] bytes = Base64.getDecoder().decode(encoded);
-        InputStreamStreamInput in = new InputStreamStreamInput(new ByteArrayInputStream(bytes));
-
-        assertEquals(version, TransportVersion.readVersion(in));
     }
 
 }


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Reapply "Remove references to V8_1_0 transport version (#136239)" (#136560) (#139008)