### PR TITLE
Register `disable_chunked_encoding` S3 repo setting

### DIFF
--- a/docs/changelog/139788.yaml
+++ b/docs/changelog/139788.yaml
@@ -1,0 +1,5 @@
+pr: 139788
+summary: Register `disable_chunked_encoding` S3 repo setting
+area: Snapshot/Restore
+type: bug
+issues: []

--- a/modules/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
+++ b/modules/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTests.java
@@ -33,7 +33,6 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.MockSecureSettings;
-import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.util.BigArrays;
@@ -69,7 +68,6 @@ import org.elasticsearch.xcontent.XContentFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -551,13 +549,6 @@ public class S3BlobStoreRepositoryTests extends ESMockAPIBasedRepositoryIntegTes
 
         public TestS3RepositoryPlugin(final Settings settings) {
             super(settings);
-        }
-
-        @Override
-        public List<Setting<?>> getSettings() {
-            final List<Setting<?>> settings = new ArrayList<>(super.getSettings());
-            settings.add(S3ClientSettings.DISABLE_CHUNKED_ENCODING);
-            return settings;
         }
 
         @Override

--- a/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3BasicCredentialsRestIT.java
+++ b/modules/repository-s3/src/javaRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3BasicCredentialsRestIT.java
@@ -50,6 +50,7 @@ public class RepositoryS3BasicCredentialsRestIT extends AbstractRepositoryS3Rest
         .keystore("s3.client." + CLIENT + ".access_key", ACCESS_KEY)
         .keystore("s3.client." + CLIENT + ".secret_key", SECRET_KEY)
         .setting("s3.client." + CLIENT + ".endpoint", s3Fixture::getAddress)
+        .setting("s3.client." + CLIENT + ".disable_chunked_encoding", () -> randomFrom("true", "false"), ignored -> randomBoolean())
         .build();
 
     @ClassRule

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositoryPlugin.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositoryPlugin.java
@@ -117,6 +117,7 @@ public class S3RepositoryPlugin extends Plugin implements RepositoryPlugin, Relo
             S3ClientSettings.MAX_RETRIES_SETTING,
             S3ClientSettings.UNUSED_USE_THROTTLE_RETRIES_SETTING,
             S3ClientSettings.USE_PATH_STYLE_ACCESS,
+            S3ClientSettings.DISABLE_CHUNKED_ENCODING,
             S3ClientSettings.UNUSED_SIGNER_OVERRIDE,
             S3ClientSettings.ADD_PURPOSE_CUSTOM_QUERY_PARAMETER,
             S3ClientSettings.REGION,


### PR DESCRIPTION
This setting needs to be registered so you can configure it in
`elasticsearch.yml` but apparently nobody noticed it was missing until
today.

Backport of #139788 to 8.19