### PR TITLE
Refactor rolling upgrade modules

### DIFF
--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/AbstractLogsdbRollingUpgradeTestCase.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/AbstractLogsdbRollingUpgradeTestCase.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.logsdb;
 
+import org.elasticsearch.client.Request;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
@@ -21,6 +22,11 @@ import org.junit.ClassRule;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import static org.hamcrest.Matchers.equalTo;
 
 public abstract class AbstractLogsdbRollingUpgradeTestCase extends ESRestTestCase {
     private static final String USER = "admin-user";
@@ -71,5 +77,37 @@ public abstract class AbstractLogsdbRollingUpgradeTestCase extends ESRestTestCas
 
     static String formatInstant(Instant instant) {
         return DateFormatter.forPattern(FormatNames.STRICT_DATE_OPTIONAL_TIME.getName()).format(instant);
+    }
+
+    static String bulkIndex(
+        String dataStreamName,
+        int numRequest,
+        int numDocs,
+        Instant startTime,
+        BiFunction<Instant, Integer, String> docSupplier
+    ) throws Exception {
+        String firstIndex = null;
+        for (int i = 0; i < numRequest; i++) {
+            var bulkRequest = new Request("POST", "/" + dataStreamName + "/_bulk");
+            StringBuilder requestBody = new StringBuilder();
+            for (int j = 0; j < numDocs; j++) {
+                requestBody.append("{\"create\": {}}");
+                requestBody.append('\n');
+                requestBody.append(docSupplier.apply(startTime, j));
+                requestBody.append('\n');
+
+                startTime = startTime.plusMillis(1);
+            }
+            bulkRequest.setJsonEntity(requestBody.toString());
+            bulkRequest.addParameter("refresh", "true");
+            var response = client().performRequest(bulkRequest);
+            assertOK(response);
+            var responseBody = entityAsMap(response);
+            assertThat("errors in response:\n " + responseBody, responseBody.get("errors"), equalTo(false));
+            if (firstIndex == null) {
+                firstIndex = (String) ((Map<?, ?>) ((Map<?, ?>) ((List<?>) responseBody.get("items")).get(0)).get("create")).get("_index");
+            }
+        }
+        return firstIndex;
     }
 }

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/AbstractLogsdbRollingUpgradeTestCase.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/AbstractLogsdbRollingUpgradeTestCase.java
@@ -9,6 +9,8 @@ package org.elasticsearch.xpack.logsdb;
 
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.common.time.FormatNames;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.util.Version;
@@ -18,6 +20,7 @@ import org.junit.Before;
 import org.junit.ClassRule;
 
 import java.io.IOException;
+import java.time.Instant;
 
 public abstract class AbstractLogsdbRollingUpgradeTestCase extends ESRestTestCase {
     private static final String USER = "admin-user";
@@ -64,5 +67,9 @@ public abstract class AbstractLogsdbRollingUpgradeTestCase extends ESRestTestCas
         logger.info("Upgrading node {} to version {}", n, upgradeVersion);
         cluster.upgradeNodeToVersion(n, upgradeVersion);
         initClient();
+    }
+
+    static String formatInstant(Instant instant) {
+        return DateFormatter.forPattern(FormatNames.STRICT_DATE_OPTIONAL_TIME.getName()).format(instant);
     }
 }

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/KeywordRollingUpgradeIT.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/KeywordRollingUpgradeIT.java
@@ -78,9 +78,9 @@ public class KeywordRollingUpgradeIT extends AbstractLogsdbRollingUpgradeTestCas
         // when - index a document
         indexDocuments(FIELD_VALUES_1);
 
