### PR TITLE
[9.3] Respect flexible field access pattern in geoip and ip_location processors (#138728)

### DIFF
--- a/docs/changelog/138728.yaml
+++ b/docs/changelog/138728.yaml
@@ -1,0 +1,5 @@
+pr: 138728
+summary: Respect flexible field access pattern in geoip and `ip_location` processors
+area: Ingest Node
+type: bug
+issues: []

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
@@ -33,6 +33,7 @@ import static org.elasticsearch.ingest.ConfigurationUtils.newConfigurationExcept
 import static org.elasticsearch.ingest.ConfigurationUtils.readBooleanProperty;
 import static org.elasticsearch.ingest.ConfigurationUtils.readOptionalList;
 import static org.elasticsearch.ingest.ConfigurationUtils.readStringProperty;
+import static org.elasticsearch.ingest.IngestPipelineFieldAccessPattern.FLEXIBLE;
 
 public final class GeoIpProcessor extends AbstractProcessor {
 
@@ -119,7 +120,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
             if (ip instanceof String ipString) {
                 Map<String, Object> data = ipDataLookup.getData(ipDatabase, ipString);
                 if (data.isEmpty() == false) {
-                    document.setFieldValue(targetField, data);
+                    writeGeoIpData(document, targetField, data);
                 }
             } else if (ip instanceof List<?> ipList) {
                 boolean match = false;
@@ -134,14 +135,14 @@ public final class GeoIpProcessor extends AbstractProcessor {
                         continue;
                     }
                     if (firstOnly) {
-                        document.setFieldValue(targetField, data);
+                        writeGeoIpData(document, targetField, data);
                         return document;
                     }
                     match = true;
                     dataList.add(data);
                 }
                 if (match) {
-                    document.setFieldValue(targetField, dataList);
+                    writeGeoIpDataList(document, targetField, dataList);
                 }
             } else {
                 throw new IllegalArgumentException("field [" + field + "] should contain only string or array of strings");
@@ -170,6 +171,107 @@ public final class GeoIpProcessor extends AbstractProcessor {
 
     Set<Property> getProperties() {
         return ipDataLookup.getProperties();
+    }
+
+    /**
+     * Writes GeoIP data to the document. In flexible field access mode, writes individual dotted fields
+     * (e.g., "my.field.city", "my.field.country") instead of a single nested object. The "location" field
+     * is written as an array [lon, lat] for better compatibility with geo_point fields in flexible mode.
+     *
+     * @param document the ingest document
+     * @param targetField the base target field path
+     * @param data the GeoIP data to write
+     */
+    private void writeGeoIpData(IngestDocument document, String targetField, Map<String, Object> data) {
+        if (document.getCurrentAccessPatternSafe() == FLEXIBLE) {
+            // In flexible mode, write each property as a separate dotted field
+            for (Map.Entry<String, Object> entry : data.entrySet()) {
+                String key = entry.getKey();
+                Object value = transformValueForFlexibleMode(key, entry.getValue());
+                document.setFieldValue(targetField + "." + key, value);
+            }
+        } else {
+            // In classic mode, write as a single nested object
+            document.setFieldValue(targetField, data);
+        }
+    }
+
+    /**
+     * Writes a list of GeoIP data to the document. In flexible field access mode, writes each property
+     * as a separate list (e.g., "my.field.city" contains a list of cities, one per IP).
+     * In classic mode, writes as a single list of maps.
+     *
+     * @param document the ingest document
+     * @param targetField the base target field path
+     * @param dataList the list of GeoIP data to write
+     */
+    private void writeGeoIpDataList(IngestDocument document, String targetField, List<Map<String, Object>> dataList) {
+        if (document.getCurrentAccessPatternSafe() == FLEXIBLE) {
+            // In flexible mode, transpose the list of maps into separate lists per property
+            // Collect all unique keys across all maps
+            Set<String> allKeys = new java.util.HashSet<>();
+            for (Map<String, Object> data : dataList) {
+                if (data != null) {
+                    allKeys.addAll(data.keySet());
+                }
+            }
+
+            // For each key, build a list of values
+            for (String key : allKeys) {
+                List<Object> valuesList = new ArrayList<>(dataList.size());
+                for (Map<String, Object> data : dataList) {
+                    if (data == null) {
+                        valuesList.add(null);
+                    } else {
+                        Object value = transformValueForFlexibleMode(key, data.get(key));
+                        valuesList.add(value);
+                    }
+                }
+                document.setFieldValue(targetField + "." + key, valuesList);
+            }
+        } else {
+            // In classic mode, write as a single list of maps
+            document.setFieldValue(targetField, dataList);
+        }
+    }
+
+    /**
+     * Transforms a GeoIP value for flexible field access mode.
+     * Converts location maps to [lon, lat] arrays and validates that only location fields contain Maps.
+     *
+     * @param key the property key
+     * @param value the property value
+     * @return the transformed value suitable for flexible mode
+     */
+    private static Object transformValueForFlexibleMode(String key, Object value) {
+        // Convert location from map {lat, lon} to array [lon, lat] in flexible mode
+        if ("location".equals(key) && value instanceof Map) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> locationMap = (Map<String, Object>) value;
+            Double lat = (Double) locationMap.get("lat");
+            Double lon = (Double) locationMap.get("lon");
+            return newMutableLocationList(lon, lat);
+        } else {
+            // Assert that we don't have any unexpected Map values (only location should be a Map)
+            assert value instanceof Map == false : "unexpected Map value for key [" + key + "]";
+        }
+        return value;
+    }
+
+    /**
+     * Creates a mutable list containing [lon, lat] coordinates.
+     * Using ArrayList instead of List.of() to allow users to modify the location field later
+     * with other processors (e.g., script processor).
+     *
+     * @param lon the longitude
+     * @param lat the latitude
+     * @return a mutable ArrayList containing [lon, lat]
+     */
+    private static List<Double> newMutableLocationList(double lon, double lat) {
+        List<Double> location = new ArrayList<>(2);
+        location.add(lon);
+        location.add(lat);
+        return location;
     }
 
     /**

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
@@ -28,12 +28,16 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.elasticsearch.ingest.IngestDocumentMatcher.assertIngestDocument;
+import static org.elasticsearch.ingest.IngestPipelineFieldAccessPattern.CLASSIC;
+import static org.elasticsearch.ingest.IngestPipelineFieldAccessPattern.FLEXIBLE;
+import static org.elasticsearch.ingest.IngestPipelineTestUtils.runWithAccessPattern;
 import static org.elasticsearch.ingest.geoip.GeoIpProcessor.GEOIP_TYPE;
 import static org.elasticsearch.ingest.geoip.GeoIpProcessor.IP_LOCATION_TYPE;
 import static org.elasticsearch.ingest.geoip.GeoIpTestUtils.copyDatabase;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -476,6 +480,16 @@ public class GeoIpProcessorTests extends ESTestCase {
         return MaxmindIpDataLookups.getMaxmindLookup(database).apply(database.properties());
     }
 
+    private static IpDataLookup getMaxmindAsnLookup() {
+        final var database = Database.Asn;
+        return MaxmindIpDataLookups.getMaxmindLookup(database).apply(database.properties());
+    }
+
+    private static IpDataLookup getMaxmindCountryLookup() {
+        final var database = Database.Country;
+        return MaxmindIpDataLookups.getMaxmindLookup(database).apply(database.properties());
+    }
+
     private static IpDataLookup getIpinfoGeolocationLookup() {
         final var database = Database.CityV2;
         return IpinfoIpDataLookups.getIpinfoLookup(database).apply(database.properties());
@@ -502,6 +516,446 @@ public class GeoIpProcessorTests extends ESTestCase {
                 super.doShutdown();
             }
         };
+    }
+
+    public void testMaxmindCityWithFlexibleFieldAccessMode() throws Exception {
+        String ip = "2602:306:33d3:8000::3257:9652";
+        GeoIpProcessor processor = new GeoIpProcessor(
+            GEOIP_TYPE,
+            randomAlphaOfLength(10),
+            null,
+            "source_field",
+            loader("GeoLite2-City.mmdb"),
+            () -> true,
+            "my.target",
+            getMaxmindCityLookup(),
+            false,
+            false,
+            "filename"
+        );
+
+        Map<String, Object> document = new HashMap<>();
+        document.put("source_field", ip);
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+
+        // Execute with flexible field access mode
+        ingestDocument = runWithAccessPattern(FLEXIBLE, ingestDocument, processor);
+
+        // Verify that individual dotted fields were created (check in source map directly)
+        Map<String, Object> sourceAndMetadata = ingestDocument.getSourceAndMetadata();
+        assertThat(sourceAndMetadata.containsKey("my.target.ip"), is(true));
+        assertThat(sourceAndMetadata.get("my.target.ip"), equalTo(ip));
+        assertThat(sourceAndMetadata.containsKey("my.target.city_name"), is(true));
+        assertThat(sourceAndMetadata.get("my.target.city_name"), equalTo("Homestead"));
+        assertThat(sourceAndMetadata.containsKey("my.target.country_name"), is(true));
+        assertThat(sourceAndMetadata.containsKey("my.target.country_iso_code"), is(true));
+        assertThat(sourceAndMetadata.containsKey("my.target.continent_name"), is(true));
+        assertThat(sourceAndMetadata.containsKey("my.target.region_name"), is(true));
+        assertThat(sourceAndMetadata.containsKey("my.target.region_iso_code"), is(true));
+
+        // Verify that location is written as an array [lon, lat] in flexible mode
+        assertThat(sourceAndMetadata.containsKey("my.target.location"), is(true));
+        Object location = sourceAndMetadata.get("my.target.location");
+        assertThat(location, instanceOf(List.class));
+        @SuppressWarnings("unchecked")
+        List<Double> locationArray = (List<Double>) location;
+        assertThat(locationArray.size(), equalTo(2));
+        assertThat(locationArray.get(0), equalTo(-80.4572)); // longitude
+        assertThat(locationArray.get(1), equalTo(25.4573)); // latitude
+
+        // Verify that the nested "my.target" object was NOT created
+        assertThat(sourceAndMetadata.containsKey("my.target"), is(false));
+    }
+
+    public void testMaxmindCityWithClassicFieldAccessMode() throws Exception {
+        String ip = "2602:306:33d3:8000::3257:9652";
+        GeoIpProcessor processor = new GeoIpProcessor(
+            GEOIP_TYPE,
+            randomAlphaOfLength(10),
+            null,
+            "source_field",
+            loader("GeoLite2-City.mmdb"),
+            () -> true,
+            "my.target",
+            getMaxmindCityLookup(),
+            false,
+            false,
+            "filename"
+        );
+
+        Map<String, Object> document = new HashMap<>();
+        document.put("source_field", ip);
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+
+        // Execute with classic field access mode (default)
+        ingestDocument = runWithAccessPattern(CLASSIC, ingestDocument, processor);
+
+        // Verify that a nested object was created (classic behavior)
+        assertThat(ingestDocument.hasField("my.target"), is(true));
+        Object target = ingestDocument.getFieldValue("my.target", Object.class);
+        assertThat(target, instanceOf(Map.class));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> data = (Map<String, Object>) target;
+        assertThat(data, notNullValue());
+        assertThat(data.get("ip"), equalTo(ip));
+        assertThat(data.get("city_name"), equalTo("Homestead"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> location = (Map<String, Object>) data.get("location");
+        assertThat(location, notNullValue());
+        assertThat(location, hasEntry("lat", 25.4573));
+        assertThat(location, hasEntry("lon", -80.4572));
+    }
+
+    public void testIpinfoGeolocationWithFlexibleFieldAccessMode() throws Exception {
+        String ip = "72.20.12.220";
+        GeoIpProcessor processor = new GeoIpProcessor(
+            IP_LOCATION_TYPE,
+            randomAlphaOfLength(10),
+            null,
+            "source_field",
+            loader("ipinfo/ip_geolocation_standard_sample.mmdb"),
+            () -> true,
+            "my.geo",
+            getIpinfoGeolocationLookup(),
+            false,
+            false,
+            "filename"
+        );
+
+        Map<String, Object> document = new HashMap<>();
+        document.put("source_field", ip);
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+
+        // Execute with flexible field access mode
+        ingestDocument = runWithAccessPattern(FLEXIBLE, ingestDocument, processor);
+
+        // Verify that individual dotted fields were created (check in source map directly)
+        Map<String, Object> sourceAndMetadata = ingestDocument.getSourceAndMetadata();
+        assertThat(sourceAndMetadata.containsKey("my.geo.ip"), is(true));
+        assertThat(sourceAndMetadata.get("my.geo.ip"), equalTo(ip));
+        assertThat(sourceAndMetadata.containsKey("my.geo.city_name"), is(true));
+        assertThat(sourceAndMetadata.get("my.geo.city_name"), equalTo("Chicago"));
+        assertThat(sourceAndMetadata.containsKey("my.geo.country_iso_code"), is(true));
+
+        // Verify that location is written as an array [lon, lat] in flexible mode
+        assertThat(sourceAndMetadata.containsKey("my.geo.location"), is(true));
+        Object location = sourceAndMetadata.get("my.geo.location");
+        assertThat(location, instanceOf(List.class));
+        @SuppressWarnings("unchecked")
+        List<Double> locationArray = (List<Double>) location;
+        assertThat(locationArray.size(), equalTo(2));
+        assertThat(locationArray.get(0), equalTo(-87.6285));
+        assertThat(locationArray.get(1), equalTo(41.8798));
+
+        // Verify that the nested "my.geo" object was NOT created
+        assertThat(sourceAndMetadata.containsKey("my.geo"), is(false));
+    }
+
+    public void testIpinfoGeolocationWithClassicFieldAccessMode() throws Exception {
+        String ip = "72.20.12.220";
+        GeoIpProcessor processor = new GeoIpProcessor(
+            IP_LOCATION_TYPE,
+            randomAlphaOfLength(10),
+            null,
+            "source_field",
+            loader("ipinfo/ip_geolocation_standard_sample.mmdb"),
+            () -> true,
+            "my.geo",
+            getIpinfoGeolocationLookup(),
+            false,
+            false,
+            "filename"
+        );
+
+        Map<String, Object> document = new HashMap<>();
+        document.put("source_field", ip);
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+
+        // Execute with classic field access mode
+        ingestDocument = runWithAccessPattern(CLASSIC, ingestDocument, processor);
+
+        // Verify that a nested object was created (classic behavior)
+        assertThat(ingestDocument.hasField("my.geo"), is(true));
+        Object target = ingestDocument.getFieldValue("my.geo", Object.class);
+        assertThat(target, instanceOf(Map.class));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> data = (Map<String, Object>) target;
+        assertThat(data, notNullValue());
+        assertThat(data.get("ip"), equalTo(ip));
+        assertThat(data.get("city_name"), equalTo("Chicago"));
+    }
+
+    public void testArrayWithFlexibleFieldAccessModeFirstOnly() throws Exception {
+        String ip1 = "2602:306:33d3:8000::3257:9652";
+        String ip2 = "82.170.213.79";
+        GeoIpProcessor processor = new GeoIpProcessor(
+            GEOIP_TYPE,
+            randomAlphaOfLength(10),
+            null,
+            "source_field",
+            loader("GeoLite2-City.mmdb"),
+            () -> true,
+            "my.target",
+            getMaxmindCityLookup(),
+            false,
+            true, // first_only = true
+            "filename"
+        );
+
+        Map<String, Object> document = new HashMap<>();
+        document.put("source_field", List.of(ip1, ip2));
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+
+        // Execute with flexible field access mode
+        ingestDocument = runWithAccessPattern(FLEXIBLE, ingestDocument, processor);
+
+        // Verify that individual dotted fields were created for the first IP only (check in source map directly)
+        Map<String, Object> sourceAndMetadata = ingestDocument.getSourceAndMetadata();
+        assertThat(sourceAndMetadata.containsKey("my.target.ip"), is(true));
+        assertThat(sourceAndMetadata.get("my.target.ip"), equalTo(ip1));
+        assertThat(sourceAndMetadata.containsKey("my.target.city_name"), is(true));
+        assertThat(sourceAndMetadata.get("my.target.city_name"), equalTo("Homestead"));
+    }
+
+    public void testIpLocationAsnWithFlexibleFieldAccessMode() throws Exception {
+        String ip = "82.171.64.0";
+        GeoIpProcessor processor = new GeoIpProcessor(
+            IP_LOCATION_TYPE,
+            randomAlphaOfLength(10),
+            null,
+            "source_field",
+            loader("GeoLite2-ASN.mmdb"),
+            () -> true,
+            "ip.asn",
+            getMaxmindAsnLookup(),
+            false,
+            false,
+            "filename"
+        );
+
+        Map<String, Object> document = new HashMap<>();
+        document.put("source_field", ip);
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+
+        // Execute with flexible field access mode
+        ingestDocument = runWithAccessPattern(FLEXIBLE, ingestDocument, processor);
+
+        // Verify that individual dotted fields were created (check in source map directly)
+        Map<String, Object> sourceAndMetadata = ingestDocument.getSourceAndMetadata();
+        assertThat(sourceAndMetadata.containsKey("ip.asn.ip"), is(true));
+        assertThat(sourceAndMetadata.get("ip.asn.ip"), equalTo(ip));
+        assertThat(sourceAndMetadata.containsKey("ip.asn.asn"), is(true));
+        assertThat(sourceAndMetadata.containsKey("ip.asn.organization_name"), is(true));
+        assertThat(sourceAndMetadata.containsKey("ip.asn.network"), is(true));
+
+        // Verify that the nested "ip.asn" object was NOT created
+        assertThat(sourceAndMetadata.containsKey("ip.asn"), is(false));
+    }
+
+    public void testIpLocationCountryWithFlexibleFieldAccessMode() throws Exception {
+        String ip = "82.170.213.79";
+        GeoIpProcessor processor = new GeoIpProcessor(
+            IP_LOCATION_TYPE,
+            randomAlphaOfLength(10),
+            null,
+            "ip_address",
+            loader("GeoLite2-Country.mmdb"),
+            () -> true,
+            "geo.country",
+            getMaxmindCountryLookup(),
+            false,
+            false,
+            "filename"
+        );
+
+        Map<String, Object> document = new HashMap<>();
+        document.put("ip_address", ip);
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+
+        // Execute with flexible field access mode
+        ingestDocument = runWithAccessPattern(FLEXIBLE, ingestDocument, processor);
+
+        // Verify that individual dotted fields were created (check in source map directly)
+        Map<String, Object> sourceAndMetadata = ingestDocument.getSourceAndMetadata();
+        assertThat(sourceAndMetadata.containsKey("geo.country.ip"), is(true));
+        assertThat(sourceAndMetadata.get("geo.country.ip"), equalTo(ip));
+        assertThat(sourceAndMetadata.containsKey("geo.country.country_iso_code"), is(true));
+        assertThat(sourceAndMetadata.get("geo.country.country_iso_code"), equalTo("NL"));
+        assertThat(sourceAndMetadata.containsKey("geo.country.country_name"), is(true));
+        assertThat(sourceAndMetadata.get("geo.country.country_name"), equalTo("Netherlands"));
+        assertThat(sourceAndMetadata.containsKey("geo.country.continent_name"), is(true));
+        assertThat(sourceAndMetadata.get("geo.country.continent_name"), equalTo("Europe"));
+
+        // Verify that the nested "geo.country" object was NOT created
+        assertThat(sourceAndMetadata.containsKey("geo.country"), is(false));
+    }
+
+    public void testBothProcessorTypesWithFlexibleMode() throws Exception {
+        // Test that both geoip and ip_location processors work correctly with flexible mode
+        String ip = "2602:306:33d3:8000::3257:9652";
+
+        // Test with GEOIP_TYPE
+        GeoIpProcessor geoipProcessor = new GeoIpProcessor(
+            GEOIP_TYPE,
+            randomAlphaOfLength(10),
+            null,
+            "ip",
+            loader("GeoLite2-City.mmdb"),
+            () -> true,
+            "geoip.result",
+            getMaxmindCityLookup(),
+            false,
+            false,
+            "filename"
+        );
+
+        Map<String, Object> document = new HashMap<>();
+        document.put("ip", ip);
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+        ingestDocument = runWithAccessPattern(FLEXIBLE, ingestDocument, geoipProcessor);
+
+        // Verify geoip processor created dotted fields (check in source map directly)
+        Map<String, Object> sourceAndMetadata = ingestDocument.getSourceAndMetadata();
+        assertThat(sourceAndMetadata.containsKey("geoip.result.city_name"), is(true));
+        assertThat(sourceAndMetadata.get("geoip.result.city_name"), equalTo("Homestead"));
+        assertThat(sourceAndMetadata.containsKey("geoip.result.location"), is(true));
+        assertThat(sourceAndMetadata.containsKey("geoip.result"), is(false));
+
+        // Test with IP_LOCATION_TYPE
+        GeoIpProcessor ipLocationProcessor = new GeoIpProcessor(
+            IP_LOCATION_TYPE,
+            randomAlphaOfLength(10),
+            null,
+            "ip",
+            loader("GeoLite2-City.mmdb"),
+            () -> true,
+            "ip_location.result",
+            getMaxmindCityLookup(),
+            false,
+            false,
+            "filename"
+        );
+
+        document = new HashMap<>();
+        document.put("ip", ip);
+        ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+        ingestDocument = runWithAccessPattern(FLEXIBLE, ingestDocument, ipLocationProcessor);
+
+        // Verify ip_location processor created dotted fields (check in source map directly)
+        sourceAndMetadata = ingestDocument.getSourceAndMetadata();
+        assertThat(sourceAndMetadata.containsKey("ip_location.result.city_name"), is(true));
+        assertThat(sourceAndMetadata.get("ip_location.result.city_name"), equalTo("Homestead"));
+        assertThat(sourceAndMetadata.containsKey("ip_location.result.location"), is(true));
+        assertThat(sourceAndMetadata.containsKey("ip_location.result"), is(false));
+    }
+
+    public void testListWithFlexibleFieldAccessMode() throws Exception {
+        GeoIpProcessor processor = new GeoIpProcessor(
+            GEOIP_TYPE,
+            randomAlphaOfLength(10),
+            null,
+            "source_field",
+            loader("GeoLite2-City.mmdb"),
+            () -> true,
+            "my.target",
+            getMaxmindCityLookup(),
+            false,
+            false,
+            "filename"
+        );
+
+        Map<String, Object> document = new HashMap<>();
+        document.put("source_field", List.of("8.8.8.8", "82.171.64.0"));
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+
+        // Execute with flexible field access mode
+        ingestDocument = runWithAccessPattern(FLEXIBLE, ingestDocument, processor);
+
+        // Verify that individual dotted fields contain lists (one value per IP)
+        Map<String, Object> sourceAndMetadata = ingestDocument.getSourceAndMetadata();
+
+        // Check that location is a list of arrays
+        assertThat(sourceAndMetadata.containsKey("my.target.location"), is(true));
+        Object location = sourceAndMetadata.get("my.target.location");
+        assertThat(location, instanceOf(List.class));
+        @SuppressWarnings("unchecked")
+        List<List<Double>> locationList = (List<List<Double>>) location;
+        assertThat(locationList.size(), equalTo(2));
+        // First IP: 8.8.8.8
+        assertThat(locationList.get(0).get(0), equalTo(-97.822d)); // longitude
+        assertThat(locationList.get(0).get(1), equalTo(37.751d)); // latitude
+        // Second IP: 82.171.64.0
+        assertThat(locationList.get(1).get(0), equalTo(5.9345d)); // longitude
+        assertThat(locationList.get(1).get(1), equalTo(50.9118d)); // latitude
+
+        // Check that city_name is a list of strings
+        assertThat(sourceAndMetadata.containsKey("my.target.city_name"), is(true));
+        Object cityName = sourceAndMetadata.get("my.target.city_name");
+        assertThat(cityName, instanceOf(List.class));
+        @SuppressWarnings("unchecked")
+        List<String> cityNameList = (List<String>) cityName;
+        assertThat(cityNameList.size(), equalTo(2));
+        assertThat(cityNameList.get(1), equalTo("Hoensbroek"));
+
+        // Check that ip is a list of strings
+        assertThat(sourceAndMetadata.containsKey("my.target.ip"), is(true));
+        Object ip = sourceAndMetadata.get("my.target.ip");
+        assertThat(ip, instanceOf(List.class));
+        @SuppressWarnings("unchecked")
+        List<String> ipList = (List<String>) ip;
+        assertThat(ipList.size(), equalTo(2));
+        assertThat(ipList.get(0), equalTo("8.8.8.8"));
+        assertThat(ipList.get(1), equalTo("82.171.64.0"));
+
+        // Verify that the nested "my.target" object was NOT created
+        assertThat(sourceAndMetadata.containsKey("my.target"), is(false));
+    }
+
+    public void testListPartiallyValidWithFlexibleFieldAccessMode() throws Exception {
+        GeoIpProcessor processor = new GeoIpProcessor(
+            GEOIP_TYPE,
+            randomAlphaOfLength(10),
+            null,
+            "source_field",
+            loader("GeoLite2-City.mmdb"),
+            () -> true,
+            "my.target",
+            getMaxmindCityLookup(),
+            false,
+            false,
+            "filename"
+        );
+
+        Map<String, Object> document = new HashMap<>();
+        document.put("source_field", List.of("8.8.8.8", "127.0.0.1"));
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+
+        // Execute with flexible field access mode
+        ingestDocument = runWithAccessPattern(FLEXIBLE, ingestDocument, processor);
+
+        // Verify that individual dotted fields contain lists with nulls for non-matching IPs
+        Map<String, Object> sourceAndMetadata = ingestDocument.getSourceAndMetadata();
+
+        // Check that location is a list with one valid location and one null
+        assertThat(sourceAndMetadata.containsKey("my.target.location"), is(true));
+        Object location = sourceAndMetadata.get("my.target.location");
+        assertThat(location, instanceOf(List.class));
+        @SuppressWarnings("unchecked")
+        List<Object> locationList = (List<Object>) location;
+        assertThat(locationList.size(), equalTo(2));
+        assertThat(locationList.get(0), instanceOf(List.class)); // First IP has location
+        assertThat(locationList.get(1), nullValue()); // Second IP (127.0.0.1) has no location data
+
+        // Check that ip list has the successful IP and null for the failed one
+        assertThat(sourceAndMetadata.containsKey("my.target.ip"), is(true));
+        Object ip = sourceAndMetadata.get("my.target.ip");
+        assertThat(ip, instanceOf(List.class));
+        @SuppressWarnings("unchecked")
+        List<String> ipList = (List<String>) ip;
+        assertThat(ipList.size(), equalTo(2));
+        assertThat(ipList.get(0), equalTo("8.8.8.8"));
+        assertThat(ipList.get(1), nullValue()); // 127.0.0.1 has no GeoIP data, so this is null
     }
 
 }

--- a/modules/ingest-geoip/src/yamlRestTest/resources/rest-api-spec/test/ingest_geoip/20_geoip_processor.yml
+++ b/modules/ingest-geoip/src/yamlRestTest/resources/rest-api-spec/test/ingest_geoip/20_geoip_processor.yml
@@ -345,3 +345,287 @@
         }
 - length: { docs: 1 }
 - match: { docs.0.doc._source.source.geo.city_name: "Linköping" }
+
+---
+"Test geoip processor with flexible field access mode":
+  - skip:
+      features: [ "flexible_field_access_pattern" ]
+      reason: "Flexible field access pattern support required"
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline_flexible"
+        body:  >
+          {
+            "description": "Test flexible field access mode with dotted target field",
+            "field_access_pattern": "flexible",
+            "processors": [
+              {
+                "geoip" : {
+                  "field" : "ip",
+                  "target_field" : "geo.location_data"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+  - do:
+      index:
+        index: test
+        id: "1"
+        pipeline: "my_pipeline_flexible"
+        body: {ip: "89.160.20.128"}
+  - do:
+      get:
+        index: test
+        id: "1"
+  - match: { _source.ip: "89.160.20.128" }
+  # In flexible mode, fields are written as dotted keys, not nested objects
+  - match: { _source.geo\.location_data\.city_name: "Linköping" }
+  - match: { _source.geo\.location_data\.country_iso_code: "SE" }
+  - match: { _source.geo\.location_data\.country_name: "Sweden" }
+  - match: { _source.geo\.location_data\.continent_name: "Europe" }
+  - match: { _source.geo\.location_data\.region_iso_code: "SE-E" }
+  - match: { _source.geo\.location_data\.region_name: "Östergötland County" }
+  # Location should be written as an array [lon, lat] in flexible mode
+  - match: { _source.geo\.location_data\.location.0: 15.6167 }
+  - match: { _source.geo\.location_data\.location.1: 58.4167 }
+  # Verify that nested object was NOT created
+  - is_false: _source.geo
+---
+"Test geoip processor flexible mode with ASN database":
+  - skip:
+      features: [ "flexible_field_access_pattern" ]
+
+      reason: "Flexible field access pattern support required"
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline_flexible_asn"
+        body:  >
+          {
+            "description": "Test flexible mode with ASN database",
+            "field_access_pattern": "flexible",
+            "processors": [
+              {
+                "geoip" : {
+                  "field" : "source_ip",
+                  "target_field" : "network.asn_info",
+                  "database_file" : "GeoLite2-ASN.mmdb"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+  - do:
+      index:
+        index: test
+        id: "1"
+        pipeline: "my_pipeline_flexible_asn"
+        body: {source_ip: "89.160.20.128"}
+  - do:
+      get:
+        index: test
+        id: "1"
+  - match: { _source.source_ip: "89.160.20.128" }
+  # In flexible mode, ASN fields are written as dotted keys
+  - match: { _source.network\.asn_info\.ip: "89.160.20.128" }
+  - match: { _source.network\.asn_info\.asn: 29518 }
+  - match: { _source.network\.asn_info\.organization_name: "Bredband2 AB" }
+  - match: { _source.network\.asn_info\.network: "89.160.0.0/17" }
+  # Verify that nested object was NOT created
+  - is_false: _source.network
+---
+"Test geoip processor flexible mode with first_only":
+  - skip:
+
+      features: [ "flexible_field_access_pattern" ]
+      reason: "Flexible field access pattern support required"
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline_flexible_first"
+        body:  >
+          {
+            "description": "Test flexible mode with array and first_only",
+            "field_access_pattern": "flexible",
+            "processors": [
+              {
+                "geoip" : {
+                  "field" : "ips",
+                  "target_field" : "geo.data",
+                  "first_only" : true
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+  - do:
+      index:
+        index: test
+        id: "1"
+        pipeline: "my_pipeline_flexible_first"
+        body: {ips: ["127.0.0.1", "89.160.20.128"]}
+  - do:
+      get:
+        index: test
+        id: "1"
+  - match: { _source.ips.0: "127.0.0.1" }
+  - match: { _source.ips.1: "89.160.20.128" }
+  # Only the first valid IP should be processed
+  - match: { _source.geo\.data\.city_name: "Linköping" }
+  - match: { _source.geo\.data\.country_iso_code: "SE" }
+  - match: { _source.geo\.data\.location.0: 15.6167 }
+  - match: { _source.geo\.data\.location.1: 58.4167 }
+---
+"Test geoip processor classic mode vs flexible mode comparison":
+  - skip:
+
+      features: [ "flexible_field_access_pattern" ]
+      reason: "Flexible field access pattern support required"
+  - do:
+      ingest.put_pipeline:
+        id: "classic_pipeline"
+        body:  >
+          {
+            "description": "Classic mode creates nested objects",
+            "processors": [
+              {
+                "geoip" : {
+                  "field" : "ip",
+                  "target_field" : "geo.info"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+  - do:
+      ingest.put_pipeline:
+        id: "flexible_pipeline"
+        body:  >
+          {
+            "description": "Flexible mode creates dotted fields",
+            "field_access_pattern": "flexible",
+            "processors": [
+              {
+                "geoip" : {
+                  "field" : "ip",
+                  "target_field" : "geo.info"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+  - do:
+      index:
+        index: test
+        id: "classic"
+        pipeline: "classic_pipeline"
+        body: {ip: "89.160.20.128"}
+  - do:
+      index:
+        index: test
+        id: "flexible"
+        pipeline: "flexible_pipeline"
+        body: {ip: "89.160.20.128"}
+  - do:
+      get:
+        index: test
+        id: "classic"
+  # Classic mode creates nested objects
+  - match: { _source.geo.info.city_name: "Linköping" }
+  - match: { _source.geo.info.location.lon: 15.6167 }
+  - do:
+      get:
+        index: test
+        id: "flexible"
+  # Flexible mode creates dotted fields
+  - match: { _source.geo\.info\.city_name: "Linköping" }
+  - match: { _source.geo\.info\.location.0: 15.6167 }
+  - is_false: _source.geo
+---
+"Test geoip processor flexible mode with array of IPs":
+  - skip:
+
+      features: [ "flexible_field_access_pattern" ]
+      reason: "Flexible field access pattern support required"
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline_flexible_array"
+        body:  >
+          {
+            "description": "Test flexible mode with array of IPs",
+            "field_access_pattern": "flexible",
+            "processors": [
+              {
+                "geoip" : {
+                  "field" : "ips",
+                  "target_field" : "geo.data",
+                  "first_only" : false
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+  - do:
+      index:
+        index: test
+        id: "1"
+        pipeline: "my_pipeline_flexible_array"
+        body: {ips: ["8.8.8.8", "82.171.64.0"]}
+  - do:
+      get:
+        index: test
+        id: "1"
+  - match: { _source.ips.0: "8.8.8.8" }
+  - match: { _source.ips.1: "82.171.64.0" }
+  # In flexible mode with arrays, each property becomes a list
+  - match: { _source.geo\.data\.ip.0: "8.8.8.8" }
+  - match: { _source.geo\.data\.ip.1: "82.171.64.0" }
+  - match: { _source.geo\.data\.city_name.1: "Hoensbroek" }
+  # Location should be a list of arrays [[lon1, lat1], [lon2, lat2]]
+  - match: { _source.geo\.data\.location.0.0: -97.822 }
+  - match: { _source.geo\.data\.location.0.1: 37.751 }
+  - match: { _source.geo\.data\.location.1.0: 5.9345 }
+  - match: { _source.geo\.data\.location.1.1: 50.9118 }
+  # Verify that nested object was NOT created
+  - is_false: _source.geo
+---
+"Test geoip processor flexible mode with partially valid array":
+  - skip:
+
+      features: [ "flexible_field_access_pattern" ]
+      reason: "Flexible field access pattern support required"
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline_flexible_partial"
+        body:  >
+          {
+            "description": "Test flexible mode with partially valid array",
+            "field_access_pattern": "flexible",
+            "processors": [
+              {
+                "geoip" : {
+                  "field" : "ips",
+                  "target_field" : "geo.data",
+                  "first_only" : false
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+  - do:
+      index:
+        index: test
+        id: "1"
+        pipeline: "my_pipeline_flexible_partial"
+        body: {ips: ["8.8.8.8", "127.0.0.1"]}
+  - do:
+      get:
+        index: test
+        id: "1"
+  - match: { _source.ips.0: "8.8.8.8" }
+  - match: { _source.ips.1: "127.0.0.1" }
+  # In flexible mode with arrays, each property becomes a list with nulls for failed lookups
+  - match: { _source.geo\.data\.ip.0: "8.8.8.8" }
+  - match: { _source.geo\.data\.ip.1: null }
+  - match: { _source.geo\.data\.location.1: null }
+  # Verify that nested object was NOT created
+  - is_false: _source.geo

--- a/modules/ingest-geoip/src/yamlRestTest/resources/rest-api-spec/test/ingest_geoip/50_ip_lookup_processor.yml
+++ b/modules/ingest-geoip/src/yamlRestTest/resources/rest-api-spec/test/ingest_geoip/50_ip_lookup_processor.yml
@@ -74,3 +74,198 @@
   - match: { _source.ip_location.asn: 57344 }
   - match: { _source.ip_location.ip: "5.104.168.0" }
   - match: { _source.ip_location.network: "5.104.168.0/23" }
+
+---
+"Test ip_location processor with flexible field access mode":
+  - skip:
+      features: [ "flexible_field_access_pattern" ]
+      reason: "Flexible field access pattern support required"
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline_flexible"
+        body:  >
+          {
+            "description": "Test flexible field access mode with dotted target field",
+            "field_access_pattern": "flexible",
+            "processors": [
+              {
+                "ip_location" : {
+                  "field" : "ip",
+                  "target_field" : "geo.location_data"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+  - do:
+      index:
+        index: test
+        id: "1"
+        pipeline: "my_pipeline_flexible"
+        body: {ip: "89.160.20.128"}
+  - do:
+      get:
+        index: test
+        id: "1"
+  - match: { _source.ip: "89.160.20.128" }
+  # In flexible mode, fields are written as dotted keys, not nested objects
+  - match: { _source.geo\.location_data\.city_name: "Linköping" }
+  - match: { _source.geo\.location_data\.country_iso_code: "SE" }
+  - match: { _source.geo\.location_data\.country_name: "Sweden" }
+  - match: { _source.geo\.location_data\.continent_name: "Europe" }
+  - match: { _source.geo\.location_data\.region_iso_code: "SE-E" }
+  - match: { _source.geo\.location_data\.region_name: "Östergötland County" }
+  # Location should be written as an array [lon, lat] in flexible mode
+  - match: { _source.geo\.location_data\.location.0: 15.6167 }
+  - match: { _source.geo\.location_data\.location.1: 58.4167 }
+  # Verify that nested object was NOT created
+  - is_false: _source.geo
+---
+"Test ip_location processor flexible mode with ASN database":
+  - skip:
+      features: [ "flexible_field_access_pattern" ]
+
+      reason: "Flexible field access pattern support required"
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline_flexible_asn"
+        body:  >
+          {
+            "description": "Test flexible mode with ASN database",
+            "field_access_pattern": "flexible",
+            "processors": [
+              {
+                "ip_location" : {
+                  "field" : "source_ip",
+                  "target_field" : "network.asn_info",
+                  "database_file" : "asn.mmdb"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+  - do:
+      index:
+        index: test
+        id: "1"
+        pipeline: "my_pipeline_flexible_asn"
+        body: {source_ip: "5.104.168.0"}
+  - do:
+      get:
+        index: test
+        id: "1"
+  - match: { _source.source_ip: "5.104.168.0" }
+  # In flexible mode, ASN fields are written as dotted keys
+  - match: { _source.network\.asn_info\.ip: "5.104.168.0" }
+  - match: { _source.network\.asn_info\.asn: 57344 }
+  - match: { _source.network\.asn_info\.organization_name: "Telehouse EAD" }
+  - match: { _source.network\.asn_info\.network: "5.104.168.0/23" }
+  # Verify that nested object was NOT created
+  - is_false: _source.network
+---
+"Test ip_location processor flexible mode with first_only":
+  - skip:
+
+      features: [ "flexible_field_access_pattern" ]
+      reason: "Flexible field access pattern support required"
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline_flexible_first"
+        body:  >
+          {
+            "description": "Test flexible mode with array and first_only",
+            "field_access_pattern": "flexible",
+            "processors": [
+              {
+                "ip_location" : {
+                  "field" : "ips",
+                  "target_field" : "geo.data",
+                  "first_only" : true
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+  - do:
+      index:
+        index: test
+        id: "1"
+        pipeline: "my_pipeline_flexible_first"
+        body: {ips: ["127.0.0.1", "89.160.20.128"]}
+  - do:
+      get:
+        index: test
+        id: "1"
+  - match: { _source.ips.0: "127.0.0.1" }
+  - match: { _source.ips.1: "89.160.20.128" }
+  # Only the first valid IP should be processed
+  - match: { _source.geo\.data\.city_name: "Linköping" }
+  - match: { _source.geo\.data\.country_iso_code: "SE" }
+  - match: { _source.geo\.data\.location.0: 15.6167 }
+  - match: { _source.geo\.data\.location.1: 58.4167 }
+---
+"Test ip_location processor classic mode vs flexible mode comparison":
+  - skip:
+
+      features: [ "flexible_field_access_pattern" ]
+      reason: "Flexible field access pattern support required"
+  - do:
+      ingest.put_pipeline:
+        id: "classic_pipeline"
+        body:  >
+          {
+            "description": "Classic mode creates nested objects",
+            "processors": [
+              {
+                "ip_location" : {
+                  "field" : "ip",
+                  "target_field" : "geo.info"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+  - do:
+      ingest.put_pipeline:
+        id: "flexible_pipeline"
+        body:  >
+          {
+            "description": "Flexible mode creates dotted fields",
+            "field_access_pattern": "flexible",
+            "processors": [
+              {
+                "ip_location" : {
+                  "field" : "ip",
+                  "target_field" : "geo.info"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+  - do:
+      index:
+        index: test
+        id: "classic"
+        pipeline: "classic_pipeline"
+        body: {ip: "89.160.20.128"}
+  - do:
+      index:
+        index: test
+        id: "flexible"
+        pipeline: "flexible_pipeline"
+        body: {ip: "89.160.20.128"}
+  - do:
+      get:
+        index: test
+        id: "classic"
+  # Classic mode creates nested objects
+  - match: { _source.geo.info.city_name: "Linköping" }
+  - match: { _source.geo.info.location.lon: 15.6167 }
+  - do:
+      get:
+        index: test
+        id: "flexible"
+  # Flexible mode creates dotted fields
+  - match: { _source.geo\.info\.city_name: "Linköping" }
+  - match: { _source.geo\.info\.location.0: 15.6167 }
+  - is_false: _source.geo


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Respect flexible field access pattern in geoip and ip_location processors (#138728)