### PR TITLE
Make `ThrottledIterator` nonblocking

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/ThrottledIterator.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/ThrottledIterator.java
@@ -34,17 +34,19 @@ public class ThrottledIterator<T> implements Releasable {
      * @param iterator The items to iterate. May be accessed by multiple threads, but accesses are always fully sequential: for any two
      *                 method calls {@code M1} and {@code M2} on this iterator, either the return of {@code M1} _happens-before_ the
      *                 invocation of {@code M2} or vice versa.
-     * @param itemConsumer The operation to perform on each item. Each operation receives a {@link Releasable} which can be used to track
-     *                     the execution of any background tasks spawned for this item and which must be closed when all processing of the
-     *                     item has finished. If the {@code iterator} has not been fully consumed then closing one operation's
-     *                     {@link Releasable} allows the operation on another item to start.
+     *
+     * @param itemConsumer The operation to perform on each item. Each operation receives a {@link Releasable} resource which can be used to
+     *                     track the execution of any background tasks spawned for this item and which must be closed when all processing of
+     *                     the item has finished. If the {@code iterator} has not been fully consumed then closing an operation's resource
+     *                     triggers the start of an operation on the next item.
      *                     <p>
-     *                     This operation may run on the thread which
-     *                     originally called {@link #run}, if this method has not yet returned. Otherwise it will run on a thread on which a
-     *                     background task previously called {@link Releasable#close()} on its resource.
+     *                     This operation may run on the thread which originally called {@link #run}, if this method has not yet returned.
+     *                     Otherwise, it will run on a thread on which a background task previously closed its tracking resource.
      *                     <p>
      *                     This operation must not throw any exceptions.
+     *
      * @param maxConcurrency The maximum number of ongoing operations at any time.
+     *
      * @param onCompletion   Executed when all items are completed.
      */
     public static <T> void run(Iterator<T> iterator, BiConsumer<Releasable, T> itemConsumer, int maxConcurrency, Runnable onCompletion) {

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/ThrottledIterator.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/ThrottledIterator.java
@@ -86,6 +86,7 @@ public class ThrottledIterator<T> implements Releasable {
                 logger.error(Strings.format("exception when processing [%s] with [%s]", item, itemConsumer), e);
                 assert false : e;
             }
+            assert permits.get() > 0; // i.e. only one thread is in this loop at once
         } while (permits.decrementAndGet() > 0);
     }
 

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/ThrottledIterator.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/ThrottledIterator.java
@@ -34,11 +34,16 @@ public class ThrottledIterator<T> implements Releasable {
      * @param iterator The items to iterate. May be accessed by multiple threads, but accesses are always fully sequential: for any two
      *                 method calls {@code M1} and {@code M2} on this iterator, either the return of {@code M1} _happens-before_ the
      *                 invocation of {@code M2} or vice versa.
-     * @param itemConsumer The operation to perform on each item. Each operation receives a {@link RefCounted} which can be used to track
-     *                     the execution of any background tasks spawned for this item. This operation may run on the thread which
+     * @param itemConsumer The operation to perform on each item. Each operation receives a {@link Releasable} which can be used to track
+     *                     the execution of any background tasks spawned for this item and which must be closed when all processing of the
+     *                     item has finished. If the {@code iterator} has not been fully consumed then closing one operation's
+     *                     {@link Releasable} allows the operation on another item to start.
+     *                     <p>
+     *                     This operation may run on the thread which
      *                     originally called {@link #run}, if this method has not yet returned. Otherwise it will run on a thread on which a
-     *                     background task previously called {@link RefCounted#decRef()} on its ref count. This operation should not throw
-     *                     any exceptions.
+     *                     background task previously called {@link Releasable#close()} on its resource.
+     *                     <p>
+     *                     This operation must not throw any exceptions.
      * @param maxConcurrency The maximum number of ongoing operations at any time.
      * @param onCompletion   Executed when all items are completed.
      */

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/ThrottledIterator.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/ThrottledIterator.java
@@ -19,7 +19,7 @@ import org.elasticsearch.logging.Logger;
 
 import java.util.Iterator;
 import java.util.Objects;
-import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 
 public class ThrottledIterator<T> implements Releasable {
@@ -31,7 +31,9 @@ public class ThrottledIterator<T> implements Releasable {
      * number of such background tasks running concurrently to avoid overwhelming the rest of the system (e.g. starving other work of access
      * to an executor).
      *
-     * @param iterator The items to iterate. May be accessed by multiple threads, but accesses are all protected by synchronizing on itself.
+     * @param iterator The items to iterate. May be accessed by multiple threads, but accesses are always fully sequential: for any two
+     *                 method calls {@code M1} and {@code M2} on this iterator, either the return of {@code M1} _happens-before_ the
+     *                 invocation of {@code M2} or vice versa.
      * @param itemConsumer The operation to perform on each item. Each operation receives a {@link RefCounted} which can be used to track
      *                     the execution of any background tasks spawned for this item. This operation may run on the thread which
      *                     originally called {@link #run}, if this method has not yet returned. Otherwise it will run on a thread on which a
@@ -49,7 +51,8 @@ public class ThrottledIterator<T> implements Releasable {
     private final RefCounted refs; // one ref for each running item, plus one for the iterator if incomplete
     private final Iterator<T> iterator;
     private final BiConsumer<Releasable, T> itemConsumer;
-    private final Semaphore permits;
+    private final AtomicInteger permits;
+    private final Releasable itemReleasable = this::onItemRelease;
 
     private ThrottledIterator(Iterator<T> iterator, BiConsumer<Releasable, T> itemConsumer, int maxConcurrency, Runnable onCompletion) {
         this.iterator = Objects.requireNonNull(iterator);
@@ -57,29 +60,26 @@ public class ThrottledIterator<T> implements Releasable {
         if (maxConcurrency <= 0) {
             throw new IllegalArgumentException("maxConcurrency must be positive");
         }
-        this.permits = new Semaphore(maxConcurrency);
+        this.permits = new AtomicInteger(maxConcurrency);
         this.refs = AbstractRefCounted.of(onCompletion);
     }
 
     private void run() {
-        while (permits.tryAcquire()) {
+        do {
             final T item;
-            synchronized (iterator) {
-                if (iterator.hasNext()) {
-                    item = iterator.next();
-                } else {
-                    permits.release();
-                    return;
-                }
+            if (iterator.hasNext()) {
+                item = iterator.next();
+            } else {
+                return;
             }
-            try (var itemRefs = new ItemRefCounted()) {
-                itemRefs.mustIncRef();
-                itemConsumer.accept(Releasables.releaseOnce(itemRefs::decRef), item);
+            try {
+                refs.mustIncRef();
+                itemConsumer.accept(Releasables.releaseOnce(itemReleasable), item);
             } catch (Exception e) {
                 logger.error(Strings.format("exception when processing [%s] with [%s]", item, itemConsumer), e);
                 assert false : e;
             }
-        }
+        } while (permits.decrementAndGet() > 0);
     }
 
     @Override
@@ -87,46 +87,13 @@ public class ThrottledIterator<T> implements Releasable {
         refs.decRef();
     }
 
-    // A RefCounted for a single item, including protection against calling back into run() if it's created and closed within a single
-    // invocation of run().
-    private class ItemRefCounted extends AbstractRefCounted implements Releasable {
-        private boolean isRecursive = true;
-
-        ItemRefCounted() {
-            refs.mustIncRef();
-        }
-
-        @Override
-        protected void closeInternal() {
-            permits.release();
-            try {
-                // Someone must now pick up the next item. Here we might be called from the run() invocation which started processing the
-                // just-completed item (via close() -> decRef()) if that item's processing didn't fork or all its forked tasks finished
-                // first. If so, there's no need to call run() here, we can just return and the next iteration of the run() loop will
-                // continue the processing; moreover calling run() in this situation could lead to a stack overflow. However if we're not
-                // within that run() invocation then ...
-                if (isRecursive() == false) {
-                    // ... we're not within any other run() invocation either, so it's safe (and necessary) to call run() here.
-                    run();
-                }
-            } finally {
-                refs.decRef();
+    private void onItemRelease() {
+        try {
+            if (permits.getAndIncrement() == 0) {
+                run();
             }
-        }
-
-        // Note on blocking: we call both of these synchronized methods exactly once (and must enter close() before calling isRecursive()).
-        // If close() releases the last ref and calls closeInternal(), and hence isRecursive(), then there's no other threads involved and
-        // hence no blocking. In contrast if close() doesn't release the last ref then it exits immediately, so the call to isRecursive()
-        // will proceed without delay in this case too.
-
-        private synchronized boolean isRecursive() {
-            return isRecursive;
-        }
-
-        @Override
-        public synchronized void close() {
-            decRef();
-            isRecursive = false;
+        } finally {
+            refs.decRef();
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/ThrottledIterator.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/ThrottledIterator.java
@@ -31,7 +31,7 @@ public class ThrottledIterator<T> implements Releasable {
      * number of such background tasks running concurrently to avoid overwhelming the rest of the system (e.g. starving other work of access
      * to an executor).
      *
-     * @param iterator The items to iterate. May be accessed by multiple threads, but accesses are always fully sequential: for any two
+     * @param iterator The items to iterate. May be accessed by multiple threads, but accesses are always strictly sequential: for any two
      *                 method calls {@code M1} and {@code M2} on this iterator, either the return of {@code M1} _happens-before_ the
      *                 invocation of {@code M2} or vice versa.
      *

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/ThrottledIteratorTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/ThrottledIteratorTests.java
@@ -12,6 +12,7 @@ package org.elasticsearch.common.util.concurrent;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.action.support.RefCountingRunnable;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.FixedExecutorBuilder;
@@ -19,11 +20,14 @@ import org.elasticsearch.threadpool.ScalingExecutorBuilder;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 
+import java.util.Iterator;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
 import java.util.stream.IntStream;
 
 public class ThrottledIteratorTests extends ESTestCase {
@@ -62,7 +66,7 @@ public class ThrottledIteratorTests extends ESTestCase {
             );
             final var blockPermits = new Semaphore(between(0, Math.min(maxRelaxedThreads, maxConcurrency) - 1));
 
-            ThrottledIterator.run(IntStream.range(0, items).boxed().iterator(), (releasable, item) -> {
+            ThrottledIterator.run(new SerialAccessAssertingIterator<>(IntStream.range(0, items).boxed().iterator()), (releasable, item) -> {
                 try (var refs = new RefCountingRunnable(() -> {
                     completedItems.incrementAndGet();
                     releasable.close();
@@ -119,6 +123,45 @@ public class ThrottledIteratorTests extends ESTestCase {
             assertTrue(itemStartLatch.await(0, TimeUnit.SECONDS));
         } finally {
             ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS);
+        }
+    }
+
+    private static class SerialAccessAssertingIterator<T> implements Iterator<T> {
+
+        private final AtomicBoolean isAccessing = new AtomicBoolean();
+        private final Iterator<T> delegate;
+
+        private SerialAccessAssertingIterator(Iterator<T> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public boolean hasNext() {
+            try (var ignored = withSerialAccessCheck()) {
+                return delegate.hasNext();
+            }
+        }
+
+        @Override
+        public T next() {
+            try (var ignored = withSerialAccessCheck()) {
+                return delegate.next();
+            }
+        }
+
+        @Override
+        public void remove() {
+            assert false : "not called";
+        }
+
+        @Override
+        public void forEachRemaining(Consumer<? super T> action) {
+            assert false : "not called";
+        }
+
+        private Releasable withSerialAccessCheck() {
+            assertTrue(isAccessing.compareAndSet(false, true));
+            return () -> assertTrue(isAccessing.compareAndSet(true, false));
         }
     }
 }


### PR DESCRIPTION
Today `ThrottledIterator` may block in `run()` while waiting for another
thread to release the mutex on `iterator`, but this wait is unnecessary:
if some thread is already executing `run()` then all other threads
handling item completions can just release their permits and move on.