### PR TITLE
Skip frozen nodes for disk usage check

### DIFF
--- a/docs/changelog/140118.yaml
+++ b/docs/changelog/140118.yaml
@@ -1,5 +1,5 @@
 pr: 140118
-summary: Skip frozen nodes for disk usage check
+summary: Skip frozen nodes on disk watermark check
 area: Infra/Core
 type: bug
 issues: []

--- a/docs/changelog/140118.yaml
+++ b/docs/changelog/140118.yaml
@@ -1,0 +1,5 @@
+pr: 140118
+summary: Skip frozen nodes for disk usage check
+area: Infra/Core
+type: bug
+issues: []

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
@@ -438,6 +438,7 @@ public class TransportDeprecationInfoAction extends TransportMasterNodeReadActio
             .map(Map.Entry::getKey)
             .map(discoveryNodes::get)
             .filter(Objects::nonNull)
+            .filter(node -> node.canContainData() && node.isDedicatedFrozenNode() == false)
             .map(DiscoveryNode::getName)
             .sorted()
             .toList();


### PR DESCRIPTION
Restores the check for frozen nodes when checking for disk usage thresholds.
This bug was introduced as part of this PR: [https://github.com/elastic/elasticsearch/pull/138115](https://github.com/elastic/elasticsearch/pull/138115)