### PR TITLE
[9.3] Fix CHUNK and TOP_SNIPPETS documentation to include optional MapExpression params (#139945)

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/functions/parameters/top_snippets.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/parameters/top_snippets.md
@@ -9,5 +9,5 @@
 :   The input text containing only query terms for snippet extraction. Lucene query syntax, operators, and wildcards are not allowed. 
 
 `options`
-:   Options to customize snippet extraction behavior.
+:   (Optional) TopSnippets additional options as [function named parameters](/reference/query-languages/esql/esql-syntax.md#esql-function-named-params).
 

--- a/docs/reference/query-languages/esql/_snippets/functions/types/chunk.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/types/chunk.md
@@ -4,6 +4,8 @@
 
 | field | chunking_settings | result |
 | --- | --- | --- |
+| keyword | named parameters | keyword |
 | keyword | | keyword |
+| text | named parameters | keyword |
 | text | | keyword |
 

--- a/docs/reference/query-languages/esql/_snippets/functions/types/top_snippets.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/types/top_snippets.md
@@ -4,6 +4,8 @@
 
 | field | query | options | result |
 | --- | --- | --- | --- |
+| keyword | keyword | named parameters | keyword |
 | keyword | keyword | | keyword |
+| text | keyword | named parameters | keyword |
 | text | keyword | | keyword |
 

--- a/docs/reference/query-languages/esql/kibana/definition/functions/chunk.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/chunk.json
@@ -20,9 +20,47 @@
       "params" : [
         {
           "name" : "field",
+          "type" : "keyword",
+          "optional" : false,
+          "description" : "The input to chunk."
+        },
+        {
+          "name" : "chunking_settings",
+          "type" : "function_named_parameters",
+          "mapParams" : "{name='separator_group', values=[markdown, plaintext], description='Sets a predefined lists of separators based on the selected text type. Values may be `markdown` or `plaintext`.\nOnly applicable to the `recursive` chunking strategy. When using the `recursive` chunking strategy one of\n`separators` or `separator_group` must be specified.\n'}, {name='overlap', values=[0], description='The number of overlapping words for chunks. It is applicable only to a `word` chunking strategy.\nThis value cannot be higher than half the `max_chunk_size` value.\n'}, {name='sentence_overlap', values=[1, 0], description='The number of overlapping sentences for chunks. It is applicable only for a `sentence` chunking strategy.\nIt can be either `1` or `0`.\n'}, {name='strategy', values=[sentence, word, none, recursive], description='The chunking strategy to use. Default value is `sentence`.'}, {name='max_chunk_size', values=[300], description='The maximum size of a chunk in words. This value cannot be lower than `20` (for `sentence` strategy)\nor `10` (for `word` or `recursive` strategies). This model should not exceed the window size for any\nassociated models using the output of this function.\n'}, {name='separators', values=[(?<!\\n)\\n\\n(?!\\n), (?<!\\n)\\n(?!\\n)], description='A list of strings used as possible split points when chunking text. Each string can be a plain string or a\nregular expression (regex) pattern. The system tries each separator in order to split the text, starting from\nthe first item in the list. After splitting, it attempts to recombine smaller pieces into larger chunks that stay\nwithin the `max_chunk_size` limit, to reduce the total number of chunks generated. Only applicable to the\n`recursive` chunking strategy. When using the `recursive` chunking strategy one of `separators` or `separator_group`\nmust be specified.\n'}",
+          "optional" : true,
+          "description" : "Options to customize chunking behavior. Defaults to {\"strategy\":\"sentence\",\"max_chunk_size\":300,\"sentence_overlap\":0}."
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "keyword"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
           "type" : "text",
           "optional" : false,
           "description" : "The input to chunk."
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "keyword"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "text",
+          "optional" : false,
+          "description" : "The input to chunk."
+        },
+        {
+          "name" : "chunking_settings",
+          "type" : "function_named_parameters",
+          "mapParams" : "{name='separator_group', values=[markdown, plaintext], description='Sets a predefined lists of separators based on the selected text type. Values may be `markdown` or `plaintext`.\nOnly applicable to the `recursive` chunking strategy. When using the `recursive` chunking strategy one of\n`separators` or `separator_group` must be specified.\n'}, {name='overlap', values=[0], description='The number of overlapping words for chunks. It is applicable only to a `word` chunking strategy.\nThis value cannot be higher than half the `max_chunk_size` value.\n'}, {name='sentence_overlap', values=[1, 0], description='The number of overlapping sentences for chunks. It is applicable only for a `sentence` chunking strategy.\nIt can be either `1` or `0`.\n'}, {name='strategy', values=[sentence, word, none, recursive], description='The chunking strategy to use. Default value is `sentence`.'}, {name='max_chunk_size', values=[300], description='The maximum size of a chunk in words. This value cannot be lower than `20` (for `sentence` strategy)\nor `10` (for `word` or `recursive` strategies). This model should not exceed the window size for any\nassociated models using the output of this function.\n'}, {name='separators', values=[(?<!\\n)\\n\\n(?!\\n), (?<!\\n)\\n(?!\\n)], description='A list of strings used as possible split points when chunking text. Each string can be a plain string or a\nregular expression (regex) pattern. The system tries each separator in order to split the text, starting from\nthe first item in the list. After splitting, it attempts to recombine smaller pieces into larger chunks that stay\nwithin the `max_chunk_size` limit, to reduce the total number of chunks generated. Only applicable to the\n`recursive` chunking strategy. When using the `recursive` chunking strategy one of `separators` or `separator_group`\nmust be specified.\n'}",
+          "optional" : true,
+          "description" : "Options to customize chunking behavior. Defaults to {\"strategy\":\"sentence\",\"max_chunk_size\":300,\"sentence_overlap\":0}."
         }
       ],
       "variadic" : false,

--- a/docs/reference/query-languages/esql/kibana/definition/functions/top_snippets.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/top_snippets.json
@@ -26,6 +26,31 @@
       "params" : [
         {
           "name" : "field",
+          "type" : "keyword",
+          "optional" : false,
+          "description" : "The input to chunk."
+        },
+        {
+          "name" : "query",
+          "type" : "keyword",
+          "optional" : false,
+          "description" : "The input text containing only query terms for snippet extraction. Lucene query syntax, operators, and wildcards are not allowed. "
+        },
+        {
+          "name" : "options",
+          "type" : "function_named_parameters",
+          "mapParams" : "{name='num_words', values=[300], description='The maximum number of words to return in each snippet.\nThis allows better control of inference costs by limiting the size of tokens per snippet.\n'}, {name='num_snippets', values=[3], description='The maximum number of matching snippets to return.'}",
+          "optional" : true,
+          "description" : "(Optional) TopSnippets additional options as [function named parameters](https://www.elastic.co/docs/reference/query-languages/esql/esql-syntax#esql-function-named-params)."
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "keyword"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
           "type" : "text",
           "optional" : false,
           "description" : "The input to chunk."
@@ -35,6 +60,31 @@
           "type" : "keyword",
           "optional" : false,
           "description" : "The input text containing only query terms for snippet extraction. Lucene query syntax, operators, and wildcards are not allowed. "
+        }
+      ],
+      "variadic" : false,
+      "returnType" : "keyword"
+    },
+    {
+      "params" : [
+        {
+          "name" : "field",
+          "type" : "text",
+          "optional" : false,
+          "description" : "The input to chunk."
+        },
+        {
+          "name" : "query",
+          "type" : "keyword",
+          "optional" : false,
+          "description" : "The input text containing only query terms for snippet extraction. Lucene query syntax, operators, and wildcards are not allowed. "
+        },
+        {
+          "name" : "options",
+          "type" : "function_named_parameters",
+          "mapParams" : "{name='num_words', values=[300], description='The maximum number of words to return in each snippet.\nThis allows better control of inference costs by limiting the size of tokens per snippet.\n'}, {name='num_snippets', values=[3], description='The maximum number of matching snippets to return.'}",
+          "optional" : true,
+          "description" : "(Optional) TopSnippets additional options as [function named parameters](https://www.elastic.co/docs/reference/query-languages/esql/esql-syntax#esql-function-named-params)."
         }
       ],
       "variadic" : false,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/TopSnippets.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/TopSnippets.java
@@ -91,16 +91,17 @@ public class TopSnippets extends EsqlScalarFunction implements OptionalArgument 
             """) Expression query,
         @MapParam(
             name = "options",
-            description = "Options to customize snippet extraction behavior.",
+            description = "(Optional) TopSnippets additional options as "
+                + "[function named parameters](/reference/query-languages/esql/esql-syntax.md#esql-function-named-params).",
             optional = true,
             params = {
                 @MapParam.MapParamEntry(
                     name = "num_snippets",
-                    type = { "integer" },
+                    type = "integer",
                     description = "The maximum number of matching snippets to return.",
                     valueHint = { "3" }
                 ),
-                @MapParam.MapParamEntry(name = "num_words", type = { "integer" }, description = """
+                @MapParam.MapParamEntry(name = "num_words", type = "integer", description = """
                     The maximum number of words to return in each snippet.
                     This allows better control of inference costs by limiting the size of tokens per snippet.
                     """, valueHint = { "300" }) }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/TopSnippetsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/TopSnippetsTests.java
@@ -126,7 +126,7 @@ public class TopSnippetsTests extends AbstractScalarFunctionTestCase {
                 MemoryIndexChunkScorer scorer = new MemoryIndexChunkScorer();
                 List<String> scoredChunks = scorer.scoreChunks(chunks, query, numSnippets, false)
                     .stream()
-                    .map(ScoredChunk::content)
+                    .map(MemoryIndexChunkScorer.ScoredChunk::content)
                     .toList();
 
                 Object expectedResult;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/TopSnippetsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/TopSnippetsTests.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.elasticsearch.compute.data.BlockUtils.toJavaObject;
+import static org.elasticsearch.xpack.esql.core.type.DataType.UNSUPPORTED;
 import static org.elasticsearch.xpack.esql.expression.function.scalar.string.TopSnippets.DEFAULT_NUM_SNIPPETS;
 import static org.elasticsearch.xpack.esql.expression.function.scalar.string.TopSnippets.DEFAULT_WORD_SIZE;
 import static org.elasticsearch.xpack.esql.expression.function.scalar.util.ChunkUtils.chunkText;
@@ -60,13 +61,14 @@ public class TopSnippetsTests extends AbstractScalarFunctionTestCase {
 
     @ParametersFactory
     public static Iterable<Object[]> parameters() {
-        return parameterSuppliersFromTypedDataWithDefaultChecks(
-            true,
-            List.of(
-                createTestCaseSupplier("TopSnippets with defaults", DataType.KEYWORD, DataType.KEYWORD),
-                createTestCaseSupplier("TopSnippets with defaults text input", DataType.TEXT, DataType.KEYWORD)
-            )
-        );
+        return parameterSuppliersFromTypedData(testCaseSuppliers());
+    }
+
+    private static List<TestCaseSupplier> testCaseSuppliers() {
+        List<TestCaseSupplier> suppliers = new ArrayList<>();
+        suppliers.add(createTestCaseSupplier("TopSnippets with defaults", DataType.KEYWORD, DataType.KEYWORD));
+        suppliers.add(createTestCaseSupplier("TopSnippets with defaults text input", DataType.TEXT, DataType.KEYWORD));
+        return addFunctionNamedParams(suppliers);
     }
 
     private static TestCaseSupplier createTestCaseSupplier(String description, DataType fieldDataType, DataType queryDataType) {
@@ -105,6 +107,56 @@ public class TopSnippetsTests extends AbstractScalarFunctionTestCase {
         });
     }
 
+    /**
+     * Adds function named parameters to all the test case suppliers provided
+     */
+    private static List<TestCaseSupplier> addFunctionNamedParams(List<TestCaseSupplier> suppliers) {
+        List<TestCaseSupplier> result = new ArrayList<>(suppliers);
+        for (TestCaseSupplier supplier : suppliers) {
+            List<DataType> dataTypes = new ArrayList<>(supplier.types());
+            dataTypes.add(UNSUPPORTED);
+            result.add(new TestCaseSupplier(supplier.name() + ", with options", dataTypes, () -> {
+                String text = randomWordsBetween(25, 50);
+                String query = randomFrom("park", "nature", "trail");
+                int numSnippets = 3;
+                int numWords = 25;
+                ChunkingSettings chunkingSettings = new SentenceBoundaryChunkingSettings(numWords, 0);
+
+                List<String> chunks = chunkText(text, chunkingSettings);
+                MemoryIndexChunkScorer scorer = new MemoryIndexChunkScorer();
+                List<String> scoredChunks = scorer.scoreChunks(chunks, query, numSnippets, false)
+                    .stream()
+                    .map(ScoredChunk::content)
+                    .toList();
+
+                Object expectedResult;
+                if (scoredChunks.isEmpty()) {
+                    expectedResult = null;
+                } else if (scoredChunks.size() == 1) {
+                    expectedResult = new BytesRef(scoredChunks.get(0).trim());
+                } else {
+                    expectedResult = scoredChunks.stream().map(s -> new BytesRef(s.trim())).toList();
+                }
+
+                List<TestCaseSupplier.TypedData> values = List.of(
+                    new TestCaseSupplier.TypedData(new BytesRef(text), supplier.types().get(0), "field"),
+                    new TestCaseSupplier.TypedData(new BytesRef(query), DataType.KEYWORD, "query"),
+                    new TestCaseSupplier.TypedData(createOptions(numSnippets, numWords), UNSUPPORTED, "options").forceLiteral()
+                );
+
+                return new TestCaseSupplier.TestCase(
+                    values,
+                    "TopSnippetsBytesRefEvaluator[str=Attribute[channel=0], query=Attribute[channel=1], "
+                        + "chunkingSettings={\"strategy\":\"sentence\",\"max_chunk_size\":25,\"sentence_overlap\":0}, "
+                        + "scorer=MemoryIndexChunkScorer, numSnippets=3]",
+                    DataType.KEYWORD,
+                    equalTo(expectedResult)
+                );
+            }));
+        }
+        return result;
+    }
+
     private static MapExpression createOptions(Integer numSnippets, Integer numWords) {
         List<Expression> optionsMap = new ArrayList<>();
 
@@ -125,6 +177,16 @@ public class TopSnippetsTests extends AbstractScalarFunctionTestCase {
     protected Expression build(Source source, List<Expression> args) {
         Expression options = args.size() < 3 ? null : args.get(2);
         return new TopSnippets(source, args.get(0), args.get(1), options);
+    }
+
+    @Override
+    public void testFold() {
+        Expression expression = buildFieldExpression(testCase);
+        // Skip testFold if the expression is not foldable (e.g., when options contains MapExpression)
+        if (expression.foldable() == false) {
+            return;
+        }
+        super.testFold();
     }
 
     public void testDefaultOptions() {


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Fix CHUNK and TOP_SNIPPETS documentation to include optional MapExpression params (#139945)