### PR TITLE
[9.3] Add upgrade.rollbacks mapping to .fleet-agents system index (#139363)

### DIFF
--- a/docs/changelog/139363.yaml
+++ b/docs/changelog/139363.yaml
@@ -1,0 +1,5 @@
+pr: 139363
+summary: Add `upgrade.rollbacks` mapping to .fleet-agents system index
+area: Infra/Plugins
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/template-resources/src/main/resources/fleet-agents.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/fleet-agents.json
@@ -349,6 +349,20 @@
         },
         "audit_unenrolled_reason": {
           "type": "keyword"
+        },
+        "upgrade": {
+          "properties":{
+            "rollbacks":{
+              "properties": {
+                "valid_until": {
+                  "type": "date"
+                },
+                "version": {
+                  "type": "version"
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/Fleet.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/Fleet.java
@@ -79,7 +79,7 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
     private static final String MAPPING_VERSION_VARIABLE = "fleet.version";
     private static final List<String> ALLOWED_PRODUCTS = List.of("kibana", "fleet");
     private static final int FLEET_ACTIONS_MAPPINGS_VERSION = 2;
-    private static final int FLEET_AGENTS_MAPPINGS_VERSION = 5;
+    private static final int FLEET_AGENTS_MAPPINGS_VERSION = 6;
     private static final int FLEET_ENROLLMENT_API_KEYS_MAPPINGS_VERSION = 3;
     private static final int FLEET_SECRETS_MAPPINGS_VERSION = 1;
     private static final int FLEET_POLICIES_MAPPINGS_VERSION = 2;


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Add upgrade.rollbacks mapping to .fleet-agents system index (#139363)