### PR TITLE
Unmute `TimeSeriesLifecycleActionsIT#testWaitForSnapshot`

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -300,9 +300,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.heap_attack.HeapAttackLookupJoinIT
   method: testLookupExplosionBigString
   issue: https://github.com/elastic/elasticsearch/issues/138510
-- class: org.elasticsearch.xpack.ilm.TimeSeriesLifecycleActionsIT
-  method: testWaitForSnapshot
-  issue: https://github.com/elastic/elasticsearch/issues/138669
 - class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
   method: testDatafeedTimingStats_DatafeedRecreated
   issue: https://github.com/elastic/elasticsearch/issues/138348

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
@@ -280,7 +280,11 @@ public class TimeSeriesLifecycleActionsIT extends IlmESRestTestCase {
         updatePolicy(client(), index, policy);
         waitForPhaseTime(phaseName);
         assertBusy(() -> {
+            // logging for investigation into https://github.com/elastic/elasticsearch/issues/138669
+            logger.info("about to explain ILM state, looking for failed_step:wait-for-snapshot");
             Map<String, Object> indexILMState = explainIndex(client(), index);
+            // logging for investigation into https://github.com/elastic/elasticsearch/issues/138669
+            logger.info("explained ILM state, looking for failed_step:wait-for-snapshot, got {}", indexILMState);
             assertThat(indexILMState.get("action"), is("wait_for_snapshot"));
             assertThat(indexILMState.get("failed_step"), is("wait-for-snapshot"));
         }, slmPolicy);


### PR DESCRIPTION
Didn't see a single failure locally (in over 10k iterations) so this
commit adds some relevant logging and unmutes it so that we can gather
further information from a failed CI run.

Relates #138669