### PR TITLE
Test fix: Call explain only once in an assertBusy

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -454,9 +454,6 @@ tests:
 - class: org.elasticsearch.index.mapper.LongSyntheticSourceNativeArrayIntegrationTests
   method: testSynthesizeArrayRandom
   issue: https://github.com/elastic/elasticsearch/issues/138819
-- class: org.elasticsearch.xpack.ilm.actions.DownsampleActionIT
-  method: testILMWaitsForTimeSeriesEndTimeToLapse
-  issue: https://github.com/elastic/elasticsearch/issues/138843
 - class: org.elasticsearch.test.rest.yaml.CcsCommonYamlTestSuiteIT
   method: test {p0=search/610_function_score/formulating a function score query with a negative number returns bad request}
   issue: https://github.com/elastic/elasticsearch/issues/138908

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/DownsampleActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/DownsampleActionIT.java
@@ -420,15 +420,16 @@ public class DownsampleActionIT extends IlmESRestTestCase {
         rolloverMaxOneDocCondition(client(), dataStream);
 
         assertBusy(() -> {
+            Map<String, Object> explainResponse = explainIndex(client(), backingIndexName);
             assertThat(
                 "index must wait in the " + WaitUntilTimeSeriesEndTimePassesStep.NAME + " until its end time lapses",
-                explainIndex(client(), backingIndexName).get("step"),
+                explainResponse.get("step"),
                 is(WaitUntilTimeSeriesEndTimePassesStep.NAME)
             );
 
-            assertThat(explainIndex(client(), backingIndexName).get("step_info"), is(notNullValue()));
+            assertThat(explainResponse.get("step_info"), is(notNullValue()));
             assertThat(
-                (String) ((Map<String, Object>) explainIndex(client(), backingIndexName).get("step_info")).get("message"),
+                (String) ((Map<String, Object>) explainResponse.get("step_info")).get("message"),
                 containsString("Waiting until the index's time series end time lapses")
             );
         }, 30, TimeUnit.SECONDS);
@@ -630,8 +631,9 @@ public class DownsampleActionIT extends IlmESRestTestCase {
             assertThat(indexExists(downsampleIndexName), is(true));
             assertThat(indexExists(firstBackingIndex), is(false));
 
-            assertThat(explainIndex(client(), downsampleIndexName).get("step"), is(PhaseCompleteStep.NAME));
-            assertThat(explainIndex(client(), downsampleIndexName).get("phase"), is("warm"));
+            Map<String, Object> explainResponse = explainIndex(client(), downsampleIndexName);
+            assertThat(explainResponse.get("step"), is(PhaseCompleteStep.NAME));
+            assertThat(explainResponse.get("phase"), is("warm"));
 
             Map<String, Object> settings = getOnlyIndexSettings(client(), downsampleIndexName);
             assertEquals(firstBackingIndex, settings.get(IndexMetadata.INDEX_DOWNSAMPLE_ORIGIN_NAME.getKey()));
@@ -674,8 +676,9 @@ public class DownsampleActionIT extends IlmESRestTestCase {
         // reach the cold/complete/complete step
         assertBusy(() -> {
             assertThat(indexExists(downsampleIndexName), is(true));
-            assertThat(explainIndex(client(), downsampleIndexName).get("step"), is(PhaseCompleteStep.NAME));
-            assertThat(explainIndex(client(), downsampleIndexName).get("phase"), is("cold"));
+            Map<String, Object> explainResponse = explainIndex(client(), downsampleIndexName);
+            assertThat(explainResponse.get("step"), is(PhaseCompleteStep.NAME));
+            assertThat(explainResponse.get("phase"), is("cold"));
             Map<String, Object> settings = getOnlyIndexSettings(client(), downsampleIndexName);
             assertEquals(
                 DownsampleConfig.SamplingMethod.getOrDefault(initialSamplingMethod).toString(),


### PR DESCRIPTION
In #138843 we saw the following NPE in one of our tests:

```
java.lang.NullPointerException: Cannot invoke "java.util.Map.get(Object)" because the return value of "java.util.Map.get(Object)" is null
```
It refer to the following lines of code:

```
assertThat(explainIndex(client(), backingIndexName).get("step_info"), is(notNullValue()));
assertThat((String) ((Map<String, Object>) explainIndex(client(), backingIndexName).get("step_info")).get("message"), containsString("Waiting until the index's time series end time lapses"));
```

The problem here is the `explainIndex` is actually a rest call meaning that the response can change between the two lines resulting in NPE. 

This appears to be an issue with the test and not the code. The test waiting until the required step, but then by the time that it tried to retrieve the explain response again, ILM has moved on and the `step_info` was not available anymore.

In this PR we ensure that when we retrieve the explain response within an `assertBusy` block we do it once.



Fixes #138843 