### PR TITLE
[9.1] Validation for index name expressions (#139023)

### DIFF
--- a/docs/changelog/139023.yaml
+++ b/docs/changelog/139023.yaml
@@ -1,0 +1,5 @@
+pr: 139023
+summary: Add comma delimiter validation to index name expressions in roles and API keys
+area: Security
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/RoleDescriptorRequestValidator.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/RoleDescriptorRequestValidator.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.core.security.action.role;
 
+import org.apache.lucene.util.automaton.RegExp;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
@@ -139,6 +140,24 @@ public class RoleDescriptorRequestValidator {
                     + "]",
                 validationException
             );
+        }
+        if (indexNameExpression != null) {
+            if (indexNameExpression.startsWith("/")) {
+                if (indexNameExpression.length() == 1 || indexNameExpression.endsWith("/") == false) {
+                    return addValidationError("invalid regular expression pattern [" + indexNameExpression + "]", validationException);
+                }
+                String regex = indexNameExpression.substring(1, indexNameExpression.length() - 1);
+                try {
+                    new RegExp(regex);
+                } catch (IllegalArgumentException e) {
+                    return addValidationError("invalid regular expression pattern [" + indexNameExpression + "]", validationException);
+                }
+            } else if (indexNameExpression.contains(",")) {
+                validationException = addValidationError(
+                    "commas [,] are not allowed in the index name expression [" + indexNameExpression + "]",
+                    validationException
+                );
+            }
         }
         return validationException;
     }


### PR DESCRIPTION
Backports the following commits to 9.1:
 - Validation for index name expressions (#139023)