### PR TITLE
[9.3] Ensure initial state discovery does not block indefinitely on startup (#139467)

### DIFF
--- a/docs/changelog/139467.yaml
+++ b/docs/changelog/139467.yaml
@@ -1,0 +1,5 @@
+pr: 139467
+summary: Ensure initial state discovery does not block indefinitely on startup
+area: Infra/Node Lifecycle
+type: bug
+issues: []

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexNodeShutdownIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexNodeShutdownIT.java
@@ -17,9 +17,7 @@ import org.elasticsearch.node.ShutdownPrepareService;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.reindex.ReindexPlugin;
 import org.elasticsearch.tasks.TaskInfo;
-import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.transport.TransportService;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -95,8 +93,6 @@ public class ReindexNodeShutdownIT extends ESIntegTestCase {
         AbstractBulkByScrollRequest<?> reindexRequest = builder.request();
         ShutdownPrepareService shutdownPrepareService = internalCluster().getInstance(ShutdownPrepareService.class, coordNodeName);
 
-        TaskManager taskManager = internalCluster().getInstance(TransportService.class, coordNodeName).getTaskManager();
-
         // Now execute the reindex action...
         ActionListener<BulkByScrollResponse> reindexListener = new ActionListener<BulkByScrollResponse>() {
             @Override
@@ -115,7 +111,7 @@ public class ReindexNodeShutdownIT extends ESIntegTestCase {
 
         // Check for reindex task to appear in the tasks list and Immediately stop coordinating node
         waitForTask(ReindexAction.INSTANCE.name(), coordNodeName);
-        shutdownPrepareService.prepareForShutdown(taskManager);
+        shutdownPrepareService.prepareForShutdown();
         internalCluster().stopNode(coordNodeName);
     }
 

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -399,12 +399,20 @@ public class Node implements Closeable {
                         latch.countDown();
                     }
                 }, state -> state.nodes().getMasterNodeId() != null, initialStateTimeout);
+                var shutdownService = injector.getInstance(ShutdownPrepareService.class);
+                shutdownService.addShutdownHook("cancel-cluster-join", latch::countDown);
 
                 try {
                     latch.await();
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     throw new ElasticsearchTimeoutException("Interrupted while waiting for initial discovery state");
+                }
+
+                if (shutdownService.isShuttingDown()) {
+                    // shutdown started in the middle of startup, so bail early
+                    logger.info("shutdown began while waiting for initial discovery state");
+                    return this;
                 }
             }
         }
