### PR TITLE
[9.3] [ML] Unmute Inference Test (#139765)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -250,9 +250,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.action.CrossClusterCancellationIT
   method: testCancelSkipUnavailable
   issue: https://github.com/elastic/elasticsearch/issues/134865
-- class: org.elasticsearch.xpack.ml.integration.InferenceIT
-  method: testInferRegressionModel
-  issue: https://github.com/elastic/elasticsearch/issues/133603
 - class: org.elasticsearch.reservedstate.service.RepositoriesFileSettingsIT
   method: testSettingsApplied
   issue: https://github.com/elastic/elasticsearch/issues/126748


### PR DESCRIPTION
Backports the following commits to 9.3:
 - [ML] Unmute Inference Test (#139765)