### PR TITLE
Optimize script sorts that do not require query scores

### DIFF
--- a/docs/changelog/139748.yaml
+++ b/docs/changelog/139748.yaml
@@ -1,0 +1,5 @@
+pr: 139748
+summary: Optimize script sorts that do not require query scores
+area: Search
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/script/BytesRefSortScript.java
+++ b/server/src/main/java/org/elasticsearch/script/BytesRefSortScript.java
@@ -28,6 +28,11 @@ public abstract class BytesRefSortScript extends AbstractSortScript {
      */
     public interface LeafFactory {
         BytesRefSortScript newInstance(DocReader reader) throws IOException;
+
+        /**
+         * Return {@code true} if the script needs {@code _score} calculated, or {@code false} otherwise.
+         */
+        boolean needs_score();
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/script/StringSortScript.java
+++ b/server/src/main/java/org/elasticsearch/script/StringSortScript.java
@@ -28,6 +28,11 @@ public abstract class StringSortScript extends AbstractSortScript {
      */
     public interface LeafFactory {
         StringSortScript newInstance(DocReader reader) throws IOException;
+
+        /**
+         * Return {@code true} if the script needs {@code _score} calculated, or {@code false} otherwise.
+         */
+        boolean needs_score();
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/script/MockScriptEngine.java
+++ b/test/framework/src/main/java/org/elasticsearch/script/MockScriptEngine.java
@@ -881,19 +881,29 @@ public class MockScriptEngine implements ScriptEngine {
 
         @Override
         public StringSortScript.LeafFactory newFactory(Map<String, Object> parameters) {
-            return docReader -> new StringSortScript(parameters, docReader) {
+            return new StringSortScript.LeafFactory() {
                 @Override
-                public String execute() {
-                    Map<String, Object> vars = new HashMap<>(parameters);
-                    vars.put("params", parameters);
-                    vars.put("doc", getDoc());
-                    try {
-                        vars.put("_score", get_score());
-                    } catch (Exception ignore) {
-                        // nothing to do: if get_score throws we don't set the _score, likely the scorer is null,
-                        // which is ok if _score was not requested e.g. top_hits.
-                    }
-                    return String.valueOf(script.apply(vars));
+                public StringSortScript newInstance(DocReader reader) throws IOException {
+                    return new StringSortScript(parameters, reader) {
+                        @Override
+                        public String execute() {
+                            Map<String, Object> vars = new HashMap<>(parameters);
+                            vars.put("params", parameters);
+                            vars.put("doc", getDoc());
+                            try {
+                                vars.put("_score", get_score());
+                            } catch (Exception ignore) {
+                                // nothing to do: if get_score throws we don't set the _score, likely the scorer is null,
+                                // which is ok if _score was not requested e.g. top_hits.
+                            }
+                            return String.valueOf(script.apply(vars));
+                        }
+                    };
+                }
+
+                @Override
+                public boolean needs_score() {
+                    return false;
                 }
             };
         }
@@ -913,19 +923,29 @@ public class MockScriptEngine implements ScriptEngine {
 
         @Override
         public BytesRefSortScript.LeafFactory newFactory(Map<String, Object> parameters) {
-            return docReader -> new BytesRefSortScript(parameters, docReader) {
+            return new BytesRefSortScript.LeafFactory() {
                 @Override
-                public BytesRefProducer execute() {
-                    Map<String, Object> vars = new HashMap<>(parameters);
-                    vars.put("params", parameters);
-                    vars.put("doc", getDoc());
-                    try {
-                        vars.put("_score", get_score());
-                    } catch (Exception ignore) {
-                        // nothing to do: if get_score throws we don't set the _score, likely the scorer is null,
-                        // which is ok if _score was not requested e.g. top_hits.
-                    }
-                    return (BytesRefProducer) script.apply(vars);
+                public BytesRefSortScript newInstance(DocReader reader) throws IOException {
+                    return new BytesRefSortScript(parameters, reader) {
+                        @Override
+                        public BytesRefProducer execute() {
+                            Map<String, Object> vars = new HashMap<>(parameters);
+                            vars.put("params", parameters);
+                            vars.put("doc", getDoc());
+                            try {
+                                vars.put("_score", get_score());
+                            } catch (Exception ignore) {
+                                // nothing to do: if get_score throws we don't set the _score, likely the scorer is null,
+                                // which is ok if _score was not requested e.g. top_hits.
+                            }
+                            return (BytesRefProducer) script.apply(vars);
+                        }
+                    };
+                }
+
+                @Override
+                public boolean needs_score() {
+                    return false;
                 }
             };
         }

--- a/test/framework/src/main/java/org/elasticsearch/script/MockScriptEngine.java
+++ b/test/framework/src/main/java/org/elasticsearch/script/MockScriptEngine.java
@@ -150,7 +150,7 @@ public class MockScriptEngine implements ScriptEngine {
 
                 @Override
                 public boolean needs_score() {
-                    return false;
+                    return true;
                 }
             };
             return context.factoryClazz.cast(factory);
@@ -903,7 +903,7 @@ public class MockScriptEngine implements ScriptEngine {
 
                 @Override
                 public boolean needs_score() {
-                    return false;
+                    return true;
                 }
             };
         }
@@ -945,7 +945,7 @@ public class MockScriptEngine implements ScriptEngine {
 
                 @Override
                 public boolean needs_score() {
-                    return false;
+                    return true;
                 }
             };
         }


### PR DESCRIPTION
Only set the sort script’s scorable when the script actually needs access to the query score. Since the scorable holds a reference to the query iterator, avoiding it allows memory to be released earlier—at segment completion rather than at the end of the shard search.