### PR TITLE
Fix index version constant

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -180,7 +180,7 @@ public class IndexVersions {
     public static final IndexVersion SPARSE_VECTOR_PRUNING_INDEX_OPTIONS_SUPPORT = def(9_031_0_00, Version.LUCENE_10_2_2);
     public static final IndexVersion DEFAULT_DENSE_VECTOR_TO_BBQ_HNSW = def(9_032_0_00, Version.LUCENE_10_2_2);
     public static final IndexVersion MATCH_ONLY_TEXT_STORED_AS_BYTES = def(9_033_0_00, Version.LUCENE_10_2_2);
-    public static final IndexVersion SECURITY_MIGRATIONS_METADATA_FLATTENED_UPDATE = def(9_034_0_00, Version.LUCENE_10_2_2);
+    public static final IndexVersion SECURITY_MIGRATIONS_METADATA_FLATTENED_UPDATE = def(9_033_0_01, Version.LUCENE_10_2_2);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -180,7 +180,7 @@ public class IndexVersions {
     public static final IndexVersion SPARSE_VECTOR_PRUNING_INDEX_OPTIONS_SUPPORT = def(9_031_0_00, Version.LUCENE_10_2_2);
     public static final IndexVersion DEFAULT_DENSE_VECTOR_TO_BBQ_HNSW = def(9_032_0_00, Version.LUCENE_10_2_2);
     public static final IndexVersion MATCH_ONLY_TEXT_STORED_AS_BYTES = def(9_033_0_00, Version.LUCENE_10_2_2);
-    public static final IndexVersion SECURITY_MIGRATIONS_METADATA_FLATTENED_UPDATE = def(9_033_0_01, Version.LUCENE_10_2_2);
+    public static final IndexVersion BACKPORT_91_SECURITY_MIGRATIONS_METADATA_FLATTENED_UPDATE = def(9_033_0_01, Version.LUCENE_10_2_2);
 
     /*
      * STOP! READ THIS FIRST! No, really,


### PR DESCRIPTION
We need to use a patch version, not a full version here. 9.1.8 was the previous commit (50f58de526b746a6cc07f0cbec0e0d510f13ce52), so this hasn't been released yet - we can modify this in time for 9.1.9.

This is the same problem as fixed in #139361 on 9.2.

Discovered by #139482.