### PR TITLE
Add hdfs-fixture port placeholder

### DIFF
--- a/test/fixtures/hdfs-fixture/src/main/java/org/elasticsearch/test/fixtures/hdfs/HdfsFixture.java
+++ b/test/fixtures/hdfs-fixture/src/main/java/org/elasticsearch/test/fixtures/hdfs/HdfsFixture.java
@@ -507,9 +507,7 @@ public class HdfsFixture extends ExternalResource {
 
     private static ServerSocket portPlaceholder() {
         try {
-            final var socket = new ServerSocket(0);
-            socket.setReuseAddress(true);
-            return socket;
+            return new ServerSocket(0);
         } catch (Exception ex) {
             LOGGER.error("Failed to find available port", ex);
             throw new RuntimeException(ex);


### PR DESCRIPTION
There is a substantial time gap between finding free port and binding it in HDFS fixture, that can lead to `java.net.BindException: Address already in use`. This PR binds free port until HDFS fixture is ready to start. https://gradle-enterprise.elastic.co/s/inqfl34rgjszo/failures#1