### PR TITLE
[9.3] Avoiding creating DataStreamShardStats objects with negative timestamps (#139854)

### DIFF
--- a/docs/changelog/139854.yaml
+++ b/docs/changelog/139854.yaml
@@ -1,0 +1,5 @@
+pr: 139854
+summary: Avoiding creating `DataStreamShardStats` objects with negative timestamps
+area: Stats
+type: bug
+issues: []

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportDataStreamsStatsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportDataStreamsStatsAction.java
@@ -141,7 +141,8 @@ public class TransportDataStreamsStatsAction extends TransportBroadcastByNodeAct
             if (maxPackedValue != null) {
                 return LongPoint.decodeDimension(maxPackedValue, 0);
             }
-            return DocValuesSkipper.globalMaxValue(searcher, DataStream.TIMESTAMP_FIELD_NAME);
+            // DocValuesSkipper.globalMaxValue() can return a negative number
+            return Math.max(0, DocValuesSkipper.globalMaxValue(searcher, DataStream.TIMESTAMP_FIELD_NAME));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/datastreams/DataStreamsStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/datastreams/DataStreamsStatsAction.java
@@ -267,6 +267,7 @@ public class DataStreamsStatsAction extends ActionType<DataStreamsStatsAction.Re
         private final long maxTimestamp;
 
         public DataStreamShardStats(ShardRouting shardRouting, StoreStats storeStats, long maxTimestamp) {
+            assert maxTimestamp >= 0 : "Negative values for maxTimestamp are not allowed";
             this.shardRouting = shardRouting;
             this.storeStats = storeStats;
             this.maxTimestamp = maxTimestamp;


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Avoiding creating DataStreamShardStats objects with negative timestamps (#139854)