### PR TITLE
Remove uses of TransportVersion.after

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -68,6 +68,11 @@ import java.util.stream.Collectors;
 public record TransportVersion(String name, int id, TransportVersion nextPatchVersion) implements VersionId<TransportVersion> {
 
     @Deprecated(forRemoval = true)
+    public boolean after(TransportVersion version) {
+        return version.id < id;
+    }
+
+    @Deprecated(forRemoval = true)
     public boolean onOrAfter(TransportVersion version) {
         throw new UnsupportedOperationException("use TransportVersion.supports(...) instead");
     }
@@ -345,7 +350,7 @@ public record TransportVersion(String name, int id, TransportVersion nextPatchVe
         }
         TransportVersion bestSoFar = VersionsHolder.ZERO;
         for (final var knownVersion : VersionsHolder.ALL_VERSIONS_BY_ID.values()) {
-            if (knownVersion.after(bestSoFar) && knownVersion.before(this)) {
+            if (knownVersion.id > bestSoFar.id && knownVersion.id < this.id) {
                 bestSoFar = knownVersion;
             }
         }

--- a/server/src/main/java/org/elasticsearch/common/io/stream/VersionCheckingStreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/VersionCheckingStreamOutput.java
@@ -63,7 +63,7 @@ public final class VersionCheckingStreamOutput extends StreamOutput {
     }
 
     private void checkVersionCompatibility(VersionedNamedWriteable namedWriteable) {
-        if (namedWriteable.getMinimalSupportedVersion().after(getTransportVersion())) {
+        if (getTransportVersion().supports(namedWriteable.getMinimalSupportedVersion()) == false) {
             throw new IllegalArgumentException(
                 "["
                     + namedWriteable.getWriteableName()

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -2556,7 +2556,7 @@ public abstract class ESRestTestCase extends ESTestCase {
                 objectPath.evaluate("nodes." + id + ".transport_version"),
                 () -> TransportVersion.minimumCompatible()
             );
-            if (minTransportVersion == null || minTransportVersion.id() > transportVersion.id()) {
+            if (minTransportVersion == null || transportVersion.supports(minTransportVersion) == false) {
                 minTransportVersion = transportVersion;
             }
         }

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -2556,7 +2556,7 @@ public abstract class ESRestTestCase extends ESTestCase {
                 objectPath.evaluate("nodes." + id + ".transport_version"),
                 () -> TransportVersion.minimumCompatible()
             );
-            if (minTransportVersion == null || minTransportVersion.after(transportVersion)) {
+            if (minTransportVersion == null || minTransportVersion.id() > transportVersion.id()) {
                 minTransportVersion = transportVersion;
             }
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ClientHelper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ClientHelper.java
@@ -158,7 +158,7 @@ public final class ClientHelper {
     ) {
         try {
             final Authentication authentication = authenticationReader.apply(authenticationHeaderKey);
-            if (authentication != null && authentication.getEffectiveSubject().getTransportVersion().after(minNodeVersion)) {
+            if (authentication != null && authentication.getEffectiveSubject().getTransportVersion().id() > minNodeVersion.id()) {
                 return authentication.maybeRewriteForOlderVersion(minNodeVersion).encode();
             }
         } catch (IOException e) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ClientHelper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ClientHelper.java
@@ -158,7 +158,7 @@ public final class ClientHelper {
     ) {
         try {
             final Authentication authentication = authenticationReader.apply(authenticationHeaderKey);
-            if (authentication != null && authentication.getEffectiveSubject().getTransportVersion().id() > minNodeVersion.id()) {
+            if (authentication != null && minNodeVersion.supports(authentication.getEffectiveSubject().getTransportVersion()) == false) {
                 return authentication.maybeRewriteForOlderVersion(minNodeVersion).encode();
             }
         } catch (IOException e) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
@@ -1589,7 +1589,7 @@ public final class Authentication implements ToXContentObject {
             : "metadata must contain authentication object for cross cluster access authentication";
         final Authentication authenticationFromMetadata = (Authentication) metadata.get(CROSS_CLUSTER_ACCESS_AUTHENTICATION_KEY);
         final TransportVersion effectiveSubjectVersion = authenticationFromMetadata.getEffectiveSubject().getTransportVersion();
-        if (effectiveSubjectVersion.id() > olderVersion.id()) {
+        if (olderVersion.supports(effectiveSubjectVersion) == false) {
             logger.trace(
                 () -> "Cross cluster access authentication has authentication field in metadata ["
                     + authenticationFromMetadata

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
@@ -1589,7 +1589,7 @@ public final class Authentication implements ToXContentObject {
             : "metadata must contain authentication object for cross cluster access authentication";
         final Authentication authenticationFromMetadata = (Authentication) metadata.get(CROSS_CLUSTER_ACCESS_AUTHENTICATION_KEY);
         final TransportVersion effectiveSubjectVersion = authenticationFromMetadata.getEffectiveSubject().getTransportVersion();
-        if (effectiveSubjectVersion.after(olderVersion)) {
+        if (effectiveSubjectVersion.id() > olderVersion.id()) {
             logger.trace(
                 () -> "Cross cluster access authentication has authentication field in metadata ["
                     + authenticationFromMetadata

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportPutInferenceModelAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportPutInferenceModelAction.java
@@ -170,7 +170,7 @@ public class TransportPutInferenceModelAction extends TransportMasterNodeAction<
         }
 
         // Check if all the nodes in this cluster know about the service
-        if (service.get().getMinimalSupportedVersion().id() > state.getMinTransportVersion().id()) {
+        if (state.getMinTransportVersion().supports(service.get().getMinimalSupportedVersion())) {
             logger.warn(
                 format(
                     "Service [%s] requires version [%s] but minimum cluster version is [%s]",

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportPutInferenceModelAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportPutInferenceModelAction.java
@@ -170,7 +170,7 @@ public class TransportPutInferenceModelAction extends TransportMasterNodeAction<
         }
 
         // Check if all the nodes in this cluster know about the service
-        if (state.getMinTransportVersion().supports(service.get().getMinimalSupportedVersion())) {
+        if (state.getMinTransportVersion().supports(service.get().getMinimalSupportedVersion()) == false) {
             logger.warn(
                 format(
                     "Service [%s] requires version [%s] but minimum cluster version is [%s]",

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportPutInferenceModelAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportPutInferenceModelAction.java
@@ -170,7 +170,7 @@ public class TransportPutInferenceModelAction extends TransportMasterNodeAction<
         }
 
         // Check if all the nodes in this cluster know about the service
-        if (service.get().getMinimalSupportedVersion().after(state.getMinTransportVersion())) {
+        if (service.get().getMinimalSupportedVersion().id() > state.getMinTransportVersion().id()) {
             logger.warn(
                 format(
                     "Service [%s] requires version [%s] but minimum cluster version is [%s]",


### PR DESCRIPTION
Clean up and remove uses of `TransportVersion.after`.