### PR TITLE
[JupiterOne] - Fix Cannot execute ILM policy delete step

### DIFF
--- a/docs/changelog/140049.yaml
+++ b/docs/changelog/140049.yaml
@@ -1,0 +1,6 @@
+pr: 140049
+summary: "[JupiterOne] Add `manage`, `create_index`, `read`, `index`, `write`, `delete`, permission for third party agent indices `kibana_system`"
+area: Authorization
+type: enhancement
+issues:
+  - 140049

--- a/docs/changelog/140049.yaml
+++ b/docs/changelog/140049.yaml
@@ -2,5 +2,3 @@ pr: 140049
 summary: "[JupiterOne] Add `manage`, `create_index`, `read`, `index`, `write`, `delete`, permission for third party agent indices `kibana_system`"
 area: Authorization
 type: enhancement
-issues:
-  - 140049

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -563,7 +563,8 @@ class KibanaOwnedReservedRoleDescriptors {
                         TransportDeleteIndexAction.TYPE.name()
                     )
                     .build(),
-                // For ExtraHop, QualysGAV, SentinelOne, Island Browser, Cyera, IRONSCALES and Axonius specific actions.
+                // For ExtraHop, QualysGAV, SentinelOne, Island Browser, Cyera, IRONSCALES, Axonius
+                // and JupiterOne specific actions.
                 // Kibana reads, writes and manages this index
                 // for configured ILM policies.
                 RoleDescriptor.IndicesPrivileges.builder()
@@ -588,7 +589,8 @@ class KibanaOwnedReservedRoleDescriptors {
                         "logs-axonius.network-*",
                         "logs-axonius.storage-*",
                         "logs-axonius.ticket-*",
-                        "logs-axonius.user-*"
+                        "logs-axonius.user-*",
+                        "logs-jupiter_one.risks_and_alerts-*"
                     )
                     .privileges(
                         "manage",

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -2002,7 +2002,8 @@ public class ReservedRolesStoreTests extends ESTestCase {
             assertThat(kibanaRole.indices().allowedIndicesMatcher(RolloverAction.NAME).test(indexAbstraction), is(true));
         });
 
-        // Tests for third-party agent indices (ExtraHop, QualysGAV, SentinelOne, Island Browser, Cyera, IRONSCALES, Axonius) that
+        // Tests for third-party agent indices (ExtraHop, QualysGAV, SentinelOne, Island Browser, Cyera,
+        // IRONSCALES, Axonius and JupiterOne) that
         // `kibana_system` has full management access to
         // This includes read, write, create, delete, and all ILM-related management actions.
         Arrays.asList(
@@ -2026,7 +2027,8 @@ public class ReservedRolesStoreTests extends ESTestCase {
             "logs-axonius.network-" + randomAlphaOfLength(randomIntBetween(1, 10)),
             "logs-axonius.storage-" + randomAlphaOfLength(randomIntBetween(1, 10)),
             "logs-axonius.ticket-" + randomAlphaOfLength(randomIntBetween(1, 10)),
-            "logs-axonius.user-" + randomAlphaOfLength(randomIntBetween(1, 10))
+            "logs-axonius.user-" + randomAlphaOfLength(randomIntBetween(1, 10)),
+            "logs-jupiter_one.risks_and_alerts-" + randomAlphaOfLength(randomIntBetween(1, 10))
         ).forEach((index_qualys_extra_hop) -> {
             final IndexAbstraction indexAbstraction = mockIndexAbstraction(index_qualys_extra_hop);
 


### PR DESCRIPTION
**PR Description:** 

```
This PR focuses on the short term solution which add the `logs-jupiter_one.risks_and_alerts-*` index under the 
kibana_system role with deletion privileges to prevent a failed deletion error when the index enters the 
deletion phase for the ILM lifecycle, in upcoming PR. As it ships transform pipeline too hence read, write permissions 
are also required.   
```
 
Current behavior:
 
It shows permission issue while deleting the index.
