### PR TITLE
[9.2] Fix CrossClusterQueryWithPartialResultsIT (#140044)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -342,9 +342,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.InferenceIT
   method: testInferClassificationModel
   issue: https://github.com/elastic/elasticsearch/issues/133448
-- class: org.elasticsearch.xpack.esql.action.CrossClusterQueryWithPartialResultsIT
-  method: testPartialResults
-  issue: https://github.com/elastic/elasticsearch/issues/131481
 - class: org.elasticsearch.xpack.ml.integration.ClassificationIT
   method: testWithCustomFeatureProcessors
   issue: https://github.com/elastic/elasticsearch/issues/134001

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterQueryWithPartialResultsIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterQueryWithPartialResultsIT.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.esql.EsqlTestUtils;
 import org.elasticsearch.xpack.esql.plugin.ComputeService;
+import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -114,7 +115,11 @@ public class CrossClusterQueryWithPartialResultsIT extends AbstractCrossClusterT
             assertThat(error.getMessage(), containsString("Accessing failing field"));
         }
         request.allowPartialResults(true);
+        // Limit to one shard per batch to prevent all ok shards from being grouped with failed shards,
+        // which could cause the ok shards to fail if a failed shard is processed first.
+        request.pragmas(new QueryPragmas(Settings.builder().put(QueryPragmas.MAX_CONCURRENT_SHARDS_PER_NODE.getKey(), 1).build()));
         try (var resp = runQuery(request)) {
+            logger.info("--> response {}", resp);
             assertTrue(resp.isPartial());
             Set<String> allIds = Stream.of(local.okIds, remote1.okIds, remote2.okIds)
                 .flatMap(Collection::stream)
@@ -143,7 +148,11 @@ public class CrossClusterQueryWithPartialResultsIT extends AbstractCrossClusterT
         request.query("FROM ok*,cluster-a:ok*,*-b:fail* | KEEP id, fail_me");
         request.allowPartialResults(true);
         request.includeCCSMetadata(randomBoolean());
+        // Limit to one shard per batch to prevent all ok shards from being grouped with failed shards,
+        // which could cause the ok shards to fail if a failed shard is processed first.
+        request.pragmas(new QueryPragmas(Settings.builder().put(QueryPragmas.MAX_CONCURRENT_SHARDS_PER_NODE.getKey(), 1).build()));
         try (var resp = runQuery(request)) {
+            logger.info("--> response {}", resp);
             assertTrue(resp.isPartial());
             Set<String> allIds = Stream.of(local.okIds, remote1.okIds).flatMap(Collection::stream).collect(Collectors.toSet());
             List<List<Object>> rows = getValuesList(resp);
@@ -155,7 +164,6 @@ public class CrossClusterQueryWithPartialResultsIT extends AbstractCrossClusterT
                 assertTrue(returnedIds.add(id));
             }
             assertThat(returnedIds, equalTo(allIds));
-
             assertClusterSuccess(resp, LOCAL_CLUSTER, local.okShards);
             assertClusterSuccess(resp, REMOTE_CLUSTER_1, remote1.okShards);
             assertClusterPartial(resp, REMOTE_CLUSTER_2, remote2.failingShards, 0);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Fix CrossClusterQueryWithPartialResultsIT (#140044)](https://github.com/elastic/elasticsearch/pull/140044)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)