### PR TITLE
PromQL: add support for binary arithmetic operators

### DIFF
--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeForkRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeForkRestTest.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.qa.rest.generative;
 
 import org.elasticsearch.xpack.esql.CsvSpecReader;
+import org.elasticsearch.xpack.esql.action.PromqlFeatures;
 import org.elasticsearch.xpack.esql.qa.rest.EsqlSpecTestCase;
 
 import java.io.IOException;
@@ -69,7 +70,7 @@ public abstract class GenerativeForkRestTest extends EsqlSpecTestCase {
 
         assumeFalse(
             "Tests using PROMQL are not supported for now",
-            testCase.requiredCapabilities.contains(PROMQL_PRE_TECH_PREVIEW_V8.capabilityName())
+            testCase.requiredCapabilities.contains(PromqlFeatures.capabilityName())
         );
 
         assumeFalse(

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-arithmetic.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-arithmetic.csv-spec
@@ -56,6 +56,108 @@ max_bits:double | step:datetime            | cluster:keyword
 59224.0         | 2024-05-10T00:00:00.000Z | staging
 ;
 
+division_metric_metric_grouping
+required_capability: ts_command_v0
+required_capability: tbucket
+TS k8s
+| STATS div=max(
+    // TODO leaving out last_over_time should be equivalent, but currently fails
+    last_over_time(network.total_bytes_in) /
+    last_over_time(network.total_bytes_in)
+  ) BY step=TBUCKET(1h), cluster
+| SORT cluster;
+
+div:long | step:datetime            | cluster:keyword
+1        | 2024-05-10T00:00:00.000Z | prod
+1        | 2024-05-10T00:00:00.000Z | qa
+1        | 2024-05-10T00:00:00.000Z | staging
+;
+
+division_metric_metric_grouping_promql
+required_capability: promql_pre_tech_preview_v9
+PROMQL index=k8s step=1h div=(
+  max by (cluster) (network.total_bytes_in / network.total_bytes_in)
+)
+| SORT cluster;
+
+div:double | step:datetime            | cluster:keyword
+1.0        | 2024-05-10T00:00:00.000Z | prod
+1.0        | 2024-05-10T00:00:00.000Z | qa
+1.0        | 2024-05-10T00:00:00.000Z | staging
+;
+
+division_metric_metric_grouping_filtering_promql
+required_capability: promql_pre_tech_preview_v9
+PROMQL index=k8s step=1h div=(
+  max by (cluster) (network.total_bytes_in{cluster!="prod"} / network.total_bytes_in{cluster=~"prod|qa"})
+) | SORT cluster;
+
+div:double | step:datetime            | cluster:keyword
+1.0        | 2024-05-10T00:00:00.000Z | qa
+;
+
+division_within_series_grouping
+required_capability: ts_command_v0
+required_capability: tbucket
+TS k8s
+| STATS div=max(
+    rate(network.total_bytes_in) /
+    rate(network.total_bytes_in)
+  ) BY step=TBUCKET(1h), cluster
+| SORT cluster;
+
+div:double | step:datetime            | cluster:keyword
+1.0        | 2024-05-10T00:00:00.000Z | prod
+1.0        | 2024-05-10T00:00:00.000Z | qa
+1.0        | 2024-05-10T00:00:00.000Z | staging
+;
+
+division_within_series_grouping_promql
+required_capability: promql_pre_tech_preview_v9
+PROMQL index=k8s step=1h div=(
+  max by (cluster) (rate(network.total_bytes_in[1h]) / rate(network.total_bytes_in[1h]))
+) | SORT cluster;
+
+div:double | step:datetime            | cluster:keyword
+1.0        | 2024-05-10T00:00:00.000Z | prod
+1.0        | 2024-05-10T00:00:00.000Z | qa
+1.0        | 2024-05-10T00:00:00.000Z | staging
+;
+
+tx_ratio
+required_capability: ts_command_v0
+required_capability: tbucket
+TS k8s
+| STATS ratio=max(
+    last_over_time(network.eth0.tx::double) /
+    (last_over_time(network.eth0.tx::double) + last_over_time(network.eth0.rx::double))
+  ) BY step=TBUCKET(1h), cluster
+| EVAL ratio=ROUND(ratio, 6), step, cluster=cluster
+| SORT ratio DESC;
+
+ratio:double | step:datetime            | cluster:keyword
+0.60063      | 2024-05-10T00:00:00.000Z | qa
+0.568155     | 2024-05-10T00:00:00.000Z | prod
+0.518662     | 2024-05-10T00:00:00.000Z | staging
+;
+
+tx_ratio_promql
+required_capability: promql_pre_tech_preview_v9
+PROMQL index=k8s step=1h ratio=(
+  max by (cluster) (
+    network.eth0.tx /
+    (network.eth0.tx + network.eth0.rx)
+  )
+)
+| EVAL ratio=ROUND(ratio, 6), step=step, cluster=cluster
+| SORT ratio DESC;
+
+ratio:double | step:datetime            | cluster:keyword
+0.60063      | 2024-05-10T00:00:00.000Z | qa
+0.568155     | 2024-05-10T00:00:00.000Z | prod
+0.518662     | 2024-05-10T00:00:00.000Z | staging
+;
+
 // TODO we don't support top-level binary operations yet
 // multiplication_cross_series_scalar_agg
 // required_capability: ts_command_v0
@@ -80,54 +182,3 @@ max_bits:double | step:datetime            | cluster:keyword
 // 10277         | 2024-05-10T00:00:00.000Z | prod
 // 7403          | 2024-05-10T00:00:00.000Z | staging
 // ;
-
-division_metric_metric_grouping_promql
-required_capability: promql_pre_tech_preview_v9
-PROMQL index=k8s step=1h div=(
-  max by (cluster) (network.total_bytes_in / network.total_bytes_in)
-) | SORT cluster;
-
-div:double | step:datetime            | cluster:keyword
-1.0        | 2024-05-10T00:00:00.000Z | prod
-1.0        | 2024-05-10T00:00:00.000Z | qa
-1.0        | 2024-05-10T00:00:00.000Z | staging
-;
-
-division_metric_metric_grouping_filtering_promql
-required_capability: promql_pre_tech_preview_v9
-PROMQL index=k8s step=1h div=(
-  max by (cluster) (network.total_bytes_in{cluster!="prod"} / network.total_bytes_in{cluster=~"prod|qa"})
-) | SORT cluster;
-
-div:double | step:datetime            | cluster:keyword
-1.0        | 2024-05-10T00:00:00.000Z | qa
-;
-
-division_within_series_grouping_promql
-required_capability: promql_pre_tech_preview_v9
-PROMQL index=k8s step=1h div=(
-  max by (cluster) (last_over_time(network.total_bytes_in[1h]) / last_over_time(network.total_bytes_in[1h]))
-) | SORT cluster;
-
-div:double | step:datetime            | cluster:keyword
-1.0        | 2024-05-10T00:00:00.000Z | prod
-1.0        | 2024-05-10T00:00:00.000Z | qa
-1.0        | 2024-05-10T00:00:00.000Z | staging
-;
-
-tx_ratio_promql
-required_capability: promql_pre_tech_preview_v9
-PROMQL index=k8s step=1h ratio=(
-  max by (cluster) (
-    network.eth0.tx /
-    (network.eth0.tx + network.eth0.rx)
-  )
-)
-| EVAL ratio=ROUND(ratio, 6), step=step, cluster=cluster
-| SORT ratio DESC;
-
-ratio:double | step:datetime            | cluster:keyword
-0.60063      | 2024-05-10T00:00:00.000Z | qa
-0.568155     | 2024-05-10T00:00:00.000Z | prod
-0.518662     | 2024-05-10T00:00:00.000Z | staging
-;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-arithmetic.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-arithmetic.csv-spec
@@ -89,7 +89,7 @@ div:double | step:datetime            | cluster:keyword
 division_metric_metric_grouping_filtering_promql
 required_capability: promql_pre_tech_preview_v9
 PROMQL index=k8s step=1h div=(
-  max by (cluster) (network.total_bytes_in{cluster!="prod"} / network.total_bytes_in{cluster=~"prod|qa"})
+  max by (cluster) (network.total_bytes_in{cluster!="prod"} / network.total_bytes_in{cluster!="staging"})
 ) | SORT cluster;
 
 div:double | step:datetime            | cluster:keyword

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-arithmetic.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-arithmetic.csv-spec
@@ -1,0 +1,133 @@
+multiplication_metric_scalar
+required_capability: ts_command_v0
+required_capability: tbucket
+TS k8s
+| STATS max_bits=max(last_over_time(network.total_bytes_in) * 8) BY TBUCKET(1h), cluster
+| SORT max_bits DESC;
+
+max_bits:long | TBUCKET(1h):date         | cluster:keyword
+86376         | 2024-05-10T00:00:00.000Z | qa
+82216         | 2024-05-10T00:00:00.000Z | prod
+59224         | 2024-05-10T00:00:00.000Z | staging
+;
+
+multiplication_metric_scalar_promql
+required_capability: promql_pre_tech_preview_v9
+PROMQL index=k8s step=1h max_bits=(
+  max by (cluster) (network.total_bytes_in * 8)
+) | SORT max_bits DESC;
+
+max_bits:double | step:datetime            | cluster:keyword
+86376.0         | 2024-05-10T00:00:00.000Z | qa
+82216.0         | 2024-05-10T00:00:00.000Z | prod
+59224.0         | 2024-05-10T00:00:00.000Z | staging
+;
+
+addition_scalar_scalar_promql
+required_capability: promql_pre_tech_preview_v9
+PROMQL index=k8s step=1h sum=(1+1);
+
+sum:double | step:datetime           
+2.0        | 2024-05-10T00:00:00.000Z
+;
+
+multiplication_within_series_agg_scalar
+required_capability: ts_command_v0
+required_capability: double_quotes_source_enclosing
+TS k8s
+| STATS max_bits=max(last_over_time(network.total_bytes_in) * 8) BY TBUCKET(1h), cluster 
+| SORT max_bits DESC;
+
+max_bits:long | TBUCKET(1h):datetime     | cluster:keyword
+86376         | 2024-05-10T00:00:00.000Z | qa
+82216         | 2024-05-10T00:00:00.000Z | prod
+59224         | 2024-05-10T00:00:00.000Z | staging
+;
+
+multiplication_within_series_agg_scalar_promql
+required_capability: promql_pre_tech_preview_v9
+PROMQL index=k8s step=1h max_bits=(
+  max by (cluster) (last_over_time(network.total_bytes_in[1h]) * 8)
+) | SORT max_bits DESC;
+
+max_bits:double | step:datetime            | cluster:keyword
+86376.0         | 2024-05-10T00:00:00.000Z | qa
+82216.0         | 2024-05-10T00:00:00.000Z | prod
+59224.0         | 2024-05-10T00:00:00.000Z | staging
+;
+
+// TODO we don't support top-level binary operations yet
+// multiplication_cross_series_scalar_agg
+// required_capability: ts_command_v0
+// TS k8s
+// | STATS max_bits=max(last_over_time(network.total_bytes_in)) * 8 BY TBUCKET(1h), cluster
+// | SORT max_bits DESC;
+// 
+// max_bits:long | TBUCKET:date             | cluster: keyword
+// 10797         | 2024-05-10T00:00:00.000Z | qa        
+// 10277         | 2024-05-10T00:00:00.000Z | prod
+// 7403          | 2024-05-10T00:00:00.000Z | staging
+// ;
+// 
+// multiplication_cross_series_agg_scalar_promql
+// required_capability: promql_pre_tech_preview_v9
+// PROMQL index=k8s step=1h max_bits=(
+//   max by (cluster) (last_over_time(network.total_bytes_in[1h])) * 8
+// ) | SORT max_bits DESC;
+// 
+// max_bits:long | TBUCKET:date             | cluster: keyword
+// 10797         | 2024-05-10T00:00:00.000Z | qa        
+// 10277         | 2024-05-10T00:00:00.000Z | prod
+// 7403          | 2024-05-10T00:00:00.000Z | staging
+// ;
+
+division_metric_metric_grouping_promql
+required_capability: promql_pre_tech_preview_v9
+PROMQL index=k8s step=1h div=(
+  max by (cluster) (network.total_bytes_in / network.total_bytes_in)
+) | SORT cluster;
+
+div:double | step:datetime            | cluster:keyword
+1.0        | 2024-05-10T00:00:00.000Z | prod
+1.0        | 2024-05-10T00:00:00.000Z | qa
+1.0        | 2024-05-10T00:00:00.000Z | staging
+;
+
+division_metric_metric_grouping_filtering_promql
+required_capability: promql_pre_tech_preview_v9
+PROMQL index=k8s step=1h div=(
+  max by (cluster) (network.total_bytes_in{cluster!="prod"} / network.total_bytes_in{cluster=~"prod|qa"})
+) | SORT cluster;
+
+div:double | step:datetime            | cluster:keyword
+1.0        | 2024-05-10T00:00:00.000Z | qa
+;
+
+division_within_series_grouping_promql
+required_capability: promql_pre_tech_preview_v9
+PROMQL index=k8s step=1h div=(
+  max by (cluster) (last_over_time(network.total_bytes_in[1h]) / last_over_time(network.total_bytes_in[1h]))
+) | SORT cluster;
+
+div:double | step:datetime            | cluster:keyword
+1.0        | 2024-05-10T00:00:00.000Z | prod
+1.0        | 2024-05-10T00:00:00.000Z | qa
+1.0        | 2024-05-10T00:00:00.000Z | staging
+;
+
+tx_ratio_promql
+required_capability: promql_pre_tech_preview_v9
+PROMQL index=k8s step=1h ratio=(
+  max by (cluster) (
+    network.eth0.tx /
+    (network.eth0.tx + network.eth0.rx)
+  )
+)
+| EVAL ratio=ROUND(ratio, 6), step=step, cluster=cluster
+| SORT ratio DESC;
+
+ratio:double | step:datetime            | cluster:keyword
+0.60063      | 2024-05-10T00:00:00.000Z | qa
+0.568155     | 2024-05-10T00:00:00.000Z | prod
+0.518662     | 2024-05-10T00:00:00.000Z | staging
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-avg-over-time.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-avg-over-time.csv-spec
@@ -18,7 +18,7 @@ cost:double       | time_bucket:datetime
 ;
 
 avg_over_time_of_double_no_grouping_promql
-required_capability: promql_pre_tech_preview_v8
+required_capability: promql_pre_tech_preview_v9
 PROMQL index=k8s step=1m cost=(sum(avg_over_time(network.cost[1m])))
 | SORT cost DESC, step DESC | LIMIT 10;
 
@@ -46,7 +46,7 @@ cost:double       | time_bucket:datetime
 ;
 
 avg_over_time_of_double_no_grouping_single_bucket_promql
-required_capability: promql_pre_tech_preview_v8
+required_capability: promql_pre_tech_preview_v9
 PROMQL index=k8s step=1h cost=(sum(avg_over_time(network.cost[1h])));
 
 cost:double       | step:datetime

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql.csv-spec
@@ -3,7 +3,7 @@
 // This makes it easy to verify that PromQL and TS produce the same results for the same functionality where applicable
 // and helps to ensure we have the same test coverage for PromQL vs TS|STATS.
 promql_start_end_step
-required_capability: promql_pre_tech_preview_v8
+required_capability: promql_pre_tech_preview_v9
 PROMQL index=k8s step=5m start="2024-05-10T00:20:00.000Z" end="2024-05-10T00:25:00.000Z" (
   sum(avg_over_time(network.cost[5m]))
 );
@@ -13,7 +13,7 @@ sum(avg_over_time(network.cost[5m])):double | step:date
 ;
 
 no_parentheses
-required_capability: promql_pre_tech_preview_v8
+required_capability: promql_pre_tech_preview_v9
 PROMQL index=k8s step=5m start="2024-05-10T00:20:00.000Z" end="2024-05-10T00:25:00.000Z" sum(avg_over_time(network.cost[5m]));
 
 sum(avg_over_time(network.cost[5m])):double | step:date
@@ -21,7 +21,7 @@ sum(avg_over_time(network.cost[5m])):double | step:date
 ;
 
 not_equals_filter
-required_capability: promql_pre_tech_preview_v8
+required_capability: promql_pre_tech_preview_v9
 PROMQL index=k8s step=1h cost=(max by (cluster) (network.total_bytes_in{cluster!="prod"}))
 | SORT cluster;
 
@@ -31,7 +31,7 @@ cost:double | step:datetime            | cluster:keyword
 ;
 
 equals_filter
-required_capability: promql_pre_tech_preview_v8
+required_capability: promql_pre_tech_preview_v9
 PROMQL index=k8s step=1h cost=(max by (cluster) (network.total_bytes_in{cluster="prod"}))
 | SORT cluster;
 
@@ -40,7 +40,7 @@ cost:double | step:datetime            | cluster:keyword
 ;
 
 not_regex_filter
-required_capability: promql_pre_tech_preview_v8
+required_capability: promql_pre_tech_preview_v9
 PROMQL index=k8s step=1h cost=(max by (cluster) (network.total_bytes_in{cluster!~"pr.d"}))
 | SORT cluster;
 
@@ -50,7 +50,7 @@ cost:double | step:datetime            | cluster:keyword
 ;
 
 regex_filter
-required_capability: promql_pre_tech_preview_v8
+required_capability: promql_pre_tech_preview_v9
 PROMQL index=k8s step=1h cost=(max by (cluster) (network.total_bytes_in{cluster=~"pr.d"}))
 | SORT cluster;
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries.csv-spec
@@ -139,7 +139,7 @@ max_rate: double | time_bucket:date
 ;
 
 oneRateWithPromql
-required_capability: promql_pre_tech_preview_v8
+required_capability: promql_pre_tech_preview_v9
 required_capability: rate_with_interpolation_v2
 
 PROMQL index=k8s step=5m max(rate(network.total_bytes_in[5m]))
@@ -163,7 +163,7 @@ max_rate: double | time_bucket:date
 ;
 
 oneRateWithSingleStepPromql
-required_capability: promql_pre_tech_preview_v8
+required_capability: promql_pre_tech_preview_v9
 PROMQL index=k8s step=1h max(rate(network.total_bytes_in[1h]));
 
 max(rate(network.total_bytes_in[1h])):double | step:datetime

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1770,7 +1770,7 @@ public class EsqlCapabilities {
          * As soon as we move into tech preview, we'll replace this capability with a "EXPONENTIAL_HISTOGRAM_TECH_PREVIEW" one.
          * At this point, we need to add new capabilities for any further changes.
          */
-        PROMQL_PRE_TECH_PREVIEW_V8(Build.current().isSnapshot()),
+        PROMQL_PRE_TECH_PREVIEW_V9(Build.current().isSnapshot()),
 
         /**
          * KNN function adds support for k and visit_percentage options

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/PromqlFeatures.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/PromqlFeatures.java
@@ -21,6 +21,10 @@ public final class PromqlFeatures {
      * Exists to provide a single point of change and minimize noise when upgrading capability versions.
      */
     public static boolean isEnabled() {
-        return EsqlCapabilities.Cap.TS_COMMAND_V0.isEnabled() && EsqlCapabilities.Cap.PROMQL_PRE_TECH_PREVIEW_V8.isEnabled();
+        return EsqlCapabilities.Cap.TS_COMMAND_V0.isEnabled() && EsqlCapabilities.Cap.PROMQL_PRE_TECH_PREVIEW_V9.isEnabled();
+    }
+
+    public static String capabilityName() {
+        return EsqlCapabilities.Cap.PROMQL_PRE_TECH_PREVIEW_V9.capabilityName();
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TranslateTimeSeriesAggregate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TranslateTimeSeriesAggregate.java
@@ -253,6 +253,8 @@ public final class TranslateTimeSeriesAggregate extends OptimizerRules.Parameter
                         }
                     }));
                 }
