### PR TITLE
Backport 9.1.8  Elasticsearch release notes 

### DIFF
--- a/docs/reference/search-connectors/release-notes.md
+++ b/docs/reference/search-connectors/release-notes.md
@@ -13,6 +13,8 @@ If you are an Enterprise Search user and want to upgrade to Elastic 9.0, refer t
 It includes detailed steps, tooling, and resources to help you transition to supported alternatives in 9.x, such as Elasticsearch, the Open Web Crawler, and self-managed connectors.
 :::
 
+## 9.1.8 [connectors-9.1.8-release-notes]
+There are no new features, enhancements, fixes, known issues, or deprecations associated with this release.
 
 ## 9.1.7 [connectors-9.1.7-release-notes]
 There are no new features, enhancements, fixes, known issues, or deprecations associated with this release.

--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -12,6 +12,9 @@ If you are migrating from a version prior to version 9.0, you must first upgrade
 
 % ## Next version [elasticsearch-nextversion-breaking-changes]
 
+## 9.1.8 [elasticsearch-9.1.8-breaking-changes]
+
+There are no breaking changes associated with this release.
 
 ## 9.1.7 [elasticsearch-9.1.7-breaking-changes]
 

--- a/docs/release-notes/changelog-bundles/9.1.8.yml
+++ b/docs/release-notes/changelog-bundles/9.1.8.yml
@@ -1,0 +1,135 @@
+version: 9.1.8
+released: false
+generated: 2025-11-29T00:20:34.256895665Z
+changelogs:
+  - pr: 108875
+    summary: Break on `FieldData` when building global ordinals
+    area: Aggregations
+    type: bug
+    issues:
+      - 97075
+  - pr: 135873
+    summary: Convert `BytesTransportResponse` when proxying response from/to local node
+    area: Network
+    type: bug
+    issues: []
+  - pr: 136886
+    summary: Fix ML calendar event update scalability issues
+    area: Machine Learning
+    type: bug
+    issues: []
+  - pr: 137230
+    summary: Principal Extraction from Certificate RDN Attribute Value in PKI Realm
+    area: Security
+    type: bug
+    issues: []
+  - pr: 137585
+    summary: "Restore API: Fix file settings handling"
+    area: Infra/Settings
+    type: bug
+    issues:
+      - 122429
+  - pr: 137637
+    summary: Fix Bug in `RankDocRetrieverBuilder` when `from` is set to Default (-1)
+    area: Search
+    type: bug
+    issues: []
+  - pr: 137638
+    summary: "ILM Explain: valid JSON on truncated step info"
+    area: ILM+SLM
+    type: bug
+    issues:
+      - 135458
+  - pr: 137652
+    summary: Fix default value for some settings when filtered
+    area: Infra/Settings
+    type: bug
+    issues:
+      - 136333
+  - pr: 137660
+    summary: Improve concurrency design of `GeoIpDownloader`
+    area: Ingest Node
+    type: bug
+    issues:
+      - 135158
+      - 130681
+      - 135132
+      - 133597
+  - pr: 137702
+    summary: Handle index deletion while querying in ES|QL
+    area: ES|QL
+    type: bug
+    issues:
+      - 135863
+  - pr: 137712
+    summary: Add User Profile Size Limit Enforced During Profile Updates
+    area: Security
+    type: bug
+    issues: []
+  - pr: 137850
+    summary: Serverless filtering create from
+    area: Indices APIs
+    type: bug
+    issues: []
+  - pr: 137859
+    summary: Add length validation for `rename_replacement` parameter in snapshot restore request
+    area: Snapshot/Restore
+    type: bug
+    issues: []
+  - pr: 137862
+    summary: "[Vector Search] Fix  wrong vector docvalue_fields"
+    area: Vector Search
+    type: bug
+    issues: []
+  - pr: 137976
+    summary: Fix for GET /_migration/deprecations doesn't check deprecated affix settings correctly
+    area: Infra/Core
+    type: bug
+    issues:
+      - 137008
+  - pr: 138053
+    summary: Upgrade UnboundID LDAP SDK to 7.0.3
+    area: Security
+    type: upgrade
+    issues: []
+  - pr: 138084
+    summary: Handle Query Timeouts During Collector Initialization in `QueryPhase`
+    area: Search
+    type: bug
+    issues: []
+  - pr: 138094
+    summary: "[IRONSCALES] Add `manage`, `create_index`, `read`, `index`, `write`, `delete`, permission for third party agent indices `kibana_system`"
+    area: Authorization
+    type: enhancement
+    issues:
+      - 138093
+  - pr: 138097
+    summary: Bump anomalies index template version to install latest
+    area: Machine Learning
+    type: bug
+    issues: []
+  - pr: 138132
+    summary: Fix integer overflow in block memory estimation
+    area: ES|QL
+    type: bug
+    issues: []
+  - pr: 138140
+    summary: Fix semantic highlighting when using a `knn` query with minimum `similarity`
+    area: Relevance
+    type: bug
+    issues: []
+  - pr: 138228
+    summary: "Fix: Downsample returns appropriate error when target index gets deleted unexpectedly."
+    area: Downsampling
+    type: bug
+    issues: []
+  - pr: 138308
+    summary: Reject mappings that (eventually) set dimension and metric in the same field
+    area: Mapping
+    type: bug
+    issues: []
+  - pr: 138589
+    summary: Upgrading commons-lang3 version for repository-hdfs plugin
+    area: Snapshot/Restore
+    type: upgrade
+    issues: []

