### PR TITLE
PromQL: apply same default limit as TS

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -1579,8 +1579,8 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
             // We check whether the query contains a TimeSeriesAggregate to determine if we should apply
             // the default limit for TS queries or for non-TS queries.
             // NOTE: PromqlCommand is translated to TimeSeriesAggregate during optimization.
-            boolean isTsAggregate = logicalPlan.collectFirstChildren(lp -> lp instanceof TimeSeriesAggregate ||
-                lp instanceof PromqlCommand).isEmpty() == false;
+            boolean isTsAggregate = logicalPlan.collectFirstChildren(lp -> lp instanceof TimeSeriesAggregate || lp instanceof PromqlCommand)
+                .isEmpty() == false;
 
             int limit;
             if (limits.isEmpty()) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -1578,10 +1578,9 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
             List<LogicalPlan> limits = logicalPlan.collectFirstChildren(Limit.class::isInstance);
             // We check whether the query contains a TimeSeriesAggregate to determine if we should apply
             // the default limit for TS queries or for non-TS queries.
-            boolean isTsAggregate = logicalPlan.collectFirstChildren(lp -> lp instanceof TimeSeriesAggregate)
-                .stream()
-                .toList()
-                .isEmpty() == false;
+            boolean isTsAggregate = logicalPlan.collectFirstChildren(lp -> lp instanceof TimeSeriesAggregate ||
+            // PromqlCommand is translated to TimeSeriesAggregate during optimization
+                lp instanceof PromqlCommand).isEmpty() == false;
             int limit;
             if (limits.isEmpty()) {
                 limit = context.configuration().resultTruncationDefaultSize(isTsAggregate); // user provided no limit: cap to a

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -1578,9 +1578,10 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
             List<LogicalPlan> limits = logicalPlan.collectFirstChildren(Limit.class::isInstance);
             // We check whether the query contains a TimeSeriesAggregate to determine if we should apply
             // the default limit for TS queries or for non-TS queries.
+            // NOTE: PromqlCommand is translated to TimeSeriesAggregate during optimization.
             boolean isTsAggregate = logicalPlan.collectFirstChildren(lp -> lp instanceof TimeSeriesAggregate ||
-            // PromqlCommand is translated to TimeSeriesAggregate during optimization
                 lp instanceof PromqlCommand).isEmpty() == false;
+
             int limit;
             if (limits.isEmpty()) {
                 limit = context.configuration().resultTruncationDefaultSize(isTsAggregate); // user provided no limit: cap to a

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -1641,7 +1641,7 @@ public class AnalyzerTests extends ESTestCase {
         var errorMsg = "Cannot use field [unsupported] with unsupported type [ip_range]";
         verifyUnsupported("""
             from test
-            | dissect unsupported \"%{foo}\"
+            | dissect unsupported "%{foo}"
             """, errorMsg);
     }
 
@@ -1649,7 +1649,7 @@ public class AnalyzerTests extends ESTestCase {
         var errorMsg = "Cannot use field [unsupported] with unsupported type [ip_range]";
         verifyUnsupported("""
             from test
-            | grok unsupported \"%{WORD:foo}\"
+            | grok unsupported "%{WORD:foo}"
             """, errorMsg);
     }
 
@@ -2057,7 +2057,7 @@ public class AnalyzerTests extends ESTestCase {
 
     public void testUnsupportedTypesInStats() {
         verifyUnsupported("""
-              row x = to_unsigned_long(\"10\")
+              row x = to_unsigned_long("10")
               | stats  avg(x), count_distinct(x), max(x), median(x), median_absolute_deviation(x), min(x), percentile(x, 10), sum(x)
             """, """
             Found 6 problems
@@ -2098,25 +2098,25 @@ public class AnalyzerTests extends ESTestCase {
     public void testInOnText() {
         assertProjectionWithMapping("""
             from a_index
-            | eval text in (\"a\", \"b\", \"c\")
+            | eval text in ("a", "b", "c")
             | keep text
             """, "mapping-multi-field-variation.json", "text");
 
         assertProjectionWithMapping("""
             from a_index
-            | eval text in (\"a\", \"b\", \"c\", text)
+            | eval text in ("a", "b", "c", text)
             | keep text
             """, "mapping-multi-field-variation.json", "text");
 
         assertProjectionWithMapping("""
             from a_index
-            | eval text not in (\"a\", \"b\", \"c\")
+            | eval text not in ("a", "b", "c")
             | keep text
             """, "mapping-multi-field-variation.json", "text");
 
         assertProjectionWithMapping("""
             from a_index
-            | eval text not in (\"a\", \"b\", \"c\", text)
+            | eval text not in ("a", "b", "c", text)
             | keep text
             """, "mapping-multi-field-variation.json", "text");
     }
@@ -2557,9 +2557,9 @@ public class AnalyzerTests extends ESTestCase {
     public void testMagnitudePlanWithDenseVectorImplicitCasting() {
         assumeTrue("v_magnitude not available", EsqlCapabilities.Cap.MAGNITUDE_SCALAR_VECTOR_FUNCTION.isEnabled());
 
-        var plan = analyze(String.format(Locale.ROOT, """
+        var plan = analyze("""
             from test | eval scalar = v_magnitude([1, 2, 3])
-            """), DENSE_VECTOR_MAPPING_FILE);
+            """, DENSE_VECTOR_MAPPING_FILE);
 
         var limit = as(plan, Limit.class);
         var eval = as(limit.child(), Eval.class);
@@ -2579,7 +2579,10 @@ public class AnalyzerTests extends ESTestCase {
             Tuple.tuple("TS test", false),
             Tuple.tuple("TS test | STATS avg(rate(network.bytes_in)) BY tbucket=bucket(@timestamp, 1 minute)| sort tbucket", true),
             Tuple.tuple("FROM test | STATS avg(to_long(network.bytes_in))", false),
-            Tuple.tuple("PROMQL index=test avg(rate(network.bytes_in[5m]))", true)
+            Tuple.tuple(
+                "PROMQL index=test step=5m start=\"2024-05-10T00:20:00.000Z\" end=\"2024-05-10T00:25:00.000Z\" avg(rate(network.bytes_in[5m]))",
+                true
+            )
         )) {
             var query = queryExp.v1();
             var expectedLimit = queryExp.v2() ? DEFAULT_TIMESERIES_LIMIT : DEFAULT_LIMIT;
@@ -3789,13 +3792,13 @@ public class AnalyzerTests extends ESTestCase {
     }
 
     private void assertProjectionWithMapping(String query, String mapping, String... names) {
-        var plan = analyze(query, mapping.toString());
+        var plan = analyze(query, mapping);
         var limit = as(plan, Limit.class);
         assertThat(Expressions.names(limit.output()), contains(names));
     }
 
     private void assertProjectionWithMapping(String query, String mapping, QueryParams params, String... names) {
-        var plan = analyze(query, mapping.toString(), params);
+        var plan = analyze(query, mapping, params);
         var limit = as(plan, Limit.class);
         assertThat(Expressions.names(limit.output()), contains(names));
     }
@@ -4039,7 +4042,7 @@ public class AnalyzerTests extends ESTestCase {
                 VerificationException.class,
                 () -> analyze("""
                     FROM books METADATA _score
-                    | RERANK \"italian food recipe\" ON missingField WITH { "inference_id" : "reranking-inference-id" }
+                    | RERANK "italian food recipe" ON missingField WITH { "inference_id" : "reranking-inference-id" }
                     """, "mapping-books.json")
 
             );
@@ -5693,7 +5696,7 @@ public class AnalyzerTests extends ESTestCase {
     public void testLikeParameters() {
         if (EsqlCapabilities.Cap.LIKE_PARAMETER_SUPPORT.isEnabled()) {
             var anonymous_plan = analyze(
-                String.format(Locale.ROOT, "from test | where first_name like ?"),
+                "from test | where first_name like ?",
                 "mapping-basic.json",
                 new QueryParams(List.of(paramAsConstant(null, "Anna*")))
             );
@@ -5707,7 +5710,7 @@ public class AnalyzerTests extends ESTestCase {
     public void testLikeListParameters() {
         if (EsqlCapabilities.Cap.LIKE_PARAMETER_SUPPORT.isEnabled()) {
             var positional_plan = analyze(
-                String.format(Locale.ROOT, "from test | where first_name like (?1, ?2)"),
+                "from test | where first_name like (?1, ?2)",
                 "mapping-basic.json",
                 new QueryParams(List.of(paramAsConstant(null, "Anna*"), paramAsConstant(null, "Chris*")))
             );
@@ -5722,7 +5725,7 @@ public class AnalyzerTests extends ESTestCase {
     public void testRLikeParameters() {
         if (EsqlCapabilities.Cap.LIKE_PARAMETER_SUPPORT.isEnabled()) {
             var named_plan = analyze(
-                String.format(Locale.ROOT, "from test | where first_name rlike ?pattern"),
+                "from test | where first_name rlike ?pattern",
                 "mapping-basic.json",
                 new QueryParams(List.of(paramAsConstant("pattern", "Anna*")))
             );
@@ -5736,7 +5739,7 @@ public class AnalyzerTests extends ESTestCase {
     public void testRLikeListParameters() {
         if (EsqlCapabilities.Cap.LIKE_PARAMETER_SUPPORT.isEnabled()) {
             var named_plan = analyze(
-                String.format(Locale.ROOT, "from test | where first_name rlike (?p1, ?p2)"),
+                "from test | where first_name rlike (?p1, ?p2)",
                 "mapping-basic.json",
                 new QueryParams(List.of(paramAsConstant("p1", "Anna*"), paramAsConstant("p2", "Chris*")))
             );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -2578,7 +2578,8 @@ public class AnalyzerTests extends ESTestCase {
             Tuple.tuple("TS test | STATS avg(rate(network.bytes_in))", true),
             Tuple.tuple("TS test", false),
             Tuple.tuple("TS test | STATS avg(rate(network.bytes_in)) BY tbucket=bucket(@timestamp, 1 minute)| sort tbucket", true),
-            Tuple.tuple("FROM test | STATS avg(to_long(network.bytes_in))", false)
+            Tuple.tuple("FROM test | STATS avg(to_long(network.bytes_in))", false),
+            Tuple.tuple("PROMQL index=test avg(rate(network.bytes_in[5m]))", true)
         )) {
             var query = queryExp.v1();
             var expectedLimit = queryExp.v2() ? DEFAULT_TIMESERIES_LIMIT : DEFAULT_LIMIT;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -2580,7 +2580,9 @@ public class AnalyzerTests extends ESTestCase {
             Tuple.tuple("TS test | STATS avg(rate(network.bytes_in)) BY tbucket=bucket(@timestamp, 1 minute)| sort tbucket", true),
             Tuple.tuple("FROM test | STATS avg(to_long(network.bytes_in))", false),
             Tuple.tuple(
-                "PROMQL index=test step=5m start=\"2024-05-10T00:20:00.000Z\" end=\"2024-05-10T00:25:00.000Z\" avg(rate(network.bytes_in[5m]))",
+                "PROMQL index=test step=5m"
+                    + " start=\"2024-05-10T00:20:00.000Z\" end=\"2024-05-10T00:25:00.000Z\" "
+                    + " avg(rate(network.bytes_in[5m]))",
                 true
             )
         )) {


### PR DESCRIPTION
Align PromQL with TS|STATS by applying a default result limit of 1M instead of the generic ES|QL default.

Issue #139876.