### PR TITLE
Adding support to DLM for the new .workflows-execution-data-stream-logs data stream

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/InternalUsers.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/InternalUsers.java
@@ -180,7 +180,9 @@ public class InternalUsers {
                         // System data stream for result history of fleet actions (see Fleet#fleetActionsResultsDescriptor)
                         ".fleet-actions-results",
                         // System data streams for storing uploaded file data for Agent diagnostics and Endpoint response actions
-                        ".fleet-fileds*"
+                        ".fleet-fileds*",
+                        // System data stream for kibana workflows logs
+                        ".workflows-execution-data-stream-logs"
                     )
                     .privileges(
                         filterNonNull(

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/user/InternalUsersTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/user/InternalUsersTests.java
@@ -253,7 +253,11 @@ public class InternalUsersTests extends ESTestCase {
         assertThat(role.application(), is(ApplicationPermission.NONE));
         assertThat(role.remoteIndices(), is(RemoteIndicesPermission.NONE));
 
-        final List<String> allowedSystemDataStreams = Arrays.asList(".fleet-actions-results", ".fleet-fileds*");
+        final List<String> allowedSystemDataStreams = Arrays.asList(
+            ".fleet-actions-results",
+            ".fleet-fileds*",
+            ".workflows-execution-data-stream-logs"
+        );
         for (var group : role.indices().groups()) {
             if (group.allowRestrictedIndices()) {
                 assertThat(group.indices(), arrayContaining(allowedSystemDataStreams.toArray(new String[0])));


### PR DESCRIPTION
DLM is only allowed to perform actions on "restricted" data streams that are in the whitelist in [InternalUsers](https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/InternalUsers.java#L179). A new restricted data stream, `.workflows-execution-data-stream-logs` , was added in https://github.com/elastic/kibana/pull/242489. This causes DLM to fail because DLM attempts to manage this data stream and fails in rollover because it does not have permissions.
This PR is meant as a stopgap -- we still have the weird situation that:

- If a new restricted data stream with a lifecycle is added, we don't know until we stand up a server
- It seems broken that DLM makes an attempt to manage every index with a lifecycle, but causes bad failures if one of those is not in the whitelist -- DLM needs to either be able to manage _all_ data streams that have a lifecycle, or have a way of knowing which ones to skip.

Note: the whitelist was introduced in https://github.com/elastic/elasticsearch/pull/96253, and there is more context in the comments on that PR.