### PR TITLE
[9.3] Fix MappingStatsTests.testToXContent flakiness (#139896)

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/MappingStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/MappingStatsTests.java
@@ -219,7 +219,7 @@ public class MappingStatsTests extends AbstractWireSerializingTestCase<MappingSt
                   "stored" : 2
                 }
               }
-            }""", Strings.toString(mappingStats, true, true));
+            }""", mappingStatsString);
     }
 
     public void testToXContentWithSomeSharedMappings() {


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Fix MappingStatsTests.testToXContent flakiness (#139896)