### PR TITLE
[9.2] [CI] Use Ubuntu 24.04 for GPU CI tasks (#139551)

### DIFF
--- a/.buildkite/pipelines/cuvs-snapshot/run-tests.yml
+++ b/.buildkite/pipelines/cuvs-snapshot/run-tests.yml
@@ -4,7 +4,7 @@ steps:
     timeout_in_minutes: 300
     agents:
       provider: aws
-      imagePrefix: elasticsearch-aws-ubuntu-2204-nvidia
+      imagePrefix: elasticsearch-aws-ubuntu-2404-nvidia
       instanceType: g6.8xlarge
       diskSizeGb: 350
       diskType: gp3

--- a/.buildkite/pipelines/cuvs-snapshot/update-snapshot.yml
+++ b/.buildkite/pipelines/cuvs-snapshot/update-snapshot.yml
@@ -3,7 +3,7 @@ steps:
     command: .buildkite/scripts/cuvs-snapshot/update-current-snapshot-version.sh
     agents:
       provider: aws
-      imagePrefix: elasticsearch-aws-ubuntu-2204-nvidia
+      imagePrefix: elasticsearch-aws-ubuntu-2404-nvidia
       instanceType: g6.2xlarge
       diskSizeGb: 350
       diskType: gp3

--- a/.buildkite/pipelines/pull-request/gpu.yml
+++ b/.buildkite/pipelines/pull-request/gpu.yml
@@ -11,7 +11,7 @@ steps:
         timeout_in_minutes: 300
         agents:
           provider: aws
-          imagePrefix: elasticsearch-aws-ubuntu-2204-nvidia
+          imagePrefix: elasticsearch-aws-ubuntu-2404-nvidia
           instanceType: g6.8xlarge
           diskSizeGb: 350
           diskType: gp3


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [[CI] Use Ubuntu 24.04 for GPU CI tasks (#139551)](https://github.com/elastic/elasticsearch/pull/139551)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)