+            } else if (agg instanceof Alias alias && alias.child() instanceof Literal) {
+                firstPassAggs.add(agg);
             }
         }
         if (aggregate.child().output().contains(timestamp.get()) == false) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/promql/PromqlExpressionBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/promql/PromqlExpressionBuilder.java
@@ -117,12 +117,12 @@ class PromqlExpressionBuilder extends PromqlIdentifierBuilder {
         if (atCtx != null) {
             Source source = source(atCtx);
             if (atCtx.AT_START() != null) {
-                if (start == null) {
+                if (start.value() == null) {
                     throw new ParsingException(source, "@ start() can only be used if parameter [start] or [time] is provided");
                 }
                 at = start;
             } else if (atCtx.AT_END() != null) {
-                if (end == null) {
+                if (end.value() == null) {
                     throw new ParsingException(source, "@ end() can only be used if parameter [end] or [time] is provided");
                 }
                 at = end;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlCommand.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlCommand.java
@@ -347,7 +347,7 @@ public class PromqlCommand extends UnaryPlan implements TelemetryAware, PostAnal
                             failures.add(
                                 fail(
                                     child,
-                                    "parse error: binary expression must contain only scalar and instant vector types",
+                                    "binary expression must contain only scalar and instant vector types",
                                     child.sourceText()
                                 )
                             );

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlCommand.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlCommand.java
@@ -15,15 +15,19 @@ import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.NameId;
+import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.util.Holder;
 import org.elasticsearch.xpack.esql.expression.function.TimestampAware;
-import org.elasticsearch.xpack.esql.expression.promql.subquery.Subquery;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.UnaryPlan;
+import org.elasticsearch.xpack.esql.plan.logical.promql.operator.VectorBinaryArithmetic;
+import org.elasticsearch.xpack.esql.plan.logical.promql.operator.VectorBinaryOperator;
+import org.elasticsearch.xpack.esql.plan.logical.promql.selector.InstantSelector;
 import org.elasticsearch.xpack.esql.plan.logical.promql.selector.RangeSelector;
 import org.elasticsearch.xpack.esql.plan.logical.promql.selector.Selector;
 
@@ -257,38 +261,110 @@ public class PromqlCommand extends UnaryPlan implements TelemetryAware, PostAnal
     @Override
     public void postAnalysisVerification(Failures failures) {
         LogicalPlan p = promqlPlan();
-        if (p instanceof AcrossSeriesAggregate == false) {
-            failures.add(fail(p, "only aggregations across timeseries are supported at this time (found [{}])", p.sourceText()));
-        }
-        p.forEachDown(lp -> {
-            if (lp instanceof Selector s) {
-                if (s.labelMatchers().nameLabel().matcher().isRegex()) {
-                    failures.add(fail(s, "regex label selectors on __name__ are not supported at this time [{}]", s.sourceText()));
-                }
-                if (s.evaluation() != null) {
-                    if (s.evaluation().offset().value() != null && s.evaluation().offsetDuration().isZero() == false) {
-                        failures.add(fail(s, "offset modifiers are not supported at this time [{}]", s.sourceText()));
-                    }
-                    if (s.evaluation().at().value() != null) {
-                        failures.add(fail(s, "@ modifiers are not supported at this time [{}]", s.sourceText()));
-                    }
-                }
-            }
-            if (lp instanceof Subquery) {
-                failures.add(fail(lp, "subqueries are not supported at this time [{}]", lp.sourceText()));
-            }
-            if (step().value() != null && lp instanceof RangeSelector rs) {
-                Duration rangeDuration = (Duration) rs.range().fold(null);
-                if (rangeDuration.equals(step().value()) == false) {
+
+        // Validate top-level expression
+        switch (p) {
+            case VectorBinaryOperator vectorBinaryOperator -> failures.add(
+                // TODO add support for top-level binary operators in TranslateTimeSeriesAggregate
+                // The limitation is in TS|STATS aggregation translation, not in PromQL support.
+                // We do support VectorBinaryArithmetic operators as nested expressions, but not at the top-level of a query.
+                fail(p, "top-level binary operators are not supported at this time [{}]", p.sourceText())
+            );
+            // TODO add support for group by all
+            case InstantSelector instantSelector -> failures.add(
+                fail(p, "top-level instant vector selectors are not supported at this time [{}]", p.sourceText())
+            );
+            case WithinSeriesAggregate withinSeriesAggregate -> failures.add(
+                fail(p, "top-level within-series aggregations are not supported at this time [{}]", p.sourceText())
+            );
+            case RangeSelector rangeSelector -> {
+                if (isRangeQuery()) {
                     failures.add(
                         fail(
-                            rs.range(),
-                            "the duration for range vector selector [{}] "
-                                + "must be equal to the query's step for range queries at this time",
-                            rs.range().sourceText()
+                            p,
+                            "invalid expression type \"range vector\" for range query, must be scalar or instant vector",
+                            p.sourceText()
                         )
                     );
                 }
+            }
+            default -> {
+                // ok
+            }
+        }
+
+        // Validate entire plan
+        Holder<List<String>> groupingAttributes = new Holder<>();
+        p.forEachDown(lp -> {
+            switch (lp) {
+                case Selector s -> {
+                    if (s.labelMatchers().nameLabel() != null && s.labelMatchers().nameLabel().matcher().isRegex()) {
+                        failures.add(fail(s, "regex label selectors on __name__ are not supported at this time [{}]", s.sourceText()));
+                    }
+                    if (s.evaluation() != null) {
+                        if (s.evaluation().offset().value() != null && s.evaluation().offsetDuration().isZero() == false) {
+                            failures.add(fail(s, "offset modifiers are not supported at this time [{}]", s.sourceText()));
+                        }
+                        if (s.evaluation().at().value() != null) {
+                            failures.add(fail(s, "@ modifiers are not supported at this time [{}]", s.sourceText()));
+                        }
+                    }
+                    if (s instanceof RangeSelector rs) {
+                        if (step().value() != null) {
+                            Duration rangeDuration = (Duration) rs.range().fold(null);
+                            if (rangeDuration.equals(step().value()) == false) {
+                                failures.add(
+                                    fail(
+                                        rs.range(),
+                                        "the duration for range vector selector [{}] "
+                                            + "must be equal to the query's step for range queries at this time",
+                                        rs.range().sourceText()
+                                    )
+                                );
+                            }
+                        }
+                    }
+                }
+                case PromqlFunctionCall functionCall -> {
+                    if (functionCall instanceof AcrossSeriesAggregate asa) {
+                        var groupings = asa.groupings().stream().map(NamedExpression::name).toList();
+                        if (groupingAttributes.get() == null) {
+                            groupingAttributes.set(groupings);
+                        } else if (groupingAttributes.get().equals(groupings) == false) {
+                            failures.add(
+                                fail(
+                                    asa,
+                                    "all across-series aggregations must have the same grouping attributes at this time [{}]",
+                                    asa.sourceText()
+                                )
+                            );
+                        }
+                    }
+                }
+                case VectorBinaryOperator binaryOperator -> {
+                    binaryOperator.children().forEach(child -> {
+                        if (child instanceof RangeSelector) {
+                            failures.add(
+                                fail(
+                                    child,
+                                    "parse error: binary expression must contain only scalar and instant vector types",
+                                    child.sourceText()
+                                )
+                            );
+                        }
+                    });
+                    if ((binaryOperator instanceof VectorBinaryArithmetic) == false) {
+                        failures.add(
+                            fail(lp, "{} queries are not supported at this time [{}]", lp.getClass().getSimpleName(), lp.sourceText())
+                        );
+                    }
+                }
+                case PlaceholderRelation placeholderRelation -> {
+                    // ok
+                }
+                default -> failures.add(
+                    fail(lp, "{} queries are not supported at this time [{}]", lp.getClass().getSimpleName(), lp.sourceText())
+                );
             }
         });
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlCommand.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlCommand.java
@@ -345,11 +345,7 @@ public class PromqlCommand extends UnaryPlan implements TelemetryAware, PostAnal
                     binaryOperator.children().forEach(child -> {
                         if (child instanceof RangeSelector) {
                             failures.add(
-                                fail(
-                                    child,
-                                    "binary expression must contain only scalar and instant vector types",
-                                    child.sourceText()
-                                )
+                                fail(child, "binary expression must contain only scalar and instant vector types", child.sourceText())
                             );
                         }
                     });

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -301,10 +301,7 @@ public class CsvTests extends ESTestCase {
                 "can't load metrics in csv tests",
                 testCase.requiredCapabilities.contains(EsqlCapabilities.Cap.TS_COMMAND_V0.capabilityName())
             );
-            assumeFalse(
-                "can't load metrics in csv tests",
-                testCase.requiredCapabilities.contains(PromqlFeatures.capabilityName())
-            );
+            assumeFalse("can't load metrics in csv tests", testCase.requiredCapabilities.contains(PromqlFeatures.capabilityName()));
             assumeFalse(
                 "can't use QSTR function in csv tests",
                 testCase.requiredCapabilities.contains(EsqlCapabilities.Cap.QSTR_FUNCTION.capabilityName())
@@ -361,10 +358,7 @@ public class CsvTests extends ESTestCase {
                 "CSV tests cannot currently handle subqueries",
                 testCase.requiredCapabilities.contains(EsqlCapabilities.Cap.SUBQUERY_IN_FROM_COMMAND.capabilityName())
             );
-            assumeFalse(
-                "can't use PromQL in csv tests",
-                testCase.requiredCapabilities.contains(PromqlFeatures.capabilityName())
-            );
+            assumeFalse("can't use PromQL in csv tests", testCase.requiredCapabilities.contains(PromqlFeatures.capabilityName()));
 
             if (Build.current().isSnapshot()) {
                 assertThat(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -55,6 +55,7 @@ import org.elasticsearch.xpack.esql.CsvTestUtils.Type;
 import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.action.EsqlExecutionInfo;
 import org.elasticsearch.xpack.esql.action.EsqlQueryRequest;
+import org.elasticsearch.xpack.esql.action.PromqlFeatures;
 import org.elasticsearch.xpack.esql.analysis.Analyzer;
 import org.elasticsearch.xpack.esql.analysis.AnalyzerContext;
 import org.elasticsearch.xpack.esql.analysis.EnrichResolution;
@@ -302,7 +303,7 @@ public class CsvTests extends ESTestCase {
             );
             assumeFalse(
                 "can't load metrics in csv tests",
-                testCase.requiredCapabilities.contains(EsqlCapabilities.Cap.PROMQL_PRE_TECH_PREVIEW_V8.capabilityName())
+                testCase.requiredCapabilities.contains(PromqlFeatures.capabilityName())
             );
             assumeFalse(
                 "can't use QSTR function in csv tests",
@@ -362,7 +363,7 @@ public class CsvTests extends ESTestCase {
             );
             assumeFalse(
                 "can't use PromQL in csv tests",
-                testCase.requiredCapabilities.contains(EsqlCapabilities.Cap.PROMQL_PRE_TECH_PREVIEW_V8.capabilityName())
+                testCase.requiredCapabilities.contains(PromqlFeatures.capabilityName())
             );
 
             if (Build.current().isSnapshot()) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/promql/PromqlVerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/promql/PromqlVerifierTests.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.withDefaultLimitWarning;
 import static org.elasticsearch.xpack.esql.analysis.VerifierTests.error;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 public class PromqlVerifierTests extends ESTestCase {
@@ -34,7 +35,21 @@ public class PromqlVerifierTests extends ESTestCase {
                 PROMQL index=test step=5m (
                   rate(network.bytes_in[5m])
                 )""", tsdb),
-            equalTo("2:3: only aggregations across timeseries are supported at this time (found [rate(network.bytes_in[5m])])")
+            equalTo("2:3: top-level within-series aggregations are not supported at this time [rate(network.bytes_in[5m])]")
+        );
+    }
+
+    public void testPromqlRangeVector() {
+        assertThat(
+            error("PROMQL index=test step=5m network.bytes_in[5m]", tsdb),
+            equalTo("1:27: invalid expression type \"range vector\" for range query, must be scalar or instant vector")
+        );
+    }
+
+    public void testPromqlRangeVectorBinaryExpression() {
+        assertThat(
+            error("PROMQL index=test step=5m max(network.bytes_in[5m] / network.bytes_in[5m])", tsdb),
+            equalTo("1:31: parse error: binary expression must contain only scalar and instant vector types")
         );
     }
 
@@ -58,34 +73,26 @@ public class PromqlVerifierTests extends ESTestCase {
     public void testPromqlSubquery() {
         assertThat(
             error("PROMQL index=test step=5m (avg(rate(network.bytes_in[5m:])))", tsdb),
-            equalTo("1:37: subqueries are not supported at this time [network.bytes_in[5m:]]")
+            equalTo("1:37: Subquery queries are not supported at this time [network.bytes_in[5m:]]")
         );
         assertThat(
             error("PROMQL index=test step=5m (avg(rate(network.bytes_in[5m:1m])))", tsdb),
-            equalTo("1:37: subqueries are not supported at this time [network.bytes_in[5m:1m]]")
+            equalTo("1:37: Subquery queries are not supported at this time [network.bytes_in[5m:1m]]")
         );
     }
 
-    @AwaitsFix(
-        bugUrl = "Doesn't parse: line 1:27: Invalid query '1+1'[ArithmeticBinaryContext] given; "
-            + "expected LogicalPlan but found VectorBinaryArithmetic"
-    )
-    public void testPromqlArithmetricOperators() {
+    public void testTopLevelArithmeticOperators() {
         assertThat(
-            error("PROMQL index=test step=5m (1+1)", tsdb),
-            equalTo("1:27: arithmetic operators are not supported at this time [foo]")
+            error("PROMQL index=k8s step=5m 1+foo", tsdb),
+            containsString("top-level binary operators are not supported at this time")
         );
         assertThat(
-            error("PROMQL index=test step=5m (foo+1)", tsdb),
-            equalTo("1:27: arithmetic operators are not supported at this time [foo]")
+            error("PROMQL index=k8s step=5m foo+bar", tsdb),
+            containsString("top-level binary operators are not supported at this time")
         );
         assertThat(
-            error("PROMQL index=test step=5m (1+foo)", tsdb),
-            equalTo("1:27: arithmetic operators are not supported at this time [foo]")
-        );
-        assertThat(
-            error("PROMQL index=test step=5m (foo+bar)", tsdb),
-            equalTo("1:27: arithmetic operators are not supported at this time [foo]")
+            error("PROMQL index=k8s step=5m max by (pod) (network.bytes_in) / 1024", tsdb),
+            containsString("top-level binary operators are not supported at this time")
         );
     }
 
@@ -115,21 +122,19 @@ public class PromqlVerifierTests extends ESTestCase {
             error("PROMQL index=test step=5m (avg(rate(network.bytes_in[5m] offset 5m)))", tsdb),
             equalTo("1:37: offset modifiers are not supported at this time [network.bytes_in[5m] offset 5m]")
         );
-        /* TODO
         assertThat(
-            error("PROMQL index=test step=5m (foo @ start())", tsdb),
-            equalTo("1:27: @ modifiers are not supported at this time [foo @ start()]")
-        );*/
+            error("PROMQL index=test step=5m start=0 end=1 (avg(foo @ start()))", tsdb),
+            equalTo("1:46: @ modifiers are not supported at this time [foo @ start()]")
+        );
     }
 
-    @AwaitsFix(
-        bugUrl = "Doesn't parse: line 1:27: Invalid query 'foo and bar'[LogicalBinaryContext] given; "
-            + "expected Expression but found InstantSelector"
-    )
     public void testLogicalSetBinaryOperators() {
-        assertThat(error("PROMQL index=test step=5m (foo and bar)", tsdb), equalTo(""));
-        assertThat(error("PROMQL index=test step=5m (foo or bar)", tsdb), equalTo(""));
-        assertThat(error("PROMQL index=test step=5m (foo unless bar)", tsdb), equalTo(""));
+        List.of("and", "or", "unless").forEach(op -> {
+            assertThat(
+                error("PROMQL index=test step=5m foo " + op + " bar", tsdb),
+                containsString("top-level binary operators are not supported at this time")
+            );
+        });
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/promql/PromqlVerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/promql/PromqlVerifierTests.java
@@ -49,7 +49,7 @@ public class PromqlVerifierTests extends ESTestCase {
     public void testPromqlRangeVectorBinaryExpression() {
         assertThat(
             error("PROMQL index=test step=5m max(network.bytes_in[5m] / network.bytes_in[5m])", tsdb),
-            equalTo("1:31: parse error: binary expression must contain only scalar and instant vector types")
+            equalTo("1:31: binary expression must contain only scalar and instant vector types")
         );
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/promql/PromqlVerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/promql/PromqlVerifierTests.java
@@ -30,13 +30,10 @@ public class PromqlVerifierTests extends ESTestCase {
     }
 
     public void testPromqlMissingAcrossSeriesAggregation() {
-        assertThat(
-            error("""
-                PROMQL index=test step=5m (
-                  rate(network.bytes_in[5m])
-                )""", tsdb),
-            equalTo("2:3: top-level within-series aggregations are not supported at this time [rate(network.bytes_in[5m])]")
-        );
+        assertThat(error("""
+            PROMQL index=test step=5m (
+              rate(network.bytes_in[5m])
+            )""", tsdb), equalTo("2:3: top-level within-series aggregations are not supported at this time [rate(network.bytes_in[5m])]"));
     }
 
     public void testPromqlRangeVector() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlLogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlLogicalPlanOptimizerTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.string.regex.RLik
 import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
 import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Div;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.NotEquals;
 import org.elasticsearch.xpack.esql.index.EsIndex;
@@ -60,6 +61,8 @@ import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_VERIFIER;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.emptyInferenceResolution;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.loadMapping;
+import static org.elasticsearch.xpack.esql.analysis.VerifierTests.error;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
@@ -272,13 +275,15 @@ public class PromqlLogicalPlanOptimizerTests extends AbstractLogicalPlanOptimize
     }
 
     public void testPromqlMaxOfLongField() {
-        var plan = planPromql("""
-            PROMQL index=k8s step=1h (
-                max(network.bytes_in)
-              )
-            """);
+        var plan = planPromql("PROMQL index=k8s step=1h max(network.bytes_in)");
         // In PromQL, the output is always double
         assertThat(plan.output().getFirst().dataType(), equalTo(DataType.DOUBLE));
+        assertThat(plan.output().getFirst().name(), equalTo("max(network.bytes_in)"));
+    }
+
+    public void testPromqlExplicitOutputName() {
+        var plan = planPromql("PROMQL index=k8s step=1h max_bytes=(max(network.bytes_in))");
+        assertThat(plan.output().getFirst().name(), equalTo("max_bytes"));
     }
 
     public void testSort() {
@@ -561,26 +566,50 @@ public class PromqlLogicalPlanOptimizerTests extends AbstractLogicalPlanOptimize
         var plan = planPromql(testQuery);
     }
 
-    // public void testPromqlArithmetricOperators() {
-    // // TODO doesn't parse
-    // // line 1:27: Invalid query '1+1'[ArithmeticBinaryContext] given; expected LogicalPlan but found VectorBinaryArithmetic
-    // assertThat(
-    // error("PROMQL index=k8s step=5m (1+1)", tsdb),
-    // equalTo("1:1: arithmetic operators are not supported at this time [foo]")
-    // );
-    // assertThat(
-    // error("PROMQL index=k8s step=5m ( foo and bar )", tsdb),
-    // equalTo("1:1: arithmetic operators are not supported at this time [foo]")
-    // );
-    // assertThat(
-    // error("PROMQL index=k8s step=5m (1+foo)", tsdb),
-    // equalTo("1:1: arithmetic operators are not supported at this time [foo]")
-    // );
-    // assertThat(
-    // error("PROMQL index=k8s step=5m (foo+bar)", tsdb),
-    // equalTo("1:1: arithmetic operators are not supported at this time [foo]")
-    // );
-    // }
+    public void testScalarAndInstantVectorArithmeticOperators() {
+        LogicalPlan plan;
+        plan = planPromql("PROMQL index=k8s step=5m max(network.bytes_in / 1024) by (pod)");
+        Div div = as(plan.collect(Eval.class).get(1).fields().getLast().child(), Div.class);
+        assertThat(div.left().sourceText(), equalTo("network.bytes_in"));
+        assertThat(as(div.right(), Literal.class).value(), equalTo(1024.0));
+    }
+
+    public void testConstantFoldingArithmeticOperators() {
+        var plan = planPromql("PROMQL index=k8s step=5m 1 + 1");
+        var eval = plan.collect(Eval.class).getFirst();
+        var literal = as(eval.fields().getFirst().child(), Literal.class);
+        assertThat(literal.value(), equalTo(2.0));
+    }
+
+    public void testTopLevelArithmeticOperators() {
+        assertThat(
+            error("PROMQL index=k8s step=5m foo and bar", tsAnalyzer),
+            containsString("top-level binary operators are not supported at this time")
+        );
+        assertThat(
+            error("PROMQL index=k8s step=5m 1+foo", tsAnalyzer),
+            containsString("top-level binary operators are not supported at this time")
+        );
+        assertThat(
+            error("PROMQL index=k8s step=5m foo+bar", tsAnalyzer),
+            containsString("top-level binary operators are not supported at this time")
+        );
+        assertThat(
+            error("PROMQL index=k8s step=5m max by (pod) (network.bytes_in) / 1024", tsAnalyzer),
+            containsString("top-level binary operators are not supported at this time")
+        );
+    }
+
+    public void testUnsupportedBinaryOperators() {
+        assertThat(
+            error("PROMQL index=k8s step=5m max(foo or bar)", tsAnalyzer),
+            containsString("VectorBinarySet queries are not supported at this time [foo or bar]")
+        );
+        assertThat(
+            error("PROMQL index=k8s step=5m max(foo > bar)", tsAnalyzer),
+            containsString("VectorBinaryComparison queries are not supported at this time [foo > bar]")
+        );
+    }
 
     protected LogicalPlan planPromql(String query) {
         query = query.replace("$now-1h", '"' + Instant.now().minus(1, ChronoUnit.HOURS).toString() + '"');

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/telemetry/VerifierMetricsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/telemetry/VerifierMetricsTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.watcher.common.stats.Counters;
 import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
+import org.elasticsearch.xpack.esql.action.PromqlFeatures;
 import org.elasticsearch.xpack.esql.analysis.Verifier;
 import org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry;
 import org.elasticsearch.xpack.esql.expression.function.FunctionDefinition;
@@ -814,7 +815,7 @@ public class VerifierMetricsTests extends ESTestCase {
 
     @AwaitsFix(bugUrl = "unresolved @timestamp field")
     public void testPromql() {
-        assumeTrue("PromQL required", EsqlCapabilities.Cap.PROMQL_PRE_TECH_PREVIEW_V8.isEnabled());
+        assumeTrue("PromQL required", PromqlFeatures.isEnabled());
         Counters c = esql("""
             PROMQL metrics step 5m (sum(salary))""");
         assertEquals(0, dissect(c));

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_usage.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_usage.yml
@@ -58,7 +58,7 @@ setup:
             - ts_command_v0
             - cosine_vector_similarity_function
             - inline_stats
-            - promql_pre_tech_preview_v8
+            - promql_pre_tech_preview_v9
       reason: "Test that should only be executed on snapshot versions"
 
   - do: { xpack.usage: { } }


### PR DESCRIPTION
Adds support for binary arithmetic operators. For example:
* `sum(rate(foo[5m]) * 60)`
* `sum(rate(foo[5m]) + rate(bar[5m]))`

What's missing is support for top-level binary operators. For example:
* `sum(rate(foo[5m])) * 60` - I think this needs adjustments in `TranslateTimeSeriesAggregate`. Possibly related to https://github.com/elastic/elasticsearch/issues/139570