### PR TITLE
[Inference API] Always use ssl settings for elastic service

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
@@ -357,12 +357,7 @@ public class InferencePlugin extends Plugin
         var inferenceServiceSettings = new CCMInformedSettings(settings, ccmFeature.get());
         inferenceServiceSettings.init(services.clusterService());
 
-        var eisRequestSenderFactoryComponents = createEisRequestSenderFactory(
-            services,
-            throttlerManager,
-            inferenceServiceSettings,
-            ccmFeature.get()
-        );
+        var eisRequestSenderFactoryComponents = createEisRequestSenderComponents(services, throttlerManager, inferenceServiceSettings);
         var elasticInferenceServiceHttpClientManager = eisRequestSenderFactoryComponents.httpClientManager();
         elasticInferenceServiceFactory.set(eisRequestSenderFactoryComponents.factory());
 
@@ -517,33 +512,21 @@ public class InferencePlugin extends Plugin
 
     private record EisRequestSenderComponents(HttpRequestSender.Factory factory, HttpClientManager httpClientManager) {}
 
-    private EisRequestSenderComponents createEisRequestSenderFactory(
+    private EisRequestSenderComponents createEisRequestSenderComponents(
         PluginServices services,
         ThrottlerManager throttlerManager,
-        ElasticInferenceServiceSettings inferenceServiceSettings,
-        CCMFeature ccmFeature
+        ElasticInferenceServiceSettings inferenceServiceSettings
     ) {
-        // Create a separate instance of HTTPClientManager with its own SSL configuration (`xpack.inference.elastic.http.ssl.*`).
-        HttpClientManager manager;
-        if (ccmFeature.isCcmSupportedEnvironment()) {
-            // If ccm is configurable then we aren't using mTLS so ignore the ssl service
-            manager = HttpClientManager.create(
-                settings,
-                services.threadPool(),
-                services.clusterService(),
-                throttlerManager,
-                inferenceServiceSettings.getConnectionTtl()
-            );
-        } else {
-            manager = HttpClientManager.create(
-                settings,
-                services.threadPool(),
-                services.clusterService(),
-                throttlerManager,
-                getSslService(),
-                inferenceServiceSettings.getConnectionTtl()
-            );
-        }
+        // Always use the SSL service to respect SSL settings like verification_mode even in CCM mode.
+        // This allows local development with self-signed certificates when verification_mode=none.
+        var manager = HttpClientManager.create(
+            settings,
+            services.threadPool(),
+            services.clusterService(),
+            throttlerManager,
+            getSslService(),
+            inferenceServiceSettings.getConnectionTtl()
+        );
 
         return new EisRequestSenderComponents(
             new HttpRequestSender.Factory(serviceComponents.get(), manager, services.clusterService()),


### PR DESCRIPTION
This PR changes how the ssl service is constructed for when the CCM environment is supported. Originally we were only using the default ssl service provided by the apache library. This caused an issue where the `xpack.inference.elastic.http.ssl.verification_mode=none` setting would be ignored and makes local development more difficult. That setting allows the elastic service to run locally with a self-signed cert. So the issue was causing problems for local development.

## Testing

Run the elastic service locally

Start elasticsearch with verification disabled

```
./gradlew :run -Drun.license_type=trial -Dtests.es.xpack.inference.elastic.url=https://localhost:8443 -Dtests.es.xpack.inference.elastic.http.ssl.verification_mode=none -Dtests.es.xpack.inference.elastic.authorization_request_interval="1m" -Dtests.es.xpack.inference.elastic.max_authorization_request_jitter="1s"
```

Configure CCM

```
PUT _inference/_ccm
{
    "api_key": "random_value"
}
```

The authorized endpoints should be added:

```
[2026-01-05T11:07:57,674][INFO ][o.e.x.i.s.e.a.AuthorizationPoller] [runTask-0] Successfully stored EIS preconfigured inference endpoint with inference ID [.anthropic-claude-3.7-sonnet-chat_completion]
[2026-01-05T11:07:57,674][INFO ][o.e.x.i.s.e.a.AuthorizationPoller] [runTask-0] Successfully stored EIS preconfigured inference endpoint with inference ID [.elser-2-elastic]
[2026-01-05T11:07:57,674][INFO ][o.e.x.i.s.e.a.AuthorizationPoller] [runTask-0] Successfully stored EIS preconfigured inference endpoint with inference ID [.openai-gpt-oss-120b-completion]
[2026-01-05T11:07:57,674][INFO ][o.e.x.i.s.e.a.AuthorizationPoller] [runTask-0] Successfully stored EIS preconfigured inference endpoint with inference ID [.openai-gpt-oss-120b-chat_completion]
[2026-01-05T11:07:57,674][INFO ][o.e.x.i.s.e.a.AuthorizationPoller] [runTask-0] Successfully stored EIS preconfigured inference endpoint with inference ID [.anthropic-claude-4.5-sonnet-completion]
[2026-01-05T11:07:57,674][INFO ][o.e.x.i.s.e.a.AuthorizationPoller] [runTask-0] Successfully stored EIS preconfigured inference endpoint with inference ID [.rainbow-sprinkles-elastic]
[2026-01-05T11:07:57,674][INFO ][o.e.x.i.s.e.a.AuthorizationPoller] [runTask-0] Successfully stored EIS preconfigured inference endpoint with inference ID [.gp-llm-v2-completion]
[2026-01-05T11:07:57,674][INFO ][o.e.x.i.s.e.a.AuthorizationPoller] [runTask-0] Successfully stored EIS preconfigured inference endpoint with inference ID [.anthropic-claude-3.7-sonnet-completion]
[2026-01-05T11:07:57,674][INFO ][o.e.x.i.s.e.a.AuthorizationPoller] [runTask-0] Successfully stored EIS preconfigured inference endpoint with inference ID [.anthropic-claude-4.5-sonnet-chat_completion]
[2026-01-05T11:07:57,674][INFO ][o.e.x.i.s.e.a.AuthorizationPoller] [runTask-0] Successfully stored EIS preconfigured inference endpoint with inference ID [.gp-llm-v2-chat_completion]
[2026-01-05T11:07:57,674][INFO ][o.e.x.i.s.e.a.AuthorizationPoller] [runTask-0] Successfully stored EIS preconfigured inference endpoint with inference ID [.jina-embeddings-v3]
```