### PR TITLE
Remove unused `VIntKeySerializer`

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/DiffableUtils.java
+++ b/server/src/main/java/org/elasticsearch/cluster/DiffableUtils.java
@@ -58,13 +58,6 @@ public final class DiffableUtils {
     }
 
     /**
-     * Returns a map key serializer for Integer keys. Encodes as VInt.
-     */
-    public static KeySerializer<Integer> getVIntKeySerializer() {
-        return VIntKeySerializer.INSTANCE;
-    }
-
-    /**
      * Returns a map key serializer for {@link Writeable} keys.
      */
     public static <W extends Writeable> KeySerializer<W> getWriteableKeySerializer(Writeable.Reader<W> reader) {
@@ -707,26 +700,6 @@ public final class DiffableUtils {
         @Override
         public Integer readKey(StreamInput in) throws IOException {
             return in.readInt();
-        }
-    }
-
-    /**
-     * Serializes Integer keys of a map as a VInt. Requires keys to be positive.
-     */
-    private static final class VIntKeySerializer implements KeySerializer<Integer> {
-        public static final IntKeySerializer INSTANCE = new IntKeySerializer();
-
-        @Override
-        public void writeKey(Integer key, StreamOutput out) throws IOException {
-            if (key < 0) {
-                throw new IllegalArgumentException("Map key [" + key + "] must be positive");
-            }
-            out.writeVInt(key);
-        }
-
-        @Override
-        public Integer readKey(StreamInput in) throws IOException {
-            return in.readVInt();
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -1727,7 +1727,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             inSyncAllocationIds = DiffableUtils.diff(
                 before.inSyncAllocationIds,
                 after.inSyncAllocationIds,
-                DiffableUtils.getVIntKeySerializer(),
+                DiffableUtils.getIntKeySerializer(),
                 DiffableUtils.StringSetValueSerializer.getInstance()
             );
             rolloverInfos = DiffableUtils.diff(before.rolloverInfos, after.rolloverInfos, DiffableUtils.getStringKeySerializer());
@@ -1780,7 +1780,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             customData = DiffableUtils.readImmutableOpenMapDiff(in, DiffableUtils.getStringKeySerializer(), CUSTOM_DIFF_VALUE_READER);
             inSyncAllocationIds = DiffableUtils.readJdkMapDiff(
                 in,
-                DiffableUtils.getVIntKeySerializer(),
+                DiffableUtils.getIntKeySerializer(),
                 DiffableUtils.StringSetValueSerializer.getInstance()
             );
             rolloverInfos = DiffableUtils.readImmutableOpenMapDiff(

--- a/server/src/test/java/org/elasticsearch/cluster/serialization/DiffableTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/serialization/DiffableTests.java
@@ -164,9 +164,7 @@ public class DiffableTests extends ESTestCase {
         protected final Set<Integer> keysToAdd = Sets.difference(randomPositiveIntSet(), keys);
         protected final Set<Integer> keysUnchanged = Sets.difference(keysThatAreNotRemoved, keysToOverride);
 
-        protected final DiffableUtils.KeySerializer<Integer> keySerializer = randomBoolean()
-            ? DiffableUtils.getIntKeySerializer()
-            : DiffableUtils.getVIntKeySerializer();
+        protected final DiffableUtils.KeySerializer<Integer> keySerializer = DiffableUtils.getIntKeySerializer();
 
         protected final boolean useProtoForDiffableSerialization = randomBoolean();
 


### PR DESCRIPTION
We use `VIntKeySerializer#INSTANCE` to serialize integer-keyed maps in a
cluster state diff, but (because of an apparent typo in 342665300b7)
this has actually been an `IntKeySerializer` all this time. This commit
removes the dead `VIntSerializer` code.