### PR TITLE
[9.2] Remove trace logger in Transformer on default path when a class doesn't need to be transformed. (#136152)

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/instrumentation/Transformer.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/instrumentation/Transformer.java
@@ -62,9 +62,7 @@ public class Transformer implements ClassFileTransformer {
                 // effectively the same as returning null anyways, so we instead log it here completely
                 return null;
             }
-        } else {
-            logger.trace("Not transforming " + className);
-            return null;
         }
+        return null;
     }
 }

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -297,9 +297,6 @@ tests:
 - class: org.elasticsearch.xpack.sql.qa.mixed_node.SqlCompatIT
   method: testNullsOrderWithMissingOrderSupportQueryingNewNode
   issue: https://github.com/elastic/elasticsearch/issues/132249
-- class: org.elasticsearch.common.logging.JULBridgeTests
-  method: testThrowable
-  issue: https://github.com/elastic/elasticsearch/issues/132280
 - class: org.elasticsearch.xpack.ml.integration.AutodetectMemoryLimitIT
   method: testManyDistinctOverFields
   issue: https://github.com/elastic/elasticsearch/issues/132308


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Remove trace logger in Transformer on default path when a class doesn't need to be transformed. (#136152)](https://github.com/elastic/elasticsearch/pull/136152)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)