### PR TITLE
Exclude search tests from common CCS test suite

### DIFF
--- a/qa/ccs-common-rest/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/TestSuiteApiCheck.java
+++ b/qa/ccs-common-rest/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/TestSuiteApiCheck.java
@@ -25,13 +25,16 @@ class TestSuiteApiCheck {
      * Returns true if the test suite should run the tests for the given API.
      * @param testSuite a concrete subclass of ESClientYamlSuiteTestCase
      * @param apiName The API name as described in the rest spec e.g. `search`
-     * @return True if the test
+     * @return True if the test should be run
      */
     public static boolean shouldExecuteTest(ESClientYamlSuiteTestCase testSuite, String apiName) {
         return switch (testSuite) {
             case CssSearchYamlTestSuiteIT cssSearch -> isSearchApi(apiName);
             case RcsCcsSearchYamlTestSuiteIT rssSearch -> isSearchApi(apiName);
-            default -> true;
+            // Search tests are not executed in the common suite.
+            case CcsCommonYamlTestSuiteIT cssCommon -> isSearchApi(apiName) == false;
+            case RcsCcsCommonYamlTestSuiteIT rssCommon -> isSearchApi(apiName) == false;
+            default -> throw new IllegalArgumentException("unexpected test suite [" + testSuite.getClass().getSimpleName() + "]");
         };
     }
 


### PR DESCRIPTION
Follow on from https://github.com/elastic/elasticsearch/pull/139107 which did not actually include the logic to stop the search tests being run in the _common_ test suite.

I tried adding a unit test for this logic but Gradle complained. As noted in https://github.com/elastic/elasticsearch/pull/139107  this should been seen as a long term solution. 