### PR TITLE
Don't dedupe keyword fields with multi values

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -211,6 +211,7 @@ public class IndexVersions {
     public static final IndexVersion TEXT_FIELDS_STORED_IN_IGNORED_SOURCE_FIX = def(9_058_0_00, Version.LUCENE_10_3_2);
     public static final IndexVersion DEFAULT_HNSW_EARLY_TERMINATION = def(9_059_0_00, Version.LUCENE_10_3_2);
     public static final IndexVersion PATTERN_TEXT_ARGS_IN_BINARY_DOC_VALUES = def(9_060_0_00, Version.LUCENE_10_3_2);
+    public static final IndexVersion KEYWORD_FIELDS_KEEP_DUPLICATES_IN_BINARY_DOC_VALUES = def(9_061_0_00, Version.LUCENE_10_3_2);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -1324,7 +1324,9 @@ public final class KeywordFieldMapper extends FieldMapper {
                     // store the value in a binary doc values field, create one if it doesn't exist
                     MultiValuedBinaryDocValuesField field = (MultiValuedBinaryDocValuesField) context.doc().getByKey(fieldName);
                     if (field == null) {
-                        Collection<BytesRef> valueCollection = keepDuplicatesInBinaryDocValues() ? new ArrayList<>() : new LinkedHashSet<>();
+                        Collection<BytesRef> valueCollection = keepDuplicatesInBinaryDocValues()
+                            ? new ArrayList<>()
+                            : new LinkedHashSet<>();
                         field = new MultiValuedBinaryDocValuesField(fieldName, valueCollection);
                         context.doc().addWithKey(fieldName, field);
                     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesField.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Set;
+
+/**
+ * A custom implementation of {@link org.apache.lucene.index.BinaryDocValues} that uses a {@link Set} to maintain a collection of unique
+ * binary doc values for fields with multiple values per document.
+ */
+public class MultiValuedBinaryDocValuesField extends CustomDocValuesField {
+
+    // vints are unlike normal ints in that they may require 5 bytes instead of 4
+    // see BytesStreamOutput.writeVInt()
+    private static final int VINT_MAX_BYTES = 5;
+
+    private final Collection<BytesRef> values;
+    private int docValuesByteCount = 0;
+
+    /**
+     * @param name name of the field
+     * @param valuesCollection an empty collection that will be used for holding values for a particular field
+     */
+    MultiValuedBinaryDocValuesField(String name, Collection<BytesRef> valuesCollection) {
+        super(name);
+        assert valuesCollection.isEmpty();  // the collection must be empty to begin with
+        this.values = valuesCollection;
+    }
+
+    public void add(BytesRef value) {
+        if (values.add(value)) {
+            // might as well track these on the go as opposed to having to loop through all entries later
+            docValuesByteCount += value.length;
+        }
+    }
+
+    /**
+     * Encodes the collection of binary doc values as a single contiguous binary array, wrapped in {@link BytesRef}. This array takes
+     * the form of [doc value count][length of value 1][value 1][length of value 2][value 2]...
+     */
+    @Override
+    public BytesRef binaryValue() {
+        int docValuesCount = values.size();
+        // the + 1 is for the total doc values count, which is prefixed at the start of the array
+        int streamSize = docValuesByteCount + (docValuesCount + 1) * VINT_MAX_BYTES;
+
+        try (BytesStreamOutput out = new BytesStreamOutput(streamSize)) {
+            out.writeVInt(docValuesCount);
+            for (BytesRef value : values) {
+                int valueLength = value.length;
+                out.writeVInt(valueLength);
+                out.writeBytes(value.bytes, value.offset, valueLength);
+            }
+            return out.bytes().toBytesRef();
+        } catch (IOException e) {
+            throw new ElasticsearchException("Failed to get binary value", e);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesField.java
@@ -10,10 +10,10 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Collection;
 import java.util.Set;
 
@@ -21,7 +21,7 @@ import java.util.Set;
  * A custom implementation of {@link org.apache.lucene.index.BinaryDocValues} that uses a {@link Set} to maintain a collection of unique
  * binary doc values for fields with multiple values per document.
  */
-public class MultiValuedBinaryDocValuesField extends CustomDocValuesField {
+final class MultiValuedBinaryDocValuesField extends CustomDocValuesField {
 
     // vints are unlike normal ints in that they may require 5 bytes instead of 4
     // see BytesStreamOutput.writeVInt()
@@ -66,7 +66,7 @@ public class MultiValuedBinaryDocValuesField extends CustomDocValuesField {
             }
             return out.bytes().toBytesRef();
         } catch (IOException e) {
-            throw new ElasticsearchException("Failed to get binary value", e);
+            throw new UncheckedIOException("Failed to get binary value", e);
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordSyntheticSourceNativeArrayIntegrationTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordSyntheticSourceNativeArrayIntegrationTests.java
@@ -62,15 +62,7 @@ public class KeywordSyntheticSourceNativeArrayIntegrationTests extends NativeArr
             new Object[] { null, null, null, "blabla" },
             new Object[] { "1", "2", "3", "blabla" } };
 
-        // values in the original array should be deduplicated
-        var expectedArrayValues = new Object[] {
-            new Object[] { null, "a", "ab", "abc", "abcd", null, "abcde" },
-            "12345",
-            new Object[] { "123", "1234", "12345" },
-            new Object[] { null, null, null, "blabla" },
-            new Object[] { "1", "2", "3", "blabla" } };
-
-        verifySyntheticArray(arrayValues, expectedArrayValues, mapping, "_id");
+        verifySyntheticArray(arrayValues, mapping, "_id");
     }
 
     public void testSynthesizeObjectArray() throws Exception {


### PR DESCRIPTION
With this change, we'll no longer deduplicate keyword fields that are stored in binary doc values. The motivation for this change is two fold:
1. To be in line with how text and match only text works with synthetic source enabled
2. To be able to resynthesize the exact source that was indexed