### PR TITLE
No EsqlIllegalArgumentException for invalid window values

### DIFF
--- a/docs/changelog/139470.yaml
+++ b/docs/changelog/139470.yaml
@@ -1,0 +1,5 @@
+pr: 139470
+summary: No `EsqlIllegalArgumentException` for invalid window values
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TranslateTimeSeriesAggregate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TranslateTimeSeriesAggregate.java
@@ -457,9 +457,8 @@ public final class TranslateTimeSeriesAggregate extends OptimizerRules.Parameter
         }
         final long bucketInMillis = getTimeBucketInMillis(agg);
         if (bucketInMillis <= 0) {
-            throw new EsqlIllegalArgumentException(
-                "Using a window in aggregation [{}] requires a time bucket in groupings",
-                agg.sourceText()
+            throw new IllegalArgumentException(
+                "Using a window in aggregation [" + agg.sourceText() + "] requires a time bucket in groupings"
             );
         }
         for (NamedExpression aggregate : agg.aggregates()) {
@@ -471,15 +470,19 @@ public final class TranslateTimeSeriesAggregate extends OptimizerRules.Parameter
                         continue;
                     }
                 }
-                throw new EsqlIllegalArgumentException(
-                    "Unsupported window [{}] for aggregate function [{}]; "
-                        + "the window must be larger than the time bucket [{}] and an exact multiple of it",
-                    window.sourceText(),
-                    af.sourceText(),
-                    Objects.requireNonNull(agg.timeBucket()).sourceText()
+                throw new IllegalArgumentException(
+                    "Unsupported window ["
+                        + window.sourceText()
+                        + "] for aggregate function ["
+                        + af.sourceText()
+                        + "]; "
+                        + "the window must be larger than the time bucket ["
+                        + Objects.requireNonNull(agg.timeBucket()).sourceText()
+                        + "] and an exact multiple of it"
                 );
             }
         }
+
     }
 
     private long getTimeBucketInMillis(TimeSeriesAggregate agg) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -21,7 +21,6 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.dissect.DissectParser;
 import org.elasticsearch.index.IndexMode;
-import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.EsqlTestUtils;
 import org.elasticsearch.xpack.esql.VerificationException;
 import org.elasticsearch.xpack.esql.action.EsqlCapabilities;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -8058,7 +8058,7 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
                 | STATS sum(rate(network.total_bytes_in, 1m)) BY TBUCKET(5m)
                 | LIMIT 10
                 """;
-            var error = expectThrows(EsqlIllegalArgumentException.class, () -> {
+            var error = expectThrows(IllegalArgumentException.class, () -> {
                 logicalOptimizerWithLatestVersion.optimize(metricsAnalyzer.analyze(parser.parseQuery(query)));
             });
             assertThat(
@@ -8077,7 +8077,7 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
                 | STATS avg(last_over_time(network.bytes_in, %s minute)) BY tbucket(5 minute)
                 | LIMIT 10
                 """, window);
-            var error = expectThrows(EsqlIllegalArgumentException.class, () -> {
+            var error = expectThrows(IllegalArgumentException.class, () -> {
                 logicalOptimizerWithLatestVersion.optimize(metricsAnalyzer.analyze(parser.parseQuery(query)));
             });
             assertThat(
@@ -8093,7 +8093,7 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
                 | STATS avg(last_over_time(network.bytes_in, %s minute))
                 | LIMIT 10
                 """, window);
-            var error = expectThrows(EsqlIllegalArgumentException.class, () -> {
+            var error = expectThrows(IllegalArgumentException.class, () -> {
                 logicalOptimizerWithLatestVersion.optimize(metricsAnalyzer.analyze(parser.parseQuery(query)));
             });
             assertThat(


### PR DESCRIPTION
`EsqlIllegalArgumentException` shouldn't be used to errors related to user-provided inputs as it leads to 500 errors. Instead, lIllegalArgumentException leads to 400s and is thus preferable.