### PR TITLE
Aggs: Account for sub-buckets in `extended_bounds`

### DIFF
--- a/docs/changelog/140006.yaml
+++ b/docs/changelog/140006.yaml
@@ -1,0 +1,5 @@
+pr: 140006
+summary: "Aggs: Account for sub-buckets in `extended_bounds`"
+area: Aggregations
+type: bug
+issues: []

--- a/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/bucket/BreakerIT.java
+++ b/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/bucket/BreakerIT.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.aggregations.bucket;
+
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.aggregations.AggregationIntegTestCase;
+import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
+import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
+import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
+import org.elasticsearch.search.aggregations.bucket.histogram.HistogramAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.histogram.InternalDateHistogram;
+import org.elasticsearch.search.aggregations.bucket.histogram.LongBounds;
+import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.MaxAggregationBuilder;
+import org.elasticsearch.search.aggregations.pipeline.MaxBucketPipelineAggregationBuilder;
+import org.junit.Before;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+public class BreakerIT extends AggregationIntegTestCase {
+    @Before
+    public void initIndex() {
+        prepareCreate("test").setMapping("@timestamp", "type=date", "n", "type=long", "kwd", "type=keyword").get(TEST_REQUEST_TIMEOUT);
+        List<IndexRequestBuilder> index = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            index.add(client().prepareIndex("test").setSource("@timestamp", i, "n", i, "kwd", "k" + i));
+        }
+        indexRandom(true, index);
+    }
+
+    public void testSmallHisto() {
+        SearchResponse response = prepareSearch().addAggregation(
+            histogram(10).subAggregation(
+                histogram(10).subAggregation(histogram(10).subAggregation(new MaxAggregationBuilder("m").field("n")))
+                    .subAggregation(new MaxBucketPipelineAggregationBuilder("max", "n > m"))
+            )
+        ).get(TEST_REQUEST_TIMEOUT);
+        try {
+            Histogram histo = response.getAggregations().get("n");
+            assertThat(
+                histo.getBuckets().stream().map(MultiBucketsAggregation.Bucket::getKeyAsString).toList(),
+                equalTo(List.of("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"))
+            );
+        } finally {
+            response.decRef();
+        }
+    }
+
+    public void testSmallDateHisto() {
+        SearchResponse response = prepareSearch().addAggregation(
+            dateHistogram("1970-01-01T00:10:00Z").subAggregation(
+                dateHistogram("1970-01-01T00:10:00Z").subAggregation(
+                    dateHistogram("1970-01-01T00:10:00Z").subAggregation(new MaxAggregationBuilder("m").field("n"))
+                ).subAggregation(new MaxBucketPipelineAggregationBuilder("max", "d > m"))
+            )
+        ).get(TEST_REQUEST_TIMEOUT);
+        try {
+            InternalDateHistogram histo = response.getAggregations().get("d");
+            assertThat(
+                histo.getBuckets().stream().map(MultiBucketsAggregation.Bucket::getKeyAsString).toList(),
+                equalTo(
+                    List.of(
+                        "1970-01-01T00:00:00.000Z",
+                        "1970-01-01T00:01:00.000Z",
+                        "1970-01-01T00:02:00.000Z",
+                        "1970-01-01T00:03:00.000Z",
+                        "1970-01-01T00:04:00.000Z",
+                        "1970-01-01T00:05:00.000Z",
+                        "1970-01-01T00:06:00.000Z",
+                        "1970-01-01T00:07:00.000Z",
+                        "1970-01-01T00:08:00.000Z",
+                        "1970-01-01T00:09:00.000Z",
+                        "1970-01-01T00:10:00.000Z"
+                    )
+                )
+            );
+        } finally {
+            response.decRef();
+        }
+    }
+
+    public void testBigHisto() {
+        Exception e = expectThrows(
+            SearchPhaseExecutionException.class,
+            () -> prepareSearch().addAggregation(
+                terms().subAggregation(
+                    histogram(1000).subAggregation(
+                        histogram(1000).subAggregation(histogram(1000).subAggregation(new MaxAggregationBuilder("m").field("n")))
+                    )
+                )
+            ).get(TEST_REQUEST_TIMEOUT)
+        );
+        assertThat(e.getCause().getMessage(), containsString("Trying to create too many buckets. Must be less than or equal to: [65536]"));
+    }
+
+    public void testBigDateHisto() {
+        Exception e = expectThrows(
+            SearchPhaseExecutionException.class,
+            () -> prepareSearch().addAggregation(
+                terms().subAggregation(
+                    dateHistogram("1970-01-01T20:00:00Z").subAggregation(
+                        dateHistogram("1970-01-01T20:00:00Z").subAggregation(
+                            dateHistogram("1970-01-01T20:00:00Z").subAggregation(new MaxAggregationBuilder("m").field("n"))
+                        )
+                    )
+                )
+            ).get(TEST_REQUEST_TIMEOUT)
+        );
+        assertThat(e.getCause().getMessage(), containsString("Trying to create too many buckets. Must be less than or equal to: [65536]"));
+    }
+
+    private TermsAggregationBuilder terms() {
+        return new TermsAggregationBuilder("kwd").field("kwd");
+    }
+
+    private HistogramAggregationBuilder histogram(int max) {
+        return new HistogramAggregationBuilder("n").field("n").interval(1).extendedBounds(0, max).format("");
+    }
+
+    private DateHistogramAggregationBuilder dateHistogram(String max) {
+        return new DateHistogramAggregationBuilder("d").field("@timestamp")
+            .fixedInterval(DateHistogramInterval.MINUTE)
+            .extendedBounds(new LongBounds("1970-01-01T00:00:00Z", max));
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/aggregations/CardinalityUpperBound.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/CardinalityUpperBound.java
@@ -34,6 +34,11 @@ public abstract class CardinalityUpperBound {
         public <R> R map(IntFunction<R> mapper) {
             return mapper.apply(0);
         }
+
+        @Override
+        public String toString() {
+            return "NONE";
+        }
     };
 
     /**
@@ -62,6 +67,11 @@ public abstract class CardinalityUpperBound {
         @Override
         public <R> R map(IntFunction<R> mapper) {
             return mapper.apply(Integer.MAX_VALUE);
+        }
+
+        @Override
+        public String toString() {
+            return "MANY";
         }
     };
 
@@ -130,6 +140,11 @@ public abstract class CardinalityUpperBound {
         @Override
         public int hashCode() {
             return Integer.hashCode(estimate);
+        }
+
+        @Override
+        public String toString() {
+            return "known[" + estimate + "]";
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalMultiBucketAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalMultiBucketAggregation.java
@@ -216,6 +216,7 @@ public abstract class InternalMultiBucketAggregation<
                 aggs.add(agg.reducePipelines(agg, reduceContext, subTree));
             }
             reducedBuckets.add(createBucket(InternalAggregations.from(aggs), bucket));
+            reduceContext.consumeBucketsAndMaybeBreak(0); // Check the real memory breaker
         }
         return reducedBuckets;
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/MultiBucketConsumerService.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/MultiBucketConsumerService.java
@@ -116,7 +116,7 @@ public class MultiBucketConsumerService {
         public void accept(int value) {
             if (value != 0) {
                 count += value;
-                if (count > limit) {
+                if (count < 0 || count > limit) {
                     logger.warn("Too many buckets (max [{}], count [{}])", limit, count);
                     throw new TooManyBucketsException(
                         "Trying to create too many buckets. Must be less than or equal to: ["

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
@@ -318,44 +318,12 @@ public class InternalHistogram extends InternalMultiBucketAggregation<InternalHi
     }
 
     private void addEmptyBuckets(List<Bucket> list, AggregationReduceContext reduceContext) {
-        /*
-         * Make sure we have space for the empty buckets we're going to add by
-         * counting all of the empties we plan to add and firing them into
-         * consumeBucketsAndMaybeBreak.
-         */
-        class Counter implements DoubleConsumer {
-            private int size = 0;
-
-            @Override
-            public void accept(double key) {
-                size++;
-                if (size >= REPORT_EMPTY_EVERY) {
-                    reduceContext.consumeBucketsAndMaybeBreak(size);
-                    size = 0;
-                }
-            }
-        }
-        Counter counter = new Counter();
-        iterateEmptyBuckets(list, list.listIterator(), counter);
-        reduceContext.consumeBucketsAndMaybeBreak(counter.size);
-
-        /*
-         * Now that we're sure we have space we allocate all the buckets.
-         */
         InternalAggregations reducedEmptySubAggs = InternalAggregations.reduce(emptyBucketInfo.subAggregations, reduceContext);
+        int count = reducedEmptySubAggs.asList().stream().mapToInt(InternalMultiBucketAggregation::countInnerBucket).sum() + 1;
         ListIterator<Bucket> iter = list.listIterator();
-        iterateEmptyBuckets(list, iter, new DoubleConsumer() {
-            private int size;
-
-            @Override
-            public void accept(double key) {
-                size++;
-                if (size >= REPORT_EMPTY_EVERY) {
-                    reduceContext.consumeBucketsAndMaybeBreak(size);
-                    size = 0;
-                }
-                iter.add(new Bucket(key, 0, format, reducedEmptySubAggs));
-            }
+        iterateEmptyBuckets(list, iter, key -> {
+            reduceContext.consumeBucketsAndMaybeBreak(count);
+            iter.add(new Bucket(key, 0, format, reducedEmptySubAggs));
         });
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/AggregatorFactoriesTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/AggregatorFactoriesTests.java
@@ -27,6 +27,8 @@ import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.nested.NestedAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.terms.SignificantTermsAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.AvgAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.CardinalityAggregationBuilder;
 import org.elasticsearch.search.aggregations.pipeline.AbstractPipelineAggregationBuilder;
 import org.elasticsearch.search.aggregations.pipeline.BucketScriptPipelineAggregationBuilder;
@@ -57,6 +59,7 @@ import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.sameInstance;
 
 public class AggregatorFactoriesTests extends ESTestCase {
     private NamedXContentRegistry xContentRegistry;
@@ -313,6 +316,15 @@ public class AggregatorFactoriesTests extends ESTestCase {
         builder.addAggregator(AggregationBuilders.avg("real").field("target"));
         PipelineTree tree = builder.buildPipelineTree();
         assertThat(tree.aggregators().stream().map(PipelineAggregator::name).collect(toList()), equalTo(List.of("foo", "bar")));
+    }
+
+    public void testBuildPipelineTreeEmpty() {
+        AggregatorFactories.Builder builder = new AggregatorFactories.Builder();
+        builder.addAggregator(
+            new TermsAggregationBuilder("t").field("kwd").subAggregation(new AvgAggregationBuilder("real").field("target"))
+        );
+        PipelineTree tree = builder.buildPipelineTree();
+        assertThat(tree, sameInstance(PipelineTree.EMPTY));
     }
 
     public void testSupportsParallelCollection() {


### PR DESCRIPTION
Properly accounts for sub-buckets in `extended_bounds` in `max_buckets`.
This mostly comes up if you have more than one `extended_bounds` in a
row. Say you have, say, three `histogram` aggs that all make 1,000
buckets via extended bounds. Like:
```
"h1": {
    "histogram": {
        "field": "number",
        "interval": 1,
        "extended_bounds": { "min": 0, "max": 1000 }
    },
    "aggs": {
        "h2": {
            "histogram": {
                "field": "number",
                "interval": 1,
                "extended_bounds": { "min": 0, "max": 1000 }
            },
            "aggs": {
                "h3": {
                    "histogram": {
                        "field": "number",
                        "interval": 1,
                        "extended_bounds": { "min": 0, "max": 1000 }
```

This spits out about ~~1,000,000~~ 1,000,000,000 (math is hard) buckets, but we were accounting for it
more like 3,000 buckets.

This also fixes a smaller bug around pipeline aggregations - we were
running them even if there aren't any. That mostly amounts to a bunch of
noop rewrites. This prevents those rewrites. I bumped into this when
debugging the counter problem.