### PR TITLE
Unmute `testSimulatedSearchRejectionLoad`

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -87,9 +87,6 @@ tests:
 - class: org.elasticsearch.xpack.core.common.notifications.AbstractAuditorTests
   method: testRecreateTemplateWhenDeleted
   issue: https://github.com/elastic/elasticsearch/issues/123232
-- class: org.elasticsearch.action.RejectionActionIT
-  method: testSimulatedSearchRejectionLoad
-  issue: https://github.com/elastic/elasticsearch/issues/125901
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=transform/transforms_reset/Test force reseting a running transform}
   issue: https://github.com/elastic/elasticsearch/issues/126240


### PR DESCRIPTION
The test failure report indicates the leak of a search context, and much
has changed in this area since that happened. Hopefully it's been fixed
by some other change but if not then we need fresh confirmation it's
still a problem. Either way, unmuting the test is the right thing to do.

Closes #125901