### PR TITLE
Rename StdDevOverTime to StddevOverTime

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/functions/parameters/stddev_over_time.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/parameters/stddev_over_time.md
@@ -3,7 +3,7 @@
 **Parameters**
 
 `field`
-:   the metric field to calculate the standard deviation of
+:   the metric field to calculate the standard deviation for
 
 `window`
 :   the time window over which to compute the standard deviation over time

--- a/docs/reference/query-languages/esql/_snippets/functions/parameters/stddev_over_time.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/parameters/stddev_over_time.md
@@ -3,7 +3,7 @@
 **Parameters**
 
 `field`
-:   The metric field to calculate the standard deviation of.
+:   the metric field to calculate the standard deviation of
 
 `window`
 :   the time window over which to compute the standard deviation over time

--- a/docs/reference/query-languages/esql/kibana/definition/functions/absent_over_time.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/absent_over_time.json
@@ -214,7 +214,7 @@
           "name" : "field",
           "type" : "tdigest",
           "optional" : false,
-          "description" : ""
+          "description" : "the metric field to calculate the value for"
         }
       ],
       "variadic" : false,

--- a/docs/reference/query-languages/esql/kibana/definition/functions/avg_over_time.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/avg_over_time.json
@@ -97,10 +97,10 @@
     {
       "params" : [
         {
-          "name" : "number",
+          "name" : "field",
           "type" : "tdigest",
           "optional" : false,
-          "description" : "Expression that outputs values to average."
+          "description" : "the metric field to calculate the value for"
         },
         {
           "name" : "window",

--- a/docs/reference/query-languages/esql/kibana/definition/functions/max_over_time.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/max_over_time.json
@@ -190,7 +190,7 @@
           "name" : "field",
           "type" : "tdigest",
           "optional" : false,
-          "description" : ""
+          "description" : "the metric field to calculate the value for"
         },
         {
           "name" : "window",

--- a/docs/reference/query-languages/esql/kibana/definition/functions/min_over_time.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/min_over_time.json
@@ -190,7 +190,7 @@
           "name" : "field",
           "type" : "tdigest",
           "optional" : false,
-          "description" : ""
+          "description" : "the metric field to calculate the value for"
         },
         {
           "name" : "window",

--- a/docs/reference/query-languages/esql/kibana/definition/functions/percentile_over_time.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/percentile_over_time.json
@@ -223,16 +223,16 @@
     {
       "params" : [
         {
-          "name" : "number",
+          "name" : "field",
           "type" : "tdigest",
           "optional" : false,
-          "description" : "Expression that outputs values to calculate the percentile of."
+          "description" : "the metric field to calculate the value for"
         },
         {
           "name" : "percentile",
           "type" : "double",
           "optional" : false,
-          "description" : ""
+          "description" : "the percentile value to compute (between 0 and 100)"
         }
       ],
       "variadic" : false,
@@ -241,16 +241,16 @@
     {
       "params" : [
         {
-          "name" : "number",
+          "name" : "field",
           "type" : "tdigest",
           "optional" : false,
-          "description" : "Expression that outputs values to calculate the percentile of."
+          "description" : "the metric field to calculate the value for"
         },
         {
           "name" : "percentile",
           "type" : "integer",
           "optional" : false,
-          "description" : ""
+          "description" : "the percentile value to compute (between 0 and 100)"
         }
       ],
       "variadic" : false,
@@ -259,16 +259,16 @@
     {
       "params" : [
         {
-          "name" : "number",
+          "name" : "field",
           "type" : "tdigest",
           "optional" : false,
-          "description" : "Expression that outputs values to calculate the percentile of."
+          "description" : "the metric field to calculate the value for"
         },
         {
           "name" : "percentile",
           "type" : "long",
           "optional" : false,
-          "description" : ""
+          "description" : "the percentile value to compute (between 0 and 100)"
         }
       ],
       "variadic" : false,

--- a/docs/reference/query-languages/esql/kibana/definition/functions/present_over_time.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/present_over_time.json
@@ -214,7 +214,7 @@
           "name" : "field",
           "type" : "tdigest",
           "optional" : false,
-          "description" : ""
+          "description" : "the metric field to calculate the value for"
         }
       ],
       "variadic" : false,

--- a/docs/reference/query-languages/esql/kibana/definition/functions/stddev_over_time.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/stddev_over_time.json
@@ -10,7 +10,7 @@
           "name" : "field",
           "type" : "double",
           "optional" : false,
-          "description" : "The metric field to calculate the standard deviation of."
+          "description" : "the metric field to calculate the standard deviation of"
         }
       ],
       "variadic" : false,
@@ -22,7 +22,7 @@
           "name" : "field",
           "type" : "integer",
           "optional" : false,
-          "description" : "The metric field to calculate the standard deviation of."
+          "description" : "the metric field to calculate the standard deviation of"
         }
       ],
       "variadic" : false,
