### PR TITLE
Removing useIlm method from MachineLearningExtension

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/DefaultMachineLearningExtension.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/DefaultMachineLearningExtension.java
@@ -28,11 +28,6 @@ public class DefaultMachineLearningExtension implements MachineLearningExtension
         MapperService.INDEX_MAPPING_DIMENSION_FIELDS_LIMIT_SETTING.getKey() };
 
     @Override
-    public boolean useIlm() {
-        return true;
-    }
-
-    @Override
     public boolean includeNodeInfo() {
         return true;
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -984,12 +984,14 @@ public class MachineLearning extends Plugin
 
         this.mlUpgradeModeActionFilter.set(new MlUpgradeModeActionFilter(clusterService));
 
+        boolean canUseIlm = DiscoveryNode.isStateless(settings) == false;
+
         MlIndexTemplateRegistry registry = new MlIndexTemplateRegistry(
             settings,
             clusterService,
             threadPool,
             client,
-            machineLearningExtension.get().useIlm(),
+            canUseIlm,
             xContentRegistry
         );
         registry.initialize();
@@ -1363,7 +1365,7 @@ public class MachineLearning extends Plugin
             machineLearningExtension.get().isAnomalyDetectionEnabled(),
             machineLearningExtension.get().isDataFrameAnalyticsEnabled(),
             machineLearningExtension.get().isNlpEnabled(),
-            machineLearningExtension.get().useIlm()
+            canUseIlm
         );
 
         MlMetrics mlMetrics = new MlMetrics(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningExtension.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningExtension.java
@@ -15,8 +15,6 @@ public interface MachineLearningExtension {
 
     default void configure(Settings settings) {}
 
-    boolean useIlm();
-
     boolean includeNodeInfo();
 
     boolean isAnomalyDetectionEnabled();

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningTests.java
@@ -272,7 +272,6 @@ public class MachineLearningTests extends ESTestCase {
 
         public static final String[] ANALYTICS_DEST_INDEX_ALLOWED_SETTINGS = {};
 
-        private final boolean useIlm;
         private final boolean includeNodeInfo;
         private final boolean isAnomalyDetectionEnabled;
         private final boolean isDataFrameAnalyticsEnabled;
@@ -285,16 +284,10 @@ public class MachineLearningTests extends ESTestCase {
             boolean isDataFrameAnalyticsEnabled,
             boolean isNlpEnabled
         ) {
-            this.useIlm = useIlm;
             this.includeNodeInfo = includeNodeInfo;
             this.isAnomalyDetectionEnabled = isAnomalyDetectionEnabled;
             this.isDataFrameAnalyticsEnabled = isDataFrameAnalyticsEnabled;
             this.isNlpEnabled = isNlpEnabled;
-        }
-
-        @Override
-        public boolean useIlm() {
-            return useIlm;
         }
 
         @Override


### PR DESCRIPTION
This removes the `useIlm` method from MachineLearningExtension since the same information can be derived from the `stateless.enabled` setting. Until now, stateless was only available in serverless so `useIlm` was always true in non-serverless. But now stateless is being moved into the main product.
Relates: ES-13583