### PR TITLE
ESQL: Fix multi-value constant propagation after STATS (#139442) 

### DIFF
--- a/docs/changelog/139442.yaml
+++ b/docs/changelog/139442.yaml
@@ -1,0 +1,6 @@
+pr: 139442
+summary: "ESQL: Fix multi-value constant propagation after `STATS`"
+area: ES|QL
+type: bug
+issues:
+  - 135926

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/enrich.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/enrich.csv-spec
@@ -762,3 +762,120 @@ FROM sample_data
 message:keyword       | language_code:keyword | first_language_name:keyword | language_name:keyword
 Connected to 10.1.0.1 | 1                     | English                     | English
 ;
+
+
+enrichOnSameFieldTwiceValues
+required_capability: enrich_load
+required_capability: attribute_equals_respects_name_id
+
+ROW a = 1, b = 2
+| EVAL language_code = a
+| ENRICH languages_policy ON language_code
+| RENAME language_name AS language_name_a
+| EVAL language_code = b
+| ENRICH languages_policy ON language_code
+| RENAME language_name AS language_name_b
+| STATS values(language_name_a), values(language_name_b)
+;
+
+values(language_name_a):keyword | values(language_name_b):keyword
+English                         | French
+;
+
+
+circularRefEnrichStats
+required_capability: enrich_load
+required_capability: fix_enrich_alias_cycle_in_deduplicate_aggs
+FROM languages_lookup 
+| RENAME language_name AS message  
+| ENRICH languages_policy ON language_code 
+| STATS a = count(to_lower(language_name)), b = count(language_name)
+;
+
+a:long  | b:long
+4       | 4
+;
+
+
+circularRefEnrichStats2
+required_capability: enrich_load
+required_capability: fix_enrich_alias_cycle_in_deduplicate_aggs
+FROM languages_lookup 
+| RENAME language_name AS message  
+| ENRICH languages_policy ON language_code 
+| STATS a = count(to_lower(language_name)), b = count(message)
+;
+
+a:long  | b:long
+4       | 4
+;
+
+
+circularRefEnrichStats3
+required_capability: enrich_load
+required_capability: fix_enrich_alias_cycle_in_deduplicate_aggs
+FROM languages_lookup 
+| ENRICH languages_policy ON language_code
+| RENAME language_name AS message
+| STATS a = count(to_lower(message)), b = count(message)
+;
+
+a:long  | b:long
+4       | 4
+;
+
+
+circularRefEnrichStats4
+required_capability: enrich_load
+required_capability: fix_enrich_alias_cycle_in_deduplicate_aggs
+FROM languages_lookup 
+| ENRICH languages_policy ON language_code WITH message=language_name
+| RENAME language_name AS message
+| STATS a = count(to_lower(message)), b = count(message)
+;
+
+a:long  | b:long
+4       | 4
+;
+
+
+circularRefEnrichStats5
+required_capability: enrich_load
+required_capability: fix_enrich_alias_cycle_in_deduplicate_aggs
+FROM languages_lookup 
+| ENRICH languages_policy ON language_code WITH message=language_name
+| STATS a = count(to_lower(language_name)), b = count(message)
+;
+
+a:long  | b:long
+4       | 4
+;
+
+
+circularRefEnrichStats6
+required_capability: enrich_load
+required_capability: fix_enrich_alias_cycle_in_deduplicate_aggs
+FROM languages_lookup 
+| RENAME language_name AS message  
+| SORT message
+| ENRICH languages_policy ON language_code 
+| STATS a = count(to_lower(language_name)), b = count(message)
+;
+
+a:long  | b:long
+4       | 4
+;
+
+
+circularRefEnrichStats7
+required_capability: enrich_load
+required_capability: fix_enrich_alias_cycle_in_deduplicate_aggs
+FROM languages_lookup 
+| ENRICH languages_policy ON language_code 
+| SORT language_name
+| STATS a = count(to_lower(language_name)), b = count(language_name)
+;
+
+a:long  | b:long
+4       | 4
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -3415,3 +3415,91 @@ a:double | b:double | c:long
 6.0      | 6.0      | 8
 ;
 
+
+statsMvConstantGroupByWhere
+required_capability: fix_stats_mv_constant_fold
+ROW a = [1, 2] 
+| STATS c = SUM(a) BY a 
+| WHERE a > 1
+;
+
+c:long | a:integer
+3      | 2
+;
+
+
+statsMvConstantGroupByAggExpr
+required_capability: fix_stats_mv_constant_fold
+ROW a = [1, 2] 
+| STATS a + SUM(a) BY a
+;
+
+a + SUM(a):long | a:integer
+4               | 1
+5               | 2
+;
+
+
+statsMvConstantGroupByEval
+required_capability: fix_stats_mv_constant_fold
+ROW a = [1, 2] 
+| STATS SUM(a) BY a 
+| EVAL b = a
+;
+
+SUM(a):long | a:integer | b:integer
+3           | 1         | 1
+3           | 2         | 2
+;
+
+
+statsByMvFieldAggExpr
+FROM employees 
+| STATS SUM(salary_change) + salary_change BY salary_change 
+| SORT salary_change 
+| LIMIT 5
+;
+
+SUM(salary_change) + salary_change:double   | salary_change:double
+-6.650000000000002                          | -9.81          
+-9.139999999999999                          | -9.28          
+0.0799999999999983                          | -9.23          
+5.75                                        | -8.94          
+3.4300000000000015                          | -8.78          
+
+;
+
+
+statsByMvFieldEval
+FROM employees 
+| STATS SUM(salary_change) BY salary_change 
+| EVAL x = salary_change 
+| SORT salary_change 
+| LIMIT 5
+;
+
+SUM(salary_change):double   | salary_change:double  | x:double
+3.1599999999999984          | -9.81                 | -9.81          
+0.14000000000000057         | -9.28                 | -9.28          
+9.309999999999999           | -9.23                 | -9.23          
+14.69                       | -8.94                 | -8.94          
+12.21                       | -8.78                 | -8.78          
+
+;
+
+
+statsByMvFieldWhere
+FROM employees 
+| STATS SUM(salary_change) BY salary_change 
+| WHERE salary_change > 1 
+| SORT salary_change 
+| LIMIT 5
+;
+
+SUM(salary_change):double   | salary_change:double
+-13.4                       | 1.03           
+17.91                       | 1.13           
+-1.0100000000000002         | 1.19           
+14.69                       | 1.92           
+6.000000000000001           | 1.98           
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1295,6 +1295,15 @@ public class EsqlCapabilities {
          */
         FIX_REPLACE_ALIASING_EVAL_WITH_PROJECT_SHADOWING,
 
+        /**
+         * Fix for multi-value constant propagation after GROUP BY.
+         * When a multi-value constant (e.g., [1, 2]) is used as GROUP BY key, the aggregation explodes
+         * it into single values. Propagating the original multi-value literal after the Aggregate would
+         * incorrectly treat the field as still being multi-valued.
+         * https://github.com/elastic/elasticsearch/issues/135926
+         */
+        FIX_STATS_MV_CONSTANT_FOLD,
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateEvalFoldables.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PropagateEvalFoldables.java
@@ -9,13 +9,17 @@ package org.elasticsearch.xpack.esql.optimizer.rules.logical;
 
 import org.elasticsearch.xpack.esql.core.expression.AttributeMap;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.optimizer.LogicalOptimizerContext;
 import org.elasticsearch.xpack.esql.optimizer.rules.RuleUtils;
+import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.Filter;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.rule.ParameterizedRule;
+
+import java.util.List;
 
 /**
  * Replace any reference attribute with its source, if it does not affect the result.
@@ -29,13 +33,33 @@ public final class PropagateEvalFoldables extends ParameterizedRule<LogicalPlan,
         if (collectRefs.isEmpty()) {
             return plan;
         }
+        // Build the final set of foldable references to propagate.
+        // We start with all collected foldable references, then exclude multi-value grouping keys.
+        AttributeMap.Builder<Expression> builder = AttributeMap.builder();
+        builder.putAll(collectRefs);
 
+        // Exclude multi-value (List) literals used as GROUP BY keys from propagation.
+        //
+        // Rationale: GROUP BY explodes multi-value fields into single values. For example:
+        // ROW a = [1, 2] | STATS x = a + SUM(a) BY a
+        // Before aggregation, `a` is multi-valued [1, 2]. After GROUP BY, `a` becomes single-valued
+        // (either 1 or 2 per group). If we propagate the original multi-value literal [1, 2] into
+        // expressions after the Aggregate (e.g., `x = a + SUM(a)`), this would incorrectly treat `a`
+        // as still being multi-valued, leading to wrong results.
         plan = plan.transformUp(p -> {
+            if (p instanceof Aggregate aggregate) {
+                aggregate.groupings().forEach(group -> {
+                    Expression resolved = collectRefs.resolve(group, group);
+                    if (resolved instanceof Literal literal && literal.value() instanceof List<?>) {
+                        builder.remove(group);
+                    }
+                });
+            }
             // Apply the replacement inside Filter and Eval (which shouldn't make a difference)
             // TODO: also allow aggregates once aggs on constants are supported.
             // C.f. https://github.com/elastic/elasticsearch/issues/100634
             if (p instanceof Filter || p instanceof Eval) {
-                p = p.transformExpressionsOnly(ReferenceAttribute.class, r -> collectRefs.resolve(r, r));
+                p = p.transformExpressionsOnly(ReferenceAttribute.class, r -> builder.build().resolve(r, r));
             }
             return p;
         });

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -7589,4 +7589,117 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
         var topN = as(changePoint.child(), TopN.class);
         var source = as(topN.child(), EsRelation.class);
     }
+
+    /**
+     * Verifies that multi-value constant literals used as GROUP BY keys are not propagated
+     * after the Aggregate node. GROUP BY explodes multi-values into single values, so propagating
+     * the original multi-value literal would be incorrect.
+     *
+     * <pre>{@code
+     * Limit[1000[INTEGER],false,false]
+     * \_Filter[a{r}#4 > 1[INTEGER]]
+     *   \_Aggregate[[a{r}#4],[SUM(a{r}#4,true[BOOLEAN],PT0S[TIME_DURATION],compensated[KEYWORD]) AS c#8, a{r}#4]]
+     *     \_LocalRelation[[a{r}#4],Page{blocks=[IntArrayBlock[positions=1, mvOrdering=DEDUPLICATED_AND_SORTED_ASCENDING, vector=IntArrayV
+     * ector[positions=2, values=[1, 2]]]]}]
+     * }</pre>
+     */
+    public void testMvConstantGroupByWhere() {
+        var plan = plan("""
+            ROW a = [1, 2]
+            | STATS c = SUM(a) BY a
+            | WHERE a > 1
+            """);
+
+        // Plan structure: Limit -> Filter -> Aggregate -> LocalRelation
+        var limit = as(plan, Limit.class);
+        var filter = as(limit.child(), Filter.class);
+
+        // The key assertion: `a` in the filter should be a ReferenceAttribute, NOT a Literal
+        // If it were a Literal([1, 2]), that would indicate incorrect constant propagation
+        var condition = as(filter.condition(), GreaterThan.class);
+        var left = as(condition.left(), ReferenceAttribute.class);
+        assertThat(Expressions.name(left), equalTo("a"));
+
+        var agg = as(filter.child(), Aggregate.class);
+        assertThat(Expressions.names(agg.groupings()), contains("a"));
+        as(agg.child(), LocalRelation.class);
+    }
+
+    /**
+     * Verifies that multi-value constant literals in aggregate expressions referencing
+     * grouping keys are not incorrectly propagated.
+     *
+     * <pre>{@code
+     * Project[[a + SUM(a){r}#8, a{r}#4]]
+     * \_Eval[[a{r}#4 + $$SUM$a_+_SUM(a)$0{r$}#9 AS a + SUM(a)#8]]
+     *   \_Limit[1000[INTEGER],false,false]
+     *     \_Aggregate[[a{r}#4],[SUM(a{r}#4,true[BOOLEAN],PT0S[TIME_DURATION],compensated[KEYWORD]) AS $$SUM$a_+_SUM(a)$0#9, a{r}#4]]
+     *       \_LocalRelation[[a{r}#4],Page{blocks=[IntArrayBlock[positions=1, mvOrdering=SORTED_ASCENDING, vector=IntArrayVector[positions=2
+     * , values=[1, 2]]]]}]
+     * }</pre>
+     */
+    public void testMvConstantGroupByAggExpr() {
+        var plan = plan("""
+            ROW a = [1, 2]
+            | STATS a + SUM(a) BY a
+            """);
+
+        // Plan structure: Project -> Eval -> Limit -> Aggregate -> LocalRelation
+        var project = as(plan, Project.class);
+        var eval = as(project.child(), Eval.class);
+
+        // The EVAL expression `a + $$SUM$...` contains `a` which should be a ReferenceAttribute
+        assertThat(eval.fields(), hasSize(1));
+        var alias = as(eval.fields().get(0), Alias.class);
+        var addExpr = as(alias.child(), Add.class);
+
+        // Left side of add should be a reference to `a`, not a literal [1, 2]
+        var left = as(addExpr.left(), ReferenceAttribute.class);
+        assertThat(Expressions.name(left), equalTo("a"));
+
+        // Right side should be a reference to the SUM result
+        var right = as(addExpr.right(), ReferenceAttribute.class);
+
+        var limit = as(eval.child(), Limit.class);
+        var agg = as(limit.child(), Aggregate.class);
+        assertThat(Expressions.names(agg.groupings()), contains("a"));
+        as(agg.child(), LocalRelation.class);
+    }
+
+    /**
+     * Verifies that multi-value constant literals used as GROUP BY keys are not propagated
+     * into EVAL expressions after the Aggregate.
+     *
+     * <pre>{@code
+     * Eval[[a{r}#4 AS b#10]]
+     * \_Limit[1000[INTEGER],false,false]
+     *   \_Aggregate[[a{r}#4],[SUM(a{r}#4,true[BOOLEAN],PT0S[TIME_DURATION],compensated[KEYWORD]) AS SUM(a)#7, a{r}#4]]
+     *     \_LocalRelation[[a{r}#4],Page{blocks=[IntArrayBlock[positions=1, mvOrdering=UNORDERED, vector=IntArrayVector[positions=2, value
+     * s=[1, 2]]]]}]
+     * }</pre>
+     */
+    public void testMvConstantGroupByEval() {
+        var plan = plan("""
+            ROW a = [1, 2]
+            | STATS SUM(a) BY a
+            | EVAL b = a
+            """);
+
+        // Plan structure: Eval -> Limit -> Aggregate -> LocalRelation
+        var eval = as(plan, Eval.class);
+
+        // The EVAL expression `b = a` should reference `a` as an attribute, not a literal
+        assertThat(eval.fields(), hasSize(1));
+        var bAlias = as(eval.fields().get(0), Alias.class);
+        assertThat(bAlias.name(), equalTo("b"));
+
+        // The child of the alias should be a ReferenceAttribute to `a`, not a Literal([1, 2])
+        var a = as(bAlias.child(), ReferenceAttribute.class);
+        assertThat(Expressions.name(a), equalTo("a"));
+
+        var limit = as(eval.child(), Limit.class);
+        var agg = as(limit.child(), Aggregate.class);
+        assertThat(Expressions.names(agg.groupings()), contains("a"));
+        as(agg.child(), LocalRelation.class);
+    }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - https://github.com/elastic/elasticsearch/pull/139442
