### PR TITLE
[Build] Skip yamlRestTestCompatibility tests when no previous unreleased minor

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/compat/compat/AbstractYamlRestCompatTestPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/compat/compat/AbstractYamlRestCompatTestPlugin.java
@@ -99,7 +99,7 @@ public abstract class AbstractYamlRestCompatTestPlugin implements Plugin<Project
         Optional<String> lastMinorProjectPath = buildParams.getBwcVersions().getUnreleased().stream().filter(v -> {
             return (v.getMajor() == currentMajor - 1);
         }).max(Comparator.naturalOrder()).map(lastMinor -> buildParams.getBwcVersions().unreleasedInfo(lastMinor).gradleProjectPath());
-        
+
         // copy compatible rest specs
         Optional<Configuration> bwcMinorConfig = lastMinorProjectPath.map(p -> project.getConfigurations().create(BWC_MINOR_CONFIG_NAME));
         Optional<Dependency> bwcMinor = lastMinorProjectPath.map(

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/compat/compat/AbstractYamlRestCompatTestPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/compat/compat/AbstractYamlRestCompatTestPlugin.java
@@ -96,14 +96,9 @@ public abstract class AbstractYamlRestCompatTestPlugin implements Plugin<Project
 
         // determine the previous rest compatibility version and BWC project path
         int currentMajor = buildParams.getBwcVersions().getCurrentVersion().getMajor();
-        System.out.println("currentMajor = " + currentMajor);
-        System.out.println("currentMinor = " + buildParams.getBwcVersions().getCurrentVersion().getMinor());
-        System.out.println(buildParams.getBwcVersions().getUnreleased());
-
         Optional<String> lastMinorProjectPath = buildParams.getBwcVersions().getUnreleased().stream().filter(v -> {
-            System.out.println(v.getMajor() + " vs " + (currentMajor - 1));
             return (v.getMajor() == currentMajor - 1);
-        }).min(Comparator.reverseOrder()).map(lastMinor -> buildParams.getBwcVersions().unreleasedInfo(lastMinor).gradleProjectPath());
+        }).max(Comparator.naturalOrder()).map(lastMinor -> buildParams.getBwcVersions().unreleasedInfo(lastMinor).gradleProjectPath());
 
         // buildParams.getBwcVersions().unreleasedInfo(lastMinor).gradleProjectPath();
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/compat/compat/AbstractYamlRestCompatTestPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/compat/compat/AbstractYamlRestCompatTestPlugin.java
@@ -99,9 +99,7 @@ public abstract class AbstractYamlRestCompatTestPlugin implements Plugin<Project
         Optional<String> lastMinorProjectPath = buildParams.getBwcVersions().getUnreleased().stream().filter(v -> {
             return (v.getMajor() == currentMajor - 1);
         }).max(Comparator.naturalOrder()).map(lastMinor -> buildParams.getBwcVersions().unreleasedInfo(lastMinor).gradleProjectPath());
-
-        // buildParams.getBwcVersions().unreleasedInfo(lastMinor).gradleProjectPath();
-
+        
         // copy compatible rest specs
         Optional<Configuration> bwcMinorConfig = lastMinorProjectPath.map(p -> project.getConfigurations().create(BWC_MINOR_CONFIG_NAME));
         Optional<Dependency> bwcMinor = lastMinorProjectPath.map(


### PR DESCRIPTION
This was brought up by the community and by the performance team. We should keep
even older branches buildable as best as possible.

This fixes a configuration issue of yamlRestTestCompatibility tests when no unreleased
previous major is available.