### PR TITLE
allocation: fix up random long usage with inclusive bound

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -503,9 +503,6 @@ tests:
 - class: org.elasticsearch.xpack.logsdb.RandomizedRollingUpgradeIT
   method: testIndexingStandardSource
   issue: https://github.com/elastic/elasticsearch/issues/139153
-- class: org.elasticsearch.cluster.routing.allocation.WriteLoadConstraintMonitorTests
-  method: testHotspotCountTurnsOff
-  issue: https://github.com/elastic/elasticsearch/issues/139161
 
 # Examples:
 #

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/WriteLoadConstraintMonitorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/WriteLoadConstraintMonitorTests.java
@@ -660,6 +660,7 @@ public class WriteLoadConstraintMonitorTests extends ESTestCase {
         long queueLatencyThresholdMillis,
         int highUtilizationThresholdPercent
     ) {
+        assert queueLatencyThresholdMillis > 0 : "queue latency threshold must be positive";
         final Set<String> hotspotNodesSet = new HashSet<>(hotspotNodes);
         final float maxRatioForUnderUtilised = (highUtilizationThresholdPercent - 1) / 100.0f;
         ClusterInfo clusterInfo = ClusterInfo.builder()
@@ -690,7 +691,7 @@ public class WriteLoadConstraintMonitorTests extends ESTestCase {
                             new NodeUsageStatsForThreadPools.ThreadPoolUsageStats(
                                 randomNonNegativeInt(),
                                 randomFloatBetween(0f, maxRatioForUnderUtilised, true),
-                                randomLongBetween(0, queueLatencyThresholdMillis)
+                                randomLongBetween(0, queueLatencyThresholdMillis - 1)
                             )
                         )
                     );


### PR DESCRIPTION
In the write load constraint monitor tests, the criteria for specifying a non-hotspot node generated a random queue latency between 0 and the hotspot threshold setting. In usage, the random number generation used the threshold as an inclusive bound, while it needed to be an exclusive bound. This became an issue recently, with the addition of tests that specify a certain number of hotspot nodes, and remove them individually throughout the test (testHotspotCountTurnsOff).

Fixes: #139161
