### PR TITLE
ES|QL: Throw error when function example cannot be found

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/DocsV3Support.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/DocsV3Support.java
@@ -1412,7 +1412,17 @@ public abstract class DocsV3Support {
             if (info.examples().length > 0) {
                 builder.startArray("examples");
                 for (Example example : info.examples()) {
-                    builder.value(loadExample(example.file(), example.tag()));
+                    var loadedExample = loadExample(example.file(), example.tag());
+                    if (loadedExample == null) {
+                        throw new IllegalArgumentException(
+                            "Failed to write Kibana function definition for function ["
+                                + name
+                                + "], example with tag ["
+                                + example.tag()
+                                + "] cannot be loaded."
+                        );
+                    }
+                    builder.value(loadedExample);
                 }
                 builder.endArray();
             } else if (info.operator().isEmpty()) {


### PR DESCRIPTION
related: https://github.com/elastic/elasticsearch/pull/139507
When we fail to load a function example, we simply add a `null` value, which then causes the Kibana CI to fail, since Kibana has proper checks when it loads the functions specification.

This adds a check similar to https://github.com/elastic/elasticsearch/pull/135094 - such that we fail early when we detect that a function example cannot be loaded.