### PR TITLE
Downsample documents in order.

### DIFF
--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/AbstractDownsampleFieldProducer.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/AbstractDownsampleFieldProducer.java
@@ -7,8 +7,6 @@
 
 package org.elasticsearch.xpack.downsample;
 
-import org.apache.lucene.internal.hppc.IntArrayList;
-
 import java.io.IOException;
 
 /**
@@ -43,5 +41,5 @@ abstract class AbstractDownsampleFieldProducer<T> implements DownsampleFieldSeri
         return isEmpty;
     }
 
-    public abstract void collect(T docValues, IntArrayList docIdBuffer) throws IOException;
+    public abstract void collect(T docValues, int docId) throws IOException;
 }

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DimensionFieldProducer.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DimensionFieldProducer.java
@@ -54,24 +54,14 @@ public class DimensionFieldProducer extends LastValueFieldProducer {
     }
 
     @Override
-    public void collect(FormattedDocValues docValues, IntArrayList docIdBuffer) throws IOException {
-        if (isEmpty() == false) {
-            assert validate(docValues, docIdBuffer);
+    public void collect(FormattedDocValues docValues, int docId) throws IOException {
+        if (isEmpty() == false || docValues.advanceExact(docId) == false) {
             return;
         }
 
-        for (int i = 0; i < docIdBuffer.size(); i++) {
-            int docId = docIdBuffer.get(i);
-            if (docValues.advanceExact(docId) == false) {
-                continue;
-            }
-            int docValueCount = docValues.docValueCount();
-            for (int j = 0; j < docValueCount; j++) {
-                collectOnce(docValues.nextValue());
-            }
-            // Only need to record one dimension value from one document, within in the same tsid-and-time-interval bucket values are the
-            // same.
-            return;
+        int docValueCount = docValues.docValueCount();
+        for (int j = 0; j < docValueCount; j++) {
+            collectOnce(docValues.nextValue());
         }
     }
 }

--- a/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/AggregateMetricDoubleFieldSerializerTests.java
+++ b/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/AggregateMetricDoubleFieldSerializerTests.java
@@ -26,7 +26,9 @@ public class AggregateMetricDoubleFieldSerializerTests extends ESTestCase {
         NumericMetricFieldProducer producer = new NumericMetricFieldProducer.AggregateGauge("my-gauge");
         var docIdBuffer = IntArrayList.from(0, 1, 2);
         var valuesInstance = createNumericValuesInstance(docIdBuffer, 55.0, 12.2, 5.5);
-        producer.collect(valuesInstance, docIdBuffer);
+        for (int i = 0; i < docIdBuffer.size(); i++) {
+            producer.collect(valuesInstance, docIdBuffer.get(i));
+        }
         try (XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent())) {
             builder.humanReadable(true).startObject();
             producer.write(builder);
@@ -48,7 +50,9 @@ public class AggregateMetricDoubleFieldSerializerTests extends ESTestCase {
         NumericMetricFieldProducer producer = new NumericMetricFieldProducer.LastValue("my-counter");
         var docIdBuffer = IntArrayList.from(0, 1, 2);
         var valuesInstance = createNumericValuesInstance(docIdBuffer, 55, 12, 5);
-        producer.collect(valuesInstance, docIdBuffer);
+        for (int i = 0; i < docIdBuffer.size(); i++) {
+            producer.collect(valuesInstance, docIdBuffer.get(i));
+        }
         AggregateMetricDoubleFieldProducer.Serializer gaugeFieldSerializer = new AggregateMetricDoubleFieldProducer.Serializer(
             "my-counter",
             List.of(producer)
@@ -66,28 +70,36 @@ public class AggregateMetricDoubleFieldSerializerTests extends ESTestCase {
         );
         var docIdBuffer = IntArrayList.from(0, 1);
         var valuesInstance = createNumericValuesInstance(docIdBuffer, 10, 5.5);
-        minProducer.collect(valuesInstance, docIdBuffer);
+        for (int i = 0; i < docIdBuffer.size(); i++) {
+            minProducer.collect(valuesInstance, docIdBuffer.get(i));
+        }
         AggregateMetricDoubleFieldProducer maxProducer = new AggregateMetricDoubleFieldProducer.Aggregate(
             "my-gauge",
             AggregateMetricDoubleFieldMapper.Metric.max
         );
         docIdBuffer = IntArrayList.from(0, 1);
         valuesInstance = createNumericValuesInstance(docIdBuffer, 30, 55.0);
-        maxProducer.collect(valuesInstance, docIdBuffer);
+        for (int i = 0; i < docIdBuffer.size(); i++) {
+            maxProducer.collect(valuesInstance, docIdBuffer.get(i));
+        }
         AggregateMetricDoubleFieldProducer sumProducer = new AggregateMetricDoubleFieldProducer.Aggregate(
             "my-gauge",
             AggregateMetricDoubleFieldMapper.Metric.sum
         );
         docIdBuffer = IntArrayList.from(0, 1);
         valuesInstance = createNumericValuesInstance(docIdBuffer, 30, 72.7);
-        sumProducer.collect(valuesInstance, docIdBuffer);
+        for (int i = 0; i < docIdBuffer.size(); i++) {
+            sumProducer.collect(valuesInstance, docIdBuffer.get(i));
+        }
         AggregateMetricDoubleFieldProducer countProducer = new AggregateMetricDoubleFieldProducer.Aggregate(
             "my-gauge",
             AggregateMetricDoubleFieldMapper.Metric.value_count
         );
         docIdBuffer = IntArrayList.from(0, 1);
         valuesInstance = createNumericValuesInstance(docIdBuffer, 2, 3);
-        countProducer.collect(valuesInstance, docIdBuffer);
+        for (int i = 0; i < docIdBuffer.size(); i++) {
+            countProducer.collect(valuesInstance, docIdBuffer.get(i));
+        }
         AggregateMetricDoubleFieldProducer.Serializer gaugeFieldSerializer = new AggregateMetricDoubleFieldProducer.Serializer(
             "my-gauge",
             List.of(maxProducer, minProducer, sumProducer, countProducer)
@@ -107,28 +119,36 @@ public class AggregateMetricDoubleFieldSerializerTests extends ESTestCase {
         );
         var docIdBuffer = IntArrayList.from(0, 1);
         var valuesInstance = createNumericValuesInstance(docIdBuffer, 10D, 5.5);
-        minProducer.collect(valuesInstance, docIdBuffer);
+        for (int i = 0; i < docIdBuffer.size(); i++) {
+            minProducer.collect(valuesInstance, docIdBuffer.get(i));
+        }
         AggregateMetricDoubleFieldProducer maxProducer = randomAggregateSubMetricFieldProducer(
             "my-gauge",
             AggregateMetricDoubleFieldMapper.Metric.max
         );
         docIdBuffer = IntArrayList.from(0, 1);
         valuesInstance = createNumericValuesInstance(docIdBuffer, 30D, 55.0);
-        maxProducer.collect(valuesInstance, docIdBuffer);
+        for (int i = 0; i < docIdBuffer.size(); i++) {
+            maxProducer.collect(valuesInstance, docIdBuffer.get(i));
+        }
         AggregateMetricDoubleFieldProducer sumProducer = randomAggregateSubMetricFieldProducer(
             "my-gauge",
             AggregateMetricDoubleFieldMapper.Metric.sum
         );
         docIdBuffer = IntArrayList.from(0, 1);
         valuesInstance = createNumericValuesInstance(docIdBuffer, 30D, 72.7);
-        sumProducer.collect(valuesInstance, docIdBuffer);
+        for (int i = 0; i < docIdBuffer.size(); i++) {
+            sumProducer.collect(valuesInstance, docIdBuffer.get(i));
+        }
         AggregateMetricDoubleFieldProducer countProducer = randomAggregateSubMetricFieldProducer(
             "my-gauge",
             AggregateMetricDoubleFieldMapper.Metric.value_count
         );
         docIdBuffer = IntArrayList.from(0, 1);
         valuesInstance = createNumericValuesInstance(docIdBuffer, 2, 3);
-        countProducer.collect(valuesInstance, docIdBuffer);
+        for (int i = 0; i < docIdBuffer.size(); i++) {
+            countProducer.collect(valuesInstance, docIdBuffer.get(i));
+        }
         AggregateMetricDoubleFieldProducer.Serializer gaugeFieldSerializer = new AggregateMetricDoubleFieldProducer.Serializer(
             "my-gauge",
             List.of(maxProducer, minProducer, sumProducer, countProducer)

--- a/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/LastValueFieldProducerTests.java
+++ b/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/LastValueFieldProducerTests.java
@@ -31,7 +31,9 @@ public class LastValueFieldProducerTests extends AggregatorTestCase {
         assertThat(lastValueFieldProducer.lastValue(), nullValue());
         var docIdBuffer = IntArrayList.from(0, 1, 2);
         var values = createValuesInstance(docIdBuffer, new String[] { "aaa", "bbb", "ccc" });
-        lastValueFieldProducer.collect(values, docIdBuffer);
+        for (int i = 0; i < docIdBuffer.size(); i++) {
+            lastValueFieldProducer.collect(values, docIdBuffer.get(i));
+        }
         assertThat(lastValueFieldProducer.lastValue(), equalTo("aaa"));
         lastValueFieldProducer.reset();
         assertThat(lastValueFieldProducer.lastValue(), nullValue());
@@ -42,7 +44,9 @@ public class LastValueFieldProducerTests extends AggregatorTestCase {
         assertThat(lastValueFieldProducer.lastValue(), nullValue());
         var docIdBuffer = IntArrayList.from(0, 1, 2);
         var values = createValuesInstance(docIdBuffer, new Double[] { 10.20D, 17.30D, 12.60D });
-        lastValueFieldProducer.collect(values, docIdBuffer);
+        for (int i = 0; i < docIdBuffer.size(); i++) {
+            lastValueFieldProducer.collect(values, docIdBuffer.get(i));
+        }
         assertThat(lastValueFieldProducer.lastValue(), equalTo(10.20D));
         lastValueFieldProducer.reset();
         assertThat(lastValueFieldProducer.lastValue(), nullValue());
@@ -53,7 +57,9 @@ public class LastValueFieldProducerTests extends AggregatorTestCase {
         assertThat(lastValueFieldProducer.lastValue(), nullValue());
         var docIdBuffer = IntArrayList.from(0, 1, 2);
         var values = createValuesInstance(docIdBuffer, new Integer[] { 10, 17, 12 });
-        lastValueFieldProducer.collect(values, docIdBuffer);
+        for (int i = 0; i < docIdBuffer.size(); i++) {
+            lastValueFieldProducer.collect(values, docIdBuffer.get(i));
+        }
         assertThat(lastValueFieldProducer.lastValue(), equalTo(10));
         lastValueFieldProducer.reset();
         assertThat(lastValueFieldProducer.lastValue(), nullValue());
@@ -64,7 +70,9 @@ public class LastValueFieldProducerTests extends AggregatorTestCase {
         assertThat(lastValueFieldProducer.lastValue(), nullValue());
         var docIdBuffer = IntArrayList.from(0, 1, 2);
         var values = createValuesInstance(docIdBuffer, new Long[] { 10L, 17L, 12L });
-        lastValueFieldProducer.collect(values, docIdBuffer);
+        for (int i = 0; i < docIdBuffer.size(); i++) {
+            lastValueFieldProducer.collect(values, docIdBuffer.get(i));
+        }
         assertThat(lastValueFieldProducer.lastValue(), equalTo(10L));
         lastValueFieldProducer.reset();
         assertThat(lastValueFieldProducer.lastValue(), nullValue());
@@ -75,7 +83,9 @@ public class LastValueFieldProducerTests extends AggregatorTestCase {
         assertThat(lastValueFieldProducer.lastValue(), nullValue());
         var docIdBuffer = IntArrayList.from(0, 1, 2);
         var values = createValuesInstance(docIdBuffer, new Boolean[] { true, false, false });
-        lastValueFieldProducer.collect(values, docIdBuffer);
+        for (int i = 0; i < docIdBuffer.size(); i++) {
+            lastValueFieldProducer.collect(values, docIdBuffer.get(i));
+        }
         assertThat(lastValueFieldProducer.lastValue(), equalTo(true));
         lastValueFieldProducer.reset();
         assertThat(lastValueFieldProducer.lastValue(), nullValue());
@@ -107,7 +117,9 @@ public class LastValueFieldProducerTests extends AggregatorTestCase {
         values.iterator = Arrays.stream(multiValue).iterator();
         LastValueFieldProducer multiLastValueProducer = new LastValueFieldProducer(randomAlphanumericOfLength(10));
         assertThat(multiLastValueProducer.lastValue(), nullValue());
-        multiLastValueProducer.collect(values, docIdBuffer);
+        for (int i = 0; i < docIdBuffer.size(); i++) {
+            multiLastValueProducer.collect(values, docIdBuffer.get(i));
+        }
         assertThat(multiLastValueProducer.lastValue(), equalTo(multiValue));
         // Ensure we read all the available values
         assertThat(values.iterator.hasNext(), equalTo(false));
@@ -141,7 +153,7 @@ public class LastValueFieldProducerTests extends AggregatorTestCase {
             }
         };
 
-        producer.collect(docValues, IntArrayList.from(1));
+        producer.collect(docValues, 1);
         assertFalse(producer.isEmpty());
         assertEquals("a\0value_a", (((Object[]) producer.lastValue())[0]).toString());
         assertEquals("b\0value_b", (((Object[]) producer.lastValue())[1]).toString());

--- a/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/NumericMetricFieldProducerTests.java
+++ b/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/NumericMetricFieldProducerTests.java
@@ -24,7 +24,9 @@ public class NumericMetricFieldProducerTests extends AggregatorTestCase {
         assertEquals(Double.MAX_VALUE, aggregateMetricFieldProducer.min, 0);
         var docIdBuffer = IntArrayList.from(0, 1, 2, 3);
         var numericValues = createNumericValuesInstance(docIdBuffer, 40, 5.5, 12.2, 55);
-        aggregateMetricFieldProducer.collect(numericValues, docIdBuffer);
+        for (int i = 0; i < docIdBuffer.size(); i++) {
+            aggregateMetricFieldProducer.collect(numericValues, docIdBuffer.get(i));
+        }
         assertEquals(5.5, aggregateMetricFieldProducer.min, 0);
         aggregateMetricFieldProducer.reset();
         assertEquals(Double.MAX_VALUE, aggregateMetricFieldProducer.min, 0);
@@ -33,7 +35,9 @@ public class NumericMetricFieldProducerTests extends AggregatorTestCase {
         assertNull(lastValueProducer.lastValue());
         docIdBuffer = IntArrayList.from(0, 1, 2, 3);
         var values = createNumericValuesInstance(docIdBuffer, 40D, 5.5, 12.2, 55D);
-        lastValueProducer.collect(values, docIdBuffer);
+        for (int i = 0; i < docIdBuffer.size(); i++) {
+            lastValueProducer.collect(values, docIdBuffer.get(i));
+        }
         assertNotNull(lastValueProducer.lastValue());
         assertEquals(40.0, lastValueProducer.lastValue(), 0);
         lastValueProducer.reset();
@@ -45,7 +49,9 @@ public class NumericMetricFieldProducerTests extends AggregatorTestCase {
         assertEquals(-Double.MAX_VALUE, aggregateMetricFieldProducer.max, 0);
         var docIdBuffer = IntArrayList.from(0, 1, 2);
         var numericValues = createNumericValuesInstance(docIdBuffer, 5.5, 12.2, 55);
-        aggregateMetricFieldProducer.collect(numericValues, docIdBuffer);
+        for (int i = 0; i < docIdBuffer.size(); i++) {
+            aggregateMetricFieldProducer.collect(numericValues, docIdBuffer.get(i));
+        }
         assertEquals(55d, aggregateMetricFieldProducer.max, 0);
         aggregateMetricFieldProducer.reset();
         assertEquals(-Double.MAX_VALUE, aggregateMetricFieldProducer.max, 0);
@@ -54,7 +60,9 @@ public class NumericMetricFieldProducerTests extends AggregatorTestCase {
         assertNull(lastValueProducer.lastValue());
         docIdBuffer = IntArrayList.from(0, 1, 2);
         var values = createNumericValuesInstance(docIdBuffer, 5.5, 12.2, 55D);
-        lastValueProducer.collect(values, docIdBuffer);
+        for (int i = 0; i < docIdBuffer.size(); i++) {
+            lastValueProducer.collect(numericValues, docIdBuffer.get(i));
+        }
         assertNotNull(lastValueProducer.lastValue());
         assertEquals(5.5, lastValueProducer.lastValue(), 0);
         lastValueProducer.reset();
@@ -66,7 +74,9 @@ public class NumericMetricFieldProducerTests extends AggregatorTestCase {
         assertEquals(0, aggregateMetricFieldProducer.sum.value(), 0);
         var docIdBuffer = IntArrayList.from(0, 1, 2);
         var numericValues = createNumericValuesInstance(docIdBuffer, 5.5, 12.2, 55);
-        aggregateMetricFieldProducer.collect(numericValues, docIdBuffer);
+        for (int i = 0; i < docIdBuffer.size(); i++) {
+            aggregateMetricFieldProducer.collect(numericValues, docIdBuffer.get(i));
+        }
         assertEquals(72.7, aggregateMetricFieldProducer.sum.value(), 0);
         aggregateMetricFieldProducer.reset();
         assertEquals(0, aggregateMetricFieldProducer.sum.value(), 0);
@@ -75,7 +85,9 @@ public class NumericMetricFieldProducerTests extends AggregatorTestCase {
         assertNull(lastValueProducer.lastValue());
         docIdBuffer = IntArrayList.from(0, 1, 2);
         var values = createNumericValuesInstance(docIdBuffer, 5.5, 12.2, 55D);
-        lastValueProducer.collect(values, docIdBuffer);
+        for (int i = 0; i < docIdBuffer.size(); i++) {
+            lastValueProducer.collect(numericValues, docIdBuffer.get(i));
+        }
         assertNotNull(lastValueProducer.lastValue());
         assertEquals(5.5, lastValueProducer.lastValue(), 0);
         lastValueProducer.reset();
@@ -111,7 +123,9 @@ public class NumericMetricFieldProducerTests extends AggregatorTestCase {
             1.6,
             1.7
         );
-        instance.collect(values, docIdBuffer);
+        for (int i = 0; i < docIdBuffer.size(); i++) {
+            instance.collect(values, docIdBuffer.get(i));
+        }
         assertEquals(15.3, instance.sum.value(), Double.MIN_NORMAL);
 
         // Summing up an array which contains NaN and infinities and expect a result same as naive summation
@@ -129,7 +143,9 @@ public class NumericMetricFieldProducerTests extends AggregatorTestCase {
             sum += d;
         }
         values = createNumericValuesInstance(docIdBuffer, valueArray);
-        instance.collect(values, docIdBuffer);
+        for (int i = 0; i < docIdBuffer.size(); i++) {
+            instance.collect(values, docIdBuffer.get(i));
+        }
         assertEquals(sum, instance.sum.value(), 1e-10);
 
         // Summing up some big double values and expect infinity result
@@ -142,7 +158,9 @@ public class NumericMetricFieldProducerTests extends AggregatorTestCase {
             valueArray[i] = Double.MAX_VALUE;
         }
         values = createNumericValuesInstance(docIdBuffer, valueArray);
-        instance.collect(values, docIdBuffer);
+        for (int i = 0; i < docIdBuffer.size(); i++) {
+            instance.collect(values, docIdBuffer.get(i));
+        }
         assertEquals(Double.POSITIVE_INFINITY, instance.sum.value(), 0d);
 
         instance.reset();
@@ -154,7 +172,9 @@ public class NumericMetricFieldProducerTests extends AggregatorTestCase {
             valueArray[i] = -Double.MAX_VALUE;
         }
         values = createNumericValuesInstance(docIdBuffer, valueArray);
-        instance.collect(values, docIdBuffer);
+        for (int i = 0; i < docIdBuffer.size(); i++) {
+            instance.collect(values, docIdBuffer.get(i));
+        }
         assertEquals(Double.NEGATIVE_INFINITY, instance.sum.value(), 0d);
     }
 
@@ -163,7 +183,9 @@ public class NumericMetricFieldProducerTests extends AggregatorTestCase {
         assertEquals(0, aggregateMetricFieldProducer.count);
         var docIdBuffer = IntArrayList.from(0, 1, 2);
         var numericValues = createNumericValuesInstance(docIdBuffer, 40, 30, 20);
-        aggregateMetricFieldProducer.collect(numericValues, docIdBuffer);
+        for (int i = 0; i < docIdBuffer.size(); i++) {
+            aggregateMetricFieldProducer.collect(numericValues, docIdBuffer.get(i));
+        }
         assertEquals(3L, aggregateMetricFieldProducer.count);
         aggregateMetricFieldProducer.reset();
         assertEquals(0, aggregateMetricFieldProducer.count);
@@ -171,7 +193,9 @@ public class NumericMetricFieldProducerTests extends AggregatorTestCase {
         var lastValueProducer = new NumericMetricFieldProducer.LastValue(randomAlphaOfLength(10));
         docIdBuffer = IntArrayList.from(0, 1, 2);
         var values = createNumericValuesInstance(docIdBuffer, 40, 30, 20);
-        lastValueProducer.collect(values, docIdBuffer);
+        for (int i = 0; i < docIdBuffer.size(); i++) {
+            lastValueProducer.collect(values, docIdBuffer.get(i));
+        }
         assertNotNull(lastValueProducer.lastValue());
         assertEquals(40, lastValueProducer.lastValue().intValue(), 0);
         lastValueProducer.reset();
@@ -185,7 +209,9 @@ public class NumericMetricFieldProducerTests extends AggregatorTestCase {
         var docIdBuffer = IntArrayList.from(0, 1, 2);
         var valuesInstance = createNumericValuesInstance(docIdBuffer, 55.0, 12.2, 5.5);
 
-        producer.collect(valuesInstance, docIdBuffer);
+        for (int i = 0; i < docIdBuffer.size(); i++) {
+            producer.collect(valuesInstance, docIdBuffer.get(i));
+        }
 
         assertFalse(producer.isEmpty());
         assertNotNull(producer.lastValue());
@@ -204,7 +230,9 @@ public class NumericMetricFieldProducerTests extends AggregatorTestCase {
         assertTrue(producer.isEmpty());
         var docIdBuffer = IntArrayList.from(0, 1, 2);
         var valuesInstance = createNumericValuesInstance(docIdBuffer, 55.0, 12.2, 5.5);
-        producer.collect(valuesInstance, docIdBuffer);
+        for (int i = 0; i < docIdBuffer.size(); i++) {
+            producer.collect(valuesInstance, docIdBuffer.get(i));
+        }
 
         assertFalse(producer.isEmpty());
 

--- a/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/TDigestHistogramFieldProducerTests.java
+++ b/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/TDigestHistogramFieldProducerTests.java
@@ -29,13 +29,16 @@ public class TDigestHistogramFieldProducerTests extends ESTestCase {
         assertTrue(producer.isEmpty());
         assertEquals("my-histogram", producer.name());
 
+        IntArrayList docIdBuffer = IntArrayList.from(1, 2);
         var docValues = createValuesInstance(
-            IntArrayList.from(1, 2),
+            docIdBuffer,
             new HistogramValue[] {
                 histogram(new double[] { 1, 2 }, new long[] { 1, 2 }),
                 histogram(new double[] { 1, 4 }, new long[] { 3, 4 }) }
         );
-        producer.collect(docValues, IntArrayList.from(1, 2));
+        for (int i = 0; i < docIdBuffer.size(); i++) {
+            producer.collect(docValues, docIdBuffer.get(i));
+        }
         assertFalse(producer.isEmpty());
 
         var builder = new XContentBuilder(XContentType.JSON.xContent(), new ByteArrayOutputStream());
@@ -51,13 +54,16 @@ public class TDigestHistogramFieldProducerTests extends ESTestCase {
         assertTrue(producer.isEmpty());
         assertEquals("my-histogram", producer.name());
 
+        IntArrayList docIdBuffer = IntArrayList.from(1, 2);
         var docValues = createValuesInstance(
-            IntArrayList.from(1, 2),
+            docIdBuffer,
             new HistogramValue[] {
                 histogram(new double[] { 1, 2 }, new long[] { 1, 2 }),
                 histogram(new double[] { 1, 4 }, new long[] { 3, 4 }) }
         );
-        producer.collect(docValues, IntArrayList.from(1, 2));
+        for (int i = 0; i < docIdBuffer.size(); i++) {
+            producer.collect(docValues, docIdBuffer.get(i));
+        }
         assertFalse(producer.isEmpty());
 
         var builder = new XContentBuilder(XContentType.JSON.xContent(), new ByteArrayOutputStream());


### PR DESCRIPTION
In this PR we change the way we downsample documents. Instead of collecting all doc ids and then collecting the doc values, now we collect the doc values per id and we downsample them in order. 