### PR TITLE
fix: ensure CPS project routing appears in the right places for `_msearch/template`

### DIFF
--- a/docs/changelog/140166.yaml
+++ b/docs/changelog/140166.yaml
@@ -1,0 +1,5 @@
+pr: 140166
+summary: "Fix: ensure CPS project routing appears in the right places for `_msearch/template`"
+area: CCS
+type: bug
+issues: []


### PR DESCRIPTION
Since both `_msearch/template` and `_search/template` share the same parser, `project_routing` could appear in the wrong place for the former endpoint. Eg:
```
{}
{"project_routing": ..., "id": ...} // This is invalid. Project routing effectively gets ignored.
```

This PR fixes this bug. See the twinned PR that contains the relevant tests.