### PR TITLE
Remove randomNonNegativeTimeValue

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/coordination/JoinStatusTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/JoinStatusTests.java
@@ -11,12 +11,10 @@ package org.elasticsearch.cluster.coordination;
 
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.EqualsHashCodeTestUtils;
 
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
 public class JoinStatusTests extends ESTestCase {
 

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/JoinStatusTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/JoinStatusTests.java
@@ -25,7 +25,7 @@ public class JoinStatusTests extends ESTestCase {
             DiscoveryNodeUtils.create(UUID.randomUUID().toString()),
             randomLongBetween(0, 1000),
             randomAlphaOfLengthBetween(0, 100),
-            randomNonNegativeTimeValue()
+            randomTimeValue()
         );
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(
             joinStatus,
@@ -57,7 +57,7 @@ public class JoinStatusTests extends ESTestCase {
                     originalJoinStatus.remoteNode(),
                     originalJoinStatus.term(),
                     originalJoinStatus.message(),
-                    randomValueOtherThan(originalJoinStatus.age(), this::randomNonNegativeTimeValue)
+                    randomValueOtherThan(originalJoinStatus.age(), ESTestCase::randomTimeValue)
                 );
             }
             case 4 -> {
@@ -66,9 +66,5 @@ public class JoinStatusTests extends ESTestCase {
             }
             default -> throw new IllegalStateException();
         }
-    }
-
-    private TimeValue randomNonNegativeTimeValue() {
-        return new TimeValue(randomIntBetween(0, 1000), randomFrom(TimeUnit.values()));
     }
 }


### PR DESCRIPTION
Removes the method `randomNonNegativeTimeValue` from `JoinStatusTests` and replaces it with the utils method `randomTimeValue` from `ESTestCase`

