### PR TITLE
PoC: Add aggregate counter downsampling

### DIFF
--- a/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DownsampleIT.java
+++ b/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DownsampleIT.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
@@ -173,6 +174,10 @@ public class DownsampleIT extends DownsamplingIntegTestCase {
                   "type": "double",
                   "time_series_metric": "gauge"
                 },
+                "metrics.requests": {
+                  "type": "double",
+                  "time_series_metric": "counter"
+                },
                 "metrics.latency": {
                   "type": "exponential_histogram",
                   "time_series_metric": "histogram"
@@ -202,6 +207,7 @@ public class DownsampleIT extends DownsamplingIntegTestCase {
 
         // Create data stream by indexing documents
         final Instant now = Instant.now();
+        AtomicInteger seed = new AtomicInteger(0);
         Supplier<XContentBuilder> sourceSupplier = () -> {
             String ts = randomDateForRange(now.minusSeconds(60 * 60).toEpochMilli(), now.plusSeconds(60 * 29).toEpochMilli());
             try {
@@ -212,6 +218,7 @@ public class DownsampleIT extends DownsamplingIntegTestCase {
                     .field("attributes.host.name", randomFrom("host1", "host2", "host3"))
                     .field("attributes.os.name", randomFrom("linux", "windows", "macos"))
                     .field("metrics.cpu_usage", randomDouble())
+                    .field("metrics.requests", seed.addAndGet(randomIntBetween(-3, 10)))
 
                     .startObject("metrics.latency")
                     .field("scale", 0)

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/AggregateCounterFieldProducer.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/AggregateCounterFieldProducer.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.downsample;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.internal.hppc.IntArrayList;
+import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+/**
+ * Base class that reads fields from the source index and produces their downsampled values
+ */
+class AggregateCounterFieldProducer extends AbstractDownsampleFieldProducer<SortedNumericDoubleValues> {
+
+    private static final Logger logger = LogManager.getLogger(AggregateCounterFieldProducer.class);
+    private double firstValue = Double.NaN;
+    private double lastValue = Double.NaN;
+    private double resetOffset = 0;
+
+    AggregateCounterFieldProducer(String name) {
+        super(name);
+    }
+
+    /**
+     * Resets the producer to an empty value.
+     */
+    public void reset() {
+        isEmpty = true;
+        firstValue = Double.NaN;
+        lastValue = Double.NaN;
+        resetOffset = 0;
+    }
+
+    @Override
+    public void collect(SortedNumericDoubleValues docValues, IntArrayList docIdBuffer) throws IOException {
+        throw new UnsupportedOperationException("collect(IntArrayList) is not supported");
+    }
+
+    public void collect(SortedNumericDoubleValues docValues, int docId) throws IOException {
+        if (docValues.advanceExact(docId) == false) {
+            return;
+        }
+        int docValuesCount = docValues.docValueCount();
+        assert docValuesCount > 0;
+        isEmpty = false;
+        var currentValue = docValues.nextValue();
+        // If this the first time we encounter a value
+        if (Double.isNaN(lastValue)) {
+            firstValue = currentValue;
+            lastValue = currentValue;
+            return;
+        }
+
+        // check for reset
+        if (currentValue > firstValue) {
+            resetOffset += firstValue;
+        }
+        firstValue = currentValue;
+    }
+
+    @Override
+    public void write(XContentBuilder builder) throws IOException {
+        if (isEmpty() == false) {
+            logger.info(
+                "Aggregated counter field '{}': {first_value: {}, last_value: {}, resetOffset: {}}",
+                name(),
+                firstValue,
+                lastValue,
+                resetOffset
+            );
+            builder.field(name(), firstValue + resetOffset);
+        }
+    }
+}

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DownsampleShardIndexer.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DownsampleShardIndexer.java
@@ -372,35 +372,32 @@ class DownsampleShardIndexer {
                 var fieldValueFetcher = fieldValueFetchers.get(i);
                 var fieldProducer = fieldValueFetcher.fieldProducer();
                 if (fieldProducer instanceof NumericMetricFieldProducer metricFieldProducer) {
-                    bufferedFieldCollectors.add(new LeafDownsampleCollector.FieldCollector<>(
-                        metricFieldProducer,
-                        fieldValueFetcher.getNumericLeaf(ctx)
-                    ));
+                    bufferedFieldCollectors.add(
+                        new LeafDownsampleCollector.FieldCollector<>(metricFieldProducer, fieldValueFetcher.getNumericLeaf(ctx))
+                    );
                 } else if (fieldProducer instanceof ExponentialHistogramFieldProducer exponentialHistogramProducer) {
-                    bufferedFieldCollectors.add(new LeafDownsampleCollector.FieldCollector<>(
-                        exponentialHistogramProducer,
-                        fieldValueFetcher.getExponentialHistogramLeaf(ctx)
-                    ));
+                    bufferedFieldCollectors.add(
+                        new LeafDownsampleCollector.FieldCollector<>(
+                            exponentialHistogramProducer,
+                            fieldValueFetcher.getExponentialHistogramLeaf(ctx)
+                        )
+                    );
                 } else if (fieldProducer instanceof AggregateMetricDoubleFieldProducer numericFieldProducer) {
-                    bufferedFieldCollectors.add(new LeafDownsampleCollector.FieldCollector<>(
-                        numericFieldProducer,
-                        fieldValueFetcher.getNumericLeaf(ctx)
-                    ));
+                    bufferedFieldCollectors.add(
+                        new LeafDownsampleCollector.FieldCollector<>(numericFieldProducer, fieldValueFetcher.getNumericLeaf(ctx))
+                    );
                 } else if (fieldProducer instanceof LastValueFieldProducer lastValueFieldProducer) {
-                    bufferedFieldCollectors.add(new LeafDownsampleCollector.FieldCollector<>(
-                        lastValueFieldProducer,
-                        fieldValueFetcher.getLeaf(ctx)
-                    ));
+                    bufferedFieldCollectors.add(
+                        new LeafDownsampleCollector.FieldCollector<>(lastValueFieldProducer, fieldValueFetcher.getLeaf(ctx))
+                    );
                 } else if (fieldProducer instanceof TDigestHistogramFieldProducer histogramFieldProducer) {
-                    bufferedFieldCollectors.add(new LeafDownsampleCollector.FieldCollector<>(
-                        histogramFieldProducer,
-                        fieldValueFetcher.getHistogramLeaf(ctx)
-                    ));
+                    bufferedFieldCollectors.add(
+                        new LeafDownsampleCollector.FieldCollector<>(histogramFieldProducer, fieldValueFetcher.getHistogramLeaf(ctx))
+                    );
                 } else if (fieldProducer instanceof AggregateCounterFieldProducer counterFieldProducer) {
-                    singleFieldCollectors.add(new LeafDownsampleCollector.FieldCollector<>(
-                        counterFieldProducer,
-                        fieldValueFetcher.getNumericLeaf(ctx)
-                    ));
+                    singleFieldCollectors.add(
+                        new LeafDownsampleCollector.FieldCollector<>(counterFieldProducer, fieldValueFetcher.getNumericLeaf(ctx))
+                    );
                 }
             }
 

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/FieldValueFetcher.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/FieldValueFetcher.java
@@ -102,8 +102,10 @@ class FieldValueFetcher {
             assert fieldType.getMetricType() == TimeSeriesParams.MetricType.GAUGE
                 || fieldType.getMetricType() == TimeSeriesParams.MetricType.COUNTER
                 : "only gauges and counters accepted, other metrics should have been handled earlier";
-            if (samplingMethod == DownsampleConfig.SamplingMethod.AGGREGATE
-                && fieldType.getMetricType() == TimeSeriesParams.MetricType.GAUGE) {
+            if (samplingMethod == DownsampleConfig.SamplingMethod.AGGREGATE) {
+                if (fieldType.getMetricType() == TimeSeriesParams.MetricType.COUNTER) {
+                    return new AggregateCounterFieldProducer(name());
+                }
                 return new NumericMetricFieldProducer.AggregateGauge(name());
             }
             return new NumericMetricFieldProducer.LastValue(name());


### PR DESCRIPTION
This is meant strictly as a feasibility experiment for adding a separate producer that reads the counter fields of each document in order.

We converted some arrays to list just to limit this change to highlight the interesting parts for early feedback. 