### PR TITLE
ESQL: add missing warnings issue additional logging (#140051)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -345,9 +345,6 @@ tests:
 - class: org.elasticsearch.smoketest.MlWithSecurityIT
   method: test {yaml=ml/sparse_vector_search/Test sparse_vector search with query vector and pruning config}
   issue: https://github.com/elastic/elasticsearch/issues/139196
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
-  method: test {csv-spec:spatial.ConvertFromStringParseError}
-  issue: https://github.com/elastic/elasticsearch/issues/139213
 - class: org.elasticsearch.xpack.inference.integration.AuthorizationTaskExecutorIT
   method: testCreatesEisChatCompletionEndpoint
   issue: https://github.com/elastic/elasticsearch/issues/138764

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/ChangePointOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/ChangePointOperator.java
@@ -15,6 +15,8 @@ import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.ml.aggs.MlAggsHelper;
 import org.elasticsearch.xpack.ml.aggs.changepoint.ChangePointDetector;
 import org.elasticsearch.xpack.ml.aggs.changepoint.ChangeType;
@@ -32,7 +34,7 @@ import java.util.List;
  * is a compute-heavy process), and then outputs all data with the change points.
  */
 public class ChangePointOperator implements Operator {
-
+    private static final Logger logger = LogManager.getLogger(ChangePointOperator.class);
     public static final int INPUT_VALUE_COUNT_LIMIT = 1000;
 
     public record Factory(int channel, String sourceText, int sourceLine, int sourceColumn) implements OperatorFactory {
@@ -189,17 +191,29 @@ public class ChangePointOperator implements Operator {
         }
 
         if (changeType instanceof ChangeType.Indeterminable indeterminable) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Change point indeterminable: {}", indeterminable.getReason());
+            }
             warnings(false).registerException(new IllegalArgumentException(indeterminable.getReason()));
         }
         if (tooManyValues) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Too many values: limit is {}, some values were ignored", INPUT_VALUE_COUNT_LIMIT);
+            }
             warnings(true).registerException(
                 new IllegalArgumentException("too many values; keeping only first " + INPUT_VALUE_COUNT_LIMIT + " values")
             );
         }
         if (hasNulls) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Values contain nulls; skipping them");
+            }
             warnings(true).registerException(new IllegalArgumentException("values contain nulls; skipping them"));
         }
         if (hasMultivalued) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Values contain multivalued entries; skipping them");
