### PR TITLE
Using stateless.enabled setting to determine correct minimum number of replicas for downsampling

### DIFF
--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/Downsample.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/Downsample.java
@@ -45,7 +45,6 @@ public class Downsample extends Plugin implements ActionPlugin, PersistentTaskPl
 
     public static final String DOWNSAMPLE_TASK_THREAD_POOL_NAME = "downsample_indexing";
     private static final int DOWNSAMPLE_TASK_THREAD_POOL_QUEUE_SIZE = 256;
-    public static final String DOWNSAMPLE_MIN_NUMBER_OF_REPLICAS_NAME = "downsample.min_number_of_replicas";
 
     @Override
     public List<ExecutorBuilder<?>> getExecutorBuilders(Settings settings) {

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/TransportDownsampleAction.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/TransportDownsampleAction.java
@@ -371,8 +371,12 @@ public class TransportDownsampleAction extends AcknowledgedTransportMasterNodeAc
             }
 
             /*
-             * When creating the downsample index, we copy the index.number_of_shards from source index,
-             * and we set the index.number_of_replicas to 0, to avoid replicating the index being built.
+             * When creating the downsample index, we copy the index.number_of_shards from source index.
+             * We set minNumReplicas to 0 if running in stateful mode, to avoid replicating the index being built.
+             * If running in stateless mode, we set minNumReplicas to 1. This is because in stateless deployments, indices without replicas
+             * are not readable, and that would break our persistent task recovery mechanism which relies on reading the latest written
+             * tsid into the downsampling target index. Not having replicas in stateless would result in downsampling persistent tasks to
+             * always start from scratch.
              * Also, we set the index.refresh_interval to -1.
              * We will set the correct number of replicas and refresh the index later.
              *

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/TransportDownsampleAction.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/TransportDownsampleAction.java
@@ -37,6 +37,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.MetadataCreateIndexService;
 import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.metadata.ProjectMetadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.routing.allocation.DataTier;
 import org.elasticsearch.cluster.routing.allocation.allocator.AllocationActionListener;
@@ -378,7 +379,7 @@ public class TransportDownsampleAction extends AcknowledgedTransportMasterNodeAc
              * We should note that there is a risk of losing a node during the downsample process. In this
              * case downsample will fail.
              */
-            int minNumReplicas = clusterService.getSettings().getAsInt(Downsample.DOWNSAMPLE_MIN_NUMBER_OF_REPLICAS_NAME, 0);
+            int minNumReplicas = DiscoveryNode.isStateless(clusterService.getSettings()) ? 1 : 0;
 
             // 3. Create downsample index
             createDownsampleIndex(


### PR DESCRIPTION
Previously, we always set `minNumReplicas` to 0 unless we were running in serverless. Serverless created the `downsample.min_number_of_replicas` setting and always set it to 1. This sets `minNumReplicas` based on the value of the `stateless.enabled` setting instead.
Note that this appears to remove the ability to read a custom `downsample.min_number_of_replicas` value from the cluster settings. However, it is only ever declared a setting in serverless code, and is only ever set to 1 in serverless. So we are not losing any functionality by removing it -- it is just no longer needed since we can now calculate it on the fly.
Relates to #99712
Relates: ES-13580