### PR TITLE
Unwrap stored fields readers to ensure that per format optimizations work

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/storedfields/FilterStoredFieldsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/storedfields/FilterStoredFieldsReader.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.storedfields;
+
+import org.apache.lucene.codecs.StoredFieldsReader;
+import org.apache.lucene.index.StoredFieldVisitor;
+
+import java.io.IOException;
+
+public abstract class FilterStoredFieldsReader extends StoredFieldsReader {
+
+    protected final StoredFieldsReader in;
+
+    public FilterStoredFieldsReader(StoredFieldsReader fieldsReader) {
+        this.in = fieldsReader;
+    }
+
+    @Override
+    public void close() throws IOException {
+        in.close();
+    }
+
+    @Override
+    public void document(int docID, StoredFieldVisitor visitor) throws IOException {
+        in.document(docID, visitor);
+    }
+
+    @Override
+    public abstract StoredFieldsReader clone();
+
+    @Override
+    public void checkIntegrity() throws IOException {
+        in.checkIntegrity();
+    }
+
+    public static StoredFieldsReader unwrap(StoredFieldsReader storedFieldsReader) {
+        while (storedFieldsReader instanceof FilterStoredFieldsReader filterStoredFieldsReader) {
+            storedFieldsReader = filterStoredFieldsReader.in;
+        }
+        return storedFieldsReader;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/storedfields/TSDBStoredFieldsFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/storedfields/TSDBStoredFieldsFormat.java
@@ -145,7 +145,8 @@ public class TSDBStoredFieldsFormat extends StoredFieldsFormat {
         private MergeState unwrapStoredFieldReaders(MergeState mergeState, boolean unwrapBloomFilterReaders) {
             StoredFieldsReader[] updatedReaders = new StoredFieldsReader[mergeState.storedFieldsReaders.length];
             for (int i = 0; i < mergeState.storedFieldsReaders.length; i++) {
-                final StoredFieldsReader storedFieldsReader = mergeState.storedFieldsReaders[i];
+                final StoredFieldsReader storedFieldsReader = FilterStoredFieldsReader.unwrap(mergeState.storedFieldsReaders[i]);
+                final StoredFieldsReader originalStoredFieldsReader = mergeState.storedFieldsReaders[i];
 
                 // We need to unwrap the stored field readers belonging to a PerFieldStoredFieldsFormat,
                 // otherwise, downstream formats won't be able to perform certain optimizations when
@@ -153,7 +154,7 @@ public class TSDBStoredFieldsFormat extends StoredFieldsFormat {
                 // (i.e. Lucene90CompressingStoredFieldsReader would do chunk merging for instances of the same class)
                 if (storedFieldsReader instanceof TSDBStoredFieldsReader reader) {
                     // In case that we're dealing with a previous format, the newer formats should be able to handle it
-                    updatedReaders[i] = unwrapBloomFilterReaders ? reader.bloomFilterStoredFieldsReader : reader.storedFieldsReader;
+                    updatedReaders[i] = unwrapBloomFilterReaders ? reader.bloomFilterStoredFieldsReader : originalStoredFieldsReader;
                 } else {
                     updatedReaders[i] = storedFieldsReader;
                 }

--- a/server/src/main/java/org/elasticsearch/index/engine/RecoverySourcePruneMergePolicy.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/RecoverySourcePruneMergePolicy.java
@@ -30,6 +30,7 @@ import org.apache.lucene.util.BitSet;
 import org.apache.lucene.util.BitSetIterator;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.codec.FilterDocValuesProducer;
+import org.elasticsearch.index.codec.storedfields.FilterStoredFieldsReader;
 import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.search.internal.FilterStoredFieldVisitor;
 
@@ -171,33 +172,6 @@ final class RecoverySourcePruneMergePolicy extends OneMergeWrappingMergePolicy {
         @Override
         public CacheHelper getReaderCacheHelper() {
             return null;
-        }
-
-        private abstract static class FilterStoredFieldsReader extends StoredFieldsReader {
-
-            protected final StoredFieldsReader in;
-
-            FilterStoredFieldsReader(StoredFieldsReader fieldsReader) {
-                this.in = fieldsReader;
-            }
-
-            @Override
-            public void close() throws IOException {
-                in.close();
-            }
-
-            @Override
-            public void document(int docID, StoredFieldVisitor visitor) throws IOException {
-                in.document(docID, visitor);
-            }
-
-            @Override
-            public abstract StoredFieldsReader clone();
-
-            @Override
-            public void checkIntegrity() throws IOException {
-                in.checkIntegrity();
-            }
         }
 
         private static class RecoverySourcePruningStoredFieldsReader extends FilterStoredFieldsReader {


### PR DESCRIPTION
This commit allows unwrapping `StoredFieldReader`s wrapped in `FilterStoredFieldsReader`,
this is useful when low level implementations make decisions based on the instance type to
optimize merging.