### PR TITLE
Es 12824 add new desired balance log info

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputer.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputer.java
@@ -403,24 +403,29 @@ public class DesiredBalanceComputer {
                         convergenceLogMsgLevel,
                         () -> Strings.format(
                             """
-                                Desired balance computation for [%d] converged after [%s] and [%d] iterations, \
-                                resumed computation [%d] times with [%d] iterations since the last resumption [%s] ago""",
+                                Desired balance computation for [%d] converged after [%s] and [%d] iterations this round, \
+                                resumed computation [%s] ago with [%d] iterations over [%d] rounds since the last convergence \
+                                [%s] ago""",
                             desiredBalanceInput.index(),
+                            TimeValue.timeValueMillis(currentTime - computationStartedTime).toString(),
+                            iterations,
                             TimeValue.timeValueMillis(currentTime - firstComputeStartedSinceConvergedTimeMillis).toString(),
                             numIterationsSinceLastConverged,
                             numComputeCallsSinceLastConverged,
-                            iterations,
-                            TimeValue.timeValueMillis(currentTime - computationStartedTime).toString()
+                            TimeValue.timeValueMillis(currentTime - lastConvergedTimeMillis).toString()
                         )
                     );
                 } else {
                     logger.log(
                         convergenceLogMsgLevel,
                         () -> Strings.format(
-                            "Desired balance computation for [%d] converged after [%s] and [%d] iterations",
+                            """
+                                Desired balance computation for [%d] converged after [%s] and [%d] iterations this round, \
+                                last convergence was [%s] ago""",
                             desiredBalanceInput.index(),
-                            TimeValue.timeValueMillis(currentTime - firstComputeStartedSinceConvergedTimeMillis).toString(),
-                            numIterationsSinceLastConverged
+                            TimeValue.timeValueMillis(currentTime - computationStartedTime).toString(),
+                            iterations,
+                            TimeValue.timeValueMillis(currentTime - lastConvergedTimeMillis).toString()
                         )
                     );
                 }
@@ -465,24 +470,29 @@ public class DesiredBalanceComputer {
                     logLevel,
                     () -> Strings.format(
                         """
-                            Desired balance computation for [%d] is still not converged after [%s] and [%d] iterations, \
-                            resumed computation [%d] times with [%d] iterations since the last resumption [%s] ago""",
+                            Desired balance computation for [%d] is still not converged after [%s] and [%d] iterations this round, \
+                            resumed computation [%s] ago with [%d] iterations over [%d] rounds since the last convergence \
+                            [%s] ago""",
                         desiredBalanceInput.index(),
+                        TimeValue.timeValueMillis(currentTime - computationStartedTime).toString(),
+                        iterations,
                         TimeValue.timeValueMillis(currentTime - firstComputeStartedSinceConvergedTimeMillis).toString(),
                         numIterationsSinceLastConverged,
                         numComputeCallsSinceLastConverged,
-                        iterations,
-                        TimeValue.timeValueMillis(currentTime - computationStartedTime).toString()
+                        TimeValue.timeValueMillis(currentTime - lastConvergedTimeMillis).toString()
                     )
                 );
             } else {
                 logger.log(
                     logLevel,
                     () -> Strings.format(
-                        "Desired balance computation for [%d] is still not converged after [%s] and [%d] iterations",
+                        """
+                            Desired balance computation for [%d] is still not converged after [%s] and [%d] iterations this round, \
+                            last convergence was [%s] ago""",
                         desiredBalanceInput.index(),
-                        TimeValue.timeValueMillis(currentTime - firstComputeStartedSinceConvergedTimeMillis).toString(),
-                        numIterationsSinceLastConverged
+                        TimeValue.timeValueMillis(currentTime - computationStartedTime).toString(),
+                        iterations,
+                        TimeValue.timeValueMillis(currentTime - lastConvergedTimeMillis).toString()
                     )
                 );
             }


### PR DESCRIPTION
    allocation: add timing and iteration to logging
    
    The DesiredBalanceComputer now has three groups of timing and iteration counts:
    the current round iteration and duration, the since-recompute iterations, round
    count, and duration, and the time since convergence. This logging change
    includes all available information in the logs, and groups them together by
    kind.
