### PR TITLE
[9.2] ES|QL: Fix ABSENT/PRESENT on agg with false filter (#139609)

### DIFF
--- a/docs/changelog/139609.yaml
+++ b/docs/changelog/139609.yaml
@@ -1,0 +1,5 @@
+pr: 139609
+summary: Fix ABSENT/PRESENT on agg with false filter
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/absent.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/absent.csv-spec
@@ -127,3 +127,15 @@ is_absent:integer
 1
 // end::absent-as-integer-result[]
 ;
+
+fixAbsentOnStatsWithFalseFilter
+required_capability: fix_present_and_absent_on_stats_with_false_filter
+
+ROW a = 3
+| STATS x = ABSENT(a) WHERE FALSE
+| KEEP x
+;
+
+x:boolean
+true
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/present.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/present.csv-spec
@@ -150,3 +150,15 @@ is_present:integer
 0
 // end::present-as-integer-result[]
 ;
+
+fixPresentOnStatsWithFalseFilter
+required_capability: fix_present_and_absent_on_stats_with_false_filter
+
+ROW a = 3
+| STATS x = PRESENT(a) WHERE FALSE
+| KEEP x
+;
+
+x:boolean
+false
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1674,6 +1674,13 @@ public class EsqlCapabilities {
          */
         FIX_ENRICH_ALIAS_CYCLE_IN_DEDUPLICATE_AGGS,
 
+        /**
+         * {@link org.elasticsearch.xpack.esql.optimizer.rules.logical.ReplaceStatsFilteredAggWithEval} replaced a stats
+         * with false filter with null with {@link org.elasticsearch.xpack.esql.expression.function.aggregate.Present} or
+         * {@link org.elasticsearch.xpack.esql.expression.function.aggregate.Absent}
+         */
+        FIX_PRESENT_AND_ABSENT_ON_STATS_WITH_FALSE_FILTER,
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceStatsFilteredAggWithEval.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/ReplaceStatsFilteredAggWithEval.java
@@ -15,9 +15,11 @@ import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.util.Holder;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Absent;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.CountDistinct;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Present;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
@@ -72,7 +74,7 @@ public class ReplaceStatsFilteredAggWithEval extends OptimizerRules.OptimizerRul
                     && aggFunction.filter() instanceof Literal literal
                     && Boolean.FALSE.equals(literal.value())) {
 
-                    Object value = aggFunction instanceof Count || aggFunction instanceof CountDistinct ? 0L : null;
+                    Object value = mapNullToValue(aggFunction);
                     Alias newAlias = alias.replaceChild(Literal.of(aggFunction, value));
                     newEvals.add(newAlias);
                     newProjections.add(newAlias.toAttribute());
@@ -114,6 +116,16 @@ public class ReplaceStatsFilteredAggWithEval extends OptimizerRules.OptimizerRul
             }
         }
         return plan;
+    }
+
+    private static Object mapNullToValue(AggregateFunction aggFunction) {
+        return switch (aggFunction) {
+            case Count ignored -> 0L;
+            case CountDistinct ignored -> 0L;
+            case Absent ignored -> true;
+            case Present ignored -> false;
+            default -> null;
+        };
     }
 
     private static LogicalPlan updateAggregate(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [ES|QL: Fix ABSENT/PRESENT on agg with false filter (#139609)](https://github.com/elastic/elasticsearch/pull/139609)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)