### PR TITLE
[9.3] ESQL: Fix extent reading when missing (#140034)

### DIFF
--- a/docs/changelog/140034.yaml
+++ b/docs/changelog/140034.yaml
@@ -1,0 +1,5 @@
+pr: 140034
+summary: Fix extent reading when missing
+area: ES|QL
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractShapeGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractShapeGeometryFieldMapper.java
@@ -82,7 +82,58 @@ public abstract class AbstractShapeGeometryFieldMapper<T> extends AbstractGeomet
                 this.fieldName = fieldName;
             }
 
-            protected void writeExtent(BlockLoader.IntBuilder builder, Extent extent) {
+            @Override
+            public BlockLoader.AllReader reader(LeafReaderContext context) throws IOException {
+                BinaryDocValues binaryDocValues = context.reader().getBinaryDocValues(fieldName);
+                return binaryDocValues == null ? new ConstantNullsReader() : new BoundsReader(binaryDocValues);
+            }
+
+            @Override
+            public BlockLoader.Builder builder(BlockLoader.BlockFactory factory, int expectedCount) {
+                return factory.ints(expectedCount);
+            }
+        }
+
+        private static class BoundsReader implements BlockLoader.AllReader {
+            private final GeometryDocValueReader reader = new GeometryDocValueReader();
+            private final BinaryDocValues binaryDocValues;
+
+            private BoundsReader(BinaryDocValues binaryDocValues) {
+                this.binaryDocValues = binaryDocValues;
+            }
+
+            @Override
+            public BlockLoader.Block read(BlockLoader.BlockFactory factory, BlockLoader.Docs docs, int offset, boolean nullsFiltered)
+                throws IOException {
+                try (var builder = factory.ints(docs.count() - offset)) {
+                    for (int i = offset; i < docs.count(); i++) {
+                        read(binaryDocValues, docs.get(i), builder);
+                    }
+                    return builder.build();
+                }
+            }
+
+            @Override
+            public void read(int docId, BlockLoader.StoredFields storedFields, BlockLoader.Builder builder) throws IOException {
+                read(binaryDocValues, docId, (org.elasticsearch.index.mapper.BlockLoader.IntBuilder) builder);
+            }
+
+            private void read(BinaryDocValues binaryDocValues, int doc, org.elasticsearch.index.mapper.BlockLoader.IntBuilder builder)
+                throws IOException {
+                if (binaryDocValues.advanceExact(doc) == false) {
+                    builder.appendNull();
+                    return;
+                }
+                reader.reset(binaryDocValues.binaryValue());
+                writeExtent(builder, reader.getExtent());
+            }
+
+            @Override
+            public boolean canReuse(int startingDocID) {
+                return true;
+            }
+
+            private void writeExtent(BlockLoader.IntBuilder builder, Extent extent) {
                 // We store the 6 values as a single multi-valued field, in the same order as the fields in the Extent class
                 builder.beginPositionEntry();
                 builder.appendInt(extent.top);
@@ -92,55 +143,6 @@ public abstract class AbstractShapeGeometryFieldMapper<T> extends AbstractGeomet
                 builder.appendInt(extent.posLeft);
                 builder.appendInt(extent.posRight);
                 builder.endPositionEntry();
-            }
-
-            @Override
-            public BlockLoader.AllReader reader(LeafReaderContext context) throws IOException {
-                return new BlockLoader.AllReader() {
-                    @Override
-                    public BlockLoader.Block read(
-                        BlockLoader.BlockFactory factory,
-                        BlockLoader.Docs docs,
-                        int offset,
-                        boolean nullsFiltered
-                    ) throws IOException {
-                        var binaryDocValues = context.reader().getBinaryDocValues(fieldName);
-                        var reader = new GeometryDocValueReader();
-                        try (var builder = factory.ints(docs.count() - offset)) {
-                            for (int i = offset; i < docs.count(); i++) {
-                                read(binaryDocValues, docs.get(i), reader, builder);
-                            }
-                            return builder.build();
-                        }
-                    }
-
-                    @Override
-                    public void read(int docId, BlockLoader.StoredFields storedFields, BlockLoader.Builder builder) throws IOException {
-                        var binaryDocValues = context.reader().getBinaryDocValues(fieldName);
-                        var reader = new GeometryDocValueReader();
-                        read(binaryDocValues, docId, reader, (IntBuilder) builder);
-                    }
-
-                    private void read(BinaryDocValues binaryDocValues, int doc, GeometryDocValueReader reader, IntBuilder builder)
-                        throws IOException {
-                        if (binaryDocValues.advanceExact(doc) == false) {
-                            builder.appendNull();
-                            return;
-                        }
-                        reader.reset(binaryDocValues.binaryValue());
-                        writeExtent(builder, reader.getExtent());
-                    }
-
-                    @Override
-                    public boolean canReuse(int startingDocID) {
-                        return true;
-                    }
-                };
-            }
-
-            @Override
-            public BlockLoader.Builder builder(BlockLoader.BlockFactory factory, int expectedCount) {
-                return factory.ints(expectedCount);
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/AbstractShapeGeometryFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/AbstractShapeGeometryFieldMapperTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.test.hamcrest.RectangleMatcher;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -39,6 +40,8 @@ import java.util.stream.IntStream;
 
 import static org.apache.lucene.geo.GeoEncodingUtils.decodeLongitude;
 import static org.elasticsearch.common.geo.Orientation.RIGHT;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 
 public class AbstractShapeGeometryFieldMapperTests extends ESTestCase {
     public void testCartesianBoundsBlockLoader() throws IOException {
@@ -61,6 +64,22 @@ public class AbstractShapeGeometryFieldMapperTests extends ESTestCase {
             g -> SpatialEnvelopeVisitor.visitGeo(g, SpatialEnvelopeVisitor.WrapLongitude.WRAP),
             AbstractShapeGeometryFieldMapperTests::makeGeoRectangle
         );
+    }
+
+    public void testCartesianBoundsNoData() throws IOException {
+        var loader = new AbstractShapeGeometryFieldMapper.AbstractShapeGeometryFieldType.BoundsBlockLoader("field");
+        try (Directory directory = newDirectory()) {
+            try (var iw = new IndexWriter(directory, new IndexWriterConfig(null /* analyzer */))) {
+                iw.addDocument(List.of());
+            }
+            try (DirectoryReader reader = DirectoryReader.open(directory)) {
+                LeafReader leaf = getOnlyLeafReader(reader);
+                try (var block = (TestBlock) loader.reader(leaf.getContext()).read(TestBlock.factory(), TestBlock.docs(0), 0, false)) {
+                    assertThat(block.size(), equalTo(1));
+                    assertThat(block.get(0), nullValue());
+                }
+            }
+        }
     }
 
     // TODO: Re-enable this test after fixing the bug in the SpatialEnvelopeVisitor regarding Rectangle crossing the dateline


### PR DESCRIPTION
Backports the following commits to 9.3:
 - ESQL: Fix extent reading when missing (#140034)