### PR TITLE
[9.3] Reject updating low-priority model deployments to more than 1 allocation (#139989)

### DIFF
--- a/docs/changelog/139989.yaml
+++ b/docs/changelog/139989.yaml
@@ -1,0 +1,6 @@
+pr: 139989
+summary: Reject updating low-priority model deployments to more than 1 allocation
+area: Machine Learning
+type: bug
+issues:
+ - 111227

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
@@ -43,6 +43,7 @@ import org.elasticsearch.xpack.core.ml.action.StartTrainedModelDeploymentAction;
 import org.elasticsearch.xpack.core.ml.action.UpdateTrainedModelAssignmentRoutingInfoAction;
 import org.elasticsearch.xpack.core.ml.inference.assignment.AdaptiveAllocationsSettings;
 import org.elasticsearch.xpack.core.ml.inference.assignment.AssignmentState;
+import org.elasticsearch.xpack.core.ml.inference.assignment.Priority;
 import org.elasticsearch.xpack.core.ml.inference.assignment.RoutingInfo;
 import org.elasticsearch.xpack.core.ml.inference.assignment.RoutingState;
 import org.elasticsearch.xpack.core.ml.inference.assignment.TrainedModelAssignment;
@@ -70,6 +71,7 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.ml.action.StartTrainedModelDeploymentAction.Request.NUMBER_OF_ALLOCATIONS;
+import static org.elasticsearch.xpack.core.ml.action.StartTrainedModelDeploymentAction.Request.PRIORITY;
 import static org.elasticsearch.xpack.core.ml.inference.assignment.TrainedModelAssignmentUtils.NODES_CHANGED_REASON;
 import static org.elasticsearch.xpack.core.ml.inference.assignment.TrainedModelAssignmentUtils.createShuttingDownRoute;
 
@@ -811,6 +813,15 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
                 return;
             }
         }
+        if (Priority.LOW.equals(existingAssignment.getTaskParams().getPriority())) {
+            if (numberOfAllocations != null && numberOfAllocations > 1) {
+                ValidationException validationException = new ValidationException();
+                validationException.addValidationError("[" + NUMBER_OF_ALLOCATIONS + "] must be 1 when [" + PRIORITY + "] is low");
+                listener.onFailure(validationException);
+                return;
+            }
+        }
+
         boolean hasUpdates = hasUpdates(numberOfAllocations, adaptiveAllocationsSettingsUpdates, existingAssignment);
         if (hasUpdates == false) {
             logger.debug("no updates to be made for deployment [{}]", deploymentId);

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/3rd_party_deployment.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/3rd_party_deployment.yml
@@ -484,6 +484,30 @@ setup:
         model_id: test_model
   - match: { stopped: true }
 ---
+"Test update deployment with low priority to multiple allocations":
+  - do:
+      ml.start_trained_model_deployment:
+        model_id: test_model
+        priority: "low"
+        number_of_allocations: 1
+        wait_for: started
+  - match: { assignment.assignment_state: started }
+  - match: { assignment.task_parameters.model_id: test_model }
+  - match: { assignment.task_parameters.priority: low }
+  - match: { assignment.task_parameters.number_of_allocations: 1 }
+
+  - do:
+      ml.update_trained_model_deployment:
+        model_id: test_model
+        body:
+          number_of_allocations: 3
+      catch: /\[number_of_allocations\] must be 1 when \[priority\] is low/
+
+  - do:
+      ml.stop_trained_model_deployment:
+        model_id: test_model
+  - match: { stopped: true }
+---
 "Test put model alias on pytorch model":
   - do:
       ml.put_trained_model_alias:


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Reject updating low-priority model deployments to more than 1 allocation (#139989)