### PR TITLE
[9.3] Larger offset when calculating the next histogram bucket to avoid col… (#139675)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -400,9 +400,6 @@ tests:
 - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
   method: test {yaml=index/100_field_name_length_limit/Test field name length limit array synthetic source}
   issue: https://github.com/elastic/elasticsearch/issues/139300
-- class: org.elasticsearch.xpack.downsample.DownsampleIT
-  method: testAggregateMethod
-  issue: https://github.com/elastic/elasticsearch/issues/139382
 - class: org.elasticsearch.xpack.inference.integration.AuthorizationTaskExecutorIT
   method: testCreatesChatCompletion_AndThenCreatesTextEmbedding
   issue: https://github.com/elastic/elasticsearch/issues/138012

--- a/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DownsampleIT.java
+++ b/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DownsampleIT.java
@@ -646,7 +646,7 @@ public class DownsampleIT extends DownsamplingIntegTestCase {
         final double[] array = new double[size];
         double minHistogramValue = randomDoubleBetween(0.0, 0.1, true);
         for (int i = 0; i < array.length; i++) {
-            array[i] = minHistogramValue += randomDoubleBetween(0.0, 0.5, true);
+            array[i] = minHistogramValue += randomDoubleBetween(0.1, 10.0, true);
         }
         return array;
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Larger offset when calculating the next histogram bucket to avoid col… (#139675)](https://github.com/elastic/elasticsearch/pull/139675)

<!--- Backport version: 9.6.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)