### PR TITLE
Fix synthetic source loader for empty tdigests

### DIFF
--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/TDigestFieldMapper.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/TDigestFieldMapper.java
@@ -566,22 +566,19 @@ public class TDigestFieldMapper extends FieldMapper {
             return docId -> {
                 if (docValues.advanceExact(docId)) {
                     // we assume the summary sub-
-                    if (minValues != null) {
-                        minValues.advanceExact(docId);
+                    if (minValues != null && minValues.advanceExact(docId)) {
                         min = NumericUtils.sortableLongToDouble(minValues.longValue());
                     } else {
                         min = Double.NaN;
                     }
 
-                    if (maxValues != null) {
-                        maxValues.advanceExact(docId);
+                    if (maxValues != null && maxValues.advanceExact(docId)) {
                         max = NumericUtils.sortableLongToDouble(maxValues.longValue());
                     } else {
                         max = Double.NaN;
                     }
 
-                    if (sumValues != null) {
-                        sumValues.advanceExact(docId);
+                    if (sumValues != null && sumValues.advanceExact(docId)) {
                         sum = NumericUtils.sortableLongToDouble(sumValues.longValue());
                     } else {
                         sum = Double.NaN;

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/mapper/TDigestFieldMapperTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/mapper/TDigestFieldMapperTests.java
@@ -452,7 +452,7 @@ public class TDigestFieldMapperTests extends MapperTestCase {
 
     static Map<String, Object> generateRandomFieldValues(int maxVals) {
         Map<String, Object> value = new LinkedHashMap<>();
-        int size = between(1, maxVals);
+        int size = between(0, maxVals);
         TDigestState digest = TDigestState.createWithoutCircuitBreaking(100);
         for (int i = 0; i < size; i++) {
             double sample = randomGaussianDouble();
@@ -469,9 +469,11 @@ public class TDigestFieldMapperTests extends MapperTestCase {
         }
         double min = digest.getMin();
         double max = digest.getMax();
-        value.put("min", min);
-        value.put("max", max);
-        value.put("sum", sum);
+        if (size > 0) {
+            value.put("min", min);
+            value.put("max", max);
+            value.put("sum", sum);
+        }
         value.put("centroids", centroids);
         value.put("counts", counts);
 


### PR DESCRIPTION
While setting up TSDB CSV tests for T-Digest, the tests would fail due to an exception in the synthetic source loaders.

There we currently don't check for the possibility of individual `sum`, `min` or `max` values being null.
In practice this likely would never happen, but the test data contains empty T-Digests which trigger this bug.

I've adapted the tests to cover this case and fixed the loader.
