### PR TITLE
ES|QL: Update docs for CCS support for FORK

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/commands/layout/fork.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/fork.md
@@ -26,7 +26,7 @@ Together with the [`FUSE`](/reference/query-languages/esql/commands/fuse.md) com
 
 **Column handling:**
 - `FORK` branches can output different columns
-- Columns with the same name must have the same data type across all branches  
+- Columns with the same name must have the same data type across all branches
 - Missing columns are filled with `null` values
 
 **Row ordering:**
@@ -41,7 +41,7 @@ Together with the [`FUSE`](/reference/query-languages/esql/commands/fuse.md) com
 **Limitations**
 
 - `FORK` supports at most 8 execution branches.
-- Using remote cluster references and `FORK` is not supported.
+- In versions older than 9.3.0 using remote cluster references and `FORK` is not supported.
 - Using more than one `FORK` command in a query is not supported.
 
 **Examples**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
@@ -948,21 +948,6 @@ public class LogicalPlanBuilder extends ExpressionBuilder {
         return f;
     }
 
-    private void checkForRemoteClusters(LogicalPlan plan, Source source, String commandName) {
-        plan.forEachUp(UnresolvedRelation.class, r -> {
-            for (var indexPattern : Strings.splitStringByCommaToArray(r.indexPattern().indexPattern())) {
-                if (RemoteClusterAware.isRemoteIndexName(indexPattern)) {
-                    throw new ParsingException(
-                        source,
-                        "invalid index pattern [{}], remote clusters are not supported with {}",
-                        r.indexPattern().indexPattern(),
-                        commandName
-                    );
-                }
-            }
-        });
-    }
-
     @Override
     @SuppressWarnings("unchecked")
     public PlanFactory visitForkCommand(EsqlBaseParser.ForkCommandContext ctx) {


### PR DESCRIPTION
does what is says - also removes an unused method 
related #139302 