### PR TITLE
Resolve all references in PromqlCommand

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlCommand.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlCommand.java
@@ -12,6 +12,7 @@ import org.elasticsearch.xpack.esql.capabilities.PostAnalysisVerificationAware;
 import org.elasticsearch.xpack.esql.capabilities.TelemetryAware;
 import org.elasticsearch.xpack.esql.common.Failures;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.AttributeSet;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.NameId;
@@ -254,6 +255,14 @@ public class PromqlCommand extends UnaryPlan implements TelemetryAware, PostAnal
         sb.append(promqlPlan.toString());
         sb.append("\n<>]]");
         return sb.toString();
+    }
+
+    @Override
+    protected AttributeSet computeReferences() {
+        // Ensures field resolution is aware of all attributes used in the PromQL plan.
+        AttributeSet.Builder references = AttributeSet.builder();
+        promqlPlan().forEachDown(lp -> references.addAll(lp.references()));
+        return references.build();
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlLogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlLogicalPlanOptimizerTests.java
@@ -33,7 +33,6 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.string.regex.RLik
 import org.elasticsearch.xpack.esql.expression.predicate.logical.And;
 import org.elasticsearch.xpack.esql.expression.predicate.logical.Not;
 import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
-import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Add;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Div;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.NotEquals;


### PR DESCRIPTION
While working on https://github.com/elastic/elasticsearch/issues/139570, I noticed that some new csv tests were failing due to missing references. Turns out that the PromqlCommand always returns empty references! Not sure how it was ever working. I think in CSV tests, we create and cache an `EsRelation` that contains all attributes, regardless of the ones that are actually used in the query.