### PR TITLE
ESQL: More care when pushing expression to load

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -391,12 +391,6 @@ tests:
 - class: org.elasticsearch.xpack.ilm.TimeSeriesLifecycleActionsIT
   method: testWaitForSnapshot
   issue: https://github.com/elastic/elasticsearch/issues/138669
-- class: org.elasticsearch.xpack.esql.optimizer.LocalLogicalPlanOptimizerTests
-  method: testAggregateMetricDoubleInlineStats
-  issue: https://github.com/elastic/elasticsearch/issues/138620
-- class: org.elasticsearch.xpack.esql.optimizer.rules.logical.local.ReplaceDateTruncBucketWithRoundToTests
-  method: testAggregateMetricDoubleInlineStats
-  issue: https://github.com/elastic/elasticsearch/issues/138620
 - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
   method: test {yaml=index/100_field_name_length_limit/Test field name length limit}
   issue: https://github.com/elastic/elasticsearch/issues/138768


### PR DESCRIPTION
We need to be even more careful when pushing expressions into field loading. With this change we only push if the EVAL/WHERE/STATS has exactly one "leaf" node ancestor *AND* it's valid for pushing.

This prevents pushing into "StubRelations" like we get with this plan:
```
FROM k8s-downsampled
| INLINE STATS tx_max = MAX(network.eth0.tx) BY pod
```

In the future we should be able to push if we can push into *all* relations rather than checking that there is just one. But baby steps.

Closes #138620
