### PR TITLE
Refactor RandomizedRollingUpgradeIT

### DIFF
--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/RandomizedRollingUpgradeIT.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/RandomizedRollingUpgradeIT.java
@@ -103,35 +103,46 @@ public class RandomizedRollingUpgradeIT extends AbstractLogsdbRollingUpgradeTest
         mappingGenerator = new MappingGenerator(specification);
     }
 
-    private void testIndexing(String indexName, Settings.Builder settings) throws IOException {
+    private TestIndexConfig createIndex(String indexName, Settings.Builder settings) throws IOException {
         var template = templateGenerator.generate();
         TestIndexConfig indexConfig = new TestIndexConfig(indexName, template, settings, mappingGenerator.generate(template));
 
         @SuppressWarnings("unchecked")
         Map<String, Object> mappingRaw = (Map<String, Object>) indexConfig.mapping.raw().get("_doc");
         String mappingStr = Strings.toString(XContentFactory.jsonBuilder().map(mappingRaw));
-        logger.info(indexName + " mappings: " + mappingStr);
+        logger.info(() -> indexName + " mappings: " + mappingStr);
         createIndex(indexName, settings.build(), mappingStr);
 
+        return indexConfig;
+    }
+
+    private void indexAndQueryDocuments(TestIndexConfig indexConfig) throws IOException {
         indexDocuments(indexConfig);
         testQueryAll(indexConfig);
         testEsqlSource(indexConfig);
+    }
+
+    private void testIndexing(String indexNameBase, Settings.Builder settings) throws IOException {
+        TestIndexConfig[] indexConfigs = new TestIndexConfig[NUM_INDICES];
+
+        for (int i = 0; i < NUM_INDICES; i++) {
+            indexConfigs[i] = createIndex(indexNameBase + i, settings);
+            indexAndQueryDocuments(indexConfigs[i]);
+        }
 
         int numNodes = Integer.parseInt(System.getProperty("tests.num_nodes", "3"));
         for (int i = 0; i < numNodes; i++) {
             upgradeNode(i);
-            indexDocuments(indexConfig);
-            testQueryAll(indexConfig);
-            testEsqlSource(indexConfig);
+            for (int j = 0; j < NUM_INDICES; j++) {
+                indexAndQueryDocuments(indexConfigs[j]);
+            }
         }
     }
 
     public void testIndexingStandardSource() throws IOException {
         Settings.Builder builder = Settings.builder().put(IndexSettings.INDEX_MAPPER_SOURCE_MODE_SETTING.getKey(), "stored");
         String indexNameBase = "test-index-standard-";
-        for (int i = 0; i < NUM_INDICES; i++) {
-            testIndexing(indexNameBase + i, builder);
-        }
+        testIndexing(indexNameBase, builder);
     }
 
     public void testIndexingSyntheticSource() throws IOException {
@@ -140,9 +151,7 @@ public class RandomizedRollingUpgradeIT extends AbstractLogsdbRollingUpgradeTest
             builder.put(Mapper.SYNTHETIC_SOURCE_KEEP_INDEX_SETTING.getKey(), "arrays");
         }
         String indexNameBase = "test-index-synthetic-";
-        for (int i = 0; i < NUM_INDICES; i++) {
-            testIndexing(indexNameBase + i, builder);
-        }
+        testIndexing(indexNameBase, builder);
     }
 
     private void indexDocuments(TestIndexConfig indexConfig) throws IOException {


### PR DESCRIPTION
This PR updates the randomized rolling upgrade test to create multiple indices with different mappings before upgrading.

In the original implementation, only the first test index was actually being upgraded, since the test would execute sequentially for each index. By the time the test reached the second index, the whole cluster had already been upgraded.