### PR TITLE
Fix SAML test initialisation flakiness

### DIFF
--- a/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlInResponseToIT.java
+++ b/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlInResponseToIT.java
@@ -13,7 +13,6 @@ import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.test.rest.ObjectPath;
 import org.elasticsearch.xcontent.json.JsonXContent;
-import org.junit.BeforeClass;
 
 import java.net.URL;
 import java.nio.charset.StandardCharsets;

--- a/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlInResponseToIT.java
+++ b/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlInResponseToIT.java
@@ -31,15 +31,6 @@ public class SamlInResponseToIT extends SamlRestTestCase {
 
     private static final int REALM_NUMBER = 1;
 
-    @BeforeClass
-    public static void enableMetadata() {
-        // during the startup, the metadata remains unavailable to prevent caching. After cluster init, we need to make metadata available
-        // explicitly. Note that unfortunately it can't work the other way round - we can't start with metadata available and then make it
-        // unavailable, because once cached, the metadata remains available for the rest of the tests. That means that this test, despite
-        // not having anything to do with metadata testing, unfortunately must explicitly make it enabled here.
-        makeMetadataAvailable(REALM_NUMBER);
-    }
-
     public void testInResponseTo_matchingValues() throws Exception {
         final String username = randomAlphaOfLengthBetween(4, 12);
         String requestId = generateRandomRequestId();

--- a/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlInResponseToIT.java
+++ b/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlInResponseToIT.java
@@ -13,6 +13,7 @@ import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.test.rest.ObjectPath;
 import org.elasticsearch.xcontent.json.JsonXContent;
+import org.junit.BeforeClass;
 
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -29,6 +30,15 @@ import static org.hamcrest.Matchers.is;
 public class SamlInResponseToIT extends SamlRestTestCase {
 
     private static final int REALM_NUMBER = 1;
+
+    @BeforeClass
+    public static void enableMetadata() {
+        // during the startup, the metadata remains unavailable to prevent caching. After cluster init, we need to make metadata available
+        // explicitly. Note that unfortunately it can't work the other way round - we can't start with metadata available and then make it
+        // unavailable, because once cached, the metadata remains available for the rest of the tests. That means that this test, despite
+        // not having anything to do with metadata testing, unfortunately must explicitly make it enabled here.
+        makeMetadataAvailable(REALM_NUMBER);
+    }
 
     public void testInResponseTo_matchingValues() throws Exception {
         final String username = randomAlphaOfLengthBetween(4, 12);

--- a/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlRestTestCase.java
+++ b/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlRestTestCase.java
@@ -197,11 +197,15 @@ public class SamlRestTestCase extends ESRestTestCase {
      */
     @Before
     public void initMetadata() {
-        enableMetadataBeforeTestIfNeeded();
+        if (isMetadataAvailable()) {
+            makeMetadataAvailable(1, 2, 3);
+        } else {
+            makeAllMetadataUnavailable();
+        }
     }
 
-    protected void enableMetadataBeforeTestIfNeeded() {
-        makeMetadataAvailable(1, 2, 3);
+    protected boolean isMetadataAvailable() {
+        return true;
     }
 
     @Override

--- a/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlRestTestCase.java
+++ b/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlRestTestCase.java
@@ -52,10 +52,7 @@ public class SamlRestTestCase extends ESRestTestCase {
     private static Path caPath;
 
     @ClassRule
-    public static TestRule ruleChain = RuleChain.outerRule(new RunnableTestRuleAdapter(SamlRestTestCase::initWebserver))
-        .around(cluster)
-        // during the startup, the metadata remains unavailable to prevent caching. After cluster init, make metadata available.
-        .around(new RunnableTestRuleAdapter(() -> makeMetadataAvailable(1, 2, 3)));
+    public static TestRule ruleChain = RuleChain.outerRule(new RunnableTestRuleAdapter(SamlRestTestCase::initWebserver)).around(cluster);
 
     private static void initWebserver() {
         try {

--- a/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlRestTestCase.java
+++ b/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlRestTestCase.java
@@ -157,7 +157,7 @@ public class SamlRestTestCase extends ESRestTestCase {
     }
 
     private static void configureMetadataResource(int realmNumber) throws CertificateException, IOException, URISyntaxException {
-        metadataAvailable.putIfAbsent(realmNumber, false);
+        metadataAvailable.put(realmNumber, false);
 
         var signingCert = getDataResource(SAML_SIGNING_CRT);
         var metadataBody = new SamlIdpMetadataBuilder().entityId(getIdpEntityId(realmNumber)).sign(signingCert).asString();

--- a/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlRestTestCase.java
+++ b/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlRestTestCase.java
@@ -193,10 +193,14 @@ public class SamlRestTestCase extends ESRestTestCase {
     }
 
     /**
-     * Make metadata available by default before each test
+     * Make metadata available by default before each test, but make this behaviour controllable by subclasses.
      */
     @Before
     public void initMetadata() {
+        enableMetadataBeforeTestIfNeeded();
+    }
+
+    protected void enableMetadataBeforeTestIfNeeded() {
         makeMetadataAvailable(1, 2, 3);
     }
 

--- a/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlRestTestCase.java
+++ b/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlRestTestCase.java
@@ -22,6 +22,7 @@ import org.elasticsearch.test.cluster.util.resource.Resource;
 import org.elasticsearch.test.junit.RunnableTestRuleAdapter;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.rules.RuleChain;
@@ -189,6 +190,14 @@ public class SamlRestTestCase extends ESRestTestCase {
             throw new FileNotFoundException("Cannot find classpath resource /ssl/ca.crt");
         }
         caPath = PathUtils.get(resource.toURI());
+    }
+
+    /**
+     * Make metadata available by default before each test
+     */
+    @Before
+    public void initMetadata() {
+        makeMetadataAvailable(1, 2, 3);
     }
 
     @Override

--- a/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlServiceProviderMetadataIT.java
+++ b/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlServiceProviderMetadataIT.java
@@ -26,8 +26,7 @@ import static org.hamcrest.Matchers.is;
 public class SamlServiceProviderMetadataIT extends SamlRestTestCase {
 
     public void testAuthenticationWhenMetadataIsUnreliable() throws Exception {
-        // Start with no metadata available
-        makeAllMetadataUnavailable();
+        // initially, metadata in unavailable for all realms
 
         final String username = randomAlphaOfLengthBetween(4, 12);
         for (int realmNumber : shuffledList(List.of(1, 2, 3))) {

--- a/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlServiceProviderMetadataIT.java
+++ b/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlServiceProviderMetadataIT.java
@@ -12,7 +12,6 @@ import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.test.rest.ObjectPath;
 import org.elasticsearch.xcontent.json.JsonXContent;
-import org.junit.Before;
 
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -27,9 +26,8 @@ import static org.hamcrest.Matchers.is;
 public class SamlServiceProviderMetadataIT extends SamlRestTestCase {
 
     /**
-     * Withing this class we explicitly need the metadata not to be enabled at the start of each test
+     * Within this class we explicitly need the metadata not to be enabled at the start of each test
      */
-    @Before
     @Override
     public void initMetadata() {
         makeAllMetadataUnavailable();

--- a/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlServiceProviderMetadataIT.java
+++ b/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlServiceProviderMetadataIT.java
@@ -29,8 +29,8 @@ public class SamlServiceProviderMetadataIT extends SamlRestTestCase {
      * Within this class we explicitly need the metadata not to be enabled at the start of each test
      */
     @Override
-    public void initMetadata() {
-        makeAllMetadataUnavailable();
+    protected void enableMetadataBeforeTestIfNeeded() {
+        // do not enable metadata
     }
 
     public void testAuthenticationWhenMetadataIsUnreliable() throws Exception {

--- a/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlServiceProviderMetadataIT.java
+++ b/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlServiceProviderMetadataIT.java
@@ -26,11 +26,11 @@ import static org.hamcrest.Matchers.is;
 public class SamlServiceProviderMetadataIT extends SamlRestTestCase {
 
     /**
-     * Within this class we explicitly need the metadata not to be enabled at the start of each test
+     * Within this class we the metadata not to be enabled at the start of each test
      */
     @Override
-    protected void enableMetadataBeforeTestIfNeeded() {
-        // do not enable metadata
+    protected boolean isMetadataAvailable() {
+        return false;
     }
 
     public void testAuthenticationWhenMetadataIsUnreliable() throws Exception {

--- a/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlServiceProviderMetadataIT.java
+++ b/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlServiceProviderMetadataIT.java
@@ -12,6 +12,7 @@ import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.test.rest.ObjectPath;
 import org.elasticsearch.xcontent.json.JsonXContent;
+import org.junit.Before;
 
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -24,6 +25,15 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 public class SamlServiceProviderMetadataIT extends SamlRestTestCase {
+
+    /**
+     * Withing this class we explicitly need the metadata not to be enabled at the start of each test
+     */
+    @Before
+    @Override
+    public void initMetadata() {
+        makeAllMetadataUnavailable();
+    }
 
     public void testAuthenticationWhenMetadataIsUnreliable() throws Exception {
         // initially, metadata in unavailable for all realms


### PR DESCRIPTION
Remove a short window of time, during which the metadata was available and potentially could be cached by a background thread, before the actual test method is called. The test method assumes that the metadata is not cached, hence that could have created the flakiness.

Closes #139067