### PR TITLE
Add debug logging for reindex shutdown test

### DIFF
--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexNodeShutdownIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexNodeShutdownIT.java
@@ -18,6 +18,7 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.reindex.ReindexPlugin;
 import org.elasticsearch.tasks.TaskInfo;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -52,6 +53,10 @@ public class ReindexNodeShutdownIT extends ESIntegTestCase {
         return new ReindexRequestBuilder(internalCluster().client(nodeName));
     }
 
+    @TestLogging(
+        value = "org.elasticsearch.index.reindex:DEBUG,org.elasticsearch.node.ShutdownPrepareService:DEBUG",
+        reason = "https://github.com/elastic/elasticsearch/issues/139806"
+    )
     public void testReindexWithShutdown() throws Exception {
         final String masterNodeName = internalCluster().startMasterOnlyNode();
         final String dataNodeName = internalCluster().startDataOnlyNode();

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -500,9 +500,6 @@ tests:
 - class: org.elasticsearch.readiness.ReadinessClusterIT
   method: testReadinessDuringRestartsNormalOrder
   issue: https://github.com/elastic/elasticsearch/issues/136955
-- class: org.elasticsearch.index.reindex.ReindexNodeShutdownIT
-  method: testReindexWithShutdown
-  issue: https://github.com/elastic/elasticsearch/issues/139806
 
 # Examples:
 #


### PR DESCRIPTION
relates https://github.com/elastic/elasticsearch/issues/139806