### PR TITLE
[Inference API] Switch EIS license to enterprise

### DIFF
--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/BaseMockEISAuthServerTest.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/BaseMockEISAuthServerTest.java
@@ -38,7 +38,7 @@ public class BaseMockEISAuthServerTest extends ESRestTestCase {
 
     private static ElasticsearchCluster cluster = ElasticsearchCluster.local()
         .distribution(DistributionType.DEFAULT)
-        .setting("xpack.license.self_generated.type", "basic")
+        .setting("xpack.license.self_generated.type", "trial")
         .setting("xpack.security.enabled", "true")
         // Adding both settings unless one feature flag is disabled in a particular environment
         .setting("xpack.inference.elastic.url", mockEISServer::getUrl)

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceBasicLicenseIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceBasicLicenseIT.java
@@ -45,28 +45,6 @@ public class InferenceBasicLicenseIT extends InferenceLicenseBaseRestTest {
         sendRestrictedRequest("PUT", endpoint, modelConfig);
     }
 
-    public void testUpdateModel_RestrictedWithBasicLicense() throws Exception {
-        var endpoint = Strings.format("_inference/%s/%s/_update?error_trace", TaskType.SPARSE_EMBEDDING, "endpoint-id");
-        var requestBody = """
-            {
-              "task_settings": {
-                "num_threads": 2
-              }
-            }
-            """;
-        sendRestrictedRequest("PUT", endpoint, requestBody);
-    }
-
-    public void testPerformInference_RestrictedWithBasicLicense() throws Exception {
-        var endpoint = Strings.format("_inference/%s/%s?error_trace", TaskType.SPARSE_EMBEDDING, "endpoint-id");
-        var requestBody = """
-            {
-              "input": ["washing", "machine"]
-            }
-            """;
-        sendRestrictedRequest("POST", endpoint, requestBody);
-    }
-
     public void testGetServices_NonRestrictedWithBasicLicense() throws Exception {
         var endpoint = "_inference/_services";
         sendNonRestrictedRequest("GET", endpoint, null, 200, false);

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceBasicLicenseIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceBasicLicenseIT.java
@@ -45,6 +45,28 @@ public class InferenceBasicLicenseIT extends InferenceLicenseBaseRestTest {
         sendRestrictedRequest("PUT", endpoint, modelConfig);
     }
 
+    public void testUpdateModel_RestrictedWithBasicLicense() throws Exception {
+        var endpoint = Strings.format("_inference/%s/%s/_update?error_trace", TaskType.SPARSE_EMBEDDING, "endpoint-id");
+        var requestBody = """
+            {
+              "task_settings": {
+                "num_threads": 2
+              }
+            }
+            """;
+        sendRestrictedRequest("PUT", endpoint, requestBody);
+    }
+
+    public void testPerformInference_RestrictedWithBasicLicense() throws Exception {
+        var endpoint = Strings.format("_inference/%s/%s?error_trace", TaskType.SPARSE_EMBEDDING, "endpoint-id");
+        var requestBody = """
+            {
+              "input": ["washing", "machine"]
+            }
+            """;
+        sendRestrictedRequest("POST", endpoint, requestBody);
+    }
+
     public void testGetServices_NonRestrictedWithBasicLicense() throws Exception {
         var endpoint = "_inference/_services";
         sendNonRestrictedRequest("GET", endpoint, null, 200, false);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
@@ -243,7 +243,7 @@ public class InferencePlugin extends Plugin
     public static final LicensedFeature.Momentary EIS_INFERENCE_FEATURE = LicensedFeature.momentary(
         "inference",
         "Elastic Inference Service",
-        License.OperationMode.BASIC
+        License.OperationMode.ENTERPRISE
     );
 
     public static final String X_ELASTIC_PRODUCT_USE_CASE_HTTP_HEADER = "X-elastic-product-use-case";


### PR DESCRIPTION
This PR switches the EIS license within the inference API from basic to enterprise. The original work to add a separate license checks for EIS and the rest of the inference was done here: https://github.com/elastic/elasticsearch/pull/137434

