### PR TITLE
[9.1] Unmute VerifyVersionConstantsIT.testLuceneVersionConstant (#139644)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -293,9 +293,6 @@ tests:
 - class: org.elasticsearch.xpack.security.SecurityRolesMultiProjectIT
   method: testUpdatingFileBasedRoleAffectsAllProjects
   issue: https://github.com/elastic/elasticsearch/issues/129775
-- class: org.elasticsearch.qa.verify_version_constants.VerifyVersionConstantsIT
-  method: testLuceneVersionConstant
-  issue: https://github.com/elastic/elasticsearch/issues/125638
 - class: org.elasticsearch.gradle.internal.InternalDistributionBwcSetupPluginFuncTest
   method: "builds distribution from branches via archives extractedAssemble [bwcDistVersion: 8.2.1, bwcProject: bugfix, expectedAssembleTaskName:
     extractedAssemble, #2]"


### PR DESCRIPTION
Backports the following commits to 9.1:
 - Unmute VerifyVersionConstantsIT.testLuceneVersionConstant (#139644)