### PR TITLE
[9.2] Fix downsampling with disabled subobjects (#138715)

### DIFF
--- a/docs/changelog/138715.yaml
+++ b/docs/changelog/138715.yaml
@@ -1,0 +1,5 @@
+pr: 138715
+summary: Fix downsampling with disabled subobjects
+area: Downsampling
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/MappingVisitor.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/MappingVisitor.java
@@ -9,10 +9,16 @@
 
 package org.elasticsearch.action.admin.cluster.stats;
 
+import org.elasticsearch.common.TriConsumer;
+
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
 
 public final class MappingVisitor {
+    public static final String PROPERTIES = "properties";
+    public static final String FIELD_TYPE = "type";
+    public static final String MULTI_FIELDS = "fields";
 
     private MappingVisitor() {}
 
@@ -34,7 +40,7 @@ public final class MappingVisitor {
         final BiConsumer<String, Map<String, ?>> propertiesMappingConsumer,
         final BiConsumer<String, Map<String, ?>> multiFieldsMappingConsumer
     ) {
-        Object properties = mapping.get("properties");
+        Object properties = mapping.get(PROPERTIES);
         if (properties instanceof Map) {
             @SuppressWarnings("unchecked")
             Map<String, ?> propertiesAsMap = (Map<String, ?>) properties;
@@ -49,7 +55,7 @@ public final class MappingVisitor {
                     visitMapping(fieldMapping, prefix + ".", propertiesMappingConsumer, multiFieldsMappingConsumer);
 
                     // Multi fields
-                    Object fieldsO = fieldMapping.get("fields");
+                    Object fieldsO = fieldMapping.get(MULTI_FIELDS);
                     if (fieldsO instanceof Map) {
                         @SuppressWarnings("unchecked")
                         Map<String, ?> fields = (Map<String, ?>) fieldsO;
@@ -83,5 +89,52 @@ public final class MappingVisitor {
             Map<String, ?> runtimeFieldMapping = (Map<String, ?>) runtimeFieldMappingObject;
             runtimeFieldMappingConsumer.accept(entry.getKey(), runtimeFieldMapping);
         }
+    }
+
+    /**
+     * This visitor traverses the source mapping and copies the structure to the destination mapping after applying
+     * the fieldMappingConsumer to the individual properties.
+     */
+    public static void visitPropertiesAndCopyMapping(
+        final Map<String, ?> sourceMapping,
+        final Map<String, Object> destMapping,
+        final TriConsumer<String, Map<String, ?>, Map<String, Object>> fieldMappingConsumer
+    ) {
+        Map<String, ?> sourceProperties = getMapOrNull(sourceMapping.get(PROPERTIES));
+        if (sourceProperties == null) {
+            return;
+        }
+        Map<String, Object> destProperties = new HashMap<>(sourceProperties.size());
+        destMapping.put(PROPERTIES, destProperties);
+
+        for (Map.Entry<String, ?> entry : sourceProperties.entrySet()) {
+            Map<String, ?> sourceFieldMapping = getMapOrNull(entry.getValue());
+            if (sourceFieldMapping == null) {
+                return;
+            }
+            var destFieldMapping = processAndCopy(entry.getKey(), sourceFieldMapping, destProperties, fieldMappingConsumer);
+            visitPropertiesAndCopyMapping(sourceFieldMapping, destFieldMapping, fieldMappingConsumer);
+        }
+    }
+
+    private static Map<String, ?> getMapOrNull(Object object) {
+        if (object instanceof Map) {
+            @SuppressWarnings("unchecked")
+            Map<String, ?> map = (Map<String, ?>) object;
+            return map;
+        }
+        return null;
+    }
+
+    private static Map<String, Object> processAndCopy(
+        String fieldName,
+        Map<String, ?> sourceFieldMapping,
+        Map<String, Object> destParentMap,
+        TriConsumer<String, Map<String, ?>, Map<String, Object>> fieldMappingConsumer
+    ) {
+        Map<String, Object> destFieldMapping = new HashMap<>(sourceFieldMapping.size());
+        destParentMap.put(fieldName, destFieldMapping);
+        fieldMappingConsumer.apply(fieldName, sourceFieldMapping, destFieldMapping);
+        return destFieldMapping;
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/MappingVisitorTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/MappingVisitorTests.java
@@ -9,6 +9,9 @@
 
 package org.elasticsearch.action.admin.cluster.stats;
 
+import org.elasticsearch.datageneration.DataGeneratorSpecification;
+import org.elasticsearch.datageneration.MappingGenerator;
+import org.elasticsearch.datageneration.TemplateGenerator;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Arrays;
@@ -18,7 +21,11 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import static org.hamcrest.Matchers.equalTo;
+
 public class MappingVisitorTests extends ESTestCase {
+
+    private static final int MAPPING_GENERATION_ROUNDS = 500;
 
     private static void collectTypes(Map<String, ?> mapping, Set<String> types) {
         MappingVisitor.visitMapping(mapping, (f, m) -> {
@@ -138,6 +145,20 @@ public class MappingVisitorTests extends ESTestCase {
         assertEquals(new HashSet<>(Arrays.asList("keyword", "object")), fields);
     }
 
+    @SuppressWarnings("unchecked")
+    public void testVisitAndCopy() {
+        DataGeneratorSpecification specification = DataGeneratorSpecification.buildDefault();
+        var template = new TemplateGenerator(specification).generate();
+        MappingGenerator mappingGenerator = new MappingGenerator(specification);
+        for (int i = 0; i < MAPPING_GENERATION_ROUNDS; i++) {
+            var mapping = mappingGenerator.generate(template).raw();
+            var properties = (Map<String, Object>) mapping.get("_doc");
+            var updatedMapping = new HashMap<String, Object>();
+            MappingVisitor.visitPropertiesAndCopyMapping(properties, updatedMapping, (f, source, dest) -> dest.put(f, source));
+            assertThat(updatedMapping, equalTo(updatedMapping));
+        }
+    }
+
     public void testCountRuntimeFields() {
         Map<String, Object> mapping = new HashMap<>();
         Set<String> fields = new HashSet<>();
@@ -168,5 +189,63 @@ public class MappingVisitorTests extends ESTestCase {
 
     private static void collectRuntimeTypes(Map<String, ?> mapping, Set<String> types) {
         MappingVisitor.visitRuntimeMapping(mapping, (f, m) -> types.add(m.get("type").toString()));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testConvertLongToKeyword() {
+        Map<String, Object> longType = Map.of("type", "long");
+        Map<String, Object> textType = Map.of("type", "text");
+        Map<String, Object> floatType = Map.of("type", "float", "scaling_factor", 1000);
+        Map<String, Object> multiField = Map.of("type", "keyword", "fields", Map.of("my-long", longType, "my-float", floatType));
+        Map<String, Object> objectField = Map.of("type", "object", "properties", Map.of("my-text", textType, "my-long", longType));
+        Map<String, Object> expectedProperties = Map.of(
+            "properties",
+            Map.of("my-long", longType, "my-float", floatType, "my-multi-field", multiField, "my-object", objectField)
+        );
+
+        HashMap<String, Object> result = new HashMap<>();
+        MappingVisitor.visitPropertiesAndCopyMapping(expectedProperties, result, (ignored, source, dest) -> {
+            for (String key : source.keySet()) {
+                if (key.equals("type") && source.get(key).equals("long")) {
+                    dest.put(key, "keyword");
+                } else {
+                    dest.put(key, source.get(key));
+                }
+            }
+        });
+
+        assertTrue(result.containsKey("properties"));
+        Map<String, Object> properties = (Map<String, Object>) result.get("properties");
+
+        assertTrue(properties.containsKey("my-long"));
+        Map<String, Object> myLong = (Map<String, Object>) properties.get("my-long");
+        assertEquals("keyword", myLong.get("type"));
+
+        assertTrue(properties.containsKey("my-float"));
+        Map<String, Object> myFloat = (Map<String, Object>) properties.get("my-float");
+        assertEquals("float", myFloat.get("type"));
+        assertEquals(1000, myFloat.get("scaling_factor"));
+
+        assertTrue(properties.containsKey("my-multi-field"));
+        Map<String, Object> myMultiField = (Map<String, Object>) properties.get("my-multi-field");
+        assertEquals("keyword", myMultiField.get("type"));
+        assertTrue(myMultiField.containsKey("fields"));
+        Map<String, Object> foundFields = (Map<String, Object>) myMultiField.get("fields");
+        assertTrue(foundFields.containsKey("my-long"));
+        // multi fields are not converted to keyword
+        assertEquals("long", ((Map<String, Object>) foundFields.get("my-long")).get("type"));
+        assertTrue(foundFields.containsKey("my-float"));
+        assertEquals("float", ((Map<String, Object>) foundFields.get("my-float")).get("type"));
+        assertEquals(1000, ((Map<String, Object>) foundFields.get("my-float")).get("scaling_factor"));
+
+        assertTrue(properties.containsKey("my-object"));
+        Map<String, Object> myObject = (Map<String, Object>) properties.get("my-object");
+        assertEquals("object", myObject.get("type"));
+        assertTrue(myObject.containsKey("properties"));
+        Map<String, Object> foundSubObjects = (Map<String, Object>) myObject.get("properties");
+        assertTrue(foundSubObjects.containsKey("my-long"));
+        assertEquals("keyword", ((Map<String, Object>) foundSubObjects.get("my-long")).get("type"));
+        assertTrue(foundSubObjects.containsKey("my-text"));
+        assertEquals("text", ((Map<String, Object>) foundSubObjects.get("my-text")).get("type"));
     }
 }

--- a/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DownsampleIT.java
+++ b/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DownsampleIT.java
@@ -117,6 +117,14 @@ public class DownsampleIT extends DownsamplingIntegTestCase {
                     "cpu_usage": {
                         "type": "double",
                         "time_series_metric": "counter"
+                    },
+                    "memory_usage": {
+                        "type": "double",
+                        "time_series_metric": "counter"
+                    },
+                    "memory_usage.free": {
+                        "type": "double",
+                        "time_series_metric": "counter"
                     }
                   }
                 }
@@ -135,6 +143,8 @@ public class DownsampleIT extends DownsamplingIntegTestCase {
                     .field("attributes.os.name", randomFrom("linux", "windows", "macos"))
                     .field("metrics.cpu_usage", randomDouble())
                     .field("metrics.memory_usage", randomDouble())
+                    .field("metrics.memory_usage.free", randomDouble())
+                    .field("metrics.load", randomDouble())
                     .endObject();
             } catch (IOException e) {
                 throw new RuntimeException(e);

--- a/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/TransportDownsampleActionTests.java
+++ b/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/TransportDownsampleActionTests.java
@@ -53,6 +53,7 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.core.downsample.DownsampleShardIndexerStatus;
 import org.elasticsearch.xpack.core.downsample.DownsampleShardPersistentTaskState;
@@ -72,6 +73,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -474,6 +477,78 @@ public class TransportDownsampleActionTests extends ESTestCase {
         DocumentMapper documentMapper = mock(DocumentMapper.class);
         when(documentMapper.mappingSource()).thenReturn(CompressedXContent.fromJSON(mapping));
         when(mapperService.merge(anyString(), any(CompressedXContent.class), any())).thenReturn(documentMapper);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testDownsamplingMapping() throws IOException {
+        Map<String, Object> sourceMapping = Map.of(
+            "runtime",
+            Map.of(
+                "day_of_week",
+                Map.of(
+                    "type",
+                    "keyword",
+                    "script",
+                    Map.of("source", "emit(doc['@timestamp'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ENGLISH))")
+                )
+            ),
+            "properties",
+            Map.of(
+                "@timestamp",
+                Map.of("type", "date", "format", "strict_date_optional_time||epoch_millis"),
+                "timestamp",
+                Map.of("type", "alias"),
+                "dimension",
+                Map.of("type", "keyword", "time_series_dimension", true),
+                "counter",
+                Map.of("type", "long", "time_series_metric", "counter"),
+                "gauge",
+                Map.of("type", "double", "time_series_metric", "gauge")
+            )
+        );
+        String downsampledMappingStr = TransportDownsampleAction.createDownsampleIndexMapping(
+            new DownsampleConfig(new DateHistogramInterval("1h")),
+            sourceMapping
+        );
+        Map<String, Object> downsampledMapping = XContentHelper.convertToMap(
+            new CompressedXContent(downsampledMappingStr).compressedReference(),
+            true,
+            XContentType.JSON
+        ).v2();
+        assertThat(downsampledMapping.containsKey("runtime"), equalTo(true));
+        Map<String, Object> downsampledRuntime = (Map<String, Object>) downsampledMapping.get("runtime");
+        assertThat(downsampledRuntime.containsKey("day_of_week"), equalTo(true));
+        assertThat(((Map<String, Object>) downsampledRuntime.get("day_of_week")).get("type"), equalTo("keyword"));
+        assertThat(downsampledMapping.containsKey("properties"), equalTo(true));
+        Map<String, Object> downsampledProperties = (Map<String, Object>) downsampledMapping.get("properties");
+        assertThat(downsampledProperties.containsKey("timestamp"), equalTo(true));
+        assertThat(((Map<String, Object>) downsampledProperties.get("timestamp")).get("type"), equalTo("alias"));
+        assertThat(downsampledProperties.containsKey("@timestamp"), equalTo(true));
+        Map<String, Object> timestamp = (Map<String, Object>) downsampledProperties.get("@timestamp");
+        assertThat(timestamp.get("type"), equalTo("date"));
+        assertThat(timestamp.get("format"), equalTo("strict_date_optional_time||epoch_millis"));
+        assertThat(timestamp.containsKey("meta"), equalTo(true));
+        assertThat(downsampledProperties.containsKey("dimension"), equalTo(true));
+        Map<String, Object> dimension = (Map<String, Object>) downsampledProperties.get("dimension");
+        assertThat(dimension.get("type"), equalTo("keyword"));
+        assertThat(dimension.get("time_series_dimension"), equalTo(true));
+        assertThat(downsampledProperties.containsKey("counter"), equalTo(true));
+        Map<String, Object> counter = (Map<String, Object>) downsampledProperties.get("counter");
+        assertThat(counter.get("type"), equalTo("long"));
+        assertThat(counter.get("time_series_metric"), equalTo("counter"));
+        assertThat(downsampledProperties.containsKey("gauge"), equalTo(true));
+        Map<String, Object> gauge = (Map<String, Object>) downsampledProperties.get("gauge");
+        assertThat(gauge.get("type"), equalTo("aggregate_metric_double"));
+        assertThat(gauge.get("default_metric"), equalTo("max"));
+        assertThat((List<String>) gauge.get("metrics"), containsInAnyOrder("max", "min", "sum", "value_count"));
+        assertThat(gauge.get("time_series_metric"), equalTo("gauge"));
+    }
+
+    private void verifyIndexFinalisation() {
+        verify(downsampleMetrics).recordOperation(anyLong(), eq(DownsampleMetrics.ActionStatus.SUCCESS));
+        verify(indicesAdminClient).refresh(any(), any());
+        verify(indicesAdminClient).flush(any(), any());
+        verify(indicesAdminClient, never()).forceMerge(any(), any());
     }
 
     private IndexMetadata.Builder createSourceIndexMetadata(String sourceIndex, int primaryShards, int replicaShards) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Fix downsampling with disabled subobjects (#138715)](https://github.com/elastic/elasticsearch/pull/138715)

<!--- Backport version: 9.6.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)