### PR TITLE
[9.2] Suppress Tika entitlement warnings from AWT (#139711)

### DIFF
--- a/distribution/src/config/log4j2.properties
+++ b/distribution/src/config/log4j2.properties
@@ -152,3 +152,7 @@ logger.esql_querylog_rolling.name = esql.querylog
 logger.esql_querylog_rolling.level = trace
 logger.esql_querylog_rolling.appenderRef.esql_querylog_rolling.ref = esql_querylog_rolling
 logger.esql_querylog_rolling.additivity = false
+
+# Suppress spurious entitlement warnings for exceptions that are caught
+logger.entitlements_awt.name = org.elasticsearch.entitlement.runtime.policy.PolicyManager.(server).java.desktop.java.awt
+logger.entitlements_awt.level = error


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Suppress Tika entitlement warnings from AWT (#139711)