### PR TITLE
Quieten many `ERROR` logs to `WARN`

### DIFF
--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleService.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleService.java
@@ -349,7 +349,7 @@ public class DataStreamLifecycleService implements ClusterStateListener, Closeab
             try {
                 run(state.projectState(projectId));
             } catch (Exception e) {
-                logger.error(Strings.format("Data stream lifecycle failed to run on project [%s]", projectId), e);
+                logger.warn(Strings.format("Data stream lifecycle failed to run on project [%s]", projectId), e);
             }
         }
     }
@@ -400,7 +400,7 @@ public class DataStreamLifecycleService implements ClusterStateListener, Closeab
             } catch (Exception e) {
                 // individual index errors would be reported via the API action listener for every delete call
                 // we could potentially record errors at a data stream level and expose it via the _data_stream API?
-                logger.error(
+                logger.warn(
                     () -> String.format(
                         Locale.ROOT,
                         "Data stream lifecycle failed to execute retention for data stream [%s]",
@@ -415,7 +415,7 @@ public class DataStreamLifecycleService implements ClusterStateListener, Closeab
                     maybeExecuteForceMerge(project, getTargetIndices(dataStream, indicesToExcludeForRemainingRun, project::index, true))
                 );
             } catch (Exception e) {
-                logger.error(
+                logger.warn(
                     () -> String.format(
                         Locale.ROOT,
                         "Data stream lifecycle failed to execute force merge for data stream [%s]",
@@ -434,7 +434,7 @@ public class DataStreamLifecycleService implements ClusterStateListener, Closeab
                     )
                 );
             } catch (Exception e) {
-                logger.error(
+                logger.warn(
                     () -> String.format(
                         Locale.ROOT,
                         "Data stream lifecycle failed to execute downsampling for data stream [%s]",
@@ -899,7 +899,7 @@ public class DataStreamLifecycleService implements ClusterStateListener, Closeab
                 );
             }
         } catch (Exception e) {
-            logger.error(
+            logger.warn(
                 () -> String.format(
                     Locale.ROOT,
                     "Data stream lifecycle encountered an error trying to roll over%s data stream [%s]",
@@ -1478,11 +1478,11 @@ public class DataStreamLifecycleService implements ClusterStateListener, Closeab
         ErrorEntry previousError = errorStore.recordError(projectId, targetIndex, e);
         ErrorEntry currentError = errorStore.getError(projectId, targetIndex);
         if (previousError == null || (currentError != null && previousError.error().equals(currentError.error()) == false)) {
-            logger.error(logMessage, e);
+            logger.warn(logMessage, e);
         } else {
             if (currentError != null) {
                 if (currentError.retryCount() % signallingErrorRetryThreshold == 0) {
-                    logger.error(
+                    logger.warn(
                         String.format(
                             Locale.ROOT,
                             "%s\nFailing since [%d], operation retried [%d] times",

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloader.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloader.java
@@ -215,7 +215,7 @@ public class GeoIpDownloader extends AbstractGeoIpDownloader {
             boolean nodeShuttingDown = e instanceof NodeClosedException
                 || (e instanceof EsRejectedExecutionException rejected && rejected.isExecutorShutdown());
             logger.log(
-                nodeShuttingDown ? Level.INFO : Level.ERROR,
+                nodeShuttingDown ? Level.INFO : Level.WARN,
                 () -> "error downloading geoip database [" + name + "] for project [" + projectId + "]",
                 e
             );
@@ -307,12 +307,12 @@ public class GeoIpDownloader extends AbstractGeoIpDownloader {
             updateDatabases();
         } catch (Exception e) {
             stats = stats.failedDownload();
-            logger.error("exception during geoip databases update", e);
+            logger.warn("exception during geoip databases update", e);
         }
         try {
             cleanDatabases();
         } catch (Exception e) {
-            logger.error("exception during geoip databases cleanup", e);
+            logger.warn("exception during geoip databases cleanup", e);
         }
     }
 

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTaskExecutor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTaskExecutor.java
@@ -541,7 +541,7 @@ public final class GeoIpDownloaderTaskExecutor extends PersistentTasksExecutor<G
             ActionListener.wrap(r -> logger.debug("Started geoip downloader task"), e -> {
                 Throwable t = e instanceof RemoteTransportException ? ExceptionsHelper.unwrapCause(e) : e;
                 if (t instanceof ResourceAlreadyExistsException == false) {
-                    logger.error("failed to create geoip downloader task", e);
+                    logger.warn("failed to create geoip downloader task", e);
                     onFailure.run();
                 }
             })
@@ -555,7 +555,7 @@ public final class GeoIpDownloaderTaskExecutor extends PersistentTasksExecutor<G
             e -> {
                 Throwable t = e instanceof RemoteTransportException ? ExceptionsHelper.unwrapCause(e) : e;
                 if (t instanceof ResourceNotFoundException == false) {
-                    logger.error("failed to remove geoip downloader task", e);
+                    logger.warn("failed to remove geoip downloader task", e);
                     onFailure.run();
                 }
             }

--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -1068,7 +1068,7 @@ public abstract class Engine implements Closeable {
         } catch (Exception ex) {
             maybeFailEngine("acquire_reader", ex);
             ensureOpen(ex); // throw EngineCloseException here if we are already closed
-            logger.error("failed to acquire reader", ex);
+            logger.warn("failed to acquire reader", ex);
             throw new EngineException(shardId, "failed to acquire reader", ex);
         } finally {
             Releasables.close(releasable);

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
@@ -245,13 +245,13 @@ public class FileSettingsService extends MasterNodeFileWatchingService implement
         if (e instanceof ExecutionException) {
             var cause = e.getCause();
             if (cause instanceof FailedToCommitClusterStateException) {
-                logger().error(Strings.format("Unable to commit cluster state while processing file [%s]", file), e);
+                logger().warn(Strings.format("Unable to commit cluster state while processing file [%s]", file), e);
                 return;
             } else if (cause instanceof XContentParseException) {
                 logger().error(Strings.format("Unable to parse settings from file [%s]", file), e);
                 return;
             } else if (cause instanceof NotMasterException) {
-                logger().error(Strings.format("Node is no longer master while processing file [%s]", file), e);
+                logger().warn(Strings.format("Node is no longer master while processing file [%s]", file), e);
                 return;
             }
         }

--- a/server/src/main/java/org/elasticsearch/rest/action/RestActionListener.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/RestActionListener.java
@@ -54,7 +54,7 @@ public abstract class RestActionListener<Response> implements ActionListener<Res
             channel.sendResponse(new RestResponse(channel, e));
         } catch (Exception inner) {
             inner.addSuppressed(e);
-            logger.error("failed to send failure response", inner);
+            logger.warn("failed to send failure response", inner);
         }
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTaskIndexService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTaskIndexService.java
@@ -298,7 +298,7 @@ public final class AsyncTaskIndexService<R extends AsyncResponse<R>> {
             } else {
                 Throwable cause = ExceptionsHelper.unwrapCause(e);
                 if (cause instanceof DocumentMissingException == false && cause instanceof VersionConflictEngineException == false) {
-                    logger.error(() -> "failed to store async-search [" + docId + "]", e);
+                    logger.warn(() -> "failed to store async-search [" + docId + "]", e);
                     // at end, we should report a failure to the listener
                     updateResponse(
                         docId,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/IndexTemplateRegistry.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/IndexTemplateRegistry.java
@@ -197,7 +197,7 @@ public abstract class IndexTemplateRegistry implements ClusterStateListener {
      * @param e The exception that caused the failure.
      */
     protected void onPutTemplateFailure(String templateName, Exception e) {
-        logger.error(() -> format("error adding index template [%s] for [%s]", templateName, getOrigin()), e);
+        logger.warn(() -> format("error adding index template [%s] for [%s]", templateName, getOrigin()), e);
     }
 
     /**
@@ -206,7 +206,7 @@ public abstract class IndexTemplateRegistry implements ClusterStateListener {
      * @param e The exception that caused the failure.
      */
     protected void onPutPolicyFailure(LifecyclePolicy policy, Exception e) {
-        logger.error(() -> format("error adding lifecycle policy [%s] for [%s]", policy.getName(), getOrigin()), e);
+        logger.warn(() -> format("error adding lifecycle policy [%s] for [%s]", policy.getName(), getOrigin()), e);
     }
 
     @Override
@@ -489,7 +489,7 @@ public abstract class IndexTemplateRegistry implements ClusterStateListener {
                     public void onResponse(AcknowledgedResponse response) {
                         creationCheck.set(false);
                         if (response.isAcknowledged() == false) {
-                            logger.error(
+                            logger.warn(
                                 "error adding legacy template [{}] for [{}], request was not acknowledged",
                                 templateName,
                                 getOrigin()
@@ -527,7 +527,7 @@ public abstract class IndexTemplateRegistry implements ClusterStateListener {
                     public void onResponse(AcknowledgedResponse response) {
                         creationCheck.set(false);
                         if (response.isAcknowledged() == false) {
-                            logger.error(
+                            logger.warn(
                                 "error adding component template [{}] for [{}], request was not acknowledged",
                                 templateName,
                                 getOrigin()
@@ -572,7 +572,7 @@ public abstract class IndexTemplateRegistry implements ClusterStateListener {
                             }
                         } else {
                             creationCheck.set(false);
-                            logger.error(
+                            logger.warn(
                                 "error adding composable template [{}] for [{}], request was not acknowledged",
                                 templateName,
                                 getOrigin()
@@ -642,7 +642,7 @@ public abstract class IndexTemplateRegistry implements ClusterStateListener {
                     public void onResponse(AcknowledgedResponse response) {
                         creationCheck.set(false);
                         if (response.isAcknowledged() == false) {
-                            logger.error(
+                            logger.warn(
                                 "error adding lifecycle policy [{}] for [{}], request was not acknowledged",
                                 policy.getName(),
                                 getOrigin()
@@ -754,7 +754,7 @@ public abstract class IndexTemplateRegistry implements ClusterStateListener {
                     public void onResponse(AcknowledgedResponse response) {
                         creationCheck.set(false);
                         if (response.isAcknowledged() == false) {
-                            logger.error(
+                            logger.warn(
                                 "error adding ingest pipeline [{}] for [{}], request was not acknowledged",
                                 pipelineConfig.getId(),
                                 getOrigin()
@@ -794,7 +794,7 @@ public abstract class IndexTemplateRegistry implements ClusterStateListener {
      * @param e The exception that caused the failure.
      */
     protected void onPutPipelineFailure(String pipelineId, Exception e) {
-        logger.error(() -> format("error adding ingest pipeline template [%s] for [%s]", pipelineId, getOrigin()), e);
+        logger.warn(() -> format("error adding ingest pipeline template [%s] for [%s]", pipelineId, getOrigin()), e);
     }
 
     /**
@@ -864,9 +864,9 @@ public abstract class IndexTemplateRegistry implements ClusterStateListener {
     }
 
     void onRolloverFailure(ProjectId projectId, Exception e) {
-        logger.error(String.format(Locale.ROOT, "[%s] related rollover failed in project [%s]", getOrigin(), projectId), e);
+        logger.warn(String.format(Locale.ROOT, "[%s] related rollover failed in project [%s]", getOrigin(), projectId), e);
         for (Throwable throwable : e.getSuppressed()) {
-            logger.error(String.format(Locale.ROOT, "[%s] related rollover failed in project [%s]", getOrigin(), projectId), throwable);
+            logger.warn(String.format(Locale.ROOT, "[%s] related rollover failed in project [%s]", getOrigin(), projectId), throwable);
         }
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Driver.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Driver.java
@@ -196,7 +196,7 @@ public class Driver implements Releasable, Describable {
                 LOGGER.debug("Cancelling running driver [{}]", shortDescription, e);
                 throw e;
             } catch (RuntimeException e) {
-                LOGGER.error(Strings.format("Error running driver [%s]", shortDescription), e);
+                LOGGER.warn(Strings.format("Error running driver [%s]", shortDescription), e);
                 throw e;
             } finally {
                 assert driverContext.assertEndRunLoop();

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilter.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilter.java
@@ -378,7 +378,7 @@ public class ShardBulkInferenceActionFilter implements MappedActionFilter {
 
                         if (ExceptionsHelper.status(exc).getStatus() >= 500) {
                             List<String> fields = requests.stream().map(FieldInferenceRequest::field).distinct().toList();
-                            logger.error("Error loading inference for inference id [" + inferenceId + "] on fields " + fields, exc);
+                            logger.warn("Error loading inference for inference id [" + inferenceId + "] on fields " + fields, exc);
                         }
                     }
                 });
@@ -453,7 +453,7 @@ public class ShardBulkInferenceActionFilter implements MappedActionFilter {
 
                     if (ExceptionsHelper.status(exc).getStatus() >= 500) {
                         List<String> fields = requests.stream().map(FieldInferenceRequest::field).distinct().toList();
-                        logger.error(
+                        logger.warn(
                             "Exception when running inference id ["
                                 + inferenceProvider.model.getInferenceEntityId()
                                 + "] on fields "

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/authorization/AuthorizationTaskExecutor.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/authorization/AuthorizationTaskExecutor.java
@@ -170,7 +170,7 @@ public class AuthorizationTaskExecutor extends PersistentTasksExecutor<Authoriza
                 exception -> {
                     var thrownException = exception instanceof RemoteTransportException ? exception.getCause() : exception;
                     if (thrownException instanceof ResourceAlreadyExistsException == false) {
-                        logger.error("Failed to create authorization poller task", exception);
+                        logger.warn("Failed to create authorization poller task", exception);
                     }
                 }
             )
@@ -237,7 +237,7 @@ public class AuthorizationTaskExecutor extends PersistentTasksExecutor<Authoriza
                 exception -> {
                     var thrownException = exception instanceof RemoteTransportException ? exception.getCause() : exception;
                     if (thrownException instanceof ResourceNotFoundException == false) {
-                        logger.error("Failed to stop authorization poller task", exception);
+                        logger.warn("Failed to stop authorization poller task", exception);
                     }
                 }
             )

--- a/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/UpdateSnapshotLifecycleStatsTask.java
+++ b/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/UpdateSnapshotLifecycleStatsTask.java
@@ -7,11 +7,13 @@
 
 package org.elasticsearch.xpack.slm;
 
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.service.MasterService;
 import org.elasticsearch.xpack.core.slm.SnapshotLifecycleMetadata;
 import org.elasticsearch.xpack.core.slm.SnapshotLifecycleStats;
 
@@ -56,9 +58,11 @@ public class UpdateSnapshotLifecycleStatsTask extends ClusterStateUpdateTask {
 
     @Override
     public void onFailure(Exception e) {
-        logger.error(
+        logger.log(
+            MasterService.isPublishFailureException(e) ? Level.DEBUG : Level.ERROR,
             () -> format(
-                "failed to update cluster state with snapshot lifecycle stats, " + "source: [" + TASK_SOURCE + "], missing stats: [%s]",
+                "failed to update cluster state with snapshot lifecycle stats, source: [%s], missing stats: [%s]",
+                TASK_SOURCE,
                 runStats
             ),
             e

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
@@ -304,7 +304,7 @@ public class TransformTask extends AllocatedPersistentTask implements TransformS
                 auditor.info(transform.getId(), "Updated transform state to [" + state.getTaskState() + "].");
                 listener.onResponse(new StartTransformAction.Response(true));
             }, exc -> {
-                logger.error(() -> format("[%s] failed updating state to [%s].", getTransformId(), state), exc);
+                logger.warn(() -> format("[%s] failed updating state to [%s].", getTransformId(), state), exc);
                 getIndexer().stop();
                 listener.onFailure(
                     new ElasticsearchException(
@@ -505,7 +505,7 @@ public class TransformTask extends AllocatedPersistentTask implements TransformS
             logger.debug("[{}] successfully updated state for transform to [{}].", transform.getId(), state.toString());
             listener.onResponse(success);
         }, failure -> {
-            logger.error(() -> "[" + transform.getId() + "] failed to update cluster state for transform.", failure);
+            logger.warn(() -> "[" + transform.getId() + "] failed to update cluster state for transform.", failure);
             listener.onFailure(failure);
         }));
     }
@@ -559,7 +559,7 @@ public class TransformTask extends AllocatedPersistentTask implements TransformS
                 return;
             }
 
-            logger.atError().withThrowable(exception).log("[{}] transform has failed; experienced: [{}].", transform.getId(), reason);
+            logger.atWarn().withThrowable(exception).log("[{}] transform has failed; experienced: [{}].", transform.getId(), reason);
             auditor.error(transform.getId(), reason);
             // The idea of stopping at the next checkpoint is no longer valid. Since a failed task could potentially START again,
             // we should set this flag to false.
@@ -576,7 +576,7 @@ public class TransformTask extends AllocatedPersistentTask implements TransformS
             persistStateToClusterState(newState, ActionListener.wrap(r -> listener.onResponse(null), e -> {
                 String msg = "Failed to persist to cluster state while marking task as failed with reason [" + reason + "].";
                 auditor.warning(transform.getId(), msg + " Failure: " + e.getMessage());
-                logger.error(() -> format("[%s] %s", getTransformId(), msg), e);
+                logger.warn(() -> format("[%s] %s", getTransformId(), msg), e);
                 listener.onFailure(e);
             }));
         }


### PR DESCRIPTION
Today we're egregiously over-using the `ERROR` log level to report
situations that do occur sometimes but which can safely be ignored. At
least, we are in practice already ignoring these things despite the
overly-dramatic logging. In order to move to a model where we can rely
on elevated `ERROR` logging as an indicator of a truly release-stopping
bug, this commit reduces a number of the worst offenders down to level
`WARN`.