### PR TITLE
Utilize bulk scorer interface in flat formats

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/ES813FlatVectorFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/ES813FlatVectorFormat.java
@@ -27,13 +27,11 @@ import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.Sorter;
 import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.KnnCollector;
-import org.apache.lucene.util.Bits;
-import org.apache.lucene.util.hnsw.OrdinalTranslatedKnnCollector;
-import org.apache.lucene.util.hnsw.RandomVectorScorer;
 
 import java.io.IOException;
 import java.util.Map;
 
+import static org.elasticsearch.index.codec.vectors.VectorScoringUtils.scoreAndCollectAll;
 import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.MAX_DIMS_COUNT;
 
 public class ES813FlatVectorFormat extends KnnVectorsFormat {
@@ -130,25 +128,12 @@ public class ES813FlatVectorFormat extends KnnVectorsFormat {
 
         @Override
         public void search(String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException {
-            collectAllMatchingDocs(knnCollector, acceptDocs, reader.getRandomVectorScorer(field, target));
-        }
-
-        private void collectAllMatchingDocs(KnnCollector knnCollector, AcceptDocs acceptDocs, RandomVectorScorer scorer)
-            throws IOException {
-            OrdinalTranslatedKnnCollector collector = new OrdinalTranslatedKnnCollector(knnCollector, scorer::ordToDoc);
-            Bits acceptedOrds = scorer.getAcceptOrds(acceptDocs.bits());
-            for (int i = 0; i < scorer.maxOrd(); i++) {
-                if (acceptedOrds == null || acceptedOrds.get(i)) {
-                    collector.collect(i, scorer.score(i));
-                    collector.incVisitedCount(1);
-                }
-            }
-            assert collector.earlyTerminated() == false;
+            scoreAndCollectAll(knnCollector, acceptDocs, reader.getRandomVectorScorer(field, target));
         }
 
         @Override
         public void search(String field, byte[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException {
-            collectAllMatchingDocs(knnCollector, acceptDocs, reader.getRandomVectorScorer(field, target));
+            scoreAndCollectAll(knnCollector, acceptDocs, reader.getRandomVectorScorer(field, target));
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/ES813Int8FlatVectorFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/ES813Int8FlatVectorFormat.java
@@ -25,13 +25,11 @@ import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.Sorter;
 import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.KnnCollector;
-import org.apache.lucene.util.Bits;
-import org.apache.lucene.util.hnsw.OrdinalTranslatedKnnCollector;
-import org.apache.lucene.util.hnsw.RandomVectorScorer;
 
 import java.io.IOException;
 import java.util.Map;
 
+import static org.elasticsearch.index.codec.vectors.VectorScoringUtils.scoreAndCollectAll;
 import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.MAX_DIMS_COUNT;
 
 public class ES813Int8FlatVectorFormat extends KnnVectorsFormat {
@@ -138,25 +136,12 @@ public class ES813Int8FlatVectorFormat extends KnnVectorsFormat {
 
         @Override
         public void search(String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException {
-            collectAllMatchingDocs(knnCollector, acceptDocs, reader.getRandomVectorScorer(field, target));
-        }
-
-        private void collectAllMatchingDocs(KnnCollector knnCollector, AcceptDocs acceptDocs, RandomVectorScorer scorer)
-            throws IOException {
-            OrdinalTranslatedKnnCollector collector = new OrdinalTranslatedKnnCollector(knnCollector, scorer::ordToDoc);
-            Bits acceptedOrds = scorer.getAcceptOrds(acceptDocs.bits());
-            for (int i = 0; i < scorer.maxOrd(); i++) {
-                if (acceptedOrds == null || acceptedOrds.get(i)) {
-                    collector.collect(i, scorer.score(i));
-                    collector.incVisitedCount(1);
-                }
-            }
-            assert collector.earlyTerminated() == false;
+            scoreAndCollectAll(knnCollector, acceptDocs, reader.getRandomVectorScorer(field, target));
         }
 
         @Override
         public void search(String field, byte[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException {
-            collectAllMatchingDocs(knnCollector, acceptDocs, reader.getRandomVectorScorer(field, target));
+            scoreAndCollectAll(knnCollector, acceptDocs, reader.getRandomVectorScorer(field, target));
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/VectorScoringUtils.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/VectorScoringUtils.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.vectors;
+
+import org.apache.lucene.search.AcceptDocs;
+import org.apache.lucene.search.KnnCollector;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.hnsw.RandomVectorScorer;
+
+import java.io.IOException;
+
+/**
+ * Utility methods for vector scoring and collection.
+ */
+public final class VectorScoringUtils {
+
+    private static final int BULK_SCORE_BLOCKS = 64;
+
+    private VectorScoringUtils() {}
+
+    /**
+     * Scores and collects all vectors using the provided scorer and collector.
+     *
+     * @param knnCollector the collector to collect scored vectors
+     * @param acceptDocs   the accept docs to filter vectors
+     * @param scorer       the vector scorer
+     * @throws IOException if an I/O error occurs
+     */
+    public static void scoreAndCollectAll(KnnCollector knnCollector, AcceptDocs acceptDocs, RandomVectorScorer scorer) throws IOException {
+        // TODO we need to switch from scorer to VectorScorer and values so the filter can be lazily applied
+        //  building the bitset eagerly is silly for scoring everything
+        if (knnCollector.k() == 0 || scorer == null) {
+            return;
+        }
+        Bits acceptedOrds = scorer.getAcceptOrds(acceptDocs.bits());
+        int[] ords = new int[BULK_SCORE_BLOCKS];
+        float[] scores = new float[BULK_SCORE_BLOCKS];
+        int numOrds = 0;
+        int numVectors = scorer.maxOrd();
+        for (int i = 0; i < numVectors; i++) {
+            if (acceptedOrds == null || acceptedOrds.get(i)) {
+                if (knnCollector.earlyTerminated()) {
+                    break;
+                }
+                ords[numOrds++] = i;
+                if (numOrds == ords.length) {
+                    knnCollector.incVisitedCount(numOrds);
+                    scorer.bulkScore(ords, scores, numOrds);
+                    for (int j = 0; j < numOrds; j++) {
+                        knnCollector.collect(scorer.ordToDoc(ords[j]), scores[j]);
+                    }
+                    numOrds = 0;
+                }
+            }
+        }
+
+        if (numOrds > 0) {
+            knnCollector.incVisitedCount(numOrds);
+            scorer.bulkScore(ords, scores, numOrds);
+            for (int j = 0; j < numOrds; j++) {
+                knnCollector.collect(scorer.ordToDoc(ords[j]), scores[j]);
+            }
+        }
+        assert knnCollector.earlyTerminated() == false;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/VectorScoringUtils.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/VectorScoringUtils.java
@@ -35,7 +35,7 @@ public final class VectorScoringUtils {
      */
     public static void scoreAndCollectAll(KnnCollector knnCollector, AcceptDocs acceptDocs, RandomVectorScorer scorer) throws IOException {
         // TODO we need to switch from scorer to VectorScorer and values so the filter can be lazily applied
-        //  building the bitset eagerly is silly for scoring everything
+        // building the bitset eagerly is silly for scoring everything
         if (knnCollector.k() == 0 || scorer == null) {
             return;
         }

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/es818/ES818BinaryQuantizedVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/es818/ES818BinaryQuantizedVectorsReader.java
@@ -45,7 +45,6 @@ import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.SuppressForbidden;
-import org.apache.lucene.util.hnsw.OrdinalTranslatedKnnCollector;
 import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.elasticsearch.index.codec.vectors.BQVectorUtils;
 import org.elasticsearch.index.codec.vectors.OptimizedScalarQuantizer;
@@ -56,6 +55,7 @@ import java.util.Map;
 
 import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsReader.readSimilarityFunction;
 import static org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsReader.readVectorEncoding;
+import static org.elasticsearch.index.codec.vectors.VectorScoringUtils.scoreAndCollectAll;
 import static org.elasticsearch.index.codec.vectors.es818.ES818BinaryQuantizedVectorsFormat.VECTOR_DATA_EXTENSION;
 
 /**
@@ -247,17 +247,7 @@ public class ES818BinaryQuantizedVectorsReader extends FlatVectorsReader {
 
     @Override
     public void search(String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException {
-        if (knnCollector.k() == 0) return;
-        final RandomVectorScorer scorer = getRandomVectorScorer(field, target);
-        if (scorer == null) return;
-        OrdinalTranslatedKnnCollector collector = new OrdinalTranslatedKnnCollector(knnCollector, scorer::ordToDoc);
-        Bits acceptedOrds = scorer.getAcceptOrds(acceptDocs.bits());
-        for (int i = 0; i < scorer.maxOrd(); i++) {
-            if (acceptedOrds == null || acceptedOrds.get(i)) {
-                collector.collect(i, scorer.score(i));
-                collector.incVisitedCount(1);
-            }
-        }
+        scoreAndCollectAll(knnCollector, acceptDocs, getRandomVectorScorer(field, target));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/es93/ES93FlatVectorFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/es93/ES93FlatVectorFormat.java
@@ -21,14 +21,12 @@ import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.search.AcceptDocs;
 import org.apache.lucene.search.KnnCollector;
-import org.apache.lucene.util.Bits;
-import org.apache.lucene.util.hnsw.OrdinalTranslatedKnnCollector;
-import org.apache.lucene.util.hnsw.RandomVectorScorer;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 
 import java.io.IOException;
 import java.util.Map;
 
+import static org.elasticsearch.index.codec.vectors.VectorScoringUtils.scoreAndCollectAll;
 import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.MAX_DIMS_COUNT;
 
 public class ES93FlatVectorFormat extends KnnVectorsFormat {
@@ -91,25 +89,12 @@ public class ES93FlatVectorFormat extends KnnVectorsFormat {
 
         @Override
         public void search(String field, float[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException {
-            collectAllMatchingDocs(knnCollector, acceptDocs, reader.getRandomVectorScorer(field, target));
-        }
-
-        private void collectAllMatchingDocs(KnnCollector knnCollector, AcceptDocs acceptDocs, RandomVectorScorer scorer)
-            throws IOException {
-            OrdinalTranslatedKnnCollector collector = new OrdinalTranslatedKnnCollector(knnCollector, scorer::ordToDoc);
-            Bits acceptedOrds = scorer.getAcceptOrds(acceptDocs.bits());
-            for (int i = 0; i < scorer.maxOrd(); i++) {
-                if (acceptedOrds == null || acceptedOrds.get(i)) {
-                    collector.collect(i, scorer.score(i));
-                    collector.incVisitedCount(1);
-                }
-            }
-            assert collector.earlyTerminated() == false;
+            scoreAndCollectAll(knnCollector, acceptDocs, reader.getRandomVectorScorer(field, target));
         }
 
         @Override
         public void search(String field, byte[] target, KnnCollector knnCollector, AcceptDocs acceptDocs) throws IOException {
-            collectAllMatchingDocs(knnCollector, acceptDocs, reader.getRandomVectorScorer(field, target));
+            scoreAndCollectAll(knnCollector, acceptDocs, reader.getRandomVectorScorer(field, target));
         }
 
         @Override


### PR DESCRIPTION
This uses the bulk scoring interface for our flat vector formats.

I don't think this is actually used if there are filters applied because of higher level optimizations. But, we should follow up to this and lazily apply the accept docs if possible, that way we don't need the higher level logic to skip the knn searcher.