### PR TITLE
Fix ContextIndexSearcherTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/internal/ContextIndexSearcherTests.java
+++ b/server/src/test/java/org/elasticsearch/search/internal/ContextIndexSearcherTests.java
@@ -618,9 +618,9 @@ public class ContextIndexSearcherTests extends ESTestCase {
     }
 
     public void testMaxClause() throws Exception {
+        ThreadPoolExecutor executor = null;
         try (Directory dir = newDirectory()) {
             indexDocs(dir);
-            ThreadPoolExecutor executor = null;
             try (var directoryReader = DirectoryReader.open(dir)) {
                 if (randomBoolean()) {
                     executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(randomIntBetween(2, 5));
@@ -647,6 +647,8 @@ public class ContextIndexSearcherTests extends ESTestCase {
                 assertThat(top.totalHits.value(), equalTo(0L));
                 assertThat(top.totalHits.relation(), equalTo(TotalHits.Relation.EQUAL_TO));
             }
+        } finally {
+            terminate(executor);
         }
     }
 


### PR DESCRIPTION
This one appeared to be missing a thread pool termination sometimes

Failure [here](https://gradle-enterprise.elastic.co/s/ok2lhw5usfvza/console-log/task/:server:test?anchor=241&page=1), added in #139752

Feel free to merge if you're OK with this fix