### PR TITLE
[9.3] ESQL: Aggressively free topn (#140126)

### DIFF
--- a/docs/changelog/140126.yaml
+++ b/docs/changelog/140126.yaml
@@ -1,0 +1,5 @@
+pr: 140126
+summary: Aggressively free topn
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/TopNOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/TopNOperator.java
@@ -592,6 +592,9 @@ public class TopNOperator implements Operator, Accountable {
              */
             output == null ? null : Releasables.wrap(() -> Iterators.map(output, p -> p::releaseBlocks))
         );
+        // Aggressively null these so they can be GCed more quickly.
+        inputQueue = null;
+        output = null;
     }
 
     private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(TopNOperator.class) + RamUsageEstimator
@@ -685,8 +688,22 @@ public class TopNOperator implements Operator, Accountable {
         @Override
         public void close() {
             Releasables.close(
-                // Release all entries in the topn
-                Releasables.wrap(this),
+                /*
+                 * Release all entries in the topn, nulling references to each row after closing them
+                 * so they can be GC immediately. Without this nulling very large heaps can race with
+                 * the circuit breaker itself. With this we're still racing, but we're only racing a
+                 * single row at a time. And single rows can only be so large. And we have enough slop
+                 * to live with being inaccurate by one row.
+                 */
+                () -> {
+                    for (int i = 0; i < getHeapArray().length; i++) {
+                        Row row = (Row) getHeapArray()[i];
+                        if (row != null) {
+                            row.close();
+                            getHeapArray()[i] = null;
+                        }
+                    }
+                },
                 // Release the array itself
                 () -> breaker.addWithoutBreaking(-Queue.sizeOf(topCount))
             );

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNOomRaceTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNOomRaceTests.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.operator.topn;
+
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.MockBigArrays;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.Driver;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.PageConsumerOperator;
+import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.test.AbstractBlockSourceOperator;
+import org.elasticsearch.compute.test.MockBlockFactory;
+import org.elasticsearch.compute.test.OperatorTestCase;
+import org.elasticsearch.compute.test.TestDriverFactory;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Rule;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+
+/**
+ * Runs a few topns in parallel trying to cause an out of memory. {@link TopNOperator} can
+ * run the JVM out of memory if it's {@link TopNOperator#close} reduces the circuit breaker
+ * but doesn't {@code null} the references as it goes. We're looking to throw a
+ * {@link CircuitBreakingException} instead.
+ * <p>
+ *     It'd be ideal if the nulling and the breaker reductions were atomic, but that's not how
+ *     Elasticsearch is. Instead, we figure for some amount of overhead of things that have
+ *     been reduced by the breaker but are not ready for GC. And that's mostly fine, so long as
+ *     the things-not-ready-for-GC are <strong>small</strong>. The entire {@linkplain TopNOperator}
+ *     can be quite a bit too big. Instead, it frees row-by-row. What's too big? We don't know
+ *     precisely, but a full {@linkplain TopNOperator} can be 100s of MB which is very much too big.
+ * </p>
+ * <p>
+ *     This is parameterized because we'd like for it to run a bunch of times on each test
+ *     execution AND because we'd like to see if failures at different points are more likely. We
+ *     don't believe it is, but we want the test executions anyway.
+ * </p>
+ */
+public class TopNOomRaceTests extends ESTestCase {
+    @ParametersFactory(argumentFormatting = "repeats = %s")
+    public static List<Object[]> parameters() {
+        List<Object[]> parameters = new ArrayList<>();
+        /*
+         * 5 here just limits the total number of runs. I could use 1, the test would
+         * just run 5 times longer.
+         */
+        for (int repeats = 5; repeats <= 100; repeats += 5) {
+            parameters.add(new Object[] { repeats });
+        }
+        return parameters;
+    }
+
+    @Rule(order = Integer.MIN_VALUE)
+    public static final AnyFailedWatcher watcher = new AnyFailedWatcher();
+    private final int repeats;
+
+    public TopNOomRaceTests(int repeats) {
+        this.repeats = repeats;
+    }
+
+    public void testRace() {
+        assumeFalse("previous test failed", watcher.anyFailed);
+        int driverCount = 6;
+        double usedByEachThread = .3;
+        ByteSizeValue limit = ByteSizeValue.ofBytes(Runtime.getRuntime().freeMemory());
+        int approxObjectRefsPerFilledRow = 5;
+        int approxSizePerFilledRow = RamUsageEstimator.NUM_BYTES_OBJECT_REF * approxObjectRefsPerFilledRow + repeats * Integer.BYTES;
+        int topCount = (int) ((double) limit.getBytes() / approxSizePerFilledRow * usedByEachThread) - 1;
+        int maxInput = topCount * 3;
+        assertThat(topCount, greaterThan(0));
+
+        BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, limit);
+        CircuitBreaker breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
+        List<DriverContext> contexts = new ArrayList<>();
+        List<Driver> drivers = new ArrayList<>();
+        for (int d = 0; d < driverCount; d++) {
+            MockBlockFactory blockFactory = new MockBlockFactory(breaker, bigArrays);
+            DriverContext driverContext = new DriverContext(bigArrays, blockFactory);
+            contexts.add(driverContext);
+
+            SourceOperator source = new AbstractBlockSourceOperator(blockFactory, 1024) {
+                int lastEnd = 0;
+
+                @Override
+                protected int remaining() {
+                    return maxInput - lastEnd;
+                }
+
+                @Override
+                protected Page createPage(int positionOffset, int length) {
+                    lastEnd = positionOffset + length;
+                    Block ints = IntVector.range(positionOffset, lastEnd, blockFactory).asBlock();
+                    Block[] blocks = new Block[repeats];
+                    blocks[0] = ints;
+                    for (int b = 1; b < repeats; b++) {
+                        ints.incRef();
+                        blocks[b] = ints;
+                    }
+                    return new Page(blocks);
+                }
+            };
+            TopNOperator topn = new TopNOperator(
+                blockFactory,
+                breaker,
+                topCount,
+                Collections.nCopies(repeats, ElementType.INT),
+                Collections.nCopies(repeats, TopNEncoder.DEFAULT_SORTABLE),
+                List.of(new TopNOperator.SortOrder(0, false, false)),
+                Integer.MAX_VALUE
+            );
+            drivers.add(TestDriverFactory.create(driverContext, source, List.of(topn), new PageConsumerOperator(page -> {
+                assertThat(page.getPositionCount(), equalTo(topCount));
+                page.close();
+            })));
+        }
+        expectThrows(CircuitBreakingException.class, () -> OperatorTestCase.runDriver(drivers));
+        for (DriverContext c : contexts) {
+            OperatorTestCase.assertDriverContext(c);
+        }
+    }
+
+    public static class AnyFailedWatcher extends TestWatcher {
+        private boolean anyFailed = false;
+
+        @Override
+        protected void failed(Throwable e, Description description) {
+            anyFailed = true;
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNRowTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNRowTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.List;
+import java.util.stream.IntStream;
 
 import static org.hamcrest.Matchers.equalTo;
 
@@ -20,19 +21,41 @@ public class TopNRowTests extends ESTestCase {
     private final CircuitBreaker breaker = new NoopCircuitBreaker(CircuitBreaker.REQUEST);
 
     public void testRamBytesUsedEmpty() {
-        TopNOperator.Row row = new TopNOperator.Row(breaker, sortOrders(), 0, 0);
+        TopNOperator.Row row = new TopNOperator.Row(breaker, sortOrders(between(1, 10)), 0, 0);
         assertThat(row.ramBytesUsed(), equalTo(expectedRamBytesUsed(row)));
     }
 
     public void testRamBytesUsedSmall() {
-        TopNOperator.Row row = new TopNOperator.Row(new NoopCircuitBreaker(CircuitBreaker.REQUEST), sortOrders(), 0, 0);
+        TopNOperator.Row row = new TopNOperator.Row(new NoopCircuitBreaker(CircuitBreaker.REQUEST), sortOrders(between(1, 10)), 0, 0);
         row.keys.append(randomByte());
         row.values.append(randomByte());
         assertThat(row.ramBytesUsed(), equalTo(expectedRamBytesUsed(row)));
     }
 
+    /**
+     * Tests the row size as measured by MAT in a heap dump from a failing test. All the
+     * magic numbers come from the heap dump. They came from the running {@link TopNOperator}'s
+     * size estimates from previous rows.
+     */
+    public void testFromHeapDump1() {
+        TopNOperator.Row row = new TopNOperator.Row(new NoopCircuitBreaker(CircuitBreaker.REQUEST), sortOrders(5), 56, 24);
+        assertThat(row.ramBytesUsed(), equalTo(expectedRamBytesUsed(row)));
+        assertThat(row.ramBytesUsed(), equalTo(304L)); // 304 is measured debugging a heap dump
+    }
+
+    /**
+     * Tests the row size as measured by MAT in a heap dump from a failing test. All the
+     * magic numbers come from the heap dump. They came from the running {@link TopNOperator}'s
+     * size estimates from previous rows.
+     */
+    public void testFromHeapDump2() {
+        TopNOperator.Row row = new TopNOperator.Row(new NoopCircuitBreaker(CircuitBreaker.REQUEST), sortOrders(1), 1160, 1_153_096);
+        assertThat(row.ramBytesUsed(), equalTo(expectedRamBytesUsed(row)));
+        assertThat(row.ramBytesUsed(), equalTo(1_154_464L)); // 1,154,464 is measured debugging a heap dump
+    }
+
     public void testRamBytesUsedBig() {
-        TopNOperator.Row row = new TopNOperator.Row(new NoopCircuitBreaker(CircuitBreaker.REQUEST), sortOrders(), 0, 0);
+        TopNOperator.Row row = new TopNOperator.Row(new NoopCircuitBreaker(CircuitBreaker.REQUEST), sortOrders(between(1, 10)), 0, 0);
         for (int i = 0; i < 10000; i++) {
             row.keys.append(randomByte());
             row.values.append(randomByte());
@@ -41,15 +64,14 @@ public class TopNRowTests extends ESTestCase {
     }
 
     public void testRamBytesUsedPreAllocated() {
-        TopNOperator.Row row = new TopNOperator.Row(new NoopCircuitBreaker(CircuitBreaker.REQUEST), sortOrders(), 64, 128);
+        TopNOperator.Row row = new TopNOperator.Row(new NoopCircuitBreaker(CircuitBreaker.REQUEST), sortOrders(between(1, 10)), 64, 128);
         assertThat(row.ramBytesUsed(), equalTo(expectedRamBytesUsed(row)));
     }
 
-    private static List<TopNOperator.SortOrder> sortOrders() {
-        return List.of(
-            new TopNOperator.SortOrder(randomNonNegativeInt(), randomBoolean(), randomBoolean()),
-            new TopNOperator.SortOrder(randomNonNegativeInt(), randomBoolean(), randomBoolean())
-        );
+    private static List<TopNOperator.SortOrder> sortOrders(int count) {
+        return IntStream.range(0, count)
+            .mapToObj(i -> new TopNOperator.SortOrder(randomNonNegativeInt(), randomBoolean(), randomBoolean()))
+            .toList();
     }
 
     private long expectedRamBytesUsed(TopNOperator.Row row) {
@@ -62,8 +84,7 @@ public class TopNRowTests extends ESTestCase {
         expected -= RamUsageTester.ramUsed(breaker);
         expected -= RamUsageTester.ramUsed("topn");
         // the sort orders are shared
-        expected -= RamUsageTester.ramUsed(sortOrders());
-        // expected -= RamUsageTester.ramUsed(row.docVector);
+        expected -= RamUsageTester.ramUsed(row.bytesOrder.sortOrders);
         return expected;
     }
 }


### PR DESCRIPTION
Backports the following commits to 9.3:
 - ESQL: Aggressively free topn (#140126)