### PR TITLE
[8.19] Making sure that failure store document converter does not hang on unexpected exceptions (#139712)

### DIFF
--- a/docs/changelog/139712.yaml
+++ b/docs/changelog/139712.yaml
@@ -1,0 +1,7 @@
+pr: 139712
+summary: Making sure that failure store document converter does not hang on unexpected
+  exceptions
+area: Data streams
+type: bug
+issues:
+ - 139707

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkOperation.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkOperation.java
@@ -54,7 +54,6 @@ import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -625,7 +624,7 @@ final class BulkOperation extends ActionRunnable<BulkResponse> {
                 failureStoreReference,
                 threadPool::absoluteTimeInMillis
             );
-        } catch (IOException ioException) {
+        } catch (Exception exception) {
             logger.debug(
                 () -> "Could not transform failed bulk request item into failure store document. Attempted for ["
                     + request.request().opType()
@@ -636,10 +635,10 @@ final class BulkOperation extends ActionRunnable<BulkResponse> {
                     + "; bulk_slot="
                     + request.id()
                     + "] Proceeding with failing the original.",
-                ioException
+                exception
             );
             // Suppress and do not redirect
-            cause.addSuppressed(ioException);
+            cause.addSuppressed(exception);
             return false;
         }
 


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Making sure that failure store document converter does not hang on unexpected exceptions (#139712)