### PR TITLE
[8.19] fix: Correctly pickup MRT value for `msearch`'s search requests (#138583)

### DIFF
--- a/docs/changelog/138583.yaml
+++ b/docs/changelog/138583.yaml
@@ -1,0 +1,5 @@
+pr: 138583
+summary: "Fix: Correctly pickup MRT value for `msearch`'s search requests"
+area: CCS
+type: bug
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/msearch/MultiSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/msearch/MultiSearchIT.java
@@ -28,8 +28,8 @@ import org.elasticsearch.xcontent.XContentType;
 import org.hamcrest.Matchers;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFirstHit;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
@@ -192,9 +192,10 @@ public class MultiSearchIT extends ESIntegTestCase {
 
             MultiSearchRequest mreq = parseRequest(body, Map.of("ccs_minimize_roundtrips", "false"));
 
+            List<SearchRequest> searchRequests = mreq.requests();
             assertThat(mreq.requests().size(), Matchers.is(2));
-            assertTrue(mreq.requests().getFirst().isCcsMinimizeRoundtrips());
-            assertFalse(mreq.requests().getLast().isCcsMinimizeRoundtrips());
+            assertTrue(mreq.requests().get(0).isCcsMinimizeRoundtrips());
+            assertFalse(mreq.requests().get(searchRequests.size() - 1).isCcsMinimizeRoundtrips());
         }
     }
 
@@ -211,9 +212,7 @@ public class MultiSearchIT extends ESIntegTestCase {
             mkRequest(body, params),
             true,
             new UsageService().getSearchUsageHolder(),
-            (ignored) -> true,
-            // Disable CPS for these tests.
-            Optional.of(false)
+            (ignored) -> true
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
@@ -150,10 +150,6 @@ public class RestMultiSearchAction extends BaseRestHandler {
             RestSearchAction.validateSearchRequest(restRequest, searchRequest);
             if (searchRequest.pointInTimeBuilder() != null) {
                 RestSearchAction.preparePointInTime(searchRequest, restRequest);
-            } else {
-                searchRequest.setCcsMinimizeRoundtrips(
-                    restRequest.paramAsBoolean("ccs_minimize_roundtrips", searchRequest.isCcsMinimizeRoundtrips())
-                );
             }
             multiRequest.add(searchRequest);
         }, extraParamParser);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [fix: Correctly pickup MRT value for `msearch`'s search requests (#138583)](https://github.com/elastic/elasticsearch/pull/138583)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)