### PR TITLE
[9.3] Revert "Attempt to clean up index before remote transfer (#115142)" (#139569)

### DIFF
--- a/docs/changelog/139569.yaml
+++ b/docs/changelog/139569.yaml
@@ -1,0 +1,5 @@
+pr: 139569
+summary: Revert "Attempt to clean up index before remote transfer"
+area: Recovery
+type: bug
+issues: []


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Revert "Attempt to clean up index before remote transfer (#115142)" (#139569)