### PR TITLE
[9.1] Fix parameter type in ml.get_categories YAML test (#138220)

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/jobs_get_result_categories.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/jobs_get_result_categories.yml
@@ -128,7 +128,7 @@ setup:
   - do:
       ml.get_categories:
         job_id: "jobs-get-result-categories"
-        category_id: "1"
+        category_id: 1
 
   - length: { categories: 1 }
   - match: { categories.0.job_id: jobs-get-result-categories }


### PR DESCRIPTION
Backports the following commits to 9.1:
 - Fix parameter type in ml.get_categories YAML test (#138220)