-        // then - verify that logsdb and synthetic source are enabled before proceeding futher
-        String firstBackingIndex = LogsdbIndexingRollingUpgradeIT.getWriteBackingIndex(client(), DATA_STREAM_NAME, 0);
-        var settings = (Map<?, ?>) LogsdbIndexingRollingUpgradeIT.getIndexSettingsWithDefaults(firstBackingIndex).get(firstBackingIndex);
+        // then - verify that logsdb and synthetic source are enabled before proceeding further
+        String firstBackingIndex = getDataStreamBackingIndexNames(DATA_STREAM_NAME).getFirst();
+        var settings = (Map<?, ?>) getIndexSettings(firstBackingIndex, true).get(firstBackingIndex);
         assertThat(((Map<?, ?>) settings.get("settings")).get("index.mode"), equalTo("logsdb"));
         assertThat(((Map<?, ?>) settings.get("defaults")).get("index.mapping.source.mode"), equalTo("SYNTHETIC"));
 

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/KeywordRollingUpgradeIT.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/KeywordRollingUpgradeIT.java
@@ -116,7 +116,7 @@ public class KeywordRollingUpgradeIT extends AbstractLogsdbRollingUpgradeTestCas
             requestBody.append("{\"create\": {}}");
             requestBody.append('\n');
             requestBody.append(
-                ITEM_TEMPLATE.replace("$now", LogsdbIndexingRollingUpgradeIT.formatInstant(startTime)).replace("$message", value)
+                ITEM_TEMPLATE.replace("$now", AbstractLogsdbRollingUpgradeTestCase.formatInstant(startTime)).replace("$message", value)
             );
             requestBody.append('\n');
 

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/LogsdbIndexingRollingUpgradeIT.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/LogsdbIndexingRollingUpgradeIT.java
@@ -8,8 +8,6 @@ package org.elasticsearch.xpack.logsdb;
 
 import org.elasticsearch.client.Request;
 import org.elasticsearch.common.network.NetworkAddress;
-import org.elasticsearch.common.time.DateFormatter;
-import org.elasticsearch.common.time.FormatNames;
 import org.elasticsearch.test.cluster.util.Version;
 import org.elasticsearch.test.rest.ObjectPath;
 
@@ -238,10 +236,6 @@ public class LogsdbIndexingRollingUpgradeIT extends AbstractLogsdbRollingUpgrade
         assertThat(maxRx, notNullValue());
         Double maxTx = ObjectPath.evaluate(responseBody, "values.0.1");
         assertThat(maxTx, notNullValue());
-    }
-
-    static String formatInstant(Instant instant) {
-        return DateFormatter.forPattern(FormatNames.STRICT_DATE_OPTIONAL_TIME.getName()).format(instant);
     }
 
     static void maybeEnableLogsdbByDefault() throws IOException {

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/TsdbIT.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/TsdbIT.java
@@ -226,12 +226,4 @@ public class TsdbIT extends AbstractLogsdbRollingUpgradeTestCase {
         assertOK(response);
         return entityAsMap(response);
     }
-
-    private static Map<?, ?> getIndex(String indexName) throws IOException {
-        var getIndexRequest = new Request("GET", "/" + indexName + "?human");
-        var response = client().performRequest(getIndexRequest);
-        assertOK(response);
-        return entityAsMap(response);
-    }
-
 }

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/TsdbIT.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/TsdbIT.java
@@ -10,8 +10,6 @@
 package org.elasticsearch.xpack.logsdb;
 
 import org.elasticsearch.client.Request;
-import org.elasticsearch.common.time.DateFormatter;
-import org.elasticsearch.common.time.FormatNames;
 import org.elasticsearch.test.rest.ObjectPath;
 
 import java.io.IOException;
@@ -214,10 +212,6 @@ public class TsdbIT extends AbstractLogsdbRollingUpgradeTestCase {
         assertOK(response);
         var responseBody = entityAsMap(response);
         assertThat(ObjectPath.evaluate(responseBody, "hits.total.value"), equalTo(expectedHitCount));
-    }
-
-    static String formatInstant(Instant instant) {
-        return DateFormatter.forPattern(FormatNames.STRICT_DATE_OPTIONAL_TIME.getName()).format(instant);
     }
 
     private static Map<String, Object> getDataStream(String dataStreamName) throws IOException {

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/TsdbIndexingRollingUpgradeIT.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/TsdbIndexingRollingUpgradeIT.java
@@ -43,7 +43,7 @@ public class TsdbIndexingRollingUpgradeIT extends AbstractLogsdbRollingUpgradeTe
         createTemplate(dataStreamName, getClass().getSimpleName().toLowerCase(Locale.ROOT), TEMPLATE);
 
         Instant startTime = Instant.now().minusSeconds(60 * 60);
-        bulkIndex(dataStreamName, 4, 1024, startTime);
+        bulkIndex(dataStreamName, 4, 1024, startTime, TsdbIndexingRollingUpgradeIT::docSupplier);
 
         String firstBackingIndex = getDataStreamBackingIndexNames(dataStreamName).getFirst();
         var settings = (Map<?, ?>) getIndexSettings(firstBackingIndex, true).get(firstBackingIndex);
@@ -65,7 +65,7 @@ public class TsdbIndexingRollingUpgradeIT extends AbstractLogsdbRollingUpgradeTe
         for (int i = 0; i < numNodes; i++) {
             upgradeNode(i);
             startTime = startTime.plusNanos(60 * 30);
-            bulkIndex(dataStreamName, 4, 1024, startTime);
+            bulkIndex(dataStreamName, 4, 1024, startTime, TsdbIndexingRollingUpgradeIT::docSupplier);
             search(dataStreamName);
             query(dataStreamName);
         }
@@ -79,38 +79,19 @@ public class TsdbIndexingRollingUpgradeIT extends AbstractLogsdbRollingUpgradeTe
         query(dataStreamName);
     }
 
