### PR TITLE
[8.19] Skip frozen nodes on disk watermark check(#140118) Solves bug introduced in #138115 (#140118)

### DIFF
--- a/docs/changelog/140118.yaml
+++ b/docs/changelog/140118.yaml
@@ -1,0 +1,5 @@
+pr: 140118
+summary: Skip frozen nodes on disk watermark check
+area: Infra/Core
+type: bug
+issues: []

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
@@ -437,6 +437,7 @@ public class TransportDeprecationInfoAction extends TransportMasterNodeReadActio
             .map(Map.Entry::getKey)
             .map(discoveryNodes::get)
             .filter(Objects::nonNull)
+            .filter(node -> node.canContainData() && node.isDedicatedFrozenNode() == false)
             .map(DiscoveryNode::getName)
             .sorted()
             .toList();

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoActionTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoActionTests.java
@@ -430,19 +430,22 @@ public class TransportDeprecationInfoActionTests extends ESTestCase {
         long totalBytesOnMachine = 100;
         long lowFreeBytes = 5;
 
-        ClusterInfo clusterInfo = ClusterInfo.builder()
-            .mostAvailableSpaceUsage(
-                Map.of(
-                    regularNodeId,
-                    new DiskUsage(regularNodeId, "", "", totalBytesOnMachine, totalBytesOnMachine),
-                    frozenNodeId,
-                    new DiskUsage(frozenNodeId, "", "", totalBytesOnMachine, lowFreeBytes),
-                    noDataNodeId,
-                    new DiskUsage(noDataNodeId, "", "", totalBytesOnMachine, lowFreeBytes)
-                )
-            )
-            .build();
-
+         ClusterInfo clusterInfo = new ClusterInfo(
+            Map.of(),
+            Map.of(
+                regularNodeId,
+                new DiskUsage(regularNodeId, "", "", totalBytesOnMachine, totalBytesOnMachine),
+                frozenNodeId,
+                new DiskUsage(frozenNodeId, "", "", totalBytesOnMachine, lowFreeBytes),
+                noDataNodeId,
+                new DiskUsage(noDataNodeId, "", "", totalBytesOnMachine, lowFreeBytes)
+            ),
+            Map.of(),
+            Map.of(),
+            Map.of(),
+            Map.of()
+        );
+        
         DiscoveryNode regularNode = mock(DiscoveryNode.class);
         when(regularNode.getId()).thenReturn(regularNodeId);
         when(regularNode.getName()).thenReturn("regular-node");
@@ -466,18 +469,21 @@ public class TransportDeprecationInfoActionTests extends ESTestCase {
         DeprecationIssue issue = TransportDeprecationInfoAction.checkDiskLowWatermark(clusterSettings, clusterInfo, discoveryNodes);
         assertNull(issue);
 
-        ClusterInfo clusterInfoWithAllExceeding = ClusterInfo.builder()
-            .mostAvailableSpaceUsage(
-                Map.of(
-                    regularNodeId,
-                    new DiskUsage(regularNodeId, "", "", totalBytesOnMachine, lowFreeBytes),
-                    frozenNodeId,
-                    new DiskUsage(frozenNodeId, "", "", totalBytesOnMachine, lowFreeBytes),
-                    noDataNodeId,
-                    new DiskUsage(noDataNodeId, "", "", totalBytesOnMachine, lowFreeBytes)
-                )
-            )
-            .build();
+        ClusterInfo clusterInfoWithAllExceeding = new ClusterInfo(
+            Map.of(),
+            Map.of(
+                regularNodeId,
+                new DiskUsage(regularNodeId, "", "", totalBytesOnMachine, lowFreeBytes),
+                frozenNodeId,
+                new DiskUsage(frozenNodeId, "", "", totalBytesOnMachine, lowFreeBytes),
+                noDataNodeId,
+                new DiskUsage(noDataNodeId, "", "", totalBytesOnMachine, lowFreeBytes)
+            ),
+            Map.of(),
+            Map.of(),
+            Map.of(),
+            Map.of()
+        );
 
         issue = TransportDeprecationInfoAction.checkDiskLowWatermark(clusterSettings, clusterInfoWithAllExceeding, discoveryNodes);
         assertNotNull(issue);

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoActionTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoActionTests.java
@@ -74,6 +74,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -387,15 +388,18 @@ public class TransportDeprecationInfoActionTests extends ESTestCase {
         DiscoveryNode node1 = mock(DiscoveryNode.class);
         when(node1.getId()).thenReturn(nodeId1);
         when(node1.getName()).thenReturn("node1");
+        when(node1.canContainData()).thenReturn(true);
         DiscoveryNodes discoveryNodes = mock(DiscoveryNodes.class);
         when(discoveryNodes.get(nodeId1)).thenReturn(node1);
         DiscoveryNode node2 = mock(DiscoveryNode.class);
         when(node2.getId()).thenReturn(nodeId2);
         when(node2.getName()).thenReturn("node2");
+        when(node2.canContainData()).thenReturn(true);
         when(discoveryNodes.get(nodeId2)).thenReturn(node2);
         DiscoveryNode node3 = mock(DiscoveryNode.class);
         when(node3.getId()).thenReturn(nodeId3);
         when(node3.getName()).thenReturn("node3");
+        when(node3.canContainData()).thenReturn(true);
         when(discoveryNodes.get(nodeId3)).thenReturn(node3);
 
         clusterSettings.applySettings(settingsWithLowWatermark);
@@ -416,6 +420,72 @@ public class TransportDeprecationInfoActionTests extends ESTestCase {
         assertThat(issue.getDetails(), containsString("(nodes impacted: [node1, node2])"));
     }
 
+    public void testCheckDiskLowWatermarkSkipsFrozenNodes() {
+        Settings settingsWithLowWatermark = Settings.builder().put("cluster.routing.allocation.disk.watermark.low", "10%").build();
+        ClusterSettings clusterSettings = new ClusterSettings(settingsWithLowWatermark, BUILT_IN_CLUSTER_SETTINGS);
+
+        String regularNodeId = "123";
+        String frozenNodeId = "456";
+        String noDataNodeId = "789";
+        long totalBytesOnMachine = 100;
+        long lowFreeBytes = 5;
+
+        ClusterInfo clusterInfo = ClusterInfo.builder()
+            .mostAvailableSpaceUsage(
+                Map.of(
+                    regularNodeId,
+                    new DiskUsage(regularNodeId, "", "", totalBytesOnMachine, totalBytesOnMachine),
+                    frozenNodeId,
+                    new DiskUsage(frozenNodeId, "", "", totalBytesOnMachine, lowFreeBytes),
+                    noDataNodeId,
+                    new DiskUsage(noDataNodeId, "", "", totalBytesOnMachine, lowFreeBytes)
+                )
+            )
+            .build();
+
+        DiscoveryNode regularNode = mock(DiscoveryNode.class);
+        when(regularNode.getId()).thenReturn(regularNodeId);
+        when(regularNode.getName()).thenReturn("regular-node");
+        when(regularNode.canContainData()).thenReturn(true);
+        when(regularNode.isDedicatedFrozenNode()).thenReturn(false);
+        DiscoveryNode frozenNode = mock(DiscoveryNode.class);
+        when(frozenNode.getId()).thenReturn(frozenNodeId);
+        when(frozenNode.getName()).thenReturn("frozen-node");
+        when(frozenNode.canContainData()).thenReturn(true);
+        when(frozenNode.isDedicatedFrozenNode()).thenReturn(true);
+        DiscoveryNode noDataNode = mock(DiscoveryNode.class);
+        when(noDataNode.getId()).thenReturn(noDataNodeId);
+        when(noDataNode.getName()).thenReturn("nodata-node");
+        when(noDataNode.canContainData()).thenReturn(false);
+        when(noDataNode.isDedicatedFrozenNode()).thenReturn(false);
+        DiscoveryNodes discoveryNodes = mock(DiscoveryNodes.class);
+        when(discoveryNodes.get(regularNodeId)).thenReturn(regularNode);
+        when(discoveryNodes.get(frozenNodeId)).thenReturn(frozenNode);
+        when(discoveryNodes.get(noDataNodeId)).thenReturn(noDataNode);
+
+        DeprecationIssue issue = TransportDeprecationInfoAction.checkDiskLowWatermark(clusterSettings, clusterInfo, discoveryNodes);
+        assertNull(issue);
+
+        ClusterInfo clusterInfoWithAllExceeding = ClusterInfo.builder()
+            .mostAvailableSpaceUsage(
+                Map.of(
+                    regularNodeId,
+                    new DiskUsage(regularNodeId, "", "", totalBytesOnMachine, lowFreeBytes),
+                    frozenNodeId,
+                    new DiskUsage(frozenNodeId, "", "", totalBytesOnMachine, lowFreeBytes),
+                    noDataNodeId,
+                    new DiskUsage(noDataNodeId, "", "", totalBytesOnMachine, lowFreeBytes)
+                )
+            )
+            .build();
+
+        issue = TransportDeprecationInfoAction.checkDiskLowWatermark(clusterSettings, clusterInfoWithAllExceeding, discoveryNodes);
+        assertNotNull(issue);
+        assertThat(issue.getDetails(), containsString("regular-node"));
+        assertThat(issue.getDetails(), not(containsString("frozen-node")));
+        assertThat(issue.getDetails(), not(containsString("nodata-node")));
+    }
+
     public void testMasterOperation() throws InterruptedException {
         try (TestThreadPool threadPool = new TestThreadPool("TransportDeprecationInfoActionTests")) {
             ClusterService clusterService = mock(ClusterService.class);
@@ -424,6 +494,7 @@ public class TransportDeprecationInfoActionTests extends ESTestCase {
             DiscoveryNode node1 = mock(DiscoveryNode.class);
             when(node1.getId()).thenReturn(nodeId);
             when(node1.getName()).thenReturn(nodeId);
+            when(node1.canContainData()).thenReturn(true);
             DiscoveryNodes discoveryNodes = mock(DiscoveryNodes.class);
             when(discoveryNodes.get(nodeId)).thenReturn(node1);
 

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoActionTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoActionTests.java
@@ -430,7 +430,7 @@ public class TransportDeprecationInfoActionTests extends ESTestCase {
         long totalBytesOnMachine = 100;
         long lowFreeBytes = 5;
 
-         ClusterInfo clusterInfo = new ClusterInfo(
+        ClusterInfo clusterInfo = new ClusterInfo(
             Map.of(),
             Map.of(
                 regularNodeId,
@@ -445,7 +445,7 @@ public class TransportDeprecationInfoActionTests extends ESTestCase {
             Map.of(),
             Map.of()
         );
-        
+
         DiscoveryNode regularNode = mock(DiscoveryNode.class);
         when(regularNode.getId()).thenReturn(regularNodeId);
         when(regularNode.getName()).thenReturn("regular-node");


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Skip frozen nodes on disk watermark check(#140118) Solves bug introduced in #138115 (#140118)