### PR TITLE
Fix docker availability handling accross platforms

### DIFF
--- a/test/fixtures/testcontainer-utils/src/main/java/org/elasticsearch/test/fixtures/testcontainers/DockerAvailability.java
+++ b/test/fixtures/testcontainer-utils/src/main/java/org/elasticsearch/test/fixtures/testcontainers/DockerAvailability.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.test.fixtures.testcontainers;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.DockerClientFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class DockerAvailability {
+
+    protected static final Logger LOGGER = LoggerFactory.getLogger(DockerAvailability.class);
+
+    private static final boolean EXCLUDED_OS = isExcludedOs();
+    private static final boolean DOCKER_PROBING_SUCCESSFUL = isDockerAvailable();
+    private static final boolean CI = Boolean.parseBoolean(System.getProperty("CI", "false"));
+    private static final String DOCKER_ON_LINUX_EXCLUSIONS_FILE = ".ci/dockerOnLinuxExclusions";
+
+    static void assumeDockerIsAvailable() {
+        org.junit.Assume.assumeFalse("The current OS is excluded from Docker-based tests", EXCLUDED_OS);
+        org.junit.Assume.assumeTrue("The current OS is excluded from Docker-based tests", DOCKER_PROBING_SUCCESSFUL);
+    }
+
+    /**
+     * see <a href="https://github.com/elastic/elasticsearch/issues/102532">https://github.com/elastic/elasticsearch/issues/102532</a>
+     * */
+    public static boolean isDockerAvailable() {
+        try {
+            LOGGER.info("Probing docker environment...");
+            DockerClientFactory.instance().client();
+            LOGGER.info("Probing docker environment successful");
+            return true;
+        } catch (Throwable ex) {
+            LOGGER.warn("Probing docker has failed; disabling test", ex);
+            return false;
+        }
+    }
+
+    private static boolean isExcludedOs() {
+        if (CI) {
+            // we dont exclude OS outside of CI environment
+            return false;
+        }
+        if (System.getProperty("os.name").toLowerCase().startsWith("windows")) {
+            return true;
+        }
+        final Path osRelease = Paths.get("/etc/os-release");
+        if (Files.exists(osRelease)) {
+            Map<String, String> values;
+
+            try {
+                final List<String> osReleaseLines = Files.readAllLines(osRelease);
+                values = parseOsRelease(osReleaseLines);
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to read /etc/os-release", e);
+            }
+
+            final String id = deriveId(values);
+            final boolean excluded = getLinuxExclusionList().contains(id);
+
+            if (excluded) {
+                LOGGER.warn("Linux OS id [{}] is present in the Docker exclude list. Tasks requiring Docker will be disabled.", id);
+            }
+
+            return excluded;
+        }
+
+        return false;
+    }
+
+    static String deriveId(Map<String, String> values) {
+        return values.get("ID") + "-" + values.get("VERSION_ID");
+    }
+
+    // visible for testing
+    static Map<String, String> parseOsRelease(final List<String> osReleaseLines) {
+        final Map<String, String> values = new HashMap<>();
+
+        osReleaseLines.stream().map(String::trim).filter(line -> (line.isEmpty() || line.startsWith("#")) == false).forEach(line -> {
+            final String[] parts = line.split("=", 2);
+            final String key = parts[0];
+            // remove optional leading and trailing quotes and whitespace
+            final String value = parts[1].replaceAll("^['\"]?\\s*", "").replaceAll("\\s*['\"]?$", "");
+
+            values.put(key, value.toLowerCase());
+        });
+
+        return values;
+    }
+
+    private static List<String> getLinuxExclusionList() {
+        File exclusionsFile = new File(System.getProperty("workspace.dir"), DOCKER_ON_LINUX_EXCLUSIONS_FILE);
+        if (exclusionsFile.exists()) {
+            try {
+                return Files.readAllLines(exclusionsFile.toPath())
+                    .stream()
+                    .map(String::trim)
+                    .filter(line -> (line.isEmpty() || line.startsWith("#")) == false)
+                    .collect(Collectors.toList());
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to read " + exclusionsFile.getAbsolutePath(), e);
+            }
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+}

--- a/test/fixtures/testcontainer-utils/src/main/java/org/elasticsearch/test/fixtures/testcontainers/DockerAvailability.java
+++ b/test/fixtures/testcontainer-utils/src/main/java/org/elasticsearch/test/fixtures/testcontainers/DockerAvailability.java
@@ -35,7 +35,10 @@ public class DockerAvailability {
 
     static void assumeDockerIsAvailable() {
         org.junit.Assume.assumeFalse("The current OS is excluded from Docker-based tests", EXCLUDED_OS);
-        org.junit.Assume.assumeTrue("The current OS is excluded from Docker-based tests", DOCKER_PROBING_SUCCESSFUL);
+        if (CI && DOCKER_PROBING_SUCCESSFUL == false) {
+            throw new AssertionError("Docker is expected to be available on this CI node but probing failed.");
+        }
+        org.junit.Assume.assumeTrue("Docker is not available", DOCKER_PROBING_SUCCESSFUL);
     }
 
     /**
@@ -54,7 +57,7 @@ public class DockerAvailability {
     }
 
     private static boolean isExcludedOs() {
-        if (CI) {
+        if (CI == false) {
             // we dont exclude OS outside of CI environment
             return false;
         }

--- a/test/fixtures/testcontainer-utils/src/main/java/org/elasticsearch/test/fixtures/testcontainers/DockerEnvironmentAwareTestContainer.java
+++ b/test/fixtures/testcontainer-utils/src/main/java/org/elasticsearch/test/fixtures/testcontainers/DockerEnvironmentAwareTestContainer.java
@@ -10,27 +10,18 @@
 package org.elasticsearch.test.fixtures.testcontainers;
 
 import org.elasticsearch.test.fixtures.CacheableTestFixture;
-import org.junit.Assume;
+import org.junit.AssumptionViolatedException;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.Future;
-import java.util.stream.Collectors;
+
+import static org.elasticsearch.test.fixtures.testcontainers.DockerAvailability.assumeDockerIsAvailable;
 
 public class DockerEnvironmentAwareTestContainer extends GenericContainer<DockerEnvironmentAwareTestContainer>
     implements
@@ -38,27 +29,6 @@ public class DockerEnvironmentAwareTestContainer extends GenericContainer<Docker
         CacheableTestFixture {
 
     protected static final Logger LOGGER = LoggerFactory.getLogger(DockerEnvironmentAwareTestContainer.class);
-
-    private static final String DOCKER_ON_LINUX_EXCLUSIONS_FILE = ".ci/dockerOnLinuxExclusions";
-
-    private static final boolean CI = Boolean.parseBoolean(System.getProperty("CI", "false"));
-    private static final boolean EXCLUDED_OS = isExcludedOs();
-    private static final boolean DOCKER_PROBING_SUCCESSFUL = isDockerAvailable();
-
-    /**
-     * see <a href="https://github.com/elastic/elasticsearch/issues/102532">https://github.com/elastic/elasticsearch/issues/102532</a>
-     * */
-    private static boolean isDockerAvailable() {
-        try {
-            LOGGER.info("Probing docker environment...");
-            DockerClientFactory.instance().client();
-            LOGGER.info("Probing docker environment successful");
-            return true;
-        } catch (Throwable ex) {
-            LOGGER.warn("Probing docker has failed; disabling test", ex);
-            return false;
-        }
-    }
 
     public DockerEnvironmentAwareTestContainer(Future<String> image) {
         super(image);
@@ -72,6 +42,8 @@ public class DockerEnvironmentAwareTestContainer extends GenericContainer<Docker
                 try {
                     start();
                     statement.evaluate();
+                } catch (AssumptionViolatedException e) {
+                    throw e;
                 } catch (Throwable e) {
                     throw new RuntimeException(e);
                 } finally {
@@ -79,13 +51,11 @@ public class DockerEnvironmentAwareTestContainer extends GenericContainer<Docker
                 }
             }
         };
-
     }
 
     @Override
     public void start() {
-        Assume.assumeFalse("Docker support excluded on OS", EXCLUDED_OS);
-        Assume.assumeTrue("Docker probing succesful", DOCKER_PROBING_SUCCESSFUL);
+        assumeDockerIsAvailable();
         withLogConsumer(new Slf4jLogConsumer(LOGGER));
         super.start();
     }
@@ -106,72 +76,4 @@ public class DockerEnvironmentAwareTestContainer extends GenericContainer<Docker
         }
     }
 
