### PR TITLE
Fix index.mapping.use_doc_values_skipper defaults in serverless

### DIFF
--- a/docs/changelog/139526.yaml
+++ b/docs/changelog/139526.yaml
@@ -1,0 +1,5 @@
+pr: 139526
+summary: Fix `index.mapping.use_doc_values_skippers` defaults in serverless
+area: Mapping
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -1245,7 +1245,8 @@ public final class IndexSettings {
         useDocValuesSkipper = scopedSettings.get(USE_DOC_VALUES_SKIPPER);
         useDocValuesSkipperForHostname = USE_DOC_VALUES_SKIPPER.exists(settings)
             ? scopedSettings.get(USE_DOC_VALUES_SKIPPER)
-            : version.onOrAfter(IndexVersions.SKIPPERS_ENABLED_BY_DEFAULT) && version.before(IndexVersions.STATELESS_SKIPPERS_ENABLED_FOR_TSDB);
+            : version.onOrAfter(IndexVersions.SKIPPERS_ENABLED_BY_DEFAULT)
+                && version.before(IndexVersions.STATELESS_SKIPPERS_ENABLED_FOR_TSDB);
         seqNoIndexOptions = scopedSettings.get(SEQ_NO_INDEX_OPTIONS_SETTING);
         useTimeSeriesDocValuesFormat = scopedSettings.get(USE_TIME_SERIES_DOC_VALUES_FORMAT_SETTING);
         useTimeSeriesDocValuesFormatLargeBlockSize = scopedSettings.get(USE_TIME_SERIES_DOC_VALUES_FORMAT_LARGE_BLOCK_SIZE);

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -773,24 +773,11 @@ public final class IndexSettings {
     public static final Setting<Boolean> USE_DOC_VALUES_SKIPPER = Setting.boolSetting("index.mapping.use_doc_values_skipper", s -> {
         IndexVersion iv = SETTING_INDEX_VERSION_CREATED.get(s);
         if (MODE.get(s) == IndexMode.TIME_SERIES) {
-            if (DiscoveryNode.isStateless(s)) {
-                if (iv.onOrAfter(IndexVersions.STATELESS_SKIPPERS_ENABLED_FOR_TSDB)) {
-                    return "true";
-                } else {
-                    return "false";
-                }
-            }
             if (iv.onOrAfter(IndexVersions.SKIPPERS_ENABLED_BY_DEFAULT)) {
                 return "true";
             }
             return "false";
         } else {
-            if (DiscoveryNode.isStateless(s)) {
-                return "false";
-            }
-            if (iv.onOrAfter(IndexVersions.SKIPPERS_ENABLED_BY_DEFAULT) && iv.before(IndexVersions.SKIPPER_DEFAULTS_ONLY_ON_TSDB)) {
-                return "true";
-            }
             return "false";
         }
     }, Property.IndexScope, Property.Final);

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -1245,7 +1245,7 @@ public final class IndexSettings {
         useDocValuesSkipper = scopedSettings.get(USE_DOC_VALUES_SKIPPER);
         useDocValuesSkipperForHostname = USE_DOC_VALUES_SKIPPER.exists(settings)
             ? scopedSettings.get(USE_DOC_VALUES_SKIPPER)
-            : version.onOrAfter(IndexVersions.SKIPPERS_ENABLED_BY_DEFAULT) && version.before(IndexVersions.SKIPPER_DEFAULTS_ONLY_ON_TSDB);
+            : version.onOrAfter(IndexVersions.SKIPPERS_ENABLED_BY_DEFAULT) && version.before(IndexVersions.STATELESS_SKIPPERS_ENABLED_FOR_TSDB);
         seqNoIndexOptions = scopedSettings.get(SEQ_NO_INDEX_OPTIONS_SETTING);
         useTimeSeriesDocValuesFormat = scopedSettings.get(USE_TIME_SERIES_DOC_VALUES_FORMAT_SETTING);
         useTimeSeriesDocValuesFormatLargeBlockSize = scopedSettings.get(USE_TIME_SERIES_DOC_VALUES_FORMAT_LARGE_BLOCK_SIZE);

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -770,6 +770,7 @@ public final class IndexSettings {
         Property.ServerlessPublic
     );
 
+    private static final boolean DOC_VALUES_SKIPPER = new FeatureFlag("doc_values_skipper").isEnabled();
     public static final Setting<Boolean> USE_DOC_VALUES_SKIPPER = Setting.boolSetting("index.mapping.use_doc_values_skipper", s -> {
         IndexVersion iv = SETTING_INDEX_VERSION_CREATED.get(s);
         if (MODE.get(s) == IndexMode.TIME_SERIES) {
@@ -778,6 +779,11 @@ public final class IndexSettings {
             }
             return "false";
         } else {
+            if (DOC_VALUES_SKIPPER
+                && iv.onOrAfter(IndexVersions.SKIPPERS_ENABLED_BY_DEFAULT)
+                && iv.before(IndexVersions.SKIPPER_DEFAULTS_ONLY_ON_TSDB)) {
+                return "true";
+            }
             return "false";
         }
     }, Property.IndexScope, Property.Final);

--- a/server/src/test/java/org/elasticsearch/index/mapper/SkipperSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/SkipperSettingsTests.java
@@ -28,10 +28,6 @@ public class SkipperSettingsTests extends ESTestCase {
             assertFalse(indexSettings.useDocValuesSkipper());
         }
         {
-            IndexSettings indexSettings = settings(IndexVersions.STANDARD_INDEXES_USE_SKIPPERS, b -> {});
-            assertTrue(indexSettings.useDocValuesSkipper());
-        }
-        {
             IndexSettings indexSettings = settings(IndexVersions.SKIPPER_DEFAULTS_ONLY_ON_TSDB, b -> {});
             assertFalse(indexSettings.useDocValuesSkipper());
         }
@@ -72,12 +68,6 @@ public class SkipperSettingsTests extends ESTestCase {
                 b -> { b.put(IndexSettings.MODE.getKey(), IndexMode.LOGSDB.getName()); }
             );
             assertFalse(indexSettings.useDocValuesSkipper());
-        }
-        {
-            IndexSettings indexSettings = settings(IndexVersions.STANDARD_INDEXES_USE_SKIPPERS, b -> {
-                b.put(IndexSettings.MODE.getKey(), IndexMode.LOGSDB.getName());
-            });
-            assertTrue(indexSettings.useDocValuesSkipper());
         }
         {
             IndexSettings indexSettings = settings(IndexVersions.SKIPPER_DEFAULTS_ONLY_ON_TSDB, b -> {


### PR DESCRIPTION
We can't detect whether or not we are in serverless during default value
setup because we don't have node settings at this point. This removes
all serverless/stateful detection logic from here, as the various different
index structure changes made during development were never released
and we can use some much simpler checks.