### PR TITLE
Avoid generating invalid docvalues params in BWC testing

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/datageneration/datasource/DefaultMappingParametersHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/datageneration/datasource/DefaultMappingParametersHandler.java
@@ -280,7 +280,7 @@ public class DefaultMappingParametersHandler implements DataSourceHandler {
         return map;
     }
 
-    public static Object extendedDocValuesParams() {
+    protected Object extendedDocValuesParams() {
         // TODO: Remove this case when FieldMapper.DocValuesParameter.EXTENDED_DOC_VALUES_PARAMS_FF is removed.
         if (Build.current().isSnapshot() == false) {
             return ESTestCase.randomBoolean();

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/AbstractLogsdbRollingUpgradeTestCase.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/AbstractLogsdbRollingUpgradeTestCase.java
@@ -13,6 +13,8 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.util.Version;
 import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.test.rest.TestFeatureService;
+import org.junit.Before;
 import org.junit.ClassRule;
 
 import java.io.IOException;
@@ -20,6 +22,22 @@ import java.io.IOException;
 public abstract class AbstractLogsdbRollingUpgradeTestCase extends ESRestTestCase {
     private static final String USER = "admin-user";
     private static final String PASS = "x-pack-test-password";
+
+    private static TestFeatureService oldClusterTestFeatureService;
+
+    @Before
+    public void retainOldClusterTestFeatureService() {
+        if (oldClusterTestFeatureService == null) {
+            assert testFeatureServiceInitialized() : "testFeatureService must be initialized, see ESRestTestCase#initClient";
+            oldClusterTestFeatureService = testFeatureService;
+        }
+    }
+
+    protected static boolean oldClusterHasFeature(String featureId) {
+        assert oldClusterTestFeatureService != null
+            : "testFeatureService of old cluster cannot be accessed before initialization is complete";
+        return oldClusterTestFeatureService.clusterHasFeature(featureId);
+    }
 
     @ClassRule
     public static final ElasticsearchCluster cluster = Clusters.oldVersionCluster(USER, PASS);

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/RandomizedRollingUpgradeIT.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/RandomizedRollingUpgradeIT.java
@@ -23,6 +23,7 @@ import org.elasticsearch.datageneration.datasource.ASCIIStringsHandler;
 import org.elasticsearch.datageneration.datasource.DataSourceHandler;
 import org.elasticsearch.datageneration.datasource.DataSourceRequest;
 import org.elasticsearch.datageneration.datasource.DataSourceResponse;
+import org.elasticsearch.datageneration.datasource.DefaultMappingParametersHandler;
 import org.elasticsearch.datageneration.datasource.MultifieldAddonHandler;
 import org.elasticsearch.datageneration.matchers.MatchResult;
 import org.elasticsearch.datageneration.matchers.Matcher;
@@ -81,6 +82,15 @@ public class RandomizedRollingUpgradeIT extends AbstractLogsdbRollingUpgradeTest
                             .collect(Collectors.toSet());
                         return new DataSourceResponse.FieldTypeGenerator.FieldTypeInfo(ESTestCase.randomFrom(options));
                     });
+                }
+            }, new DefaultMappingParametersHandler() {
+                @Override
+                protected Object extendedDocValuesParams() {
+                    if (oldClusterHasFeature("mapper.keyword.store_high_cardinality_in_binary_doc_values")) {
+                        return super.extendedDocValuesParams();
+                    }
+
+                    return ESTestCase.randomBoolean();
                 }
             }))
             .withDataSourceHandlers(List.of(MultifieldAddonHandler.STRING_TYPE_HANDLER))


### PR DESCRIPTION
This PR prevents generating mappings with the keyword field `cardinality` parameter set if the cluster under test does not support that parameter.