### PR TITLE
[9.2] Skip frozen nodes on disk watermark check(#140118) Solves bug introduced in #138115 (#140118)

### DIFF
--- a/docs/changelog/140118.yaml
+++ b/docs/changelog/140118.yaml
@@ -1,0 +1,5 @@
+pr: 140118
+summary: Skip frozen nodes on disk watermark check
+area: Infra/Core
+type: bug
+issues: []

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
@@ -438,6 +438,7 @@ public class TransportDeprecationInfoAction extends TransportMasterNodeReadActio
             .map(Map.Entry::getKey)
             .map(discoveryNodes::get)
             .filter(Objects::nonNull)
+            .filter(node -> node.canContainData() && node.isDedicatedFrozenNode() == false)
             .map(DiscoveryNode::getName)
             .sorted()
             .toList();


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Skip frozen nodes on disk watermark check(#140118) Solves bug introduced in #138115 (#140118)