### PR TITLE
Fix an OOM error when creating to many chained synonym graph token filter.

### DIFF
--- a/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/analysis-common/50_chained_synonym_filters.yml
+++ b/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/analysis-common/50_chained_synonym_filters.yml
@@ -1,0 +1,101 @@
+---
+"Test chained synonym_graph filters":
+  - do:
+      indices.create:
+        index: test_chained_synonyms
+        body:
+          settings:
+            analysis:
+              filter:
+                synonyms_a:
+                  type: synonym_graph
+                  synonyms: [ "foo, bar" ]
+                synonyms_b:
+                  type: synonym_graph
+                  synonyms: [ "baz, qux" ]
+                synonyms_c:
+                  type: synonym_graph
+                  synonyms: [ "hello, world" ]
+              analyzer:
+                chained_syn:
+                  tokenizer: standard
+                  filter: [ lowercase, synonyms_a, synonyms_b, synonyms_c ]
+          mappings:
+            properties:
+              text:
+                type: text
+                analyzer: chained_syn
+
+  - do:
+      index:
+        index: test_chained_synonyms
+        id: "1"
+        body:
+          text: "foo baz hello"
+        refresh: true
+
+  # Test that all three chained synonym filters work correctly
+  - do:
+      search:
+        index: test_chained_synonyms
+        body:
+          query:
+            match:
+              text: "bar qux world"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "1" }
+
+  # Verify analyzer behavior - synonym_graph produces synonym first, then original
+  - do:
+      indices.analyze:
+        index: test_chained_synonyms
+        body:
+          text: "foo"
+          analyzer: chained_syn
+  - length: { tokens: 2 }
+  - match: { tokens.0.position: 0 }
+  - match: { tokens.1.position: 0 }
+
+  # Test with multi-word query to verify all chained filters work together
+  - do:
+      indices.analyze:
+        index: test_chained_synonyms
+        body:
+          text: "foo baz hello"
+          analyzer: chained_syn
+  # Each word that matches a synonym expands to 2 tokens: foo→(foo,bar), baz→(baz,qux), hello→(hello,world)
+  - length: { tokens: 6 }
+  # Verify positions: each synonym pair at same position
+  - match: { tokens.0.position: 0 }
+  - match: { tokens.1.position: 0 }
+  - match: { tokens.2.position: 1 }
+  - match: { tokens.3.position: 1 }
+  - match: { tokens.4.position: 2 }
+  - match: { tokens.5.position: 2 }
+  # Verify token content - synonym_graph produces synonym first, then original
+  - match: { tokens.0.token: "bar" }
+  - match: { tokens.1.token: "foo" }
+  - match: { tokens.2.token: "qux" }
+  - match: { tokens.3.token: "baz" }
+  - match: { tokens.4.token: "world" }
+  - match: { tokens.5.token: "hello" }
+
+  # Test that analyzer reload doesn't cause issues (critical for the fix)
+  - do:
+      indices.close:
+        index: test_chained_synonyms
+
+  - do:
+      indices.open:
+        index: test_chained_synonyms
+
+  # Verify it still works after reload
+  - do:
+      search:
+        index: test_chained_synonyms
+        body:
+          query:
+            match:
+              text: "bar qux world"
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "1" }


### PR DESCRIPTION
1. b36152d53e1054e5a732efe5a2991bd9e2fbb794: Add YAML REST tests that describe the current behavior when chaining synonym graph token filters (check no functional regression in the patch)
2. 589c712c9174d82e90b18cc216111129f062a9f7: Add unit tests for chained analyzer creation at scale (100 synonyms set each containing 10_000 rules).
3. 32d60e57c3ba6926ac53fdf65ec8bdc8e5ab2c14 Fix that prevent to apply preceding synonym filter when building the synonym token filter