### PR TITLE
[9.2] allocation: fix up a random string sequence collision (#139225)

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/RebalanceOnlyWhenActiveAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/RebalanceOnlyWhenActiveAllocationDeciderTests.java
@@ -65,7 +65,7 @@ public class RebalanceOnlyWhenActiveAllocationDeciderTests extends ESAllocationT
     public void testAllowRebalanceForMultipleIndicesAcrossMultipleProjects() {
         final List<ShardRouting> shards = new ArrayList<>();
 
-        final List<String> nodeIds = randomList(3, 10, () -> randomAlphaOfLengthBetween(3, 8));
+        final List<String> nodeIds = new ArrayList<>(randomUnique(() -> randomIdentifier(), randomIntBetween(3, 10)));
         final GlobalRoutingTable.Builder routingTable = GlobalRoutingTable.builder();
         final Metadata.Builder metadata = Metadata.builder();
 


### PR DESCRIPTION
Backports the following commits to 9.2:
 - allocation: fix up a random string sequence collision (#139225)