### PR TITLE
Enable large numeric blocks for TSDB codec in production

### DIFF
--- a/docs/changelog/139503.yaml
+++ b/docs/changelog/139503.yaml
@@ -3,3 +3,11 @@ summary: Enable large numeric blocks for TSDB codec in production
 area: Codec
 type: enhancement
 issues: []
+highlight:
+  title: Enable large numeric blocks for TSDB codec
+  body: |-
+    The size of numeric blocks gets increased from 128 to 512, for indices with [index.mode:time-series].
+    This mostly improves compression for multi-values in fields using sorted-set doc values, such as keyword and
+    ip fields, as run-length encoding covers more data for the same storage footprint.
+
+  notable: true

--- a/docs/changelog/139503.yaml
+++ b/docs/changelog/139503.yaml
@@ -1,0 +1,5 @@
+pr: 139503
+summary: Enable large numeric blocks for TSDB codec in production
+area: Codec
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/codec/PerFieldFormatSupplier.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/PerFieldFormatSupplier.java
@@ -44,8 +44,6 @@ public class PerFieldFormatSupplier {
     private static final Set<String> INCLUDE_META_FIELDS;
     private static final Set<String> EXCLUDE_MAPPER_TYPES;
 
-    private static final boolean TSDB_USE_LARGE_NUMERIC_BLOCKS = new FeatureFlag("tsdb_large_numeric_blocks").isEnabled();
-
     static {
         // TODO: should we just allow all fields to use tsdb doc values codec?
         // Avoid using tsdb codec for fields like _seq_no, _primary_term.
@@ -63,9 +61,7 @@ public class PerFieldFormatSupplier {
     private static final DocValuesFormat docValuesFormat = new Lucene90DocValuesFormat();
     private static final KnnVectorsFormat knnVectorsFormat = new ES93HnswVectorsFormat();
     private static final ES819TSDBDocValuesFormat tsdbDocValuesFormat = ES819TSDBDocValuesFormat.getInstance(false);
-    private static final ES819TSDBDocValuesFormat tsdbDocValuesFormatLargeNumericBlock = ES819TSDBDocValuesFormat.getInstance(
-        TSDB_USE_LARGE_NUMERIC_BLOCKS
-    );
+    private static final ES819TSDBDocValuesFormat tsdbDocValuesFormatLargeNumericBlock = ES819TSDBDocValuesFormat.getInstance(true);
     private static final ES812PostingsFormat es812PostingsFormat = new ES812PostingsFormat();
     private static final PostingsFormat completionPostingsFormat = PostingsFormat.forName("Completion101");
 

--- a/server/src/main/java/org/elasticsearch/index/codec/PerFieldFormatSupplier.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/PerFieldFormatSupplier.java
@@ -14,7 +14,6 @@ import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.codecs.lucene90.Lucene90DocValuesFormat;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.FeatureFlag;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersions;


### PR DESCRIPTION
Enables the uses of large numeric blocks in the TSDB codec. This is limited to the `time-series` index mode; `logsdb` mode continues to use standard numeric blocks.

Related to [136307](https://github.com/elastic/elasticsearch/issues/136307)