### PR TITLE
Fix bug introduced when we fixed multi-fields in #138869

### DIFF
--- a/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DownsampleIT.java
+++ b/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DownsampleIT.java
@@ -144,6 +144,13 @@ public class DownsampleIT extends DownsamplingIntegTestCase {
         String mapping = """
             {
               "properties": {
+                "@timestamp": {
+                  "type": "date"
+                },
+                "timestamp": {
+                  "path": "@timestamp",
+                  "type": "alias"
+                },
                 "attributes": {
                   "type": "passthrough",
                   "priority": 10,

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/FieldValueFetcher.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/FieldValueFetcher.java
@@ -115,7 +115,7 @@ class FieldValueFetcher {
             if (fieldType instanceof AggregateMetricDoubleFieldMapper.AggregateMetricDoubleFieldType aggMetricFieldType) {
                 fetchers.addAll(AggregateSubMetricFieldValueFetcher.create(context, aggMetricFieldType, samplingMethod));
             } else {
-                if (context.fieldExistsInIndex(fieldType.name())) {
+                if (context.fieldExistsInIndex(field)) {
                     final IndexFieldData<?> fieldData;
                     if (fieldType instanceof FlattenedFieldMapper.RootFlattenedFieldType flattenedFieldType) {
                         var keyedFieldType = flattenedFieldType.getKeyedFieldType();

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/TimeSeriesFields.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/TimeSeriesFields.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.downsample;
 
 import org.elasticsearch.action.admin.cluster.stats.MappingVisitor;
-import org.elasticsearch.index.mapper.FieldAliasMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MappingLookup;
@@ -70,7 +69,6 @@ record TimeSeriesFields(String[] metricFields, String[] dimensionFields, String[
         final MappingLookup lookup = mapperService.mappingLookup();
         final MappedFieldType fieldType = lookup.getFieldType(field);
         return fieldType != null
-            && fieldType.typeName().equals(FieldAliasMapper.CONTENT_TYPE) == false
             && (timestampField.equals(field) == false)
             && (fieldType.isAggregatable())
             && (fieldType.isDimension() == false)

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/TimeSeriesFields.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/TimeSeriesFields.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.downsample;
 
 import org.elasticsearch.action.admin.cluster.stats.MappingVisitor;
+import org.elasticsearch.index.mapper.FieldAliasMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MappingLookup;
@@ -69,6 +70,7 @@ record TimeSeriesFields(String[] metricFields, String[] dimensionFields, String[
         final MappingLookup lookup = mapperService.mappingLookup();
         final MappedFieldType fieldType = lookup.getFieldType(field);
         return fieldType != null
+            && fieldType.typeName().equals(FieldAliasMapper.CONTENT_TYPE) == false
             && (timestampField.equals(field) == false)
             && (fieldType.isAggregatable())
             && (fieldType.isDimension() == false)


### PR DESCRIPTION
In #138869 we fixed the handling of the multi-fields; however, we introduced a bug when a mapping contains a alias type.

For example, the following mapping:

```
"@timestamp": {
  "type": "date"
}, 
"timestamp": {
  "type": "alias",
  "path": "@timestamp"
}
```

The cause of the bug was that in the `FieldValueFetcher` we switch the check wether a field is indexed from the name we retrieved in the label to the name of the field type. In this case, the label is `timestamp`  which does not in the indexed but the name of the field type is "@timestamp".