### PR TITLE
[8.19] Address CompoundRetrieverBuilder Failure Handling (#136732)

### DIFF
--- a/docs/changelog/136732.yaml
+++ b/docs/changelog/136732.yaml
@@ -1,0 +1,5 @@
+pr: 136732
+summary: Added logic for individual shard failure handling for `CompoundRetrieverBuilder` and fixed how partial search results flag is passed through to `CompoundRetrieverBuilder`
+area: Search
+type: bug
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchRedStateIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchRedStateIndexIT.java
@@ -96,7 +96,7 @@ public class SearchRedStateIndexIT extends ESIntegTestCase {
     }
 
     private void setClusterDefaultAllowPartialResults(boolean allowPartialResults) {
-        String key = SearchService.DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS.getKey();
+        String key = SearchService.DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS_SETTING.getKey();
 
         Settings persistentSettings = Settings.builder().put(key, allowPartialResults).build();
 
@@ -130,6 +130,6 @@ public class SearchRedStateIndexIT extends ESIntegTestCase {
 
     @After
     public void cleanup() throws Exception {
-        updateClusterSettings(Settings.builder().putNull(SearchService.DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS.getKey()));
+        updateClusterSettings(Settings.builder().putNull(SearchService.DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS_SETTING.getKey()));
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
+import static org.elasticsearch.search.SearchService.DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS;
 
 /**
  * A request to execute search against one or more indices (or all).
@@ -329,7 +330,10 @@ public class SearchRequest extends LegacyActionRequest implements IndicesRequest
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
         boolean scroll = scroll() != null;
-        boolean allowPartialSearchResults = allowPartialSearchResults() != null && allowPartialSearchResults();
+
+        boolean allowPartialSearchResults = allowPartialSearchResults() == null
+            ? DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS
+            : allowPartialSearchResults();
 
         if (source != null) {
             validationException = source.validate(validationException, scroll, allowPartialSearchResults);

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -506,6 +506,9 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
 
         final SearchSourceBuilder source = original.source();
         final boolean isExplain = source != null && source.explain() != null && source.explain();
+        final boolean allowPartialSearchResults = original.allowPartialSearchResults() != null
+            ? original.allowPartialSearchResults()
+            : searchService.defaultAllowPartialSearchResults();
         if (shouldOpenPIT(source)) {
             // disabling shard reordering for request
             original.setPreFilterShardSize(Integer.MAX_VALUE);
@@ -539,7 +542,8 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                     timeProvider::absoluteStartMillis,
                     resolvedIndices,
                     original.pointInTimeBuilder(),
-                    isExplain
+                    isExplain,
+                    allowPartialSearchResults
                 ),
                 rewriteListener
             );

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -355,7 +355,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
         MasterService.MASTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING,
         MasterService.MASTER_SERVICE_STARVATION_LOGGING_THRESHOLD_SETTING,
         SearchService.DEFAULT_SEARCH_TIMEOUT_SETTING,
-        SearchService.DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS,
+        SearchService.DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS_SETTING,
         TransportSearchAction.SHARD_COUNT_LIMIT_SETTING,
         TransportSearchAction.DEFAULT_PRE_FILTER_SHARD_SIZE,
         RemoteClusterService.REMOTE_CLUSTER_SKIP_UNAVAILABLE,

--- a/server/src/main/java/org/elasticsearch/index/query/QueryRewriteContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryRewriteContext.java
@@ -48,6 +48,8 @@ import java.util.function.LongSupplier;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.search.SearchService.DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS;
+
 /**
  * Context object used to rewrite {@link QueryBuilder} instances into simplified version.
  */
@@ -73,6 +75,48 @@ public class QueryRewriteContext {
     private final PointInTimeBuilder pit;
     private QueryRewriteInterceptor queryRewriteInterceptor;
     private final boolean isExplain;
+    private final boolean allowPartialSearchResults;
+
+    public QueryRewriteContext(
+        final XContentParserConfiguration parserConfiguration,
+        final Client client,
+        final LongSupplier nowInMillis,
+        final MapperService mapperService,
+        final MappingLookup mappingLookup,
+        final Map<String, MappedFieldType> runtimeMappings,
+        final IndexSettings indexSettings,
+        final Index fullyQualifiedIndex,
+        final Predicate<String> indexNameMatcher,
+        final NamedWriteableRegistry namedWriteableRegistry,
+        final ValuesSourceRegistry valuesSourceRegistry,
+        final BooleanSupplier allowExpensiveQueries,
+        final ScriptCompiler scriptService,
+        final ResolvedIndices resolvedIndices,
+        final PointInTimeBuilder pit,
+        final QueryRewriteInterceptor queryRewriteInterceptor,
+        final boolean isExplain,
+        final boolean allowPartialSearchResults
+    ) {
+        this.parserConfiguration = parserConfiguration;
+        this.client = client;
+        this.nowInMillis = nowInMillis;
+        this.mapperService = mapperService;
+        this.mappingLookup = Objects.requireNonNull(mappingLookup);
+        this.allowUnmappedFields = indexSettings == null || indexSettings.isDefaultAllowUnmappedFields();
+        this.runtimeMappings = runtimeMappings;
+        this.indexSettings = indexSettings;
+        this.fullyQualifiedIndex = fullyQualifiedIndex;
+        this.indexNameMatcher = indexNameMatcher;
+        this.writeableRegistry = namedWriteableRegistry;
+        this.valuesSourceRegistry = valuesSourceRegistry;
+        this.allowExpensiveQueries = allowExpensiveQueries;
+        this.scriptService = scriptService;
+        this.resolvedIndices = resolvedIndices;
+        this.pit = pit;
+        this.queryRewriteInterceptor = queryRewriteInterceptor;
+        this.isExplain = isExplain;
+        this.allowPartialSearchResults = allowPartialSearchResults;
+    }
 
     public QueryRewriteContext(
         final XContentParserConfiguration parserConfiguration,
@@ -93,25 +137,26 @@ public class QueryRewriteContext {
         final QueryRewriteInterceptor queryRewriteInterceptor,
         final boolean isExplain
     ) {
-
-        this.parserConfiguration = parserConfiguration;
-        this.client = client;
-        this.nowInMillis = nowInMillis;
-        this.mapperService = mapperService;
-        this.mappingLookup = Objects.requireNonNull(mappingLookup);
-        this.allowUnmappedFields = indexSettings == null || indexSettings.isDefaultAllowUnmappedFields();
-        this.runtimeMappings = runtimeMappings;
-        this.indexSettings = indexSettings;
-        this.fullyQualifiedIndex = fullyQualifiedIndex;
-        this.indexNameMatcher = indexNameMatcher;
-        this.writeableRegistry = namedWriteableRegistry;
-        this.valuesSourceRegistry = valuesSourceRegistry;
-        this.allowExpensiveQueries = allowExpensiveQueries;
-        this.scriptService = scriptService;
-        this.resolvedIndices = resolvedIndices;
-        this.pit = pit;
-        this.queryRewriteInterceptor = queryRewriteInterceptor;
-        this.isExplain = isExplain;
+        this(
+            parserConfiguration,
+            client,
+            nowInMillis,
+            mapperService,
+            Objects.requireNonNull(mappingLookup),
+            runtimeMappings,
+            indexSettings,
+            fullyQualifiedIndex,
+            indexNameMatcher,
+            namedWriteableRegistry,
+            valuesSourceRegistry,
+            allowExpensiveQueries,
+            scriptService,
+            resolvedIndices,
+            pit,
+            queryRewriteInterceptor,
+            isExplain,
+            DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS
+        );
     }
 
     public QueryRewriteContext(final XContentParserConfiguration parserConfiguration, final Client client, final LongSupplier nowInMillis) {
@@ -132,7 +177,8 @@ public class QueryRewriteContext {
             null,
             null,
             null,
-            false
+            false,
+            DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS
         );
     }
 
@@ -144,7 +190,48 @@ public class QueryRewriteContext {
         final PointInTimeBuilder pit,
         final QueryRewriteInterceptor queryRewriteInterceptor
     ) {
-        this(parserConfiguration, client, nowInMillis, resolvedIndices, pit, queryRewriteInterceptor, false);
+        this(
+            parserConfiguration,
+            client,
+            nowInMillis,
+            resolvedIndices,
+            pit,
+            queryRewriteInterceptor,
+            false,
+            DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS
+        );
+    }
+
+    public QueryRewriteContext(
+        final XContentParserConfiguration parserConfiguration,
+        final Client client,
+        final LongSupplier nowInMillis,
+        final ResolvedIndices resolvedIndices,
+        final PointInTimeBuilder pit,
+        final QueryRewriteInterceptor queryRewriteInterceptor,
+        final boolean isExplain,
+        final boolean allowPartialSearchResults
+    ) {
+        this(
+            parserConfiguration,
+            client,
+            nowInMillis,
+            null,
+            MappingLookup.EMPTY,
+            Collections.emptyMap(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            resolvedIndices,
+            pit,
+            queryRewriteInterceptor,
+            isExplain,
+            allowPartialSearchResults
+        );
     }
 
     public QueryRewriteContext(
@@ -173,7 +260,8 @@ public class QueryRewriteContext {
             resolvedIndices,
             pit,
             queryRewriteInterceptor,
-            isExplain
+            isExplain,
+            DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS
         );
     }
 
@@ -281,6 +369,10 @@ public class QueryRewriteContext {
 
     public boolean isExplain() {
         return this.isExplain;
+    }
+
+    public boolean allowPartialSearchResults() {
+        return this.allowPartialSearchResults;
     }
 
     public NamedWriteableRegistry getWriteableRegistry() {

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -1797,9 +1797,19 @@ public class IndicesService extends AbstractLifecycleComponent
         LongSupplier nowInMillis,
         ResolvedIndices resolvedIndices,
         PointInTimeBuilder pit,
-        final boolean isExplain
+        final boolean isExplain,
+        final boolean allowPartialSearchResults
     ) {
-        return new QueryRewriteContext(parserConfig, client, nowInMillis, resolvedIndices, pit, queryRewriteInterceptor, isExplain);
+        return new QueryRewriteContext(
+            parserConfig,
+            client,
+            nowInMillis,
+            resolvedIndices,
+            pit,
+            queryRewriteInterceptor,
+            isExplain,
+            allowPartialSearchResults
+        );
     }
 
     public DataRewriteContext getDataRewriteContext(LongSupplier nowInMillis) {

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -1786,13 +1786,6 @@ public class IndicesService extends AbstractLifecycleComponent
     /**
      * Returns a new {@link QueryRewriteContext} with the given {@code now} provider
      */
-    public QueryRewriteContext getRewriteContext(LongSupplier nowInMillis, ResolvedIndices resolvedIndices, PointInTimeBuilder pit) {
-        return getRewriteContext(nowInMillis, resolvedIndices, pit, false);
-    }
-
-    /**
-     * Returns a new {@link QueryRewriteContext} with the given {@code now} provider
-     */
     public QueryRewriteContext getRewriteContext(
         LongSupplier nowInMillis,
         ResolvedIndices resolvedIndices,

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -220,9 +220,11 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         Property.Dynamic,
         Property.NodeScope
     );
-    public static final Setting<Boolean> DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS = Setting.boolSetting(
+
+    public static final boolean DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS = true;
+    public static final Setting<Boolean> DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS_SETTING = Setting.boolSetting(
         "search.default_allow_partial_results",
-        true,
+        DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS,
         Property.Dynamic,
         Property.NodeScope
     );
@@ -392,9 +394,9 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
 
         minimumDocsPerSlice = MINIMUM_DOCS_PER_SLICE.get(settings);
 
-        defaultAllowPartialSearchResults = DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS.get(settings);
+        defaultAllowPartialSearchResults = DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS_SETTING.get(settings);
         clusterService.getClusterSettings()
-            .addSettingsUpdateConsumer(DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS, this::setDefaultAllowPartialSearchResults);
+            .addSettingsUpdateConsumer(DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS_SETTING, this::setDefaultAllowPartialSearchResults);
 
         maxOpenScrollContext = MAX_OPEN_SCROLL_CONTEXT.get(settings);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(MAX_OPEN_SCROLL_CONTEXT, this::setMaxOpenScrollContext);
@@ -2093,8 +2095,18 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
     /**
      * Returns a new {@link QueryRewriteContext} with the given {@code now} provider
      */
-    public QueryRewriteContext getRewriteContext(LongSupplier nowInMillis, ResolvedIndices resolvedIndices, PointInTimeBuilder pit) {
-        return getRewriteContext(nowInMillis, resolvedIndices, pit, false);
+    public QueryRewriteContext getRewriteContext(
+        LongSupplier nowInMillis,
+        ResolvedIndices resolvedIndices,
+        PointInTimeBuilder pit
+    ) {
+        return getRewriteContext(
+            nowInMillis,
+            resolvedIndices,
+            pit,
+            false,
+            DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS
+        );
     }
 
     /**
@@ -2104,9 +2116,16 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         LongSupplier nowInMillis,
         ResolvedIndices resolvedIndices,
         PointInTimeBuilder pit,
-        final boolean isExplain
+        final boolean isExplain,
+        final boolean allowPartialSearchResults
     ) {
-        return indicesService.getRewriteContext(nowInMillis, resolvedIndices, pit, isExplain);
+        return indicesService.getRewriteContext(
+            nowInMillis,
+            resolvedIndices,
+            pit,
+            isExplain,
+            allowPartialSearchResults
+        );
     }
 
     public CoordinatorRewriteContextProvider getCoordinatorRewriteContextProvider(LongSupplier nowInMillis) {

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -2095,18 +2095,8 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
     /**
      * Returns a new {@link QueryRewriteContext} with the given {@code now} provider
      */
-    public QueryRewriteContext getRewriteContext(
-        LongSupplier nowInMillis,
-        ResolvedIndices resolvedIndices,
-        PointInTimeBuilder pit
-    ) {
-        return getRewriteContext(
-            nowInMillis,
-            resolvedIndices,
-            pit,
-            false,
-            DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS
-        );
+    public QueryRewriteContext getRewriteContext(LongSupplier nowInMillis, ResolvedIndices resolvedIndices, PointInTimeBuilder pit) {
+        return getRewriteContext(nowInMillis, resolvedIndices, pit, false, DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS);
     }
 
     /**
@@ -2119,13 +2109,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         final boolean isExplain,
         final boolean allowPartialSearchResults
     ) {
-        return indicesService.getRewriteContext(
-            nowInMillis,
-            resolvedIndices,
-            pit,
-            isExplain,
-            allowPartialSearchResults
-        );
+        return indicesService.getRewriteContext(nowInMillis, resolvedIndices, pit, isExplain, allowPartialSearchResults);
     }
 
     public CoordinatorRewriteContextProvider getCoordinatorRewriteContextProvider(LongSupplier nowInMillis) {

--- a/server/src/main/java/org/elasticsearch/search/retriever/CompoundRetrieverBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/CompoundRetrieverBuilder.java
@@ -19,6 +19,7 @@ import org.elasticsearch.action.search.MultiSearchRequest;
 import org.elasticsearch.action.search.MultiSearchResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.action.search.TransportMultiSearchAction;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -174,9 +175,14 @@ public abstract class CompoundRetrieverBuilder<T extends CompoundRetrieverBuilde
                             }
                         } else {
                             assert item.getResponse() != null;
-                            var rankDocs = getRankDocs(item.getResponse());
-                            innerRetrievers.get(i).retriever().setRankDocs(rankDocs);
-                            topDocs.add(rankDocs);
+                            // TODO: handle partial failures by passing them back up with the results
+                            if (item.getResponse().getFailedShards() > 0 && ctx.allowPartialSearchResults() == false) {
+                                statusCode = handleShardFailures(item.getResponse(), statusCode, failures);
+                            } else {
+                                var rankDocs = getRankDocs(item.getResponse());
+                                innerRetrievers.get(i).retriever().setRankDocs(rankDocs);
+                                topDocs.add(rankDocs);
+                            }
                         }
                     }
                     if (false == failures.isEmpty()) {
@@ -210,6 +216,37 @@ public abstract class CompoundRetrieverBuilder<T extends CompoundRetrieverBuilde
         );
         rankDocsRetrieverBuilder.retrieverName(retrieverName());
         return rankDocsRetrieverBuilder;
+    }
+
+    int handleShardFailures(SearchResponse response, int statusCode, List<Exception> failures) {
+        ShardSearchFailure[] shardFailures = response.getShardFailures();
+        for (ShardSearchFailure shardFailure : shardFailures) {
+            if (shardFailure != null) {
+                int shardFailureStatusCode = ExceptionsHelper.status(shardFailure.getCause()).getStatus();
+                failures.add(
+                    processInnerItemFailureException(
+                        new ElasticsearchStatusException(
+                            "failed to retrieve data from shard ["
+                                + shardFailure.shardId()
+                                + "] with message: "
+                                + shardFailure.getCause().getMessage(),
+                            RestStatus.fromCode(shardFailureStatusCode)
+                        )
+                    )
+                );
+                statusCode = Math.max(shardFailureStatusCode, statusCode);
+            }
+        }
+        return statusCode;
+    }
+
+    /**
+     * Overridable method to check or modify any failures from child retrievers if needed
+     * @param ex the exception thrown
+     * @return the failure exception
+     */
+    protected Exception processInnerItemFailureException(Exception ex) {
+        return ex;
     }
 
     @Override
@@ -246,12 +283,6 @@ public abstract class CompoundRetrieverBuilder<T extends CompoundRetrieverBuilde
                     rankWindowSize,
                     size
                 ),
-                validationException
-            );
-        }
-        if (allowPartialSearchResults) {
-            validationException = addValidationError(
-                "cannot specify [" + getName() + "] and [allow_partial_search_results]",
                 validationException
             );
         }

--- a/server/src/test/java/org/elasticsearch/action/search/SearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchRequestTests.java
@@ -297,12 +297,7 @@ public class SearchRequestTests extends AbstractSearchTestCase {
             searchRequest.allowPartialSearchResults(true);
             searchRequest.scroll((Scroll) null);
             ActionRequestValidationException validationErrors = searchRequest.validate();
-            assertNotNull(validationErrors);
-            assertEquals(1, validationErrors.validationErrors().size());
-            assertEquals(
-                "cannot specify [test_compound_retriever_builder] and [allow_partial_search_results]",
-                validationErrors.validationErrors().get(0)
-            );
+            assertNull(validationErrors);
         }
         {
             // scroll and compound retriever

--- a/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
@@ -1743,9 +1743,8 @@ public class TransportSearchActionTests extends ESTestCase {
             NodeClient client = new NodeClient(settings, threadPool);
 
             SearchService searchService = mock(SearchService.class);
-            when(searchService.getRewriteContext(any(), any(), any(), anyBoolean())).thenReturn(
-                new QueryRewriteContext(null, null, null, null, null, null)
-            );
+            when(searchService.getRewriteContext(any(), any(), any(), anyBoolean(), anyBoolean()))
+                .thenReturn(new QueryRewriteContext(null, null, null, null, null, null));
             ClusterService clusterService = new ClusterService(
                 settings,
                 new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),

--- a/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
@@ -1743,8 +1743,9 @@ public class TransportSearchActionTests extends ESTestCase {
             NodeClient client = new NodeClient(settings, threadPool);
 
             SearchService searchService = mock(SearchService.class);
-            when(searchService.getRewriteContext(any(), any(), any(), anyBoolean(), anyBoolean()))
-                .thenReturn(new QueryRewriteContext(null, null, null, null, null, null));
+            when(searchService.getRewriteContext(any(), any(), any(), anyBoolean(), anyBoolean())).thenReturn(
+                new QueryRewriteContext(null, null, null, null, null, null)
+            );
             ClusterService clusterService = new ClusterService(
                 settings,
                 new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),

--- a/server/src/test/java/org/elasticsearch/search/retriever/CompoundRetrieverBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/retriever/CompoundRetrieverBuilderTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.search.retriever;
+
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.search.SearchShardTarget;
+import org.elasticsearch.test.ESTestCase;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+
+public class CompoundRetrieverBuilderTests extends ESTestCase {
+    public void testShardFailureHandling() {
+        SearchResponse response = Mockito.mock(SearchResponse.class);
+        ShardSearchFailure[] shardFailures = new ShardSearchFailure[2];
+        shardFailures[0] = new ShardSearchFailure(
+            new IOException("some shard failed"), // 500
+            new SearchShardTarget("1", new ShardId("1", "1", 1), "foo")
+        );
+        shardFailures[1] = new ShardSearchFailure(
+            new IOException("some second shard failed"), // 500
+            new SearchShardTarget("2", new ShardId("2", "2", 2), "bar")
+        );
+        when(response.getShardFailures()).thenReturn(shardFailures);
+
+        int priorStatusCode = randomIntBetween(200, 600);
+        List<Exception> failures = new ArrayList<>();
+        int shardFailureStatusCode = new TestCompoundRetrieverBuilder(0).handleShardFailures(response, priorStatusCode, failures);
+
+        assertEquals(2, failures.size());
+        assertEquals("failed to retrieve data from shard [1] with message: some shard failed", failures.get(0).getMessage());
+        assertEquals("failed to retrieve data from shard [2] with message: some second shard failed", failures.get(1).getMessage());
+        assertEquals(Math.max(priorStatusCode, 500), shardFailureStatusCode);
+    }
+}

--- a/x-pack/plugin/rank-rrf/src/internalClusterTest/java/org/elasticsearch/xpack/rank/FailingQueryPlugin.java
+++ b/x-pack/plugin/rank-rrf/src/internalClusterTest/java/org/elasticsearch/xpack/rank/FailingQueryPlugin.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.rank;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.SearchPlugin;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+public class FailingQueryPlugin extends Plugin implements SearchPlugin {
+    public FailingQueryPlugin() {}
+
+    @Override
+    public List<QuerySpec<?>> getQueries() {
+        return List.of(
+            new QuerySpec<QueryBuilder>(
+                ShardFailingQueryBuilder.NAME,
+                ShardFailingQueryBuilder::new,
+                ShardFailingQueryBuilder::fromXContent
+            )
+        );
+    }
+
+    @Override
+    public List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return Stream.of(
+            new NamedWriteableRegistry.Entry(ShardFailingQueryBuilder.class, ShardFailingQueryBuilder.NAME, ShardFailingQueryBuilder::new)
+        ).toList();
+    }
+}

--- a/x-pack/plugin/rank-rrf/src/internalClusterTest/java/org/elasticsearch/xpack/rank/ShardFailingQueryBuilder.java
+++ b/x-pack/plugin/rank-rrf/src/internalClusterTest/java/org/elasticsearch/xpack/rank/ShardFailingQueryBuilder.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.rank;
+
+import org.apache.lucene.index.CorruptIndexException;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.store.DataInput;
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.query.AbstractQueryBuilder;
+import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
+
+import java.io.IOException;
+
+public class ShardFailingQueryBuilder extends AbstractQueryBuilder<ShardFailingQueryBuilder> {
+    public static final String NAME = "shard_failing_query";
+
+    public static ShardFailingQueryBuilder fromXContent(XContentParser parser) {
+        return new ShardFailingQueryBuilder();
+    }
+
+    public ShardFailingQueryBuilder() {}
+
+    public ShardFailingQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    @Override
+    public TransportVersion getMinimalSupportedVersion() {
+        return TransportVersion.current();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+
+    }
+
+    @Override
+    protected void doXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(NAME);
+        builder.endObject();
+    }
+
+    @Override
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
+        if (context.getShardId() % 2 == 0) {
+            throw new CorruptIndexException("simulated failure", (DataInput) null);
+        } else {
+            return new MatchAllDocsQuery();
+        }
+    }
+
+    @Override
+    protected boolean doEquals(ShardFailingQueryBuilder other) {
+        return true;
+    }
+
+    @Override
+    protected int doHashCode() {
+        return 0;
+    }
+}

--- a/x-pack/plugin/rank-rrf/src/internalClusterTest/java/org/elasticsearch/xpack/rank/linear/LinearRetrieverIT.java
+++ b/x-pack/plugin/rank-rrf/src/internalClusterTest/java/org/elasticsearch/xpack/rank/linear/LinearRetrieverIT.java
@@ -38,6 +38,8 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.rank.FailingQueryPlugin;
+import org.elasticsearch.xpack.rank.ShardFailingQueryBuilder;
 import org.elasticsearch.xpack.rank.rrf.RRFRankPlugin;
 import org.junit.Before;
 
@@ -45,6 +47,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
@@ -66,7 +69,7 @@ public class LinearRetrieverIT extends ESIntegTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return List.of(RRFRankPlugin.class);
+        return List.of(RRFRankPlugin.class, FailingQueryPlugin.class);
     }
 
     @Before
@@ -111,7 +114,8 @@ public class LinearRetrieverIT extends ESIntegTestCase {
               }
             }
             """;
-        createIndex(INDEX, Settings.builder().put(SETTING_NUMBER_OF_SHARDS, randomIntBetween(1, 5)).build());
+        int shardCount = randomIntBetween(1, 5);
+        createIndex(INDEX, Settings.builder().put(SETTING_NUMBER_OF_SHARDS, shardCount).build());
         admin().indices().preparePutMapping(INDEX).setSource(mapping, XContentType.JSON).get();
         indexDoc(INDEX, "doc_1", DOC_FIELD, "doc_1", TOPIC_FIELD, "technology", TEXT_FIELD, "term");
         indexDoc(
@@ -834,5 +838,55 @@ public class LinearRetrieverIT extends ESIntegTestCase {
             searchResponse -> assertThat(searchResponse.getHits().getTotalHits().value, is(4L))
         );
         assertThat(numAsyncCalls.get(), equalTo(4));
+    }
+
+    public void testLinearRetrieverPartialSearchErrorsFalse() {
+        final int rankWindowSize = 100;
+        SearchSourceBuilder source = new SearchSourceBuilder();
+        StandardRetrieverBuilder failingRetriever = new StandardRetrieverBuilder(new ShardFailingQueryBuilder());
+        StandardRetrieverBuilder standardRetriever = new StandardRetrieverBuilder(QueryBuilders.matchAllQuery());
+        source.retriever(
+            new LinearRetrieverBuilder(
+                Arrays.asList(
+                    new CompoundRetrieverBuilder.RetrieverSource(standardRetriever, null),
+                    new CompoundRetrieverBuilder.RetrieverSource(failingRetriever, null)
+                ),
+                rankWindowSize
+            )
+        );
+
+        // a failure should throw an exception when partial results are not allowed
+        SearchRequestBuilder req = client().prepareSearch(INDEX).setAllowPartialSearchResults(false).setSource(source);
+        Exception ex = expectThrows(ElasticsearchStatusException.class, req::get);
+        assertTrue(ex.getSuppressed()[0].toString().contains("simulated failure"));
+    }
+
+    public void testLinearRetrieverPartialSearchErrorsTrue() {
+        final int rankWindowSize = 100;
+        SearchSourceBuilder source = new SearchSourceBuilder();
+        StandardRetrieverBuilder failingRetriever = new StandardRetrieverBuilder(new ShardFailingQueryBuilder());
+        StandardRetrieverBuilder standardRetriever = new StandardRetrieverBuilder(QueryBuilders.matchAllQuery());
+        source.retriever(
+            new LinearRetrieverBuilder(
+                Arrays.asList(
+                    new CompoundRetrieverBuilder.RetrieverSource(standardRetriever, null),
+                    new CompoundRetrieverBuilder.RetrieverSource(failingRetriever, null)
+                ),
+                rankWindowSize
+            )
+        );
+
+        // when partial search results are allowed we should instead get a result and for now ignore partial failures
+        SearchRequestBuilder req = client().prepareSearch(INDEX).setAllowPartialSearchResults(true).setSource(source);
+
+        long shardCount = Objects.requireNonNull(client().admin().indices().prepareStats(INDEX).get().getPrimaries().getShards())
+            .getTotalCount();
+
+        if (shardCount == 1) {
+            Exception ex = expectThrows(ElasticsearchStatusException.class, req::get);
+            assertTrue(ex.getSuppressed()[0].toString().contains("simulated failure"));
+        } else {
+            assertResponse(req, searchResponse -> { assertEquals(shardCount / 2 + shardCount % 2, searchResponse.getFailedShards()); });
+        }
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Address CompoundRetrieverBuilder Failure Handling #136732](https://github.com/elastic/elasticsearch/pull/136732)