-    static String deriveId(Map<String, String> values) {
-        return values.get("ID") + "-" + values.get("VERSION_ID");
-    }
-
-    private static boolean isExcludedOs() {
-        if (CI) {
-            // we dont exclude OS outside of CI environment
-            return false;
-        }
-        if (System.getProperty("os.name").toLowerCase().startsWith("windows")) {
-            return true;
-        }
-        final Path osRelease = Paths.get("/etc/os-release");
-        if (Files.exists(osRelease)) {
-            Map<String, String> values;
-
-            try {
-                final List<String> osReleaseLines = Files.readAllLines(osRelease);
-                values = parseOsRelease(osReleaseLines);
-            } catch (IOException e) {
-                throw new RuntimeException("Failed to read /etc/os-release", e);
-            }
-
-            final String id = deriveId(values);
-            final boolean excluded = getLinuxExclusionList().contains(id);
-
-            if (excluded) {
-                LOGGER.warn("Linux OS id [{}] is present in the Docker exclude list. Tasks requiring Docker will be disabled.", id);
-            }
-
-            return excluded;
-        }
-
-        return false;
-    }
-
-    private static List<String> getLinuxExclusionList() {
-        File exclusionsFile = new File(System.getProperty("workspace.dir"), DOCKER_ON_LINUX_EXCLUSIONS_FILE);
-        if (exclusionsFile.exists()) {
-            try {
-                return Files.readAllLines(exclusionsFile.toPath())
-                    .stream()
-                    .map(String::trim)
-                    .filter(line -> (line.isEmpty() || line.startsWith("#")) == false)
-                    .collect(Collectors.toList());
-            } catch (IOException e) {
-                throw new RuntimeException("Failed to read " + exclusionsFile.getAbsolutePath(), e);
-            }
-        } else {
-            return Collections.emptyList();
-        }
-    }
-
-    // visible for testing
-    static Map<String, String> parseOsRelease(final List<String> osReleaseLines) {
-        final Map<String, String> values = new HashMap<>();
-
-        osReleaseLines.stream().map(String::trim).filter(line -> (line.isEmpty() || line.startsWith("#")) == false).forEach(line -> {
-            final String[] parts = line.split("=", 2);
-            final String key = parts[0];
-            // remove optional leading and trailing quotes and whitespace
-            final String value = parts[1].replaceAll("^['\"]?\\s*", "").replaceAll("\\s*['\"]?$", "");
-
-            values.put(key, value.toLowerCase());
-        });
-
-        return values;
-    }
 }

