### PR TITLE
Fix flakiness in SamlServiceProviderMetadataIT

### DIFF
--- a/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlRestTestCase.java
+++ b/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlRestTestCase.java
@@ -37,6 +37,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.security.GeneralSecurityException;
 import java.security.cert.CertificateException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +47,7 @@ public class SamlRestTestCase extends ESRestTestCase {
     protected static final String SAML_SIGNING_KEY = "/saml/signing.key";
 
     private static HttpsServer httpsServer;
-    private static final Map<Integer, Boolean> metadataAvailable = new HashMap<>();
+    private static final Map<Integer, Boolean> metadataAvailable = Collections.synchronizedMap(new HashMap<>());
     public static final ElasticsearchCluster cluster = initTestCluster();
     private static Path caPath;
 

--- a/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlRestTestCase.java
+++ b/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlRestTestCase.java
@@ -37,17 +37,17 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.security.GeneralSecurityException;
 import java.security.cert.CertificateException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class SamlRestTestCase extends ESRestTestCase {
     protected static final String SAML_SIGNING_CRT = "/saml/signing.crt";
     protected static final String SAML_SIGNING_KEY = "/saml/signing.key";
 
     private static HttpsServer httpsServer;
-    private static final Map<Integer, Boolean> metadataAvailable = Collections.synchronizedMap(new HashMap<>());
+    private static final Map<Integer, Boolean> metadataAvailable = new ConcurrentHashMap<>();
     public static final ElasticsearchCluster cluster = initTestCluster();
     private static Path caPath;
 


### PR DESCRIPTION
There is a potential thread issue, where the contents of shared metadataAvailable field could be cached by a thread and not read the newest changes, causing the test to fail on rare occasion

Closes #139067