### PR TITLE
[9.2] Make testTopNSortExpressionWithinRemoteEnrichAliasing not require exact temp name (#139006)

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/HoistRemoteEnrichTopNTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/HoistRemoteEnrichTopNTests.java
@@ -252,7 +252,7 @@ public class HoistRemoteEnrichTopNTests extends AbstractLogicalPlanOptimizerTest
         assertFalse(topn.local());
         Order topNOrder = topn.order().get(1);
         NamedExpression expr = as(topNOrder.child(), NamedExpression.class);
-        assertThat(expr.name(), startsWith("$$order_by$1$0"));
+        assertThat(expr.name(), startsWith("$$order_by$1$"));
         var enrich = as(topn.child(), Enrich.class);
         assertThat(enrich.mode(), is(Enrich.Mode.REMOTE));
         var innerTopN = as(enrich.child(), TopN.class);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Make testTopNSortExpressionWithinRemoteEnrichAliasing not require exact temp name (#139006)](https://github.com/elastic/elasticsearch/pull/139006)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

Closes: https://github.com/elastic/elasticsearch/issues/139377