### PR TITLE
[ES|QL] Add support for avg as default AMD metric

### DIFF
--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/MultiClusterSpecIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/MultiClusterSpecIT.java
@@ -432,6 +432,22 @@ public class MultiClusterSpecIT extends EsqlSpecTestCase {
         }
     }
 
+    @Override
+    protected boolean supportsAmdAvgMetric() {
+        try {
+            return RestEsqlTestCase.hasCapabilities(
+                client(),
+                List.of(EsqlCapabilities.Cap.AGGREGATE_METRIC_DOUBLE_AVG_AS_DEFAULT_METRIC.capabilityName())
+            )
+                && RestEsqlTestCase.hasCapabilities(
+                    remoteClusterClient(),
+                    List.of(EsqlCapabilities.Cap.AGGREGATE_METRIC_DOUBLE_AVG_AS_DEFAULT_METRIC.capabilityName())
+                );
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     /**
      * Convert index patterns and subqueries in FROM commands to use remote indices for a given test case.
      */

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
@@ -188,7 +188,8 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
                 supportsExponentialHistograms(),
                 supportsTDigestField(),
                 supportsHistogramDataType(),
-                supportsBFloat16ElementType()
+                supportsBFloat16ElementType(),
+                supportsAmdAvgMetric()
             );
             return null;
         });
