### PR TITLE
[9.1] Making sure that failure store document converter does not hang on unexpected exceptions (#139712)

### DIFF
--- a/docs/changelog/139712.yaml
+++ b/docs/changelog/139712.yaml
@@ -1,0 +1,7 @@
+pr: 139712
+summary: Making sure that failure store document converter does not hang on unexpected
+  exceptions
+area: Data streams
+type: bug
+issues:
+ - 139707

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkOperation.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkOperation.java
@@ -57,7 +57,6 @@ import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -639,7 +638,7 @@ final class BulkOperation extends ActionRunnable<BulkResponse> {
                 failureStoreReference,
                 threadPool::absoluteTimeInMillis
             );
-        } catch (IOException ioException) {
+        } catch (Exception exception) {
             logger.debug(
                 () -> "Could not transform failed bulk request item into failure store document. Attempted for ["
                     + request.request().opType()
@@ -650,10 +649,10 @@ final class BulkOperation extends ActionRunnable<BulkResponse> {
                     + "; bulk_slot="
                     + request.id()
                     + "] Proceeding with failing the original.",
-                ioException
+                exception
             );
             // Suppress and do not redirect
-            cause.addSuppressed(ioException);
+            cause.addSuppressed(exception);
             return false;
         }
 

--- a/server/src/test/java/org/elasticsearch/action/bulk/BulkOperationTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/BulkOperationTests.java
@@ -59,6 +59,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpNodeClient;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xcontent.XContentParseException;
 import org.junit.After;
 import org.junit.Before;
 
@@ -575,24 +576,30 @@ public class BulkOperationTests extends ESTestCase {
         NodeClient client = getNodeClient(
             thatFailsDocuments(Map.of(new IndexAndId(ds2BackingIndex1.getIndex().getName(), "3"), () -> new MapperException("root cause")))
         );
+        // Testing that we handle exceptions including IOExceptions and other exceptions:
+        List<Exception> transformFailures = List.of(
+            new IOException("Could not serialize json"),
+            new XContentParseException("[1:337] Duplicate field 'foo'")
+        );
+        for (Exception transformFailure : transformFailures) {
+            // Mock a failure store document converter that always fails
+            FailureStoreDocumentConverter mockConverter = mock(FailureStoreDocumentConverter.class);
+            when(mockConverter.transformFailedRequest(any(), any(), any(), any())).thenThrow(transformFailure);
 
-        // Mock a failure store document converter that always fails
-        FailureStoreDocumentConverter mockConverter = mock(FailureStoreDocumentConverter.class);
-        when(mockConverter.transformFailedRequest(any(), any(), any(), any())).thenThrow(new IOException("Could not serialize json"));
+            BulkResponse bulkItemResponses = safeAwait(l -> newBulkOperation(client, bulkRequest, mockConverter, l).run());
 
-        BulkResponse bulkItemResponses = safeAwait(l -> newBulkOperation(client, bulkRequest, mockConverter, l).run());
-
-        assertThat(bulkItemResponses.hasFailures(), is(true));
-        BulkItemResponse failedItem = Arrays.stream(bulkItemResponses.getItems())
-            .filter(BulkItemResponse::isFailed)
-            .findFirst()
-            .orElseThrow(() -> new AssertionError("Could not find redirected item"));
-        assertThat(failedItem.getFailure().getCause(), is(instanceOf(MapperException.class)));
-        assertThat(failedItem.getFailure().getCause().getMessage(), is(equalTo("root cause")));
-        assertThat(failedItem.getFailure().getCause().getSuppressed().length, is(not(equalTo(0))));
-        assertThat(failedItem.getFailure().getCause().getSuppressed()[0], is(instanceOf(IOException.class)));
-        assertThat(failedItem.getFailure().getCause().getSuppressed()[0].getMessage(), is(equalTo("Could not serialize json")));
-        assertThat(failedItem.getFailureStoreStatus(), equalTo(IndexDocFailureStoreStatus.FAILED));
+            assertThat(bulkItemResponses.hasFailures(), is(true));
+            BulkItemResponse failedItem = Arrays.stream(bulkItemResponses.getItems())
+                .filter(BulkItemResponse::isFailed)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Could not find redirected item"));
+            assertThat(failedItem.getFailure().getCause(), is(instanceOf(MapperException.class)));
+            assertThat(failedItem.getFailure().getCause().getMessage(), is(equalTo("root cause")));
+            assertThat(failedItem.getFailure().getCause().getSuppressed().length, is(not(equalTo(0))));
+            assertThat(failedItem.getFailure().getCause().getSuppressed()[0], is(instanceOf(transformFailure.getClass())));
+            assertThat(failedItem.getFailure().getCause().getSuppressed()[0].getMessage(), is(equalTo(transformFailure.getMessage())));
+            assertThat(failedItem.getFailureStoreStatus(), equalTo(IndexDocFailureStoreStatus.FAILED));
+        }
     }
 
     /**


### PR DESCRIPTION
Backports the following commits to 9.1:
 - Making sure that failure store document converter does not hang on unexpected exceptions (#139712)