### PR TITLE
ES|QL: fix null folding of nested COALESCE

### DIFF
--- a/docs/changelog/140028.yaml
+++ b/docs/changelog/140028.yaml
@@ -1,0 +1,5 @@
+pr: 140028
+summary: Fix null folding of nested COALESCE
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/eval.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/eval.csv-spec
@@ -834,7 +834,17 @@ foo       | 1         | 9
 
 foldCoalesce
 required_capability: fix_fold_coalesce
-ROW x = null|  EVAL append_coalesce = MV_APPEND("2", COALESCE(x, "1"))
+ROW x = null |  EVAL append_coalesce = MV_APPEND("2", COALESCE(x, "1"))
+;
+
+x:null | append_coalesce:keyword
+null   | [2, 1]
+;
+
+
+foldCoalesceLiteral
+required_capability: fix_fold_coalesce
+ROW x = null |  EVAL append_coalesce = MV_APPEND("2", COALESCE(null, "1"))
 ;
 
 x:null | append_coalesce:keyword

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/eval.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/eval.csv-spec
@@ -830,3 +830,13 @@ row x = 1
 a:keyword | z:integer | x:integer
 foo       | 1         | 9
 ;
+
+
+foldCoalesce
+required_capability: fix_fold_coalesce
+ROW x = null|  EVAL append_coalesce = MV_APPEND("2", COALESCE(x, "1"))
+;
+
+x:null | append_coalesce:keyword
+null   | [2, 1]
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1822,6 +1822,12 @@ public class EsqlCapabilities {
          */
         ENABLE_REDUCE_NODE_LATE_MATERIALIZATION(Build.current().isSnapshot()),
 
+        /**
+         * Fix folding of coalesce function
+         * https://github.com/elastic/elasticsearch/issues/139887
+         */
+        FIX_FOLD_COALESCE,
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/FoldNullTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/FoldNullTests.java
@@ -37,6 +37,7 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.math.Cos;
 import org.elasticsearch.xpack.esql.expression.function.scalar.math.Pow;
 import org.elasticsearch.xpack.esql.expression.function.scalar.math.Round;
 import org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.AbstractMultivalueFunction;
+import org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvAppend;
 import org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvAvg;
 import org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvCount;
 import org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvDedupe;
@@ -46,6 +47,7 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvMax;
 import org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvMedian;
 import org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvMin;
 import org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvSum;
+import org.elasticsearch.xpack.esql.expression.function.scalar.nulls.Coalesce;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.LTrim;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.Substring;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.regex.RLike;
@@ -271,6 +273,15 @@ public class FoldNullTests extends ESTestCase {
     public void testNullCategorizeGroupingNotFolded() {
         Categorize categorize = new Categorize(EMPTY, NULL, NULL);
         assertEquals(categorize, foldNull(categorize));
+    }
+
+    public void testNestedCoalesce() {
+        MvAppend append = new MvAppend(
+            EMPTY,
+            Literal.keyword(EMPTY, "foo"),
+            new Coalesce(EMPTY, NULL, List.of(Literal.keyword(EMPTY, "bar")))
+        );
+        assertEquals(append, foldNull(append));
     }
 
     private void assertNullLiteral(Expression expression) {


### PR DESCRIPTION
COALESCE can't be folded if one of the children is null, even if it's nested inside other expressions.
The same applies to all the functions that don't have `Nullability.TRUE` (eg. `Case` and `MvUnion`)

Fixes: https://github.com/elastic/elasticsearch/issues/139344