### PR TITLE
Add lucene query for wildcards on high cardinality keyword fields.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -1090,10 +1090,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                     return new WildcardQuery(term, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, MultiTermQuery.DOC_VALUES_REWRITE);
                 }
 
-                StringFieldScript.LeafFactory leafFactory = storedInBinaryDocValues()
-                    ? ctx -> new SortedBinaryDocValuesStringFieldScript(name(), context.lookup(), ctx)
-                    : ctx -> new SortedSetDocValuesStringFieldScript(name(), context.lookup(), ctx);
-
+                StringFieldScript.LeafFactory leafFactory = ctx -> new SortedSetDocValuesStringFieldScript(name(), context.lookup(), ctx);
                 return new StringScriptFieldWildcardQuery(new Script(""), leafFactory, name(), value, caseInsensitive);
             }
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -72,6 +72,7 @@ import org.elasticsearch.index.query.AutomatonQueryWithDescription;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.similarity.SimilarityProvider;
 import org.elasticsearch.lucene.queries.SlowCustomBinaryDocValuesTermQuery;
+import org.elasticsearch.lucene.queries.SlowCustomBinaryDocValuesWildcardQuery;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptCompiler;
 import org.elasticsearch.script.SortedBinaryDocValuesStringFieldScript;
@@ -1080,7 +1081,11 @@ public final class KeywordFieldMapper extends FieldMapper {
                     value = indexedValueForSearch(value).utf8ToString();
                 }
 
