### PR TITLE
Fix TransportVersionTests.testVersionComparison

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -488,9 +488,6 @@ tests:
 - class: org.elasticsearch.simdvec.Int7SQVectorScorerFactoryTests
   method: testBulk
   issue: https://github.com/elastic/elasticsearch/issues/139079
-- class: org.elasticsearch.TransportVersionTests
-  method: testVersionComparison
-  issue: https://github.com/elastic/elasticsearch/issues/139122
 - class: org.elasticsearch.upgrades.IndexSortUpgradeIT
   method: testIndexSortForNumericTypes {upgradedNodes=1}
   issue: https://github.com/elastic/elasticsearch/issues/139127

--- a/server/src/test/java/org/elasticsearch/TransportVersionTests.java
+++ b/server/src/test/java/org/elasticsearch/TransportVersionTests.java
@@ -39,7 +39,11 @@ public class TransportVersionTests extends ESTestCase {
             TransportVersion.minimumCompatible(),
             TransportVersionUtils.getPreviousVersion(TransportVersion.current())
         );
-        TransportVersion newer = TransportVersionUtils.randomVersionBetween(random(), older, TransportVersion.current());
+        TransportVersion newer = TransportVersionUtils.randomVersionBetween(
+            random(),
+            TransportVersionUtils.getNextVersion(older),
+            TransportVersion.current()
+        );
         assertThat(older.before(newer), is(true));
         assertThat(older.before(older), is(false));
         assertThat(newer.before(older), is(false));


### PR DESCRIPTION
Fixed a test bug where newer version could be the same as older version due to inclusive values for randomization.

Closes https://github.com/elastic/elasticsearch/issues/139122