### PR TITLE
Avoid having a vector similarity function after FORK / Subqueries

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/VectorSimilarityFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/vector/VectorSimilarityFunction.java
@@ -219,7 +219,7 @@ public abstract class VectorSimilarityFunction extends BinaryScalarFunction
         return (plan, failures) -> {
             plan.forEachUp(LogicalPlan.class, lp -> {
                 if (lp instanceof Fork) {
-                    failures.add(Failure.fail(plan,"Vector similarity functions cannot be added after FORK or Subqueries"));
+                    failures.add(Failure.fail(plan, "Vector similarity functions cannot be added after FORK or Subqueries"));
                 }
             });
         };


### PR DESCRIPTION
Vector similarity functions can't yet be pushed down to FORK or subqueries until the work in https://github.com/elastic/elasticsearch/issues/137679 is done.

In the meantime, we will forbid to use vector similarity functions when they can't be pushed down.