### PR TITLE
Fix release test for node_reduction profiling

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -433,12 +433,6 @@ tests:
 - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
   method: test {yaml=index/100_field_name_length_limit/Test field name length limit array synthetic source}
   issue: https://github.com/elastic/elasticsearch/issues/139300
-- class: org.elasticsearch.xpack.esql.qa.single_node.RestEsqlIT
-  method: testProfile {SYNC}
-  issue: https://github.com/elastic/elasticsearch/issues/139303
-- class: org.elasticsearch.xpack.esql.qa.single_node.RestEsqlIT
-  method: testProfile {ASYNC}
-  issue: https://github.com/elastic/elasticsearch/issues/139304
 - class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
   method: test {yaml=search.retrievers/result-diversification/10_mmr_result_diversification_retriever/Test MMR result diversification single index float type}
   issue: https://github.com/elastic/elasticsearch/issues/139335

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/RestEsqlIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/RestEsqlIT.java
@@ -381,7 +381,13 @@ public class RestEsqlIT extends RestEsqlTestCase {
                     assertFalse(plan.containsKey("reduction_nanos"));
                 }
                 case "node_reduce" -> {
-                    assertThat((int) plan.get("reduction_nanos"), greaterThanOrEqualTo(0));
+                    if (Build.current().isSnapshot()) {
+                        // Node reduction depends on a pragma for now, so not available on non-snapshot builds - timing won't be available
+                        assertThat((int) plan.get("reduction_nanos"), greaterThanOrEqualTo(0));
+                    } else {
+                        // Remove the if and check reduction_nanos is there when the following fails
+                        assertNull(plan.get("reduction_nanos"));
+                    }
                     assertFalse(plan.containsKey("logical_optimization_nanos"));
                     assertFalse(plan.containsKey("physical_optimization_nanos"));
                 }


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch/issues/139303
Closes https://github.com/elastic/elasticsearch/issues/139274

node_reduce phase is controlled by a query pragma, meaning that it's only available on snapshot builds.

Modifies the profiling test so it does check for this to happen only on snapshots.