@@ -594,8 +602,7 @@ public class Node implements Closeable {
      * logic should use Node Shutdown, see {@link org.elasticsearch.cluster.metadata.NodesShutdownMetadata}.
      */
     public void prepareForClose() {
-        injector.getInstance(ShutdownPrepareService.class)
-            .prepareForShutdown(injector.getInstance(TransportService.class).getTaskManager());
+        injector.getInstance(ShutdownPrepareService.class).prepareForShutdown();
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -1285,7 +1285,7 @@ class NodeConstruction {
             onlinePrewarmingService
         );
 
-        final ShutdownPrepareService shutdownPrepareService = new ShutdownPrepareService(settings, httpServerTransport, terminationHandler);
+        final var shutdownPrepareService = new ShutdownPrepareService(settings, httpServerTransport, taskManager, terminationHandler);
 
         modules.add(loadPersistentTasksService(settingsModule, clusterService, threadPool, clusterModule.getIndexNameExpressionResolver()));
 

--- a/server/src/main/java/org/elasticsearch/node/ShutdownPrepareService.java
+++ b/server/src/main/java/org/elasticsearch/node/ShutdownPrepareService.java
@@ -24,10 +24,10 @@ import org.elasticsearch.node.internal.TerminationHandler;
 import org.elasticsearch.tasks.TaskManager;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -44,17 +44,7 @@ import static org.elasticsearch.core.Strings.format;
  */
 public class ShutdownPrepareService {
 
-    private final Logger logger = LogManager.getLogger(ShutdownPrepareService.class);
-    private final Settings settings;
-    private final HttpServerTransport httpServerTransport;
-    private final TerminationHandler terminationHandler;
-    private volatile boolean hasBeenShutdown = false;
-
-    public ShutdownPrepareService(Settings settings, HttpServerTransport httpServerTransport, TerminationHandler terminationHandler) {
-        this.settings = settings;
-        this.httpServerTransport = httpServerTransport;
-        this.terminationHandler = terminationHandler;
-    }
+    private record ShutdownHook(String name, Runnable action) {}
 
     public static final Setting<TimeValue> MAXIMUM_SHUTDOWN_TIMEOUT_SETTING = Setting.positiveTimeSetting(
         "node.maximum_shutdown_grace_period",
@@ -68,6 +58,37 @@ public class ShutdownPrepareService {
         Setting.Property.NodeScope
     );
 
+    private final Logger logger = LogManager.getLogger(ShutdownPrepareService.class);
+    private final TimeValue maxTimeout;
+    private final List<ShutdownHook> hooks = new ArrayList<>();
+    private volatile boolean isShuttingDown = false;
+
+    @SuppressWarnings(value = "this-escape")
+    public ShutdownPrepareService(
+        Settings settings,
+        HttpServerTransport httpServerTransport,
+        TaskManager taskManager,
+        TerminationHandler terminationHandler
+    ) {
+        this.maxTimeout = MAXIMUM_SHUTDOWN_TIMEOUT_SETTING.get(settings);
+
+        final var reindexTimeout = MAXIMUM_REINDEXING_TIMEOUT_SETTING.get(settings);
+        addShutdownHook("http-server-transport-stop", httpServerTransport::close);
+        addShutdownHook("async-search-stop", () -> awaitSearchTasksComplete(maxTimeout, taskManager));
+        addShutdownHook("reindex-stop", () -> awaitReindexTasksComplete(reindexTimeout, taskManager));
+        if (terminationHandler != null) {
+            addShutdownHook("termination-handler-stop", terminationHandler::handleTermination);
+        }
+    }
+
+    public void addShutdownHook(String name, Runnable action) {
+        hooks.add(new ShutdownHook(name, action));
+    }
+
+    public boolean isShuttingDown() {
+        return isShuttingDown;
+    }
+
     /**
      * Invokes hooks to prepare this node to be closed. This should be called when Elasticsearch receives a request to shut down
      * gracefully from the underlying operating system, before system resources are closed. This method will block
@@ -76,11 +97,9 @@ public class ShutdownPrepareService {
      * Note that this class is part of infrastructure to react to signals from the operating system - most graceful shutdown
      * logic should use Node Shutdown, see {@link org.elasticsearch.cluster.metadata.NodesShutdownMetadata}.
      */
-    public void prepareForShutdown(TaskManager taskManager) {
-        assert hasBeenShutdown == false;
-        hasBeenShutdown = true;
-        final var maxTimeout = MAXIMUM_SHUTDOWN_TIMEOUT_SETTING.get(settings);
-        final var reindexTimeout = MAXIMUM_REINDEXING_TIMEOUT_SETTING.get(settings);
+    public void prepareForShutdown() {
+        assert isShuttingDown == false;
+        isShuttingDown = true;
 
         record Stopper(String name, SubscribableListener<Void> listener) {
             boolean isIncomplete() {
@@ -91,26 +110,19 @@ public class ShutdownPrepareService {
         final var stoppers = new ArrayList<Stopper>();
         final var allStoppersFuture = new PlainActionFuture<Void>();
         try (var listeners = new RefCountingListener(allStoppersFuture)) {
-            final BiConsumer<String, Runnable> stopperRunner = (name, action) -> {
-                final var stopper = new Stopper(name, new SubscribableListener<>());
+            for (var hook : hooks) {
+                final var stopper = new Stopper(hook.name(), new SubscribableListener<>());
                 stoppers.add(stopper);
                 stopper.listener().addListener(listeners.acquire());
                 new Thread(() -> {
                     try {
-                        action.run();
+                        hook.action.run();
                     } catch (Exception ex) {
                         logger.warn("unexpected exception in shutdown task [" + stopper.name() + "]", ex);
                     } finally {
                         stopper.listener().onResponse(null);
                     }
                 }, stopper.name()).start();
-            };
-
-            stopperRunner.accept("http-server-transport-stop", httpServerTransport::close);
-            stopperRunner.accept("async-search-stop", () -> awaitSearchTasksComplete(maxTimeout, taskManager));
-            stopperRunner.accept("reindex-stop", () -> awaitReindexTasksComplete(reindexTimeout, taskManager));
-            if (terminationHandler != null) {
-                stopperRunner.accept("termination-handler-stop", terminationHandler::handleTermination);
             }
         }
 

--- a/server/src/test/java/org/elasticsearch/node/NodeTests.java
+++ b/server/src/test/java/org/elasticsearch/node/NodeTests.java
@@ -8,6 +8,7 @@
  */
 package org.elasticsearch.node;
 
+import org.apache.logging.log4j.Level;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.bootstrap.BootstrapCheck;
@@ -23,6 +24,7 @@ import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.core.RestApiVersion;
+import org.elasticsearch.discovery.SettingsBasedSeedHostsProvider;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.gateway.PersistedClusterStateService;
 import org.elasticsearch.index.IndexModule;
@@ -44,7 +46,10 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.MockHttpTransport;
+import org.elasticsearch.test.MockLog;
+import org.elasticsearch.test.NodeRoles;
 import org.elasticsearch.test.rest.FakeRestRequest;
+import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.ContextParser;
@@ -70,7 +75,9 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 
+import static org.elasticsearch.node.Node.INITIAL_STATE_TIMEOUT_SETTING;
 import static org.elasticsearch.test.NodeRoles.dataNode;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -336,13 +343,6 @@ public class NodeTests extends ESTestCase {
         IllegalStateException e = expectThrows(IllegalStateException.class, () -> node.awaitClose(10L, TimeUnit.SECONDS));
         shard.store().decRef();
         assertThat(e.getMessage(), containsString("Something is leaking index readers or store references"));
-    }
-
-    public void testStartOnClosedTransport() throws IOException {
-        try (Node node = new MockNode(baseSettings().build(), basePlugins())) {
-            node.prepareForClose();
-            expectThrows(AssertionError.class, node::start);    // this would be IllegalStateException in a real Node with assertions off
-        }
     }
 
     public void testCreateWithCircuitBreakerPlugins() throws IOException {
@@ -674,5 +674,71 @@ public class NodeTests extends ESTestCase {
                 );
             }
         }
+    }
+
+    public void testInitialClusterStateWaitCancelledOnShutdown() throws Exception {
+
+        Consumer<MockNode> startNode = node -> {
+            try {
+                node.start();
+            } catch (NodeValidationException e) {
+                throw new AssertionError(e);
+            }
+        };
+        Settings baseSettings = Settings.builder()
+            .put(ClusterName.CLUSTER_NAME_SETTING.getKey(), InternalTestCluster.clusterName("single-node-cluster", randomLong()))
+            .put(NetworkModule.TRANSPORT_TYPE_KEY, getTestTransportType())
+            .build();
+        Settings masterSettings = Settings.builder()
+            .put(baseSettings)
+            .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
+            .put("node.name", "master_node")
+            .build();
+        List<Class<? extends Plugin>> plugins = basePlugins();
+        plugins.add(MockTransportService.TestPlugin.class);
+
+        try (MockNode masterNode = new MockNode(NodeRoles.masterOnlyNode(masterSettings), plugins)) {
+            startNode.accept(masterNode);
+
+            CountDownLatch reachedBlock = new CountDownLatch(1);
+
+            var transportService = asInstanceOf(MockTransportService.class, masterNode.injector().getInstance(TransportService.class));
+            transportService.addRequestHandlingBehavior("internal:discovery/request_peers", (handler, request, channel, task) -> {
+                logger.info("blocking peer discovery");
+                reachedBlock.countDown();
+            });
+            String masterAddress = masterNode.injector().getInstance(TransportService.class).getLocalNode().getAddress().toString();
+
+            Settings nodeSettings = NodeRoles.dataOnlyNode(
+                Settings.builder()
+                    .put(baseSettings)
+                    .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
+                    .put(INITIAL_STATE_TIMEOUT_SETTING.getKey(), "1h")
+                    .putList("cluster.initial_master_nodes", "master_node")
+                    .put("node.name", "joining_node")
+                    .putList(SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING.getKey(), masterAddress)
+                    .build()
+            );
+            try (MockLog mockLog = MockLog.capture(Node.class); MockNode joiningNode = new MockNode(nodeSettings, plugins)) {
+                mockLog.addExpectation(
+                    new MockLog.SeenEventExpectation(
+                        "aborted initial state log",
+                        Node.class.getName(),
+                        Level.INFO,
+                        "shutdown began while waiting for initial discovery state"
+                    )
+                );
+
+                Thread startupThread = new Thread(() -> startNode.accept(joiningNode));
+                startupThread.start();
+                safeAwait(reachedBlock);
+
+                joiningNode.prepareForClose();
+                // startup should now complete on its own even though the discover request is blocked
+                startupThread.join();
+                mockLog.assertAllExpectationsMatched();
+            }
+        }
+
     }
 }


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Ensure initial state discovery does not block indefinitely on startup (#139467)