### PR TITLE
Gates INLINESTATS test to not execute for non-snapshot CI builds

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/DeduplicateAggsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/DeduplicateAggsTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.optimizer.rules.logical;
 
 import org.elasticsearch.common.lucene.BytesRefs;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Expressions;
@@ -581,6 +582,7 @@ public class DeduplicateAggsTests extends AbstractLogicalPlanOptimizerTests {
      * pe{f}#15]]
      */
     public void testDuplicatedInlineAggWithFoldableIdenticalExpressions() {
+        assumeTrue("requires INLINESTATS command to be enabled", EsqlCapabilities.Cap.INLINESTATS.isEnabled());
         String query = """
                 FROM airports
                 | INLINESTATS a = 2*COUNT_DISTINCT(scalerank, 100),


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch/issues/139451

## Why
Because `INLINESTATS` was a snapshot only feature in 9.1, so it looks like some builds in the CI execute the tests in non-snapshot mode and that test should be gated for the `INLINESTATS` capability.
