### PR TITLE
Fix a validation message in TimeSeriesGroupByAll

### DIFF
--- a/docs/changelog/139882.yaml
+++ b/docs/changelog/139882.yaml
@@ -1,0 +1,5 @@
+pr: 139882
+summary: Fix a validation message in `TimeSeriesGroupByAll`
+area: ES|QL
+type: enhancement
+issues: []

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/TimeSeriesGroupByAll.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/TimeSeriesGroupByAll.java
@@ -89,7 +89,11 @@ public class TimeSeriesGroupByAll extends Rule<LogicalPlan, LogicalPlan> {
         for (Expression grouping : aggregate.groupings()) {
             if (Functions.isGrouping(Alias.unwrap(grouping)) == false) {
                 throw new IllegalArgumentException(
-                    "Only grouping functions are supported (e.g. tbucket). Found [" + grouping.sourceText() + "]."
+                    "Only grouping functions are supported (e.g. tbucket) when the time series aggregation function ["
+                        + lastTSAggFunction.sourceText()
+                        + "] is not wrapped with another aggregation function. Found ["
+                        + grouping.sourceText()
+                        + "]."
                 );
             }
             groupings.add(grouping);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/TimeSeriesGroupByAll.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/TimeSeriesGroupByAll.java
@@ -89,7 +89,7 @@ public class TimeSeriesGroupByAll extends Rule<LogicalPlan, LogicalPlan> {
         for (Expression grouping : aggregate.groupings()) {
             if (Functions.isGrouping(Alias.unwrap(grouping)) == false) {
                 throw new IllegalArgumentException(
-                    "Cannot mix time-series aggregate and grouping attributes. Found [" + grouping.sourceText() + "]."
+                    "Only grouping functions are supported (e.g. tbucket). Found [" + grouping.sourceText() + "]."
                 );
             }
             groupings.add(grouping);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
@@ -13,7 +13,6 @@ import org.antlr.v4.runtime.tree.ParseTree;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Build;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.core.Tuple;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TimeSeriesBareAggregationsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TimeSeriesBareAggregationsTests.java
@@ -266,7 +266,7 @@ public class TimeSeriesBareAggregationsTests extends AbstractLogicalPlanOptimize
             | STATS rate(network.total_bytes_out) BY region, TBUCKET(1hour)
             """); });
 
-        assertThat(error.getMessage(), equalTo("Cannot mix time-series aggregate and grouping attributes. Found [region]."));
+        assertThat(error.getMessage(), equalTo("Only grouping functions are supported (e.g. tbucket). Found [region]."));
     }
 
     private TimeSeriesAggregate findTimeSeriesAggregate(LogicalPlan plan) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TimeSeriesBareAggregationsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TimeSeriesBareAggregationsTests.java
@@ -33,13 +33,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_VERIFIER;
-import static org.elasticsearch.xpack.esql.EsqlTestUtils.emptyInferenceResolution;
-import static org.elasticsearch.xpack.esql.EsqlTestUtils.loadMapping;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.*;
 import static org.elasticsearch.xpack.esql.analysis.AnalyzerTestUtils.defaultLookupResolution;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 
 public class TimeSeriesBareAggregationsTests extends AbstractLogicalPlanOptimizerTests {
 
@@ -266,7 +262,13 @@ public class TimeSeriesBareAggregationsTests extends AbstractLogicalPlanOptimize
             | STATS rate(network.total_bytes_out) BY region, TBUCKET(1hour)
             """); });
 
-        assertThat(error.getMessage(), equalTo("Only grouping functions are supported (e.g. tbucket). Found [region]."));
+        assertThat(
+            error.getMessage(),
+            equalTo(
+                "Only grouping functions are supported (e.g. tbucket) when the time series aggregation function "
+                    + "[rate(network.total_bytes_out)] is not wrapped with another aggregation function. Found [region]."
+            )
+        );
     }
 
     private TimeSeriesAggregate findTimeSeriesAggregate(LogicalPlan plan) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TimeSeriesBareAggregationsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TimeSeriesBareAggregationsTests.java
@@ -33,9 +33,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.elasticsearch.xpack.esql.EsqlTestUtils.*;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_VERIFIER;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.emptyInferenceResolution;
+import static org.elasticsearch.xpack.esql.EsqlTestUtils.loadMapping;
 import static org.elasticsearch.xpack.esql.analysis.AnalyzerTestUtils.defaultLookupResolution;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 
 public class TimeSeriesBareAggregationsTests extends AbstractLogicalPlanOptimizerTests {
 


### PR DESCRIPTION
Change a message that is used in the exception inside the validation loop: "Only grouping functions are supported (e.g. tbucket)."