### PR TITLE
Check if the test index exists after cluster upgrade

### DIFF
--- a/x-pack/plugin/logsdb/qa/legacy-rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/AbstractStringTypeRollingUpgradeIT.java
+++ b/x-pack/plugin/logsdb/qa/legacy-rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/AbstractStringTypeRollingUpgradeIT.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.upgrades;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
+
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;

--- a/x-pack/plugin/logsdb/qa/legacy-rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/AbstractStringTypeRollingUpgradeIT.java
+++ b/x-pack/plugin/logsdb/qa/legacy-rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/AbstractStringTypeRollingUpgradeIT.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.upgrades;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
-
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
@@ -119,7 +118,7 @@ public abstract class AbstractStringTypeRollingUpgradeIT extends AbstractRolling
             assertDataStream(dataStreamName, templateId);
 
             // when/then - run some queries and verify results
-            ensureGreen(dataStreamName);
+            checkIndexHealth(dataStreamName);
             search(dataStreamName);
             phraseSearch(dataStreamName);
             query(dataStreamName);
@@ -128,13 +127,13 @@ public abstract class AbstractStringTypeRollingUpgradeIT extends AbstractRolling
             bulkIndex(dataStreamName, NUM_REQUESTS, NUM_DOCS_PER_REQUEST);
 
             // when/then
-            ensureGreen(dataStreamName);
+            checkIndexHealth(dataStreamName);
             search(dataStreamName);
             phraseSearch(dataStreamName);
             query(dataStreamName);
         } else if (isUpgradedCluster()) {
             // when/then
-            ensureGreen(dataStreamName);
+            checkIndexHealth(dataStreamName);
             bulkIndex(dataStreamName, NUM_REQUESTS, NUM_DOCS_PER_REQUEST);
             search(dataStreamName);
             phraseSearch(dataStreamName);
@@ -146,10 +145,20 @@ public abstract class AbstractStringTypeRollingUpgradeIT extends AbstractRolling
             assertOK(client().performRequest(forceMergeRequest));
 
             // then continued
-            ensureGreen(dataStreamName);
+            checkIndexHealth(dataStreamName);
             search(dataStreamName);
             query(dataStreamName);
         }
+    }
+
+    private void checkIndexHealth(String dataStreamName) throws IOException {
+        // first check if the index exists
+        if (indexExists(dataStreamName) == false) {
+            fail(String.format("Index %s doesn't exist!", dataStreamName));
+        }
+
+        // next, check the health of the index
+        ensureGreen(dataStreamName);
     }
 
     private String prepareTemplate(boolean shouldIncludeKeywordMultifield) throws IOException {


### PR DESCRIPTION
While investigating https://github.com/elastic/elasticsearch/issues/139865, I noticed that our error messages could be better. More specifically, the index didn't exist, while the error message was:

> java.lang.AssertionError: timed out waiting for green state for index [logs-bwc-test-multifield] cluster state [{

This threw me off as it looked like a generic error with a deeper root cause. 

With this change, the new error message will be:

```
MatchOnlyTextRollingUpgradeIT > testIndexingWithMultifield {upgradedNodes=3} FAILED
    java.lang.AssertionError: Index logs-bwc-test-multifield doesn't exist!
        at __randomizedtesting.SeedInfo.seed([A9A7960CD41FAF8D:883A7932D514F18C]:0)
        at org.junit.Assert.fail(Assert.java:89)
        at org.elasticsearch.upgrades.AbstractStringTypeRollingUpgradeIT.checkIndexHealth(AbstractStringTypeRollingUpgradeIT.java:157)
        at org.elasticsearch.upgrades.AbstractStringTypeRollingUpgradeIT.testIndexing(AbstractStringTypeRollingUpgradeIT.java:136)
        at org.elasticsearch.upgrades.MatchOnlyTextRollingUpgradeIT.testIndexing(MatchOnlyTextRollingUpgradeIT.java:36)
```