### PR TITLE
[9.1] Remove trace logger in Transformer on default path when a class doesn't need to be transformed. (#136152)

### DIFF
--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/instrumentation/Transformer.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/instrumentation/Transformer.java
@@ -62,9 +62,7 @@ public class Transformer implements ClassFileTransformer {
                 // effectively the same as returning null anyways, so we instead log it here completely
                 return null;
             }
-        } else {
-            logger.trace("Not transforming " + className);
-            return null;
         }
+        return null;
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Remove trace logger in Transformer on default path when a class doesn't need to be transformed. (#136152)](https://github.com/elastic/elasticsearch/pull/136152)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)