@@ -34,7 +34,7 @@
           "name" : "field",
           "type" : "long",
           "optional" : false,
-          "description" : "The metric field to calculate the standard deviation of."
+          "description" : "the metric field to calculate the standard deviation of"
         }
       ],
       "variadic" : false,

--- a/docs/reference/query-languages/esql/kibana/definition/functions/stddev_over_time.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/stddev_over_time.json
@@ -10,7 +10,7 @@
           "name" : "field",
           "type" : "double",
           "optional" : false,
-          "description" : "the metric field to calculate the standard deviation of"
+          "description" : "the metric field to calculate the standard deviation for"
         }
       ],
       "variadic" : false,
@@ -22,7 +22,7 @@
           "name" : "field",
           "type" : "integer",
           "optional" : false,
-          "description" : "the metric field to calculate the standard deviation of"
+          "description" : "the metric field to calculate the standard deviation for"
         }
       ],
       "variadic" : false,
@@ -34,7 +34,7 @@
           "name" : "field",
           "type" : "long",
           "optional" : false,
-          "description" : "the metric field to calculate the standard deviation of"
+          "description" : "the metric field to calculate the standard deviation for"
         }
       ],
       "variadic" : false,

--- a/docs/reference/query-languages/esql/kibana/definition/functions/sum_over_time.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/sum_over_time.json
@@ -100,7 +100,7 @@
           "name" : "field",
           "type" : "tdigest",
           "optional" : false,
