### PR TITLE
[9.3] Fix CrossClusterQueryWithPartialResultsIT (#140044)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -268,9 +268,6 @@ tests:
 - class: org.elasticsearch.gradle.TestClustersPluginFuncTest
   method: override jdk usage via ES_JAVA_HOME for known jdk os incompatibilities
   issue: https://github.com/elastic/elasticsearch/issues/135413
-- class: org.elasticsearch.xpack.esql.action.CrossClusterQueryWithPartialResultsIT
-  method: testOneRemoteClusterPartial
-  issue: https://github.com/elastic/elasticsearch/issues/124055
 - class: org.elasticsearch.xpack.security.authz.microsoft.MicrosoftGraphAuthzPluginIT
   method: testConcurrentAuthentication
   issue: https://github.com/elastic/elasticsearch/issues/135777

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterQueryWithPartialResultsIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterQueryWithPartialResultsIT.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.esql.EsqlTestUtils;
 import org.elasticsearch.xpack.esql.plugin.ComputeService;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -117,7 +118,11 @@ public class CrossClusterQueryWithPartialResultsIT extends AbstractCrossClusterT
         request.query("FROM ok*,fail*,*:ok*,*:fail* | KEEP id, fail_me | LIMIT 1000");
         request.includeCCSMetadata(randomBoolean());
         request.allowPartialResults(true);
+        // Limit to one shard per batch to prevent all ok shards from being grouped with failed shards,
+        // which could cause the ok shards to fail if a failed shard is processed first.
+        request.pragmas(new QueryPragmas(Settings.builder().put(QueryPragmas.MAX_CONCURRENT_SHARDS_PER_NODE.getKey(), 1).build()));
         try (var resp = runQuery(request)) {
+            logger.info("--> response {}", resp);
             assertTrue(resp.isPartial());
             Set<String> allIds = Stream.of(local.okIds, remote1.okIds, remote2.okIds)
                 .flatMap(Collection::stream)
@@ -148,7 +153,11 @@ public class CrossClusterQueryWithPartialResultsIT extends AbstractCrossClusterT
         request.query("FROM ok*,cluster-a:ok*,*-b:fail* | KEEP id, fail_me");
         request.allowPartialResults(true);
         request.includeCCSMetadata(randomBoolean());
+        // Limit to one shard per batch to prevent all ok shards from being grouped with failed shards,
+        // which could cause the ok shards to fail if a failed shard is processed first.
+        request.pragmas(new QueryPragmas(Settings.builder().put(QueryPragmas.MAX_CONCURRENT_SHARDS_PER_NODE.getKey(), 1).build()));
         try (var resp = runQuery(request)) {
+            logger.info("--> response {}", resp);
             assertTrue(resp.isPartial());
             Set<String> allIds = Stream.of(local.okIds, remote1.okIds).flatMap(Collection::stream).collect(Collectors.toSet());
             List<List<Object>> rows = getValuesList(resp);
@@ -160,7 +169,6 @@ public class CrossClusterQueryWithPartialResultsIT extends AbstractCrossClusterT
                 assertTrue(returnedIds.add(id));
             }
             assertThat(returnedIds, equalTo(allIds));
-
             assertClusterSuccess(resp, LOCAL_CLUSTER, local.okShards);
             assertClusterSuccess(resp, REMOTE_CLUSTER_1, remote1.okShards);
             assertClusterPartial(resp, REMOTE_CLUSTER_2, remote2.failingShards, 0);


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Fix CrossClusterQueryWithPartialResultsIT (#140044)