--- a/docs/release-notes/deprecations.md
+++ b/docs/release-notes/deprecations.md
@@ -16,6 +16,13 @@ To give you insight into what deprecated features you’re using, {{es}}:
 
 % ## Next version [elasticsearch-nextversion-deprecations]
 
+## 9.1.8 [elasticsearch-9.1.8-deprecations]
+```{applies_to}
+stack: ga 9.1.8
+```
+
+There are no deprecations associated with this release.
+
 ## 9.1.7 [elasticsearch-9.1.7-deprecations]
 
 There are no deprecations associated with this release.

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -20,6 +20,77 @@ To check for security updates, go to [Security announcements for the Elastic sta
 % ### Fixes [elasticsearch-next-fixes]
 % *
 
+## 9.1.8 [elasticsearch-9.1.8-release-notes]
+
+### Features and enhancements [elasticsearch-9.1.8-features-enhancements]
+
+Authorization:
+* [IRONSCALES] Add `manage`, `create_index`, `read`, `index`, `write`, `delete`, permission for third party agent indices `kibana_system` [#138094](https://github.com/elastic/elasticsearch/pull/138094) (issue: [#138093](https://github.com/elastic/elasticsearch/issues/138093))
+
+Security:
+* Upgrade UnboundID LDAP SDK to 7.0.3 [#138053](https://github.com/elastic/elasticsearch/pull/138053)
+
+Snapshot/Restore:
+* Upgrading commons-lang3 version for repository-hdfs plugin [#138589](https://github.com/elastic/elasticsearch/pull/138589)
+
+
+### Fixes [elasticsearch-9.1.8-fixes]
+
+Aggregations:
+* Break on `FieldData` when building global ordinals [#108875](https://github.com/elastic/elasticsearch/pull/108875) (issue: [#97075](https://github.com/elastic/elasticsearch/issues/97075))
+
+Downsampling:
+* Fix: Downsample returns appropriate error when target index gets deleted unexpectedly. [#138228](https://github.com/elastic/elasticsearch/pull/138228)
+
+ES|QL:
+* Fix integer overflow in block memory estimation [#138132](https://github.com/elastic/elasticsearch/pull/138132)
+* Handle index deletion while querying in ES|QL [#137702](https://github.com/elastic/elasticsearch/pull/137702) (issue: [#135863](https://github.com/elastic/elasticsearch/issues/135863))
+
+ILM+SLM:
+* ILM Explain: valid JSON on truncated step info [#137638](https://github.com/elastic/elasticsearch/pull/137638) (issue: [#135458](https://github.com/elastic/elasticsearch/issues/135458))
+
+Indices APIs:
+* Serverless filtering create from [#137850](https://github.com/elastic/elasticsearch/pull/137850)
+
+Infra/Core:
+* Fix for GET /_migration/deprecations doesn't check deprecated affix settings correctly [#137976](https://github.com/elastic/elasticsearch/pull/137976) (issue: [#137008](https://github.com/elastic/elasticsearch/issues/137008))
+
+Infra/Settings:
+* Fix default value for some settings when filtered [#137652](https://github.com/elastic/elasticsearch/pull/137652) (issue: [#136333](https://github.com/elastic/elasticsearch/issues/136333))
+* Restore API: Fix file settings handling [#137585](https://github.com/elastic/elasticsearch/pull/137585) (issue: [#122429](https://github.com/elastic/elasticsearch/issues/122429))
+
+Ingest Node:
+* Improve concurrency design of `GeoIpDownloader` [#137660](https://github.com/elastic/elasticsearch/pull/137660) (issues: [#135158](https://github.com/elastic/elasticsearch/issues/135158), [#130681](https://github.com/elastic/elasticsearch/issues/130681), [#135132](https://github.com/elastic/elasticsearch/issues/135132), [#133597](https://github.com/elastic/elasticsearch/issues/133597))
+
+Machine Learning:
+* Bump anomalies index template version to install latest [#138097](https://github.com/elastic/elasticsearch/pull/138097)
+* Fix ML calendar event update scalability issues [#136886](https://github.com/elastic/elasticsearch/pull/136886)
+
+Mapping:
+* Reject mappings that (eventually) set dimension and metric in the same field [#138308](https://github.com/elastic/elasticsearch/pull/138308)
+
+Network:
+* Convert `BytesTransportResponse` when proxying response from/to local node [#135873](https://github.com/elastic/elasticsearch/pull/135873)
+
+Relevance:
+* Fix semantic highlighting when using a `knn` query with minimum `similarity` [#138140](https://github.com/elastic/elasticsearch/pull/138140)
+
+Search:
+* Fix Bug in `RankDocRetrieverBuilder` when `from` is set to Default (-1) [#137637](https://github.com/elastic/elasticsearch/pull/137637)
+* Handle Query Timeouts During Collector Initialization in `QueryPhase` [#138084](https://github.com/elastic/elasticsearch/pull/138084)
+
+Security:
+* Add User Profile Size Limit Enforced During Profile Updates [#137712](https://github.com/elastic/elasticsearch/pull/137712)
+* Principal Extraction from Certificate RDN Attribute Value in PKI Realm [#137230](https://github.com/elastic/elasticsearch/pull/137230)
+
+Snapshot/Restore:
+* Add length validation for `rename_replacement` parameter in snapshot restore request [#137859](https://github.com/elastic/elasticsearch/pull/137859)
+
+Vector Search:
+* [Vector Search] Fix  wrong vector docvalue_fields [#137862](https://github.com/elastic/elasticsearch/pull/137862)
+
+
+
 ## 9.1.7 [elasticsearch-9.1.7-release-notes]
 
 ### Features and enhancements [elasticsearch-9.1.7-features-enhancements]
@@ -74,7 +145,6 @@ Search:
 * Make `MutableSearchResponse` ref-counted to prevent use-after-close in async search [#134359](https://github.com/elastic/elasticsearch/pull/134359)
 * Remove early phase failure in batched [#136889](https://github.com/elastic/elasticsearch/pull/136889) (issue: [#134151](https://github.com/elastic/elasticsearch/issues/134151))
 * [LTR] Fix feature display order when using explain [#137671](https://github.com/elastic/elasticsearch/pull/137671)
-
 
 ## 9.1.6 [elasticsearch-9.1.6-release-notes]
 


### PR DESCRIPTION
This PR backports the following release note updates to the 9.1 branch.
https://github.com/elastic/elasticsearch/pull/138785
https://github.com/elastic/elasticsearch/pull/138849