### PR TITLE
Assigned dedicated master roles to nodes running the old version in m…

### DIFF
--- a/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/Clusters.java
+++ b/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/Clusters.java
@@ -18,18 +18,16 @@ public class Clusters {
         boolean isDetachedVersion = System.getProperty("tests.bwc.refspec.main") != null;
         var cluster = ElasticsearchCluster.local()
             .distribution(DistributionType.DEFAULT)
-            .withNode(node -> node.version(oldVersionString, isDetachedVersion))
-            .withNode(node -> node.version(Version.CURRENT))
-            .withNode(node -> node.version(oldVersionString, isDetachedVersion))
-            .withNode(node -> node.version(Version.CURRENT))
+            .withNode(node -> node.version(oldVersionString, isDetachedVersion).setting("node.roles", "[master,data,ingest]"))
+            .withNode(node -> node.version(Version.CURRENT).setting("node.roles", "[data,ingest]"))
+            .withNode(node -> node.version(oldVersionString, isDetachedVersion).setting("node.roles", "[master,data,ingest]"))
+            .withNode(node -> node.version(Version.CURRENT).setting("node.roles", "[data,ingest]"))
             .setting("xpack.security.enabled", "false")
             .setting("xpack.license.self_generated.type", "trial");
         if (supportRetryOnShardFailures(oldVersion) == false) {
             cluster.setting("cluster.routing.rebalance.enable", "none");
         }
-        // Temporarily disable DocumentMapper and MapperService assertions for #138796
-        // TODO set back to: 8.18.0
-        if (oldVersion.before(Version.fromString("9.3.0"))) {
+        if (oldVersion.before(Version.fromString("8.18.0"))) {
             cluster.jvmArg("-da:org.elasticsearch.index.mapper.DocumentMapper");
             cluster.jvmArg("-da:org.elasticsearch.index.mapper.MapperService");
         }

--- a/x-pack/plugin/inference/qa/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/inference/qa/mixed/MixedClustersSpec.java
+++ b/x-pack/plugin/inference/qa/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/inference/qa/mixed/MixedClustersSpec.java
@@ -17,8 +17,8 @@ public class MixedClustersSpec {
         boolean isDetachedVersion = System.getProperty("tests.bwc.refspec.main") != null;
         return ElasticsearchCluster.local()
             .distribution(DistributionType.DEFAULT)
-            .withNode(node -> node.version(oldVersion, isDetachedVersion))
-            .withNode(node -> node.version(Version.CURRENT))
+            .withNode(node -> node.version(oldVersion, isDetachedVersion).setting("node.roles", "[master,data,ingest]"))
+            .withNode(node -> node.version(Version.CURRENT).setting("node.roles", "[data,ingest]"))
             .setting("xpack.security.enabled", "false")
             .setting("xpack.license.self_generated.type", "trial")
             .build();


### PR DESCRIPTION
This addresses https://github.com/elastic/elasticsearch/issues/138796.

My explanation as to why we need to do this can be found [here](https://github.com/elastic/elasticsearch/issues/138796#issuecomment-3634607896).

Since these tests are super flaky, its difficult to say whether this 100% fixes our problem. That being said, I've rerun the entire suite five times in a CI env, which would normally fail consistency, and this time everything passes.

Note, we need to use the `test-full-bwc` label as its what originally caught these issues.