### PR TITLE
Re-enable assertions in DocumentMapper and MapperService in LogsDB upgrade tests

### DIFF
--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/Clusters.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/Clusters.java
@@ -33,13 +33,6 @@ public class Clusters {
             cluster.setting("cluster.routing.rebalance.enable", "none");
         }
 
-        // Temporarily disable DocumentMapper and MapperService assertions for #138796
-        // TODO reenable these assertions
-        if (oldVersion.before(Version.fromString("9.3.0"))) {
-            cluster.jvmArg("-da:org.elasticsearch.index.mapper.DocumentMapper");
-            cluster.jvmArg("-da:org.elasticsearch.index.mapper.MapperService");
-        }
-
         return cluster.build();
     }
 


### PR DESCRIPTION
Now that #138796 is closed, we can reenable the assertions.

Related to #139505.

Related to #139408.