### PR TITLE
Test data selector resolution

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/IndexResolutionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/IndexResolutionIT.java
@@ -89,6 +89,16 @@ public class IndexResolutionIT extends AbstractEsqlIntegTestCase {
         try (var response = run(syncEsqlQueryRequest("FROM data-stream-1::data"))) {
             assertOk(response);
         }
+        expectThrows(
+            org.elasticsearch.xpack.esql.parser.ParsingException.class,
+            containsString("Invalid index name [data-stream-1::fake]"),
+            () -> run(syncEsqlQueryRequest("FROM data-stream-1::fake"))
+        );
+        expectThrows(
+            VerificationException.class,
+            containsString("Unknown index [no-such-data-stream::data]"),
+            () -> run(syncEsqlQueryRequest("FROM no-such-data-stream::data"))
+        );
     }
 
     public void testResolvesPattern() {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/IndexResolutionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/IndexResolutionIT.java
@@ -86,6 +86,9 @@ public class IndexResolutionIT extends AbstractEsqlIntegTestCase {
         try (var response = run(syncEsqlQueryRequest("FROM data-stream-1"))) {
             assertOk(response);
         }
+        try (var response = run(syncEsqlQueryRequest("FROM data-stream-1::data"))) {
+            assertOk(response);
+        }
     }
 
     public void testResolvesPattern() {


### PR DESCRIPTION
This change adds a test that verifies index selector could be resolved as well.
In this case `::data` is verified that is pointing to the original data stream.