### PR TITLE
[9.2] [ES|QL] Compare query builders using identity (#139080)

### DIFF
--- a/docs/changelog/139080.yaml
+++ b/docs/changelog/139080.yaml
@@ -1,0 +1,5 @@
+pr: 139080
+summary: "[ES|QL] Compare query builders using identity"
+area: "ES|QL"
+type: bug
+issues: []

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/FullTextFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/FullTextFunction.java
@@ -145,7 +145,7 @@ public abstract class FullTextFunction extends Function
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), query, queryBuilder);
+        return Objects.hash(super.hashCode(), query, System.identityHashCode(queryBuilder));
     }
 
     @Override
@@ -154,7 +154,9 @@ public abstract class FullTextFunction extends Function
             return false;
         }
 
-        return Objects.equals(queryBuilder, ((FullTextFunction) obj).queryBuilder) && Objects.equals(query, ((FullTextFunction) obj).query);
+        // Compare query builders using identity because that's how they are compared during query rewriting
+        FullTextFunction other = (FullTextFunction) obj;
+        return queryBuilder == other.queryBuilder && Objects.equals(query, other.query);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/SingleFieldFullTextFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/SingleFieldFullTextFunction.java
@@ -192,14 +192,14 @@ public abstract class SingleFieldFullTextFunction extends FullTextFunction
         // We override equals and hashcode to ignore options when comparing two function instances
         if (o == null || getClass() != o.getClass()) return false;
         SingleFieldFullTextFunction that = (SingleFieldFullTextFunction) o;
-        return Objects.equals(field(), that.field())
-            && Objects.equals(query(), that.query())
-            && Objects.equals(queryBuilder(), that.queryBuilder());
+
+        // Compare query builders using identity because that's how they are compared during query rewriting
+        return Objects.equals(field(), that.field()) && Objects.equals(query(), that.query()) && queryBuilder() == that.queryBuilder();
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(field(), query(), queryBuilder());
+        return Objects.hash(field(), query(), System.identityHashCode(queryBuilder()));
     }
 
     /**


### PR DESCRIPTION
Backports the following commits to 9.2:
 - [ES|QL] Compare query builders using identity (#139080)