### PR TITLE
ESQL: Use a 9.3-exclusive version for exp. histogram

### DIFF
--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
@@ -370,7 +370,7 @@ public enum DataType implements Writeable {
         builder().esType("exponential_histogram")
             .estimatedSize(16 * 160)// guess 160 buckets (OTEL default for positive values only histograms) with 16 bytes per bucket
             .docValues()
-            .underConstruction(DataTypesTransportVersions.RESOLVE_FIELDS_RESPONSE_USED_TV)
+            .underConstruction(DataTypesTransportVersions.TEXT_SIMILARITY_RANK_DOC_EXPLAIN_CHUNKS_VERSION)
     ),
 
     /*
@@ -1043,10 +1043,11 @@ public enum DataType implements Writeable {
         );
 
         /**
-         * First transport version after the PR that introduced the exponential histogram data type.
+         * First transport version after the PR that introduced the exponential histogram data type which was NOT also backported to 9.2.
+         * (Exp. histogram was added as SNAPSHOT-only to 9.3.)
          */
-        public static final TransportVersion RESOLVE_FIELDS_RESPONSE_USED_TV = TransportVersion.fromName(
-            "esql_resolve_fields_response_used"
+        public static final TransportVersion TEXT_SIMILARITY_RANK_DOC_EXPLAIN_CHUNKS_VERSION = TransportVersion.fromName(
+            "text_similarity_rank_docs_explain_chunks"
         );
     }
 }


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/137432 added a minimum transport version to data types that are *under construction*, so that even in SNAPSHOT builds a coordinator node can decide whether other nodes or clusters are new enough to understand a data type that recently became supported in ESQL.

The `EXPONENTIAL_HISTOGRAM` type is one such type that is currently under construction. https://github.com/elastic/elasticsearch/pull/137432 wrongly gave it a minimum transport version that was also backported to 9.2, even though the type is exclusive to 9.3 so far (even in SNAPSHOT builds).

To keep things consistent, use a newer minimum transport version for `EXPONENTIAL_HISTOGRAM`, namely the first version after it was added which was also not backported to 9.2.

(There wasn't any breakage from this because we don't have tests that do anything with `EXPONENTIAL_HISTOGRAM` in mixed 9.2/9.3 clusters/CCS to my knowledge.)