### PR TITLE
[CI] Use Ubuntu 24.04 for GPU CI tasks

### DIFF
--- a/.buildkite/pipelines/cuvs-snapshot/run-tests.yml
+++ b/.buildkite/pipelines/cuvs-snapshot/run-tests.yml
@@ -4,7 +4,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: aws
-      imagePrefix: elasticsearch-aws-ubuntu-2204-nvidia
+      imagePrefix: elasticsearch-aws-ubuntu-2404-nvidia
       instanceType: g6.8xlarge
       diskSizeGb: 350
       diskType: gp3

--- a/.buildkite/pipelines/cuvs-snapshot/update-snapshot.yml
+++ b/.buildkite/pipelines/cuvs-snapshot/update-snapshot.yml
@@ -3,7 +3,7 @@ steps:
     command: .buildkite/scripts/cuvs-snapshot/update-current-snapshot-version.sh
     agents:
       provider: aws
-      imagePrefix: elasticsearch-aws-ubuntu-2204-nvidia
+      imagePrefix: elasticsearch-aws-ubuntu-2404-nvidia
       instanceType: g6.2xlarge
       diskSizeGb: 350
       diskType: gp3

--- a/.buildkite/pipelines/pull-request/gpu.yml
+++ b/.buildkite/pipelines/pull-request/gpu.yml
@@ -11,7 +11,7 @@ steps:
         timeout_in_minutes: 300
         agents:
           provider: aws
-          imagePrefix: elasticsearch-aws-ubuntu-2204-nvidia
+          imagePrefix: elasticsearch-aws-ubuntu-2404-nvidia
           instanceType: g6.8xlarge
           diskSizeGb: 350
           diskType: gp3


### PR DESCRIPTION
- Switch to the new 24.04 image to resolve an issue with Docker tests