### PR TITLE
Unmute RestClientSingleHostIntegTests.testRequestResetAndAbort

### DIFF
--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientSingleHostIntegTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientSingleHostIntegTests.java
@@ -283,7 +283,7 @@ public class RestClientSingleHostIntegTests extends RestClientTestCase {
                 httpGet.abort();
                 Future<HttpResponse> future = client.execute(httpHost, httpGet, null);
                 try {
-                    future.get();
+                    future.get(5, TimeUnit.SECONDS);
                     fail("expected cancellation exception");
                 } catch (CancellationException e) {
                     // expected
@@ -298,7 +298,7 @@ public class RestClientSingleHostIntegTests extends RestClientTestCase {
                 assertTrue(httpGet.isAborted());
                 try {
                     assertTrue(future.isDone());
-                    future.get();
+                    future.get(5, TimeUnit.SECONDS);
                 } catch (CancellationException e) {
                     // expected sometimes - if the future was cancelled before executing successfully
                 }
@@ -308,7 +308,7 @@ public class RestClientSingleHostIntegTests extends RestClientTestCase {
                 assertFalse(httpGet.isAborted());
                 Future<HttpResponse> future = client.execute(httpHost, httpGet, null);
                 assertFalse(httpGet.isAborted());
-                assertEquals(200, future.get().getStatusLine().getStatusCode());
+                assertEquals(200, future.get(5, TimeUnit.SECONDS).getStatusLine().getStatusCode());
                 assertFalse(future.isCancelled());
             }
         }

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -1,7 +1,4 @@
 tests:
-- class: "org.elasticsearch.client.RestClientSingleHostIntegTests"
-  issue: "https://github.com/elastic/elasticsearch/issues/102717"
-  method: "testRequestResetAndAbort"
 - class: org.elasticsearch.packaging.test.PackagesSecurityAutoConfigurationTests
   method: test20SecurityNotAutoConfiguredOnReInstallation
   issue: https://github.com/elastic/elasticsearch/issues/112635


### PR DESCRIPTION
Unmute this test that's been muted for ages and add some timeouts on `Future.get()` calls so if and when it does hang, it doesn't trip the entire suite timeout.

Closes https://github.com/elastic/elasticsearch/issues/102717