### PR TITLE
[9.3] fix and unmute SamlRedirectTests (#139459)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -403,9 +403,6 @@ tests:
 - class: org.elasticsearch.xpack.downsample.DownsampleIT
   method: testAggregateMethod
   issue: https://github.com/elastic/elasticsearch/issues/139382
-- class: org.elasticsearch.xpack.security.authc.saml.SamlRedirectTests
-  method: testRedirectUrlWithRelayStateAndSigning
-  issue: https://github.com/elastic/elasticsearch/issues/139389
 - class: org.elasticsearch.xpack.inference.integration.AuthorizationTaskExecutorIT
   method: testCreatesChatCompletion_AndThenCreatesTextEmbedding
   issue: https://github.com/elastic/elasticsearch/issues/138012


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [fix and unmute SamlRedirectTests (#139459)](https://github.com/elastic/elasticsearch/pull/139459)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)