### PR TITLE
Impose a maximum timeout on user-supplied tasks

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/metadata/CreateIndexTimeoutIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/metadata/CreateIndexTimeoutIT.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.action.admin.indices.create.TransportCreateIndexAction;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.action.admin.indices.mapping.put.TransportAutoPutMappingAction;
+import org.elasticsearch.action.admin.indices.mapping.put.TransportPutMappingAction;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.action.support.master.MasterNodeRequest;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateUpdateTask;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+
+import static org.elasticsearch.cluster.metadata.MetadataCreateIndexService.CREATE_INDEX_MAX_TIMEOUT_SETTING;
+import static org.elasticsearch.cluster.metadata.MetadataMappingService.PUT_MAPPING_MAX_TIMEOUT_SETTING;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+
+public class CreateIndexTimeoutIT extends ESIntegTestCase {
+
+    public static class TestPlugin extends Plugin {
+        @Override
+        public List<Setting<?>> getSettings() {
+            return CollectionUtils.appendToCopyNoNullElements(
+                super.getSettings(),
+                CREATE_INDEX_MAX_TIMEOUT_SETTING,
+                PUT_MAPPING_MAX_TIMEOUT_SETTING
+            );
+        }
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return CollectionUtils.appendToCopyNoNullElements(super.nodePlugins(), TestPlugin.class);
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
+        return Settings.builder()
+            .put(otherSettings)
+            .put(CREATE_INDEX_MAX_TIMEOUT_SETTING.getKey(), "1ms")
+            .put(PUT_MAPPING_MAX_TIMEOUT_SETTING.getKey(), "1ms")
+            .build();
+    }
+
+    private Releasable withBlockedMasterService(ClusterService masterClusterService) {
+        final var barrier = new CyclicBarrier(2);
+        masterClusterService.submitUnbatchedStateUpdateTask("blocking task", new ClusterStateUpdateTask() {
+            @Override
+            public ClusterState execute(ClusterState currentState) {
+                safeAwait(barrier);
+                safeAwait(barrier);
+                return currentState;
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                fail(e);
+            }
+        });
+        safeAwait(barrier);
+        return () -> safeAwait(barrier);
+    }
+
+    public void testReducePriorities() {
+        final var masterClusterService = internalCluster().getCurrentMasterNodeInstance(ClusterService.class);
+        final var indexName = "index-" + randomIdentifier();
+
+        try (var ignored = withBlockedMasterService(masterClusterService)) {
+            final var createIndexRequest = new CreateIndexRequest(indexName);
+            setArbitraryMasterNodeTimeout(createIndexRequest);
+            assertThat(
+                asInstanceOf(
+                    ProcessClusterEventTimeoutException.class,
+                    ExceptionsHelper.unwrapCause(
+                        safeAwaitFailure(
+                            CreateIndexResponse.class,
+                            l -> client().execute(TransportCreateIndexAction.TYPE, createIndexRequest, l)
+                        )
+                    )
+                ).getMessage(),
+                allOf(
+                    containsString("failed to process cluster event"),
+                    containsString("create-index"),
+                    containsString(indexName),
+                    containsString("within 1ms")
+                )
+            );
+        }
+
+        updateClusterSettings(Settings.builder().put(CREATE_INDEX_MAX_TIMEOUT_SETTING.getKey(), randomFrom("-1", "60s", "1h")));
+
+        final ActionFuture<CreateIndexResponse> createIndexResponseFuture;
+        try (var ignored = withBlockedMasterService(masterClusterService)) {
+            final var createIndexRequest = new CreateIndexRequest(indexName);
+            setArbitraryMasterNodeTimeout(createIndexRequest);
+            createIndexResponseFuture = client().execute(TransportCreateIndexAction.TYPE, createIndexRequest);
+            awaitPendingTask(masterClusterService, "create-index [" + indexName + "]");
+        }
+        safeGet(createIndexResponseFuture);
+
+        try (var ignored = withBlockedMasterService(masterClusterService)) {
+            final var putMappingRequest = new PutMappingRequest().setConcreteIndex(
+                masterClusterService.state().metadata().getProject(ProjectId.DEFAULT).index(indexName).getIndex()
+            ).source("f", "type=keyword");
+            setArbitraryMasterNodeTimeout(putMappingRequest);
+            assertThat(
+                asInstanceOf(
+                    ProcessClusterEventTimeoutException.class,
+                    ExceptionsHelper.unwrapCause(
+                        safeAwaitFailure(
+                            AcknowledgedResponse.class,
+                            l -> client().execute(
+                                randomFrom(TransportPutMappingAction.TYPE, TransportAutoPutMappingAction.TYPE),
+                                putMappingRequest,
+                                l
+                            )
+                        )
+                    )
+                ).getMessage(),
+                allOf(
+                    containsString("failed to process cluster event"),
+                    containsString("put-mapping"),
+                    containsString(indexName),
+                    containsString("within 1ms")
+                )
+            );
+        }
+
+        updateClusterSettings(Settings.builder().put(PUT_MAPPING_MAX_TIMEOUT_SETTING.getKey(), randomFrom("-1", "60s", "1h")));
+
+        final ActionFuture<AcknowledgedResponse> putMappingResponseFuture;
+        try (var ignored = withBlockedMasterService(masterClusterService)) {
+            final var putMappingRequest = new PutMappingRequest().setConcreteIndex(
+                masterClusterService.state().metadata().getProject(ProjectId.DEFAULT).index(indexName).getIndex()
+            ).source("f", "type=keyword");
+            setArbitraryMasterNodeTimeout(putMappingRequest);
+            putMappingResponseFuture = client().execute(
+                randomFrom(TransportPutMappingAction.TYPE, TransportAutoPutMappingAction.TYPE),
+                putMappingRequest
+            );
+            awaitPendingTask(masterClusterService, "put-mapping [" + indexName + "/");
+        }
+        safeGet(putMappingResponseFuture);
+
+        updateClusterSettings(
+            Settings.builder().putNull(CREATE_INDEX_MAX_TIMEOUT_SETTING.getKey()).putNull(PUT_MAPPING_MAX_TIMEOUT_SETTING.getKey())
+        );
+    }
+
+    private static void awaitPendingTask(ClusterService masterClusterService, String taskSourcePrefix) {
+        assertTrue(
+            waitUntil(
+                () -> masterClusterService.getMasterService()
+                    .pendingTasks()
+                    .stream()
+                    .anyMatch(pct -> pct.getSource().toString().startsWith(taskSourcePrefix))
+            )
+        );
+    }
+
+    private static void setArbitraryMasterNodeTimeout(MasterNodeRequest<?> masterNodeRequest) {
+        if (randomBoolean()) {
+            masterNodeRequest.masterNodeTimeout(
+                // doesn't matter what timeout we set, we'll always have a 1ms timeout
+                randomFrom(
+                    MasterNodeRequest.INFINITE_MASTER_NODE_TIMEOUT,
+                    TimeValue.MINUS_ONE,
+                    TimeValue.ZERO,
+                    TimeValue.THIRTY_SECONDS,
+                    TimeValue.MAX_VALUE
+                )
+            );
+        }
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -40,6 +40,7 @@ import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.routing.allocation.DataTier;
 import org.elasticsearch.cluster.routing.allocation.allocator.AllocationActionListener;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.cluster.service.MasterService;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
@@ -132,6 +133,14 @@ public class MetadataCreateIndexService {
         Setting.Property.NodeScope
     );
 
+    // Deliberately not registered so it can only be set in tests/plugins.
+    public static final Setting<TimeValue> CREATE_INDEX_MAX_TIMEOUT_SETTING = Setting.timeSetting(
+        "cluster.service.create_index.max_timeout",
+        TimeValue.MINUS_ONE,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
     private static final Logger logger = LogManager.getLogger(MetadataCreateIndexService.class);
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(MetadataCreateIndexService.class);
 
@@ -162,6 +171,8 @@ public class MetadataCreateIndexService {
     private final ClusterBlocksTransformer blocksTransformerUponIndexCreation;
     private final Priority clusterStateUpdateTaskPriority;
 
+    private volatile TimeValue maxMasterNodeTimeout;
+
     public MetadataCreateIndexService(
         final Settings settings,
         final ClusterService clusterService,
@@ -190,6 +201,7 @@ public class MetadataCreateIndexService {
         this.threadPool = threadPool;
         this.blocksTransformerUponIndexCreation = createClusterBlocksTransformerForIndexCreation(settings);
         this.clusterStateUpdateTaskPriority = CREATE_INDEX_PRIORITY_SETTING.get(settings);
+        clusterService.getClusterSettings().initializeAndWatch(CREATE_INDEX_MAX_TIMEOUT_SETTING, v -> maxMasterNodeTimeout = v);
     }
 
     /**
@@ -300,37 +312,42 @@ public class MetadataCreateIndexService {
         final ActionListener<ShardsAcknowledgedResponse> listener
     ) {
         logger.trace("createIndex[{}]", request);
-        onlyCreateIndex(masterNodeTimeout, ackTimeout, request, listener.delegateFailureAndWrap((delegate, response) -> {
-            if (response.isAcknowledged()) {
-                logger.trace(
-                    "[{}] index creation in project [{}] acknowledged, waiting for active shards [{}]",
-                    request.index(),
-                    request.projectId(),
-                    request.waitForActiveShards()
-                );
-                ActiveShardsObserver.waitForActiveShards(
-                    clusterService,
-                    request.projectId(),
-                    new String[] { request.index() },
-                    request.waitForActiveShards(),
-                    waitForActiveShardsTimeout,
-                    delegate.map(shardsAcknowledged -> {
-                        if (shardsAcknowledged == false) {
-                            logger.debug(
-                                "[{}] index created, but the operation timed out while waiting for enough shards to be started.",
-                                request.index()
-                            );
-                        } else {
-                            logger.trace("[{}] index created and shards acknowledged", request.index());
-                        }
-                        return ShardsAcknowledgedResponse.of(true, shardsAcknowledged);
-                    })
-                );
-            } else {
-                logger.trace("index creation not acknowledged for [{}]", request);
-                delegate.onResponse(ShardsAcknowledgedResponse.NOT_ACKNOWLEDGED);
-            }
-        }));
+        onlyCreateIndex(
+            MasterService.maybeLimitMasterNodeTimeout(masterNodeTimeout, maxMasterNodeTimeout),
+            ackTimeout,
+            request,
+            listener.delegateFailureAndWrap((delegate, response) -> {
+                if (response.isAcknowledged()) {
+                    logger.trace(
+                        "[{}] index creation in project [{}] acknowledged, waiting for active shards [{}]",
+                        request.index(),
+                        request.projectId(),
+                        request.waitForActiveShards()
+                    );
+                    ActiveShardsObserver.waitForActiveShards(
+                        clusterService,
+                        request.projectId(),
+                        new String[] { request.index() },
+                        request.waitForActiveShards(),
+                        waitForActiveShardsTimeout,
+                        delegate.map(shardsAcknowledged -> {
+                            if (shardsAcknowledged == false) {
+                                logger.debug(
+                                    "[{}] index created, but the operation timed out while waiting for enough shards to be started.",
+                                    request.index()
+                                );
+                            } else {
+                                logger.trace("[{}] index created and shards acknowledged", request.index());
+                            }
+                            return ShardsAcknowledgedResponse.of(true, shardsAcknowledged);
+                        })
+                    );
+                } else {
+                    logger.trace("index creation not acknowledged for [{}]", request);
+                    delegate.onResponse(ShardsAcknowledgedResponse.NOT_ACKNOWLEDGED);
+                }
+            })
+        );
     }
 
     private void onlyCreateIndex(

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -201,7 +201,13 @@ public class MetadataCreateIndexService {
         this.threadPool = threadPool;
         this.blocksTransformerUponIndexCreation = createClusterBlocksTransformerForIndexCreation(settings);
         this.clusterStateUpdateTaskPriority = CREATE_INDEX_PRIORITY_SETTING.get(settings);
-        clusterService.getClusterSettings().initializeAndWatch(CREATE_INDEX_MAX_TIMEOUT_SETTING, v -> maxMasterNodeTimeout = v);
+
+        if (clusterService.getClusterSettings().isDynamicSetting(CREATE_INDEX_MAX_TIMEOUT_SETTING.getKey())) {
+            // setting only registered in some tests today
+            clusterService.getClusterSettings().initializeAndWatch(CREATE_INDEX_MAX_TIMEOUT_SETTING, v -> maxMasterNodeTimeout = v);
+        } else {
+            maxMasterNodeTimeout = CREATE_INDEX_MAX_TIMEOUT_SETTING.get(clusterService.getSettings());
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMappingService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMappingService.java
@@ -86,7 +86,13 @@ public class MetadataMappingService {
             PUT_MAPPING_PRIORITY_SETTING.get(clusterService.getSettings()),
             new PutMappingExecutor(indexSettingProviders)
         );
-        clusterService.getClusterSettings().initializeAndWatch(PUT_MAPPING_MAX_TIMEOUT_SETTING, v -> maxMasterNodeTimeout = v);
+
+        if (clusterService.getClusterSettings().isDynamicSetting(PUT_MAPPING_MAX_TIMEOUT_SETTING.getKey())) {
+            // setting only registered in some tests today
+            clusterService.getClusterSettings().initializeAndWatch(PUT_MAPPING_MAX_TIMEOUT_SETTING, v -> maxMasterNodeTimeout = v);
+        } else {
+            maxMasterNodeTimeout = PUT_MAPPING_MAX_TIMEOUT_SETTING.get(clusterService.getSettings());
+        }
     }
 
     record PutMappingClusterStateUpdateTask(PutMappingClusterStateUpdateRequest request, ActionListener<AcknowledgedResponse> listener)

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMappingService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMappingService.java
@@ -262,17 +262,6 @@ public class MetadataMappingService {
 
     }
 
-    private TimeValue maybeLimitMasterNodeTimeout(TimeValue masterNodeTimeout) {
-        logger.info("--> maybeLimitMasterNodeTimeout({}) vs {}", masterNodeTimeout, maxMasterNodeTimeout);
-        if (maxMasterNodeTimeout.millis() < 0 || 0 <= maxMasterNodeTimeout.compareTo(masterNodeTimeout)) {
-            logger.info("--> maybeLimitMasterNodeTimeout({}) vs {}: no limit needed", masterNodeTimeout, maxMasterNodeTimeout);
-            return masterNodeTimeout;
-        } else {
-            logger.info("--> maybeLimitMasterNodeTimeout({}) vs {}: limit needed", masterNodeTimeout, maxMasterNodeTimeout);
-            return maxMasterNodeTimeout;
-        }
-    }
-
     public void putMapping(final PutMappingClusterStateUpdateRequest request, final ActionListener<AcknowledgedResponse> listener) {
         try {
             // TODO: instead of considering the whole request as a no-op, we could filter out indices that don't need an update and only

--- a/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
@@ -1544,7 +1544,7 @@ public class MasterService extends AbstractLifecycleComponent {
             // requesting infinite timeout, so limit applies
             return maxTimeout;
         }
-        return requestTimeout.compareTo(maxTimeout) < 0 ? requestTimeout : maxTimeout;
+        return TimeValue.min(requestTimeout, maxTimeout);
     }
 
     @FunctionalInterface

--- a/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
@@ -1528,6 +1528,25 @@ public class MasterService extends AbstractLifecycleComponent {
         );
     }
 
+    /**
+     * Allows to impose an optional limit on a master node timeout specified in a request.
+     *
+     * @param requestTimeout The requested master-node timeout.
+     * @param maxTimeout     The maximum configured master-node timeout.
+     * @return An appropriate master-node timeout for the task.
+     */
+    public static TimeValue maybeLimitMasterNodeTimeout(TimeValue requestTimeout, TimeValue maxTimeout) {
+        if (maxTimeout.millis() <= 0) {
+            // no max timeout specified
+            return requestTimeout;
+        }
+        if (requestTimeout.millis() <= 0) {
+            // requesting infinite timeout, so limit applies
+            return maxTimeout;
+        }
+        return requestTimeout.compareTo(maxTimeout) < 0 ? requestTimeout : maxTimeout;
+    }
+
     @FunctionalInterface
     private interface BatchConsumer<T extends ClusterStateTaskListener> {
         void runBatch(

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamLifecycleWithRetentionWarningsTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamLifecycleWithRetentionWarningsTests.java
@@ -35,6 +35,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.elasticsearch.cluster.metadata.DataStreamLifecycleTests.randomDownsamplingRounds;
+import static org.elasticsearch.common.settings.ClusterSettings.BUILT_IN_CLUSTER_SETTINGS;
 import static org.elasticsearch.common.settings.Settings.builder;
 import static org.elasticsearch.indices.ShardLimitValidatorTests.createTestShardLimitService;
 import static org.hamcrest.Matchers.containsString;
@@ -250,6 +251,8 @@ public class DataStreamLifecycleWithRetentionWarningsTests extends ESTestCase {
         when(indicesService.createIndex(any(), any(), eq(false))).thenReturn(indexService);
         when(indexService.index()).thenReturn(new Index(randomAlphaOfLength(10), randomUUID()));
         ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.getSettings()).thenReturn(Settings.EMPTY);
+        when(clusterService.getClusterSettings()).thenReturn(new ClusterSettings(Settings.EMPTY, BUILT_IN_CLUSTER_SETTINGS));
         MetadataCreateIndexService createIndexService = new MetadataCreateIndexService(
             Settings.EMPTY,
             clusterService,

--- a/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
@@ -88,6 +88,7 @@ import java.util.stream.Collectors;
 import static java.util.Collections.emptySet;
 import static org.elasticsearch.action.support.ActionTestUtils.assertNoSuccessListener;
 import static org.elasticsearch.cluster.service.MasterService.MAX_TASK_DESCRIPTION_CHARS;
+import static org.elasticsearch.cluster.service.MasterService.maybeLimitMasterNodeTimeout;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
@@ -2739,5 +2740,40 @@ public class MasterServiceTests extends ESTestCase {
         public void onFailure(Exception e) {
             throw new AssertionError("should not be called", e);
         }
+    }
+
+    public void testMaybeLimitMasterNodeTimeout() {
+
+        // returns the request timeout if the max is unspecified
+        for (final var requestTimeout : List.of(
+            randomTimeValue(),
+            TimeValue.MINUS_ONE,
+            TimeValue.ZERO,
+            TimeValue.timeValueMillis(1),
+            TimeValue.THIRTY_SECONDS,
+            TimeValue.ONE_MINUTE,
+            TimeValue.ONE_HOUR,
+            TimeValue.MAX_VALUE
+        )) {
+            assertSame(requestTimeout, maybeLimitMasterNodeTimeout(requestTimeout, TimeValue.MINUS_ONE));
+            // undocumented, but zero also means an infinite timeout against which we must protect
+            assertSame(requestTimeout, maybeLimitMasterNodeTimeout(requestTimeout, TimeValue.ZERO));
+        }
+
+        // returns the limit if the requested timeout is unlimited or larger than the limit
+        for (final var requestTimeout : List.of(
+            TimeValue.MINUS_ONE,
+            TimeValue.ZERO /* undocumented, but zero here means an infinite timeout against which we must protect */,
+            TimeValue.ONE_MINUTE,
+            TimeValue.ONE_HOUR,
+            TimeValue.MAX_VALUE
+        )) {
+            assertSame(TimeValue.ONE_MINUTE, maybeLimitMasterNodeTimeout(requestTimeout, TimeValue.ONE_MINUTE));
+            assertSame(TimeValue.ONE_MINUTE, maybeLimitMasterNodeTimeout(requestTimeout, TimeValue.ONE_MINUTE));
+        }
+
+        // returns the smaller one when both specified
+        assertSame(TimeValue.ONE_MINUTE, maybeLimitMasterNodeTimeout(TimeValue.ONE_HOUR, TimeValue.ONE_MINUTE));
+        assertSame(TimeValue.THIRTY_SECONDS, maybeLimitMasterNodeTimeout(TimeValue.THIRTY_SECONDS, TimeValue.ONE_MINUTE));
     }
 }


### PR DESCRIPTION
In #139699 we introduced a way to reduce the priority of user-supplied
tasks in order to reduce the impact of starvation caused by such tasks.
However, even at `NORMAL` priority these tasks may sit in the master's
queue for as long as the user wants so they can still cause starvation.

With this commit we introduce settings that allow an operator to impose
a limit on the timeouts on these tasks to ensure that the master can
shed the corresponding load and make progress on other non-user-supplied
tasks instead.