### PR TITLE
Unmute CrossClusterEsqlRCS1EnrichUnavailableRemotesIT testEsqlEnrichWithSkipUnavailable

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -349,9 +349,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
   method: testDatafeedTimingStats_DatafeedRecreated
   issue: https://github.com/elastic/elasticsearch/issues/138348
-- class: org.elasticsearch.xpack.remotecluster.CrossClusterEsqlRCS1EnrichUnavailableRemotesIT
-  method: testEsqlEnrichWithSkipUnavailable
-  issue: https://github.com/elastic/elasticsearch/issues/138793
 - class: org.elasticsearch.xpack.ilm.actions.DownsampleActionIT
   method: testILMWaitsForTimeSeriesEndTimeToLapse
   issue: https://github.com/elastic/elasticsearch/issues/138843


### PR DESCRIPTION
It looks like one failure was a timeout on connection between 

Closes https://github.com/elastic/elasticsearch/issues/138793