### PR TITLE
[Inference API] Use dimensions field in JinaAI text_embedding requests

### DIFF
--- a/docs/changelog/139395.yaml
+++ b/docs/changelog/139395.yaml
@@ -1,0 +1,5 @@
+pr: 139395
+summary: Use dimensions field in JinaAI `text_embedding` requests
+area: Inference
+type: bug
+issues: []

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/request/JinaAIEmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/request/JinaAIEmbeddingsRequest.java
@@ -34,6 +34,7 @@ public class JinaAIEmbeddingsRequest extends JinaAIRequest {
     private final String model;
     private final String inferenceEntityId;
     private final JinaAIEmbeddingType embeddingType;
+    private final Integer dimensions;
 
     public JinaAIEmbeddingsRequest(List<String> input, InputType inputType, JinaAIEmbeddingsModel embeddingsModel) {
         Objects.requireNonNull(embeddingsModel);
@@ -45,6 +46,7 @@ public class JinaAIEmbeddingsRequest extends JinaAIRequest {
         model = embeddingsModel.getServiceSettings().getCommonSettings().modelId();
         embeddingType = embeddingsModel.getServiceSettings().getEmbeddingType();
         inferenceEntityId = embeddingsModel.getInferenceEntityId();
+        dimensions = embeddingsModel.getServiceSettings().dimensions();
     }
 
     @Override
@@ -52,7 +54,7 @@ public class JinaAIEmbeddingsRequest extends JinaAIRequest {
         HttpPost httpPost = new HttpPost(account.uri());
 
         ByteArrayEntity byteEntity = new ByteArrayEntity(
-            Strings.toString(new JinaAIEmbeddingsRequestEntity(input, inputType, taskSettings, model, embeddingType))
+            Strings.toString(new JinaAIEmbeddingsRequestEntity(input, inputType, taskSettings, model, embeddingType, dimensions))
                 .getBytes(StandardCharsets.UTF_8)
         );
         httpPost.setEntity(byteEntity);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/request/JinaAIEmbeddingsRequestEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/jinaai/request/JinaAIEmbeddingsRequestEntity.java
@@ -26,7 +26,8 @@ public record JinaAIEmbeddingsRequestEntity(
     InputType inputType,
     JinaAIEmbeddingsTaskSettings taskSettings,
     @Nullable String model,
-    @Nullable JinaAIEmbeddingType embeddingType
+    @Nullable JinaAIEmbeddingType embeddingType,
+    Integer dimensions
 ) implements ToXContentObject {
 
     private static final String SEARCH_DOCUMENT = "retrieval.passage";
@@ -38,6 +39,7 @@ public record JinaAIEmbeddingsRequestEntity(
     public static final String TASK_TYPE_FIELD = "task";
     public static final String LATE_CHUNKING = "late_chunking";
     static final String EMBEDDING_TYPE_FIELD = "embedding_type";
+    static final String DIMENSIONS_FIELD = "dimensions";
     // Late chunking models have a token limit of 8000 or ~6000 words (using a rough 1 token:0.75 words ratio). We set the maximum word
     // count with a bit of extra room to 5500 words.
     static final int MAX_WORD_COUNT_FOR_LATE_CHUNKING = 5500;
@@ -67,6 +69,10 @@ public record JinaAIEmbeddingsRequestEntity(
 
         if (taskSettings.getLateChunking() != null) {
             builder.field(LATE_CHUNKING, taskSettings.getLateChunking() && getInputWordCount() <= MAX_WORD_COUNT_FOR_LATE_CHUNKING);
+        }
+
+        if (dimensions != null) {
+            builder.field(DIMENSIONS_FIELD, dimensions);
         }
 
         builder.endObject();

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/jinaai/JinaAIServiceTests.java
@@ -947,23 +947,27 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
                 """;
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
 
+            String apiKey = "apiKey";
+            int dimensions = 1024;
+            String modelName = "jina-clip-v2";
             var model = JinaAIEmbeddingsModelTests.createModel(
                 getUrl(webServer),
-                "secret",
+                apiKey,
                 JinaAIEmbeddingsTaskSettings.EMPTY_SETTINGS,
-                1024,
-                1024,
-                "jina-clip-v2",
+                500,
+                dimensions,
+                modelName,
                 null,
                 JinaAIEmbeddingType.FLOAT
             );
             PlainActionFuture<InferenceServiceResults> listener = new PlainActionFuture<>();
+            List<String> input = List.of("abc");
             service.infer(
                 model,
                 null,
                 null,
                 null,
-                List.of("abc"),
+                input,
                 false,
                 new HashMap<>(),
                 InputType.INGEST,
@@ -981,12 +985,25 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
                 webServer.requests().get(0).getHeader(HttpHeaders.CONTENT_TYPE),
                 equalTo(XContentType.JSON.mediaType())
             );
-            MatcherAssert.assertThat(webServer.requests().get(0).getHeader(HttpHeaders.AUTHORIZATION), equalTo("Bearer secret"));
+            MatcherAssert.assertThat(webServer.requests().get(0).getHeader(HttpHeaders.AUTHORIZATION), equalTo("Bearer " + apiKey));
 
             var requestMap = entityAsMap(webServer.requests().get(0).getBody());
             MatcherAssert.assertThat(
                 requestMap,
-                is(Map.of("input", List.of("abc"), "model", "jina-clip-v2", "task", "retrieval.passage", "embedding_type", "float"))
+                is(
+                    Map.of(
+                        "input",
+                        input,
+                        "model",
+                        modelName,
+                        "task",
+                        "retrieval.passage",
+                        "embedding_type",
+                        "float",
+                        "dimensions",
+                        dimensions
+                    )
+                )
             );
         }
     }
@@ -1018,23 +1035,27 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
                 """;
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
 
+            String apiKey = "apiKey";
+            int dimensions = 1024;
+            String modelName = "jina-clip-v2";
             var model = JinaAIEmbeddingsModelTests.createModel(
                 getUrl(webServer),
-                "secret",
+                apiKey,
                 JinaAIEmbeddingsTaskSettings.EMPTY_SETTINGS,
-                1024,
-                1024,
-                "jina-clip-v2",
+                500,
+                dimensions,
+                modelName,
                 null,
                 JinaAIEmbeddingType.FLOAT
             );
             PlainActionFuture<InferenceServiceResults> listener = new PlainActionFuture<>();
+            List<String> input = List.of("abc");
             service.infer(
                 model,
                 null,
                 null,
                 null,
-                List.of("abc"),
+                input,
                 false,
                 new HashMap<>(),
                 InputType.SEARCH,
@@ -1052,12 +1073,25 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
                 webServer.requests().get(0).getHeader(HttpHeaders.CONTENT_TYPE),
                 equalTo(XContentType.JSON.mediaType())
             );
-            MatcherAssert.assertThat(webServer.requests().get(0).getHeader(HttpHeaders.AUTHORIZATION), equalTo("Bearer secret"));
+            MatcherAssert.assertThat(webServer.requests().get(0).getHeader(HttpHeaders.AUTHORIZATION), equalTo("Bearer " + apiKey));
 
             var requestMap = entityAsMap(webServer.requests().get(0).getBody());
             MatcherAssert.assertThat(
                 requestMap,
-                is(Map.of("input", List.of("abc"), "model", "jina-clip-v2", "task", "retrieval.query", "embedding_type", "float"))
+                is(
+                    Map.of(
+                        "input",
+                        input,
+                        "model",
+                        modelName,
+                        "task",
+                        "retrieval.query",
+                        "embedding_type",
+                        "float",
+                        "dimensions",
+                        dimensions
+                    )
+                )
             );
         }
     }
@@ -1073,23 +1107,27 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
                 """;
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
 
+            String apiKey = "apiKey";
+            int dimensions = 1024;
+            String modelName = "jina-clip-v2";
             var model = JinaAIEmbeddingsModelTests.createModel(
                 getUrl(webServer),
-                "secret",
+                apiKey,
                 JinaAIEmbeddingsTaskSettings.EMPTY_SETTINGS,
-                1024,
-                1024,
-                "jina-clip-v2",
+                500,
+                dimensions,
+                modelName,
                 null,
                 JinaAIEmbeddingType.FLOAT
             );
             PlainActionFuture<InferenceServiceResults> listener = new PlainActionFuture<>();
+            List<String> input = List.of("abc");
             service.infer(
                 model,
                 null,
                 null,
                 null,
-                List.of("abc"),
+                input,
                 false,
                 new HashMap<>(),
                 InputType.CLUSTERING,
@@ -1107,12 +1145,12 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
                 webServer.requests().get(0).getHeader(HttpHeaders.CONTENT_TYPE),
                 equalTo(XContentType.JSON.mediaType())
             );
-            MatcherAssert.assertThat(webServer.requests().get(0).getHeader(HttpHeaders.AUTHORIZATION), equalTo("Bearer secret"));
+            MatcherAssert.assertThat(webServer.requests().get(0).getHeader(HttpHeaders.AUTHORIZATION), equalTo("Bearer " + apiKey));
 
             var requestMap = entityAsMap(webServer.requests().get(0).getBody());
             MatcherAssert.assertThat(
                 requestMap,
-                is(Map.of("input", List.of("abc"), "model", "jina-clip-v2", "task", "separation", "embedding_type", "float"))
+                is(Map.of("input", input, "model", modelName, "task", "separation", "embedding_type", "float", "dimensions", dimensions))
             );
         }
     }
@@ -1144,29 +1182,22 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
                 """;
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
 
+            String apiKey = "apiKey";
+            int dimensions = 1024;
+            String modelName = "jina-clip-v2";
             var model = JinaAIEmbeddingsModelTests.createModel(
                 getUrl(webServer),
-                "secret",
+                apiKey,
                 JinaAIEmbeddingsTaskSettings.EMPTY_SETTINGS,
-                1024,
-                1024,
-                "jina-clip-v2",
+                500,
+                dimensions,
+                modelName,
                 null,
                 JinaAIEmbeddingType.FLOAT
             );
             PlainActionFuture<InferenceServiceResults> listener = new PlainActionFuture<>();
-            service.infer(
-                model,
-                null,
-                null,
-                null,
-                List.of("abc"),
-                false,
-                new HashMap<>(),
-                null,
-                InferenceAction.Request.DEFAULT_TIMEOUT,
-                listener
-            );
+            List<String> input = List.of("abc");
+            service.infer(model, null, null, null, input, false, new HashMap<>(), null, InferenceAction.Request.DEFAULT_TIMEOUT, listener);
 
             var result = listener.actionGet(TIMEOUT);
 
@@ -1178,10 +1209,13 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
                 webServer.requests().get(0).getHeader(HttpHeaders.CONTENT_TYPE),
                 equalTo(XContentType.JSON.mediaType())
             );
-            MatcherAssert.assertThat(webServer.requests().get(0).getHeader(HttpHeaders.AUTHORIZATION), equalTo("Bearer secret"));
+            MatcherAssert.assertThat(webServer.requests().get(0).getHeader(HttpHeaders.AUTHORIZATION), equalTo("Bearer " + apiKey));
 
             var requestMap = entityAsMap(webServer.requests().get(0).getBody());
-            MatcherAssert.assertThat(requestMap, is(Map.of("input", List.of("abc"), "model", "jina-clip-v2", "embedding_type", "float")));
+            MatcherAssert.assertThat(
+                requestMap,
+                is(Map.of("input", input, "model", modelName, "embedding_type", "float", "dimensions", dimensions))
+            );
         }
     }
 
@@ -1564,23 +1598,27 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
                 """;
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
 
+            String apiKey = "apiKey";
+            int dimensions = 1024;
+            String modelName = "jina-clip-v2";
             var model = JinaAIEmbeddingsModelTests.createModel(
                 getUrl(webServer),
-                "secret",
+                apiKey,
                 new JinaAIEmbeddingsTaskSettings((InputType) null),
-                1024,
-                1024,
-                "jina-clip-v2",
+                500,
+                dimensions,
+                modelName,
                 null,
                 JinaAIEmbeddingType.FLOAT
             );
             PlainActionFuture<InferenceServiceResults> listener = new PlainActionFuture<>();
+            List<String> input = List.of("abc");
             service.infer(
                 model,
                 null,
                 null,
                 null,
-                List.of("abc"),
+                input,
                 false,
                 new HashMap<>(),
                 InputType.UNSPECIFIED,
@@ -1597,10 +1635,13 @@ public class JinaAIServiceTests extends InferenceServiceTestCase {
                 webServer.requests().get(0).getHeader(HttpHeaders.CONTENT_TYPE),
                 equalTo(XContentType.JSON.mediaType())
             );
-            MatcherAssert.assertThat(webServer.requests().get(0).getHeader(HttpHeaders.AUTHORIZATION), equalTo("Bearer secret"));
+            MatcherAssert.assertThat(webServer.requests().get(0).getHeader(HttpHeaders.AUTHORIZATION), equalTo("Bearer " + apiKey));
 
             var requestMap = entityAsMap(webServer.requests().get(0).getBody());
-            MatcherAssert.assertThat(requestMap, is(Map.of("input", List.of("abc"), "model", "jina-clip-v2", "embedding_type", "float")));
+            MatcherAssert.assertThat(
+                requestMap,
+                is(Map.of("input", input, "model", modelName, "embedding_type", "float", "dimensions", dimensions))
+            );
         }
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/jinaai/request/JinaAIEmbeddingsRequestEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/jinaai/request/JinaAIEmbeddingsRequestEntityTests.java
@@ -30,8 +30,9 @@ public class JinaAIEmbeddingsRequestEntityTests extends ESTestCase {
             List.of("abc"),
             InputType.INTERNAL_INGEST,
             new JinaAIEmbeddingsTaskSettings(InputType.INGEST, true),
-            "model",
-            JinaAIEmbeddingType.FLOAT
+            "modelName",
+            JinaAIEmbeddingType.FLOAT,
+            512
         );
 
         XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
@@ -39,7 +40,8 @@ public class JinaAIEmbeddingsRequestEntityTests extends ESTestCase {
         String xContentResult = Strings.toString(builder);
 
         MatcherAssert.assertThat(xContentResult, is("""
-            {"input":["abc"],"model":"model","embedding_type":"float","task":"retrieval.passage","late_chunking":true}"""));
+            {"input":["abc"],"model":"modelName","embedding_type":"float",\
+            "task":"retrieval.passage","late_chunking":true,"dimensions":512}"""));
     }
 
     public void testXContent_WritesOnlyLateChunkingField_WhenItIsTheOnlyOptionalFieldDefined() throws IOException {
@@ -48,6 +50,7 @@ public class JinaAIEmbeddingsRequestEntityTests extends ESTestCase {
             InputType.INTERNAL_INGEST,
             new JinaAIEmbeddingsTaskSettings(null, false),
             "model",
+            null,
             null
         );
 
@@ -69,6 +72,7 @@ public class JinaAIEmbeddingsRequestEntityTests extends ESTestCase {
             InputType.INTERNAL_INGEST,
             new JinaAIEmbeddingsTaskSettings(null, true),
             "model",
+            null,
             null
         );
 
@@ -96,6 +100,7 @@ public class JinaAIEmbeddingsRequestEntityTests extends ESTestCase {
             null,
             new JinaAIEmbeddingsTaskSettings(InputType.SEARCH, null),
             "model",
+            null,
             null
         );
 
@@ -113,7 +118,8 @@ public class JinaAIEmbeddingsRequestEntityTests extends ESTestCase {
             null,
             JinaAIEmbeddingsTaskSettings.EMPTY_SETTINGS,
             "model",
-            JinaAIEmbeddingType.FLOAT
+            JinaAIEmbeddingType.FLOAT,
+            null
         );
 
         XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
@@ -130,7 +136,8 @@ public class JinaAIEmbeddingsRequestEntityTests extends ESTestCase {
             InputType.CLUSTERING,
             JinaAIEmbeddingsTaskSettings.EMPTY_SETTINGS,
             "model",
-            JinaAIEmbeddingType.BIT
+            JinaAIEmbeddingType.BIT,
+            null
         );
 
         XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
@@ -147,7 +154,8 @@ public class JinaAIEmbeddingsRequestEntityTests extends ESTestCase {
             InputType.SEARCH,
             JinaAIEmbeddingsTaskSettings.EMPTY_SETTINGS,
             "model",
-            JinaAIEmbeddingType.BINARY
+            JinaAIEmbeddingType.BINARY,
+            null
         );
 
         XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);


### PR DESCRIPTION
The dimensions field was parsed from the service settings but never used. This commit includes the dimensions field in text embedding requests sent to JinaAI.