+            }
             warnings(true).registerException(
                 new IllegalArgumentException(
                     "values contains multivalued entries; skipping them (please consider reducing them with e.g. MV_AVG or MV_SUM)"

--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/MultiClusterSpecIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/MultiClusterSpecIT.java
@@ -75,8 +75,8 @@ import static org.mockito.Mockito.when;
 @ThreadLeakFilters(filters = TestClustersThreadFilter.class)
 public class MultiClusterSpecIT extends EsqlSpecTestCase {
 
-    static ElasticsearchCluster remoteCluster = Clusters.remoteCluster();
-    static ElasticsearchCluster localCluster = Clusters.localCluster(remoteCluster);
+    static ElasticsearchCluster remoteCluster = Clusters.remoteCluster(LOGGING_CLUSTER_SETTINGS);
+    static ElasticsearchCluster localCluster = Clusters.localCluster(remoteCluster, LOGGING_CLUSTER_SETTINGS);
 
     @ClassRule
     public static TestRule clusterRule = RuleChain.outerRule(remoteCluster).around(localCluster);

--- a/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/EsqlSpecIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/EsqlSpecIT.java
@@ -13,10 +13,16 @@ import org.elasticsearch.xpack.esql.qa.rest.EsqlSpecTestCase;
 import org.junit.ClassRule;
 
 import java.io.IOException;
+import java.util.Map;
 
 public class EsqlSpecIT extends EsqlSpecTestCase {
     @ClassRule
-    public static ElasticsearchCluster cluster = Clusters.testCluster(spec -> spec.plugin("inference-service-test"));
+    public static ElasticsearchCluster cluster = Clusters.testCluster(spec -> {
+        spec.plugin("inference-service-test");
+        for (Map.Entry<String, String> entry : LOGGING_CLUSTER_SETTINGS.entrySet()) {
+            spec.setting(entry.getKey(), entry.getValue());
+        }
+    });
 
     @Override
     protected String getTestRestCluster() {

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/Clusters.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/Clusters.java
@@ -9,7 +9,11 @@ package org.elasticsearch.xpack.esql.qa.single_node;
 
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.local.LocalClusterConfigProvider;
+import org.elasticsearch.test.cluster.local.LocalClusterSpecBuilder;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+import org.elasticsearch.xpack.esql.qa.rest.EsqlSpecTestCase;
+
+import java.util.Map;
 
 public class Clusters {
 
@@ -25,5 +29,11 @@ public class Clusters {
             .shared(true)
             .apply(() -> configProvider)
             .build();
+    }
+
+    public static void addAdditionalLoggingSettings(LocalClusterSpecBuilder<?> spec) {
+        for (Map.Entry<String, String> entry : EsqlSpecTestCase.LOGGING_CLUSTER_SETTINGS.entrySet()) {
+            spec.setting(entry.getKey(), entry.getValue());
+        }
     }
 }

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/EsqlSpecIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/EsqlSpecIT.java
@@ -30,9 +30,10 @@ import java.util.List;
 @ThreadLeakFilters(filters = TestClustersThreadFilter.class)
 public class EsqlSpecIT extends EsqlSpecTestCase {
     @ClassRule
-    public static ElasticsearchCluster cluster = Clusters.testCluster(
-        spec -> spec.plugin("inference-service-test").setting("logger." + ComputeService.class.getName(), "DEBUG") // So we log a profile
-    );
+    public static ElasticsearchCluster cluster = Clusters.testCluster(spec -> {
+        spec.plugin("inference-service-test").setting("logger." + ComputeService.class.getName(), "DEBUG"); // So we log a profile
+        Clusters.addAdditionalLoggingSettings(spec);
+    });
 
     @Override
     protected String getTestRestCluster() {

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/GenerativeForkIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/GenerativeForkIT.java
@@ -18,7 +18,10 @@ import org.junit.ClassRule;
 @ThreadLeakFilters(filters = TestClustersThreadFilter.class)
 public class GenerativeForkIT extends GenerativeForkRestTest {
     @ClassRule
-    public static ElasticsearchCluster cluster = Clusters.testCluster(spec -> spec.plugin("inference-service-test"));
+    public static ElasticsearchCluster cluster = Clusters.testCluster(spec -> {
+        spec.plugin("inference-service-test");
+        Clusters.addAdditionalLoggingSettings(spec);
+    });
 
     @Override
     protected String getTestRestCluster() {

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
@@ -104,6 +104,14 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
     protected final Mode mode;
     protected static Boolean supportsTook;
 
+    public static final Map<String, String> LOGGING_CLUSTER_SETTINGS = Map.of(
+        // additional logging for https://github.com/elastic/elasticsearch/issues/139262 investigation
+        "logger.org.elasticsearch.compute.operator.ChangePointOperator",
+        "DEBUG",
+        "logger.org.elasticsearch.xpack.esql.expression.function.scalar.convert",
+        "TRACE"
+    );
+
     @ParametersFactory(argumentFormatting = "csv-spec:%2$s.%3$s")
     public static List<Object[]> readScriptSpec() throws Exception {
         List<URL> urls = classpathResources("/*.csv-spec");


### PR DESCRIPTION
Try to gather more information for
https://github.com/elastic/elasticsearch/issues/139262 investigation by enabling logging in some key areas, after observing that most of the failures come from conversion failures tests.

Backports https://github.com/elastic/elasticsearch/pull/140051

(cherry picked from commit 2eaed45f6dd834ce53f1672eed1b01bd99e3a340)