### PR TITLE
Fix persistent task serialization tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -1,7 +1,4 @@
 tests:
-- class: "org.elasticsearch.client.RestClientSingleHostIntegTests"
-  issue: "https://github.com/elastic/elasticsearch/issues/102717"
-  method: "testRequestResetAndAbort"
 - class: org.elasticsearch.packaging.test.PackagesSecurityAutoConfigurationTests
   method: test20SecurityNotAutoConfiguredOnReInstallation
   issue: https://github.com/elastic/elasticsearch/issues/112635
@@ -457,12 +454,6 @@ tests:
 - class: org.elasticsearch.index.mapper.LongSyntheticSourceNativeArrayIntegrationTests
   method: testSynthesizeArrayRandom
   issue: https://github.com/elastic/elasticsearch/issues/139562
-- class: org.elasticsearch.persistent.ClusterPersistentTasksCustomMetadataTests
-  method: testMinVersionSerialization
-  issue: https://github.com/elastic/elasticsearch/issues/139624
-- class: org.elasticsearch.persistent.PersistentTasksCustomMetadataTests
-  method: testMinVersionSerialization
-  issue: https://github.com/elastic/elasticsearch/issues/139625
 
 # Examples:
 #

--- a/server/src/test/java/org/elasticsearch/persistent/BasePersistentTasksCustomMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/persistent/BasePersistentTasksCustomMetadataTests.java
@@ -31,7 +31,6 @@ import java.util.Optional;
 import static org.elasticsearch.cluster.metadata.Metadata.CONTEXT_MODE_GATEWAY;
 import static org.elasticsearch.cluster.metadata.Metadata.CONTEXT_MODE_SNAPSHOT;
 import static org.elasticsearch.persistent.PersistentTasksExecutor.NO_NODE_FOUND;
-import static org.elasticsearch.test.TransportVersionUtils.getFirstVersion;
 import static org.elasticsearch.test.TransportVersionUtils.getNextVersion;
 import static org.elasticsearch.test.TransportVersionUtils.getPreviousVersion;
 import static org.elasticsearch.test.TransportVersionUtils.randomVersionBetween;

--- a/server/src/test/java/org/elasticsearch/persistent/BasePersistentTasksCustomMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/persistent/BasePersistentTasksCustomMetadataTests.java
@@ -201,7 +201,7 @@ public abstract class BasePersistentTasksCustomMetadataTests<T extends Metadata.
     public void testMinVersionSerialization() throws IOException {
         PersistentTasks.Builder<?> tasks = builder();
 
-        TransportVersion minVersion = getFirstVersion();
+        TransportVersion minVersion = TransportVersion.minimumCompatible();
         TransportVersion streamVersion = randomVersionBetween(random(), minVersion, getPreviousVersion(TransportVersion.current()));
         tasks.addTask(
             "test_compatible_version",


### PR DESCRIPTION
Address test failures related to selecting incompatible transport versions.

Closes https://github.com/elastic/elasticsearch/issues/139625
Closes https://github.com/elastic/elasticsearch/issues/139624