### PR TITLE
Fix GoogleCloudStorageBlobStoreRepositoryTests#testReadNonExistingPath

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -454,9 +454,6 @@ tests:
 - class: org.elasticsearch.xpack.inference.integration.AuthorizationTaskExecutorIT
   method: testCreatesChatCompletion_AndThenCreatesTextEmbedding
   issue: https://github.com/elastic/elasticsearch/issues/138012
-- class: org.elasticsearch.repositories.gcs.GoogleCloudStorageBlobStoreRepositoryTests
-  method: testReadNonExistingPath
-  issue: https://github.com/elastic/elasticsearch/issues/139436
 - class: org.elasticsearch.xpack.unsignedlong.UnsignedLongSyntheticSourceNativeArrayIntegrationTests
   method: testSynthesizeArrayRandom
   issue: https://github.com/elastic/elasticsearch/issues/139376

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESBlobStoreRepositoryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESBlobStoreRepositoryIntegTestCase.java
@@ -131,7 +131,7 @@ public abstract class ESBlobStoreRepositoryIntegTestCase extends ESIntegTestCase
         try (BlobStore store = newBlobStore()) {
             final BlobContainer container = store.blobContainer(BlobPath.EMPTY);
             expectThrows(NoSuchFileException.class, () -> {
-                try (InputStream is = container.readBlob(randomPurpose(), "non-existing")) {
+                try (InputStream is = container.readBlob(randomRetryingPurpose(), "non-existing")) {
                     is.read();
                 }
             });


### PR DESCRIPTION
Now we don't retry for `REPOSITORY_ANALYSIS` we need to be careful not to use it in tests we expect to be resilient to simulated failures.

Closes: #139436
