### PR TITLE
[9.3] Increase error bounds for RandomizedTimeSeriesIT.testRateGroupBySubset (#139884)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -451,6 +451,29 @@ tests:
 - class: org.elasticsearch.persistent.ClusterPersistentTasksCustomMetadataTests
   method: testMinVersionSerialization
   issue: https://github.com/elastic/elasticsearch/issues/139741
+- class: org.elasticsearch.xpack.logsdb.RandomizedRollingUpgradeIT
+  method: testIndexingSyntheticSource
+  issue: https://github.com/elastic/elasticsearch/issues/139482
+- class: org.elasticsearch.xpack.esql.qa.single_node.AllSupportedFieldsIT
+  issue: https://github.com/elastic/elasticsearch/pull/139744
+- class: org.elasticsearch.index.mapper.SkipperSettingsTests
+  method: testTSDBSkipperSettingDefaults
+  issue: https://github.com/elastic/elasticsearch/issues/139824
+- class: org.elasticsearch.test.rest.yaml.CssSearchYamlTestSuiteIT
+  method: test {p0=search.retrievers/result-diversification/10_mmr_result_diversification_retriever/Test MMR result diversification multiple indexes}
+  issue: https://github.com/elastic/elasticsearch/issues/139826
+- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
+  method: test {csv-spec:stats_all_first_all_last.All_last_long_by_date}
+  issue: https://github.com/elastic/elasticsearch/issues/139841
+- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
+  method: test {yaml=search.retrievers/result-diversification/10_mmr_result_diversification_retriever/Test MMR result diversification single index float type}
+  issue: https://github.com/elastic/elasticsearch/issues/139848
+- class: org.elasticsearch.search.vectors.RescoreKnnVectorQueryTests
+  method: testRescoreDocs
+  issue: https://github.com/elastic/elasticsearch/issues/139859
+- class: org.elasticsearch.search.vectors.RescoreKnnVectorQueryTests
+  method: testRescoreSingleAndBulkEquality
+  issue: https://github.com/elastic/elasticsearch/issues/139869
 
 # Examples:
 #

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -451,29 +451,6 @@ tests:
 - class: org.elasticsearch.persistent.ClusterPersistentTasksCustomMetadataTests
   method: testMinVersionSerialization
   issue: https://github.com/elastic/elasticsearch/issues/139741
-- class: org.elasticsearch.xpack.logsdb.RandomizedRollingUpgradeIT
-  method: testIndexingSyntheticSource
-  issue: https://github.com/elastic/elasticsearch/issues/139482
-- class: org.elasticsearch.xpack.esql.qa.single_node.AllSupportedFieldsIT
-  issue: https://github.com/elastic/elasticsearch/pull/139744
-- class: org.elasticsearch.index.mapper.SkipperSettingsTests
-  method: testTSDBSkipperSettingDefaults
-  issue: https://github.com/elastic/elasticsearch/issues/139824
-- class: org.elasticsearch.test.rest.yaml.CssSearchYamlTestSuiteIT
-  method: test {p0=search.retrievers/result-diversification/10_mmr_result_diversification_retriever/Test MMR result diversification multiple indexes}
-  issue: https://github.com/elastic/elasticsearch/issues/139826
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlSpecIT
-  method: test {csv-spec:stats_all_first_all_last.All_last_long_by_date}
-  issue: https://github.com/elastic/elasticsearch/issues/139841
-- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
-  method: test {yaml=search.retrievers/result-diversification/10_mmr_result_diversification_retriever/Test MMR result diversification single index float type}
-  issue: https://github.com/elastic/elasticsearch/issues/139848
-- class: org.elasticsearch.search.vectors.RescoreKnnVectorQueryTests
-  method: testRescoreDocs
-  issue: https://github.com/elastic/elasticsearch/issues/139859
-- class: org.elasticsearch.search.vectors.RescoreKnnVectorQueryTests
-  method: testRescoreSingleAndBulkEquality
-  issue: https://github.com/elastic/elasticsearch/issues/139869
 
 # Examples:
 #

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/RandomizedTimeSeriesIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/RandomizedTimeSeriesIT.java
@@ -373,10 +373,11 @@ public class RandomizedTimeSeriesIT extends AbstractEsqlIntegTestCase {
                 lastValue = currentValue; // Update last value for next iteration
             }
             if (deltaAgg.equals(DeltaAgg.INCREASE)) {
+                // TODO: get tighter bounds by applying interpolation instead of median between adjacent buckets
                 return new RateRange(
-                    counterGrowth * 0.5, // INCREASE is RATE multiplied by the window size
+                    counterGrowth * 0.01, // INCREASE is RATE multiplied by the window size
                     // Upper bound is extrapolated to the window size
-                    counterGrowth * secondsInWindow / tsDurationSeconds * 1.5
+                    counterGrowth * secondsInWindow / tsDurationSeconds * 4
                 );
             } else {
                 // TODO: get tighter bounds by applying interpolation instead of median between adjacent buckets


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Increase error bounds for RandomizedTimeSeriesIT.testRateGroupBySubset (#139884)](https://github.com/elastic/elasticsearch/pull/139884)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)