### PR TITLE
[TEST] Reduce docCount for DownsampleActionSingleNodeTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -448,9 +448,6 @@ tests:
 - class: org.elasticsearch.xpack.unsignedlong.UnsignedLongSyntheticSourceNativeArrayIntegrationTests
   method: testSynthesizeArrayRandom
   issue: https://github.com/elastic/elasticsearch/issues/139376
-- class: org.elasticsearch.xpack.downsample.DownsampleActionSingleNodeTests
-  method: testDownsampleDatastream
-  issue: https://github.com/elastic/elasticsearch/issues/139438
 - class: org.elasticsearch.xpack.esql.optimizer.LocalLogicalPlanOptimizerTests
   method: testReductionPlanForTopNWithPushedDownFunctionsInOrder
   issue: https://github.com/elastic/elasticsearch/issues/139490

--- a/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
+++ b/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
@@ -180,7 +180,7 @@ public class DownsampleActionSingleNodeTests extends ESSingleNodeTestCase {
         sourceIndex = randomAlphaOfLength(14).toLowerCase(Locale.ROOT);
         downsampleIndex = "downsample-" + sourceIndex;
         startTime = randomLongBetween(946769284000L, 1607470084000L); // random date between 2000-2020
-        docCount = randomIntBetween(1000, 9000);
+        docCount = randomIntBetween(1000, 7000);
         numOfShards = randomIntBetween(1, 1);
         numOfReplicas = randomIntBetween(0, 0);
 


### PR DESCRIPTION
Reduce the limit from 9k to 7k, to avoid OOMEs and unmute the test.

Fixes #139438 