### PR TITLE
Bug fix: the filter of a data stream alias is not always properly removed.

### DIFF
--- a/docs/changelog/139679.yaml
+++ b/docs/changelog/139679.yaml
@@ -1,0 +1,5 @@
+pr: 139679
+summary: "Bug fix: the filter of a data stream alias is not always properly removed"
+area: Data streams
+type: bug
+issues: []

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/140_data_stream_aliases.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/140_data_stream_aliases.yml
@@ -392,3 +392,78 @@
   - match: { action_results.1.status: 404 }
   - match: { action_results.1.action: { 'type': 'remove', 'indices': ['log-test-1', 'log-test-2'], 'aliases': ['test_non_existing'] } }
   - match: { action_results.1.error.type: aliases_not_found_exception }
+
+---
+"Ensure filtered data stream alias is properly removed":
+  - requires:
+      reason: "Bug was fixed in 9.3"
+      test_runner_features: [ "allowed_warnings", "capabilities" ]
+      capabilities:
+        - method: POST
+          path: /_aliases
+          capabilities: [ fix_filtered_data_stream_alias_removal ]
+  - do:
+      allowed_warnings:
+        - "index template [my-template] has index patterns [log-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template] will take precedence during new index creation"
+      indices.put_index_template:
+        name: my-template
+        body:
+          index_patterns: [ log-* ]
+          template:
+            settings:
+              index.number_of_replicas: 0
+          data_stream: { }
+
+  - do:
+      indices.create_data_stream:
+        name: log-test-1
+  - is_true: acknowledged
+  - do:
+      indices.create_data_stream:
+        name: log-test-2
+  - is_true: acknowledged
+
+  - do:
+      indices.update_aliases:
+        body:
+          actions:
+            - add:
+                index: log-test-1
+                aliases: filtered-alias
+                filter:
+                  term:
+                    env: production
+            - add:
+                index: log-test-2
+                aliases: filtered-alias
+                filter:
+                  term:
+                    env: production
+  - is_true: acknowledged
+  - is_false: errors
+
+  - do:
+      indices.update_aliases:
+        body:
+          actions:
+            - remove:
+                index: log-test-1
+                aliases: filtered-alias
+  - is_true: acknowledged
+  - is_false: errors
+
+  - do:
+      indices.update_aliases:
+        body:
+          actions:
+            - add:
+                index: log-test-1
+                aliases: filtered-alias
+  - is_true: acknowledged
+  - is_false: errors
+
+  - do:
+      indices.get_alias: { }
+
+  - is_false: log-test-1.aliases.filtered-alias.filter
+  - is_true: log-test-2.aliases.filtered-alias.filter

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamAlias.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamAlias.java
@@ -275,7 +275,12 @@ public class DataStreamAlias implements SimpleDiffable<DataStreamAlias>, ToXCont
             if (dataStream.equals(writeDataStream)) {
                 writeDataStream = null;
             }
-            return new DataStreamAlias(name, List.copyOf(dataStreams), dataStreamToFilterMap, writeDataStream);
+            Map<String, CompressedXContent> updatedDataStreamMap = dataStreamToFilterMap;
+            if (dataStreamToFilterMap.containsKey(dataStream)) {
+                updatedDataStreamMap = new HashMap<>(dataStreamToFilterMap);
+                updatedDataStreamMap.remove(dataStream);
+            }
+            return new DataStreamAlias(name, List.copyOf(dataStreams), updatedDataStreamMap, writeDataStream);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamAlias.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamAlias.java
@@ -232,15 +232,16 @@ public class DataStreamAlias implements SimpleDiffable<DataStreamAlias>, ToXCont
         }
 
         boolean filterUpdated;
