### PR TITLE
[9.2] Fix index version constant

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -188,7 +188,7 @@ public class IndexVersions {
     public static final IndexVersion IGNORED_SOURCE_COALESCED_ENTRIES = def(9_039_0_00, Version.LUCENE_10_3_0);
     public static final IndexVersion BACKPORT_UPGRADE_TO_LUCENE_10_3_1 = def(9_039_0_01, Version.LUCENE_10_3_1);
     public static final IndexVersion BACKPORT_UPGRADE_TO_LUCENE_10_3_2 = def(9_039_0_02, Version.LUCENE_10_3_2);
-    public static final IndexVersion SECURITY_MIGRATIONS_METADATA_FLATTENED_UPDATE = def(9_040_0_00, Version.LUCENE_10_3_2);
+    public static final IndexVersion BACKPORT_SECURITY_MIGRATIONS_METADATA_FLATTENED_UPDATE = def(9_039_0_03, Version.LUCENE_10_3_2);
 
     /*
      * STOP! READ THIS FIRST! No, really,


### PR DESCRIPTION
We need to use a patch version, not a full version here. 9.2.2 was the previous commit, so this hasn't been released yet - we can modify this in time for 9.2.3.