### PR TITLE
[9.2] Fix pragmas in CrossClusterQueryWithPartialResultsIT (#140110)

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterQueryWithPartialResultsIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClusterQueryWithPartialResultsIT.java
@@ -118,6 +118,7 @@ public class CrossClusterQueryWithPartialResultsIT extends AbstractCrossClusterT
         // Limit to one shard per batch to prevent all ok shards from being grouped with failed shards,
         // which could cause the ok shards to fail if a failed shard is processed first.
         request.pragmas(new QueryPragmas(Settings.builder().put(QueryPragmas.MAX_CONCURRENT_SHARDS_PER_NODE.getKey(), 1).build()));
+        request.acceptedPragmaRisks(true);
         try (var resp = runQuery(request)) {
             logger.info("--> response {}", resp);
             assertTrue(resp.isPartial());
@@ -151,6 +152,7 @@ public class CrossClusterQueryWithPartialResultsIT extends AbstractCrossClusterT
         // Limit to one shard per batch to prevent all ok shards from being grouped with failed shards,
         // which could cause the ok shards to fail if a failed shard is processed first.
         request.pragmas(new QueryPragmas(Settings.builder().put(QueryPragmas.MAX_CONCURRENT_SHARDS_PER_NODE.getKey(), 1).build()));
+        request.acceptedPragmaRisks(true);
         try (var resp = runQuery(request)) {
             logger.info("--> response {}", resp);
             assertTrue(resp.isPartial());


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Fix pragmas in CrossClusterQueryWithPartialResultsIT (#140110)