### PR TITLE
[9.2][ML] Fix for flaky sparse_vector_search test (#138740)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -70,9 +70,6 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=transform/transforms_start_stop/Test start/stop/start transform}
   issue: https://github.com/elastic/elasticsearch/issues/119508
-- class: org.elasticsearch.smoketest.MlWithSecurityIT
-  method: test {yaml=ml/sparse_vector_search/Test sparse_vector search with query vector and pruning config}
-  issue: https://github.com/elastic/elasticsearch/issues/119548
 - class: org.elasticsearch.xpack.ml.integration.ForecastIT
   method: testOverflowToDisk
   issue: https://github.com/elastic/elasticsearch/issues/117740

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/sparse_vector_search.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/sparse_vector_search.yml
@@ -251,7 +251,7 @@ teardown:
               field: ml.tokens
               query_vector:
                 the: 0.5
-                comforter: 2.0
+                comforter: 3.0
                 smells: 1.0
                 bad: 1.0
               prune: true
@@ -261,7 +261,7 @@ teardown:
                 only_score_pruned_tokens: false
 
   - match: { hits.total.value: 3 }
-  - match: { hits.hits.0._score: 4 }
+  - match: { hits.hits.0._score: 6 }
 
 ---
 "Test sparse_vector search with query vector and pruning config with only score pruned tokens":


### PR DESCRIPTION
Tweak params in "sparse_vector_search/Test sparse_vector search with query vector and pruning config" yaml rest test for more deterministic outcome. The test has now been unmuted.

Tested with

```
for (( i=0; i<100; ++i )); do echo $i; ./gradlew ":x-pack:plugin:ml:qa:ml-with-security:yamlRestTest" --tests "org.elasticsearch.smoketest.MlWithSecurityIT.test {yaml=ml/sparse_vector_search/Test sparse_vector search with query vector and pruning config}"; if [ $? != 0 ]; then echo "test failed"; break; fi ; done
```

with no failures.

Backports #138740

Fixes #119548

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