-                if (caseInsensitive == false && storedInBinaryDocValues() == false) {
+                if (storedInBinaryDocValues()) {
+                    return new SlowCustomBinaryDocValuesWildcardQuery(name(), value, caseInsensitive);
+                }
+
+                if (caseInsensitive == false) {
                     Term term = new Term(name(), value);
                     return new WildcardQuery(term, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT, MultiTermQuery.DOC_VALUES_REWRITE);
                 }

--- a/server/src/main/java/org/elasticsearch/lucene/queries/AbstractBinaryDocValuesQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/AbstractBinaryDocValuesQuery.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.lucene.queries;
+
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.ConstantScoreScorer;
+import org.apache.lucene.search.ConstantScoreWeight;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.ScorerSupplier;
+import org.apache.lucene.search.TwoPhaseIterator;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.mapper.blockloader.docvalues.CustomBinaryDocValuesReader;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+abstract class AbstractBinaryDocValuesQuery extends Query {
+
+    final String fieldName;
+    final Predicate<BytesRef> matcher;
+
+    AbstractBinaryDocValuesQuery(String fieldName, Predicate<BytesRef> matcher) {
+        this.fieldName = Objects.requireNonNull(fieldName);
+        this.matcher = Objects.requireNonNull(matcher);
+    }
+
+    @Override
+    public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+        float matchCost = matchCost();
+        return new ConstantScoreWeight(this, boost) {
+
+            @Override
+            public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
+                final BinaryDocValues values = context.reader().getBinaryDocValues(fieldName);
+                if (values == null) {
+                    return null;
+                }
+
+                final TwoPhaseIterator iterator = new TwoPhaseIterator(values) {
+
+                    final CustomBinaryDocValuesReader reader = new CustomBinaryDocValuesReader();
+
+                    @Override
+                    public boolean matches() throws IOException {
+                        BytesRef binaryValue = values.binaryValue();
+                        return reader.match(binaryValue, matcher);
+                    }
+
+                    @Override
+                    public float matchCost() {
+                        return matchCost;
+                    }
+                };
+
+                return new DefaultScorerSupplier(new ConstantScoreScorer(score(), scoreMode, iterator));
+            }
+
+            @Override
+            public boolean isCacheable(LeafReaderContext ctx) {
+                return DocValues.isCacheable(ctx, fieldName);
+            }
+        };
+    }
+
+    protected abstract float matchCost();
+
+    @Override
+    public void visit(QueryVisitor visitor) {
+        if (visitor.acceptField(fieldName)) {
+            visitor.visitLeaf(this);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesWildcardQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesWildcardQuery.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.lucene.queries;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.WildcardQuery;
+import org.apache.lucene.util.automaton.Automaton;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.apache.lucene.util.automaton.Operations;
+import org.elasticsearch.common.lucene.search.AutomatonQueries;
+
+import java.util.Objects;
+
+/**
+ * A query for matching an exact BytesRef value for a specific field.
+ * The equavalent of {@link org.elasticsearch.search.runtime.StringScriptFieldWildcardQuery}, but then without the scripting overhead and
+ * just for binary doc values.
+ * <p>
+ * This implementation is slow, because it potentially scans binary doc values for each document.
+ */
+// TODO: create abstract class for binary doc values based automaton queries in follow up, in order to support regex and fuzzy queries.
+public final class SlowCustomBinaryDocValuesWildcardQuery extends AbstractBinaryDocValuesQuery {
+
+    private final String pattern;
+    private final boolean caseInsensitive;
+
+    public SlowCustomBinaryDocValuesWildcardQuery(String fieldName, String pattern, boolean caseInsensitive) {
+        this(fieldName, pattern, caseInsensitive, buildByteRunAutomaton(fieldName, pattern, caseInsensitive));
+    }
+
+    private SlowCustomBinaryDocValuesWildcardQuery(String fieldName, String pattern, boolean caseInsensitive, ByteRunAutomaton automaton) {
+        super(fieldName, value -> automaton.run(value.bytes, value.offset, value.length));
+        this.pattern = Objects.requireNonNull(pattern);
+        this.caseInsensitive = caseInsensitive;
+    }
+
+    private static ByteRunAutomaton buildByteRunAutomaton(String fieldName, String pattern, boolean caseInsensitive) {
+        Term term = new Term(Objects.requireNonNull(fieldName), Objects.requireNonNull(pattern));
+        Automaton automaton;
+        if (caseInsensitive) {
+            automaton = AutomatonQueries.toCaseInsensitiveWildcardAutomaton(term);
+        } else {
+            automaton = WildcardQuery.toAutomaton(term, Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
+        }
+        return new ByteRunAutomaton(automaton);
+    }
+
+    @Override
+    protected float matchCost() {
+        return 1000f; // This is just expensive, not sure what the actual cost is.
+    }
+
+    @Override
+    public String toString(String field) {
+        return "SlowCustomBinaryDocValuesWildcardQuery(fieldName="
+            + field
+            + ",pattern="
+            + pattern
+            + ",caseInsensitive="
+            + caseInsensitive
+            + ")";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (sameClassAs(o) == false) {
+            return false;
+        }
+        SlowCustomBinaryDocValuesWildcardQuery that = (SlowCustomBinaryDocValuesWildcardQuery) o;
+        return Objects.equals(fieldName, that.fieldName)
+            && Objects.equals(pattern, that.pattern)
+            && caseInsensitive == that.caseInsensitive;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(classHash(), fieldName, pattern, caseInsensitive);
+    }
+}

--- a/server/src/test/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesWildcardQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesWildcardQueryTests.java
@@ -10,7 +10,6 @@ package org.elasticsearch.lucene.queries;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.SortedDocValuesField;
-import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.IndexSearcher;

--- a/server/src/test/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesWildcardQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesWildcardQueryTests.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+package org.elasticsearch.lucene.queries;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MultiTermQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.WildcardQuery;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.automaton.Operations;
+import org.elasticsearch.index.mapper.BinaryFieldMapper;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+public class SlowCustomBinaryDocValuesWildcardQueryTests extends ESTestCase {
+
+    public void testBasics() throws Exception {
+        String fieldName = "field";
+        try (Directory dir = newDirectory()) {
+            Map<String, Long> expectedCounts = new HashMap<>();
+            expectedCounts.put("a", 2L);
+            expectedCounts.put("b", 5L);
+            expectedCounts.put("c", 1L);
+            expectedCounts.put("d", 3L);
+            expectedCounts.put("e", 10L);
+            try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
+                for (var entry : expectedCounts.entrySet()) {
+                    for (int i = 0; i < entry.getValue(); i++) {
+                        Document document = new Document();
+                        var field = new BinaryFieldMapper.CustomBinaryDocValuesField(
+                            "field",
+                            entry.getKey().getBytes(StandardCharsets.UTF_8)
+                        );
+                        if (randomBoolean()) {
+                            field.add("z".getBytes(StandardCharsets.UTF_8));
+                        }
+                        document.add(field);
+                        writer.addDocument(document);
+                    }
+                }
+
+                // search
+                try (IndexReader reader = writer.getReader()) {
+                    IndexSearcher searcher = newSearcher(reader);
+                    for (var entry : expectedCounts.entrySet()) {
+                        long count = searcher.count(new SlowCustomBinaryDocValuesWildcardQuery(fieldName, entry.getKey() + "*", false));
+                        assertEquals(entry.getValue().longValue(), count);
+                    }
+                }
+            }
+        }
+    }
+
+    public void testNoField() throws IOException {
+        String fieldName = "field";
+
+        // no field in index
+        try (Directory dir = newDirectory()) {
+            try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
+                writer.addDocument(new Document());
+                try (IndexReader reader = writer.getReader()) {
+                    IndexSearcher searcher = newSearcher(reader);
+                    Query query = new SlowCustomBinaryDocValuesWildcardQuery(fieldName, "a*", false);
+                    assertEquals(0, searcher.count(query));
+                }
+            }
+        }
+
+        // no field in segment
+        try (Directory dir = newDirectory()) {
+            try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
+                Document document = new Document();
+                document.add(new BinaryFieldMapper.CustomBinaryDocValuesField("field", "a".getBytes(StandardCharsets.UTF_8)));
+                writer.addDocument(document);
+                writer.commit();
+                writer.addDocument(new Document());
+                try (IndexReader reader = writer.getReader()) {
+                    IndexSearcher searcher = newSearcher(reader);
+                    Query query = new SlowCustomBinaryDocValuesWildcardQuery(fieldName, "a*", false);
+                    assertEquals(1, searcher.count(query));
+                }
+            }
+        }
+    }
+
+    public void testAgainstWildcardQuery() throws IOException {
+        List<String> randomValues = randomList(8, 32, () -> randomAlphaOfLength(8));
+
+        try (Directory dir = newDirectory()) {
+            try (RandomIndexWriter writer = new RandomIndexWriter(random(), dir)) {
+                for (String randomValue : randomValues) {
+                    Document document = new Document();
+                    document.add(new SortedDocValuesField("baseline_field", new BytesRef(randomValue)));
+                    document.add(
+                        new BinaryFieldMapper.CustomBinaryDocValuesField("contender_field", randomValue.getBytes(StandardCharsets.UTF_8))
+                    );
+                    writer.addDocument(document);
+                }
+
+                try (IndexReader reader = writer.getReader()) {
+                    String randomWildcard = randomFrom(randomValues).substring(0, 2) + "*";
+                    IndexSearcher searcher = newSearcher(reader);
+
+                    Query baselineQuery = new WildcardQuery(
+                        new Term("baseline_field", randomWildcard),
+                        Operations.DEFAULT_DETERMINIZE_WORK_LIMIT,
+                        MultiTermQuery.DOC_VALUES_REWRITE
+                    );
+                    TopDocs baselineResults = searcher.search(baselineQuery, 32);
+
+                    Query contenderQuery = new SlowCustomBinaryDocValuesWildcardQuery("contender_field", randomWildcard, false);
+                    TopDocs contenderResults = searcher.search(contenderQuery, 32);
+
+                    assertThat(contenderResults.totalHits, equalTo(baselineResults.totalHits));
+                    assertThat(baselineResults.scoreDocs.length, greaterThanOrEqualTo(1));
+                    assertThat(baselineResults.scoreDocs.length, equalTo(contenderResults.scoreDocs.length));
+                    for (int i = 0; i < baselineResults.scoreDocs.length; i++) {
+                        assertThat(baselineResults.scoreDocs[i].doc, equalTo(contenderResults.scoreDocs[i].doc));
+                        assertThat(baselineResults.scoreDocs[i].score, equalTo(contenderResults.scoreDocs[i].score));
+                    }
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Speeds to wildcard queries on high cardinality keyword fields up by roughly 50% compared to using `StringScriptFieldWildcardQuery`.

Also added a base class (`AbstractBinaryDocValuesQuery `) for both `SlowCustomBinaryDocValuesTermQuery ` and `SlowCustomBinaryDocValuesWildcardQuery `.