### PR TITLE
[9.2] Add reindex YAML tests to rest-resources-zip (#138271)

### DIFF
--- a/modules/reindex/build.gradle
+++ b/modules/reindex/build.gradle
@@ -54,7 +54,7 @@ restResources {
 }
 
 configurations {
-  basicRestSpecs {
+  restTests {
     attributes {
       attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.DIRECTORY_TYPE)
     }
@@ -62,7 +62,7 @@ configurations {
 }
 
 artifacts {
-  basicRestSpecs(new File(projectDir, "src/yamlRestTest/resources/rest-api-spec/test"))
+  restTests(new File(projectDir, "src/yamlRestTest/resources/rest-api-spec/test"))
 }
 
 tasks.named("thirdPartyAudit").configure {

--- a/x-pack/qa/multi-project/core-rest-tests-with-multiple-projects/build.gradle
+++ b/x-pack/qa/multi-project/core-rest-tests-with-multiple-projects/build.gradle
@@ -30,7 +30,7 @@ dependencies {
   clusterModules project(':test:external-modules:test-multi-project')
   restTestConfig project(path: ':modules:data-streams', configuration: "restTests")
   restTestConfig project(path: ':modules:ingest-common', configuration: "basicRestSpecs")
-  restTestConfig project(path: ':modules:reindex', configuration: "basicRestSpecs")
+  restTestConfig project(path: ':modules:reindex', configuration: "restTests")
   restTestConfig project(path: ':modules:streams', configuration: "restTests")
 }
 

--- a/x-pack/rest-resources-zip/build.gradle
+++ b/x-pack/rest-resources-zip/build.gradle
@@ -22,6 +22,7 @@ dependencies {
   freeTests project(path: ':modules:analysis-common', configuration: 'restTests')
   freeTests project(path: ':modules:data-streams', configuration: 'restTests')
   freeTests project(path: ':modules:ingest-geoip', configuration: 'restTests')
+  freeTests project(path: ':modules:reindex', configuration: 'restTests')
   freeTests project(path: ':modules:streams', configuration: 'restTests')
   compatApis project(path: ':rest-api-spec', configuration: 'restCompatSpecs')
   compatApis project(path: ':x-pack:plugin', configuration: 'restCompatSpecs')


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Add reindex YAML tests to rest-resources-zip (#138271)