### PR TITLE
docs: explain how fields are counted towards total_fields.limit

### DIFF
--- a/docs/reference/elasticsearch/index-settings/mapping-limit.md
+++ b/docs/reference/elasticsearch/index-settings/mapping-limit.md
@@ -30,6 +30,156 @@ $$$total-fields-limit$$$
 
     ::::
 
+### How fields are counted [mapping-fields-counting]
+
+The `index.mapping.total_fields.limit` setting counts **all mappers**, not just leaf fields. This includes:
+
+- **Object mappers**: Each level in a dotted field path counts separately
+- **Field mappers**: Leaf fields like `keyword`, `text`, `long`, etc.
+- **Multi-fields**: Each sub-field (e.g., `.keyword`, `.raw`) counts individually
+- **Field aliases**: Each alias counts as one mapper
+- **Runtime fields**: Each runtime field counts towards the limit
+
+Metadata fields (`_id`, `_source`, `_routing`, etc.) do **not** count towards this limit.
+
+#### Example: Counting a nested field path
+
+For a field path like `host.os.name`, Elasticsearch creates three mappers:
+
+- `host` (object mapper)
+- `host.os` (object mapper)
+- `host.os.name` (field mapper)
+
+A common mistake is counting only leaf fields (fields with a `type` property). This undercounts because object mappers have `properties` instead of `type`.
+
+#### Example: Full mapping count
+
+```json
+{
+  "mappings": {
+    "properties": {
+      "host": {
+        "properties": {
+          "name": { "type": "keyword" }
+        }
+      },
+      "message": {
+        "type": "text",
+        "fields": {
+          "keyword": { "type": "keyword" }
+        }
+      }
+    }
+  }
+}
+```
+
+This mapping counts as **4 mappers**:
+
+- `host` (object mapper)
+- `host.name` (field mapper)
+- `message` (field mapper)
+- `message.keyword` (multi-field)
+
+#### Example: Multi-fields
+
+Each multi-field counts separately. A text field with multiple sub-fields can quickly add up:
+
+```json
+{
+  "mappings": {
+    "properties": {
+      "title": {
+        "type": "text",
+        "fields": {
+          "keyword": { "type": "keyword" },
+          "raw": { "type": "keyword", "index": false }
+        }
+      }
+    }
+  }
+}
+```
+
+This mapping counts as **3 mappers**:
+
+- `title` (field mapper)
+- `title.keyword` (multi-field)
+- `title.raw` (multi-field)
+
+#### Example: Runtime fields
+
+Runtime fields also count towards the limit:
+
+```json
+{
+  "mappings": {
+    "properties": {
+      "timestamp": { "type": "date" }
+    },
+    "runtime": {
+      "day_of_week": {
+        "type": "keyword",
+        "script": {
+          "source": "emit(doc['timestamp'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ROOT))"
+        }
+      }
+    }
+  }
+}
+```
+
+This mapping counts as **2 mappers**:
+
+- `timestamp` (field mapper)
+- `day_of_week` (runtime field)
+
+#### Example: Field aliases
+
+Field aliases count towards the limit:
+
+```json
+{
+  "mappings": {
+    "properties": {
+      "user_id": { "type": "keyword" },
+      "user": {
+        "type": "alias",
+        "path": "user_id"
+      }
+    }
+  }
+}
+```
+
+This mapping counts as **2 mappers**:
+
+- `user_id` (field mapper)
+- `user` (field alias)
+
+### Reducing field count with `subobjects: false` [reducing-field-count]
+
+The [`subobjects`](/reference/elasticsearch/mapping-reference/subobjects.md) setting prevents the creation of intermediate object mappers. With `subobjects: false`, dotted field names are stored as literal strings rather than creating nested objects.
+
+```json
+{
+  "mappings": {
+    "subobjects": false,
+    "properties": {
+      "host.os.name": { "type": "keyword" }
+    }
+  }
+}
+```
+
+This creates only **1 mapper** instead of 3, because `host.os.name` is treated as a literal field name rather than a nested path.
+
+For indices with deeply nested fields (such as ECS-style mappings), using `subobjects: false` can significantly reduce the mapper count.
+
+::::{note}
+When using [`index.mode: logsdb`](docs-content://manage-data/data-store/data-streams/logs-data-stream.md), `subobjects` defaults to `false` at the root level.
+::::
+
 $$$ignore-dynamic-beyond-limit$$$
 `index.mapping.total_fields.ignore_dynamic_beyond_limit` {applies_to}`serverless: all`
 :   This setting determines what happens when a dynamically mapped field would exceed the total fields limit. When set to `false` (the default), the index request of the document that tries to add a dynamic field to the mapping will fail with the message `Limit of total fields [X] has been exceeded`. When set to `true`, the index request will not fail. Instead, fields that would exceed the limit are not added to the mapping, similar to [`dynamic: false`](/reference/elasticsearch/mapping-reference/dynamic.md). The fields that were not added to the mapping will be added to the [`_ignored` field](/reference/elasticsearch/mapping-reference/mapping-ignored-field.md). The default value is `false`.

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldCountingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldCountingTests.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class FieldCountingTests extends MapperServiceTestCase {
+
+    public void testNestedFieldPathWithSubobjectsTrue() throws Exception {
+        assertFieldCount(true, b -> {
+            b.startObject("host");
+            b.startObject("properties");
+            b.startObject("os");
+            b.startObject("properties");
+            b.startObject("name").field("type", "keyword").endObject();
+            b.endObject();
+            b.endObject();
+            b.endObject();
+            b.endObject();
+        }, 3L);
+    }
+
+    public void testNestedFieldPathWithSubobjectsFalse() throws Exception {
+        assertFieldCount(false, b -> {
+            b.startObject("host.os.name").field("type", "keyword").endObject();
+        }, 1L);
+    }
+
+    public void testObjectAndMultiFieldWithSubobjectsTrue() throws Exception {
+        assertFieldCount(true, b -> {
+            b.startObject("host");
+            b.startObject("properties");
+            b.startObject("name").field("type", "keyword").endObject();
+            b.endObject();
+            b.endObject();
+            b.startObject("message");
+            b.field("type", "text");
+            b.startObject("fields");
+            b.startObject("keyword").field("type", "keyword").endObject();
+            b.endObject();
+            b.endObject();
+        }, 4L);
+    }
+
+    public void testObjectAndMultiFieldWithSubobjectsFalse() throws Exception {
+        assertFieldCount(false, b -> {
+            b.startObject("host.name").field("type", "keyword").endObject();
+            b.startObject("message");
+            b.field("type", "text");
+            b.startObject("fields");
+            b.startObject("keyword").field("type", "keyword").endObject();
+            b.endObject();
+            b.endObject();
+        }, 3L);
+    }
+
+    public void testMultiFields() throws Exception {
+        assertFieldCount(true, b -> {
+            b.startObject("title");
+            b.field("type", "text");
+            b.startObject("fields");
+            b.startObject("keyword").field("type", "keyword").endObject();
+            b.startObject("raw").field("type", "keyword").field("index", false).endObject();
+            b.endObject();
+            b.endObject();
+        }, 3L);
+    }
+
+    public void testRuntimeFields() throws Exception {
+        final MapperService mapperService = createMapperService(mapping(b -> {
+            b.startObject("timestamp").field("type", "date").endObject();
+        }));
+        assertThat(mapperService.mappingLookup().getTotalFieldsCount(), equalTo(1L));
+
+        merge(mapperService, runtimeMapping(b -> {
+            b.startObject("day_of_week").field("type", "keyword").endObject();
+        }));
+        assertThat(mapperService.mappingLookup().getTotalFieldsCount(), equalTo(2L));
+    }
+
+    public void testFieldAliases() throws Exception {
+        assertFieldCount(true, b -> {
+            b.startObject("user_id").field("type", "keyword").endObject();
+            b.startObject("user");
+            b.field("type", "alias");
+            b.field("path", "user_id");
+            b.endObject();
+        }, 2L);
+    }
+
+    public void testNestedObjectWithAliasWithSubobjectsTrue() throws Exception {
+        assertFieldCount(true, b -> {
+            b.startObject("host");
+            b.startObject("properties");
+            b.startObject("name").field("type", "keyword").endObject();
+            b.endObject();
+            b.endObject();
+            b.startObject("hostname");
+            b.field("type", "alias");
+            b.field("path", "host.name");
+            b.endObject();
+        }, 3L);
+    }
+
+    public void testNestedObjectWithAliasWithSubobjectsFalse() throws Exception {
+        assertFieldCount(false, b -> {
+            b.startObject("host.name").field("type", "keyword").endObject();
+            b.startObject("hostname");
+            b.field("type", "alias");
+            b.field("path", "host.name");
+            b.endObject();
+        }, 2L);
+    }
+
+    private void assertFieldCount(final boolean subobjects, final CheckedConsumer<XContentBuilder, IOException> mapping, final long expectedCount)
+        throws Exception {
+        final MapperService mapperService = createMapperService(subobjects ? mapping(mapping) : mappingNoSubobjects(mapping));
+        assertThat(mapperService.mappingLookup().getTotalFieldsCount(), equalTo(expectedCount));
+    }
+}


### PR DESCRIPTION
## Summary

Adds comprehensive documentation explaining how Elasticsearch counts fields towards the `index.mapping.total_fields.limit` setting.

This addresses a common source of confusion where users count only leaf fields (fields with a `type` property) but miss object mappers (which have `properties` instead). For deeply nested field paths like those in ECS-style mappings, this can cause users to significantly underestimate their actual mapper count.

**Changes:**
- Explain what counts towards the limit (object mappers, field mappers, multi-fields, aliases, runtime fields)
- Clarify that metadata fields do not count
- Add examples showing how nested paths like `host.os.name` create 3 mappers, not 1
- Add example showing full mapping count breakdown
- Document how `subobjects: false` reduces field count
- Note that `logsdb` mode defaults `subobjects` to `false`

## Test plan

- [ ] Documentation renders correctly
- [ ] Examples are accurate and consistent with Elasticsearch behavior