### PR TITLE
Unmute missing hostname field test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -238,9 +238,6 @@ tests:
   - class: org.elasticsearch.search.basic.SearchWithRandomIOExceptionsIT
     method: testRandomDirectoryIOExceptions
     issue: https://github.com/elastic/elasticsearch/issues/118733
-  - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-    method: test {p0=logsdb/10_settings/missing hostname field}
-    issue: https://github.com/elastic/elasticsearch/issues/120476
   - class: org.elasticsearch.action.search.SearchQueryThenFetchAsyncActionTests
     method: testBottomFieldSort
     issue: https://github.com/elastic/elasticsearch/issues/118214


### PR DESCRIPTION
This doesn't fail locally after repeated runs, and was probably a transient
backport artifact.

Closes #120476