### PR TITLE
[9.2] fix: Correctly pickup MRT value for `msearch`'s search requests (#138583)

### DIFF
--- a/docs/changelog/138583.yaml
+++ b/docs/changelog/138583.yaml
@@ -1,0 +1,5 @@
+pr: 138583
+summary: "Fix: Correctly pickup MRT value for `msearch`'s search requests"
+area: CCS
+type: bug
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/msearch/MultiSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/msearch/MultiSearchIT.java
@@ -29,7 +29,6 @@ import org.hamcrest.Matchers;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFirstHit;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/msearch/MultiSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/msearch/MultiSearchIT.java
@@ -211,9 +211,7 @@ public class MultiSearchIT extends ESIntegTestCase {
             mkRequest(body, params),
             true,
             new UsageService().getSearchUsageHolder(),
-            (ignored) -> true,
-            // Disable CPS for these tests.
-            Optional.of(false)
+            (ignored) -> true
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
@@ -141,10 +141,6 @@ public class RestMultiSearchAction extends BaseRestHandler {
             RestSearchAction.validateSearchRequest(restRequest, searchRequest);
             if (searchRequest.pointInTimeBuilder() != null) {
                 RestSearchAction.preparePointInTime(searchRequest, restRequest);
-            } else {
-                searchRequest.setCcsMinimizeRoundtrips(
-                    restRequest.paramAsBoolean("ccs_minimize_roundtrips", searchRequest.isCcsMinimizeRoundtrips())
-                );
             }
             multiRequest.add(searchRequest);
         }, extraParamParser);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [fix: Correctly pickup MRT value for `msearch`'s search requests (#138583)](https://github.com/elastic/elasticsearch/pull/138583)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)