--- a/test/fixtures/testcontainer-utils/src/main/java/org/elasticsearch/test/fixtures/testcontainers/Junit4NetworkRule.java
+++ b/test/fixtures/testcontainer-utils/src/main/java/org/elasticsearch/test/fixtures/testcontainers/Junit4NetworkRule.java
@@ -9,10 +9,13 @@
 
 package org.elasticsearch.test.fixtures.testcontainers;
 
+import org.junit.AssumptionViolatedException;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.testcontainers.containers.Network;
+
+import static org.elasticsearch.test.fixtures.testcontainers.DockerAvailability.assumeDockerIsAvailable;
 
 public class Junit4NetworkRule implements TestRule {
 
@@ -27,11 +30,23 @@ public class Junit4NetworkRule implements TestRule {
         return new Statement() {
             @Override
             public void evaluate() throws Throwable {
-                network.getId();
-                statement.evaluate();
-                network.close();
+                try {
+                    assumeDockerIsAvailable();
+                    network.getId();
+                    statement.evaluate();
+                    network.close();
+                } catch (AssumptionViolatedException e) {
+                    throw e;
+                } finally {
+                    try {
+                        network.close();
+                    } catch (Throwable e) {
+
+                    }
+                }
             }
         };
+
     }
 
     public static Junit4NetworkRule from(Network network) {

--- a/test/fixtures/testcontainer-utils/src/test/java/org/elasticsearch/test/fixtures/testcontainers/Junit4NetworkRuleTests.java
+++ b/test/fixtures/testcontainer-utils/src/test/java/org/elasticsearch/test/fixtures/testcontainers/Junit4NetworkRuleTests.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.test.fixtures.testcontainers;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -16,11 +17,17 @@ import org.testcontainers.containers.Network;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.elasticsearch.test.fixtures.testcontainers.DockerAvailability.assumeDockerIsAvailable;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class Junit4NetworkRuleTests {
+
+    @BeforeClass
+    public static void checkDockerAvailable() {
+        assumeDockerIsAvailable();
+    }
 
     @Test
     public void testNetworkLifecycle() throws Throwable {


### PR DESCRIPTION
This addresses some issues detecting docker availability and test skipping on windows after updating testcontainer to > 2.x. This is a fallout from our improvements on rerunning periodic builds and I ran into this repeatedly there 