### PR TITLE
Enable invalid cluster alias test in QueryRewriteContextMultiClustersIT when security is enabled

### DIFF
--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/QueryRewriteContextMultiClustersIT.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/QueryRewriteContextMultiClustersIT.java
@@ -225,8 +225,6 @@ public class QueryRewriteContextMultiClustersIT extends AbstractMultiClustersTes
     }
 
     public void testInvalidClusterAlias() {
-        // TODO: Enable this test for all cases when bug is fixed
-        assumeFalse("Test is currently broken when security is enabled due to unrelated bug", securityEnabled);
         SearchRequestBuilder request = buildSearchRequest(
             List.of(INDEX_1, INDEX_2),
             List.of(REMOTE_CLUSTER_A, REMOTE_CLUSTER_B, "missing-cluster-alias"),


### PR DESCRIPTION
With https://github.com/elastic/elasticsearch/pull/138546 merged, we can enable the invalid cluster alias test when security is enabled.