-          "description" : ""
+          "description" : "the metric field to calculate the value for"
         },
         {
           "name" : "window",

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
@@ -53,7 +53,7 @@ import org.elasticsearch.xpack.esql.expression.function.aggregate.Sample;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.SpatialCentroid;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.SpatialExtent;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.StdDev;
-import org.elasticsearch.xpack.esql.expression.function.aggregate.StdDevOverTime;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.StddevOverTime;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Sum;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.SumOverTime;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Top;
@@ -551,7 +551,7 @@ public class EsqlFunctionRegistry {
                 def(MaxOverTime.class, bi(MaxOverTime::new), "max_over_time"),
                 def(MinOverTime.class, bi(MinOverTime::new), "min_over_time"),
                 def(SumOverTime.class, bi(SumOverTime::new), "sum_over_time"),
-                def(StdDevOverTime.class, bi(StdDevOverTime::new), "stddev_over_time"),
+                def(StddevOverTime.class, bi(StddevOverTime::new), "stddev_over_time"),
                 def(VarianceOverTime.class, bi(VarianceOverTime::new), "variance_over_time", "stdvar_over_time"),
                 def(CountOverTime.class, bi(CountOverTime::new), "count_over_time"),
                 def(CountDistinctOverTime.class, bi(CountDistinctOverTime::new), "count_distinct_over_time"),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/StddevOverTime.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/StddevOverTime.java
@@ -27,7 +27,7 @@ import static java.util.Collections.emptyList;
 /**
  * Similar to {@link StdDev}, but it is used to calculate the standard deviation over a time series of values from the given field.
  */
-public class StdDevOverTime extends TimeSeriesAggregateFunction {
+public class StddevOverTime extends TimeSeriesAggregateFunction {
     @FunctionInfo(
         returnType = "double",
         description = "Calculates the population standard deviation over time of a numeric field.",
@@ -36,12 +36,12 @@ public class StdDevOverTime extends TimeSeriesAggregateFunction {
         preview = true,
         examples = { @Example(file = "k8s-timeseries", tag = "stddev_over_time") }
     )
-    public StdDevOverTime(
+    public StddevOverTime(
         Source source,
         @Param(
             name = "field",
             type = { "double", "integer", "long" },
-            description = "The metric field to calculate the standard deviation of."
+            description = "the metric field to calculate the standard deviation of"
         ) Expression field,
         @Param(
             name = "window",
@@ -53,7 +53,7 @@ public class StdDevOverTime extends TimeSeriesAggregateFunction {
         this(source, field, Literal.TRUE, Objects.requireNonNullElse(window, NO_WINDOW));
     }
 
-    public StdDevOverTime(Source source, Expression field, Expression filter, Expression window) {
+    public StddevOverTime(Source source, Expression field, Expression filter, Expression window) {
         super(source, field, filter, window, emptyList());
     }
 
@@ -73,18 +73,18 @@ public class StdDevOverTime extends TimeSeriesAggregateFunction {
     }
 
     @Override
-    protected NodeInfo<StdDevOverTime> info() {
-        return NodeInfo.create(this, StdDevOverTime::new, field(), filter(), window());
+    protected NodeInfo<StddevOverTime> info() {
+        return NodeInfo.create(this, StddevOverTime::new, field(), filter(), window());
     }
 
     @Override
-    public StdDevOverTime replaceChildren(List<Expression> newChildren) {
-        return new StdDevOverTime(source(), newChildren.get(0), newChildren.get(1), newChildren.get(2));
+    public StddevOverTime replaceChildren(List<Expression> newChildren) {
+        return new StddevOverTime(source(), newChildren.get(0), newChildren.get(1), newChildren.get(2));
     }
 
     @Override
-    public StdDevOverTime withFilter(Expression filter) {
-        return new StdDevOverTime(source(), field(), filter, window());
+    public StddevOverTime withFilter(Expression filter) {
+        return new StddevOverTime(source(), field(), filter, window());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/StddevOverTime.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/StddevOverTime.java
@@ -41,7 +41,7 @@ public class StddevOverTime extends TimeSeriesAggregateFunction {
         @Param(
             name = "field",
             type = { "double", "integer", "long" },
-            description = "the metric field to calculate the standard deviation of"
+            description = "the metric field to calculate the standard deviation for"
         ) Expression field,
         @Param(
             name = "window",

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/promql/function/PromqlFunctionRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/promql/function/PromqlFunctionRegistry.java
@@ -31,7 +31,7 @@ import org.elasticsearch.xpack.esql.expression.function.aggregate.PercentileOver
 import org.elasticsearch.xpack.esql.expression.function.aggregate.PresentOverTime;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Rate;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.StdDev;
-import org.elasticsearch.xpack.esql.expression.function.aggregate.StdDevOverTime;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.StddevOverTime;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Sum;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.SumOverTime;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.TimeSeriesAggregateFunction;
@@ -75,7 +75,7 @@ public class PromqlFunctionRegistry {
                 withinSeriesOverTimeWithWindow("max_over_time", MaxOverTime::new),
                 withinSeriesOverTimeWithWindow("min_over_time", MinOverTime::new),
                 withinSeriesOverTimeWithWindow("sum_over_time", SumOverTime::new),
-                withinSeriesOverTime("stddev_over_time", StdDevOverTime::new),
+                withinSeriesOverTime("stddev_over_time", StddevOverTime::new),
                 withinSeriesOverTime("stdvar_over_time", VarianceOverTime::new) },
             // Selection range functions (require timestamp)
             new FunctionDefinition[] {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/StddevOverTimeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/StddevOverTimeTests.java
@@ -34,6 +34,6 @@ public class StddevOverTimeTests extends AbstractFunctionTestCase {
 
     @Override
     protected Expression build(Source source, List<Expression> args) {
-        return new StdDevOverTime(source, args.get(0), AggregateFunction.NO_WINDOW);
+        return new StddevOverTime(source, args.get(0), AggregateFunction.NO_WINDOW);
     }
 }


### PR DESCRIPTION
We've mismatching function names, `std_dev` and `stddev_over_time`. This change alignes camelcasing with the actual name for the latter.

Minor cleanup: add missing descriptions from #139268