### PR TITLE
Revert "Wrap metering parser decorator around dot expanding parser if necessary (#138660)"

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DotExpandingXContentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DotExpandingXContentParser.java
@@ -390,27 +390,11 @@ class DotExpandingXContentParser extends FilterXContentParserWrapper {
     }
 
     @Override
-    public XContentString optimizedText() throws IOException {
-        if (state == State.EXPANDING_START_OBJECT) {
-            throw new IllegalStateException("Can't get text on a " + currentToken() + " at " + getTokenLocation());
-        }
-        return super.optimizedText();
-    }
-
-    @Override
     public String textOrNull() throws IOException {
         if (state == State.EXPANDING_START_OBJECT) {
             throw new IllegalStateException("Can't get text on a " + currentToken() + " at " + getTokenLocation());
         }
         return super.textOrNull();
-    }
-
-    @Override
-    public String text() throws IOException {
-        if (state == State.EXPANDING_START_OBJECT) {
-            throw new IllegalStateException("Can't get text on a " + currentToken() + " at " + getTokenLocation());
-        }
-        return super.text();
     }
 
     @Override


### PR DESCRIPTION
This reverts commit c3a3f244aaa6eb4c125a4e65cd0ec59268cb00cd.

Unfortunately we cannot rely on DotExpandingXContentParser to expand nested, dotted field names.
This is due to the metering parser iterating over skipped children to ensure these are properly metered.
Because of this DotExpandingXContentParser might encounter invalid field names that cannot be expanded properly, e.g.
dot prefixed index names in a dictionary object.