### PR TITLE
[9.1] [ES|QL] Compare query builders using identity (#139080)

### DIFF
--- a/docs/changelog/139080.yaml
+++ b/docs/changelog/139080.yaml
@@ -1,0 +1,5 @@
+pr: 139080
+summary: "[ES|QL] Compare query builders using identity"
+area: "ES|QL"
+type: bug
+issues: []

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/FullTextFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/fulltext/FullTextFunction.java
@@ -149,7 +149,7 @@ public abstract class FullTextFunction extends Function
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), query, queryBuilder);
+        return Objects.hash(super.hashCode(), query, System.identityHashCode(queryBuilder));
     }
 
     @Override
@@ -158,7 +158,9 @@ public abstract class FullTextFunction extends Function
             return false;
         }
 
-        return Objects.equals(queryBuilder, ((FullTextFunction) obj).queryBuilder) && Objects.equals(query, ((FullTextFunction) obj).query);
+        // Compare query builders using identity because that's how they are compared during query rewriting
+        FullTextFunction other = (FullTextFunction) obj;
+        return queryBuilder == other.queryBuilder && Objects.equals(query, other.query);
     }
 
     @Override


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[ES|QL] Compare query builders using identity (#139080)](https://github.com/elastic/elasticsearch/pull/139080)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)