### PR TITLE
Binary doc values have stale value offset array if block contains all empty values

### DIFF
--- a/docs/changelog/139922.yaml
+++ b/docs/changelog/139922.yaml
@@ -1,0 +1,6 @@
+pr: 139922
+summary: Binary doc values have stale value offset array if block contains all empty
+  values
+area: Codec
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesProducer.java
@@ -55,6 +55,7 @@ import org.elasticsearch.index.mapper.blockloader.docvalues.BlockDocValuesReader
 import org.elasticsearch.index.mapper.blockloader.docvalues.CustomBinaryDocValuesReader;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import static org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesFormat.SKIP_INDEX_JUMP_LENGTH_PER_LEVEL;
 import static org.elasticsearch.index.codec.tsdb.es819.ES819TSDBDocValuesFormat.SKIP_INDEX_MAX_LEVEL;
@@ -537,6 +538,7 @@ final class ES819TSDBDocValuesProducer extends DocValuesProducer {
             int uncompressedBlockLength = compressedData.readVInt();
 
             if (uncompressedBlockLength == 0) {
+                Arrays.fill(uncompressedDocStarts, 0);
                 return;
             }
 

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/es819/ES819TSDBDocValuesFormatTests.java
@@ -173,6 +173,20 @@ public class ES819TSDBDocValuesFormatTests extends ES87TSDBDocValuesFormatTests 
         assertBinaryValues(binaryValues);
     }
 
+    public void testBlockWiseBinaryWithEmptySequences() throws Exception {
+        // Test long sequences that either have values or are all empty
+        List<String> binaryValues = new ArrayList<>();
+        int numSequences = 10;
+        for (int i = 0; i < numSequences; i++) {
+            int numInSequence = randomIntBetween(0, 3 * BLOCK_COUNT_THRESHOLD);
+            boolean emptySequence = randomBoolean();
+            for (int j = 0; j < numInSequence; j++) {
+                binaryValues.add(emptySequence ? "" : randomAlphaOfLengthBetween(0, 5));
+            }
+        }
+        assertBinaryValues(binaryValues);
+    }
+
     public void testBlockWiseBinaryLargeValues() throws Exception {
         boolean sparse = randomBoolean();
         int numBlocksBound = 5;


### PR DESCRIPTION
If all values are empty, the offsets array isn't decoded. This causes the offsets already present in the offsets array to be used.  Instead need to either clear the offset array or read the compressed offsets (which are all 0s.) As follow-up, we should not send the empty offsets at all; but this will require codec version change.