### PR TITLE
Ensure the order of converters in ValuesFromManyReader

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/ValuesFromManyReader.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/read/ValuesFromManyReader.java
@@ -22,7 +22,7 @@ import org.elasticsearch.search.fetch.StoredFieldsSpec;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -85,7 +85,7 @@ class ValuesFromManyReader extends ValuesReader {
                  * loading in a way that is correct for the mapped field type, and then convert between that type and the desired type.
                  */
                 fieldTypeBuilders[f] = operator.fields[f].info.type().newBlockBuilder(docs.getPositionCount(), operator.blockFactory);
-                buildersAndLoaders.add(new HashMap<>());
+                buildersAndLoaders.add(new LinkedHashMap<>()); // use LinkedHashMap to preserve insertion order
             }
             try (ComputeBlockLoaderFactory loaderBlockFactory = new ComputeBlockLoaderFactory(operator.blockFactory)) {
                 int p = forwards[offset];


### PR DESCRIPTION
When loading from multiple shards, we previously stored converters and block builders in a HashMap. At build time, we traverse these to apply conversions to rows. However, because HashMap does not guarantee iteration order, the rows and converters could become misaligned, leading to incorrect output where the wrong converter is applied to the wrong shard.

This change replaces HashMap with LinkedHashMap to preserve insertion order.

This bug typically manifests when using more than 16 target shards (exceeding the default HashMap capacity) and became visible when the default number of shards in serverless was increased from 3 to 6.

Ideally, we should replace the Map with a List, as we read shards in monotonically increasing order. I will follow up to remove this map soon.

I labelled this for an unreleased bug in 9.3.0 (see #132757)