### PR TITLE
Add block loader for the _id field of time-series indices

### DIFF
--- a/docs/changelog/140102.yaml
+++ b/docs/changelog/140102.yaml
@@ -1,0 +1,7 @@
+pr: 140102
+summary: Add block loader for the `_id` field of time-series indices
+area: ES|QL
+type: bug
+issues:
+ - 140033
+ - 135689

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingHashBuilder.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingHashBuilder.java
@@ -47,6 +47,10 @@ public class RoutingHashBuilder {
         }
     }
 
+    public void clear() {
+        hashes.clear();
+    }
+
     /**
      * Only expected to be called for old indices created before
      * {@link IndexVersions#TIME_SERIES_ROUTING_HASH_IN_ID} while creating (during ingestion)

--- a/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
@@ -127,7 +127,7 @@ public abstract class IdFieldMapper extends MetadataFieldMapper {
 
         @Override
         public BlockLoader blockLoader(BlockLoaderContext blContext) {
-            return new BlockStoredFieldsReader.IdBlockLoader();
+            return IdLoader.create(blContext.indexSettings(), blContext.mappingLookup()).blockLoader();
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
@@ -38,6 +38,7 @@ import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.index.fielddata.IndexOrdinalsFieldData;
 import org.elasticsearch.index.mapper.IdLoader;
 import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.NestedLookup;
 import org.elasticsearch.index.mapper.SourceLoader;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
@@ -946,6 +947,7 @@ final class DefaultSearchContext extends SearchContext {
 
     @Override
     public IdLoader newIdLoader() {
-        return IdLoader.create(indexService.mapperService());
+        MapperService mapperService = indexService.mapperService();
+        return IdLoader.create(mapperService.getIndexSettings(), mapperService.mappingLookup());
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/TsidExtractingIdFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TsidExtractingIdFieldMapperTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.index.mapper;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
@@ -758,39 +759,52 @@ public class TsidExtractingIdFieldMapperTests extends MetadataMapperTestCase {
     }
 
     private final TestCase testCase;
+    private final BlockLoaderTestRunner blockLoaderTestRunner;
 
     private static final int ROUTING_HASH = 7;
 
     public TsidExtractingIdFieldMapperTests(@Named("testCase") TestCase testCase) {
         this.testCase = testCase;
+        this.blockLoaderTestRunner = new BlockLoaderTestRunner(
+            new BlockLoaderTestCase.Params(false, randomFrom(MappedFieldType.FieldExtractPreference.values())),
+            false
+        );
     }
 
     public void testExpectedIdWithRoutingPath() throws IOException {
-        assertThat(parse(mapperService(false), testCase.source).id(), equalTo(testCase.expectedIdWithRoutingPath));
+        MapperService mapperService = mapperService(false);
+        ParsedDocument parsed = parse(mapperService, testCase.source);
+        assertThat(parsed.id(), equalTo(testCase.expectedIdWithRoutingPath));
+        verifyIdFromBlockLoader(mapperService, parsed, testCase.expectedIdWithRoutingPath);
     }
 
     public void testExpectedIdWithIndexDimensions() throws IOException {
-        assertThat(parse(mapperService(true), testCase.source).id(), equalTo(testCase.expectedIdWithIndexDimensions));
+        MapperService mapperService = mapperService(true);
+        ParsedDocument parsed = parse(mapperService, testCase.source);
+        assertThat(parsed.id(), equalTo(testCase.expectedIdWithIndexDimensions));
+        verifyIdFromBlockLoader(mapperService, parsed, testCase.expectedIdWithIndexDimensions);
     }
 
     public void testProvideExpectedIdWithRoutingPath() throws IOException {
-        assertThat(
-            parse(testCase.expectedIdWithRoutingPath, mapperService(false), testCase.source).id(),
-            equalTo(testCase.expectedIdWithRoutingPath)
-        );
+        MapperService mapperService = mapperService(false);
+        ParsedDocument parsed = parse(testCase.expectedIdWithRoutingPath, mapperService, testCase.source);
+        assertThat(parsed.id(), equalTo(testCase.expectedIdWithRoutingPath));
+        verifyIdFromBlockLoader(mapperService, parsed, testCase.expectedIdWithRoutingPath);
     }
 
     public void testProvideExpectedIdWithIndexDimensions() throws IOException {
-        assertThat(
-            parse(testCase.expectedIdWithIndexDimensions, mapperService(true), testCase.source).id(),
-            equalTo(testCase.expectedIdWithIndexDimensions)
-        );
+        MapperService mapperService = mapperService(true);
+        ParsedDocument parsed = parse(testCase.expectedIdWithIndexDimensions, mapperService, testCase.source);
+        assertThat(parsed.id(), equalTo(testCase.expectedIdWithIndexDimensions));
+        verifyIdFromBlockLoader(mapperService, parsed, testCase.expectedIdWithIndexDimensions);
     }
 
     public void testEquivalentSourcesWithRoutingPath() throws IOException {
         MapperService mapperService = mapperService(false);
         for (CheckedConsumer<XContentBuilder, IOException> equivalent : testCase.equivalentSources) {
-            assertThat(parse(mapperService, equivalent).id(), equalTo(testCase.expectedIdWithRoutingPath));
+            ParsedDocument parsed = parse(mapperService, equivalent);
+            assertThat(parsed.id(), equalTo(testCase.expectedIdWithRoutingPath));
+            verifyIdFromBlockLoader(mapperService, parsed, testCase.expectedIdWithRoutingPath);
         }
     }
 
@@ -975,5 +989,9 @@ public class TsidExtractingIdFieldMapperTests extends MetadataMapperTestCase {
                     + "]"
             )
         );
+    }
+
+    private void verifyIdFromBlockLoader(MapperService mapperService, ParsedDocument doc, String expectedId) throws IOException {
+        blockLoaderTestRunner.runTest(mapperService, doc, new BytesRef(expectedId), "_id");
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/blockloader/TextFieldWithParentBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/blockloader/TextFieldWithParentBlockLoaderTests.java
@@ -40,7 +40,7 @@ public class TextFieldWithParentBlockLoaderTests extends MapperServiceTestCase {
 
     public TextFieldWithParentBlockLoaderTests(BlockLoaderTestCase.Params params) {
         this.params = params;
-        this.runner = new BlockLoaderTestRunner(params);
+        this.runner = new BlockLoaderTestRunner(params, randomBoolean());
     }
 
     // This is similar to BlockLoaderTestCase#testBlockLoaderOfMultiField but has customizations required to properly test the case

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/BlockLoaderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/BlockLoaderTestCase.java
@@ -65,7 +65,7 @@ public abstract class BlockLoaderTestCase extends MapperServiceTestCase {
         this.fieldType = fieldType;
         this.params = params;
         this.customDataSourceHandlers = customDataSourceHandlers;
-        this.runner = new BlockLoaderTestRunner(params);
+        this.runner = new BlockLoaderTestRunner(params, randomBoolean());
 
         this.fieldName = randomAlphaOfLengthBetween(5, 10);
     }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/BlockLoaderTestRunner.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/BlockLoaderTestRunner.java
@@ -45,7 +45,6 @@ public class BlockLoaderTestRunner {
     private final BlockLoaderTestCase.Params params;
     private final boolean allowDummyDocs;
 
-
     public BlockLoaderTestRunner(BlockLoaderTestCase.Params params, boolean allowDummyDocs) {
         this.params = params;
         this.allowDummyDocs = allowDummyDocs;

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/BlockLoaderTestRunner.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/BlockLoaderTestRunner.java
@@ -43,35 +43,43 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class BlockLoaderTestRunner {
     private final BlockLoaderTestCase.Params params;
+    private final boolean allowDummyDocs;
 
-    public BlockLoaderTestRunner(BlockLoaderTestCase.Params params) {
+
+    public BlockLoaderTestRunner(BlockLoaderTestCase.Params params, boolean allowDummyDocs) {
         this.params = params;
+        this.allowDummyDocs = allowDummyDocs;
     }
 
     public void runTest(MapperService mapperService, Map<String, Object> document, Object expected, String blockLoaderFieldName)
         throws IOException {
         var documentXContent = XContentBuilder.builder(XContentType.JSON.xContent()).map(document);
+        var source = new SourceToParse(
+            "1",
+            BytesReference.bytes(documentXContent),
+            XContentType.JSON,
+            null,
+            Map.of(),
+            Map.of(),
+            true,
+            XContentMeteringParserDecorator.NOOP,
+            null
+        );
+        var parsedDoc = mapperService.documentMapper().parse(source);
+        runTest(mapperService, parsedDoc, expected, blockLoaderFieldName);
+    }
 
-        Object blockLoaderResult = setupAndInvokeBlockLoader(mapperService, documentXContent, blockLoaderFieldName);
+    public void runTest(MapperService mapperService, ParsedDocument parsedDoc, Object expected, String blockLoaderFieldName)
+        throws IOException {
+        Object blockLoaderResult = setupAndInvokeBlockLoader(mapperService, parsedDoc, blockLoaderFieldName);
         assertThat(blockLoaderResult, prettyEqualTo(expected));
     }
 
-    private Object setupAndInvokeBlockLoader(MapperService mapperService, XContentBuilder document, String fieldName) throws IOException {
+    private Object setupAndInvokeBlockLoader(MapperService mapperService, ParsedDocument parsedDoc, String fieldName) throws IOException {
         try (Directory directory = newDirectory()) {
             RandomIndexWriter iw = new RandomIndexWriter(random(), directory);
 
-            var source = new SourceToParse(
-                "1",
-                BytesReference.bytes(document),
-                XContentType.JSON,
-                null,
-                Map.of(),
-                Map.of(),
-                true,
-                XContentMeteringParserDecorator.NOOP,
-                null
-            );
-            LuceneDocument doc = mapperService.documentMapper().parse(source).rootDoc();
+            LuceneDocument doc = parsedDoc.rootDoc();
 
             /*
              * Add three documents with doc id 0, 1, 2. The real document is 1.
@@ -110,7 +118,7 @@ public class BlockLoaderTestRunner {
                     } else if (i == offset) {
                         docArray[i] = 1;
                     } else {
-                        docArray[i] = 2;
+                        docArray[i] = allowDummyDocs ? 2 : 1;
                     }
                 }
             }


### PR DESCRIPTION
ES can prune the `_id` stored field when documents are not needed for replication or recovery, or we will skip storing the field `_id`. Currently, the block loader for the `_id` field assumes it is stored in a stored field, so accessing `_id` in time-series indices may fail if the stored field has been pruned.

This change adds a block loader for the `_id` field in time-series indices that always synthesizes `_id` from `_tsid` and `@timestamp`, as done in the search API.

Closes #135689
Closes #140033