### PR TITLE
[9.2] rest-api-spec: fix required annotations (#138147)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.downsample.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.downsample.json
@@ -24,13 +24,11 @@
           "parts": {
             "index": {
               "type": "string",
-              "description": "The index to downsample",
-              "required": true
+              "description": "The index to downsample"
             },
             "target_index": {
               "type": "string",
-              "description": "The name of the target index to store downsampled data",
-              "required": true
+              "description": "The name of the target index to store downsampled data"
             }
           }
         }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.clear_trained_model_deployment_cache.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.clear_trained_model_deployment_cache.json
@@ -24,8 +24,7 @@
           "parts": {
             "model_id": {
               "type": "string",
-              "description": "The unique identifier of the trained model.",
-              "required": true
+              "description": "The unique identifier of the trained model."
             }
           }
         }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.infer_trained_model.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.infer_trained_model.json
@@ -24,8 +24,7 @@
           "parts": {
             "model_id": {
               "type": "string",
-              "description": "The unique identifier of the trained model.",
-              "required": true
+              "description": "The unique identifier of the trained model."
             }
           }
         }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.start_trained_model_deployment.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.start_trained_model_deployment.json
@@ -24,8 +24,7 @@
           "parts": {
             "model_id": {
               "type": "string",
-              "description": "The unique identifier of the trained model.",
-              "required": true
+              "description": "The unique identifier of the trained model."
             }
           }
         }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.stop_trained_model_deployment.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.stop_trained_model_deployment.json
@@ -24,8 +24,7 @@
           "parts": {
             "model_id": {
               "type": "string",
-              "description": "The unique identifier of the trained model.",
-              "required": true
+              "description": "The unique identifier of the trained model."
             }
           }
         }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/monitoring.bulk.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/monitoring.bulk.json
@@ -28,14 +28,17 @@
     "params": {
       "system_id": {
         "type": "string",
+        "required": true,
         "description": "Identifier of the monitored system"
       },
       "system_api_version": {
         "type": "string",
+        "required": true,
         "description": "API Version of the monitored system"
       },
       "interval": {
         "type": "string",
+        "required": true,
         "description": "Collection interval (e.g., '10s' or '10000ms') of the payload"
       }
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.schedule_now_transform.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.schedule_now_transform.json
@@ -24,7 +24,6 @@
           "parts": {
             "transform_id": {
               "type": "string",
-              "required": true,
               "description": "The id of the transform."
             }
           }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.update_transform.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.update_transform.json
@@ -24,7 +24,6 @@
           "parts": {
             "transform_id": {
               "type": "string",
-              "required": true,
               "description": "The id of the transform."
             }
           }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/monitoring/bulk/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/monitoring/bulk/10_basic.yml
@@ -139,36 +139,6 @@
 
   - match: { hits.total: 0 }
 
-  # Missing a system_id causes it to fail
-  - do:
-      catch: bad_request
-      monitoring.bulk:
-        system_api_version: "7"
-        interval:           "10s"
-        body:
-          - '{"index": {"_type": "default_type"}}'
-          - '{"field_1": "value_1"}'
-
-  # Missing a system_api_version causes it to fail
-  - do:
-      catch: bad_request
-      monitoring.bulk:
-        system_id:          "kibana"
-        interval:           "10s"
-        body:
-          - '{"index": {"_type": "default_type"}}'
-          - '{"field_1": "value_1"}'
-
-  # Missing an interval causes it to fail
-  - do:
-      catch: bad_request
-      monitoring.bulk:
-        system_id:          "kibana"
-        system_api_version: "7"
-        body:
-          - '{"index": {"_type": "default_type"}}'
-          - '{"field_1": "value_1"}'
-
 ---
 "Bulk indexing of monitoring data on closed indices should throw an export exception":
   - skip:


### PR DESCRIPTION
Backports the following commits to 9.2:
 - rest-api-spec: fix required annotations (#138147)