### PR TITLE
Init Lookup Driver Just once - part 1

### DIFF
--- a/docs/changelog/139207.yaml
+++ b/docs/changelog/139207.yaml
@@ -1,0 +1,5 @@
+pr: 139207
+summary: Init Lookup Driver Just once
+area: ES|QL
+type: enhancement
+issues: []

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/ProjectOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/ProjectOperator.java
@@ -54,6 +54,14 @@ public class ProjectOperator extends AbstractPageMappingOperator {
         }
     }
 
+    /**
+     * Get the projection array (list of block indices to keep).
+     * Exposed for testing to verify projection behavior.
+     */
+    public int[] getProjection() {
+        return projection.clone();
+    }
+
     @Override
     public String toString() {
         if (projection.length < 10) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/LookupEnrichQueryGenerator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/LookupEnrichQueryGenerator.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.operator.lookup;
 
 import org.apache.lucene.search.Query;
+import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.core.Nullable;
 
 /**
@@ -20,11 +21,11 @@ public interface LookupEnrichQueryGenerator {
      * Returns the query at the given position.
      */
     @Nullable
-    Query getQuery(int position);
+    Query getQuery(int position, Page inputPage);
 
     /**
-     * Returns the number of queries in this generator
+     * Returns the number of queries in this generator.
      */
-    int getPositionCount();
+    int getPositionCount(Page inputPage);
 
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/MergePositionsOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/MergePositionsOperator.java
@@ -131,6 +131,14 @@ public final class MergePositionsOperator implements Operator {
         return page;
     }
 
+    /**
+     * Get the selected positions block (may be a range block or dictionary ordinals).
+     * Exposed for testing to verify optimization behavior.
+     */
+    public IntBlock getSelectedPositions() {
+        return selectedPositions;
+    }
+
     @Override
     public void close() {
         Releasables.close(Releasables.wrap(builders), selectedPositions, () -> {

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -650,7 +650,7 @@ public class CsvTestsDataLoader {
         }
     }
 
-    private static void loadEnrichPolicy(RestClient client, String policyName, String policyFileName, Logger logger) throws IOException {
+    public static void loadEnrichPolicy(RestClient client, String policyName, String policyFileName, Logger logger) throws IOException {
         logger.info("Loading enrich policy [{}] from file [{}]", policyName, policyFileName);
         URL policyMapping = getResource("/" + policyFileName);
         String entity = readTextFile(policyMapping);
@@ -736,7 +736,7 @@ public class CsvTestsDataLoader {
      *   - multi-values are comma separated
      *   - commas inside multivalue fields can be escaped with \ (backslash) character
      */
-    private static void loadCsvData(RestClient client, String indexName, URL resource, boolean allowSubFields, Logger logger)
+    public static void loadCsvData(RestClient client, String indexName, URL resource, boolean allowSubFields, Logger logger)
         throws IOException {
 
         ArrayList<String> failures = new ArrayList<>();

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/LookupJoinIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/LookupJoinIT.java
@@ -1,0 +1,421 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.TransportAction;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.mapper.extras.MapperExtrasPlugin;
+import org.elasticsearch.ingest.common.IngestCommonPlugin;
+import org.elasticsearch.injection.guice.Inject;
+import org.elasticsearch.license.LicenseService;
+import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.protocol.xpack.XPackInfoRequest;
+import org.elasticsearch.protocol.xpack.XPackInfoResponse;
+import org.elasticsearch.reindex.ReindexPlugin;
+import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
+import org.elasticsearch.test.junit.annotations.TestLogging;
+import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
+import org.elasticsearch.xpack.core.XPackSettings;
+import org.elasticsearch.xpack.core.action.TransportXPackInfoAction;
+import org.elasticsearch.xpack.core.action.XPackInfoFeatureAction;
+import org.elasticsearch.xpack.core.action.XPackInfoFeatureResponse;
+import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
+import org.elasticsearch.xpack.core.enrich.action.ExecuteEnrichPolicyAction;
+import org.elasticsearch.xpack.core.enrich.action.GetEnrichPolicyAction;
+import org.elasticsearch.xpack.core.enrich.action.PutEnrichPolicyAction;
+import org.elasticsearch.xpack.enrich.EnrichPlugin;
+import org.elasticsearch.xpack.esql.CsvTestsDataLoader;
+import org.elasticsearch.xpack.esql.plugin.EsqlPlugin;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+import static org.elasticsearch.test.ESIntegTestCase.Scope.SUITE;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.getValuesList;
+import static org.elasticsearch.xpack.esql.action.EsqlQueryRequest.syncEsqlQueryRequest;
+
+@ClusterScope(scope = SUITE, numDataNodes = 1, numClientNodes = 0, supportsDedicatedMasters = false)
+@TestLogging(
+    value = "org.elasticsearch.xpack.esql:TRACE,org.elasticsearch.compute:TRACE",
+    reason = "debug lookup join expression resolution"
+)
+public class LookupJoinIT extends AbstractEsqlIntegTestCase {
+
+    private static final String EMPLOYEES_INDEX = "employees";
+    private static final String AGES_INDEX = "ages";
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        List<Class<? extends Plugin>> plugins = new ArrayList<>();
+        plugins.add(EsqlPlugin.class);
+        plugins.add(MapperExtrasPlugin.class);
+        plugins.add(LocalStateEnrich.class);
+        plugins.add(IngestCommonPlugin.class);
+        plugins.add(ReindexPlugin.class);
+        return plugins;
+    }
+
+    public static class LocalStateEnrich extends LocalStateCompositeXPackPlugin {
+
+        public LocalStateEnrich(final Settings settings, final Path configPath) throws Exception {
+            super(settings, configPath);
+
+            plugins.add(new EnrichPlugin(settings) {
+                @Override
+                protected XPackLicenseState getLicenseState() {
+                    return this.getLicenseState();
+                }
+            });
+        }
+
+        public static class EnrichTransportXPackInfoAction extends TransportXPackInfoAction {
+            @Inject
+            public EnrichTransportXPackInfoAction(
+                TransportService transportService,
+                ActionFilters actionFilters,
+                LicenseService licenseService,
+                NodeClient client
+            ) {
+                super(transportService, actionFilters, licenseService, client);
+            }
+
+            @Override
+            protected List<ActionType<XPackInfoFeatureResponse>> infoActions() {
+                return Collections.singletonList(XPackInfoFeatureAction.ENRICH);
+            }
+        }
+
+        @Override
+        protected Class<? extends TransportAction<XPackInfoRequest, XPackInfoResponse>> getInfoAction() {
+            return EnrichTransportXPackInfoAction.class;
+        }
+    }
+
+    @Override
+    protected boolean addMockHttpTransport() {
+        return false;  // Need real HTTP transport for RestClient
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal, otherSettings))
+            // Disable security to avoid security context issues with enrich policy actions
+            .put(XPackSettings.SECURITY_ENABLED.getKey(), false)
+            .build();
+    }
+
+    @Before
+    public void setupEnrichPolicy() {
+        // Load ages data and enrich policy before any test runs
+        if (indexExists(AGES_INDEX) == false) {
+            loadAgesData();
+        }
+        ensureAgesEnrichPolicy();
+    }
+
+    private void ensureIndicesAndData() {
+        if (indexExists(EMPLOYEES_INDEX) == false) {
+            loadEmployeesData();
+        } else {
+            // Index exists, but verify it has data
+            refresh(EMPLOYEES_INDEX);
+            ensureGreen(EMPLOYEES_INDEX);
+        }
+    }
+
+    private void ensureAgesEnrichPolicy() {
+        // Check if policy already exists
+        boolean policyExists = false;
+        try {
+            var response = client().execute(
+                GetEnrichPolicyAction.INSTANCE,
+                new GetEnrichPolicyAction.Request(TEST_REQUEST_TIMEOUT, "ages_policy")
+            ).actionGet();
+            var policies = response.getPolicies();
+            policyExists = policies.stream().anyMatch(p -> p.getName().equals("ages_policy"));
+        } catch (Exception e) {
+            // Policy doesn't exist, will create it
+        }
+
+        if (policyExists == false) {
+            // Create the policy fresh
+            loadAgesEnrichPolicy();
+
+            // Verify the policy was created successfully and is accessible
+            try {
+                var response = client().execute(
+                    GetEnrichPolicyAction.INSTANCE,
+                    new GetEnrichPolicyAction.Request(TEST_REQUEST_TIMEOUT, "ages_policy")
+                ).actionGet();
+                var policies = response.getPolicies();
+                boolean verified = policies.stream().anyMatch(p -> p.getName().equals("ages_policy"));
+                if (verified == false) {
+                    throw new AssertionError("Enrich policy was loaded but verification failed");
+                }
+            } catch (Exception e) {
+                throw new AssertionError("Failed to verify enrich policy was created: " + e.getMessage(), e);
+            }
+        }
+    }
+
+    private void loadEmployeesData() {
+        try {
+            RestClient restClient = getRestClient();
+            org.elasticsearch.logging.Logger logger = org.elasticsearch.logging.LogManager.getLogger(CsvTestsDataLoader.class);
+
+            loadSingleDataset(
+                restClient,
+                logger,
+                EMPLOYEES_INDEX,
+                "mapping-default.json",
+                "employees.csv",
+                Settings.builder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0).build()
+            );
+            // Refresh the index to make data available
+            refresh(EMPLOYEES_INDEX);
+            ensureGreen(EMPLOYEES_INDEX);
+        } catch (IOException e) {
+            throw new AssertionError("Failed to load employees CSV data", e);
+        }
+    }
+
+    private void loadAgesData() {
+        try {
+            RestClient restClient = getRestClient();
+            org.elasticsearch.logging.Logger logger = org.elasticsearch.logging.LogManager.getLogger(CsvTestsDataLoader.class);
+
+            loadSingleDataset(
+                restClient,
+                logger,
+                AGES_INDEX,
+                "mapping-ages.json",
+                "ages.csv",
+                Settings.builder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0).build()
+            );
+            // Refresh the index to make data available for enrich policy execution
+            refresh(AGES_INDEX);
+        } catch (IOException e) {
+            throw new AssertionError("Failed to load ages CSV data", e);
+        }
+    }
+
+    private void loadAgesEnrichPolicy() {
+        // Ensure ages index exists and is ready
+        if (indexExists(AGES_INDEX) == false) {
+            throw new AssertionError("Ages index does not exist");
+        }
+
+        // Ensure ages index is refreshed before creating enrich policy
+        refresh(AGES_INDEX);
+        ensureGreen(AGES_INDEX);
+
+        EnrichPolicy policy = new EnrichPolicy(
+            "range",
+            null, // query
+            List.of(AGES_INDEX), // indices
+            "age_range", // match_field
+            List.of("description") // enrich_fields
+        );
+
+        client().execute(PutEnrichPolicyAction.INSTANCE, new PutEnrichPolicyAction.Request(TEST_REQUEST_TIMEOUT, "ages_policy", policy))
+            .actionGet();
+
+        client().execute(ExecuteEnrichPolicyAction.INSTANCE, new ExecuteEnrichPolicyAction.Request(TEST_REQUEST_TIMEOUT, "ages_policy"))
+            .actionGet();
+
+        ensureGreen(); // Wait for enrich index to be ready
+    }
+
+    /**
+     * Loads a single dataset following the CsvTestsDataLoader.load() pattern.
+     * Creates the index and loads CSV data using the public loadCsvData() method.
+     */
+    private void loadSingleDataset(
+        RestClient restClient,
+        org.elasticsearch.logging.Logger logger,
+        String indexName,
+        String mappingFileName,
+        String csvFileName,
+        Settings indexSettings
+    ) throws IOException {
+        URL mappingResource = CsvTestsDataLoader.class.getResource("/" + mappingFileName);
+        URL csvResource = CsvTestsDataLoader.class.getResource("/data/" + csvFileName);
+        if (mappingResource == null || csvResource == null) {
+            throw new IllegalArgumentException("Cannot find resources for " + indexName);
+        }
+
+        String mappingContent = CsvTestsDataLoader.readTextFile(mappingResource);
+        ESRestTestCase.createIndex(restClient, indexName, indexSettings, mappingContent, null);
+
+        // Use the public loadCsvData() method to reuse existing CSV parsing logic
+        CsvTestsDataLoader.loadCsvData(restClient, indexName, csvResource, false, logger);
+    }
+
+    private EsqlQueryResponse runQuery(String query) {
+        return run(syncEsqlQueryRequest(query));
+    }
+
+    /**
+     * Verifies that the query results match the expected data.
+     * @param actualValues The actual results from the query
+     * @param expectedRows Expected rows, where each row is an array of expected values in column order
+     */
+    private void verifyResults(List<List<Object>> actualValues, Object[]... expectedRows) {
+        if (actualValues.size() != expectedRows.length) {
+            fail(
+                String.format(
+                    Locale.ROOT,
+                    "Result count mismatch.%nExpected: %d rows%nActual: %d rows%n%nExpected results:%n%s%n%nActual results:%n%s",
+                    expectedRows.length,
+                    actualValues.size(),
+                    formatRows(expectedRows),
+                    formatRows(actualValues)
+                )
+            );
+        }
+        for (int i = 0; i < expectedRows.length; i++) {
+            List<Object> actualRow = actualValues.get(i);
+            Object[] expectedRow = expectedRows[i];
+            if (actualRow.size() != expectedRow.length) {
+                fail(
+                    String.format(
+                        Locale.ROOT,
+                        "Row %d column count mismatch.%nExpected: %d columns%nActual: %d "
+                            + "columns%n%nExpected row %d: %s%nActual row %d: %s%n%nAll "
+                            + "expected results:%n%s%n%nAll actual results:%n%s",
+                        i,
+                        expectedRow.length,
+                        actualRow.size(),
+                        i,
+                        formatRow(expectedRow),
+                        i,
+                        formatRow(actualRow),
+                        formatRows(expectedRows),
+                        formatRows(actualValues)
+                    )
+                );
+            }
+            for (int j = 0; j < expectedRow.length; j++) {
+                if (Objects.equals(actualRow.get(j), expectedRow[j]) == false) {
+                    fail(
+                        String.format(
+                            Locale.ROOT,
+                            "Row %d, column %d mismatch.%nExpected: %s%nActual: %s%n%n"
+                                + "Expected row %d: %s%nActual row %d: %s%n%nAll expected results:"
+                                + "%n%s%n%nAll actual results:%n%s",
+                            i,
+                            j,
+                            expectedRow[j],
+                            actualRow.get(j),
+                            i,
+                            formatRow(expectedRow),
+                            i,
+                            formatRow(actualRow),
+                            formatRows(expectedRows),
+                            formatRows(actualValues)
+                        )
+                    );
+                }
+            }
+        }
+    }
+
+    private String formatRows(Object[]... rows) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < rows.length; i++) {
+            sb.append("Row ").append(i).append(": ").append(formatRow(rows[i])).append("\n");
+        }
+        return sb.toString();
+    }
+
+    private String formatRows(List<List<Object>> rows) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < rows.size(); i++) {
+            sb.append("Row ").append(i).append(": ").append(formatRow(rows.get(i))).append("\n");
+        }
+        return sb.toString();
+    }
+
+    private String formatRow(Object[] row) {
+        return java.util.Arrays.toString(row);
+    }
+
+    private String formatRow(List<Object> row) {
+        return row.toString();
+    }
+
+    // Test case ported from enrichAgesStatsYear in enrich.csv-spec
+
+    public void testEnrichAgesStatsYear() {
+        ensureIndicesAndData();
+
+        // First, verify there's data in the employees index
+        String simpleQuery = String.format(Locale.ROOT, "FROM %s | LIMIT 10", EMPLOYEES_INDEX);
+        try (EsqlQueryResponse simpleResponse = runQuery(simpleQuery)) {
+            List<List<Object>> simpleValues = getValuesList(simpleResponse);
+            if (simpleValues.isEmpty()) {
+                throw new AssertionError("No data found in employees index - simple SELECT returned 0 rows");
+            }
+        }
+
+        // Verify enrich policy exists before running query
+        try {
+            var response = client().execute(
+                GetEnrichPolicyAction.INSTANCE,
+                new GetEnrichPolicyAction.Request(TEST_REQUEST_TIMEOUT, "ages_policy")
+            ).actionGet();
+            var policies = response.getPolicies();
+            boolean policyExists = policies.stream().anyMatch(p -> p.getName().equals("ages_policy"));
+            if (policyExists == false) {
+                throw new AssertionError("Enrich policy ages_policy does not exist before query execution");
+            }
+        } catch (Exception e) {
+            throw new AssertionError("Failed to verify enrich policy exists before query: " + e.getMessage(), e);
+        }
+
+        String query = String.format(Locale.ROOT, """
+            FROM %s
+            | WHERE birth_date > "1960-01-01"
+            | EVAL birth_year = DATE_EXTRACT("year", birth_date)
+            | EVAL age = 2022 - birth_year
+            | ENRICH ages_policy ON age WITH age_group = description
+            | STATS count=count(age_group) BY age_group, birth_year
+            | KEEP birth_year, age_group, count
+            | SORT birth_year DESC
+            """, EMPLOYEES_INDEX);
+
+        try (EsqlQueryResponse response = runQuery(query)) {
+            List<List<Object>> values = getValuesList(response);
+            verifyResults(
+                values,
+                new Object[] { 1965L, "Middle-aged", 1L },
+                new Object[] { 1964L, "Middle-aged", 4L },
+                new Object[] { 1963L, "Middle-aged", 7L },
+                new Object[] { 1962L, "Senior", 6L },
+                new Object[] { 1961L, "Senior", 8L },
+                new Object[] { 1960L, "Senior", 8L }
+            );
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichLookupService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichLookupService.java
@@ -19,7 +19,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BlockStreamInput;
 import org.elasticsearch.compute.data.Page;
@@ -114,15 +113,15 @@ public class EnrichLookupService extends AbstractLookupService<EnrichLookupServi
         TransportRequest request,
         SearchExecutionContext context,
         AliasFilter aliasFilter,
-        Block inputBlock,
         Warnings warnings
     ) {
         DataType inputDataType = request.inputDataType;
         MappedFieldType fieldType = context.getFieldType(request.matchField);
         validateTypes(inputDataType, fieldType);
+        int channelOffset = 0;
         return switch (request.matchType) {
-            case "match", "range" -> termQueryList(fieldType, context, aliasFilter, inputBlock, inputDataType);
-            case "geo_match" -> QueryList.geoShapeQueryList(fieldType, context, aliasFilter, inputBlock);
+            case "match", "range" -> termQueryList(fieldType, context, aliasFilter, channelOffset, inputDataType);
+            case "geo_match" -> QueryList.geoShapeQueryList(fieldType, context, aliasFilter, channelOffset);
             default -> throw new EsqlIllegalArgumentException("illegal match type " + request.matchType);
         };
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/LookupExecutionMapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/LookupExecutionMapper.java
@@ -1,0 +1,417 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.enrich;
+
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.LocalCircuitBreaker;
+import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.lucene.IndexedByShardIdFromSingleton;
+import org.elasticsearch.compute.lucene.read.ValuesSourceReaderOperator;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Operator;
+import org.elasticsearch.compute.operator.OutputOperator;
+import org.elasticsearch.compute.operator.ProjectOperator;
+import org.elasticsearch.compute.operator.SinkOperator;
+import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.operator.Warnings;
+import org.elasticsearch.compute.operator.lookup.EnrichQuerySourceOperator;
+import org.elasticsearch.compute.operator.lookup.LookupEnrichQueryGenerator;
+import org.elasticsearch.compute.operator.lookup.MergePositionsOperator;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.index.mapper.BlockLoader;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
+import org.elasticsearch.xpack.esql.core.expression.Alias;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.plan.physical.FieldExtractExec;
+import org.elasticsearch.xpack.esql.plan.physical.LookupMergeDropExec;
+import org.elasticsearch.xpack.esql.plan.physical.OutputExec;
+import org.elasticsearch.xpack.esql.plan.physical.ParameterizedQueryExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.plan.physical.UnaryExec;
+import org.elasticsearch.xpack.esql.planner.EsPhysicalOperationProviders;
+import org.elasticsearch.xpack.esql.planner.PlannerUtils;
+import org.elasticsearch.xpack.esql.plugin.EsqlPlugin;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Plans the execution of a lookup physical plan by converting it to operators.
+ */
+public class LookupExecutionMapper {
+    private final BlockFactory blockFactory;
+    private final BigArrays bigArrays;
+    private final LocalCircuitBreaker.SizeSettings localBreakerSettings;
+    private final boolean mergePages;
+
+    public LookupExecutionMapper(
+        BlockFactory blockFactory,
+        BigArrays bigArrays,
+        LocalCircuitBreaker.SizeSettings localBreakerSettings,
+        boolean mergePages
+    ) {
+        this.blockFactory = blockFactory;
+        this.bigArrays = bigArrays;
+        this.localBreakerSettings = localBreakerSettings;
+        this.mergePages = mergePages;
+    }
+
+    /**
+     * Result of block optimization contains optimized page and finish operator details.
+     * Implements Releasable to manage ownership of selectedPositions when it's not from dictionary.
+     */
+    private static final class BlockOptimization implements Releasable {
+        private final Page optimizedPage;
+        private IntBlock selectedPositions;  // null if no merge, otherwise the selectedPositions block for MergePositionsOperator
+        private final boolean selectedPositionsFromDictionary;  // true if selectedPositions comes from ordinals/dictionary
+
+        BlockOptimization(Page optimizedPage, IntBlock selectedPositions, boolean selectedPositionsFromDictionary) {
+            this.optimizedPage = optimizedPage;
+            this.selectedPositions = selectedPositions;
+            this.selectedPositionsFromDictionary = selectedPositionsFromDictionary;
+        }
+
+        Page optimizedPage() {
+            return optimizedPage;
+        }
+
+        IntBlock selectedPositions() {
+            return selectedPositions;
+        }
+
+        /**
+         * Releases ownership of selectedPositions if we own it.
+         * Call this when transferring ownership to another component (e.g., MergePositionsOperator).
+         * Safe to call multiple times - subsequent calls are no-ops.
+         */
+        void releaseSelectedPositions() {
+            // Only close selectedPositions if we own it (not from dictionary)
+            // When selectedPositionsFromDictionary is true, the block is owned by the original block
+            if (selectedPositionsFromDictionary == false && selectedPositions != null) {
+                Releasables.close(selectedPositions);
+                selectedPositions = null;  // Mark as released to prevent double-close
+            }
+        }
+
+        @Override
+        public void close() {
+            // Close if we own it. Safe to call even if releaseSelectedPositions() was already called,
+            // as setting selectedPositions to null prevents double-close.
+            releaseSelectedPositions();
+        }
+    }
+
+    /**
+     * Maps a physical plan to operators for execution.
+     */
+    public AbstractLookupService.LookupQueryPlan map(
+        AbstractLookupService.TransportRequest request,
+        PhysicalPlan physicalPlan,
+        AbstractLookupService.LookupShardContext shardContext,
+        List<Releasable> releasables
+    ) throws IOException {
+        // Create driver context
+        final LocalCircuitBreaker localBreaker = new LocalCircuitBreaker(
+            blockFactory.breaker(),
+            localBreakerSettings.overReservedBytes(),
+            localBreakerSettings.maxOverReservedBytes()
+        );
+        releasables.add(localBreaker);
+        final DriverContext driverContext = new DriverContext(bigArrays, blockFactory.newChildFactory(localBreaker));
+
+        // Create warnings
+        var warnings = Warnings.createWarnings(
+            DriverContext.WarningsMode.COLLECT,
+            request.source.source().getLineNumber(),
+            request.source.source().getColumnNumber(),
+            request.source.text()
+        );
+
+        // Optimize input block and create optimized page
+        // Use try-with-resources to ensure optimization is always closed
+        try (BlockOptimization optimization = optimizeBlockAndCreatePage(request.inputPage)) {
+            List<Page> collectedPages = Collections.synchronizedList(new ArrayList<>());
+            List<Operator> operators = new ArrayList<>();
+            mapLookupNode(
+                physicalPlan,
+                shardContext,
+                driverContext,
+                warnings,
+                request,
+                optimization.optimizedPage(),
+                optimization,
+                releasables,
+                collectedPages,
+                operators
+            );
+
+            // Extract source (first), sink (last), and intermediate operators
+            if (operators.isEmpty()) {
+                throw new IllegalStateException("No operators planned");
+            }
+            SourceOperator sourceOperator = (SourceOperator) operators.get(0);
+            SinkOperator sinkOperator = operators.size() > 1 ? (SinkOperator) operators.get(operators.size() - 1) : null;
+            List<Operator> intermediateOperators = operators.size() > 2 ? operators.subList(1, operators.size() - 1) : List.of();
+
+            return new AbstractLookupService.LookupQueryPlan(
+                shardContext,
+                localBreaker,
+                driverContext,
+                (EnrichQuerySourceOperator) sourceOperator,
+                intermediateOperators,
+                collectedPages,
+                (OutputOperator) sinkOperator
+            );
+        }
+    }
+
+    /**
+     * Optimizes the input block and creates the optimized page (matches main branch logic).
+     * Also determines the selectedPositions for MergePositionsOperator.
+     * Structure matches main branch: if ordinals optimization applies, use dictionary block and ordinals;
+     * else if mergePages, create range block; else no selectedPositions (dropDocBlockOperator case).
+     */
+    private BlockOptimization optimizeBlockAndCreatePage(Page inputPage) {
+        final OrdinalBytesRefBlock ordinalsBytesRefBlock;
+        Block inputBlock = inputPage.getBlock(0);
+        Block optimizedBlock = inputBlock;
+        IntBlock selectedPositions = null;
+        boolean selectedPositionsFromDictionary = false;
+
+        if (mergePages  // TODO fix this optimization for Lookup.
+            && inputBlock instanceof BytesRefBlock bytesRefBlock
+            && (ordinalsBytesRefBlock = bytesRefBlock.asOrdinals()) != null) {
+
+            optimizedBlock = ordinalsBytesRefBlock.getDictionaryVector().asBlock();
+            selectedPositions = ordinalsBytesRefBlock.getOrdinalsBlock();
+            selectedPositionsFromDictionary = true;
+        } else {
+            if (mergePages) {
+                selectedPositions = IntVector.range(0, inputBlock.getPositionCount(), blockFactory).asBlock();
+            }
+        }
+
+        Page optimizedPage = (optimizedBlock != inputBlock) ? createPageWithOptimizedBlock(inputPage, 0, optimizedBlock) : inputPage;
+
+        return new BlockOptimization(optimizedPage, selectedPositions, selectedPositionsFromDictionary);
+    }
+
+    /**
+     * Recursively maps a PhysicalPlan node to operators, processing children first.
+     * Appends operators to the provided list where first is source, last is sink, and middle are intermediate operators.
+     */
+    private void mapLookupNode(
+        PhysicalPlan node,
+        AbstractLookupService.LookupShardContext shardContext,
+        DriverContext driverContext,
+        Warnings warnings,
+        AbstractLookupService.TransportRequest request,
+        Page inputPage,
+        BlockOptimization optimization,
+        List<Releasable> releasables,
+        List<Page> collectedPages,
+        List<Operator> operators
+    ) throws IOException {
+        if (node instanceof UnaryExec unaryExec) {
+            mapLookupNode(
+                unaryExec.child(),
+                shardContext,
+                driverContext,
+                warnings,
+                request,
+                inputPage,
+                optimization,
+                releasables,
+                collectedPages,
+                operators
+            );
+        }
+
+        // Map this node based on its type
+        if (node instanceof OutputExec) {
+            mapOutputExec(operators, collectedPages, releasables);
+        } else if (node instanceof LookupMergeDropExec lookupMergeDropExec) {
+            mapLookupMergeDropExec(lookupMergeDropExec, operators, driverContext, optimization, releasables);
+        } else if (node instanceof FieldExtractExec fieldExtractExec) {
+            mapFieldExtractExec(fieldExtractExec, operators, shardContext, driverContext, releasables);
+        } else if (node instanceof ParameterizedQueryExec parameterizedQueryExec) {
+            mapParameterizedQueryExec(parameterizedQueryExec, shardContext, driverContext, warnings, inputPage, releasables, operators);
+        } else {
+            throw new EsqlIllegalArgumentException("unknown physical plan node [" + node.nodeName() + "]");
+        }
+    }
+
+    private void mapOutputExec(List<Operator> operators, List<Page> collectedPages, List<Releasable> releasables) {
+        OutputOperator outputOperator = new OutputOperator(List.of(), Function.identity(), collectedPages::add);
+        releasables.add(outputOperator);
+
+        if (operators == null || operators.isEmpty()) {
+            throw new IllegalStateException("Operators cannot be null or empty");
+        }
+        operators.add(outputOperator);
+    }
+
+    private void mapLookupMergeDropExec(
+        LookupMergeDropExec lookupMergeDropExec,
+        List<Operator> operators,
+        DriverContext driverContext,
+        BlockOptimization optimization,
+        List<Releasable> releasables
+    ) {
+        // Use pre-computed optimization result to create finish operator
+        Operator finishOperator = createFinishOperator(lookupMergeDropExec, driverContext, optimization, releasables);
+        operators.add(finishOperator);
+    }
+
+    private void mapFieldExtractExec(
+        FieldExtractExec fieldExtractExec,
+        List<Operator> operators,
+        AbstractLookupService.LookupShardContext shardContext,
+        DriverContext driverContext,
+        List<Releasable> releasables
+    ) {
+
+        EsPhysicalOperationProviders.ShardContext esShardContext = shardContext.context();
+        List<ValuesSourceReaderOperator.FieldInfo> fields = new ArrayList<>(fieldExtractExec.attributesToExtract().size());
+        for (NamedExpression extractField : fieldExtractExec.attributesToExtract()) {
+            String fieldName = extractField instanceof FieldAttribute fa ? fa.fieldName().string()
+                : extractField instanceof Alias a ? ((NamedExpression) a.child()).name()
+                : extractField.name();
+            BlockLoader loader = esShardContext.blockLoader(
+                fieldName,
+                extractField.dataType() == DataType.UNSUPPORTED,
+                MappedFieldType.FieldExtractPreference.NONE,
+                null
+            );
+            fields.add(
+                new ValuesSourceReaderOperator.FieldInfo(
+                    extractField.name(),
+                    PlannerUtils.toElementType(extractField.dataType()),
+                    false,
+                    shardIdx -> {
+                        if (shardIdx != 0) {
+                            throw new IllegalStateException("only one shard");
+                        }
+                        return loader;
+                    }
+                )
+            );
+        }
+        ValuesSourceReaderOperator operator = new ValuesSourceReaderOperator(
+            driverContext.blockFactory(),
+            Long.MAX_VALUE,
+            fields,
+            new IndexedByShardIdFromSingleton<>(
+                new ValuesSourceReaderOperator.ShardContext(
+                    esShardContext.searcher().getIndexReader(),
+                    esShardContext::newSourceLoader,
+                    EsqlPlugin.STORED_FIELDS_SEQUENTIAL_PROPORTION.getDefault(org.elasticsearch.common.settings.Settings.EMPTY)
+                )
+            ),
+            0
+        );
+        releasables.add(operator);
+        operators.add(operator);
+    }
+
+    private void mapParameterizedQueryExec(
+        ParameterizedQueryExec parameterizedQueryExec,
+        AbstractLookupService.LookupShardContext shardContext,
+        DriverContext driverContext,
+        Warnings warnings,
+        Page inputPage,
+        List<Releasable> releasables,
+        List<Operator> operators
+    ) {
+        // inputPage is already optimized (from BlockOptimization)
+        LookupEnrichQueryGenerator queryList = parameterizedQueryExec.queryList();
+
+        EnrichQuerySourceOperator sourceOperator = new EnrichQuerySourceOperator(
+            driverContext.blockFactory(),
+            EnrichQuerySourceOperator.DEFAULT_MAX_PAGE_SIZE,
+            queryList,
+            inputPage,  // Use optimized page (already optimized in planExecution)
+            new IndexedByShardIdFromSingleton<>(shardContext.context()),
+            0,
+            warnings
+        );
+        releasables.add(sourceOperator);
+
+        // Add source operator: [source]
+        operators.add(sourceOperator);
+    }
+
+    /**
+     * Creates a new Page with the optimized block replacing the block at the specified channelOffset.
+     */
+    private Page createPageWithOptimizedBlock(Page originalPage, int channelOffset, Block optimizedBlock) {
+        Block[] blocks = new Block[originalPage.getBlockCount()];
+        for (int i = 0; i < blocks.length; i++) {
+            blocks[i] = (i == channelOffset) ? optimizedBlock : originalPage.getBlock(i);
+        }
+        return new Page(blocks);
+    }
+
+    /**
+     * Creates the finish operator (MergePositionsOperator or dropDocBlockOperator) using pre-computed optimization.
+     */
+    private Operator createFinishOperator(
+        LookupMergeDropExec lookupMergeDropExec,
+        DriverContext driverContext,
+        BlockOptimization optimization,
+        List<Releasable> releasables
+    ) {
+        if (mergePages) {
+            // Use pre-computed selectedPositions from optimization
+            IntBlock selectedPositions = optimization.selectedPositions();
+            if (selectedPositions != null && lookupMergeDropExec.mergingChannels().length > 0) {
+                Operator finishOperator = new MergePositionsOperator(
+                    1,
+                    lookupMergeDropExec.mergingChannels(),
+                    lookupMergeDropExec.mergingTypes(),
+                    selectedPositions,
+                    driverContext.blockFactory()
+                );
+                // MergePositionsOperator calls mustIncRef() on selectedPositions, taking ownership
+                // Release our reference to selectedPositions if we own it
+                optimization.releaseSelectedPositions();
+                releasables.add(finishOperator);
+                return finishOperator;
+            }
+        }
+        // No merge: just drop doc block
+        Operator finishOperator = dropDocBlockOperator(lookupMergeDropExec.extractFields());
+        releasables.add(finishOperator);
+        return finishOperator;
+    }
+
+    /**
+     * Drop just the first block, keeping the remaining.
+     */
+    private Operator dropDocBlockOperator(List<NamedExpression> extractFields) {
+        int end = extractFields.size() + 1;
+        List<Integer> projection = new ArrayList<>(end);
+        for (int i = 1; i <= end; i++) {
+            projection.add(i);
+        }
+        return new ProjectOperator(projection);
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/LookupMergeDropExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/LookupMergeDropExec.java
@@ -16,9 +16,9 @@ import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Stream;
 
 /**
  * Physical plan node representing the merge/drop step of a lookup operation.
@@ -84,14 +84,7 @@ public class LookupMergeDropExec extends UnaryExec {
 
     @Override
     public List<Attribute> output() {
-        List<Attribute> childOutput = child().output();
-        if (extractFields.isEmpty()) {
-            return childOutput;
-        }
-        List<Attribute> output = new ArrayList<>(childOutput.size() + extractFields.size());
-        output.addAll(childOutput);
-        output.addAll(extractFields.stream().map(NamedExpression::toAttribute).toList());
-        return output;
+        return Stream.concat(child().output().stream(), extractFields.stream().map(NamedExpression::toAttribute)).toList();
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/LookupMergeDropExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/LookupMergeDropExec.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.AttributeSet;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Physical plan node representing the merge/drop step of a lookup operation.
+ * This handles either merging multiple result pages into one (via MergePositionsOperator)
+ * or dropping the doc block (via ProjectOperator).
+ * This is used internally by lookup services to represent the lookup structure
+ * before converting to operators.
+ */
+public class LookupMergeDropExec extends UnaryExec {
+    private final List<NamedExpression> extractFields;
+    private final ElementType[] mergingTypes;
+    private final int[] mergingChannels;
+
+    public LookupMergeDropExec(
+        Source source,
+        PhysicalPlan child,
+        List<NamedExpression> extractFields,
+        ElementType[] mergingTypes,
+        int[] mergingChannels
+    ) {
+        super(source, child);
+        this.extractFields = extractFields;
+        this.mergingTypes = mergingTypes;
+        this.mergingChannels = mergingChannels;
+    }
+
+    @Override
+    protected AttributeSet computeReferences() {
+        return AttributeSet.EMPTY;
+    }
+
+    @Override
+    protected NodeInfo<LookupMergeDropExec> info() {
+        return NodeInfo.create(this, LookupMergeDropExec::new, child(), extractFields, mergingTypes, mergingChannels);
+    }
+
+    @Override
+    public LookupMergeDropExec replaceChild(PhysicalPlan newChild) {
+        return new LookupMergeDropExec(source(), newChild, extractFields, mergingTypes, mergingChannels);
+    }
+
+    public List<NamedExpression> extractFields() {
+        return extractFields;
+    }
+
+    public ElementType[] mergingTypes() {
+        return mergingTypes;
+    }
+
+    public int[] mergingChannels() {
+        return mergingChannels;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        throw new UnsupportedOperationException("not serialized");
+    }
+
+    @Override
+    public String getWriteableName() {
+        throw new UnsupportedOperationException("not serialized");
+    }
+
+    @Override
+    public List<Attribute> output() {
+        List<Attribute> childOutput = child().output();
+        if (extractFields.isEmpty()) {
+            return childOutput;
+        }
+        List<Attribute> output = new ArrayList<>(childOutput.size() + extractFields.size());
+        output.addAll(childOutput);
+        output.addAll(extractFields.stream().map(NamedExpression::toAttribute).toList());
+        return output;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (super.equals(o) == false) return false;
+        LookupMergeDropExec lookupMergeDropExec = (LookupMergeDropExec) o;
+        return Objects.equals(extractFields, lookupMergeDropExec.extractFields)
+            && java.util.Arrays.equals(mergingTypes, lookupMergeDropExec.mergingTypes)
+            && java.util.Arrays.equals(mergingChannels, lookupMergeDropExec.mergingChannels);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+            super.hashCode(),
+            extractFields,
+            java.util.Arrays.hashCode(mergingTypes),
+            java.util.Arrays.hashCode(mergingChannels)
+        );
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/ParameterizedQueryExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/ParameterizedQueryExec.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plan.physical;
+
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.compute.operator.lookup.LookupEnrichQueryGenerator;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Physical plan node representing a lookup source operation.
+ * This represents the source of a lookup query before conversion to operators.
+ * The QueryList is created during physical plan creation and will receive the Block at runtime.
+ */
+public class ParameterizedQueryExec extends LeafExec {
+    private final List<Attribute> output;
+    private final LookupEnrichQueryGenerator queryList;
+
+    public ParameterizedQueryExec(Source source, List<Attribute> output, LookupEnrichQueryGenerator queryList) {
+        super(source);
+        this.output = output;
+        this.queryList = queryList;
+    }
+
+    @Override
+    public List<Attribute> output() {
+        return output;
+    }
+
+    public LookupEnrichQueryGenerator queryList() {
+        return queryList;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        throw new UnsupportedOperationException("not serialized");
+    }
+
+    @Override
+    public String getWriteableName() {
+        throw new UnsupportedOperationException("not serialized");
+    }
+
+    @Override
+    protected NodeInfo<ParameterizedQueryExec> info() {
+        return NodeInfo.create(this, ParameterizedQueryExec::new, output, queryList);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ParameterizedQueryExec that = (ParameterizedQueryExec) o;
+        return Objects.equals(output, that.output) && Objects.equals(queryList, that.queryList);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(output, queryList);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/enrich/LookupExecutionMapperTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/enrich/LookupExecutionMapperTests.java
@@ -1,0 +1,668 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.enrich;
+
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.MockBigArrays;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.BytesRefVector;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.LocalCircuitBreaker;
+import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.lucene.read.ValuesSourceReaderOperator;
+import org.elasticsearch.compute.operator.Operator;
+import org.elasticsearch.compute.operator.OutputOperator;
+import org.elasticsearch.compute.operator.ProjectOperator;
+import org.elasticsearch.compute.operator.lookup.EnrichQuerySourceOperator;
+import org.elasticsearch.compute.operator.lookup.LookupEnrichQueryGenerator;
+import org.elasticsearch.compute.operator.lookup.MergePositionsOperator;
+import org.elasticsearch.compute.test.NoOpReleasable;
+import org.elasticsearch.compute.test.TestBlockFactory;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.MapperServiceTestCase;
+import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.elasticsearch.search.internal.AliasFilter;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.EsField;
+import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
+import org.elasticsearch.xpack.esql.plan.physical.FieldExtractExec;
+import org.elasticsearch.xpack.esql.plan.physical.LookupMergeDropExec;
+import org.elasticsearch.xpack.esql.plan.physical.OutputExec;
+import org.elasticsearch.xpack.esql.plan.physical.ParameterizedQueryExec;
+import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
+import org.elasticsearch.xpack.esql.planner.EsPhysicalOperationProviders;
+import org.hamcrest.MatcherAssert;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.mock;
+
+public class LookupExecutionMapperTests extends ESTestCase {
+    private BlockFactory blockFactory;
+    private BigArrays bigArrays;
+    private List<Releasable> releasables;
+    private Directory testDirectory;
+    private DirectoryReader testReader;
+    private MapperService mapperService;
+
+    @Before
+    public void setup() throws IOException {
+        blockFactory = TestBlockFactory.getNonBreakingInstance();
+        bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, new NoneCircuitBreakerService()).withCircuitBreaking();
+        releasables = new ArrayList<>();
+
+        // Create a minimal index for testing
+        testDirectory = newDirectory();
+        try (RandomIndexWriter writer = new RandomIndexWriter(random(), testDirectory)) {
+            writer.commit();
+        }
+        testReader = DirectoryReader.open(testDirectory);
+        MapperServiceTestCase mapperHelper = new MapperServiceTestCase() {
+        };
+        String mapping = "{\n  \"doc\": { \"properties\": { \"field1\": { \"type\": \"keyword\" } } }\n}";
+        mapperService = mapperHelper.createMapperService(mapping);
+        releasables.add(() -> {
+            try {
+                org.elasticsearch.core.IOUtils.close(testReader, mapperService, testDirectory);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    @After
+    public void cleanup() {
+        Releasables.close(releasables);
+        blockFactory = null;
+        bigArrays = null;
+    }
+
+    /**
+     * Creates a physical plan matching the structure from createLookupPhysicalPlan():
+     * OutputExec -> LookupMergeDropExec -> (FieldExtractExec?) -> ParameterizedQueryExec
+     */
+    private PhysicalPlan createLookupPhysicalPlan(List<NamedExpression> extractFields) {
+        // Create doc attribute
+        FieldAttribute docAttribute = new FieldAttribute(
+            Source.EMPTY,
+            null,
+            null,
+            EsQueryExec.DOC_ID_FIELD.getName(),
+            EsQueryExec.DOC_ID_FIELD
+        );
+        List<Attribute> sourceOutput = List.of(docAttribute);
+
+        // Create ParameterizedQueryExec
+        LookupEnrichQueryGenerator queryList = mock(LookupEnrichQueryGenerator.class);
+        ParameterizedQueryExec source = new ParameterizedQueryExec(Source.EMPTY, sourceOutput, queryList);
+
+        PhysicalPlan plan = source;
+
+        // Add FieldExtractExec if we have extract fields
+        if (extractFields.isEmpty() == false) {
+            List<Attribute> extractAttributes = new ArrayList<>();
+            for (NamedExpression extractField : extractFields) {
+                extractAttributes.add(extractField.toAttribute());
+            }
+            plan = new FieldExtractExec(Source.EMPTY, plan, extractAttributes, MappedFieldType.FieldExtractPreference.NONE);
+        }
+
+        // Add LookupMergeDropExec
+        final ElementType[] mergingTypes = new ElementType[extractFields.size()];
+        for (int i = 0; i < extractFields.size(); i++) {
+            mergingTypes[i] = org.elasticsearch.xpack.esql.planner.PlannerUtils.toElementType(extractFields.get(i).dataType());
+        }
+        final int[] mergingChannels = IntStream.range(0, extractFields.size()).map(i -> i + 2).toArray();
+        plan = new LookupMergeDropExec(Source.EMPTY, plan, extractFields, mergingTypes, mergingChannels);
+
+        // Add OutputExec
+        plan = new OutputExec(Source.EMPTY, plan, page -> {});
+
+        return plan;
+    }
+
+    public void testEnrichLookupNoMerge() throws IOException {
+        // Test enrich lookup with mergePages=false and no extract fields (lookup join case)
+        LookupExecutionMapper mapper = new LookupExecutionMapper(
+            blockFactory,
+            bigArrays,
+            new LocalCircuitBreaker.SizeSettings(Settings.EMPTY),
+            false
+        );
+
+        BytesRefBlock inputBlock = blockFactory.newBytesRefBlockBuilder(2)
+            .appendBytesRef(new BytesRef("a"))
+            .appendBytesRef(new BytesRef("b"))
+            .build();
+        Page inputPage = new Page(inputBlock);
+
+        // No extract fields - just lookup join
+        List<NamedExpression> extractFields = Collections.emptyList();
+        PhysicalPlan plan = createLookupPhysicalPlan(extractFields);
+
+        AbstractLookupService.TransportRequest request = createMockRequest(inputPage, extractFields);
+        AbstractLookupService.LookupShardContext shardContext = createMockShardContext();
+
+        AbstractLookupService.LookupQueryPlan queryPlan = mapper.map(request, plan, shardContext, releasables);
+        MatcherAssert.assertThat(queryPlan, notNullValue());
+
+        // Verify complete plan structure
+        // Expected: EnrichQuerySourceOperator -> ProjectOperator -> OutputOperator
+        verifyCompletePlan(queryPlan, List.of(EnrichQuerySourceOperator.class, ProjectOperator.class, OutputOperator.class));
+
+        // Verify EnrichQuerySourceOperator
+        EnrichQuerySourceOperator sourceOp = verifyEnrichQuerySourceOperator(queryPlan);
+
+        // Verify ProjectOperator
+        ProjectOperator projectOp = (ProjectOperator) queryPlan.operators().get(0);
+        verifyProjectOperator(projectOp, extractFields.size());
+
+        // Verify OutputOperator
+        verifyOutputOperator(queryPlan);
+    }
+
+    public void testEnrichLookupDictionaryOptimization() throws IOException {
+        LookupExecutionMapper mapper = new LookupExecutionMapper(
+            blockFactory,
+            bigArrays,
+            new LocalCircuitBreaker.SizeSettings(Settings.EMPTY),
+            true
+        );
+
+        // Create a BytesRefBlock with ordinals for dictionary optimization
+        BytesRefVector dictionary = blockFactory.newBytesRefVectorBuilder(2)
+            .appendBytesRef(new BytesRef("a"))
+            .appendBytesRef(new BytesRef("b"))
+            .build();
+        IntBlock ordinals = blockFactory.newIntBlockBuilder(3).appendInt(0).appendInt(1).appendInt(0).build();
+        OrdinalBytesRefBlock ordinalBlock = new OrdinalBytesRefBlock(ordinals, dictionary);
+        Page inputPage = new Page(ordinalBlock);
+
+        List<NamedExpression> extractFields = List.of(
+            createFieldAttribute("field1", DataType.KEYWORD),
+            createFieldAttribute("field2", DataType.INTEGER)
+        );
+        PhysicalPlan plan = createLookupPhysicalPlan(extractFields);
+
+        AbstractLookupService.TransportRequest request = createMockRequest(inputPage, extractFields);
+        AbstractLookupService.LookupShardContext shardContext = createMockShardContext();
+
+        AbstractLookupService.LookupQueryPlan queryPlan = mapper.map(request, plan, shardContext, releasables);
+        MatcherAssert.assertThat(queryPlan, notNullValue());
+
+        // Verify complete plan structure
+        // Expected: EnrichQuerySourceOperator -> ValuesSourceReaderOperator -> MergePositionsOperator -> OutputOperator
+        verifyCompletePlan(
+            queryPlan,
+            List.of(EnrichQuerySourceOperator.class, ValuesSourceReaderOperator.class, MergePositionsOperator.class, OutputOperator.class)
+        );
+
+        // Verify EnrichQuerySourceOperator with dictionary optimization
+        EnrichQuerySourceOperator sourceOp = verifyEnrichQuerySourceOperator(queryPlan);
+        verifyDictionaryOptimization(sourceOp, 2);
+
+        // Verify ValuesSourceReaderOperator
+        ValuesSourceReaderOperator valuesOp = verifyValuesSourceReaderOperator(queryPlan, 0);
+
+        // Verify MergePositionsOperator with dictionary ordinals
+        MergePositionsOperator mergeOp = (MergePositionsOperator) queryPlan.operators().get(1);
+        verifyMergePositionsOperator(mergeOp, 3, false); // 3 positions, not range block
+
+        // Verify OutputOperator
+        verifyOutputOperator(queryPlan);
+    }
+
+    public void testEnrichLookupRangeBlockOptimization() throws IOException {
+        LookupExecutionMapper mapper = new LookupExecutionMapper(
+            blockFactory,
+            bigArrays,
+            new LocalCircuitBreaker.SizeSettings(Settings.EMPTY),
+            true
+        );
+
+        BytesRefBlock inputBlock = blockFactory.newBytesRefBlockBuilder(3)
+            .appendBytesRef(new BytesRef("a"))
+            .appendBytesRef(new BytesRef("b"))
+            .appendBytesRef(new BytesRef("c"))
+            .build();
+        Page inputPage = new Page(inputBlock);
+
+        List<NamedExpression> extractFields = List.of(
+            createFieldAttribute("field1", DataType.KEYWORD),
+            createFieldAttribute("field2", DataType.INTEGER),
+            createFieldAttribute("field3", DataType.LONG)
+        );
+        PhysicalPlan plan = createLookupPhysicalPlan(extractFields);
+
+        AbstractLookupService.TransportRequest request = createMockRequest(inputPage, extractFields);
+        AbstractLookupService.LookupShardContext shardContext = createMockShardContext();
+
+        AbstractLookupService.LookupQueryPlan queryPlan = mapper.map(request, plan, shardContext, releasables);
+        MatcherAssert.assertThat(queryPlan, notNullValue());
+
+        // Verify complete plan structure
+        // Expected: EnrichQuerySourceOperator -> ValuesSourceReaderOperator -> MergePositionsOperator -> OutputOperator
+        verifyCompletePlan(
+            queryPlan,
+            List.of(EnrichQuerySourceOperator.class, ValuesSourceReaderOperator.class, MergePositionsOperator.class, OutputOperator.class)
+        );
+
+        // Verify EnrichQuerySourceOperator with range block optimization (no optimization on input page)
+        EnrichQuerySourceOperator sourceOp = verifyEnrichQuerySourceOperator(queryPlan);
+        verifyNoPageOptimization(sourceOp, inputBlock);
+
+        // Verify ValuesSourceReaderOperator
+        ValuesSourceReaderOperator valuesOp = verifyValuesSourceReaderOperator(queryPlan, 0);
+
+        // Verify MergePositionsOperator with range block
+        MergePositionsOperator mergeOp = (MergePositionsOperator) queryPlan.operators().get(1);
+        verifyMergePositionsOperator(mergeOp, 3, true); // 3 positions, range block
+
+        // Verify OutputOperator
+        verifyOutputOperator(queryPlan);
+    }
+
+    public void testLookupJoinNoExtraFields() throws IOException {
+        // Test lookup join where we don't need to get extra fields (no extract fields, no merge)
+        // This is the simplest lookup join case - just joining without extracting additional fields
+        LookupExecutionMapper mapper = new LookupExecutionMapper(
+            blockFactory,
+            bigArrays,
+            new LocalCircuitBreaker.SizeSettings(Settings.EMPTY),
+            false
+        );
+
+        BytesRefBlock inputBlock = blockFactory.newBytesRefBlockBuilder(3)
+            .appendBytesRef(new BytesRef("key1"))
+            .appendBytesRef(new BytesRef("key2"))
+            .appendBytesRef(new BytesRef("key3"))
+            .build();
+        Page inputPage = new Page(inputBlock);
+
+        // No extract fields - pure lookup join without extra field extraction
+        List<NamedExpression> extractFields = Collections.emptyList();
+        PhysicalPlan plan = createLookupPhysicalPlan(extractFields);
+
+        AbstractLookupService.TransportRequest request = createMockRequest(inputPage, extractFields);
+        AbstractLookupService.LookupShardContext shardContext = createMockShardContext();
+
+        AbstractLookupService.LookupQueryPlan queryPlan = mapper.map(request, plan, shardContext, releasables);
+        MatcherAssert.assertThat(queryPlan, notNullValue());
+
+        // Verify complete plan structure
+        // Expected: EnrichQuerySourceOperator -> ProjectOperator -> OutputOperator
+        // No ValuesSourceReaderOperator (no extract fields), no MergePositionsOperator (no merge)
+        verifyCompletePlan(queryPlan, List.of(EnrichQuerySourceOperator.class, ProjectOperator.class, OutputOperator.class));
+
+        // Verify EnrichQuerySourceOperator
+        EnrichQuerySourceOperator sourceOp = verifyEnrichQuerySourceOperator(queryPlan);
+
+        // Verify ProjectOperator - should just drop doc block (projection = [1] since no extract fields)
+        ProjectOperator projectOp = (ProjectOperator) queryPlan.operators().get(0);
+        verifyProjectOperator(projectOp, 0); // 0 extract fields
+
+        // Verify OutputOperator
+        verifyOutputOperator(queryPlan);
+    }
+
+    public void testEnrichLookupNoMergeWithExtractFields() throws IOException {
+        // Test enrich lookup with mergePages=false but with extract fields (uses ProjectOperator, not MergePositionsOperator)
+        LookupExecutionMapper mapper = new LookupExecutionMapper(
+            blockFactory,
+            bigArrays,
+            new LocalCircuitBreaker.SizeSettings(Settings.EMPTY),
+            false
+        );
+
+        BytesRefBlock inputBlock = blockFactory.newBytesRefBlockBuilder(2)
+            .appendBytesRef(new BytesRef("a"))
+            .appendBytesRef(new BytesRef("b"))
+            .build();
+        Page inputPage = new Page(inputBlock);
+
+        List<NamedExpression> extractFields = List.of(createFieldAttribute("field1", DataType.KEYWORD));
+        PhysicalPlan plan = createLookupPhysicalPlan(extractFields);
+
+        AbstractLookupService.TransportRequest request = createMockRequest(inputPage, extractFields);
+        AbstractLookupService.LookupShardContext shardContext = createMockShardContext();
+
+        AbstractLookupService.LookupQueryPlan queryPlan = mapper.map(request, plan, shardContext, releasables);
+        MatcherAssert.assertThat(queryPlan, notNullValue());
+
+        // Verify complete plan structure
+        // Expected: EnrichQuerySourceOperator -> ValuesSourceReaderOperator -> ProjectOperator -> OutputOperator
+        verifyCompletePlan(
+            queryPlan,
+            List.of(EnrichQuerySourceOperator.class, ValuesSourceReaderOperator.class, ProjectOperator.class, OutputOperator.class)
+        );
+
+        // Verify EnrichQuerySourceOperator
+        EnrichQuerySourceOperator sourceOp = verifyEnrichQuerySourceOperator(queryPlan);
+
+        // Verify ValuesSourceReaderOperator
+        ValuesSourceReaderOperator valuesOp = verifyValuesSourceReaderOperator(queryPlan, 0);
+
+        // Verify ProjectOperator
+        ProjectOperator projectOp = (ProjectOperator) queryPlan.operators().get(1);
+        verifyProjectOperator(projectOp, extractFields.size());
+
+        // Verify OutputOperator
+        verifyOutputOperator(queryPlan);
+    }
+
+    public void testEnrichLookupMergeWithEmptyExtractFields() throws IOException {
+        // Test enrich lookup with mergePages=true but empty extract fields
+        // This is an edge case: when mergingChannels is empty, we should use dropDocBlockOperator instead of MergePositionsOperator
+        LookupExecutionMapper mapper = new LookupExecutionMapper(
+            blockFactory,
+            bigArrays,
+            new LocalCircuitBreaker.SizeSettings(Settings.EMPTY),
+            true
+        );
+
+        BytesRefBlock inputBlock = blockFactory.newBytesRefBlockBuilder(2)
+            .appendBytesRef(new BytesRef("a"))
+            .appendBytesRef(new BytesRef("b"))
+            .build();
+        Page inputPage = new Page(inputBlock);
+
+        // Empty extract fields - but mergePages=true
+        List<NamedExpression> extractFields = Collections.emptyList();
+        PhysicalPlan plan = createLookupPhysicalPlan(extractFields);
+
+        AbstractLookupService.TransportRequest request = createMockRequest(inputPage, extractFields);
+        AbstractLookupService.LookupShardContext shardContext = createMockShardContext();
+
+        AbstractLookupService.LookupQueryPlan queryPlan = mapper.map(request, plan, shardContext, releasables);
+        MatcherAssert.assertThat(queryPlan, notNullValue());
+
+        // Verify complete plan structure
+        // Expected: EnrichQuerySourceOperator -> ProjectOperator -> OutputOperator
+        // Even though mergePages=true, empty mergingChannels means we use dropDocBlockOperator (ProjectOperator) instead of
+        // MergePositionsOperator
+        verifyCompletePlan(queryPlan, List.of(EnrichQuerySourceOperator.class, ProjectOperator.class, OutputOperator.class));
+
+        // Verify EnrichQuerySourceOperator
+        EnrichQuerySourceOperator sourceOp = verifyEnrichQuerySourceOperator(queryPlan);
+
+        // Verify ProjectOperator - should drop doc block (projection = [1] since no extract fields)
+        ProjectOperator projectOp = (ProjectOperator) queryPlan.operators().get(0);
+        verifyProjectOperator(projectOp, 0); // 0 extract fields
+
+        // Verify OutputOperator
+        verifyOutputOperator(queryPlan);
+    }
+
+    public void testEnrichLookupWithEmptyInputPage() throws IOException {
+        // Test enrich lookup with empty input page (0 positions) - edge case
+        // This verifies that the mapper handles empty input correctly, especially for range block creation
+        LookupExecutionMapper mapper = new LookupExecutionMapper(
+            blockFactory,
+            bigArrays,
+            new LocalCircuitBreaker.SizeSettings(Settings.EMPTY),
+            true
+        );
+
+        // Create empty input page (0 positions)
+        BytesRefBlock inputBlock = blockFactory.newBytesRefBlockBuilder(0).build();
+        Page inputPage = new Page(inputBlock);
+
+        List<NamedExpression> extractFields = List.of(createFieldAttribute("field1", DataType.KEYWORD));
+        PhysicalPlan plan = createLookupPhysicalPlan(extractFields);
+
+        AbstractLookupService.TransportRequest request = createMockRequest(inputPage, extractFields);
+        AbstractLookupService.LookupShardContext shardContext = createMockShardContext();
+
+        AbstractLookupService.LookupQueryPlan queryPlan = mapper.map(request, plan, shardContext, releasables);
+        MatcherAssert.assertThat(queryPlan, notNullValue());
+
+        // Verify complete plan structure
+        // Expected: EnrichQuerySourceOperator -> ValuesSourceReaderOperator -> MergePositionsOperator -> OutputOperator
+        // Even with empty input, the plan structure should be correct
+        verifyCompletePlan(
+            queryPlan,
+            List.of(EnrichQuerySourceOperator.class, ValuesSourceReaderOperator.class, MergePositionsOperator.class, OutputOperator.class)
+        );
+
+        // Verify EnrichQuerySourceOperator
+        EnrichQuerySourceOperator sourceOp = verifyEnrichQuerySourceOperator(queryPlan);
+        verifyNoPageOptimization(sourceOp, inputBlock);
+
+        // Verify ValuesSourceReaderOperator
+        ValuesSourceReaderOperator valuesOp = verifyValuesSourceReaderOperator(queryPlan, 0);
+
+        // Verify MergePositionsOperator with empty range block (0 positions)
+        MergePositionsOperator mergeOp = (MergePositionsOperator) queryPlan.operators().get(1);
+        verifyMergePositionsOperator(mergeOp, 0, true); // 0 positions, range block
+
+        // Verify OutputOperator
+        verifyOutputOperator(queryPlan);
+    }
+
+    // Verification helper methods
+
+    /**
+     * Verifies the complete plan structure with all operators.
+     * @param queryPlan The query plan to verify
+     * @param expectedOperators List of expected operator types in order: [source, intermediate1, intermediate2, ..., output]
+     */
+    private void verifyCompletePlan(AbstractLookupService.LookupQueryPlan queryPlan, List<Class<? extends Operator>> expectedOperators) {
+        if (expectedOperators.size() < 2) {
+            throw new IllegalArgumentException("Expected operators list must have at least 2 elements (source and output)");
+        }
+
+        // Verify source operator (first in list)
+        MatcherAssert.assertThat("Source operator type mismatch", queryPlan.queryOperator(), instanceOf(expectedOperators.get(0)));
+
+        // Verify intermediate operators (middle of list)
+        List<Operator> actualOperators = queryPlan.operators();
+        int expectedIntermediateCount = expectedOperators.size() - 2; // Exclude source and output
+        MatcherAssert.assertThat("Intermediate operators count mismatch", actualOperators.size(), is(expectedIntermediateCount));
+
+        for (int i = 0; i < expectedIntermediateCount; i++) {
+            Class<? extends Operator> expectedType = expectedOperators.get(i + 1); // +1 to skip source
+            MatcherAssert.assertThat(
+                "Operator at index " + i + " should be " + expectedType.getSimpleName(),
+                actualOperators.get(i),
+                instanceOf(expectedType)
+            );
+        }
+
+        // Verify output operator (last in list)
+        MatcherAssert.assertThat(
+            "Output operator type mismatch",
+            queryPlan.outputOperator(),
+            instanceOf(expectedOperators.get(expectedOperators.size() - 1))
+        );
+    }
+
+    /**
+     * Verifies EnrichQuerySourceOperator and returns it.
+     */
+    private EnrichQuerySourceOperator verifyEnrichQuerySourceOperator(AbstractLookupService.LookupQueryPlan queryPlan) {
+        EnrichQuerySourceOperator sourceOp = queryPlan.queryOperator();
+        MatcherAssert.assertThat(sourceOp, notNullValue());
+        MatcherAssert.assertThat(sourceOp, instanceOf(EnrichQuerySourceOperator.class));
+        Page inputPage = sourceOp.getInputPage();
+        MatcherAssert.assertThat(inputPage, notNullValue());
+        return sourceOp;
+    }
+
+    /**
+     * Verifies ValuesSourceReaderOperator at the specified index.
+     */
+    private ValuesSourceReaderOperator verifyValuesSourceReaderOperator(AbstractLookupService.LookupQueryPlan queryPlan, int index) {
+        Operator operator = queryPlan.operators().get(index);
+        MatcherAssert.assertThat(operator, instanceOf(ValuesSourceReaderOperator.class));
+        return (ValuesSourceReaderOperator) operator;
+    }
+
+    /**
+     * Verifies ProjectOperator projection.
+     */
+    private void verifyProjectOperator(ProjectOperator projectOp, int extractFieldsCount) {
+        MatcherAssert.assertThat(projectOp, notNullValue());
+        int[] projection = projectOp.getProjection();
+        MatcherAssert.assertThat("Projection should have extractFields.size() + 1 elements", projection.length, is(extractFieldsCount + 1));
+        // Verify projection starts at 1 (skipping doc block at index 0) and contains sequential values
+        for (int i = 0; i < projection.length; i++) {
+            MatcherAssert.assertThat("Projection should contain sequential values starting from 1", projection[i], is(i + 1));
+        }
+    }
+
+    /**
+     * Verifies MergePositionsOperator with range block or dictionary ordinals.
+     */
+    private void verifyMergePositionsOperator(MergePositionsOperator mergeOp, int expectedPositionCount, boolean isRangeBlock) {
+        MatcherAssert.assertThat(mergeOp, notNullValue());
+        IntBlock selectedPositions = mergeOp.getSelectedPositions();
+        MatcherAssert.assertThat(selectedPositions, notNullValue());
+        MatcherAssert.assertThat(
+            "Selected positions should have expected position count",
+            selectedPositions.getPositionCount(),
+            is(expectedPositionCount)
+        );
+
+        if (isRangeBlock) {
+            // Verify it's a range block (vector with sequential values 0, 1, 2, ...)
+            IntVector selectedPositionsVector = selectedPositions.asVector();
+            MatcherAssert.assertThat("Selected positions should be a vector (range block)", selectedPositionsVector, notNullValue());
+            for (int i = 0; i < expectedPositionCount; i++) {
+                MatcherAssert.assertThat("Range block position " + i + " should be " + i, selectedPositionsVector.getInt(i), is(i));
+            }
+        } else {
+            // Dictionary ordinals case - just verify it exists and has correct count
+            // The actual values come from the dictionary ordinals
+        }
+    }
+
+    /**
+     * Verifies dictionary optimization was applied to the input page.
+     */
+    private void verifyDictionaryOptimization(EnrichQuerySourceOperator sourceOp, int expectedDictionarySize) {
+        Page optimizedPage = sourceOp.getInputPage();
+        Block optimizedBlock = optimizedPage.getBlock(0);
+        MatcherAssert.assertThat(
+            "Optimized block should be a BytesRefBlock (dictionary block)",
+            optimizedBlock,
+            instanceOf(BytesRefBlock.class)
+        );
+        MatcherAssert.assertThat(
+            "Dictionary block should have dictionary size positions",
+            optimizedBlock.getPositionCount(),
+            is(expectedDictionarySize)
+        );
+
+        // Verify the dictionary values are present
+        BytesRefBlock dictBlock = (BytesRefBlock) optimizedBlock;
+        BytesRef value1 = new BytesRef();
+        BytesRef value2 = new BytesRef();
+        dictBlock.getBytesRef(0, value1);
+        dictBlock.getBytesRef(1, value2);
+        // The dictionary should contain "a" and "b" (order may vary)
+        MatcherAssert.assertThat(
+            "Dictionary block should contain expected values",
+            (value1.utf8ToString().equals("a") && value2.utf8ToString().equals("b"))
+                || (value1.utf8ToString().equals("b") && value2.utf8ToString().equals("a")),
+            is(true)
+        );
+    }
+
+    /**
+     * Verifies that no page optimization was applied (input page is original).
+     */
+    private void verifyNoPageOptimization(EnrichQuerySourceOperator sourceOp, Block expectedInputBlock) {
+        Page sourceInputPage = sourceOp.getInputPage();
+        MatcherAssert.assertThat(
+            "Input page should be the original page when no optimization is used",
+            sourceInputPage.getBlock(0),
+            is(expectedInputBlock)
+        );
+    }
+
+    /**
+     * Verifies OutputOperator.
+     */
+    private void verifyOutputOperator(AbstractLookupService.LookupQueryPlan queryPlan) {
+        OutputOperator outputOp = queryPlan.outputOperator();
+        MatcherAssert.assertThat(outputOp, notNullValue());
+        MatcherAssert.assertThat(outputOp, instanceOf(OutputOperator.class));
+    }
+
+    // Helper methods
+
+    private AbstractLookupService.TransportRequest createMockRequest(Page inputPage, List<NamedExpression> extractFields) {
+        return new LookupFromIndexService.TransportRequest(
+            "test-session",
+            new ShardId("test", "n/a", 0),
+            "test-index",
+            inputPage,
+            null,
+            extractFields,
+            Collections.emptyList(),
+            Source.EMPTY,
+            null,
+            null
+        );
+    }
+
+    private AbstractLookupService.LookupShardContext createMockShardContext() throws IOException {
+        MapperServiceTestCase mapperHelper = new MapperServiceTestCase() {
+        };
+        SearchExecutionContext executionCtx = mapperHelper.createSearchExecutionContext(mapperService, newSearcher(testReader));
+        EsPhysicalOperationProviders.DefaultShardContext shardContext = new EsPhysicalOperationProviders.DefaultShardContext(
+            0,
+            new NoOpReleasable(),
+            executionCtx,
+            AliasFilter.EMPTY
+        );
+        return new AbstractLookupService.LookupShardContext(
+            shardContext,
+            executionCtx,
+            () -> {} // No-op releasable
+        );
+    }
+
+    private FieldAttribute createFieldAttribute(String name, DataType type) {
+        return new FieldAttribute(
+            Source.EMPTY,
+            name,
+            new EsField(name, type, Collections.emptyMap(), false, EsField.TimeSeriesFieldType.NONE)
+        );
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/tree/EsqlNodeSubclassTests.java
@@ -11,6 +11,7 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.elasticsearch.Build;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.core.SuppressForbidden;
@@ -393,6 +394,24 @@ public class EsqlNodeSubclassTests<T extends B, B extends Node<B>> extends NodeS
             return makeArg(toBuildClass, wt.getUpperBounds()[0]);
         }
         Class<?> argClass = (Class<?>) argType;
+
+        // Handle array types - can't mock arrays, so create them directly
+        if (argClass == int[].class) {
+            int arrayLength = between(0, 5);
+            int[] array = new int[arrayLength];
+            for (int i = 0; i < arrayLength; i++) {
+                array[i] = randomInt();
+            }
+            return array;
+        }
+        if (argClass == ElementType[].class) {
+            int arrayLength = between(0, 5);
+            ElementType[] array = new ElementType[arrayLength];
+            for (int i = 0; i < arrayLength; i++) {
+                array[i] = randomFrom(ElementType.values());
+            }
+            return array;
+        }
 
         /*
          * Sometimes all of the required type information isn't in the ctor


### PR DESCRIPTION
**This PR is a refactoring step towards Init Lookup Driver Just once.** 

 Currently, AbstractLookupService::doLookup() creates operators directly from the request and input page. Since operators are tightly coupled with the driver and input pages, they cannot be reused across multiple pages. We plan to add local logical and physical planning. However, we cannot do that per page as it would add too much overhead. We need to perform planning once during session initialization rather than for every page. This PR takes a step in that direction by generating a physical plan first that can be shared across multiple pages. Main changes include: 
    1. Refactor `AbstractLookupService::doLookup()`. Instead of creating operators directly, we now first create a PhysicalPlan and then use a new LookupExecutionMapper class to map the PhysicalPlan to operators. This separation allows the PhysicalPlan to be generated once and cached in a future PR, since it doesn't depend on the input page data.
    2. QueryLists are not not dependent on a particular page and stateless in terms of page contents. They use channelOffset instead of blocks. QueryLists are to be created during planning (before we have input pages), so they can no longer store blocks directly. Instead, each QueryList stores a channelOffset (the index of the block within a page). Since the page structure is consistent across all pages in a session, the channelOffset remains the same. At runtime, when getQuery() is called, the QueryList extracts the appropriate block from the current page using inputPage.getBlock(channelOffset)
    3. New Physical Plan Nodes - LookupDropMergeExec and ParameterizedQueryExec
    4. New LookupExecutionMapper - converts a Physical Plan to Operators for the lookup node, handles dictionary encoding optimization for Enrich (and possibly lookup join in the future). 