### PR TITLE
ES|QL: fix DataNodeRequestSenderTests.testLimitConcurrentNodes

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/DataNodeRequestSenderTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/DataNodeRequestSenderTests.java
@@ -73,6 +73,8 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.in;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 
 public class DataNodeRequestSenderTests extends ComputeTestCase {
@@ -344,7 +346,7 @@ public class DataNodeRequestSenderTests extends ComputeTestCase {
             });
         }));
         assertThat(sent.size(), equalTo(shards));
-        assertThat(maxConcurrentRequests.get(), equalTo(concurrency));
+        assertThat(maxConcurrentRequests.get(), is(lessThanOrEqualTo(concurrency)));
         assertThat(response.totalShards, equalTo(shards));
         assertThat(response.successfulShards, equalTo(shards));
         assertThat(response.failedShards, equalTo(0));


### PR DESCRIPTION
Fixing a race condition in `DataNodeRequestSenderTests.testLimitConcurrentNodes`

In the very unlikely case that the requests are executed sequentially (ie. that they never overlap), `concurrentRequests` is incremented to 1 and then immediately decremented to 0, so `maxConcurrentRequests` will be 1 at most.

What we really want to test here is that we never exceed the maximum number of concurrent requests, so we can relax the assertion a bit.

~~I'm also adding another test that forces the execution of at least N requests concurrently.~~

I'm refactoring the test a bit, adding some constraints that force requests to pile up

Fixes: https://github.com/elastic/elasticsearch/issues/139935