### PR TITLE
Reduce priority of clear-cache tasks

### DIFF
--- a/docs/changelog/139685.yaml
+++ b/docs/changelog/139685.yaml
@@ -1,0 +1,5 @@
+pr: 139685
+summary: Reduce priority of clear-cache tasks
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/registry/ClearInferenceEndpointCacheAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/registry/ClearInferenceEndpointCacheAction.java
@@ -90,7 +90,7 @@ public class ClearInferenceEndpointCacheAction extends AcknowledgedTransportMast
         );
         this.projectResolver = projectResolver;
         this.inferenceEndpointRegistry = inferenceEndpointRegistry;
-        this.taskQueue = clusterService.createTaskQueue(TASK_QUEUE_NAME, Priority.IMMEDIATE, new CacheMetadataUpdateTaskExecutor());
+        this.taskQueue = clusterService.createTaskQueue(TASK_QUEUE_NAME, Priority.NORMAL, new CacheMetadataUpdateTaskExecutor());
         clusterService.addListener(
             event -> event.state()
                 .metadata()

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelCacheMetadataService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelCacheMetadataService.java
@@ -40,7 +40,7 @@ public class TrainedModelCacheMetadataService implements ClusterStateListener {
     public TrainedModelCacheMetadataService(ClusterService clusterService, Client client) {
         this.client = new OriginSettingClient(client, ML_ORIGIN);
         CacheMetadataUpdateTaskExecutor metadataUpdateTaskExecutor = new CacheMetadataUpdateTaskExecutor();
-        this.metadataUpdateTaskQueue = clusterService.createTaskQueue(TASK_QUEUE_NAME, Priority.IMMEDIATE, metadataUpdateTaskExecutor);
+        this.metadataUpdateTaskQueue = clusterService.createTaskQueue(TASK_QUEUE_NAME, Priority.NORMAL, metadataUpdateTaskExecutor);
         clusterService.addListener(this);
     }
 


### PR DESCRIPTION
`IMMEDIATE` is only approprate for truly critical tasks such as
`node-left`. This commit reduces these tasks to `NORMAL` priority.