### PR TITLE
Rethrottle route consistent `task_id` placeholder

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/RestRethrottleAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/RestRethrottleAction.java
@@ -34,9 +34,9 @@ public class RestRethrottleAction extends BaseRestHandler {
     @Override
     public List<Route> routes() {
         return List.of(
-            new Route(POST, "/_update_by_query/{taskId}/_rethrottle"),
-            new Route(POST, "/_delete_by_query/{taskId}/_rethrottle"),
-            new Route(POST, "/_reindex/{taskId}/_rethrottle")
+            new Route(POST, "/_update_by_query/{task_id}/_rethrottle"),
+            new Route(POST, "/_delete_by_query/{task_id}/_rethrottle"),
+            new Route(POST, "/_reindex/{task_id}/_rethrottle")
         );
     }
 
@@ -48,7 +48,7 @@ public class RestRethrottleAction extends BaseRestHandler {
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) {
         RethrottleRequest internalRequest = new RethrottleRequest();
-        internalRequest.setTargetTaskId(new TaskId(request.param("taskId")));
+        internalRequest.setTargetTaskId(new TaskId(request.param("task_id")));
         Float requestsPerSecond = AbstractBaseReindexRestHandler.parseRequestsPerSecond(request);
         if (requestsPerSecond == null) {
             throw new IllegalArgumentException("requests_per_second is a required parameter");


### PR DESCRIPTION
- Consistent with `/_tasks` endpoints, and with existing rest-specs: https://github.com/elastic/elasticsearch/blob/b6ead64c5c8b80684d1dfc9c041a748a755037aa/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query_rethrottle.json#L17
- Fixes issue if we use `task_id` in new reindex resilience endpoints (different placeholder names cause an error)
