### PR TITLE
UnMuting Incorrectly Muted Token Filters Test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -63,9 +63,6 @@ tests:
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=nodes.stats/11_indices_metrics/indices mappings exact count test for indices level}
   issue: https://github.com/elastic/elasticsearch/issues/120950
-- class: org.elasticsearch.analysis.common.CommonAnalysisClientYamlTestSuiteIT
-  method: test {yaml=analysis-common/40_token_filters/stemmer_override file access}
-  issue: https://github.com/elastic/elasticsearch/issues/121625
 - class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
   method: test {yaml=snapshot.delete/10_basic/Delete a snapshot asynchronously}
   issue: https://github.com/elastic/elasticsearch/issues/122102


### PR DESCRIPTION
This test was incorrectly muted related to entitlements work previously and unfortunately fell through the cracks.  Unmuting now to fix. 

Fixes: https://github.com/elastic/elasticsearch/issues/121625