### PR TITLE
[9.2] Fix offset maths bug in InetAddress parsing (#139420)

### DIFF
--- a/docs/changelog/139420.yaml
+++ b/docs/changelog/139420.yaml
@@ -1,0 +1,5 @@
+pr: 139420
+summary: Fix offset maths bug in `InetAddress` parsing
+area: Mapping
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/common/network/InetAddresses.java
+++ b/server/src/main/java/org/elasticsearch/common/network/InetAddresses.java
@@ -97,7 +97,7 @@ public class InetAddresses {
                 if (i == offset + length - 1) {
                     return null;  // Filter out strings that end in % and have an empty scope ID.
                 }
-                length = i;
+                length = i - offset;
                 break; // Everything after a '%' is ignored (it's a Scope ID)
             }
         }

--- a/server/src/test/java/org/elasticsearch/common/network/InetAddressesTests.java
+++ b/server/src/test/java/org/elasticsearch/common/network/InetAddressesTests.java
@@ -240,6 +240,17 @@ public class InetAddressesTests extends ESTestCase {
         }
     }
 
+    public void testScopeIDWithOffsets() {
+        String ipString = "2001:db8::1:0:1:0%5";
+        byte[] bytes = ipString.getBytes(StandardCharsets.UTF_8);
+        int offset = randomInt(8);
+        byte[] bytesWithPadding = new byte[bytes.length + offset];
+        System.arraycopy(bytes, 0, bytesWithPadding, offset, bytes.length);
+        InetAddress addr = InetAddresses.forString(bytesWithPadding, offset, bytes.length);
+        // scope id is ignored
+        assertEquals("2001:db8::1:0:1:0", InetAddresses.toAddrString(addr));
+    }
+
     public void testToUriStringIPv4() {
         String ipStr = "1.2.3.4";
         InetAddress ip = InetAddresses.forString(ipStr);


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Fix offset maths bug in InetAddress parsing (#139420)