### PR TITLE
[9.3] Add back support for deserializing old refresh token in test (#139811)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -373,12 +373,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
   method: testStopLookback_closeJobFalse
   issue: https://github.com/elastic/elasticsearch/issues/139024
-- class: org.elasticsearch.xpack.security.authc.TokenServiceTests
-  method: testInvalidateRefreshTokenThatIsAlreadyInvalidated
-  issue: https://github.com/elastic/elasticsearch/issues/139026
-- class: org.elasticsearch.xpack.security.authc.TokenServiceTests
-  method: testSupersedingTokenEncryption
-  issue: https://github.com/elastic/elasticsearch/issues/139031
 - class: org.elasticsearch.xpack.search.AsyncSearchConcurrentStatusIT
   method: testConcurrentStatusFetchWhileTaskCloses
   issue: https://github.com/elastic/elasticsearch/issues/138543

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
@@ -118,6 +118,7 @@ import static org.elasticsearch.test.TestMatchers.throwableWithMessage;
 import static org.elasticsearch.xpack.security.authc.TokenService.RAW_TOKEN_BYTES_LENGTH;
 import static org.elasticsearch.xpack.security.authc.TokenService.RAW_TOKEN_BYTES_TOTAL_LENGTH;
 import static org.elasticsearch.xpack.security.authc.TokenService.RAW_TOKEN_DOC_ID_BYTES_LENGTH;
+import static org.elasticsearch.xpack.security.authc.TokenService.VERSION_CLIENT_AUTH_FOR_REFRESH;
 import static org.elasticsearch.xpack.security.authc.TokenService.VERSION_GET_TOKEN_DOC_FOR_REFRESH;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.contains;
@@ -538,7 +539,20 @@ public class TokenServiceTests extends ESTestCase {
         String iv,
         String salt
     ) {
-        return new RefreshTokenStatus(invalidated, authentication, refreshed, refreshInstant, supersedingTokens, iv, salt);
+        if (authentication.getEffectiveSubject().getTransportVersion().supports(VERSION_CLIENT_AUTH_FOR_REFRESH)) {
+            return new RefreshTokenStatus(invalidated, authentication, refreshed, refreshInstant, supersedingTokens, iv, salt);
+        } else {
+            return new RefreshTokenStatus(
+                invalidated,
+                authentication.getEffectiveSubject().getUser().principal(),
+                authentication.getAuthenticatingSubject().getRealm().getName(),
+                refreshed,
+                refreshInstant,
+                supersedingTokens,
+                iv,
+                salt
+            );
+        }
     }
 
     private void storeTokenHeader(ThreadContext requestContext, String tokenString) {


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Add back support for deserializing old refresh token in test (#139811)