### PR TITLE
[8.19] More reliable trigger for security index migration (#139028)

### DIFF
--- a/docs/changelog/139028.yaml
+++ b/docs/changelog/139028.yaml
@@ -1,0 +1,5 @@
+pr: 139028
+summary: More reliable trigger for security index migration
+area: Security
+type: bug
+issues: []

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityMigrations.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityMigrations.java
@@ -102,6 +102,13 @@ public class SecurityMigrations {
         )
     );
 
+    /**
+     * @return The highest migration version that is currently defined
+     */
+    public static int highestMigrationVersion() {
+        return MIGRATIONS_BY_VERSION.lastKey();
+    }
+
     public static class RoleMetadataFlattenedMigration implements SecurityMigration {
 
         @Override


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [More reliable trigger for security index migration (#139028)](https://github.com/elastic/elasticsearch/pull/139028)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)