@@ -330,6 +331,13 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
 
     protected boolean supportsBFloat16ElementType() {
         return RestEsqlTestCase.hasCapabilities(client(), List.of(EsqlCapabilities.Cap.GENERIC_VECTOR_FORMAT.capabilityName()));
+    }
+
+    protected boolean supportsAmdAvgMetric() {
+        return RestEsqlTestCase.hasCapabilities(
+            client(),
+            List.of(EsqlCapabilities.Cap.AGGREGATE_METRIC_DOUBLE_AVG_AS_DEFAULT_METRIC.capabilityName())
+        );
     }
 
     protected void doTest() throws Throwable {

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
@@ -264,7 +264,8 @@ public abstract class GenerativeRestTest extends ESRestTestCase implements Query
     }
 
     private List<String> availableIndices() throws IOException {
-        return availableDatasetsForEs(true, supportsSourceFieldMapping(), false, requiresTimeSeries(), false, false, false, false).stream()
+        return availableDatasetsForEs(true, supportsSourceFieldMapping(), false, requiresTimeSeries(), false, false, false, false, false)
+            .stream()
             .filter(x -> x.requiresInferenceEndpoint() == false)
             .map(x -> x.indexName())
             .toList();

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -43,6 +43,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -368,6 +369,7 @@ public class CsvTestsDataLoader {
                 true,
                 true,
                 true,
+                true,
                 (restClient, indexName, indexMapping, indexSettings) -> {
                     // don't use ESRestTestCase methods here or, if you do, test running the main method before making the change
                     StringBuilder jsonBody = new StringBuilder("{");
@@ -396,7 +398,8 @@ public class CsvTestsDataLoader {
         boolean exponentialHistogramFieldSupported,
         boolean tDigestFieldSupported,
         boolean histogramFieldSupported,
-        boolean bFloat16ElementTypeSupported
+        boolean bFloat16ElementTypeSupported,
+        boolean amdAvgMetricSupported
     ) throws IOException {
         Set<TestDataset> testDataSets = new HashSet<>();
 
@@ -408,7 +411,8 @@ public class CsvTestsDataLoader {
                 && (exponentialHistogramFieldSupported || containsExponentialHistogramFields(dataset) == false)
                 && (tDigestFieldSupported || containsTDigestFields(dataset) == false)
                 && (histogramFieldSupported || containsHistogramFields(dataset) == false)
-                && (bFloat16ElementTypeSupported || containsBFloat16ElementType(dataset) == false)) {
+                && (bFloat16ElementTypeSupported || containsBFloat16ElementType(dataset) == false)
+                && (amdAvgMetricSupported || containsAmdAvgMetric(dataset) == false)) {
                 testDataSets.add(dataset);
             }
         }
@@ -484,6 +488,39 @@ public class CsvTestsDataLoader {
         return false;
     }
 
+    private static boolean containsAmdAvgMetric(TestDataset dataset) throws IOException {
+        if (dataset.mappingFileName() == null) {
+            return false;
+        }
+        String mappingJsonText = readTextFile(getResource("/" + dataset.mappingFileName()));
+        JsonNode mappingNode = new ObjectMapper().readTree(mappingJsonText);
+        return loopConditionCheck(mappingNode, fieldProperties -> {
+            JsonNode typeNode = fieldProperties.get("type");
+            JsonNode defaultMetricNode = fieldProperties.get("default_metric");
+            return typeNode != null
+                && typeNode.asText().equals("aggregate_metric_double")
+                && defaultMetricNode != null
+                && defaultMetricNode.asText().equals("avg");
+        });
+    }
+
+    private static boolean loopConditionCheck(JsonNode topNode, Predicate<JsonNode> check) {
+        if (topNode == null) {
+            return false;
+        }
+        JsonNode properties = topNode.get("properties");
+        if (properties == null) {
+            return false;
+        }
+        for (var fieldWithValue : properties.properties()) {
+            JsonNode fieldProperties = fieldWithValue.getValue();
+            if (loopConditionCheck(fieldProperties, check) || check.test(fieldProperties)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private static boolean isTimeSeries(TestDataset dataset) throws IOException {
         Settings settings = dataset.readSettingsFile();
         String mode = settings.get("index.mode");
@@ -496,7 +533,18 @@ public class CsvTestsDataLoader {
         boolean supportsSourceFieldMapping,
         boolean inferenceEnabled
     ) throws IOException {
-        loadDataSetIntoEs(client, supportsIndexModeLookup, supportsSourceFieldMapping, inferenceEnabled, false, false, false, false, false);
+        loadDataSetIntoEs(
+            client,
+            supportsIndexModeLookup,
+            supportsSourceFieldMapping,
+            inferenceEnabled,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false
+        );
     }
 
     public static void loadDataSetIntoEs(
@@ -508,7 +556,8 @@ public class CsvTestsDataLoader {
         boolean exponentialHistogramFieldSupported,
         boolean tDigestFieldSupported,
         boolean histogramFieldSupported,
-        boolean bFloat16ElementTypeSupported
+        boolean bFloat16ElementTypeSupported,
+        boolean amdAvgMetricSupported
     ) throws IOException {
         loadDataSetIntoEs(
             client,
@@ -520,6 +569,7 @@ public class CsvTestsDataLoader {
             tDigestFieldSupported,
             histogramFieldSupported,
             bFloat16ElementTypeSupported,
+            amdAvgMetricSupported,
             (restClient, indexName, indexMapping, indexSettings) -> {
                 ESRestTestCase.createIndex(restClient, indexName, indexSettings, indexMapping, null);
             }
@@ -536,6 +586,7 @@ public class CsvTestsDataLoader {
         boolean tDigestFieldSupported,
         boolean histogramFieldSupported,
         boolean bFloat16ElementTypeSupported,
+        boolean amdAvgMetricSupported,
         IndexCreator indexCreator
     ) throws IOException {
         Logger logger = LogManager.getLogger(CsvTestsDataLoader.class);
@@ -550,7 +601,8 @@ public class CsvTestsDataLoader {
             exponentialHistogramFieldSupported,
             tDigestFieldSupported,
             histogramFieldSupported,
-            bFloat16ElementTypeSupported
+            bFloat16ElementTypeSupported,
+            amdAvgMetricSupported
         )) {
             load(client, dataset, logger, indexCreator);
             loadedDatasets.add(dataset.indexName);

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/inlinestats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/inlinestats.csv-spec
@@ -4145,7 +4145,7 @@ from employees
 
 inlineStatsOnAggregateMetricDouble
 required_capability: inline_stats
-required_capability: aggregate_metric_double_v0
+required_capability: aggregate_metric_double_avg_as_default_metric
 required_capability: dense_vector_agg_metric_double_if_version
 FROM k8s-downsampled
 | INLINE STATS tx_max = MAX(network.eth0.tx) BY pod

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-downsampled-mappings.json
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-downsampled-mappings.json
@@ -72,7 +72,7 @@
                 "sum",
                 "value_count"
               ],
-              "default_metric" : "max",
+              "default_metric" : "avg",
               "time_series_metric": "gauge"
             },
             "rx": {
@@ -83,7 +83,7 @@
                 "sum",
                 "value_count"
               ],
-              "default_metric" : "max",
+              "default_metric" : "avg",
               "time_series_metric": "gauge"
             },
             "last_up": {

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-absent-over-time.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-absent-over-time.csv-spec
@@ -150,7 +150,7 @@ false              | staging         | 2024-05-10T00:20:00.000Z
 
 absent_over_time_of_aggregate_metric_double
 required_capability: ts_command_v0
-required_capability: aggregate_metric_double_v0
+required_capability: aggregate_metric_double_avg_as_default_metric
 TS k8s-downsampled | STATS is_present = max(absent_over_time(network.eth0.tx)) BY cluster, time_bucket = tbucket(10 minute) | SORT time_bucket, cluster | LIMIT 10;
 
 is_present:boolean | cluster:keyword | time_bucket:datetime
@@ -247,7 +247,7 @@ false              | staging         | 2024-05-10T00:20:00.000Z
 
 absent_over_time_older_than_10d
 required_capability: ts_command_v0
-required_capability: aggregate_metric_double_v0
+required_capability: aggregate_metric_double_avg_as_default_metric
 TS k8s-downsampled | WHERE cluster == "qa" AND @timestamp < now() - 10 day | STATS is_present = max(absent_over_time(network.eth0.rx)) BY pod, time_bucket = tbucket(10 minute) | SORT time_bucket, pod | LIMIT 5;
 
 is_present:boolean | pod:keyword | time_bucket:datetime

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-avg-over-time.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-avg-over-time.csv-spec
@@ -89,7 +89,7 @@ clients:double | cluster:keyword | time_bucket:datetime
 
 avg_over_time_of_aggregate_metric_double
 required_capability: ts_command_v0
-required_capability: aggregate_metric_double_v0
+required_capability: aggregate_metric_double_avg_as_default_metric
 TS k8s-downsampled | STATS tx = sum(avg_over_time(network.eth0.tx)) BY time_bucket = bucket(@timestamp, 10minute) | SORT time_bucket | LIMIT 10;
 tx:double         | time_bucket:datetime
 4362.2            | 2024-05-09T23:30:00.000Z
@@ -99,7 +99,7 @@ tx:double         | time_bucket:datetime
 
 avg_over_time_of_aggregate_metric_double_grouping
 required_capability: ts_command_v0
-required_capability: aggregate_metric_double_v0
+required_capability: aggregate_metric_double_avg_as_default_metric
 TS k8s-downsampled | STATS tx = sum(avg_over_time(network.eth0.tx)) BY cluster, time_bucket = bucket(@timestamp, 10minute) | SORT time_bucket, cluster | LIMIT 10;
 
 tx:double          | cluster:keyword | time_bucket:datetime
@@ -148,7 +148,7 @@ tx:double          | cluster:keyword | time_bucket:datetime
 
 avg_over_time_older_than_10d
 required_capability: ts_command_v0
-required_capability: aggregate_metric_double_v0
+required_capability: aggregate_metric_double_avg_as_default_metric
 TS k8s-downsampled | WHERE cluster == "qa" AND @timestamp < now() - 10 day | STATS cost = avg(avg_over_time(network.eth0.rx)) BY pod, time_bucket = bucket(@timestamp, 10minute) | SORT time_bucket, pod | LIMIT 5;
 
 cost:double | pod:keyword | time_bucket:datetime
@@ -252,7 +252,7 @@ events:double      | pod:keyword | time_bucket:datetime
 
 avg_over_time_aggregate_metric_double_implicit_casting
 required_capability: ts_command_v0
-required_capability: aggregate_metric_double_v0
+required_capability: aggregate_metric_double_avg_as_default_metric
 TS k8s* | STATS bytes = sum(avg_over_time(network.eth0.rx)) by time_bucket = bucket(@timestamp, 10minute) | SORT bytes desc, time_bucket | LIMIT 10 ;
 
 bytes:double       | time_bucket:datetime
@@ -266,7 +266,7 @@ bytes:double       | time_bucket:datetime
 
 avg_over_time_aggregate_metric_double_implicit_casting_grouping
 required_capability: ts_command_v0
-required_capability: aggregate_metric_double_v0
+required_capability: aggregate_metric_double_avg_as_default_metric
 TS k8s* | STATS bytes = sum(avg_over_time(network.eth0.rx)) by pod, time_bucket = bucket(@timestamp, 10minute) | SORT bytes desc, pod, time_bucket | LIMIT 10 ;
 
 bytes:double       | pod:keyword | time_bucket:datetime

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-count-over-time.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-count-over-time.csv-spec
@@ -176,7 +176,7 @@ pod:long | cluster:keyword | time_bucket:datetime
 
 count_over_time_of_aggregate_metric_double
 required_capability: ts_command_v0
-required_capability: aggregate_metric_double_v0
+required_capability: aggregate_metric_double_avg_as_default_metric
 TS k8s-downsampled | STATS tx = sum(count_over_time(network.eth0.tx)) BY cluster, time_bucket = bucket(@timestamp, 10minute) | SORT time_bucket, cluster | LIMIT 10;
 
 tx:long | cluster:keyword | time_bucket:datetime
@@ -273,7 +273,7 @@ tx:long | cluster:keyword | time_bucket:datetime
 
 count_over_time_older_than_10d
 required_capability: ts_command_v0
-required_capability: aggregate_metric_double_v0
+required_capability: aggregate_metric_double_avg_as_default_metric
 TS k8s-downsampled | WHERE cluster == "qa" AND @timestamp < now() - 10 day | STATS cost = avg(count_over_time(network.eth0.rx)) BY pod, time_bucket = bucket(@timestamp, 10minute) | SORT time_bucket, pod | LIMIT 5;
 
 cost:double | pod:keyword | time_bucket:datetime
@@ -353,7 +353,7 @@ events:long | pod:keyword | time_bucket:datetime
 
 count_over_time_aggregate_metric_double_implicit_casting
 required_capability: ts_command_v0
-required_capability: aggregate_metric_double_v0
+required_capability: aggregate_metric_double_avg_as_default_metric
 TS k8s* | STATS bytes = sum(count_over_time(network.eth0.rx)) by pod, time_bucket = bucket(@timestamp, 10minute) | SORT bytes, pod, time_bucket | LIMIT 10 ;
 
 bytes:long | pod:keyword | time_bucket:datetime

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-increase.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-increase.csv-spec
@@ -141,6 +141,7 @@ increase_bytes:double | cluster:keyword | time_bucket:datetime     | increase_kb
 increase_of_aggregate_metric
 required_capability: increase
 required_capability: ts_command_v0
+required_capability: aggregate_metric_double_avg_as_default_metric
 TS k8s-downsampled
 | STATS sum_bytes = sum(increase(network.total_bytes_in)),
         max_bytes = max(increase(network.total_bytes_in)), 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-irate.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-irate.csv-spec
@@ -109,6 +109,7 @@ irate_bytes:double | cluster:keyword | time_bucket:datetime     | irate_kb:doubl
 
 irate_of_aggregate_metric
 required_capability: ts_command_v0
+required_capability: aggregate_metric_double_avg_as_default_metric
 TS k8s-downsampled
 | STATS sum_bytes = sum(irate(network.total_bytes_in)),
         max_bytes = max(irate(network.total_bytes_in)), 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-max-over-time.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-max-over-time.csv-spec
@@ -323,7 +323,7 @@ false       | staging         | 2024-05-10T00:03:00.000Z
 
 max_over_time_of_aggregate_metric_double
 required_capability: ts_command_v0
-required_capability: aggregate_metric_double_v0
+required_capability: aggregate_metric_double_avg_as_default_metric
 TS k8s-downsampled | STATS tx = sum(max_over_time(network.eth0.tx)) BY time_bucket = bucket(@timestamp, 10minute) | SORT time_bucket | LIMIT 10;
 tx:double | time_bucket:datetime
 6053.0    | 2024-05-09T23:30:00.000Z
@@ -333,7 +333,7 @@ tx:double | time_bucket:datetime
 
 max_over_time_of_aggregate_metric_double_grouping
 required_capability: ts_command_v0
-required_capability: aggregate_metric_double_v0
+required_capability: aggregate_metric_double_avg_as_default_metric
 TS k8s-downsampled | STATS tx = sum(max_over_time(network.eth0.tx)) BY cluster, time_bucket = bucket(@timestamp, 10minute) | SORT time_bucket, cluster | LIMIT 10;
 
 tx:double | cluster:keyword | time_bucket:datetime
@@ -366,7 +366,7 @@ tx:long | cluster:keyword | time_bucket:datetime
 
 max_over_time_older_than_10h
 required_capability: ts_command_v0
-required_capability: aggregate_metric_double_v0
+required_capability: aggregate_metric_double_avg_as_default_metric
 TS k8s-downsampled | WHERE cluster == "qa" AND @timestamp < now() - 10 day | STATS cost = avg(max_over_time(network.eth0.rx)) BY pod, time_bucket = bucket(@timestamp, 10minute) | SORT time_bucket, pod | LIMIT 5;
 
 cost:double | pod:keyword | time_bucket:datetime
@@ -462,7 +462,7 @@ events:long | pod:keyword | time_bucket:datetime
 
 max_over_time_aggregate_metric_double_implicit_casting
 required_capability: ts_command_v0
-required_capability: aggregate_metric_double_v0
+required_capability: aggregate_metric_double_avg_as_default_metric
 TS k8s* | STATS bytes = sum(max_over_time(network.eth0.rx)) by time_bucket = bucket(@timestamp, 10minute) | SORT bytes desc, time_bucket | LIMIT 10 ;
 
 bytes:double | time_bucket:datetime
@@ -476,7 +476,7 @@ bytes:double | time_bucket:datetime
 
 max_over_time_aggregate_metric_double_implicit_casting_grouping
 required_capability: ts_command_v0
-required_capability: aggregate_metric_double_v0
+required_capability: aggregate_metric_double_avg_as_default_metric
 TS k8s* | STATS bytes = sum(max_over_time(network.eth0.rx)) by pod, time_bucket = bucket(@timestamp, 10minute) | SORT bytes desc, pod, time_bucket | LIMIT 10 ;
 
 bytes:double | pod:keyword | time_bucket:datetime

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-min-over-time.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-min-over-time.csv-spec
@@ -317,7 +317,7 @@ false       | staging         | 2024-05-10T00:03:00.000Z
 
 min_over_time_of_aggregate_metric_double
 required_capability: ts_command_v0
-required_capability: aggregate_metric_double_v0
+required_capability: aggregate_metric_double_avg_as_default_metric
 TS k8s-downsampled | STATS tx = sum(min_over_time(network.eth0.tx)) BY time_bucket = bucket(@timestamp, 10minute) | SORT time_bucket | LIMIT 10;
 
 tx:double | time_bucket:datetime
@@ -328,7 +328,7 @@ tx:double | time_bucket:datetime
 
 min_over_time_of_aggregate_metric_double_grouping
 required_capability: ts_command_v0
-required_capability: aggregate_metric_double_v0
+required_capability: aggregate_metric_double_avg_as_default_metric
 TS k8s-downsampled | STATS tx = sum(min_over_time(network.eth0.tx)) BY cluster, time_bucket = bucket(@timestamp, 10minute) | SORT time_bucket, cluster | LIMIT 10;
 
 tx:double | cluster:keyword | time_bucket:datetime
@@ -361,7 +361,7 @@ tx:long | cluster:keyword | time_bucket:datetime
 
 min_over_time_older_than_10h
 required_capability: ts_command_v0
-required_capability: aggregate_metric_double_v0
+required_capability: aggregate_metric_double_avg_as_default_metric
 TS k8s-downsampled | WHERE cluster == "qa" AND @timestamp < now() - 10 day | STATS cost = avg(min_over_time(network.eth0.rx)) BY pod, time_bucket = bucket(@timestamp, 10minute) | SORT time_bucket, pod | LIMIT 5;
 
 cost:double | pod:keyword | time_bucket:datetime
@@ -440,7 +440,7 @@ events:long | pod:keyword | time_bucket:datetime
 
 min_over_time_aggregate_metric_double_implicit_casting
 required_capability: ts_command_v0
-required_capability: aggregate_metric_double_v0
+required_capability: aggregate_metric_double_avg_as_default_metric
 TS k8s* | STATS bytes = sum(min_over_time(network.eth0.rx)) by time_bucket = bucket(@timestamp, 10minute) | SORT bytes, time_bucket | LIMIT 10 ;
 
 bytes:double | time_bucket:datetime
@@ -454,7 +454,7 @@ bytes:double | time_bucket:datetime
 
 min_over_time_aggregate_metric_double_implicit_casting_grouping
 required_capability: ts_command_v0
-required_capability: aggregate_metric_double_v0
+required_capability: aggregate_metric_double_avg_as_default_metric
 TS k8s* | STATS bytes = sum(min_over_time(network.eth0.rx)) by pod, time_bucket = bucket(@timestamp, 10minute) | SORT bytes, pod, time_bucket | LIMIT 10 ;
 
 bytes:double | pod:keyword | time_bucket:datetime

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-present-over-time.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-present-over-time.csv-spec
@@ -150,7 +150,7 @@ true     | staging         | 2024-05-10T00:20:00.000Z
 
 present_over_time_of_aggregate_metric_double
 required_capability: ts_command_v0
-required_capability: aggregate_metric_double_v0
+required_capability: aggregate_metric_double_avg_as_default_metric
 TS k8s-downsampled | STATS is_present = max(present_over_time(network.eth0.tx)) BY cluster, time_bucket = tbucket(10 minute) | SORT time_bucket, cluster | LIMIT 10;
 
 is_present:boolean | cluster:keyword | time_bucket:datetime
@@ -247,7 +247,7 @@ true      | staging         | 2024-05-10T00:20:00.000Z
 
 present_over_time_older_than_10d
 required_capability: ts_command_v0
-required_capability: aggregate_metric_double_v0
+required_capability: aggregate_metric_double_avg_as_default_metric
 TS k8s-downsampled | WHERE cluster == "qa" AND @timestamp < now() - 10 day | STATS is_present = max(present_over_time(network.eth0.rx)) BY pod, time_bucket = tbucket(10 minute) | SORT time_bucket, pod | LIMIT 5;
 
 is_present:boolean | pod:keyword | time_bucket:datetime

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-rate.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-rate.csv-spec
@@ -165,6 +165,7 @@ rate_bytes:double | cluster:keyword | time_bucket:datetime     | rate_kb:double
 rate_of_aggregate_metric
 required_capability: ts_command_v0
 required_capability: rate_with_interpolation
+required_capability: aggregate_metric_double_avg_as_default_metric
 
 TS k8s-downsampled
 | STATS sum_bytes = sum(rate(network.total_bytes_in)),

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-sum-over-time.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-sum-over-time.csv-spec
@@ -53,7 +53,7 @@ clients:double | cluster:keyword | time_bucket:datetime
 
 sum_over_time_of_aggregate_metric_double
 required_capability: ts_command_v0
-required_capability: aggregate_metric_double_v0
+required_capability: aggregate_metric_double_avg_as_default_metric
 TS k8s-downsampled | STATS tx = sum(sum_over_time(network.eth0.tx)) BY time_bucket = bucket(@timestamp, 10minute) | SORT time_bucket | LIMIT 10;
 
 tx:double | time_bucket:datetime
@@ -64,7 +64,7 @@ tx:double | time_bucket:datetime
 
 sum_over_time_of_aggregate_metric_double_grouping
 required_capability: ts_command_v0
-required_capability: aggregate_metric_double_v0
+required_capability: aggregate_metric_double_avg_as_default_metric
 TS k8s-downsampled | STATS tx = sum(sum_over_time(network.eth0.tx)) BY cluster, time_bucket = bucket(@timestamp, 10minute) | SORT time_bucket, cluster | LIMIT 10;
 
 tx:double | cluster:keyword | time_bucket:datetime
@@ -125,7 +125,7 @@ tx:long | cluster:keyword | time_bucket:datetime
 
 sum_over_time_older_than_10d
 required_capability: ts_command_v0
-required_capability: aggregate_metric_double_v0
+required_capability: aggregate_metric_double_avg_as_default_metric
 TS k8s-downsampled | WHERE cluster == "qa" AND @timestamp < now() - 10 day | STATS cost = avg(sum_over_time(network.eth0.rx)) BY pod, time_bucket = bucket(@timestamp, 10minute) | SORT time_bucket, pod | LIMIT 5;
 
 cost:double | pod:keyword | time_bucket:datetime
@@ -204,7 +204,7 @@ events:long | pod:keyword | time_bucket:datetime
 
 sum_over_time_aggregate_metric_double_implicit_casting
 required_capability: ts_command_v0
-required_capability: aggregate_metric_double_v0
+required_capability: aggregate_metric_double_avg_as_default_metric
 TS k8s* | STATS bytes = sum(sum_over_time(network.eth0.rx)) by time_bucket = bucket(@timestamp, 10minute) | SORT bytes desc, time_bucket | LIMIT 10 ;
 
 bytes:double | time_bucket:datetime
@@ -218,7 +218,7 @@ bytes:double | time_bucket:datetime
 
 sum_over_time_aggregate_metric_double_implicit_casting_grouping
 required_capability: ts_command_v0
-required_capability: aggregate_metric_double_v0
+required_capability: aggregate_metric_double_avg_as_default_metric
 TS k8s* | STATS bytes = sum(sum_over_time(network.eth0.rx)) by pod, time_bucket = bucket(@timestamp, 10minute) | SORT bytes desc, pod, time_bucket | LIMIT 10 ;
 
 bytes:double | pod:keyword | time_bucket:datetime

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries.csv-spec
@@ -1060,56 +1060,56 @@ max_deriv:double | max_rate:double | time_bucket:date_nanos   | cluster:keyword
 
 DefaultMetricWithFrom
 required_capability: ts_command_v0
-required_capability: aggregate_metric_double_default_metric
+required_capability: aggregate_metric_double_avg_as_default_metric
 FROM k8s-downsampled
 | STATS max = max(network.eth0.tx), std_dev = ROUND(STD_DEV(network.eth0.tx), 7) by pod
 | sort pod
 ;
 
 max:double | std_dev:double | pod:keyword
-1060.0     | 331.5018947    | one
-824.0      | 151.9744943    | three
-1419.0     | 364.4118888    | two
+1060.0     | 275.6970067    | one
+824.0      | 184.1213952    | three
+1419.0     | 356.9865993    | two
 ;
 
 DefaultMetricWithTS
 required_capability: ts_command_v0
-required_capability: aggregate_metric_double_default_metric
+required_capability: aggregate_metric_double_avg_as_default_metric
 TS k8s-downsampled
 | STATS max = max(network.eth0.tx), std_dev = ROUND(STD_DEV(network.eth0.tx), 7) by pod
 | sort pod
 ;
 
 max:double | std_dev:double | pod:keyword
-1060.0     | 355.3786713    | one
-824.0      | 180.6918802    | three
-815.0      | 102.3469046    | two
+998.0      | 335.8395781    | one
+734.0      | 228.887527     | three
+576.0      | 58.4465568     | two
 ;
 
 DefaultMetricWithFromImplicitCasting
 required_capability: ts_command_v0
-required_capability: aggregate_metric_double_default_metric
+required_capability: aggregate_metric_double_avg_as_default_metric
 FROM k8s*
 | STATS min = min(network.eth0.tx), std_dev = ROUND(STD_DEV(network.eth0.tx), 7) by pod
 | sort pod
 ;
 
 min:double | std_dev:double | pod:keyword
-18.0       | 380.8643432    | one
-48.0       | 340.5483293    | three
-20.0       | 431.2070165    | two
+18.0       | 375.1480039    | one
+48.0       | 347.6778006    | three
+20.0       | 428.6422763    | two
 ;
 
 DefaultMetricWithTSImplicitCasting
 required_capability: ts_command_v0
-required_capability: aggregate_metric_double_default_metric
+required_capability: aggregate_metric_double_avg_as_default_metric
 TS k8s*
-| STATS min = min(network.eth0.tx), std_dev = ROUND(STD_DEV(network.eth0.tx), 7) by pod
+| STATS min = min(network.eth0.tx), max = max(network.eth0.tx), std_dev = ROUND(STD_DEV(network.eth0.tx), 7) by pod
 | sort pod
 ;
 
-min:double | std_dev:double | pod:keyword
-193.0      | 427.9853269    | one
-715.0      | 208.6955678    | three
-602.0      | 375.7757842    | two
+min:double | max:double | std_dev:double | pod:keyword
+176.0      | 1380.0     | 428.6282305    | one
+239.0      | 1241.0     | 366.7649929    | three
+438.0      | 1716.0     | 450.5833552    | two
 ;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/subquery.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/subquery.csv-spec
@@ -918,6 +918,7 @@ FROM sample_data, (FROM k8s)
 
 subqueryInFromWithTimeSeriesDataTypesInMainQuery
 required_capability: subquery_in_from_command
+required_capability: aggregate_metric_double_avg_as_default_metric
 
 FROM k8s-downsampled, (FROM sample_data)
 | WHERE @timestamp <= "2024-05-09T23:30:00.000Z"
@@ -946,6 +947,7 @@ FROM k8s-downsampled, (FROM sample_data)
 
 subqueryInFromWithTimeSeriesDataTypesInMainQueryAndSubquery
 required_capability: subquery_in_from_command
+required_capability: aggregate_metric_double_avg_as_default_metric
 
 FROM k8s, (FROM k8s-downsampled | WHERE @timestamp <= "2024-05-09T23:30:00.000Z")
 | WHERE @timestamp <= "2024-05-10T00:01:00.000Z"

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -978,6 +978,11 @@ public class EsqlCapabilities {
         AGGREGATE_METRIC_DOUBLE_DEFAULT_METRIC,
 
         /**
+         * Support avg as a possible default metric for aggregate_metric_double
+         */
+        AGGREGATE_METRIC_DOUBLE_AVG_AS_DEFAULT_METRIC,
+
+        /**
          * Support change point detection "CHANGE_POINT".
          */
         CHANGE_POINT,

--- a/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldBlockLoaderTests.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldBlockLoaderTests.java
@@ -46,6 +46,7 @@ public class AggregateMetricDoubleFieldBlockLoaderTests extends BlockLoaderTestC
 
             // put explicit `null` for metrics that are not present, this is how the block looks like
             Arrays.stream(AggregateMetricDoubleFieldMapper.Metric.values())
+                .filter(m -> m != AggregateMetricDoubleFieldMapper.Metric.avg)
                 .map(AggregateMetricDoubleFieldMapper.Metric::toString)
                 .sorted()
                 .forEach(m -> {

--- a/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldMapperTests.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldMapperTests.java
@@ -42,14 +42,15 @@ import org.junit.Assert;
 import org.junit.AssumptionViolatedException;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
+import static org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.Metric.avg;
 import static org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.Names.IGNORE_MALFORMED;
 import static org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper.Names.METRICS;
 import static org.hamcrest.Matchers.containsString;
@@ -455,7 +456,7 @@ public class AggregateMetricDoubleFieldMapperTests extends MapperTestCase {
      *  subfields of aggregate_metric_double should not be searchable or exposed in field_caps
      */
     public void testNoSubFieldsIterated() throws IOException {
-        Metric[] values = Metric.values();
+        Metric[] values = Stream.of(Metric.values()).filter(m -> m != avg).toArray(Metric[]::new);
         List<Metric> subset = randomSubsetOf(randomIntBetween(1, values.length), values);
         DocumentMapper mapper = createDocumentMapper(
             fieldMapping(b -> b.field("type", CONTENT_TYPE).field(METRICS_FIELD, subset).field(DEFAULT_METRIC, subset.get(0)))
@@ -587,7 +588,7 @@ public class AggregateMetricDoubleFieldMapperTests extends MapperTestCase {
 
         public AggregateMetricDoubleSyntheticSourceSupport(boolean malformedExample) {
             this.malformedExample = malformedExample;
-            this.storedMetrics = EnumSet.copyOf(randomNonEmptySubsetOf(Arrays.asList(Metric.values())));
+            this.storedMetrics = EnumSet.copyOf(randomNonEmptySubsetOf(Stream.of(Metric.values()).filter(m -> m != avg).toList()));
         }
 
         @Override

--- a/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/mapper/datageneration/AggregateMetricDoubleDataSourceHandler.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/mapper/datageneration/AggregateMetricDoubleDataSourceHandler.java
@@ -13,9 +13,9 @@ import org.elasticsearch.datageneration.datasource.DataSourceResponse;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateMetricDoubleFieldMapper;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.stream.Stream;
 
 public class AggregateMetricDoubleDataSourceHandler implements DataSourceHandler {
     @Override
@@ -46,7 +46,9 @@ public class AggregateMetricDoubleDataSourceHandler implements DataSourceHandler
             var map = new HashMap<String, Object>();
 
             List<AggregateMetricDoubleFieldMapper.Metric> metrics = ESTestCase.randomNonEmptySubsetOf(
-                Arrays.asList(AggregateMetricDoubleFieldMapper.Metric.values())
+                Stream.of(AggregateMetricDoubleFieldMapper.Metric.values())
+                    .filter(m -> m != AggregateMetricDoubleFieldMapper.Metric.avg)
+                    .toList()
             );
 
             map.put("metrics", metrics.stream().map(Enum::toString).toList());


### PR DESCRIPTION
This commit adds support for using average as the default metric for
aggregate_metric_double on the ES|QL side. This means that in queries
containing STATS commands on aggregate_metric_doubles that are not one
of the 5 classically supported aggregations (min, max, sum, count, avg),
we can run the aggregation on the average value (sum/count) of an
aggregate_metric_double.
i.e. `STATS std_dev(agg_metric)` will run standard deviation on the
aggregate_metric_double's average value (agg_metric.sum / agg_metric.count)
for each doc, provided the mapping states the aggregate_metric_double's
default metric is avg.

Implicit casting with other numerics is also supported.
