### PR TITLE
Backport 9.2.2 and 9.1.8 Elasticsearch release notes

### DIFF
--- a/docs/reference/search-connectors/release-notes.md
+++ b/docs/reference/search-connectors/release-notes.md
@@ -13,6 +13,9 @@ If you are an Enterprise Search user and want to upgrade to Elastic 9.0, refer t
 It includes detailed steps, tooling, and resources to help you transition to supported alternatives in 9.x, such as Elasticsearch, the Open Web Crawler, and self-managed connectors.
 :::
 
+## 9.2.2 [connectors-9.2.2-release-notes]
+There are no new features, enhancements, fixes, known issues, or deprecations associated with this release.
+
 ## 9.2.1 [connectors-9.2.1-release-notes]
 There are no new features, enhancements, fixes, known issues, or deprecations associated with this release.
 
@@ -22,6 +25,9 @@ There are no new features, enhancements, fixes, known issues, or deprecations as
 * Refactored pagination from OFFSET-based to keyset (primary-key) pagination in the MySQL connector. This delivers 3×+ faster syncs on large tables and modest gains on smaller ones. [#3719](https://github.com/elastic/connectors/pull/3719).
 
 * Updated the Jira connector to use the new `/rest/api/3/search/jql` endpoint, ensuring compatibility with Jira’s latest API. [#3710](https://github.com/elastic/connectors/pull/3710).
+
+## 9.1.8 [connectors-9.1.8-release-notes]
+There are no new features, enhancements, fixes, known issues, or deprecations associated with this release.
 
 ## 9.1.7 [connectors-9.1.7-release-notes]
 There are no new features, enhancements, fixes, known issues, or deprecations associated with this release.

--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -12,6 +12,14 @@ If you are migrating from a version prior to version 9.0, you must first upgrade
 
 % ## Next version [elasticsearch-nextversion-breaking-changes]
 
+## 9.2.2 [elasticsearch-9.2.2-breaking-changes]
+
+There are no breaking changes associated with this release.
+
+## 9.1.8 [elasticsearch-9.1.8-breaking-changes]
+
+There are no breaking changes associated with this release.
+
 ## 9.2.1 [elasticsearch-9.2.1-breaking-changes]
 
 There are no breaking changes associated with this release.

--- a/docs/release-notes/changelog-bundles/9.2.2.yml
+++ b/docs/release-notes/changelog-bundles/9.2.2.yml
@@ -1,0 +1,227 @@
+version: 9.2.2
+released: false
+generated: 2025-11-29T00:13:53.871438437Z
+changelogs:
+  - pr: 108875
+    summary: Break on `FieldData` when building global ordinals
+    area: Aggregations
+    type: bug
+    issues:
+      - 97075
+  - pr: 135873
+    summary: Convert `BytesTransportResponse` when proxying response from/to local node
+    area: Network
+    type: bug
+    issues: []
+  - pr: 136886
+    summary: Fix ML calendar event update scalability issues
+    area: Machine Learning
+    type: bug
+    issues: []
+  - pr: 137126
+    summary: Use IVF_PQ for GPU index build for large datasets
+    area: Vector Search
+    type: enhancement
+    issues: []
+  - pr: 137230
+    summary: Principal Extraction from Certificate RDN Attribute Value in PKI Realm
+    area: Security
+    type: bug
+    issues: []
+  - pr: 137430
+    summary: ES|QL - Full text functions accept null as field parameter
+    area: ES|QL
+    type: bug
+    issues:
+      - 136608
+  - pr: 137585
+    summary: "Restore API: Fix file settings handling"
+    area: Infra/Settings
+    type: bug
+    issues:
+      - 122429
+  - pr: 137637
+    summary: Fix Bug in `RankDocRetrieverBuilder` when `from` is set to Default (-1)
+    area: Search
+    type: bug
+    issues: []
+  - pr: 137638
+    summary: "ILM Explain: valid JSON on truncated step info"
+    area: ILM+SLM
+    type: bug
+    issues:
+      - 135458
+  - pr: 137652
+    summary: Fix default value for some settings when filtered
+    area: Infra/Settings
+    type: bug
+    issues:
+      - 136333
+  - pr: 137660
+    summary: Improve concurrency design of `GeoIpDownloader`
+    area: Ingest Node
+    type: bug
+    issues:
+      - 135158
+      - 130681
+      - 135132
+      - 133597
+  - pr: 137671
+    summary: "[LTR] Fix feature display order when using explain"
+    area: Search
+    type: bug
+    issues: []
+  - pr: 137702
+    summary: Handle index deletion while querying in ES|QL
+    area: ES|QL
+    type: bug
+    issues:
+      - 135863
+  - pr: 137718
+    summary: "OTLP: return correct response type for partial successes"
+    area: TSDB
+    type: bug
+    issues: []
+  - pr: 137721
+    summary: Do not calculate query plan diff when not needed
+    area: ES|QL
+    type: enhancement
+    issues: []
+  - pr: 137850
+    summary: Serverless filtering create from
+    area: Indices APIs
+    type: bug
+    issues: []
+  - pr: 137852
+    summary: Fixing get data stream API when data stream index mode has been changed to `time_series`
+    area: Data streams
+    type: bug
+    issues: []
+  - pr: 137859
+    summary: Add length validation for `rename_replacement` parameter in snapshot restore request
+    area: Snapshot/Restore
+    type: bug
+    issues: []
+  - pr: 137862
+    summary: "[Vector Search] Fix  wrong vector docvalue_fields"
+    area: Vector Search
+    type: bug
+    issues: []
+  - pr: 137926
+    summary: Fix parsing of Google Model Garden Anthropic `message_start` event during `chat_completion` operation
+    area: Machine Learning
+    type: bug
+    issues: []
+  - pr: 137964
+    summary: Fix for GET /_migration/deprecations doesn't report node deprecations if low watermark exceeded and GET /_migration/deprecations doesn't report node-level failures properly
+    area: Infra/Core
+    type: bug
+    issues:
+      - 137010
+      - 137004
+  - pr: 137976
+    summary: Fix for GET /_migration/deprecations doesn't check deprecated affix settings correctly
+    area: Infra/Core
+    type: bug
+    issues:
+      - 137008
+  - pr: 137992
+    summary: Prevent passing a pipeline to a logs stream bulk index request body
+    area: Data streams
+    type: bug
+    issues: []
+  - pr: 138053
+    summary: Upgrade UnboundID LDAP SDK to 7.0.3
+    area: Security
+    type: upgrade
+    issues: []
+  - pr: 138084
+    summary: Handle Query Timeouts During Collector Initialization in `QueryPhase`
+    area: Search
+    type: bug
+    issues: []
+  - pr: 138094
+    summary: "[IRONSCALES] Add `manage`, `create_index`, `read`, `index`, `write`, `delete`, permission for third party agent indices `kibana_system`"
+    area: Authorization
+    type: enhancement
+    issues:
+      - 138093
+  - pr: 138097
+    summary: Bump anomalies index template version to install latest
+    area: Machine Learning
+    type: bug
+    issues: []
+  - pr: 138122
+    summary: Add validation for updating `num_threads`
+    area: Machine Learning
+    type: bug
+    issues:
+      - 137129
+  - pr: 138132
+    summary: Fix integer overflow in block memory estimation
+    area: ES|QL
+    type: bug
+    issues: []
+  - pr: 138138
+    summary: Fixing sorted indices for GPU built indices
+    area: Vector Search
+    type: bug
+    issues: []
+  - pr: 138140
+    summary: Fix semantic highlighting when using a `knn` query with minimum `similarity` and when using `bbq_disk`
+    area: Relevance
+    type: bug
+    issues: []
+  - pr: 138228
+    summary: "Fix: Downsample returns appropriate error when target index gets deleted unexpectedly."
+    area: Downsampling
+    type: bug
+    issues: []
+  - pr: 138230
+    summary: Update to Lucene 10.3.2
+    area: Vector Search
+    type: bug
+    issues:
+      - 135718
+  - pr: 138265
+    summary: Fix `index.mapping.pattern_text.disable_templating` not registered issue
+    area: Mapping
+    type: bug
+    issues: []
+  - pr: 138308
+    summary: Reject mappings that (eventually) set dimension and metric in the same field
+    area: Mapping
+    type: bug
+    issues: []
+  - pr: 138363
+    summary: Fix StringIndexOutOfBoundsException in COMPLETION command when options are omitted.
+    area: ES|QL
+    type: bug
+    issues:
+      - 138361
+  - pr: 138438
+    summary: Change `DatabaseNodeService` error logs to warnings
+    area: Ingest Node
+    type: bug
+    issues: []
+  - pr: 138539
+    summary: Handle serialization of null blocks in `AggregateMetricDoubleBlock`
+    area: ES|QL
+    type: bug
+    issues: []
+  - pr: 138589
+    summary: Upgrading commons-lang3 version for repository-hdfs plugin
+    area: Snapshot/Restore
+    type: upgrade
+    issues: []
+  - pr: 138624
+    summary: Handle individual doc parsing failure in bulk request with pipeline
+    area: Ingest Node
+    type: bug
+    issues:
+      - 138445
+  - pr: 138644
+    summary: "Fix: add missing `vector_similarity_support` in InferenceFeatures"
+    area: Search
+    type: bug
+    issues: []

--- a/docs/release-notes/deprecations.md
+++ b/docs/release-notes/deprecations.md
@@ -16,6 +16,14 @@ To give you insight into what deprecated features you’re using, {{es}}:
 
 % ## Next version [elasticsearch-nextversion-deprecations]
 
+## 9.2.2 [elasticsearch-9.2.2-deprecations]
+
+There are no deprecations associated with this release.
+
+## 9.1.8 [elasticsearch-9.1.8-deprecations]
+
+There are no deprecations associated with this release.
+
 ## 9.1.7 [elasticsearch-9.1.7-deprecations]
 
 There are no deprecations associated with this release.

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -20,6 +20,169 @@ To check for security updates, go to [Security announcements for the Elastic sta
 % ### Fixes [elasticsearch-next-fixes]
 % *
 
+## 9.2.2 [elasticsearch-9.2.2-release-notes]
+
+### Features and enhancements [elasticsearch-9.2.2-features-enhancements]
+
+Authorization:
+* [IRONSCALES] Add `manage`, `create_index`, `read`, `index`, `write`, `delete`, permission for third party agent indices `kibana_system` [#138094](https://github.com/elastic/elasticsearch/pull/138094) (issue: [#138093](https://github.com/elastic/elasticsearch/issues/138093))
+
+ES|QL:
+* Do not calculate query plan diff when not needed [#137721](https://github.com/elastic/elasticsearch/pull/137721)
+
+Security:
+* Upgrade UnboundID LDAP SDK to 7.0.3 [#138053](https://github.com/elastic/elasticsearch/pull/138053)
+
+Snapshot/Restore:
+* Upgrading commons-lang3 version for repository-hdfs plugin [#138589](https://github.com/elastic/elasticsearch/pull/138589)
+
+Vector Search:
+* Use IVF_PQ for GPU index build for large datasets [#137126](https://github.com/elastic/elasticsearch/pull/137126)
+
+
+### Fixes [elasticsearch-9.2.2-fixes]
+
+Aggregations:
+* Break on `FieldData` when building global ordinals [#108875](https://github.com/elastic/elasticsearch/pull/108875) (issue: [#97075](https://github.com/elastic/elasticsearch/issues/97075))
+
+Data streams:
+* Fixing get data stream API when data stream index mode has been changed to `time_series` [#137852](https://github.com/elastic/elasticsearch/pull/137852)
+* Prevent passing a pipeline to a logs stream bulk index request body [#137992](https://github.com/elastic/elasticsearch/pull/137992)
+
+Downsampling:
+* Fix: Downsample returns appropriate error when target index gets deleted unexpectedly. [#138228](https://github.com/elastic/elasticsearch/pull/138228)
+
+ES|QL:
+* ES|QL - Full text functions accept null as field parameter [#137430](https://github.com/elastic/elasticsearch/pull/137430) (issue: [#136608](https://github.com/elastic/elasticsearch/issues/136608))
+* Fix StringIndexOutOfBoundsException in COMPLETION command when options are omitted. [#138363](https://github.com/elastic/elasticsearch/pull/138363) (issue: [#138361](https://github.com/elastic/elasticsearch/issues/138361))
+* Fix integer overflow in block memory estimation [#138132](https://github.com/elastic/elasticsearch/pull/138132)
+* Handle index deletion while querying in ES|QL [#137702](https://github.com/elastic/elasticsearch/pull/137702) (issue: [#135863](https://github.com/elastic/elasticsearch/issues/135863))
+* Handle serialization of null blocks in `AggregateMetricDoubleBlock` [#138539](https://github.com/elastic/elasticsearch/pull/138539)
+
+ILM+SLM:
+* ILM Explain: valid JSON on truncated step info [#137638](https://github.com/elastic/elasticsearch/pull/137638) (issue: [#135458](https://github.com/elastic/elasticsearch/issues/135458))
+
+Indices APIs:
+* Serverless filtering create from [#137850](https://github.com/elastic/elasticsearch/pull/137850)
+
+Infra/Core:
+* Fix for GET /_migration/deprecations doesn't check deprecated affix settings correctly [#137976](https://github.com/elastic/elasticsearch/pull/137976) (issue: [#137008](https://github.com/elastic/elasticsearch/issues/137008))
+* Fix for GET /_migration/deprecations doesn't report node deprecations if low watermark exceeded and GET /_migration/deprecations doesn't report node-level failures properly [#137964](https://github.com/elastic/elasticsearch/pull/137964) (issues: [#137010](https://github.com/elastic/elasticsearch/issues/137010), [#137004](https://github.com/elastic/elasticsearch/issues/137004))
+
+Infra/Settings:
+* Fix default value for some settings when filtered [#137652](https://github.com/elastic/elasticsearch/pull/137652) (issue: [#136333](https://github.com/elastic/elasticsearch/issues/136333))
+* Restore API: Fix file settings handling [#137585](https://github.com/elastic/elasticsearch/pull/137585) (issue: [#122429](https://github.com/elastic/elasticsearch/issues/122429))
+
+Ingest Node:
+* Change `DatabaseNodeService` error logs to warnings [#138438](https://github.com/elastic/elasticsearch/pull/138438)
+* Handle individual doc parsing failure in bulk request with pipeline [#138624](https://github.com/elastic/elasticsearch/pull/138624) (issue: [#138445](https://github.com/elastic/elasticsearch/issues/138445))
+* Improve concurrency design of `GeoIpDownloader` [#137660](https://github.com/elastic/elasticsearch/pull/137660) (issues: [#135158](https://github.com/elastic/elasticsearch/issues/135158), [#130681](https://github.com/elastic/elasticsearch/issues/130681), [#135132](https://github.com/elastic/elasticsearch/issues/135132), [#133597](https://github.com/elastic/elasticsearch/issues/133597))
+
+Machine Learning:
+* Add validation for updating `num_threads` [#138122](https://github.com/elastic/elasticsearch/pull/138122) (issue: [#137129](https://github.com/elastic/elasticsearch/issues/137129))
+* Bump anomalies index template version to install latest [#138097](https://github.com/elastic/elasticsearch/pull/138097)
+* Fix ML calendar event update scalability issues [#136886](https://github.com/elastic/elasticsearch/pull/136886)
+* Fix parsing of Google Model Garden Anthropic `message_start` event during `chat_completion` operation [#137926](https://github.com/elastic/elasticsearch/pull/137926)
+
+Mapping:
+* Fix `index.mapping.pattern_text.disable_templating` not registered issue [#138265](https://github.com/elastic/elasticsearch/pull/138265)
+* Reject mappings that (eventually) set dimension and metric in the same field [#138308](https://github.com/elastic/elasticsearch/pull/138308)
+
+Network:
+* Convert `BytesTransportResponse` when proxying response from/to local node [#135873](https://github.com/elastic/elasticsearch/pull/135873)
+
+Relevance:
+* Fix semantic highlighting when using a `knn` query with minimum `similarity` and when using `bbq_disk` [#138140](https://github.com/elastic/elasticsearch/pull/138140)
+
+Search:
+* Fix Bug in `RankDocRetrieverBuilder` when `from` is set to Default (-1) [#137637](https://github.com/elastic/elasticsearch/pull/137637)
+* Fix: add missing `vector_similarity_support` in InferenceFeatures [#138644](https://github.com/elastic/elasticsearch/pull/138644)
+* Handle Query Timeouts During Collector Initialization in `QueryPhase` [#138084](https://github.com/elastic/elasticsearch/pull/138084)
+* [LTR] Fix feature display order when using explain [#137671](https://github.com/elastic/elasticsearch/pull/137671)
+
+Security:
+* Principal Extraction from Certificate RDN Attribute Value in PKI Realm [#137230](https://github.com/elastic/elasticsearch/pull/137230)
+
+Snapshot/Restore:
+* Add length validation for `rename_replacement` parameter in snapshot restore request [#137859](https://github.com/elastic/elasticsearch/pull/137859)
+
+TSDB:
+* OTLP: return correct response type for partial successes [#137718](https://github.com/elastic/elasticsearch/pull/137718)
+
+Vector Search:
+* Fixing sorted indices for GPU built indices [#138138](https://github.com/elastic/elasticsearch/pull/138138)
+* Update to Lucene 10.3.2 [#138230](https://github.com/elastic/elasticsearch/pull/138230) (issue: [#135718](https://github.com/elastic/elasticsearch/issues/135718))
+* [Vector Search] Fix  wrong vector docvalue_fields [#137862](https://github.com/elastic/elasticsearch/pull/137862)
+
+## 9.1.8 [elasticsearch-9.1.8-release-notes]
+
+### Features and enhancements [elasticsearch-9.1.8-features-enhancements]
+
+Authorization:
+* [IRONSCALES] Add `manage`, `create_index`, `read`, `index`, `write`, `delete`, permission for third party agent indices `kibana_system` [#138094](https://github.com/elastic/elasticsearch/pull/138094) (issue: [#138093](https://github.com/elastic/elasticsearch/issues/138093))
+
+Security:
+* Upgrade UnboundID LDAP SDK to 7.0.3 [#138053](https://github.com/elastic/elasticsearch/pull/138053)
+
+Snapshot/Restore:
+* Upgrading commons-lang3 version for repository-hdfs plugin [#138589](https://github.com/elastic/elasticsearch/pull/138589)
+
+
+### Fixes [elasticsearch-9.1.8-fixes]
+
+Aggregations:
+* Break on `FieldData` when building global ordinals [#108875](https://github.com/elastic/elasticsearch/pull/108875) (issue: [#97075](https://github.com/elastic/elasticsearch/issues/97075))
+
+Downsampling:
+* Fix: Downsample returns appropriate error when target index gets deleted unexpectedly. [#138228](https://github.com/elastic/elasticsearch/pull/138228)
+
+ES|QL:
+* Fix integer overflow in block memory estimation [#138132](https://github.com/elastic/elasticsearch/pull/138132)
+* Handle index deletion while querying in ES|QL [#137702](https://github.com/elastic/elasticsearch/pull/137702) (issue: [#135863](https://github.com/elastic/elasticsearch/issues/135863))
+
+ILM+SLM:
+* ILM Explain: valid JSON on truncated step info [#137638](https://github.com/elastic/elasticsearch/pull/137638) (issue: [#135458](https://github.com/elastic/elasticsearch/issues/135458))
+
+Indices APIs:
+* Serverless filtering create from [#137850](https://github.com/elastic/elasticsearch/pull/137850)
+
+Infra/Core:
+* Fix for GET /_migration/deprecations doesn't check deprecated affix settings correctly [#137976](https://github.com/elastic/elasticsearch/pull/137976) (issue: [#137008](https://github.com/elastic/elasticsearch/issues/137008))
+
+Infra/Settings:
+* Fix default value for some settings when filtered [#137652](https://github.com/elastic/elasticsearch/pull/137652) (issue: [#136333](https://github.com/elastic/elasticsearch/issues/136333))
+* Restore API: Fix file settings handling [#137585](https://github.com/elastic/elasticsearch/pull/137585) (issue: [#122429](https://github.com/elastic/elasticsearch/issues/122429))
+
+Ingest Node:
+* Improve concurrency design of `GeoIpDownloader` [#137660](https://github.com/elastic/elasticsearch/pull/137660) (issues: [#135158](https://github.com/elastic/elasticsearch/issues/135158), [#130681](https://github.com/elastic/elasticsearch/issues/130681), [#135132](https://github.com/elastic/elasticsearch/issues/135132), [#133597](https://github.com/elastic/elasticsearch/issues/133597))
+
+Machine Learning:
+* Bump anomalies index template version to install latest [#138097](https://github.com/elastic/elasticsearch/pull/138097)
+* Fix ML calendar event update scalability issues [#136886](https://github.com/elastic/elasticsearch/pull/136886)
+
+Mapping:
+* Reject mappings that (eventually) set dimension and metric in the same field [#138308](https://github.com/elastic/elasticsearch/pull/138308)
+
+Network:
+* Convert `BytesTransportResponse` when proxying response from/to local node [#135873](https://github.com/elastic/elasticsearch/pull/135873)
+
+Relevance:
+* Fix semantic highlighting when using a `knn` query with minimum `similarity` [#138140](https://github.com/elastic/elasticsearch/pull/138140)
+
+Search:
+* Fix Bug in `RankDocRetrieverBuilder` when `from` is set to Default (-1) [#137637](https://github.com/elastic/elasticsearch/pull/137637)
+* Handle Query Timeouts During Collector Initialization in `QueryPhase` [#138084](https://github.com/elastic/elasticsearch/pull/138084)
+
+Security:
+* Add User Profile Size Limit Enforced During Profile Updates [#137712](https://github.com/elastic/elasticsearch/pull/137712)
+* Principal Extraction from Certificate RDN Attribute Value in PKI Realm [#137230](https://github.com/elastic/elasticsearch/pull/137230)
+
+Snapshot/Restore:
+* Add length validation for `rename_replacement` parameter in snapshot restore request [#137859](https://github.com/elastic/elasticsearch/pull/137859)
+
+Vector Search:
+* [Vector Search] Fix  wrong vector docvalue_fields [#137862](https://github.com/elastic/elasticsearch/pull/137862)
+
 ## 9.1.7 [elasticsearch-9.1.7-release-notes]
 
 ### Features and enhancements [elasticsearch-9.1.7-features-enhancements]


### PR DESCRIPTION
This PR backports the following release note updates to the 9.1 branch.
https://github.com/elastic/elasticsearch/pull/138784
https://github.com/elastic/elasticsearch/pull/138849