### PR TITLE
[9.1] Improve stats performance when the number of shards is very large (#138126)

### DIFF
--- a/docs/changelog/138126.yaml
+++ b/docs/changelog/138126.yaml
@@ -1,0 +1,6 @@
+pr: 138126
+summary: Improving performance of stats APIs when the number of shards is very large
+area: Stats
+type: bug
+issues:
+ - 97222

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
@@ -22,11 +22,13 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardsIterator;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.util.CachedSupplier;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.CommitStats;
 import org.elasticsearch.index.seqno.RetentionLeaseStats;
 import org.elasticsearch.index.seqno.SeqNoStats;
 import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.indices.IndicesQueryCache;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.injection.guice.Inject;
 import org.elasticsearch.tasks.CancellableTask;
@@ -35,12 +37,13 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
+import java.util.function.Supplier;
 
 public class TransportIndicesStatsAction extends TransportBroadcastByNodeAction<
     IndicesStatsRequest,
     IndicesStatsResponse,
     ShardStats,
-    Void> {
+    Supplier<IndicesQueryCache.CacheTotals>> {
 
     private final IndicesService indicesService;
     private final ProjectResolver projectResolver;
@@ -113,18 +116,31 @@ public class TransportIndicesStatsAction extends TransportBroadcastByNodeAction<
     }
 
     @Override
+    protected Supplier<IndicesQueryCache.CacheTotals> createNodeContext() {
+        return CachedSupplier.wrap(() -> IndicesQueryCache.getCacheTotalsForAllShards(indicesService));
+    }
+
+    @Override
     protected void shardOperation(
         IndicesStatsRequest request,
         ShardRouting shardRouting,
         Task task,
-        Void nodeContext,
+        Supplier<IndicesQueryCache.CacheTotals> context,
         ActionListener<ShardStats> listener
     ) {
         ActionListener.completeWith(listener, () -> {
             assert task instanceof CancellableTask;
             IndexService indexService = indicesService.indexServiceSafe(shardRouting.shardId().getIndex());
             IndexShard indexShard = indexService.getShard(shardRouting.shardId().id());
-            CommonStats commonStats = CommonStats.getShardLevelStats(indicesService.getIndicesQueryCache(), indexShard, request.flags());
+            CommonStats commonStats = CommonStats.getShardLevelStats(
+                indicesService.getIndicesQueryCache(),
+                indexShard,
+                request.flags(),
+                () -> {
+                    final IndicesQueryCache queryCache = indicesService.getIndicesQueryCache();
+                    return (queryCache == null) ? 0L : queryCache.getSharedRamSizeForShard(indexShard.shardId(), context.get());
+                }
+            );
             CommitStats commitStats;
             SeqNoStats seqNoStats;
             RetentionLeaseStats retentionLeaseStats;

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -186,6 +186,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
@@ -519,33 +520,40 @@ public class IndicesService extends AbstractLifecycleComponent
     }
 
     static Map<Index, List<IndexShardStats>> statsByShard(final IndicesService indicesService, final CommonStatsFlags flags) {
+        Map<ShardId, Long> shardIdToSharedRam = IndicesQueryCache.getSharedRamSizeForAllShards(indicesService);
         final Map<Index, List<IndexShardStats>> statsByShard = new HashMap<>();
-
         for (final IndexService indexService : indicesService) {
             for (final IndexShard indexShard : indexService) {
+                // get the shared ram for this shard id (or zero if there's nothing in the map)
                 try {
-                    final IndexShardStats indexShardStats = indicesService.indexShardStats(indicesService, indexShard, flags);
-
+                    final IndexShardStats indexShardStats = indicesService.indexShardStats(
+                        indicesService,
+                        indexShard,
+                        flags,
+                        () -> shardIdToSharedRam.getOrDefault(indexShard.shardId(), 0L)
+                    );
                     if (indexShardStats == null) {
                         continue;
                     }
-
                     if (statsByShard.containsKey(indexService.index()) == false) {
                         statsByShard.put(indexService.index(), arrayAsArrayList(indexShardStats));
                     } else {
                         statsByShard.get(indexService.index()).add(indexShardStats);
                     }
                 } catch (IllegalIndexShardStateException | AlreadyClosedException e) {
-                    // we can safely ignore illegal state on ones that are closing for example
                     logger.trace(() -> format("%s ignoring shard stats", indexShard.shardId()), e);
                 }
             }
         }
-
         return statsByShard;
     }
 
-    IndexShardStats indexShardStats(final IndicesService indicesService, final IndexShard indexShard, final CommonStatsFlags flags) {
+    IndexShardStats indexShardStats(
+        final IndicesService indicesService,
+        final IndexShard indexShard,
+        final CommonStatsFlags flags,
+        final Supplier<Long> precomputedSharedRam
+    ) {
         if (indexShard.routingEntry() == null) {
             return null;
         }
@@ -570,7 +578,7 @@ public class IndicesService extends AbstractLifecycleComponent
                 new ShardStats(
                     indexShard.routingEntry(),
                     indexShard.shardPath(),
-                    CommonStats.getShardLevelStats(indicesService.getIndicesQueryCache(), indexShard, flags),
+                    CommonStats.getShardLevelStats(indicesService.getIndicesQueryCache(), indexShard, flags, precomputedSharedRam),
                     commitStats,
                     seqNoStats,
                     retentionLeaseStats,

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/VersionStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/VersionStatsTests.java
@@ -115,7 +115,7 @@ public class VersionStatsTests extends AbstractWireSerializingTestCase<VersionSt
         ShardStats shardStats = new ShardStats(
             shardRouting,
             new ShardPath(false, path, path, shardRouting.shardId()),
-            CommonStats.getShardLevelStats(null, indexShard, new CommonStatsFlags(CommonStatsFlags.Flag.Store)),
+            CommonStats.getShardLevelStats(null, indexShard, new CommonStatsFlags(CommonStatsFlags.Flag.Store), () -> 0L),
             null,
             null,
             null,

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -1626,7 +1626,7 @@ public class IndexShardTests extends IndexShardTestCase {
         ShardStats stats = new ShardStats(
             shard.routingEntry(),
             shard.shardPath(),
-            CommonStats.getShardLevelStats(new IndicesQueryCache(Settings.EMPTY), shard, new CommonStatsFlags()),
+            CommonStats.getShardLevelStats(new IndicesQueryCache(Settings.EMPTY), shard, new CommonStatsFlags(), () -> 0L),
             shard.commitStats(),
             shard.seqNoStats(),
             shard.getRetentionLeaseStats(),

--- a/server/src/test/java/org/elasticsearch/indices/IndicesQueryCacheTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesQueryCacheTests.java
@@ -30,8 +30,11 @@ import org.apache.lucene.util.Accountable;
 import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.cache.query.QueryCacheStats;
 import org.elasticsearch.index.cache.query.TrivialQueryCachingPolicy;
+import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESTestCase;
 
@@ -44,6 +47,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThan;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class IndicesQueryCacheTests extends ESTestCase {
 
@@ -54,10 +59,6 @@ public class IndicesQueryCacheTests extends ESTestCase {
 
         DummyQuery(int id) {
             this(Integer.toString(id), 10);
-        }
-
-        DummyQuery(String id) {
-            this(id, 10);
         }
 
         DummyQuery(String id, long sizeInCache) {
@@ -86,10 +87,10 @@ public class IndicesQueryCacheTests extends ESTestCase {
         }
 
         @Override
-        public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+        public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) {
             return new ConstantScoreWeight(this, boost) {
                 @Override
-                public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
+                public ScorerSupplier scorerSupplier(LeafReaderContext context) {
                     Scorer scorer = new ConstantScoreScorer(score(), scoreMode, DocIdSetIterator.all(context.reader().maxDoc()));
                     return new DefaultScorerSupplier(scorer);
                 }
@@ -125,7 +126,7 @@ public class IndicesQueryCacheTests extends ESTestCase {
         IndicesQueryCache cache = new IndicesQueryCache(settings);
         s.setQueryCache(cache);
 
-        QueryCacheStats stats = cache.getStats(shard);
+        QueryCacheStats stats = cache.getStats(shard, () -> 0L);
         assertEquals(0L, stats.getCacheSize());
         assertEquals(0L, stats.getCacheCount());
         assertEquals(0L, stats.getHitCount());
@@ -133,7 +134,7 @@ public class IndicesQueryCacheTests extends ESTestCase {
 
         assertEquals(1, s.count(new DummyQuery(0)));
 
-        stats = cache.getStats(shard);
+        stats = cache.getStats(shard, () -> 0L);
         assertEquals(1L, stats.getCacheSize());
         assertEquals(1L, stats.getCacheCount());
         assertEquals(0L, stats.getHitCount());
@@ -143,7 +144,7 @@ public class IndicesQueryCacheTests extends ESTestCase {
             assertEquals(1, s.count(new DummyQuery(i)));
         }
 
-        stats = cache.getStats(shard);
+        stats = cache.getStats(shard, () -> 0L);
         assertEquals(10L, stats.getCacheSize());
         assertEquals(20L, stats.getCacheCount());
         assertEquals(0L, stats.getHitCount());
@@ -151,7 +152,7 @@ public class IndicesQueryCacheTests extends ESTestCase {
 
         s.count(new DummyQuery(10));
 
-        stats = cache.getStats(shard);
+        stats = cache.getStats(shard, () -> 0L);
         assertEquals(10L, stats.getCacheSize());
         assertEquals(20L, stats.getCacheCount());
         assertEquals(1L, stats.getHitCount());
@@ -160,7 +161,7 @@ public class IndicesQueryCacheTests extends ESTestCase {
         IOUtils.close(r, dir);
 
         // got emptied, but no changes to other metrics
-        stats = cache.getStats(shard);
+        stats = cache.getStats(shard, () -> 0L);
         assertEquals(0L, stats.getCacheSize());
         assertEquals(20L, stats.getCacheCount());
         assertEquals(1L, stats.getHitCount());
@@ -169,7 +170,7 @@ public class IndicesQueryCacheTests extends ESTestCase {
         cache.onClose(shard);
 
         // forgot everything
-        stats = cache.getStats(shard);
+        stats = cache.getStats(shard, () -> 0L);
         assertEquals(0L, stats.getCacheSize());
         assertEquals(0L, stats.getCacheCount());
         assertEquals(0L, stats.getHitCount());
@@ -209,13 +210,13 @@ public class IndicesQueryCacheTests extends ESTestCase {
 
         assertEquals(1, s1.count(new DummyQuery(0)));
 
-        QueryCacheStats stats1 = cache.getStats(shard1);
+        QueryCacheStats stats1 = cache.getStats(shard1, () -> 0L);
         assertEquals(1L, stats1.getCacheSize());
         assertEquals(1L, stats1.getCacheCount());
         assertEquals(0L, stats1.getHitCount());
         assertEquals(2L, stats1.getMissCount());
 
-        QueryCacheStats stats2 = cache.getStats(shard2);
+        QueryCacheStats stats2 = cache.getStats(shard2, () -> 0L);
         assertEquals(0L, stats2.getCacheSize());
         assertEquals(0L, stats2.getCacheCount());
         assertEquals(0L, stats2.getHitCount());
@@ -223,13 +224,13 @@ public class IndicesQueryCacheTests extends ESTestCase {
 
         assertEquals(1, s2.count(new DummyQuery(0)));
 
-        stats1 = cache.getStats(shard1);
+        stats1 = cache.getStats(shard1, () -> 0L);
         assertEquals(1L, stats1.getCacheSize());
         assertEquals(1L, stats1.getCacheCount());
         assertEquals(0L, stats1.getHitCount());
         assertEquals(2L, stats1.getMissCount());
 
-        stats2 = cache.getStats(shard2);
+        stats2 = cache.getStats(shard2, () -> 0L);
         assertEquals(1L, stats2.getCacheSize());
         assertEquals(1L, stats2.getCacheCount());
         assertEquals(0L, stats2.getHitCount());
@@ -239,13 +240,13 @@ public class IndicesQueryCacheTests extends ESTestCase {
             assertEquals(1, s2.count(new DummyQuery(i)));
         }
 
-        stats1 = cache.getStats(shard1);
+        stats1 = cache.getStats(shard1, () -> 0L);
         assertEquals(0L, stats1.getCacheSize()); // evicted
         assertEquals(1L, stats1.getCacheCount());
         assertEquals(0L, stats1.getHitCount());
         assertEquals(2L, stats1.getMissCount());
 
-        stats2 = cache.getStats(shard2);
+        stats2 = cache.getStats(shard2, () -> 0L);
         assertEquals(10L, stats2.getCacheSize());
         assertEquals(20L, stats2.getCacheCount());
         assertEquals(1L, stats2.getHitCount());
@@ -254,13 +255,13 @@ public class IndicesQueryCacheTests extends ESTestCase {
         IOUtils.close(r1, dir1);
 
         // no changes
-        stats1 = cache.getStats(shard1);
+        stats1 = cache.getStats(shard1, () -> 0L);
         assertEquals(0L, stats1.getCacheSize());
         assertEquals(1L, stats1.getCacheCount());
         assertEquals(0L, stats1.getHitCount());
         assertEquals(2L, stats1.getMissCount());
 
-        stats2 = cache.getStats(shard2);
+        stats2 = cache.getStats(shard2, () -> 0L);
         assertEquals(10L, stats2.getCacheSize());
         assertEquals(20L, stats2.getCacheCount());
         assertEquals(1L, stats2.getHitCount());
@@ -269,13 +270,13 @@ public class IndicesQueryCacheTests extends ESTestCase {
         cache.onClose(shard1);
 
         // forgot everything about shard1
-        stats1 = cache.getStats(shard1);
+        stats1 = cache.getStats(shard1, () -> 0L);
         assertEquals(0L, stats1.getCacheSize());
         assertEquals(0L, stats1.getCacheCount());
         assertEquals(0L, stats1.getHitCount());
         assertEquals(0L, stats1.getMissCount());
 
-        stats2 = cache.getStats(shard2);
+        stats2 = cache.getStats(shard2, () -> 0L);
         assertEquals(10L, stats2.getCacheSize());
         assertEquals(20L, stats2.getCacheCount());
         assertEquals(1L, stats2.getHitCount());
@@ -285,14 +286,14 @@ public class IndicesQueryCacheTests extends ESTestCase {
         cache.onClose(shard2);
 
         // forgot everything about shard2
-        stats1 = cache.getStats(shard1);
+        stats1 = cache.getStats(shard1, () -> 0L);
         assertEquals(0L, stats1.getCacheSize());
         assertEquals(0L, stats1.getCacheCount());
         assertEquals(0L, stats1.getHitCount());
         assertEquals(0L, stats1.getMissCount());
         assertEquals(0L, stats1.getMemorySizeInBytes());
 
-        stats2 = cache.getStats(shard2);
+        stats2 = cache.getStats(shard2, () -> 0L);
         assertEquals(0L, stats2.getCacheSize());
         assertEquals(0L, stats2.getCacheCount());
         assertEquals(0L, stats2.getHitCount());
@@ -341,7 +342,7 @@ public class IndicesQueryCacheTests extends ESTestCase {
             assertEquals(1, s2.count(new DummyQuery(i)));
         }
 
-        QueryCacheStats stats1 = cache.getStats(shard1);
+        QueryCacheStats stats1 = cache.getStats(shard1, () -> 0L);
         assertEquals(0L, stats1.getCacheSize());
         assertEquals(1L, stats1.getCacheCount());
 
@@ -420,12 +421,30 @@ public class IndicesQueryCacheTests extends ESTestCase {
         assertNotSame(weight, cached);
         assertFalse(weight.scorerCalled);
         assertFalse(weight.scorerSupplierCalled);
-        cached.scorerSupplier(s.getIndexReader().leaves().get(0));
+        cached.scorerSupplier(s.getIndexReader().leaves().getFirst());
         assertFalse(weight.scorerCalled);
         assertTrue(weight.scorerSupplierCalled);
         IOUtils.close(r, dir);
         cache.onClose(shard);
         cache.close();
+    }
+
+    private IndicesService getTestIndicesService(List<Tuple<IndexShard, Long>> shardsAndSizes, long sharedRamBytesUsed) {
+        IndicesQueryCache queryCache = mock(IndicesQueryCache.class);
+        for (Tuple<IndexShard, Long> shardAndSize : shardsAndSizes) {
+            when(queryCache.getCacheSizeForShard(shardAndSize.v1().shardId())).thenReturn(shardAndSize.v2());
+        }
+        when(queryCache.getSharedRamBytesUsed()).thenReturn(sharedRamBytesUsed);
+        return getTestIndicesService(shardsAndSizes.stream().map(Tuple::v1).toList(), queryCache);
+    }
+
+    private IndicesService getTestIndicesService(List<IndexShard> shards, IndicesQueryCache queryCache) {
+        IndexService indexService = mock(IndexService.class);
+        when(indexService.iterator()).thenAnswer(ignored -> shards.iterator());
+        IndicesService indicesService = mock(IndicesService.class);
+        when(indicesService.iterator()).thenAnswer(ignored -> List.of(indexService).iterator());
+        when(indicesService.getIndicesQueryCache()).thenReturn(queryCache);
+        return indicesService;
     }
 
     public void testGetStatsMemory() throws Exception {
@@ -458,7 +477,7 @@ public class IndicesQueryCacheTests extends ESTestCase {
         shard1Segment2Searcher.setQueryCache(cache);
         shard2Searcher.setQueryCache(cache);
 
-        assertEquals(0L, cache.getStats(shard1).getMemorySizeInBytes());
+        assertEquals(0L, cache.getStats(shard1, () -> 0L).getMemorySizeInBytes());
 
         final long largeQuerySize = randomIntBetween(100, 1000);
         final long smallQuerySize = randomIntBetween(10, 50);
@@ -469,65 +488,93 @@ public class IndicesQueryCacheTests extends ESTestCase {
         for (int i = 0; i < shard1Queries; ++i) {
             shard1Segment1Searcher.count(new DummyQuery("ingest1-" + i, largeQuerySize));
         }
+        IndexShard indexShard1 = mock(IndexShard.class);
+        when(indexShard1.shardId()).thenReturn(shard1);
+        IndexShard indexShard2 = mock(IndexShard.class);
+        when(indexShard2.shardId()).thenReturn(shard2);
         long shard1Segment1CacheMemory = calculateActualCacheMemoryForSegment(shard1Queries, largeQuerySize, shard1Segment1Docs);
-        assertThat(cache.getStats(shard1).getMemorySizeInBytes(), equalTo(shard1Segment1CacheMemory));
-        assertThat(cache.getStats(shard2).getMemorySizeInBytes(), equalTo(0L));
-        for (int i = 0; i < shard2Queries; ++i) {
-            shard2Searcher.count(new DummyQuery("ingest2-" + i, smallQuerySize));
-        }
-        /*
-         * Now that we have cached some smaller things for shard2, the cache memory for shard1 has gone down. This is expected because we
-         * report cache memory proportional to the number of segments for each shard, ignoring the number of documents or the actual
-         * document sizes. Since the shard2 requests were smaller, the average cache memory size per segment has now gone down.
-         */
-        assertThat(cache.getStats(shard1).getMemorySizeInBytes(), lessThan(shard1Segment1CacheMemory));
-        long shard1CacheBytes = cache.getStats(shard1).getMemorySizeInBytes();
-        long shard2CacheBytes = cache.getStats(shard2).getMemorySizeInBytes();
-        long shard2Segment1CacheMemory = calculateActualCacheMemoryForSegment(shard2Queries, smallQuerySize, shard2Segment1Docs);
 
-        long totalMemory = shard1Segment1CacheMemory + shard2Segment1CacheMemory;
-        // Each shard has some fixed overhead that we need to account for:
-        long shard1Overhead = calculateOverheadForSegment(shard1Queries, shard1Segment1Docs);
-        long shard2Overhead = calculateOverheadForSegment(shard2Queries, shard2Segment1Docs);
-        long totalMemoryMinusOverhead = totalMemory - (shard1Overhead + shard2Overhead);
-        /*
-         * Note that the expected amount of memory we're calculating is based on the proportion of the number of queries to each shard
-         * (since each shard currently only has queries to one segment)
-         */
-        double shard1Segment1CacheMemoryShare = ((double) shard1Queries / (shard1Queries + shard2Queries)) * (totalMemoryMinusOverhead)
-            + shard1Overhead;
-        double shard2Segment1CacheMemoryShare = ((double) shard2Queries / (shard1Queries + shard2Queries)) * (totalMemoryMinusOverhead)
-            + shard2Overhead;
-        assertThat((double) shard1CacheBytes, closeTo(shard1Segment1CacheMemoryShare, 1)); // accounting for rounding
-        assertThat((double) shard2CacheBytes, closeTo(shard2Segment1CacheMemoryShare, 1)); // accounting for rounding
-
-        // Now we cache just more "big" searches on shard1, but on a different segment:
-        for (int i = 0; i < shard1Queries; ++i) {
-            shard1Segment2Searcher.count(new DummyQuery("ingest3-" + i, largeQuerySize));
+        {
+            IndicesService indicesService = getTestIndicesService(List.of(indexShard1), cache);
+            IndicesQueryCache.CacheTotals cacheTotals = IndicesQueryCache.getCacheTotalsForAllShards(indicesService);
+            final long sharedRamSizeShard1 = cache.getSharedRamSizeForShard(shard1, cacheTotals);
+            final long sharedRamSizeShard2 = cache.getSharedRamSizeForShard(shard2, cacheTotals);
+            assertThat(cache.getStats(shard1, () -> sharedRamSizeShard1).getMemorySizeInBytes(), equalTo(shard1Segment1CacheMemory));
+            assertThat(cache.getStats(shard2, () -> sharedRamSizeShard2).getMemorySizeInBytes(), equalTo(0L));
+            for (int i = 0; i < shard2Queries; ++i) {
+                shard2Searcher.count(new DummyQuery("ingest2-" + i, smallQuerySize));
+            }
         }
-        long shard1Segment2CacheMemory = calculateActualCacheMemoryForSegment(shard1Queries, largeQuerySize, shard1Segment2Docs);
-        totalMemory = shard1Segment1CacheMemory + shard2Segment1CacheMemory + shard1Segment2CacheMemory;
-        // Each shard has some fixed overhead that we need to account for:
-        shard1Overhead = shard1Overhead + calculateOverheadForSegment(shard1Queries, shard1Segment2Docs);
-        totalMemoryMinusOverhead = totalMemory - (shard1Overhead + shard2Overhead);
-        /*
-         * Note that the expected amount of memory we're calculating is based on the proportion of the number of queries to each segment.
-         * The number of documents and the size of documents is irrelevant (aside from computing the fixed overhead).
-         */
-        shard1Segment1CacheMemoryShare = ((double) (2 * shard1Queries) / ((2 * shard1Queries) + shard2Queries)) * (totalMemoryMinusOverhead)
-            + shard1Overhead;
-        shard1CacheBytes = cache.getStats(shard1).getMemorySizeInBytes();
-        assertThat((double) shard1CacheBytes, closeTo(shard1Segment1CacheMemoryShare, 1)); // accounting for rounding
+        double shard1Segment1CacheMemoryShare;
+        {
+            /*
+             * Now that we have cached some smaller things for shard2, the cache memory for shard1 has gone down. This is expected because
+             * we report cache memory proportional to the number of segments for each shard, ignoring the number of documents or the actual
+             * document sizes. Since the shard2 requests were smaller, the average cache memory size per segment has now gone down.
+             */
+            IndicesService indicesService = getTestIndicesService(List.of(indexShard1, indexShard2), cache);
+            IndicesQueryCache.CacheTotals cacheTotals = IndicesQueryCache.getCacheTotalsForAllShards(indicesService);
+            final long sharedRamSizeShard1 = cache.getSharedRamSizeForShard(shard1, cacheTotals);
+            final long sharedRamSizeShard2 = cache.getSharedRamSizeForShard(shard2, cacheTotals);
+            assertThat(cache.getStats(shard1, () -> sharedRamSizeShard1).getMemorySizeInBytes(), lessThan(shard1Segment1CacheMemory));
+            long shard1CacheBytes = cache.getStats(shard1, () -> sharedRamSizeShard1).getMemorySizeInBytes();
+            long shard2CacheBytes = cache.getStats(shard2, () -> sharedRamSizeShard2).getMemorySizeInBytes();
+            long shard2Segment1CacheMemory = calculateActualCacheMemoryForSegment(shard2Queries, smallQuerySize, shard2Segment1Docs);
 
-        // Now make sure the cache only has items for shard2:
-        for (int i = 0; i < (maxCacheSize * 2); ++i) {
-            shard2Searcher.count(new DummyQuery("ingest4-" + i, smallQuerySize));
+            long totalMemory = shard1Segment1CacheMemory + shard2Segment1CacheMemory;
+            // Each shard has some fixed overhead that we need to account for:
+            long shard1Overhead = calculateOverheadForSegment(shard1Queries, shard1Segment1Docs);
+            long shard2Overhead = calculateOverheadForSegment(shard2Queries, shard2Segment1Docs);
+            long totalMemoryMinusOverhead = totalMemory - (shard1Overhead + shard2Overhead);
+            /*
+             * Note that the expected amount of memory we're calculating is based on the proportion of the number of queries to each shard
+             * (since each shard currently only has queries to one segment)
+             */
+            shard1Segment1CacheMemoryShare = ((double) shard1Queries / (shard1Queries + shard2Queries)) * (totalMemoryMinusOverhead)
+                + shard1Overhead;
+            double shard2Segment1CacheMemoryShare = ((double) shard2Queries / (shard1Queries + shard2Queries)) * (totalMemoryMinusOverhead)
+                + shard2Overhead;
+            assertThat((double) shard1CacheBytes, closeTo(shard1Segment1CacheMemoryShare, 1)); // accounting for rounding
+            assertThat((double) shard2CacheBytes, closeTo(shard2Segment1CacheMemoryShare, 1)); // accounting for rounding
+
+            // Now we cache just more "big" searches on shard1, but on a different segment:
+            for (int i = 0; i < shard1Queries; ++i) {
+                shard1Segment2Searcher.count(new DummyQuery("ingest3-" + i, largeQuerySize));
+            }
+            long shard1Segment2CacheMemory = calculateActualCacheMemoryForSegment(shard1Queries, largeQuerySize, shard1Segment2Docs);
+            totalMemory = shard1Segment1CacheMemory + shard2Segment1CacheMemory + shard1Segment2CacheMemory;
+            // Each shard has some fixed overhead that we need to account for:
+            shard1Overhead = shard1Overhead + calculateOverheadForSegment(shard1Queries, shard1Segment2Docs);
+            totalMemoryMinusOverhead = totalMemory - (shard1Overhead + shard2Overhead);
+            /*
+             * Note that the expected amount of memory we're calculating is based on the proportion of the number of queries to each
+             * segment. The number of documents and the size of documents is irrelevant (aside from computing the fixed overhead).
+             */
+            shard1Segment1CacheMemoryShare = ((double) (2 * shard1Queries) / ((2 * shard1Queries) + shard2Queries))
+                * (totalMemoryMinusOverhead) + shard1Overhead;
         }
-        assertThat(cache.getStats(shard1).getMemorySizeInBytes(), equalTo(0L));
-        assertThat(
-            cache.getStats(shard2).getMemorySizeInBytes(),
-            equalTo(calculateActualCacheMemoryForSegment(maxCacheSize, smallQuerySize, shard2Segment1Docs))
-        );
+        {
+            IndicesService indicesService = getTestIndicesService(List.of(indexShard1, indexShard2), cache);
+            IndicesQueryCache.CacheTotals cacheTotals = IndicesQueryCache.getCacheTotalsForAllShards(indicesService);
+            final long sharedRamSizeShard1 = cache.getSharedRamSizeForShard(shard1, cacheTotals);
+            final long shard1CacheBytes = cache.getStats(shard1, () -> sharedRamSizeShard1).getMemorySizeInBytes();
+            assertThat((double) shard1CacheBytes, closeTo(shard1Segment1CacheMemoryShare, 1)); // accounting for rounding
+        }
+        {
+            // Now make sure the cache only has items for shard2:
+            for (int i = 0; i < (maxCacheSize * 2); ++i) {
+                shard2Searcher.count(new DummyQuery("ingest4-" + i, smallQuerySize));
+            }
+            IndicesService indicesService = getTestIndicesService(List.of(indexShard2), cache);
+            IndicesQueryCache.CacheTotals cacheTotals = IndicesQueryCache.getCacheTotalsForAllShards(indicesService);
+            final long sharedRamSizeShard1 = cache.getSharedRamSizeForShard(shard1, cacheTotals);
+            final long sharedRamSizeShard2 = cache.getSharedRamSizeForShard(shard2, cacheTotals);
+            assertThat(cache.getStats(shard1, () -> sharedRamSizeShard1).getMemorySizeInBytes(), equalTo(0L));
+            assertThat(
+                cache.getStats(shard2, () -> sharedRamSizeShard2).getMemorySizeInBytes(),
+                equalTo(calculateActualCacheMemoryForSegment(maxCacheSize, smallQuerySize, shard2Segment1Docs))
+            );
+        }
 
         IOUtils.close(closeableList);
         cache.onClose(shard1);

--- a/server/src/test/java/org/elasticsearch/indices/IndicesServiceCloseTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesServiceCloseTests.java
@@ -180,17 +180,17 @@ public class IndicesServiceCloseTests extends ESTestCase {
         assertEquals(1, searcher.getIndexReader().maxDoc());
 
         Query query = LongPoint.newRangeQuery("foo", 0, 5);
-        assertEquals(0L, cache.getStats(shard.shardId()).getCacheSize());
+        assertEquals(0L, cache.getStats(shard.shardId(), () -> 0L).getCacheSize());
         searcher.search(new ConstantScoreQuery(query), 1);
-        assertEquals(1L, cache.getStats(shard.shardId()).getCacheSize());
+        assertEquals(1L, cache.getStats(shard.shardId(), () -> 0L).getCacheSize());
 
         searcher.close();
         assertEquals(2, indicesService.indicesRefCount.refCount());
-        assertEquals(1L, cache.getStats(shard.shardId()).getCacheSize());
+        assertEquals(1L, cache.getStats(shard.shardId(), () -> 0L).getCacheSize());
 
         node.close();
         assertEquals(0, indicesService.indicesRefCount.refCount());
-        assertEquals(0L, cache.getStats(shard.shardId()).getCacheSize());
+        assertEquals(0L, cache.getStats(shard.shardId(), () -> 0L).getCacheSize());
     }
 
     public void testCloseWhileOngoingRequestUsesQueryCache() throws Exception {
@@ -221,13 +221,13 @@ public class IndicesServiceCloseTests extends ESTestCase {
         assertEquals(1, indicesService.indicesRefCount.refCount());
 
         Query query = LongPoint.newRangeQuery("foo", 0, 5);
-        assertEquals(0L, cache.getStats(shard.shardId()).getCacheSize());
+        assertEquals(0L, cache.getStats(shard.shardId(), () -> 0L).getCacheSize());
         searcher.search(new ConstantScoreQuery(query), 1);
-        assertEquals(1L, cache.getStats(shard.shardId()).getCacheSize());
+        assertEquals(1L, cache.getStats(shard.shardId(), () -> 0L).getCacheSize());
 
         searcher.close();
         assertEquals(0, indicesService.indicesRefCount.refCount());
-        assertEquals(0L, cache.getStats(shard.shardId()).getCacheSize());
+        assertEquals(0L, cache.getStats(shard.shardId(), () -> 0L).getCacheSize());
     }
 
     public void testCloseWhileOngoingRequestUsesRequestCache() throws Exception {

--- a/server/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
@@ -105,6 +105,8 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.matchesRegex;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -613,14 +615,18 @@ public class IndicesServiceTests extends ESSingleNodeTestCase {
 
                 shardStats.add(successfulShardStats);
 
-                when(mockIndicesService.indexShardStats(mockIndicesService, shard, CommonStatsFlags.ALL)).thenReturn(successfulShardStats);
+                when(mockIndicesService.indexShardStats(eq(mockIndicesService), eq(shard), eq(CommonStatsFlags.ALL), any())).thenReturn(
+                    successfulShardStats
+                );
             } else {
-                when(mockIndicesService.indexShardStats(mockIndicesService, shard, CommonStatsFlags.ALL)).thenThrow(expectedException);
+                when(mockIndicesService.indexShardStats(eq(mockIndicesService), eq(shard), eq(CommonStatsFlags.ALL), any())).thenThrow(
+                    expectedException
+                );
             }
         }
 
-        when(mockIndicesService.iterator()).thenReturn(Collections.singleton(indexService).iterator());
-        when(indexService.iterator()).thenReturn(shards.iterator());
+        when(mockIndicesService.iterator()).thenAnswer(invocation -> Collections.singleton(indexService).iterator());
+        when(indexService.iterator()).thenAnswer(unused -> shards.iterator());
         when(indexService.index()).thenReturn(index);
 
         // real one, which has a logger defined


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Improve stats performance when the number of shards is very large (#138126)](https://github.com/elastic/elasticsearch/pull/138126)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)