### PR TITLE
Unmute test fix #129517

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -141,9 +141,6 @@ tests:
 - class: org.elasticsearch.xpack.profiling.action.GetStatusActionIT
   method: testWaitsUntilResourcesAreCreated
   issue: https://github.com/elastic/elasticsearch/issues/129486
-- class: org.elasticsearch.search.query.VectorIT
-  method: testFilteredQueryStrategy
-  issue: https://github.com/elastic/elasticsearch/issues/129517
 - class: org.elasticsearch.xpack.security.SecurityRolesMultiProjectIT
   method: testUpdatingFileBasedRoleAffectsAllProjects
   issue: https://github.com/elastic/elasticsearch/issues/129775


### PR DESCRIPTION
IDK why this sucker is still muted. 

Issue closed back in jun: https://github.com/elastic/elasticsearch/issues/129517

PR to fix it: https://github.com/elastic/elasticsearch/pull/129590

Looks like two muting 🚢 passed in the night.