### PR TITLE
[9.2] Fix bug introduced when we fixed multi-fields in #138869 (#139104)

### DIFF
--- a/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DownsampleIT.java
+++ b/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DownsampleIT.java
@@ -49,6 +49,13 @@ public class DownsampleIT extends DownsamplingIntegTestCase {
             {
               %s
               "properties": {
+                "@timestamp": {
+                  "type": "date"
+                },
+                "timestamp": {
+                  "path": "@timestamp",
+                  "type": "alias"
+                },
                 "attributes": {
                   "type": "passthrough",
                   "priority": 10,
@@ -92,6 +99,13 @@ public class DownsampleIT extends DownsamplingIntegTestCase {
         String mapping = """
             {
               "properties": {
+                "@timestamp": {
+                  "type": "date"
+                },
+                "timestamp": {
+                  "path": "@timestamp",
+                  "type": "alias"
+                },
                 "attributes.os.name": {
                   "type": "keyword",
                   "time_series_dimension": true

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/FieldValueFetcher.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/FieldValueFetcher.java
@@ -101,7 +101,7 @@ class FieldValueFetcher {
                     }
                 }
             } else {
-                if (context.fieldExistsInIndex(fieldType.name())) {
+                if (context.fieldExistsInIndex(field)) {
                     final IndexFieldData<?> fieldData;
                     if (fieldType instanceof FlattenedFieldMapper.RootFlattenedFieldType flattenedFieldType) {
                         var keyedFieldType = flattenedFieldType.getKeyedFieldType();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Fix bug introduced when we fixed multi-fields in #138869 (#139104)](https://github.com/elastic/elasticsearch/pull/139104)

<!--- Backport version: 9.6.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)