### PR TITLE
ES|QL: Move SET project_routing to tech preview

### DIFF
--- a/docs/reference/query-languages/esql/kibana/definition/settings/project_routing.json
+++ b/docs/reference/query-languages/esql/kibana/definition/settings/project_routing.json
@@ -3,7 +3,7 @@
   "name" : "project_routing",
   "type" : "keyword",
   "serverlessOnly" : true,
-  "preview" : false,
-  "snapshotOnly" : true,
+  "preview" : true,
+  "snapshotOnly" : false,
   "description" : "A project routing expression, used to define which projects to route the query to. Only supported if Cross-Project Search is enabled."
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/QuerySettings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/QuerySettings.java
@@ -25,13 +25,12 @@ public class QuerySettings {
         "project_routing",
         DataType.KEYWORD,
         true,
-        false,
         true,
+        false,
         "A project routing expression, "
             + "used to define which projects to route the query to. "
             + "Only supported if Cross-Project Search is enabled.",
-        // TODO enable this when CPS is ready and we move this to tech preview
-        // (value, ctx) -> ctx.crossProjectEnabled() ? null : "not enabled",
+        (value, ctx) -> ctx.crossProjectEnabled() ? null : "cross-project search not enabled",
         (value) -> Foldables.stringLiteralValueOf(value, "Unexpected value"),
         null
     );


### PR DESCRIPTION
Moving `project_routing` setting to tech preview, and enabling validation to make sure it's allowed only on CPS