### PR TITLE
ESQL: Convert TS server error to user error

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/TimeSeriesGroupByAll.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/TimeSeriesGroupByAll.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.analysis;
 
-import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
@@ -67,10 +66,13 @@ public class TimeSeriesGroupByAll extends Rule<LogicalPlan, LogicalPlan> {
         }
 
         if (lastNonTSAggFunction != null) {
-            throw new EsqlIllegalArgumentException(
-                "Cannot mix time-series aggregate [{}] and regular aggregate [{}] in the same TimeSeriesAggregate.",
-                lastTSAggFunction.sourceText(),
-                lastNonTSAggFunction.sourceText()
+            throw new IllegalArgumentException(
+                "Cannot mix time-series aggregate ["
+                    + lastTSAggFunction.sourceText()
+                    + "] and regular aggregate ["
+                    + lastNonTSAggFunction.sourceText()
+                    + "] in the same TimeSeriesAggregate."
+
             );
         }
 
@@ -86,9 +88,9 @@ public class TimeSeriesGroupByAll extends Rule<LogicalPlan, LogicalPlan> {
 
         for (Expression grouping : aggregate.groupings()) {
             if (Functions.isGrouping(Alias.unwrap(grouping)) == false) {
-                throw new EsqlIllegalArgumentException(
-                    "Cannot mix time-series aggregate and grouping attributes. Found [{}].",
-                    grouping.sourceText()
+                throw new IllegalArgumentException(
+                    "Cannot mix time-series aggregate and grouping attributes. Found [" + grouping.sourceText() + "]."
+
                 );
             }
             groupings.add(grouping);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TimeSeriesBareAggregationsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TimeSeriesBareAggregationsTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.esql.optimizer.rules.logical;
 
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.index.IndexMode;
-import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.EsqlTestUtils;
 import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.analysis.Analyzer;
@@ -264,7 +263,7 @@ public class TimeSeriesBareAggregationsTests extends AbstractLogicalPlanOptimize
     public void testMixedBareOverTimeAndRegularAggregates() {
         assumeTrue("requires metrics command", EsqlCapabilities.Cap.METRICS_GROUP_BY_ALL.isEnabled());
 
-        var error = expectThrows(EsqlIllegalArgumentException.class, () -> { planK8s("""
+        var error = expectThrows(IllegalArgumentException.class, () -> { planK8s("""
             TS k8s
             | STATS avg_over_time(network.cost), sum(network.total_bytes_in)
             """); });
@@ -277,7 +276,7 @@ public class TimeSeriesBareAggregationsTests extends AbstractLogicalPlanOptimize
     public void testGroupingKeyInAggregatesListPreserved() {
         assumeTrue("requires metrics command", EsqlCapabilities.Cap.METRICS_GROUP_BY_ALL.isEnabled());
 
-        var error = expectThrows(EsqlIllegalArgumentException.class, () -> { planK8s("""
+        var error = expectThrows(IllegalArgumentException.class, () -> { planK8s("""
             TS k8s
             | STATS rate(network.total_bytes_out) BY region, TBUCKET(1hour)
             """); });


### PR DESCRIPTION
`EsqlIllegalArgumentException` ends up in a server error (5XX). `IllegalArgumentException` is used instead for user errors (4XX).

I'm changing these, as they are user validations