### PR TITLE
[9.3] Fix bare time series aggs server error (#139612)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-rate.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-rate.csv-spec
@@ -335,3 +335,62 @@ rate_bytes_in:double | cluster:keyword | time_bucket:datetime
 8.939832             | qa              | 2024-05-10T00:14:00.000Z
 9.2257               | prod            | 2024-05-10T00:20:00.000Z
 ;
+
+bare_rate_outputs_dimensions
+required_capability: ts_command_v0
+required_capability: metrics_group_by_all
+required_capability: metrics_group_by_all_with_ts_dimensions
+
+TS k8s
+| STATS rate=rate(network.total_bytes_in)
+| SORT rate DESC
+;
+ignoreOrder:true
+
+rate:double        | _timeseries:keyword
+4.689830508474576  | "{""cluster"":""staging"",""pod"":""one"",""region"":""us""}"
+6.54326561324304   | "{""cluster"":""staging"",""pod"":""three"",""region"":""us""}"
+7.340495867768595  | "{""cluster"":""prod"",""pod"":""two"",""region"":[""eu"",""us""]}"
+7.377611940298507  | "{""cluster"":""staging"",""pod"":""two"",""region"":""us""}"
+8.434290687554395  | "{""cluster"":""prod"",""pod"":""three"",""region"":[""eu"",""us""]}"
+8.716707021791768  | "{""cluster"":""prod"",""pod"":""one"",""region"":[""eu"",""us""]}"
+9.485643970467596  | "{""cluster"":""qa"",""pod"":""three""}"
+10.649149922720246 | "{""cluster"":""qa"",""pod"":""one""}"
+13.17372515125324  | "{""cluster"":""qa"",""pod"":""two""}"
+;
+
+bare_rate_with_tbucket_outputs_dimensions
+required_capability: ts_command_v0
+required_capability: metrics_group_by_all
+required_capability: metrics_group_by_all_with_ts_dimensions
+
+TS k8s
+| STATS rate=rate(network.total_bytes_in) BY tbucket = TBUCKET(1 hour)
+| SORT rate DESC
+;
+ignoreOrder:true
+
+rate:double        | _timeseries:keyword                                   | tbucket:datetime
+1.6554700854700857 | "{""cluster"":""staging"",""pod"":""one"",""region"":""us""}"       | 2024-05-10T00:00:00.000Z
+2.5258595644176904 | "{""cluster"":""staging"",""pod"":""three"",""region"":""us""}"     | 2024-05-10T00:00:00.000Z
+2.621423611111111  | "{""cluster"":""prod"",""pod"":""two"",""region"":[""eu"",""us""]}"   | 2024-05-10T00:00:00.000Z
+2.830347222222222  | "{""cluster"":""prod"",""pod"":""three"",""region"":[""eu"",""us""]}" | 2024-05-10T00:00:00.000Z
+2.874194651741293  | "{""cluster"":""staging"",""pod"":""two"",""region"":""us""}"       | 2024-05-10T00:00:00.000Z
+3.1304347826086953 | "{""cluster"":""prod"",""pod"":""one"",""region"":[""eu"",""us""]}"   | 2024-05-10T00:00:00.000Z
+3.3457754629629632 | "{""cluster"":""qa"",""pod"":""three""}"                        | 2024-05-10T00:00:00.000Z
+3.959770114942529  | "{""cluster"":""qa"",""pod"":""one""}"                          | 2024-05-10T00:00:00.000Z
+4.379885057471264  | "{""cluster"":""qa"",""pod"":""two""}"                          | 2024-05-10T00:00:00.000Z
+;
+
+wrapped_rate
+required_capability: ts_command_v0
+required_capability: metrics_group_by_all
+required_capability: metrics_group_by_all_with_ts_dimensions
+
+TS k8s
+| STATS max_rate = MAX(rate(network.total_bytes_in))
+| EVAL max_rate=ROUND(max_rate, 6) | KEEP max_rate;
+
+max_rate:double 
+13.173725
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries.csv-spec
@@ -901,68 +901,6 @@ sum:double | _timeseries:keyword                                                
 210.625    | "{""cluster"":""qa"",""pod"":""one""}"                                | 2024-05-10T00:00:00.000Z
 ;
 
-bare_rate_outputs_dimensions
-required_capability: ts_command_v0
-required_capability: metrics_group_by_all
-required_capability: metrics_group_by_all_with_ts_dimensions
-
-
-TS k8s
-| STATS rate=rate(network.total_bytes_in)
-| SORT rate DESC
-;
-ignoreOrder:true
-
-rate:double        | _timeseries:keyword
-4.689830508474576  | "{""cluster"":""staging"",""pod"":""one"",""region"":""us""}"
-6.54326561324304   | "{""cluster"":""staging"",""pod"":""three"",""region"":""us""}"
-7.340495867768595  | "{""cluster"":""prod"",""pod"":""two"",""region"":[""eu"",""us""]}"
-7.377611940298507  | "{""cluster"":""staging"",""pod"":""two"",""region"":""us""}"
-8.434290687554395  | "{""cluster"":""prod"",""pod"":""three"",""region"":[""eu"",""us""]}"
-8.716707021791768  | "{""cluster"":""prod"",""pod"":""one"",""region"":[""eu"",""us""]}"
-9.485643970467596  | "{""cluster"":""qa"",""pod"":""three""}"
-10.649149922720246 | "{""cluster"":""qa"",""pod"":""one""}"
-13.17372515125324  | "{""cluster"":""qa"",""pod"":""two""}"
-
-;
-
-bare_rate_with_tbucket_outputs_dimensions
-required_capability: ts_command_v0
-required_capability: metrics_group_by_all
-required_capability: metrics_group_by_all_with_ts_dimensions
-
-TS k8s
-| STATS rate=rate(network.total_bytes_in) BY tbucket = TBUCKET(1 hour)
-| SORT rate DESC
-;
-ignoreOrder:true
-
-rate:double        | _timeseries:keyword                                   | tbucket:datetime
-1.6554700854700857 | "{""cluster"":""staging"",""pod"":""one"",""region"":""us""}"       | 2024-05-10T00:00:00.000Z
-2.5258595644176904 | "{""cluster"":""staging"",""pod"":""three"",""region"":""us""}"     | 2024-05-10T00:00:00.000Z
-2.621423611111111  | "{""cluster"":""prod"",""pod"":""two"",""region"":[""eu"",""us""]}"   | 2024-05-10T00:00:00.000Z
-2.830347222222222  | "{""cluster"":""prod"",""pod"":""three"",""region"":[""eu"",""us""]}" | 2024-05-10T00:00:00.000Z
-2.874194651741293  | "{""cluster"":""staging"",""pod"":""two"",""region"":""us""}"       | 2024-05-10T00:00:00.000Z
-3.1304347826086953 | "{""cluster"":""prod"",""pod"":""one"",""region"":[""eu"",""us""]}"   | 2024-05-10T00:00:00.000Z
-3.3457754629629632 | "{""cluster"":""qa"",""pod"":""three""}"                        | 2024-05-10T00:00:00.000Z
-3.959770114942529  | "{""cluster"":""qa"",""pod"":""one""}"                          | 2024-05-10T00:00:00.000Z
-4.379885057471264  | "{""cluster"":""qa"",""pod"":""two""}"                          | 2024-05-10T00:00:00.000Z
- 
-;
-
-wrapped_rate
-required_capability: ts_command_v0
-required_capability: metrics_group_by_all
-required_capability: metrics_group_by_all_with_ts_dimensions
-
-TS k8s
-| STATS max_rate = MAX(rate(network.total_bytes_in))
-| EVAL max_rate=ROUND(max_rate, 6) | KEEP max_rate;
-
-max_rate:double 
-13.173725
-;
-
 oneRateIncreaseWithBucketAndClusterThenFilter
 required_capability: ts_command_v0
 required_capability: rate_with_interpolation

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/TimeSeriesGroupByAll.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/TimeSeriesGroupByAll.java
@@ -90,7 +90,6 @@ public class TimeSeriesGroupByAll extends Rule<LogicalPlan, LogicalPlan> {
             if (Functions.isGrouping(Alias.unwrap(grouping)) == false) {
                 throw new IllegalArgumentException(
                     "Cannot mix time-series aggregate and grouping attributes. Found [" + grouping.sourceText() + "]."
-
                 );
             }
             groupings.add(grouping);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/MetadataAttribute.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/MetadataAttribute.java
@@ -170,6 +170,10 @@ public class MetadataAttribute extends TypedAttribute {
         return a instanceof MetadataAttribute ma && ma.name().equals(SCORE);
     }
 
+    public static boolean isTimeSeriesAttribute(Expression a) {
+        return a instanceof Attribute ma && ma.name().equals(TIMESERIES);
+    }
+
     @Override
     protected int innerHashCode(boolean ignoreIds) {
         return Objects.hash(super.innerHashCode(ignoreIds), searchable);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/PostOptimizationPhasePlanVerifier.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/PostOptimizationPhasePlanVerifier.java
@@ -90,8 +90,8 @@ public abstract class PostOptimizationPhasePlanVerifier<P extends QueryPlan<P>> 
             // TranslateTimeSeriesAggregate may add a _timeseries attribute into the projection
             boolean hasTimeSeriesReplacingTsId = optimizedPlan.anyMatch(
                 a -> a instanceof TimeSeriesAggregate ts
-                    && ts.output().stream().anyMatch(g -> g.name().equals(MetadataAttribute.TIMESERIES))
-                    && expectedOutputAttributes.stream().noneMatch(g -> g.name().equals(MetadataAttribute.TIMESERIES))
+                    && ts.output().stream().anyMatch(MetadataAttribute::isTimeSeriesAttribute)
+                    && expectedOutputAttributes.stream().noneMatch(MetadataAttribute::isTimeSeriesAttribute)
             );
 
             boolean ignoreError = hasProjectAwayColumns || hasLookupJoinExec || hasTextGroupingInTimeSeries || hasTimeSeriesReplacingTsId;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ExtractDimensionFieldsAfterAggregation.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/physical/local/ExtractDimensionFieldsAfterAggregation.java
@@ -93,7 +93,7 @@ public final class ExtractDimensionFieldsAfterAggregation extends PhysicalOptimi
                             throw new IllegalStateException("expected one intermediate attribute for [" + af + "] but got [" + size + "]");
                         }
                         Attribute oldAttr = oldIntermediates.get(intermediateOffset);
-                        if (dimensionField.name().equals(MetadataAttribute.TIMESERIES)) {
+                        if (MetadataAttribute.isTimeSeriesAttribute(dimensionField)) {
                             var sourceField = new FieldAttribute(
                                 dimensionField.source(),
                                 null,
@@ -161,7 +161,7 @@ public final class ExtractDimensionFieldsAfterAggregation extends PhysicalOptimi
 
     private static Attribute valuesOfDimensionField(AggregateFunction af, AttributeSet inputAttributes) {
         if (af instanceof DimensionValues values && values.hasFilter() == false && values.field() instanceof Attribute attr) {
-            if (inputAttributes.contains(attr) == false || attr.name().equals(MetadataAttribute.TIMESERIES)) {
+            if (inputAttributes.contains(attr) == false || MetadataAttribute.isTimeSeriesAttribute(attr)) {
                 return attr;
             }
         }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -3423,7 +3423,35 @@ public class VerifierTests extends ESTestCase {
             ),
             equalTo("1:29: 'num_words' option must be a positive integer, found [0]")
         );
+    }
 
+    public void testTimeSeriesWithUnsupportedDataType() {
+        assumeTrue("requires metrics command", EsqlCapabilities.Cap.METRICS_GROUP_BY_ALL_WITH_TS_DIMENSIONS.isEnabled());
+
+        // GroupByAll
+        assertThat(
+            error("TS k8s | STATS rate(network.eth0.tx)", k8s),
+            equalTo(
+                "1:16: first argument of [rate(network.eth0.tx)] must be [counter_long, counter_integer or counter_double], "
+                    + "found value [network.eth0.tx] type [integer]"
+            )
+        );
+
+        assertThat(
+            error("TS k8s | STATS rate(network.eth0.tx) by tbucket(1m)", k8s),
+            equalTo(
+                "1:16: first argument of [rate(network.eth0.tx)] must be [counter_long, counter_integer or counter_double], "
+                    + "found value [network.eth0.tx] type [integer]"
+            )
+        );
+
+        assertThat(
+            error("TS k8s | STATS avg(rate(network.eth0.tx))", k8s),
+            equalTo(
+                "1:20: first argument of [rate(network.eth0.tx)] must be [counter_long, counter_integer or counter_double], "
+                    + "found value [network.eth0.tx] type [integer]"
+            )
+        );
     }
 
     public void testMvIntersectionValidatesDataTypesAreEqual() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TimeSeriesBareAggregationsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TimeSeriesBareAggregationsTests.java
@@ -99,13 +99,10 @@ public class TimeSeriesBareAggregationsTests extends AbstractLogicalPlanOptimize
         assertThat("Should have aggregates", aggregates.isEmpty(), is(false));
 
         List<Attribute> output = plan.output();
-        boolean hasTimeseries = output.stream().anyMatch(attr -> attr.name().equals(MetadataAttribute.TIMESERIES));
+        boolean hasTimeseries = output.stream().anyMatch(MetadataAttribute::isTimeSeriesAttribute);
         assertThat("Should have _timeseries in output", hasTimeseries, is(true));
 
-        Attribute timeseriesAttr = output.stream()
-            .filter(attr -> attr.name().equals(MetadataAttribute.TIMESERIES))
-            .findFirst()
-            .orElse(null);
+        Attribute timeseriesAttr = output.stream().filter(MetadataAttribute::isTimeSeriesAttribute).findFirst().orElse(null);
 
         assertNotNull(timeseriesAttr);
         assertThat("_timeseries attribute should exist", timeseriesAttr, is(instanceOf(Attribute.class)));
@@ -133,13 +130,10 @@ public class TimeSeriesBareAggregationsTests extends AbstractLogicalPlanOptimize
         assertThat("Should have aggregates", aggregates.isEmpty(), is(false));
 
         List<Attribute> output = plan.output();
-        boolean hasTimeseries = output.stream().anyMatch(attr -> attr.name().equals(MetadataAttribute.TIMESERIES));
+        boolean hasTimeseries = output.stream().anyMatch(MetadataAttribute::isTimeSeriesAttribute);
         assertThat("Should have _timeseries in output", hasTimeseries, is(true));
 
-        Attribute timeseriesAttr = output.stream()
-            .filter(attr -> attr.name().equals(MetadataAttribute.TIMESERIES))
-            .findFirst()
-            .orElse(null);
+        Attribute timeseriesAttr = output.stream().filter(MetadataAttribute::isTimeSeriesAttribute).findFirst().orElse(null);
 
         assertNotNull(timeseriesAttr);
         assertThat("_timeseries attribute should exist", timeseriesAttr, is(instanceOf(Attribute.class)));
@@ -170,13 +164,10 @@ public class TimeSeriesBareAggregationsTests extends AbstractLogicalPlanOptimize
         assertThat("Should group by bucket", hasBucket, is(true));
 
         List<Attribute> output = plan.output();
-        boolean hasTimeseries = output.stream().anyMatch(attr -> attr.name().equals(MetadataAttribute.TIMESERIES));
+        boolean hasTimeseries = output.stream().anyMatch(MetadataAttribute::isTimeSeriesAttribute);
         assertThat("Should have _timeseries in output", hasTimeseries, is(true));
 
-        Attribute timeseriesAttr = output.stream()
-            .filter(attr -> attr.name().equals(MetadataAttribute.TIMESERIES))
-            .findFirst()
-            .orElse(null);
+        Attribute timeseriesAttr = output.stream().filter(MetadataAttribute::isTimeSeriesAttribute).findFirst().orElse(null);
 
         assertNotNull(timeseriesAttr);
         assertThat("_timeseries attribute should exist", timeseriesAttr, is(instanceOf(Attribute.class)));
@@ -207,13 +198,10 @@ public class TimeSeriesBareAggregationsTests extends AbstractLogicalPlanOptimize
         assertThat("Should group by bucket", hasBucket, is(true));
 
         List<Attribute> output = plan.output();
-        boolean hasTimeseries = output.stream().anyMatch(attr -> attr.name().equals(MetadataAttribute.TIMESERIES));
+        boolean hasTimeseries = output.stream().anyMatch(MetadataAttribute::isTimeSeriesAttribute);
         assertThat("Should have _timeseries in output", hasTimeseries, is(true));
 
-        Attribute timeseriesAttr = output.stream()
-            .filter(attr -> attr.name().equals(MetadataAttribute.TIMESERIES))
-            .findFirst()
-            .orElse(null);
+        Attribute timeseriesAttr = output.stream().filter(MetadataAttribute::isTimeSeriesAttribute).findFirst().orElse(null);
 
         assertNotNull(timeseriesAttr);
         assertThat("_timeseries attribute should exist", timeseriesAttr, is(instanceOf(Attribute.class)));
@@ -247,13 +235,10 @@ public class TimeSeriesBareAggregationsTests extends AbstractLogicalPlanOptimize
         assertThat("Should still group by _tsid", hasTsid, is(true));
 
         List<Attribute> output = plan.output();
-        boolean hasTimeseries = output.stream().anyMatch(attr -> attr.name().equals(MetadataAttribute.TIMESERIES));
+        boolean hasTimeseries = output.stream().anyMatch(MetadataAttribute::isTimeSeriesAttribute);
         assertThat("Should have _timeseries in output", hasTimeseries, is(true));
 
-        Attribute timeseriesAttr = output.stream()
-            .filter(attr -> attr.name().equals(MetadataAttribute.TIMESERIES))
-            .findFirst()
-            .orElse(null);
+        Attribute timeseriesAttr = output.stream().filter(MetadataAttribute::isTimeSeriesAttribute).findFirst().orElse(null);
 
         assertNotNull(timeseriesAttr);
         assertThat("_timeseries attribute should exist", timeseriesAttr, is(instanceOf(Attribute.class)));


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Fix bare time series aggs server error (#139612)](https://github.com/elastic/elasticsearch/pull/139612)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)