### PR TITLE
Fixed an edge case that forced some text fields to be stored in ignored source

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -207,6 +207,7 @@ public class IndexVersions {
     public static final IndexVersion TIME_SERIES_USE_STORED_FIELDS_BLOOM_FILTER_FOR_ID = def(9_055_0_00, Version.LUCENE_10_3_2);
     public static final IndexVersion AGG_METRIC_DOUBLE_REMOVE_POINTS = def(9_056_0_00, Version.LUCENE_10_3_2);
     public static final IndexVersion STATELESS_SKIPPERS_ENABLED_FOR_TSDB = def(9_057_0_00, Version.LUCENE_10_3_2);
+    public static final IndexVersion TEXT_FIELDS_STORED_IN_IGNORED_SOURCE_FIX = def(9_058_0_00, Version.LUCENE_10_3_2);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -321,11 +321,6 @@ public final class TextFieldMapper extends FieldMapper {
             });
 
             this.store = Parameter.storeParam(m -> ((TextFieldMapper) m).store, () -> {
-                // ideally and for simplicity, store should be set to false by default
-                if (keywordMultiFieldsNotStoredWhenIgnoredIndexVersionCheck(indexCreatedVersion)) {
-                    return false;
-                }
-
                 // however, because historically we set store to true to support synthetic source, we must also keep that logic:
                 if (multiFieldsNotStoredByDefaultIndexVersionCheck(indexCreatedVersion)) {
                     return isSyntheticSourceEnabled

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -1172,8 +1172,10 @@ public final class TextFieldMapper extends FieldMapper {
          * There was an unintended change that resulted in some text fields being stored in ignored source.
          */
         private boolean wasIndexCreatedWhenTextFieldsWereStoredInIgnoredSource() {
-            return indexCreatedVersion.between(IndexVersions.KEYWORD_MULTI_FIELDS_NOT_STORED_WHEN_IGNORED,
-                                               IndexVersions.TEXT_FIELDS_STORED_IN_IGNORED_SOURCE_FIX);
+            return indexCreatedVersion.between(
+                IndexVersions.KEYWORD_MULTI_FIELDS_NOT_STORED_WHEN_IGNORED,
+                IndexVersions.TEXT_FIELDS_STORED_IN_IGNORED_SOURCE_FIX
+            );
         }
 
         FallbackSyntheticSourceBlockLoader fallbackSyntheticSourceBlockLoader(BlockLoaderContext blContext) {
@@ -1730,7 +1732,8 @@ public final class TextFieldMapper extends FieldMapper {
         }
 
         // this check exists for BWC purposes - there was a bug that resulted in some text fields being stored in ignored source
-        if (fieldType().syntheticSourceDelegate.isEmpty() && indexCreatedVersion.before(IndexVersions.TEXT_FIELDS_STORED_IN_IGNORED_SOURCE_FIX)) {
+        if (fieldType().syntheticSourceDelegate.isEmpty()
+            && indexCreatedVersion.before(IndexVersions.TEXT_FIELDS_STORED_IN_IGNORED_SOURCE_FIX)) {
             return super.syntheticSourceSupport();
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -321,6 +321,11 @@ public final class TextFieldMapper extends FieldMapper {
             });
 
             this.store = Parameter.storeParam(m -> ((TextFieldMapper) m).store, () -> {
+                // ideally and for simplicity, store should be set to false by default
+                if (keywordMultiFieldsNotStoredWhenIgnoredIndexVersionCheck(indexCreatedVersion)) {
+                    return false;
+                }
+
                 // however, because historically we set store to true to support synthetic source, we must also keep that logic:
                 if (multiFieldsNotStoredByDefaultIndexVersionCheck(indexCreatedVersion)) {
                     return isSyntheticSourceEnabled
@@ -409,7 +414,8 @@ public final class TextFieldMapper extends FieldMapper {
                     SyntheticSourceHelper.syntheticSourceDelegate(fieldType.stored(), multiFields),
                     meta.getValue(),
                     eagerGlobalOrdinals.getValue(),
-                    indexPhrases.getValue()
+                    indexPhrases.getValue(),
+                    indexCreatedVersion
                 );
                 if (fieldData.getValue()) {
                     ft.setFielddata(true, freqFilter.getValue());
@@ -689,6 +695,7 @@ public final class TextFieldMapper extends FieldMapper {
         private PrefixFieldType prefixFieldType;
         private final boolean indexPhrases;
         private final boolean eagerGlobalOrdinals;
+        private final IndexVersion indexCreatedVersion;
         /**
          * In some configurations text fields use a sub-keyword field to provide
          * their values for synthetic source. This is that field. Or empty if we're
@@ -706,7 +713,8 @@ public final class TextFieldMapper extends FieldMapper {
             KeywordFieldMapper.KeywordFieldType syntheticSourceDelegate,
             Map<String, String> meta,
             boolean eagerGlobalOrdinals,
-            boolean indexPhrases
+            boolean indexPhrases,
+            IndexVersion indexCreatedVersion
         ) {
             super(name, indexed ? IndexType.terms(true, false) : IndexType.NONE, stored, tsi, meta, isSyntheticSource, isWithinMultiField);
             fielddata = false;
@@ -714,6 +722,34 @@ public final class TextFieldMapper extends FieldMapper {
             this.syntheticSourceDelegate = Optional.ofNullable(syntheticSourceDelegate);
             this.eagerGlobalOrdinals = eagerGlobalOrdinals;
             this.indexPhrases = indexPhrases;
+            this.indexCreatedVersion = indexCreatedVersion;
+        }
+
+        public TextFieldType(
+            String name,
+            boolean indexed,
+            boolean stored,
+            TextSearchInfo tsi,
+            boolean isSyntheticSource,
+            boolean isWithinMultiField,
+            KeywordFieldMapper.KeywordFieldType syntheticSourceDelegate,
+            Map<String, String> meta,
+            boolean eagerGlobalOrdinals,
+            boolean indexPhrases
+        ) {
+            this(
+                name,
+                indexed,
+                stored,
+                tsi,
+                isSyntheticSource,
+                isWithinMultiField,
+                syntheticSourceDelegate,
+                meta,
+                eagerGlobalOrdinals,
+                indexPhrases,
+                IndexVersion.current()
+            );
         }
 
         public TextFieldType(String name, boolean indexed, boolean stored, Map<String, String> meta) {
@@ -730,6 +766,7 @@ public final class TextFieldMapper extends FieldMapper {
             syntheticSourceDelegate = null;
             eagerGlobalOrdinals = false;
             indexPhrases = false;
+            indexCreatedVersion = IndexVersion.current();
         }
 
         public TextFieldType(String name, boolean isSyntheticSource, boolean isWithinMultiField) {
@@ -743,7 +780,8 @@ public final class TextFieldMapper extends FieldMapper {
                 null,
                 Collections.emptyMap(),
                 false,
-                false
+                false,
+                IndexVersion.current()
             );
         }
 
@@ -763,7 +801,8 @@ public final class TextFieldMapper extends FieldMapper {
                 syntheticSourceDelegate,
                 Collections.emptyMap(),
                 false,
-                false
+                false,
+                IndexVersion.current()
             );
         }
 
@@ -1075,6 +1114,7 @@ public final class TextFieldMapper extends FieldMapper {
 
         @Override
         public BlockLoader blockLoader(BlockLoaderContext blContext) {
+            // 1. check if we can load from a synthetic source delegate
             if (canUseSyntheticSourceDelegateForLoading()) {
                 return new BlockLoader.Delegating(syntheticSourceDelegate.get().blockLoader(blContext)) {
                     @Override
@@ -1083,6 +1123,8 @@ public final class TextFieldMapper extends FieldMapper {
                     }
                 };
             }
+
+            // 2. check if we can load from a parent field
             /*
              * If this is a sub-text field try and return the parent's loader. Text
              * fields will always be slow to load and if the parent is exact then we
@@ -1103,22 +1145,35 @@ public final class TextFieldMapper extends FieldMapper {
                     }
                 }
             }
+
+            // 3. bwc - check if we need to load from ignored source (aka fallback synthetic source)
+            if (wasIndexCreatedWhenTextFieldsWereStoredInIgnoredSource()) {
+                if (isSyntheticSourceEnabled() && syntheticSourceDelegate.isEmpty() && parentField == null && isStored() == false) {
+                    return fallbackSyntheticSourceBlockLoader(blContext);
+                }
+            }
+
+            // 4. check if we can load from a stored field
             if (isStored()) {
                 return new BlockStoredFieldsReader.BytesFromStringsBlockLoader(name());
             }
 
-            // _ignored_source field will contain entries for this field if it is not stored
-            // and there is no syntheticSourceDelegate.
-            // See #syntheticSourceSupport().
-            // But if a text field is a multi field it won't have an entry in _ignored_source.
-            // The parent might, but we don't have enough context here to figure this out.
-            // So we bail.
+            // 5. check if we can load from a fallback stored field
             if (isSyntheticSourceEnabled() && syntheticSourceDelegate.isEmpty() && parentField == null) {
-                return fallbackSyntheticSourceBlockLoader(blContext);
+                return new BlockStoredFieldsReader.BytesFromStringsBlockLoader(syntheticSourceFallbackFieldName());
             }
-            // otherwise, load values from _source (synthetic or not)
+
+            // 6. load directly from _source (synthetic or not)
             SourceValueFetcher fetcher = SourceValueFetcher.toString(blContext.sourcePaths(name()), blContext.indexSettings());
             return new BlockSourceReader.BytesRefsBlockLoader(fetcher, blockReaderDisiLookup(blContext));
+        }
+
+        /**
+         * There was an unintended change that resulted in some text fields being stored in ignored source.
+         */
+        private boolean wasIndexCreatedWhenTextFieldsWereStoredInIgnoredSource() {
+            return indexCreatedVersion.between(IndexVersions.KEYWORD_MULTI_FIELDS_NOT_STORED_WHEN_IGNORED,
+                                               IndexVersions.TEXT_FIELDS_STORED_IN_IGNORED_SOURCE_FIX);
         }
 
         FallbackSyntheticSourceBlockLoader fallbackSyntheticSourceBlockLoader(BlockLoaderContext blContext) {
@@ -1260,7 +1315,7 @@ public final class TextFieldMapper extends FieldMapper {
     public static class ConstantScoreTextFieldType extends TextFieldType {
 
         public ConstantScoreTextFieldType(String name, boolean indexed, boolean stored, TextSearchInfo tsi, Map<String, String> meta) {
-            super(name, indexed, stored, tsi, false, false, null, meta, false, false);
+            super(name, indexed, stored, tsi, false, false, null, meta, false, false, IndexVersion.current());
         }
 
         public ConstantScoreTextFieldType(String name) {
@@ -1468,22 +1523,17 @@ public final class TextFieldMapper extends FieldMapper {
             }
         }
 
-        // if the field isn't stored, yet we need it stored for synthetic source, then attempt to use the synthetic source delegate
-        if (fieldType().storeFieldForSyntheticSource(indexCreatedVersion)
-            && fieldType.stored() == false
-            && fieldType().syntheticSourceDelegate.isPresent()) {
-
-            // check if the delegate can even handle storing for us
+        // if we need to support synthetic source, yet the field isn't stored, then we need an alternative way of loading the field
+        if (fieldType().storeFieldForSyntheticSource(indexCreatedVersion) && fieldType.stored() == false) {
+            // rely on the delegate field if we can
             if (fieldType().canUseSyntheticSourceDelegateForSyntheticSource(value)) {
                 return;
             }
 
-            // if not, then store the field ourselves
+            // otherwise, just store the field ourselves
             final String fieldName = fieldType().syntheticSourceFallbackFieldName();
             context.doc().add(new StoredField(fieldName, value));
         }
-
-        // if we get to this point and synthetic source is enabled, then the field will be stored in ignored source
     }
 
     /**
@@ -1679,8 +1729,8 @@ public final class TextFieldMapper extends FieldMapper {
             });
         }
 
-        // if there is no synthetic source delegate, then fall back to ignored source
-        if (fieldType().syntheticSourceDelegate.isEmpty()) {
+        // this check exists for BWC purposes - there was a bug that resulted in some text fields being stored in ignored source
+        if (fieldType().syntheticSourceDelegate.isEmpty() && indexCreatedVersion.before(IndexVersions.TEXT_FIELDS_STORED_IN_IGNORED_SOURCE_FIX)) {
             return super.syntheticSourceSupport();
         }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/BlockSourceReaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BlockSourceReaderTests.java
@@ -90,8 +90,10 @@ public class BlockSourceReaderTests extends MapperServiceTestCase {
         var sourceLoaderLeaf = sourceLoader.leaf(ctx.reader(), null);
 
         assertThat(loader.rowStrideStoredFieldSpec().requiresSource(), equalTo(true));
+        var storedFieldSpec = loader.rowStrideStoredFieldSpec()
+            .merge(new StoredFieldsSpec(true, false, sourceLoader.requiredStoredFields()));
         var storedFields = new BlockLoaderStoredFieldsFromLeafLoader(
-            StoredFieldLoader.fromSpec(loader.rowStrideStoredFieldSpec()).getLoader(ctx, null),
+            StoredFieldLoader.fromSpec(storedFieldSpec).getLoader(ctx, null),
             sourceLoaderLeaf
         );
         BlockLoader.Builder builder = loader.builder(TestBlock.factory(), 1);

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -91,7 +91,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
@@ -316,7 +318,8 @@ public class TextFieldMapperTests extends MapperTestCase {
         }
     }
 
-    public void testStoreParameterDefaultsToFalseWithLatestIndexVersionWhenSyntheticSourceIsEnabled() throws IOException {
+    public void testStoreParameterDefaultsToTrueWithLatestIndexVersionWhenSyntheticSourceIsEnabled() throws IOException {
+        // given
         var indexSettings = getIndexSettingsBuilder().put(IndexSettings.INDEX_MAPPER_SOURCE_MODE_SETTING.getKey(), "synthetic").build();
 
         var mapping = mapping(b -> {
@@ -325,16 +328,50 @@ public class TextFieldMapperTests extends MapperTestCase {
             b.endObject();
         });
 
+        // when
         DocumentMapper mapper = createMapperService(indexSettings, mapping).documentMapper();
 
+        // then
         var source = source(b -> b.field("name", "quick brown fox"));
         ParsedDocument doc = mapper.parse(source);
+
+        // expect store to be true since synthetic source is enabled
+        List<IndexableField> fields = doc.rootDoc().getFields("name");
+        IndexableFieldType fieldType = fields.get(0).fieldType();
+        assertThat(fieldType.stored(), is(true));
+
+        // there should be nothing in ignored_source
+        List<IndexableField> ignoredSourceFields = doc.rootDoc().getFields("_ignored_source");
+        assertThat(ignoredSourceFields, empty());
+    }
+
+    public void testStoreParameterDefaultsToFalseWithLatestIndexVersion() throws IOException {
+        // given
+        var mapping = mapping(b -> {
+            b.startObject("name");
+            b.field("type", "text");
+            b.endObject();
+        });
+
+        // when
+        DocumentMapper mapper = createMapperService(mapping).documentMapper();
+
+        // then
+        var source = source(b -> b.field("name", "quick brown fox"));
+        ParsedDocument doc = mapper.parse(source);
+
+        // expect store to be false since synthetic source is not enabled
         List<IndexableField> fields = doc.rootDoc().getFields("name");
         IndexableFieldType fieldType = fields.get(0).fieldType();
         assertThat(fieldType.stored(), is(false));
+
+        // the value for the field should be in regular _source since synthetic source is not enabled
+        List<IndexableField> sourceFields = doc.rootDoc().getFields("_source");
+        assertThat(sourceFields, hasSize(1));
     }
 
     public void testStoreParameterDefaultsSyntheticSource() throws IOException {
+        // given
         var indexSettings = getIndexSettingsBuilder().put(IndexSettings.INDEX_MAPPER_SOURCE_MODE_SETTING.getKey(), "synthetic").build();
 
         var mapping = mapping(b -> {
@@ -343,11 +380,15 @@ public class TextFieldMapperTests extends MapperTestCase {
             b.endObject();
         });
 
+        // when
         IndexVersion bwcIndexVersion = IndexVersions.MAPPER_TEXT_MATCH_ONLY_MULTI_FIELDS_DEFAULT_NOT_STORED;
         DocumentMapper mapper = createMapperService(bwcIndexVersion, indexSettings, mapping).documentMapper();
 
+        // then
         var source = source(b -> b.field("name", "quick brown fox"));
         ParsedDocument doc = mapper.parse(source);
+
+        // expect the default to be true since synthetic source is enabled
         List<IndexableField> fields = doc.rootDoc().getFields("name");
         IndexableFieldType fieldType = fields.get(0).fieldType();
         assertThat(fieldType.stored(), is(true));

--- a/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/Clusters.java
+++ b/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/Clusters.java
@@ -27,9 +27,7 @@ public class Clusters {
         if (supportRetryOnShardFailures(oldVersion) == false) {
             cluster.setting("cluster.routing.rebalance.enable", "none");
         }
-        // Temporarily disable DocumentMapper and MapperService assertions for #138796
-        // TODO set back to: 8.18.0
-        if (oldVersion.before(Version.fromString("9.3.0"))) {
+        if (oldVersion.before(Version.fromString("8.18.0"))) {
             cluster.jvmArg("-da:org.elasticsearch.index.mapper.DocumentMapper");
             cluster.jvmArg("-da:org.elasticsearch.index.mapper.MapperService");
         }

--- a/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/Clusters.java
+++ b/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/Clusters.java
@@ -27,7 +27,9 @@ public class Clusters {
         if (supportRetryOnShardFailures(oldVersion) == false) {
             cluster.setting("cluster.routing.rebalance.enable", "none");
         }
-        if (oldVersion.before(Version.fromString("8.18.0"))) {
+        // Temporarily disable DocumentMapper and MapperService assertions for #138796
+        // TODO set back to: 8.18.0
+        if (oldVersion.before(Version.fromString("9.3.0"))) {
             cluster.jvmArg("-da:org.elasticsearch.index.mapper.DocumentMapper");
             cluster.jvmArg("-da:org.elasticsearch.index.mapper.MapperService");
         }


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/issues/138796 we discovered a bug where due to [this check](https://github.com/elastic/elasticsearch/blob/5e856890ac9fd8700323a120558f4b1300415f9b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java#L1479), some text fields were being stored in ignored source. This was unintended.

Unfortunately, while 9.3 is not yet released, the bug is already in serverless. This PR aims to address that.

First, we're going to keep `store` new default as it makes fixing this bug easier. And second, we're going to apply an upper and lower index version check to still read ignored source in block loaders for indices created between when the bug was introduced and now.