### PR TITLE
[9.3] Unmute `testSimulatedSearchRejectionLoad` (#140064)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -90,9 +90,6 @@ tests:
 - class: org.elasticsearch.xpack.core.common.notifications.AbstractAuditorTests
   method: testRecreateTemplateWhenDeleted
   issue: https://github.com/elastic/elasticsearch/issues/123232
-- class: org.elasticsearch.action.RejectionActionIT
-  method: testSimulatedSearchRejectionLoad
-  issue: https://github.com/elastic/elasticsearch/issues/125901
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=transform/transforms_reset/Test force reseting a running transform}
   issue: https://github.com/elastic/elasticsearch/issues/126240


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Unmute `testSimulatedSearchRejectionLoad` (#140064)