### PR TITLE
Use LongUpDownCounter for Linked Project Error Metrics

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
@@ -102,9 +102,16 @@ public final class RemoteClusterService extends RemoteClusterAware
          *  the functionality to do it the right way is not yet ready -- replace this code when it's ready.
          */
         this.crossProjectEnabled = settings.getAsBoolean("serverless.cross_project.enabled", false);
+        // Since this counter may never be incremented we need to force an initial observed value of zero via add(0) so the metric will be
+        // in the mappings of the indices of the APM data stream, otherwise we will encounter 'not found' errors in dashboards and alerts.
+        // See observability-dev issue #3042.
         transportService.getTelemetryProvider()
             .getMeterRegistry()
-            .registerLongCounter(CONNECTION_ATTEMPT_FAILURES_COUNTER_NAME, "linked project connection attempt failure count", "count");
+            .registerLongUpDownCounter(
+                CONNECTION_ATTEMPT_FAILURES_COUNTER_NAME,
+                "linked project connection attempt failure count",
+                "count"
+            ).add(0);
     }
 
     public RemoteClusterCredentialsManager getRemoteClusterCredentialsManager() {

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
@@ -107,11 +107,8 @@ public final class RemoteClusterService extends RemoteClusterAware
         // See observability-dev issue #3042.
         transportService.getTelemetryProvider()
             .getMeterRegistry()
-            .registerLongUpDownCounter(
-                CONNECTION_ATTEMPT_FAILURES_COUNTER_NAME,
-                "linked project connection attempt failure count",
-                "count"
-            ).add(0);
+            .registerLongUpDownCounter(CONNECTION_ATTEMPT_FAILURES_COUNTER_NAME, "linked project connection attempt failure count", "count")
+            .add(0);
     }
 
     public RemoteClusterCredentialsManager getRemoteClusterCredentialsManager() {

--- a/server/src/test/java/org/elasticsearch/transport/RemoteConnectionStrategyTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteConnectionStrategyTests.java
@@ -266,7 +266,7 @@ public class RemoteConnectionStrategyTests extends ESTestCase {
                     if (shouldConnectFail) {
                         metricRecorder.collect();
                         final var counterName = RemoteClusterService.CONNECTION_ATTEMPT_FAILURES_COUNTER_NAME;
-                        final var measurements = metricRecorder.getMeasurements(InstrumentType.LONG_COUNTER, counterName);
+                        final var measurements = metricRecorder.getMeasurements(InstrumentType.LONG_UP_DOWN_COUNTER, counterName);
                         assertFalse(measurements.isEmpty());
                         final var measurement = measurements.getLast();
                         assertThat(measurement.getLong(), equalTo(1L));


### PR DESCRIPTION
Replaces `LongCounter` with `LongUpDownCounter` for the metric used for linked project connection errors.  Since the metric may not be incremented for long periods of time it was not appearing in the mappings of the current index of the APM datastream.  This results in 'not found' errors when developing dashboards and alerts.  The change required adding an initial zero value so the metric will be collected every polling cycle.  Per a request from core-infra the string concatenation has been eliminated from the metric attribute strings for easier code search.

Using the `LongUpDownCounter` with an initial `add(0)` at registration time I was able to observe the metric in the polled values:
```
$ ./gradlew run -Dtests.es.logger.level=ERROR --with-apm-server --apm-metrics="es.projects.linked.connections.error.total"
...
Metricset [runTask-0]: {"timestamp":1765923703735396,"tags":{"otel_instrumentation_scope_name":"elasticsearch"},"samples":{"es.projects.linked.connections.error.total":{"value":0}}}
Metricset [runTask-0]: {"timestamp":1765923713731978,"tags":{"otel_instrumentation_scope_name":"elasticsearch"},"samples":{"es.projects.linked.connections.error.total":{"value":0}}}
Metricset [runTask-0]: {"timestamp":1765923723734827,"tags":{"otel_instrumentation_scope_name":"elasticsearch"},"samples":{"es.projects.linked.connections.error.total":{"value":0}}}
...
```

I also was able to artificially inject some actual increments, and observed the zero value still being collected when no actual increments were coming through:
```
Metricset [runTask-0]: {"timestamp":1765923159434143,"tags":{"otel_instrumentation_scope_name":"elasticsearch"},"samples":{"es.projects.linked.connections.error.total":{"value":0}}}
Metricset [runTask-0]: {"timestamp":1765923169438216,"tags":{"otel_instrumentation_scope_name":"elasticsearch","es_linked_project_alias":"DEFAULT","es_linked_project_attempt":"initial","es_linked_project_id":"DEFAULT"},"samples":{"es.projects.linked.connections.error.total":{"value":1}}}
Metricset [runTask-0]: {"timestamp":1765923169438216,"tags":{"otel_instrumentation_scope_name":"elasticsearch"},"samples":{"es.projects.linked.connections.error.total":{"value":0}}}
Metricset [runTask-0]: {"timestamp":1765923179436766,"tags":{"otel_instrumentation_scope_name":"elasticsearch","es_linked_project_alias":"DEFAULT","es_linked_project_attempt":"initial","es_linked_project_id":"DEFAULT"},"samples":{"es.projects.linked.connections.error.total":{"value":1}}}
Metricset [runTask-0]: {"timestamp":1765923179436766,"tags":{"otel_instrumentation_scope_name":"elasticsearch"},"samples":{"es.projects.linked.connections.error.total":{"value":0}}}
```

This refactoring is necessary since the suggested workaround of using an explicit formula instead of a quick function in the dashboards did not prevent the 'not found' issue.

Relates: ES-12696
Relates: ES-12697