### PR TITLE
Rewritten integer sorts need to use SortedNumericSortField (#139538)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/fielddata/IndexNumericFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/IndexNumericFieldData.java
@@ -197,7 +197,7 @@ public abstract class IndexNumericFieldData implements IndexFieldData<LeafNumeri
             return rewrittenSortField;
         }
 
-        SortField rewrittenSortField = new SortField(sortField.getField(), SortField.Type.LONG, reverse);
+        SortField rewrittenSortField = new SortedNumericSortField(sortField.getField(), SortField.Type.LONG, reverse);
         rewrittenSortField.setMissingValue(longSource.missingObject(missingValue, reverse));
         // we don't optimize sorting on int field for old indices
         rewrittenSortField.setOptimizeSortWithPoints(false);

--- a/server/src/test/java/org/elasticsearch/search/sort/FieldSortBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/FieldSortBuilderTests.java
@@ -22,6 +22,7 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.sandbox.document.HalfFloatPoint;
 import org.apache.lucene.search.SortField;
+import org.apache.lucene.search.SortedNumericSortField;
 import org.apache.lucene.search.SortedSetSelector;
 import org.apache.lucene.search.SortedSetSortField;
 import org.apache.lucene.search.TermQuery;
@@ -720,6 +721,9 @@ public class FieldSortBuilderTests extends AbstractSortTestCase<FieldSortBuilder
     private void assertIntegerSortRewrite(IndexVersion version, SortField.Type expectedType) throws IOException {
         FieldSortBuilder builder = new FieldSortBuilder("custom-integer");
         SortFieldAndFormat sff = builder.build(createMockSearchExecutionContext(version));
+        if (sff.field().getType() == SortField.Type.LONG) {
+            assertThat(sff.field(), instanceOf(SortedNumericSortField.class));
+        }
         SortField sf = Lucene.rewriteMergeSortField(sff.field());
         assertThat(sf.getType(), equalTo(expectedType));
     }


### PR DESCRIPTION
Sorts against integer fields in pre-8.19 indexes are rewritten to use 
LongComparators to stay consistent with pre-written index metadata. 
These also need to always expect multi-valued fields.  #139293 incorrectly 
built single-valued sorts in certain circumstances, which would then 
throw runtime errors.