-        if (filterAsMap != null || dataStreamToFilterMap.containsKey(dataStream)) {
+        if (filterAsMap != null) {
             CompressedXContent previousFilter = dataStreamToFilterMap.get(dataStream);
-            if (previousFilter == null || filterAsMap == null) {
+            if (previousFilter == null) {
                 filterUpdated = true;
             } else {
                 filterUpdated = filterAsMap.equals(decompress(previousFilter)) == false;
             }
         } else {
-            filterUpdated = false;
+            // If the data stream alias contains an orphaned filter, we want to reset it. Otherwise, there the filter is preserved
+            filterUpdated = hasOrphanedFilter(dataStream);
         }
 
         Set<String> dataStreams = new HashSet<>(this.dataStreams);
@@ -257,6 +258,10 @@ public class DataStreamAlias implements SimpleDiffable<DataStreamAlias>, ToXCont
         } else {
             return this;
         }
+    }
+
+    private boolean hasOrphanedFilter(String dataStream) {
+        return dataStreamToFilterMap.containsKey(dataStream) && dataStreams.contains(dataStream) == false;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestIndicesAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestIndicesAliasesAction.java
@@ -20,6 +20,7 @@ import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.rest.RestUtils.getAckTimeout;
@@ -27,6 +28,8 @@ import static org.elasticsearch.rest.RestUtils.getMasterNodeTimeout;
 
 @ServerlessScope(Scope.PUBLIC)
 public class RestIndicesAliasesAction extends BaseRestHandler {
+
+    private static final Set<String> CAPABILITIES = Set.of("fix_filtered_data_stream_alias_removal");
 
     @Override
     public String getName() {
@@ -48,5 +51,10 @@ public class RestIndicesAliasesAction extends BaseRestHandler {
             throw new IllegalArgumentException("No action specified");
         }
         return channel -> client.admin().indices().aliases(indicesAliasesRequest, new RestToXContentListener<>(channel));
+    }
+
+    @Override
+    public Set<String> supportedCapabilities() {
+        return CAPABILITIES;
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamAliasTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamAliasTests.java
@@ -182,6 +182,18 @@ public class DataStreamAliasTests extends AbstractXContentSerializingTestCase<Da
         assertThat(result.getFilter("ds-2"), nullValue());
     }
 
+    public void testRemovalOfOrphanedFilters() {
+        DataStreamAlias alias = new DataStreamAlias("my-alias", List.of("ds-1", "ds-2"), null, Map.of("unknown", Map.of("term", Map.of("field", "value"))));
+        DataStreamAlias result = alias.removeDataStream("unknown");
+        assertThat(result, not(sameInstance(alias)));
+        assertThat(result.getDataStreams(), containsInAnyOrder("ds-1", "ds-2"));
+        assertThat(result.getFilter("unknown"), nullValue());
+        result = alias.update("unknown", false, null);
+        assertThat(result, not(sameInstance(alias)));
+        assertThat(result.getDataStreams(), containsInAnyOrder("ds-1", "ds-2", "unknown"));
+        assertThat(result.getFilter("unknown"), nullValue());
+    }
+
     public void testIntersect() {
         {
             DataStreamAlias alias1 = new DataStreamAlias("my-alias", List.of("ds-1", "ds-2"), null, null);

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamAliasTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamAliasTests.java
@@ -174,6 +174,12 @@ public class DataStreamAliasTests extends AbstractXContentSerializingTestCase<Da
         alias = new DataStreamAlias("my-alias", List.of("ds-1"), null, null);
         result = alias.removeDataStream("ds-2");
         assertThat(result, sameInstance(alias));
+        // Remove a filtered data stream
+        alias = new DataStreamAlias("my-alias", List.of("ds-1", "ds-2"), null, Map.of("ds-2", Map.of("term", Map.of("field", "value"))));
+        result = alias.removeDataStream("ds-2");
+        assertThat(result, not(sameInstance(alias)));
+        assertThat(result.getDataStreams(), containsInAnyOrder("ds-1"));
+        assertThat(result.getFilter("ds-2"), nullValue());
     }
 
     public void testIntersect() {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamAliasTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamAliasTests.java
@@ -183,7 +183,12 @@ public class DataStreamAliasTests extends AbstractXContentSerializingTestCase<Da
     }
 
     public void testRemovalOfOrphanedFilters() {
-        DataStreamAlias alias = new DataStreamAlias("my-alias", List.of("ds-1", "ds-2"), null, Map.of("unknown", Map.of("term", Map.of("field", "value"))));
+        DataStreamAlias alias = new DataStreamAlias(
+            "my-alias",
+            List.of("ds-1", "ds-2"),
+            null,
+            Map.of("unknown", Map.of("term", Map.of("field", "value")))
+        );
         DataStreamAlias result = alias.removeDataStream("unknown");
         assertThat(result, not(sameInstance(alias)));
         assertThat(result.getDataStreams(), containsInAnyOrder("ds-1", "ds-2"));


### PR DESCRIPTION
A data stream alias that has more than 1 data stream does not handle correctly the removal of a filtered data stream alias. It currently retains the filter even after the alias is removed.

```
# Create 2 data streams

PUT _data_stream/logs-yyy-default
PUT _data_stream/logs-xxx-default

# Add a filtered alias to one and a simple alias to the other.
POST _aliases
{
  "actions": [
    {
      "add": {
        "index": "logs-yyy-default",
        "alias": "myalias",
        "filter": {
          "term": {
            "type": "mytype"
          }
        }
      }
    },
    {
      "add": {
        "index": "logs-xxx-default",
        "alias": "myalias"
      }
    }
  ]
}

# Remove the filtered alias
POST _aliases
{
  "actions": [
    {
      "remove": {
        "index": "logs-yyy-default",
        "alias": "myalias"
      }
    }
  ]
}

# Add back the alias but WITHOUT filter
POST _aliases
{
  "actions": [
    {
      "add": {
        "index": "logs-yyy-default",
        "alias": "myalias"
       }
    }
  ]
}

```

The last alias will contain the initial filter while it should not. This PR fixes that.

Furthermore, we edit the update and removal of data streams from an alias to be able to handle orphaned aliases.