### PR TITLE
[9.2] ESQL: Prevent circular alias references in `DeduplicateAggs` (#139175)

### DIFF
--- a/docs/changelog/139175.yaml
+++ b/docs/changelog/139175.yaml
@@ -1,0 +1,7 @@
+pr: 139175
+summary: "ESQL: Prevent circular alias references in `DeduplicateAggs`"
+area: ES|QL
+type: bug
+issues:
+  - 138346
+  - 139541

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/enrich.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/enrich.csv-spec
@@ -781,3 +781,72 @@ ROW a = 1, b = 2
 values(language_name_a):keyword | values(language_name_b):keyword
 English                         | French
 ;
+
+
+circularRefEnrichStats
+required_capability: enrich_load
+required_capability: fix_enrich_alias_cycle_in_deduplicate_aggs
+FROM languages_lookup 
+| RENAME language_name AS message  
+| ENRICH languages_policy ON language_code 
+| STATS a = count(to_lower(language_name)), b = count(language_name)
+;
+
+a:long  | b:long
+4       | 4
+;
+
+
+circularRefEnrichStats2
+required_capability: enrich_load
+required_capability: fix_enrich_alias_cycle_in_deduplicate_aggs
+FROM languages_lookup 
+| RENAME language_name AS message  
+| ENRICH languages_policy ON language_code 
+| STATS a = count(to_lower(language_name)), b = count(message)
+;
+
+a:long  | b:long
+4       | 4
+;
+
+
+circularRefEnrichStats3
+required_capability: enrich_load
+required_capability: fix_enrich_alias_cycle_in_deduplicate_aggs
+FROM languages_lookup 
+| ENRICH languages_policy ON language_code
+| RENAME language_name AS message
+| STATS a = count(to_lower(message)), b = count(message)
+;
+
+a:long  | b:long
+4       | 4
+;
+
+
+circularRefEnrichStats4
+required_capability: enrich_load
+required_capability: fix_enrich_alias_cycle_in_deduplicate_aggs
+FROM languages_lookup 
+| ENRICH languages_policy ON language_code WITH message=language_name
+| RENAME language_name AS message
+| STATS a = count(to_lower(message)), b = count(message)
+;
+
+a:long  | b:long
+4       | 4
+;
+
+
+circularRefEnrichStats5
+required_capability: enrich_load
+required_capability: fix_enrich_alias_cycle_in_deduplicate_aggs
+FROM languages_lookup 
+| ENRICH languages_policy ON language_code WITH message=language_name
+| STATS a = count(to_lower(language_name)), b = count(message)
+;
+
+a:long  | b:long
+4       | 4
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1667,6 +1667,13 @@ public class EsqlCapabilities {
 
         FULL_TEXT_FUNCTIONS_ACCEPT_NULL_FIELD,
 
+        /**
+         * Fix for circular reference in alias chains during PushDownEnrich and aggregate deduplication.
+         * Prevents "Potential cycle detected" errors when aliases reference each other.
+         * https://github.com/elastic/elasticsearch/issues/138346
+         */
+        FIX_ENRICH_ALIAS_CYCLE_IN_DEDUPLICATE_AGGS,
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Enrich.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/Enrich.java
@@ -233,7 +233,9 @@ public class Enrich extends UnaryPlan
             if (enrichField.name().equals(newName)) {
                 newEnrichFields.add(enrichField);
             } else if (enrichField instanceof ReferenceAttribute ra) {
-                newEnrichFields.add(new Alias(ra.source(), newName, ra, new NameId(), ra.synthetic()));
+                // It's safe to generate new name ids when assigning new names - the original attribute representing
+                // the field in the enrich index cannot be directly referenced in downstream plans, anyway
+                newEnrichFields.add(new Alias(ra.source(), newName, ra.withId(new NameId()), new NameId(), ra.synthetic()));
             } else if (enrichField instanceof Alias a) {
                 newEnrichFields.add(new Alias(a.source(), newName, a.child(), new NameId(), a.synthetic()));
             } else {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [ESQL: Prevent circular alias references in `DeduplicateAggs` (#139175)](https://github.com/elastic/elasticsearch/pull/139175)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)