### PR TITLE
[8.19] Change checkFileRead to throw IOException (#139320)

### DIFF
--- a/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementChecker.java
+++ b/libs/entitlement/bridge/src/main/java/org/elasticsearch/entitlement/bridge/EntitlementChecker.java
@@ -15,6 +15,7 @@ import java.io.File;
 import java.io.FileDescriptor;
 import java.io.FileFilter;
 import java.io.FilenameFilter;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
@@ -59,7 +60,6 @@ import java.nio.file.FileStore;
 import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitor;
 import java.nio.file.LinkOption;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.WatchEvent;
@@ -92,6 +92,21 @@ import javax.net.ssl.SSLSocketFactory;
 
 /**
  * Contains one "check" method for each distinct JDK method we want to instrument.
+ * <p>
+ * Methods starting with {@code check$} (with the dollar sign) follow a strict naming convention
+ * that allows them to be matched up directly against the corresponding target method or constructor
+ * by {@code InstrumentationService}.
+ * The naming convention uses dollar signs as separators,
+ * which works nicely because JCL methods don't use dollar signs.
+ * <p>
+ * Methods not starting with {@code check$} (for example, {@link #checkPathToRealPath})
+ * are processed by {@code DynamicInstrumentation} and follow a different convention.
+ * They are matched up with the appropriate implementation classes at runtime
+ * once we know what they are.
+ * <p>
+ * Some of these methods have a {@code throws} clause.
+ * The rule is that the check method should not throw a checked exception
+ * unless that exception is also thrown by the instrumented method under the same circumstances.
  */
 @SuppressWarnings("unused") // Called from instrumentation code inserted by the Entitlements agent
 public interface EntitlementChecker {
@@ -1177,7 +1192,14 @@ public interface EntitlementChecker {
     void checkType(Class<?> callerClass, FileStore that);
 
     // path
-    void checkPathToRealPath(Class<?> callerClass, Path that, LinkOption... options) throws NoSuchFileException;
+
+    /**
+     * From {@link Path#toRealPath(LinkOption...)}...
+     *
+     * @throws  IOException
+     *          if the file does not exist or an I/O error occurs
+     */
+    void checkPathToRealPath(Class<?> callerClass, Path that, LinkOption... options) throws IOException;
 
     void checkPathRegister(Class<?> callerClass, Path that, WatchService watcher, WatchEvent.Kind<?>... events);
 

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/ElasticsearchEntitlementChecker.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/ElasticsearchEntitlementChecker.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.io.FileDescriptor;
 import java.io.FileFilter;
 import java.io.FilenameFilter;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
@@ -66,7 +67,6 @@ import java.nio.file.FileStore;
 import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitor;
 import java.nio.file.LinkOption;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -2634,7 +2634,7 @@ public class ElasticsearchEntitlementChecker implements EntitlementChecker {
     }
 
     @Override
-    public void checkPathToRealPath(Class<?> callerClass, Path that, LinkOption... options) throws NoSuchFileException {
+    public void checkPathToRealPath(Class<?> callerClass, Path that, LinkOption... options) throws IOException {
         boolean followLinks = true;
         for (LinkOption option : options) {
             if (option == LinkOption.NOFOLLOW_LINKS) {

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyChecker.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyChecker.java
@@ -13,10 +13,10 @@ import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.entitlement.runtime.policy.entitlements.Entitlement;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.JarURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 
 /**
@@ -52,7 +52,7 @@ public interface PolicyChecker {
 
     void checkFileRead(Class<?> callerClass, File file);
 
-    void checkFileRead(Class<?> callerClass, Path path, boolean followLinks) throws NoSuchFileException;
+    void checkFileRead(Class<?> callerClass, Path path, boolean followLinks) throws IOException;
 
     void checkFileRead(Class<?> callerClass, Path path);
 

--- a/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyCheckerImpl.java
+++ b/libs/entitlement/src/main/java/org/elasticsearch/entitlement/runtime/policy/PolicyCheckerImpl.java
@@ -34,7 +34,6 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
@@ -206,16 +205,13 @@ public class PolicyCheckerImpl implements PolicyChecker {
     public void checkFileRead(Class<?> callerClass, Path path) {
         try {
             checkFileRead(callerClass, path, false);
-        } catch (NoSuchFileException e) {
-            assert false : "NoSuchFileException should only be thrown when following links";
-            var notEntitledException = new NotEntitledException(e.getMessage());
-            notEntitledException.addSuppressed(e);
-            throw notEntitledException;
+        } catch (IOException e) {
+            throw new AssertionError("IOException should be impossible unless following links", e);
         }
     }
 
     @Override
-    public void checkFileRead(Class<?> callerClass, Path path, boolean followLinks) throws NoSuchFileException {
+    public void checkFileRead(Class<?> callerClass, Path path, boolean followLinks) throws IOException {
         if (isPathOnDefaultFilesystem(path) == false) {
             return;
         }
@@ -229,15 +225,9 @@ public class PolicyCheckerImpl implements PolicyChecker {
         Path realPath = null;
         boolean canRead = entitlements.fileAccess().canRead(path);
         if (canRead && followLinks) {
-            try {
-                realPath = path.toRealPath();
-                if (realPath.equals(path) == false) {
-                    canRead = entitlements.fileAccess().canRead(realPath);
-                }
-            } catch (NoSuchFileException e) {
-                throw e; // rethrow
-            } catch (IOException e) {
-                canRead = false;
+            realPath = path.toRealPath();
+            if (realPath.equals(path) == false) {
+                canRead = entitlements.fileAccess().canRead(realPath);
             }
         }
 


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Change checkFileRead to throw IOException (#139320)