### PR TITLE
Check field storage when synthetic source is enabled, in tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -88,17 +88,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 
 public class TextFieldMapperTests extends MapperTestCase {
@@ -339,6 +333,38 @@ public class TextFieldMapperTests extends MapperTestCase {
         IndexableFieldType fieldType = fields.get(0).fieldType();
         assertThat(fieldType.stored(), is(false));
 
+        // the field shouldn't be stored anywhere, only indexed
+        FieldStorageVerifier.forField("name", doc.rootDoc()).verify();
+
+        // the value for the field should be in regular _source since synthetic source is not enabled
+        List<IndexableField> sourceFields = doc.rootDoc().getFields("_source");
+        assertThat(sourceFields, hasSize(1));
+    }
+
+    public void testStoringWhenStoreIsSet() throws IOException {
+        // given
+        var mapping = mapping(b -> {
+            b.startObject("name");
+            b.field("type", "text");
+            b.field("store", true);
+            b.endObject();
+        });
+
+        // when
+        DocumentMapper mapper = createMapperService(mapping).documentMapper();
+
+        // then
+        var source = source(b -> b.field("name", "quick brown fox"));
+        ParsedDocument doc = mapper.parse(source);
+
+        // expect store to be set
+        List<IndexableField> fields = doc.rootDoc().getFields("name");
+        IndexableFieldType fieldType = fields.get(0).fieldType();
+        assertThat(fieldType.stored(), is(true));
+
+        // the field to be stored in a stored field since store was explicitly set
+        FieldStorageVerifier.forField("name", doc.rootDoc()).expectStoredField().verify();
+
         // the value for the field should be in regular _source since synthetic source is not enabled
         List<IndexableField> sourceFields = doc.rootDoc().getFields("_source");
         assertThat(sourceFields, hasSize(1));
@@ -364,13 +390,10 @@ public class TextFieldMapperTests extends MapperTestCase {
         IndexableFieldType fieldType = fields.get(0).fieldType();
         assertThat(fieldType.stored(), is(false));
 
-        // verify that the field is stored in a fallback stored field
-        IndexableField textFallbackField = doc.rootDoc().getField("name._original");
-        assertThat(textFallbackField, notNullValue());
+        // the field should be stored in a fallback stored field name._original
+        FieldStorageVerifier.forField("name", doc.rootDoc()).expectStoredField().verify();
 
-        // verify that the field wasn't double stored in ignored source
-        List<IndexableField> ignoredSourceFields = doc.rootDoc().getFields("_ignored_source");
-        assertThat(ignoredSourceFields, empty());
+        assertIgnoredSourceIsEmpty(doc);
     }
 
     public void testStoringWhenSyntheticSourceIsEnabledInLegacyIndexVersion() throws IOException {
@@ -396,13 +419,37 @@ public class TextFieldMapperTests extends MapperTestCase {
         IndexableFieldType fieldType = fields.get(0).fieldType();
         assertThat(fieldType.stored(), is(true));
 
-        // verify that the field wasn't double stored in a fallback stored field
-        IndexableField textFallbackField = doc.rootDoc().getField("name._original");
-        assertThat(textFallbackField, nullValue());
+        // the field should be stored in a fallback stored field named._original
+        FieldStorageVerifier.forField("name", doc.rootDoc()).expectStoredField().verify();
 
-        // verify that the field wasn't double stored in ignored source
-        List<IndexableField> ignoredSourceFields = doc.rootDoc().getFields("_ignored_source");
-        assertThat(ignoredSourceFields, empty());
+        assertIgnoredSourceIsEmpty(doc);
+    }
+
+    public void testStoringWhenSyntheticSourceIsEnabledAndStoreIsSet() throws IOException {
+        // given
+        var mapping = mapping(b -> {
+            b.startObject("name");
+            b.field("type", "text");
+            b.field("store", true);
+            b.endObject();
+        });
+
+        // when
+        DocumentMapper mapper = createSytheticSourceMapperService(mapping).documentMapper();
+
+        // then
+        var source = source(b -> b.field("name", "quick brown fox"));
+        ParsedDocument doc = mapper.parse(source);
+
+        // expect store to be set
+        List<IndexableField> fields = doc.rootDoc().getFields("name");
+        IndexableFieldType fieldType = fields.get(0).fieldType();
+        assertThat(fieldType.stored(), is(true));
+
+        // the field should be stored in a stored field since store was explicitly set
+        FieldStorageVerifier.forField("name", doc.rootDoc()).expectStoredField().verify();
+
+        assertIgnoredSourceIsEmpty(doc);
     }
 
     public void testStoringWhenSyntheticSourceIsEnabledAndThereIsAKeywordMultiField() throws IOException {
@@ -430,13 +477,13 @@ public class TextFieldMapperTests extends MapperTestCase {
         IndexableFieldType fieldType = fields.get(0).fieldType();
         assertThat(fieldType.stored(), is(false));
 
-        // verify that the field wasn't double stored in a fallback stored field since here the keyword field can be using for loading
-        IndexableField textFallbackField = doc.rootDoc().getField("name._original");
-        assertThat(textFallbackField, nullValue());
+        // the field not to be stored by its corresponding field mapper, but...
+        FieldStorageVerifier.forField("name", doc.rootDoc()).verify();
 
-        // verify that the field wasn't double stored in ignored source
-        List<IndexableField> ignoredSourceFields = doc.rootDoc().getFields("_ignored_source");
-        assertThat(ignoredSourceFields, empty());
+        // by the keyword multi field, since keywords have doc_values by default
+        FieldStorageVerifier.forField("name.keyword", doc.rootDoc()).expectDocValues().verify();
+
+        assertIgnoredSourceIsEmpty(doc);
     }
 
     public void testStoringWhenSyntheticSourceIsEnabledAndThereIsAKeywordMultiFieldInLegacyIndexVersion() throws IOException {
@@ -470,16 +517,125 @@ public class TextFieldMapperTests extends MapperTestCase {
         IndexableFieldType fieldType = fields.get(0).fieldType();
         assertThat(fieldType.stored(), is(false));
 
-        // verify that the field wasn't double stored in a fallback stored field since here the keyword field can be using for loading
-        IndexableField textFallbackField = doc.rootDoc().getField("name._original");
-        assertThat(textFallbackField, nullValue());
+        // the field should not to be stored by its corresponding field mapper, but...
+        FieldStorageVerifier.forField("name", doc.rootDoc()).verify();
 
-        // verify that the field wasn't double stored in ignored source
-        List<IndexableField> ignoredSourceFields = doc.rootDoc().getFields("_ignored_source");
-        assertThat(ignoredSourceFields, empty());
+        // by the keyword multi field, since keywords have doc_values by default
+        FieldStorageVerifier.forField("name.keyword", doc.rootDoc()).expectDocValues().verify();
+
+        assertIgnoredSourceIsEmpty(doc);
+    }
+
+    public void testStoringWhenSyntheticSourceIsEnabledAndThereIsAKeywordMultiFieldAndStoreIsSet() throws IOException {
+        // given
+        var mapping = mapping(b -> {
+            b.startObject("name");
+            b.field("type", "text");
+            b.field("store", true);
+            b.startObject("fields");
+            b.startObject("keyword");
+            b.field("type", "keyword");
+            b.endObject();
+            b.endObject();
+            b.endObject();
+        });
+
+        // when
+        DocumentMapper mapper = createSytheticSourceMapperService(mapping).documentMapper();
+
+        // then
+        var source = source(b -> b.field("name", "quick brown fox"));
+        ParsedDocument doc = mapper.parse(source);
+
+        // expect store to be set
+        List<IndexableField> fields = doc.rootDoc().getFields("name");
+        IndexableFieldType fieldType = fields.get(0).fieldType();
+        assertThat(fieldType.stored(), is(true));
+
+        // the field should be double stored:
+
+        // the field should be stored in a stored field since store was explicitly set
+        FieldStorageVerifier.forField("name", doc.rootDoc()).expectStoredField().verify();
+
+        // the field should also be stored by the keyword multi field since it'll have doc values by default
+        FieldStorageVerifier.forField("name.keyword", doc.rootDoc()).expectDocValues().verify();
+
+        assertIgnoredSourceIsEmpty(doc);
+    }
+
+    public void testStoringWhenSyntheticSourceIsEnabledAndThereIsAKeywordMultiFieldAndValueExceedsIgnoreAbove() throws IOException {
+        // given
+        var mapping = mapping(b -> {
+            b.startObject("name");
+            b.field("type", "text");
+            b.startObject("fields");
+            b.startObject("keyword");
+            b.field("type", "keyword");
+            b.field("ignore_above", 5);
+            b.endObject();
+            b.endObject();
+            b.endObject();
+        });
+
+        // when
+        DocumentMapper mapper = createSytheticSourceMapperService(mapping).documentMapper();
+
+        // then
+        var source = source(b -> b.field("name", "quick brown fox"));
+        ParsedDocument doc = mapper.parse(source);
+
+        // expect store to default to false
+        List<IndexableField> fields = doc.rootDoc().getFields("name");
+        IndexableFieldType fieldType = fields.get(0).fieldType();
+        assertThat(fieldType.stored(), is(false));
+
+        // the field should be stored in a fallback stored field name._original since the keyword cannot act as the delegate
+        // due to the value exceeding ignore_above
+        FieldStorageVerifier.forField("name", doc.rootDoc()).expectStoredField().verify();
+
+        // there should be nothing stored by the keyword multi field since the value exceeds ignore_above
+        FieldStorageVerifier.forField("name.keyword", doc.rootDoc()).verify();
+
+        assertIgnoredSourceIsEmpty(doc);
+    }
+
+    public void testStoringWhenSyntheticSourceIsEnabledAndThereIsAKeywordMultiFieldAndValueDoesNotExceedIgnoreAbove() throws IOException {
+        // given
+        var mapping = mapping(b -> {
+            b.startObject("name");
+            b.field("type", "text");
+            b.startObject("fields");
+            b.startObject("keyword");
+            b.field("type", "keyword");
+            b.field("ignore_above", 50);
+            b.endObject();
+            b.endObject();
+            b.endObject();
+        });
+
+        // when
+        DocumentMapper mapper = createSytheticSourceMapperService(mapping).documentMapper();
+
+        // then
+        var source = source(b -> b.field("name", "quick brown fox"));
+        ParsedDocument doc = mapper.parse(source);
+
+        // expect store to default to false
+        List<IndexableField> fields = doc.rootDoc().getFields("name");
+        IndexableFieldType fieldType = fields.get(0).fieldType();
+        assertThat(fieldType.stored(), is(false));
+
+        // the field should not to be stored by its corresponding field mapper, but...
+        FieldStorageVerifier.forField("name", doc.rootDoc()).verify();
+
+        // by its delegate keyword field
+        FieldStorageVerifier.forField("name.keyword", doc.rootDoc()).expectDocValues().verify();
+
+        assertIgnoredSourceIsEmpty(doc);
     }
 
     public void testStoreParameterDefaultsSyntheticSourceTextFieldIsMultiField() throws IOException {
+        // given
         var indexSettingsBuilder = getIndexSettingsBuilder();
         indexSettingsBuilder.put(IndexSettings.INDEX_MAPPER_SOURCE_MODE_SETTING.getKey(), "synthetic");
         var indexSettings = indexSettingsBuilder.build();
@@ -495,14 +651,24 @@ public class TextFieldMapperTests extends MapperTestCase {
             b.endObject();
         });
 
+        // when
         IndexVersion bwcIndexVersion = IndexVersions.MAPPER_TEXT_MATCH_ONLY_MULTI_FIELDS_DEFAULT_NOT_STORED;
         DocumentMapper mapper = createMapperService(bwcIndexVersion, indexSettings, mapping).documentMapper();
 
         var source = source(b -> b.field("name", "quick brown fox"));
         ParsedDocument doc = mapper.parse(source);
+
         List<IndexableField> fields = doc.rootDoc().getFields("name.text");
         IndexableFieldType fieldType = fields.get(0).fieldType();
         assertThat(fieldType.stored(), is(false));
+
+        // the text multi-field should not store anything - the parent keyword field handles storage
+        FieldStorageVerifier.forField("name.text", doc.rootDoc()).verify();
+
+        // the parent keyword field should store in doc values
+        FieldStorageVerifier.forField("name", doc.rootDoc()).expectDocValues().verify();
+
+        assertIgnoredSourceIsEmpty(doc);
     }
 
     public void testStoreParameterDefaultsSyntheticSourceTextFieldIsMultiFieldBwc() throws IOException {
@@ -525,45 +691,18 @@ public class TextFieldMapperTests extends MapperTestCase {
 
         var source = source(b -> b.field("name", "quick brown fox"));
         ParsedDocument doc = mapper.parse(source);
+
         List<IndexableField> fields = doc.rootDoc().getFields("name.text");
         IndexableFieldType fieldType = fields.get(0).fieldType();
         assertThat(fieldType.stored(), is(true));
-    }
 
-    public void testDelegatesSyntheticSourceToKeywordMultiField() throws IOException {
-        var indexSettingsBuilder = getIndexSettingsBuilder();
-        indexSettingsBuilder.put(IndexSettings.INDEX_MAPPER_SOURCE_MODE_SETTING.getKey(), "synthetic");
-        var indexSettings = indexSettingsBuilder.build();
+        // this is double stored, but we expect it to be in legacy index versions:
 
-        var mapping = mapping(b -> {
-            b.startObject("name");
-            b.field("type", "text");
-            b.field("store", false);
-            b.startObject("fields");
-            b.startObject("keyword");
-            b.field("type", "keyword");
-            b.endObject();
-            b.endObject();
-            b.endObject();
-        });
-        DocumentMapper mapper = createMapperService(indexSettings, mapping).documentMapper();
+        // in legacy index versions, the text multi-field was stored as a stored field
+        FieldStorageVerifier.forField("name.text", doc.rootDoc()).expectStoredField().verify();
 
-        var source = source(b -> b.field("name", "QUICK Brown fox"));
-        ParsedDocument doc = mapper.parse(source);
-        IndexableField textFallbackField = doc.rootDoc().getField("name._original");
-        assertThat(textFallbackField, nullValue());
-        IndexableFieldType keywordFieldType = doc.rootDoc().getField("name.keyword").fieldType();
-        assertThat(keywordFieldType.docValuesType(), not(is(DocValuesType.NONE)));
-
-        Set<String> ignoredFields = doc.rootDoc()
-            .getFields(IgnoredSourceFieldMapper.NAME)
-            .stream()
-            .flatMap(field -> IgnoredSourceFieldMapper.CoalescedIgnoredSourceEncoding.decode(field.binaryValue()).stream())
-            .map(IgnoredSourceFieldMapper.NameValue::name)
-            .collect(Collectors.toSet());
-        assertThat("name", not(in(ignoredFields)));
-
-        assertThat(syntheticSource(mapper, b -> b.field("name", "QUICK Brown fox")), equalTo("{\"name\":\"QUICK Brown fox\"}"));
+        // the parent keyword field should store in doc values
+        FieldStorageVerifier.forField("name", doc.rootDoc()).expectDocValues().verify();
     }
 
     public void testDoesNotDelegateSyntheticSourceForNormalizedKeywordMultiFieldWhenStoreOriginalValue() throws IOException {
@@ -589,19 +728,12 @@ public class TextFieldMapperTests extends MapperTestCase {
         var source = source(b -> b.field("name", "QUICK Brown fox"));
         ParsedDocument doc = mapper.parse(source);
 
-        // expect the original, non-normalized value to be stored in a fallback stored field
-        IndexableField textFallbackField = doc.rootDoc().getField("name._original");
-        assertThat(textFallbackField, notNullValue());
+        // expect the original, non-normalized value to be stored in a fallback stored field name._original
+        FieldStorageVerifier.forField("name", doc.rootDoc()).expectStoredField().verify();
 
-        // verify that we're not double storing the value in ignored source
-        Set<String> ignoredFields = doc.rootDoc()
-            .getFields(IgnoredSourceFieldMapper.NAME)
-            .stream()
-            .flatMap(field -> IgnoredSourceFieldMapper.CoalescedIgnoredSourceEncoding.decode(field.binaryValue()).stream())
-            .map(IgnoredSourceFieldMapper.NameValue::name)
-            .collect(Collectors.toSet());
-        assertThat(ignoredFields, empty());
+        assertIgnoredSourceIsEmpty(doc);
 
+        // verify that source is synthesized correctly
         assertThat(syntheticSource(mapper, b -> b.field("name", "QUICK Brown fox")), equalTo("{\"name\":\"QUICK Brown fox\"}"));
     }
 
@@ -627,16 +759,14 @@ public class TextFieldMapperTests extends MapperTestCase {
 
         var source = source(b -> b.field("name", "QUICK Brown fox"));
         ParsedDocument doc = mapper.parse(source);
-        IndexableField textFallbackField = doc.rootDoc().getField("name._original");
-        assertThat(textFallbackField, nullValue());
 
-        Set<String> ignoredFields = doc.rootDoc()
-            .getFields(IgnoredSourceFieldMapper.NAME)
-            .stream()
-            .flatMap(field -> IgnoredSourceFieldMapper.CoalescedIgnoredSourceEncoding.decode(field.binaryValue()).stream())
-            .map(IgnoredSourceFieldMapper.NameValue::name)
-            .collect(Collectors.toSet());
-        assertThat("name", not(in(ignoredFields)));
+        // the field not to be stored by its corresponding field mapper, but...
+        FieldStorageVerifier.forField("name", doc.rootDoc()).verify();
+
+        // by the keyword multi field, since keywords have doc_values by default
+        FieldStorageVerifier.forField("name.keyword", doc.rootDoc()).expectDocValues().verify();
+
+        assertIgnoredSourceIsEmpty(doc);
 
         assertThat(syntheticSource(mapper, b -> b.field("name", "QUICK Brown fox")), equalTo("{\"name\":\"quick brown fox\"}"));
     }
@@ -663,6 +793,9 @@ public class TextFieldMapperTests extends MapperTestCase {
         List<IndexableField> fields = doc.rootDoc().getFields("field");
         assertEquals(1, fields.size());
         assertTrue(fields.get(0).fieldType().stored());
+
+        // we enabled store, so the field should be stored in a stored field
+        FieldStorageVerifier.forField("field", doc.rootDoc()).expectStoredField().verify();
     }
 
     public void testDisableIndex() throws IOException {

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/FieldStorageVerifier.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/FieldStorageVerifier.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.IndexableField;
+import org.elasticsearch.common.Strings;
+
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.elasticsearch.test.ESTestCase.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Utility class for verifying that fields are stored exactly where we expect them to. This helps identify when we're double storing.
+ *
+ * <p>A field's value can be stored in multiple ways:
+ * <ul>
+ *   <li><b>STORED_FIELD</b> - Lucene stored field</li>
+ *   <li><b>DOC_VALUES</b> - Doc values</li>
+ *   <li><b>IGNORED_SOURCE</b> - Stored in _ignored_source</li>
+ * </ul>
+ *
+ * <p>Internally, the verifier checks both the primary field name and the fallback field (fieldName._original), and fails if the field is
+ * stored at unexpected locations.
+ */
+public class FieldStorageVerifier {
+
+    public enum StorageType {
+        STORED_FIELD,
+        DOC_VALUES,
+        IGNORED_SOURCE
+    }
+
+    private final String fieldName;
+    private final String fallbackFieldName;
+    private final LuceneDocument document;
+
+    private final EnumSet<StorageType> expectedStorageTypes = EnumSet.noneOf(StorageType.class);
+
+    private FieldStorageVerifier(String fieldName, LuceneDocument document) {
+        this.fieldName = fieldName;
+        this.fallbackFieldName = fieldName + TextFamilyFieldType.FALLBACK_FIELD_NAME_SUFFIX;
+        this.document = document;
+    }
+
+    public static FieldStorageVerifier forField(String fieldName, LuceneDocument document) {
+        return new FieldStorageVerifier(fieldName, document);
+    }
+
+    public FieldStorageVerifier expectStoredField() {
+        expectedStorageTypes.add(StorageType.STORED_FIELD);
+        return this;
+    }
+
+    public FieldStorageVerifier expectDocValues() {
+        expectedStorageTypes.add(StorageType.DOC_VALUES);
+        return this;
+    }
+
+    public FieldStorageVerifier expectIgnoredSource() {
+        expectedStorageTypes.add(StorageType.IGNORED_SOURCE);
+        return this;
+    }
+
+    /**
+     * Verifies that the field is stored as expected.
+     */
+    public void verify() {
+        StorageLocations actualStorage = detectActualStorage();
+
+        // first, check for double storage - each storage type should appear at most one location
+        for (StorageType type : StorageType.values()) {
+            Set<String> locations = actualStorage.fieldNamesFor(type);
+            assertThat(
+                Strings.format("Field '%s' has double storage for %s at locations: %s", fieldName, type, locations),
+                locations.size(),
+                lessThanOrEqualTo(1)
+            );
+        }
+
+        // then verify that storage types match expectations
+        assertThat(
+            Strings.format("Field '%s' storage mismatch. Expected: %s, Actual: %s", fieldName, expectedStorageTypes, actualStorage),
+            actualStorage.storageTypes(),
+            equalTo(expectedStorageTypes)
+        );
+    }
+
+    private StorageLocations detectActualStorage() {
+        StorageLocations storage = new StorageLocations();
+
+        // check primary field and fallback field
+        checkFieldStorage(fieldName, storage);
+        checkFieldStorage(fallbackFieldName, storage);
+
+        // check ignored source
+        checkIgnoredSource(fieldName, storage);
+        checkIgnoredSource(fallbackFieldName, storage);
+
+        return storage;
+    }
+
+    private void checkFieldStorage(String fieldName, StorageLocations storage) {
+        for (IndexableField field : document.getFields(fieldName)) {
+            if (field.fieldType().stored()) {
+                storage.add(StorageType.STORED_FIELD, fieldName);
+                assertThat(field, notNullValue());
+            }
+            if (field.fieldType().docValuesType() != DocValuesType.NONE) {
+                storage.add(StorageType.DOC_VALUES, fieldName);
+                assertThat(field, notNullValue());
+            }
+        }
+    }
+
+    private void checkIgnoredSource(String fieldName, StorageLocations storage) {
+        List<IndexableField> ignoredSourceFields = document.getFields(IgnoredSourceFieldMapper.NAME);
+
+        if (ignoredSourceFields.isEmpty()) {
+            return;
+        }
+
+        for (IndexableField ignoredField : ignoredSourceFields) {
+            // extract all entries from ignored source
+            List<IgnoredSourceFieldMapper.NameValue> entries = IgnoredSourceFieldMapper.CoalescedIgnoredSourceEncoding.decode(
+                ignoredField.binaryValue()
+            );
+
+            for (IgnoredSourceFieldMapper.NameValue entry : entries) {
+                if (entry.name().equals(fieldName)) {
+                    storage.add(StorageType.IGNORED_SOURCE, fieldName);
+                    assertTrue(entry.hasValue());
+                }
+            }
+        }
+    }
+
+    /**
+     * An abstraction over a Map that is used to track each location the field is stored at.
+     */
+    private static class StorageLocations {
+        private final EnumMap<StorageType, Set<String>> storageLocations = new EnumMap<>(StorageType.class);
+
+        void add(StorageType type, String fieldName) {
+            storageLocations.computeIfAbsent(type, k -> new HashSet<>()).add(fieldName);
+        }
+
+        EnumSet<StorageType> storageTypes() {
+            if (storageLocations.isEmpty()) {
+                return EnumSet.noneOf(StorageType.class);
+            }
+            return EnumSet.copyOf(storageLocations.keySet());
+        }
+
+        Set<String> fieldNamesFor(StorageType type) {
+            return storageLocations.getOrDefault(type, Set.of());
+        }
+
+        @Override
+        public String toString() {
+            if (storageLocations.isEmpty()) {
+                return "no storage";
+            }
+            StringBuilder sb = new StringBuilder();
+            storageLocations.forEach((type, fields) -> {
+                if (sb.length() > 0) {
+                    sb.append(", ");
+                }
+                sb.append(type).append(" in ").append(fields);
+            });
+            return sb.toString();
+        }
+    }
+
+}

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -333,6 +333,17 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
         }
     }
 
+    protected void assertIgnoredSourceIsEmpty(ParsedDocument doc) {
+        Set<String> ignoredFields = doc.rootDoc()
+            .getFields(IgnoredSourceFieldMapper.NAME)
+            .stream()
+            .flatMap(field -> IgnoredSourceFieldMapper.CoalescedIgnoredSourceEncoding.decode(field.binaryValue()).stream())
+            .map(IgnoredSourceFieldMapper.NameValue::name)
+            .collect(Collectors.toSet());
+
+        assertThat(ignoredFields, empty());
+    }
+
     protected void assertExistsQuery(MapperService mapperService) throws IOException {
         LuceneDocument fields = mapperService.documentMapper().parse(source(this::writeField)).rootDoc();
         SearchExecutionContext searchExecutionContext = createSearchExecutionContext(mapperService);

--- a/test/framework/src/test/java/org/elasticsearch/index/mapper/FieldStorageVerifierTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/index/mapper/FieldStorageVerifierTests.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.document.BinaryDocValuesField;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+
+public class FieldStorageVerifierTests extends ESTestCase {
+
+    public void testVerifyPassesWhenNoStorageExpectedAndNothingStored() {
+        LuceneDocument doc = new LuceneDocument();
+        FieldStorageVerifier.forField("myfield", doc).verify();
+    }
+
+    public void testVerifyPassesWhenStoredFieldExpectedAndFieldIsStored() {
+        LuceneDocument doc = new LuceneDocument();
+        doc.add(new StoredField("myfield", "test value"));
+
+        FieldStorageVerifier.forField("myfield", doc).expectStoredField().verify();
+    }
+
+    public void testVerifyPassesWhenDocValuesExpectedAndDocValuesExist() {
+        LuceneDocument doc = new LuceneDocument();
+        doc.add(new BinaryDocValuesField("myfield", new BytesRef("test value")));
+
+        FieldStorageVerifier.forField("myfield", doc).expectDocValues().verify();
+    }
+
+    public void testVerifyPassesWhenStoredFieldExpectedInFallbackField() {
+        LuceneDocument doc = new LuceneDocument();
+        doc.add(new StoredField("myfield._original", "test value"));
+
+        FieldStorageVerifier.forField("myfield", doc).expectStoredField().verify();
+    }
+
+    public void testVerifyPassesWhenDocValuesExpectedInFallbackField() {
+        LuceneDocument doc = new LuceneDocument();
+        doc.add(new BinaryDocValuesField("myfield._original", new BytesRef("test value")));
+
+        FieldStorageVerifier.forField("myfield", doc).expectDocValues().verify();
+    }
+
+    public void testVerifyFailsWhenStoredFieldExpectedButNotPresent() {
+        LuceneDocument doc = new LuceneDocument();
+
+        AssertionError error = expectThrows(
+            AssertionError.class,
+            () -> FieldStorageVerifier.forField("myfield", doc).expectStoredField().verify()
+        );
+
+        assertThat(error.getMessage(), containsString("myfield"));
+        assertThat(error.getMessage(), containsString("storage mismatch"));
+    }
+
+    public void testVerifyFailsWhenDocValuesExpectedButNotPresent() {
+        LuceneDocument doc = new LuceneDocument();
+
+        AssertionError error = expectThrows(
+            AssertionError.class,
+            () -> FieldStorageVerifier.forField("myfield", doc).expectDocValues().verify()
+        );
+
+        assertThat(error.getMessage(), containsString("myfield"));
+        assertThat(error.getMessage(), containsString("storage mismatch"));
+    }
+
+    public void testVerifyFailsWhenNoStorageExpectedButStoredFieldPresent() {
+        LuceneDocument doc = new LuceneDocument();
+        doc.add(new StoredField("myfield", "test value"));
+
+        AssertionError error = expectThrows(AssertionError.class, () -> FieldStorageVerifier.forField("myfield", doc).verify());
+
+        assertThat(error.getMessage(), containsString("myfield"));
+        assertThat(error.getMessage(), containsString("storage mismatch"));
+    }
+
+    public void testVerifyFailsWhenNoStorageExpectedButDocValuesPresent() {
+        LuceneDocument doc = new LuceneDocument();
+        doc.add(new BinaryDocValuesField("myfield", new BytesRef("test value")));
+
+        AssertionError error = expectThrows(AssertionError.class, () -> FieldStorageVerifier.forField("myfield", doc).verify());
+
+        assertThat(error.getMessage(), containsString("myfield"));
+        assertThat(error.getMessage(), containsString("storage mismatch"));
+    }
+
+    public void testVerifyFailsWhenStoredFieldExpectedButDocValuesPresent() {
+        LuceneDocument doc = new LuceneDocument();
+        doc.add(new BinaryDocValuesField("myfield", new BytesRef("test value")));
+
+        AssertionError error = expectThrows(
+            AssertionError.class,
+            () -> FieldStorageVerifier.forField("myfield", doc).expectStoredField().verify()
+        );
+
+        assertThat(error.getMessage(), containsString("myfield"));
+        assertThat(error.getMessage(), containsString("storage mismatch"));
+    }
+
+    public void testVerifyFailsWhenDocValuesExpectedButStoredFieldPresent() {
+        LuceneDocument doc = new LuceneDocument();
+        doc.add(new StoredField("myfield", "test value"));
+
+        AssertionError error = expectThrows(
+            AssertionError.class,
+            () -> FieldStorageVerifier.forField("myfield", doc).expectDocValues().verify()
+        );
+
+        assertThat(error.getMessage(), containsString("myfield"));
+        assertThat(error.getMessage(), containsString("storage mismatch"));
+    }
+
+    public void testVerifyFailsOnDoubleStorageSameType() {
+        LuceneDocument doc = new LuceneDocument();
+        doc.add(new StoredField("myfield", "value1"));
+        doc.add(new StoredField("myfield._original", "value2"));
+
+        // should fail - field is stored twice
+        AssertionError error = expectThrows(
+            AssertionError.class,
+            () -> FieldStorageVerifier.forField("myfield", doc).expectStoredField().verify()
+        );
+
+        assertThat(error.getMessage(), containsString("myfield"));
+        assertThat(error.getMessage(), containsString("double storage"));
+    }
+
+    public void testVerifyFailsOnDoubleStorageDocValues() {
+        LuceneDocument doc = new LuceneDocument();
+        doc.add(new BinaryDocValuesField("myfield", new BytesRef("value1")));
+        doc.add(new BinaryDocValuesField("myfield._original", new BytesRef("value2")));
+
+        // should fail - field is stored twice
+        AssertionError error = expectThrows(
+            AssertionError.class,
+            () -> FieldStorageVerifier.forField("myfield", doc).expectDocValues().verify()
+        );
+
+        assertThat(error.getMessage(), containsString("myfield"));
+        assertThat(error.getMessage(), containsString("double storage"));
+    }
+
+    public void testVerifyFailsWhenStoredFieldExpectedButDoubledStoredInDocValues() {
+        LuceneDocument doc = new LuceneDocument();
+        doc.add(new StoredField("myfield", "potato"));
+        doc.add(new BinaryDocValuesField("myfield", new BytesRef("potato")));
+
+        AssertionError error = expectThrows(
+            AssertionError.class,
+            () -> FieldStorageVerifier.forField("myfield", doc).expectStoredField().verify()
+        );
+
+        assertThat(error.getMessage(), containsString("myfield"));
+        assertThat(error.getMessage(), containsString("storage mismatch"));
+    }
+
+    public void testVerifyFailsWhenDocValuesExpectedButDoubledStoredInStoredField() {
+        LuceneDocument doc = new LuceneDocument();
+        doc.add(new StoredField("myfield", "potato"));
+        doc.add(new BinaryDocValuesField("myfield", new BytesRef("potato")));
+
+        AssertionError error = expectThrows(
+            AssertionError.class,
+            () -> FieldStorageVerifier.forField("myfield", doc).expectDocValues().verify()
+        );
+
+        assertThat(error.getMessage(), containsString("myfield"));
+        assertThat(error.getMessage(), containsString("storage mismatch"));
+    }
+
+    public void testVerifyPassesWithMultipleExpectedStorageTypes() {
+        LuceneDocument doc = new LuceneDocument();
+        doc.add(new StoredField("myfield", "potato"));
+        doc.add(new BinaryDocValuesField("myfield", new BytesRef("potato")));
+
+        // should pass - expecting both stored field and doc values
+        FieldStorageVerifier.forField("myfield", doc).expectStoredField().expectDocValues().verify();
+    }
+
+    public void testVerifyPassesWithMultiValuedStoredField() {
+        LuceneDocument doc = new LuceneDocument();
+        doc.add(new StoredField("myfield", "potato1"));
+        doc.add(new StoredField("myfield", "potato2"));
+        doc.add(new StoredField("myfield", "potato3"));
+
+        FieldStorageVerifier.forField("myfield", doc).expectStoredField().verify();
+    }
+
+    public void testVerifyFailsWhenOnlyOneOfMultipleExpectedTypesPresent() {
+        LuceneDocument doc = new LuceneDocument();
+        doc.add(new StoredField("myfield", "test value"));
+
+        // should fail - expecting both stored field and doc values, but only stored field present
+        AssertionError error = expectThrows(
+            AssertionError.class,
+            () -> FieldStorageVerifier.forField("myfield", doc).expectStoredField().expectDocValues().verify()
+        );
+
+        assertThat(error.getMessage(), containsString("myfield"));
+        assertThat(error.getMessage(), containsString("storage mismatch"));
+    }
+
+    public void testVerifyPassesWhenIgnoredSourceExpectedAndFieldIsInIgnoredSource() {
+        LuceneDocument doc = new LuceneDocument();
+        addToIgnoredSource(doc, "myfield", "test value");
+
+        FieldStorageVerifier.forField("myfield", doc).expectIgnoredSource().verify();
+    }
+
+    public void testVerifyFailsWhenIgnoredSourceExpectedButNotPresent() {
+        LuceneDocument doc = new LuceneDocument();
+
+        AssertionError error = expectThrows(
+            AssertionError.class,
+            () -> FieldStorageVerifier.forField("myfield", doc).expectIgnoredSource().verify()
+        );
+
+        assertThat(error.getMessage(), containsString("myfield"));
+        assertThat(error.getMessage(), containsString("storage mismatch"));
+    }
+
+    public void testVerifyFailsWhenNoStorageExpectedButIgnoredSourcePresent() {
+        LuceneDocument doc = new LuceneDocument();
+        addToIgnoredSource(doc, "myfield", "test value");
+
+        // expecting no storage, but field is in ignored source
+        AssertionError error = expectThrows(AssertionError.class, () -> FieldStorageVerifier.forField("myfield", doc).verify());
+
+        assertThat(error.getMessage(), containsString("myfield"));
+        assertThat(error.getMessage(), containsString("storage mismatch"));
+    }
+
+    public void testVerifyFailsWhenStoredFieldExpectedButDoubleStoredInIgnoredSource() {
+        LuceneDocument doc = new LuceneDocument();
+        doc.add(new StoredField("myfield", "potato1"));
+        addToIgnoredSource(doc, "myfield", "potato2");
+
+        AssertionError error = expectThrows(
+            AssertionError.class,
+            () -> FieldStorageVerifier.forField("myfield", doc).expectStoredField().verify()
+        );
+
+        assertThat(error.getMessage(), containsString("myfield"));
+        assertThat(error.getMessage(), containsString("storage mismatch"));
+    }
+
+    public void testVerifyFailsWhenDocValuesExpectedButDoubleStoredInIgnoredSource() {
+        LuceneDocument doc = new LuceneDocument();
+        doc.add(new BinaryDocValuesField("myfield", new BytesRef("potato1")));
+        addToIgnoredSource(doc, "myfield", "potato2");
+
+        AssertionError error = expectThrows(
+            AssertionError.class,
+            () -> FieldStorageVerifier.forField("myfield", doc).expectDocValues().verify()
+        );
+
+        assertThat(error.getMessage(), containsString("myfield"));
+        assertThat(error.getMessage(), containsString("storage mismatch"));
+    }
+
+    private void addToIgnoredSource(LuceneDocument doc, String fieldName, String value) {
+        var nameValue = new IgnoredSourceFieldMapper.NameValue(fieldName, 0, new BytesRef(value), doc);
+        BytesRef encoded = IgnoredSourceFieldMapper.CoalescedIgnoredSourceEncoding.encode(List.of(nameValue));
+        doc.add(new StoredField(IgnoredSourceFieldMapper.NAME, encoded));
+    }
+}


### PR DESCRIPTION
Currently, when testing field mappers against synthetic source, we rarely check if fields are stored appropriately and not double stored. This has led to regressions in releases and in serverless that go unnoticed; the most recent example being https://github.com/elastic/elasticsearch/pull/139415. 

`FieldStorageVerifier` aims to help with that by providing a simple API that can be leveraged to verify that a field is stored exactly where we expect it to. The class itself looks for all instances of a given field in a given document. If said instances don't match expectations, it complains.

Example use case:

```
FieldStorageVerifier.forField("name", doc.rootDoc())
    .expectDocValues()
    .verify();
```

Will verify that `name` is only stored in doc_values. If `name` is stored anywhere else, like ignored_source or a `StoredField`, then the verification check will fail. Furthermore, if `name` is stored twice in doc_values, as with fallback fields, the check will also fail. This helps us confirm:
- `name` is not doubled stored
- `name` is stored in the expected place; in this case doc_values

I've updated `TextFieldMapperTests` for now, with more field mappers to follow in future PRs.

This closes https://github.com/elastic/elasticsearch/issues/139550