### PR TITLE
Improves mutateInstance Javadoc

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractWireTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractWireTestCase.java
@@ -47,6 +47,16 @@ public abstract class AbstractWireTestCase<T> extends ESTestCase {
     /**
      * Returns an instance which is mutated slightly so it should not be equal
      * to the given instance.
+     * <p>
+     * More specifically, this method should change individual fields within the
+     * object to verify that its {@code equals()} implementation actually checks
+     * every field for equality. Using default code such as
+     * {@code randomValueOtherThan(instance, this::createTestInstance);} does <i>not</i>
+     * achieve this goal, since {@code randomValueOtherThan} only ever returns values
+     * which aren't {@code equals()} to the original anyway.
+     * <p>
+     * Additionally, since Java automatically implements {@code equals()} for records,
+     * for these classes, {@link #mutateInstance} can return null
      */
     protected abstract T mutateInstance(T instance) throws IOException;
 


### PR DESCRIPTION
Extends the Javadoc for the `AbstractWireTestCase.mutateInstance` method to clarify exactly what mutations should occur to make the wire serialization tests valid

