### PR TITLE
[9.3] Register `disable_chunked_encoding` S3 repo setting (#139788)

### DIFF
--- a/docs/changelog/139788.yaml
+++ b/docs/changelog/139788.yaml
@@ -1,0 +1,5 @@
+pr: 139788
+summary: Register `disable_chunked_encoding` S3 repo setting
+area: Snapshot/Restore
+type: bug
+issues: []

--- a/modules/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
+++ b/modules/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
@@ -36,7 +36,6 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.MockSecureSettings;
-import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.util.BigArrays;
@@ -73,7 +72,6 @@ import org.elasticsearch.xcontent.XContentFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -646,13 +644,6 @@ public class S3BlobStoreRepositoryTests extends ESMockAPIBasedRepositoryIntegTes
 
         public TestS3RepositoryPlugin(final Settings settings) {
             super(settings);
-        }
-
-        @Override
-        public List<Setting<?>> getSettings() {
-            final List<Setting<?>> settings = new ArrayList<>(super.getSettings());
-            settings.add(S3ClientSettings.DISABLE_CHUNKED_ENCODING);
-            return settings;
         }
 
         @Override

--- a/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3BasicCredentialsRestIT.java
+++ b/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3BasicCredentialsRestIT.java
@@ -54,6 +54,7 @@ public class RepositoryS3BasicCredentialsRestIT extends AbstractRepositoryS3Rest
         .setting("s3.client." + CLIENT + ".endpoint", s3Fixture::getAddress)
         .systemProperty("es.insecure_network_trace_enabled", "true")
         .setting("logger.org.apache.http.headers", "TRACE")
+        .setting("s3.client." + CLIENT + ".disable_chunked_encoding", () -> randomFrom("true", "false"), ignored -> randomBoolean())
         .build();
 
     @ClassRule

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositoryPlugin.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositoryPlugin.java
@@ -150,6 +150,7 @@ public class S3RepositoryPlugin extends Plugin implements RepositoryPlugin, Relo
             S3ClientSettings.API_CALL_TIMEOUT_SETTING,
             S3ClientSettings.UNUSED_USE_THROTTLE_RETRIES_SETTING,
             S3ClientSettings.USE_PATH_STYLE_ACCESS,
+            S3ClientSettings.DISABLE_CHUNKED_ENCODING,
             S3ClientSettings.UNUSED_SIGNER_OVERRIDE,
             S3ClientSettings.ADD_PURPOSE_CUSTOM_QUERY_PARAMETER,
             S3ClientSettings.REGION,


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Register `disable_chunked_encoding` S3 repo setting (#139788)