### PR TITLE
Store fallback text fields in binary doc values

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -212,7 +212,7 @@ public class IndexVersions {
     public static final IndexVersion DEFAULT_HNSW_EARLY_TERMINATION = def(9_059_0_00, Version.LUCENE_10_3_2);
     public static final IndexVersion PATTERN_TEXT_ARGS_IN_BINARY_DOC_VALUES = def(9_060_0_00, Version.LUCENE_10_3_2);
     public static final IndexVersion KEYWORD_FIELDS_KEEP_DUPLICATES_IN_BINARY_DOC_VALUES = def(9_061_0_00, Version.LUCENE_10_3_2);
-    public static final IndexVersion SYNTHETIC_SOURCE_FALLBACK_TEXT_FIELDS_IN_BINARY_DOC_VALUES = def(9_062_0_00, Version.LUCENE_10_3_2);
+    public static final IndexVersion STORE_FALLBACK_TEXT_FIELDS_IN_BINARY_DOC_VALUES = def(9_062_0_00, Version.LUCENE_10_3_2);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -212,6 +212,7 @@ public class IndexVersions {
     public static final IndexVersion DEFAULT_HNSW_EARLY_TERMINATION = def(9_059_0_00, Version.LUCENE_10_3_2);
     public static final IndexVersion PATTERN_TEXT_ARGS_IN_BINARY_DOC_VALUES = def(9_060_0_00, Version.LUCENE_10_3_2);
     public static final IndexVersion KEYWORD_FIELDS_KEEP_DUPLICATES_IN_BINARY_DOC_VALUES = def(9_061_0_00, Version.LUCENE_10_3_2);
+    public static final IndexVersion SYNTHETIC_SOURCE_FALLBACK_TEXT_FIELDS_IN_BINARY_DOC_VALUES = def(9_062_0_00, Version.LUCENE_10_3_2);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -98,11 +98,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -1553,7 +1555,6 @@ public final class KeywordFieldMapper extends FieldMapper {
 
         return layers;
     }
-
 
     public CompositeSyntheticFieldLoader syntheticFieldLoader(String fullFieldName, String leafFieldName) {
         return new CompositeSyntheticFieldLoader(leafFieldName, fullFieldName, syntheticFieldLoaderLayers());

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -98,13 +98,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -1493,7 +1491,11 @@ public final class KeywordFieldMapper extends FieldMapper {
         return super.syntheticSourceSupport();
     }
 
-    public CompositeSyntheticFieldLoader syntheticFieldLoader(String fullFieldName, String leafFieldName) {
+    /**
+     * Returns the layers for loading synthetic source values for this keyword field.
+     * These can be used by parent fields to combine layers from multiple sources.
+     */
+    public List<CompositeSyntheticFieldLoader.Layer> syntheticFieldLoaderLayers() {
         assert fieldType.stored() || docValuesParameters.enabled();
 
         var layers = new ArrayList<CompositeSyntheticFieldLoader.Layer>(2);
@@ -1549,7 +1551,12 @@ public final class KeywordFieldMapper extends FieldMapper {
             }
         }
 
-        return new CompositeSyntheticFieldLoader(leafFieldName, fullFieldName, layers);
+        return layers;
+    }
+
+
+    public CompositeSyntheticFieldLoader syntheticFieldLoader(String fullFieldName, String leafFieldName) {
+        return new CompositeSyntheticFieldLoader(leafFieldName, fullFieldName, syntheticFieldLoaderLayers());
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -1544,7 +1544,7 @@ public final class TextFieldMapper extends FieldMapper {
                 // store the value in a binary doc values field, create one if it doesn't exist
                 MultiValuedBinaryDocValuesField field = (MultiValuedBinaryDocValuesField) context.doc().getByKey(fallbackFieldName);
                 if (field == null) {
-                    field = new MultiValuedBinaryDocValuesField(fallbackFieldName, MultiValuedBinaryDocValuesField.Ordering.INSERTION);
+                    field = new MultiValuedBinaryDocValuesField(fallbackFieldName, new ArrayList<>());
                     context.doc().addWithKey(fallbackFieldName, field);
                 }
                 field.add(bytesRef);

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -69,6 +69,7 @@ import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.fielddata.SourceValueFetcherSortedBinaryIndexFieldData;
 import org.elasticsearch.index.fielddata.StoredFieldSortedBinaryIndexFieldData;
 import org.elasticsearch.index.fielddata.plain.PagedBytesIndexFieldData;
+import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromCustomBinaryBlockLoader;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.similarity.SimilarityProvider;
 import org.elasticsearch.script.field.DelegateDocValuesField;
@@ -1158,8 +1159,11 @@ public final class TextFieldMapper extends FieldMapper {
                 return new BlockStoredFieldsReader.BytesFromStringsBlockLoader(name());
             }
 
-            // 5. check if we can load from a fallback stored field
+            // 5. check if we can load from a fallback field
             if (isSyntheticSourceEnabled() && syntheticSourceDelegate.isEmpty() && parentField == null) {
+                if (storeFallbackFieldsInBinaryDocValues(indexCreatedVersion)) {
+                    return new BytesRefsFromCustomBinaryBlockLoader(syntheticSourceFallbackFieldName());
+                }
                 return new BlockStoredFieldsReader.BytesFromStringsBlockLoader(syntheticSourceFallbackFieldName());
             }
 
@@ -1533,9 +1537,30 @@ public final class TextFieldMapper extends FieldMapper {
             }
 
             // otherwise, just store the field ourselves
-            final String fieldName = fieldType().syntheticSourceFallbackFieldName();
-            context.doc().add(new StoredField(fieldName, value));
+            final String fallbackFieldName = fieldType().syntheticSourceFallbackFieldName();
+            final BytesRef bytesRef = new BytesRef(value);
+
+            if (storeFallbackFieldsInBinaryDocValues()) {
+                // store the value in a binary doc values field, create one if it doesn't exist
+                MultiValuedBinaryDocValuesField field = (MultiValuedBinaryDocValuesField) context.doc().getByKey(fallbackFieldName);
+                if (field == null) {
+                    field = new MultiValuedBinaryDocValuesField(fallbackFieldName, MultiValuedBinaryDocValuesField.Ordering.INSERTION);
+                    context.doc().addWithKey(fallbackFieldName, field);
+                }
+                field.add(bytesRef);
+            } else {
+                // otherwise for bwc, store the value in a stored fields like we used to
+                context.doc().add(new StoredField(fallbackFieldName, value));
+            }
         }
+    }
+
+    private boolean storeFallbackFieldsInBinaryDocValues() {
+        return storeFallbackFieldsInBinaryDocValues(indexCreatedVersion);
+    }
+
+    private static boolean storeFallbackFieldsInBinaryDocValues(final IndexVersion indexCreatedVersion) {
+        return indexCreatedVersion.onOrAfter(IndexVersions.SYNTHETIC_SOURCE_STORE_FALLBACK_TEXT_FIELDS_IN_BINARY_DOC_VALUES);
     }
 
     /**
@@ -1742,29 +1767,30 @@ public final class TextFieldMapper extends FieldMapper {
     }
 
     private SourceLoader.SyntheticFieldLoader syntheticFieldLoader(String fullFieldName, String leafFieldName) {
-        // since we don't know whether the delegate field loader can be used for synthetic source until parsing, we need to check both this
-        // field and the delegate
+        var layers = new ArrayList<CompositeSyntheticFieldLoader.Layer>();
 
-        // first field loader - to check whether the field's value was stored under this text field
-        final String fieldName = fieldType().syntheticSourceFallbackFieldName();
-        final var thisFieldLayer = new CompositeSyntheticFieldLoader.StoredFieldLayer(fieldName) {
-            @Override
-            protected void writeValue(Object value, XContentBuilder b) throws IOException {
-                b.value(value.toString());
-            }
-        };
-
-        final CompositeSyntheticFieldLoader fieldLoader = new CompositeSyntheticFieldLoader(leafFieldName, fullFieldName, thisFieldLayer);
-
-        // second loader - to check whether the field's value was stored by a keyword delegate field
-        var kwd = TextFieldMapper.SyntheticSourceHelper.getKeywordFieldMapperForSyntheticSource(this);
-        if (kwd != null) {
-            // merge the two field loaders into one
-            var kwdFieldLoader = kwd.syntheticFieldLoader(fullPath(), leafName());
-            return fieldLoader.mergedWith(kwdFieldLoader);
+        // layer for loading from a fallback field created during indexing by this text field mapper
+        final String fallbackFieldName = fieldType().syntheticSourceFallbackFieldName();
+        if (storeFallbackFieldsInBinaryDocValues()) {
+            layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fallbackFieldName));
+        } else {
+            // for bwc - fallback fields were originally stored in StoredFields
+            layers.add(new CompositeSyntheticFieldLoader.StoredFieldLayer(fallbackFieldName) {
+                @Override
+                protected void writeValue(Object value, XContentBuilder b) throws IOException {
+                    b.value(value.toString());
+                }
+            });
         }
 
-        return fieldLoader;
+        // because we don't know whether the delegate can be used for loading fields (ex. the delegate ignored some values or the delegate
+        // doesn't even exist in the first place), we must check both the current field, as well as the delegate
+        var kwd = TextFieldMapper.SyntheticSourceHelper.getKeywordFieldMapperForSyntheticSource(this);
+        if (kwd != null) {
+            layers.addAll(kwd.syntheticFieldLoaderLayers());
+        }
+
+        return new CompositeSyntheticFieldLoader(leafFieldName, fullFieldName, layers);
     }
 
     public static class SyntheticSourceHelper {

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -1560,7 +1560,7 @@ public final class TextFieldMapper extends FieldMapper {
     }
 
     private static boolean storeFallbackFieldsInBinaryDocValues(final IndexVersion indexCreatedVersion) {
-        return indexCreatedVersion.onOrAfter(IndexVersions.SYNTHETIC_SOURCE_STORE_FALLBACK_TEXT_FIELDS_IN_BINARY_DOC_VALUES);
+        return indexCreatedVersion.onOrAfter(IndexVersions.STORE_FALLBACK_TEXT_FIELDS_IN_BINARY_DOC_VALUES);
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -390,8 +390,8 @@ public class TextFieldMapperTests extends MapperTestCase {
         IndexableFieldType fieldType = fields.get(0).fieldType();
         assertThat(fieldType.stored(), is(false));
 
-        // the field should be stored in a fallback stored field name._original
-        FieldStorageVerifier.forField("name", doc.rootDoc()).expectStoredField().verify();
+        // the field should be stored in binary doc values (name._original)
+        FieldStorageVerifier.forField("name", doc.rootDoc()).expectDocValues().verify();
 
         assertIgnoredSourceIsEmpty(doc);
     }
@@ -589,9 +589,9 @@ public class TextFieldMapperTests extends MapperTestCase {
         IndexableFieldType fieldType = fields.get(0).fieldType();
         assertThat(fieldType.stored(), is(false));
 
-        // the field should be stored in a fallback stored field name._original since the keyword cannot act as the delegate
+        // the field should be stored in binary doc values (name._original) since the keyword cannot act as the delegate
         // due to the value exceeding ignore_above
-        FieldStorageVerifier.forField("name", doc.rootDoc()).expectStoredField().verify();
+        FieldStorageVerifier.forField("name", doc.rootDoc()).expectDocValues().verify();
 
         // there should be nothing stored by the keyword multi field since the value exceeds ignore_above
         FieldStorageVerifier.forField("name.keyword", doc.rootDoc()).verify();
@@ -728,8 +728,8 @@ public class TextFieldMapperTests extends MapperTestCase {
         var source = source(b -> b.field("name", "QUICK Brown fox"));
         ParsedDocument doc = mapper.parse(source);
 
-        // expect the original, non-normalized value to be stored in a fallback stored field name._original
-        FieldStorageVerifier.forField("name", doc.rootDoc()).expectStoredField().verify();
+        // expect the original, non-normalized value to be stored in binary doc values (name._original)
+        FieldStorageVerifier.forField("name", doc.rootDoc()).expectDocValues().verify();
 
         assertIgnoredSourceIsEmpty(doc);
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldTypeTests.java
@@ -41,9 +41,12 @@ import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.mapper.TextFieldMapper.TextFieldType;
+import org.elasticsearch.index.mapper.blockloader.docvalues.BytesRefsFromCustomBinaryBlockLoader;
 import org.elasticsearch.script.ScriptCompiler;
+import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -53,6 +56,7 @@ import java.util.List;
 
 import static org.apache.lucene.search.MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -302,37 +306,6 @@ public class TextFieldTypeTests extends FieldTypeTestCase {
         );
     }
 
-    public void testBlockLoaderUsesSyntheticSourceDelegateWhenIgnoreAboveIsNotSet() {
-        // given
-        KeywordFieldMapper.KeywordFieldType syntheticSourceDelegate = new KeywordFieldMapper.KeywordFieldType(
-            "child",
-            true,
-            true,
-            Collections.emptyMap()
-        );
-
-        TextFieldType ft = new TextFieldType(
-            "parent",
-            true,
-            false,
-            new TextSearchInfo(TextFieldMapper.Defaults.FIELD_TYPE, null, Lucene.STANDARD_ANALYZER, Lucene.STANDARD_ANALYZER),
-            true,
-            false,
-            syntheticSourceDelegate,
-            Collections.singletonMap("potato", "tomato"),
-            false,
-            false
-        );
-
-        // when
-        BlockLoader blockLoader = ft.blockLoader(mock(MappedFieldType.BlockLoaderContext.class));
-
-        // then
-        // verify that we delegate block loading to the synthetic source delegate
-        assertTrue(blockLoader instanceof BlockLoader.Delegating);
-        assertThat(((BlockLoader.Delegating) blockLoader).delegatingTo(), equalTo("child"));
-    }
-
     public void testBlockLoaderDoesNotUseSyntheticSourceDelegateWhenIgnoreAboveIsSet() {
         // given
         Settings settings = Settings.builder()
@@ -432,4 +405,195 @@ public class TextFieldTypeTests extends FieldTypeTestCase {
         // verify that we don't delegate anything
         assertFalse(blockLoader instanceof BlockLoader.Delegating);
     }
+
+    public void testBlockLoaderLoadsFromSourceByDefault() {
+        // given - text field with default settings (no synthetic source, no store)
+        TextFieldType ft = new TextFieldType("field", false, false);
+
+        // we must mock IndexSettings as the block loader will check them for the index version
+        Settings settings = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
+            .build();
+        IndexSettings indexSettings = new IndexSettings(IndexMetadata.builder("index").settings(settings).build(), settings);
+
+        // when
+        var context = mock(MappedFieldType.BlockLoaderContext.class);
+        when(context.indexSettings()).thenReturn(indexSettings);
+        BlockLoader blockLoader = ft.blockLoader(context);
+
+        // then
+        assertThat(blockLoader, instanceOf(BlockSourceReader.BytesRefsBlockLoader.class));
+    }
+
+    public void testBlockLoaderLoadsFromStoredField() {
+        // given - text field thats stored
+        TextFieldType ft = new TextFieldType(
+            "field",
+            true,
+            true,
+            new TextSearchInfo(TextFieldMapper.Defaults.FIELD_TYPE, null, Lucene.STANDARD_ANALYZER, Lucene.STANDARD_ANALYZER),
+            false,
+            false,
+            null,
+            Collections.emptyMap(),
+            false,
+            false
+        );
+
+        // when
+        var context = mock(MappedFieldType.BlockLoaderContext.class);
+        BlockLoader blockLoader = ft.blockLoader(context);
+
+        // then
+        assertThat(blockLoader, instanceOf(BlockStoredFieldsReader.BytesFromStringsBlockLoader.class));
+    }
+
+    public void testBlockLoaderLoadsFromStoredFieldWhenSyntheticSourceIsEnabled() {
+        // given - text field thats stored
+        TextFieldType ft = new TextFieldType(
+            "field",
+            true,
+            true,
+            new TextSearchInfo(TextFieldMapper.Defaults.FIELD_TYPE, null, Lucene.STANDARD_ANALYZER, Lucene.STANDARD_ANALYZER),
+            true,
+            false,
+            null,
+            Collections.emptyMap(),
+            false,
+            false
+        );
+
+        // when
+        var context = mock(MappedFieldType.BlockLoaderContext.class);
+        BlockLoader blockLoader = ft.blockLoader(context);
+
+        // then
+        assertThat(blockLoader, instanceOf(BlockStoredFieldsReader.BytesFromStringsBlockLoader.class));
+    }
+
+    public void testBlockLoaderLoadsFromFallbackFieldWhenSyntheticSourceIsEnabled() {
+        // given - text field thats not stored and has no synthetic source delegate
+        TextFieldType ft = new TextFieldType("field", true, false);
+
+        // when
+        var context = mock(MappedFieldType.BlockLoaderContext.class);
+        BlockLoader blockLoader = ft.blockLoader(context);
+
+        // then
+        assertThat(blockLoader, instanceOf(BytesRefsFromCustomBinaryBlockLoader.class));
+    }
+
+    public void testBlockLoaderDelegatesToSyntheticSourceDelegate() {
+        // given
+        KeywordFieldMapper.KeywordFieldType keywordDelegate = new KeywordFieldMapper.KeywordFieldType("field.keyword");
+
+        TextFieldType ft = new TextFieldType("field", true, false, keywordDelegate);
+
+        // when
+        var context = mock(MappedFieldType.BlockLoaderContext.class);
+        BlockLoader blockLoader = ft.blockLoader(context);
+
+        // then
+        // should delegate to the keyword multi-field
+        assertThat(blockLoader, instanceOf(BlockLoader.Delegating.class));
+        assertThat(((BlockLoader.Delegating) blockLoader).delegatingTo(), equalTo("field.keyword"));
+    }
+
+    public void testBlockLoaderDelegatesToParentKeywordField() {
+        // given - text field as a multi-field of a keyword parent
+        String parentFieldName = "parent";
+        String childFieldName = "parent.text";
+
+        KeywordFieldMapper.KeywordFieldType parentKeywordType = new KeywordFieldMapper.KeywordFieldType(parentFieldName);
+
+        TextFieldType ft = new TextFieldType(childFieldName, false, true);
+
+        // when
+        var mockedSearchLookup = mock(SearchLookup.class);
+        when(mockedSearchLookup.fieldType(parentFieldName)).thenReturn(parentKeywordType);
+
+        var context = mock(MappedFieldType.BlockLoaderContext.class);
+        when(context.parentField(childFieldName)).thenReturn(parentFieldName);
+        when(context.lookup()).thenReturn(mockedSearchLookup);
+
+        BlockLoader blockLoader = ft.blockLoader(context);
+
+        // then - should delegate to parent keyword field
+        assertThat(blockLoader, instanceOf(BlockLoader.Delegating.class));
+        assertThat(((BlockLoader.Delegating) blockLoader).delegatingTo(), equalTo(parentFieldName));
+    }
+
+    public void testBlockLoaderLoadsFromIgnoredSourceInLegacyIndexVersion() {
+        // given - text field created in version range where text fields were unintentionally stored in ignored source
+        Settings settings = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersions.KEYWORD_MULTI_FIELDS_NOT_STORED_WHEN_IGNORED)
+            .put(IndexSettings.MODE.getKey(), IndexMode.STANDARD)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
+            .build();
+        IndexSettings indexSettings = new IndexSettings(IndexMetadata.builder("index").settings(settings).build(), settings);
+
+        TextFieldType ft = new TextFieldType(
+            "field",
+            true,
+            false,
+            new TextSearchInfo(TextFieldMapper.Defaults.FIELD_TYPE, null, Lucene.STANDARD_ANALYZER, Lucene.STANDARD_ANALYZER),
+            true,
+            false,
+            null,
+            Collections.emptyMap(),
+            false,
+            false,
+            IndexVersions.KEYWORD_MULTI_FIELDS_NOT_STORED_WHEN_IGNORED
+        );
+
+        // when
+        var context = mock(MappedFieldType.BlockLoaderContext.class);
+        when(context.indexSettings()).thenReturn(indexSettings);
+        when(context.fieldNames()).thenReturn(FieldNamesFieldMapper.FieldNamesFieldType.get(false));
+
+        BlockLoader blockLoader = ft.blockLoader(context);
+
+        // then
+        assertThat(blockLoader, instanceOf(FallbackSyntheticSourceBlockLoader.class));
+    }
+
+    public void testBlockLoaderLoadsFromFallbackStoredFieldWhenSyntheticSourceIsEnabledInLegacyIndexVersion() {
+        // given
+        IndexVersion legacyVersion = IndexVersions.PATTERN_TEXT_ARGS_IN_BINARY_DOC_VALUES;
+
+        Settings settings = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, legacyVersion)
+            .put(IndexSettings.MODE.getKey(), IndexMode.STANDARD)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
+            .build();
+        IndexSettings indexSettings = new IndexSettings(IndexMetadata.builder("index").settings(settings).build(), settings);
+
+        TextFieldType ft = new TextFieldType(
+            "field",
+            true,
+            false,
+            new TextSearchInfo(TextFieldMapper.Defaults.FIELD_TYPE, null, Lucene.STANDARD_ANALYZER, Lucene.STANDARD_ANALYZER),
+            true,
+            false,
+            null,
+            Collections.emptyMap(),
+            false,
+            false,
+            legacyVersion
+        );
+
+        // when
+        var context = mock(MappedFieldType.BlockLoaderContext.class);
+        when(context.parentField("field")).thenReturn(null);
+        when(context.indexSettings()).thenReturn(indexSettings);
+        BlockLoader blockLoader = ft.blockLoader(context);
+
+        // then
+        assertThat(blockLoader, instanceOf(BlockStoredFieldsReader.BytesFromStringsBlockLoader.class));
+    }
+
 }


### PR DESCRIPTION
This addresses a part of https://github.com/elastic/logs-program/issues/22.

With this change, we will store fallback (`field._original`) text fields in binary doc values as opposed to `StoredFields`.