-    static void bulkIndex(String dataStreamName, int numRequest, int numDocs, Instant startTime) throws Exception {
-        for (int i = 0; i < numRequest; i++) {
-            var bulkRequest = new Request("POST", "/" + dataStreamName + "/_bulk");
-            StringBuilder requestBody = new StringBuilder();
-            for (int j = 0; j < numDocs; j++) {
-                String podName = "pod" + j % 5; // Not realistic, but makes asserting search / query response easier.
-                String podUid = randomUUID();
-                String podIp = NetworkAddress.format(randomIp(true));
-                long podTx = randomLong();
-                long podRx = randomLong();
+    static String docSupplier(Instant time, int j) {
+        String podName = "pod" + j % 5; // Not realistic, but makes asserting search / query response easier.
+        String podUid = randomUUID();
+        String podIp = NetworkAddress.format(randomIp(true));
+        long podTx = randomLong();
+        long podRx = randomLong();
 
-                requestBody.append("{\"create\": {}}");
-                requestBody.append('\n');
-                requestBody.append(
-                    BULK_ITEM_TEMPLATE.replace("$now", formatInstant(startTime))
-                        .replace("$name", podName)
-                        .replace("$uid", podUid)
-                        .replace("$ip", podIp)
-                        .replace("$tx", Long.toString(podTx))
-                        .replace("$rx", Long.toString(podRx))
-                );
-                requestBody.append('\n');
-
-                startTime = startTime.plusMillis(1);
-            }
-            bulkRequest.setJsonEntity(requestBody.toString());
-            bulkRequest.addParameter("refresh", "true");
-            var response = client().performRequest(bulkRequest);
-            assertOK(response);
-            var responseBody = entityAsMap(response);
-            assertThat("errors in response:\n " + responseBody, responseBody.get("errors"), equalTo(false));
-        }
+        return BULK_ITEM_TEMPLATE.replace("$now", formatInstant(time))
+            .replace("$name", podName)
+            .replace("$uid", podUid)
+            .replace("$ip", podIp)
+            .replace("$tx", Long.toString(podTx))
+            .replace("$rx", Long.toString(podRx));
     }
 
     void search(String dataStreamName) throws Exception {

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/TsdbIndexingRollingUpgradeIT.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/TsdbIndexingRollingUpgradeIT.java
@@ -45,8 +45,8 @@ public class TsdbIndexingRollingUpgradeIT extends AbstractLogsdbRollingUpgradeTe
         Instant startTime = Instant.now().minusSeconds(60 * 60);
         bulkIndex(dataStreamName, 4, 1024, startTime);
 
-        String firstBackingIndex = getWriteBackingIndex(client(), dataStreamName, 0);
-        var settings = (Map<?, ?>) getIndexSettingsWithDefaults(firstBackingIndex).get(firstBackingIndex);
+        String firstBackingIndex = getDataStreamBackingIndexNames(dataStreamName).getFirst();
+        var settings = (Map<?, ?>) getIndexSettings(firstBackingIndex, true).get(firstBackingIndex);
         assertThat(((Map<?, ?>) settings.get("settings")).get("index.mode"), equalTo("time_series"));
         assertThat(((Map<?, ?>) settings.get("defaults")).get("index.mapping.source.mode"), equalTo("SYNTHETIC"));
 


### PR DESCRIPTION
Small refactoring to the logsdb upgrade tests:

- We reuse helper methods provided by the `ESRestTestCase` to retrieve the data stream's backing indices and the settings.
- We pulled up the `formatInstant` and `bulkIndex` because they can be used in other tests too, for example in https://github.com/elastic/elasticsearch/pull/140021.