### PR TITLE
Undo not-preferred in allocation explain

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/WriteLoadConstraintDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/WriteLoadConstraintDeciderIT.java
@@ -10,10 +10,8 @@
 package org.elasticsearch.cluster.routing.allocation.decider;
 
 import org.apache.logging.log4j.Level;
-import org.elasticsearch.action.admin.cluster.allocation.ClusterAllocationExplainRequest;
 import org.elasticsearch.action.admin.cluster.allocation.DesiredBalanceRequest;
 import org.elasticsearch.action.admin.cluster.allocation.DesiredBalanceResponse;
-import org.elasticsearch.action.admin.cluster.allocation.TransportClusterAllocationExplainAction;
 import org.elasticsearch.action.admin.cluster.allocation.TransportGetDesiredBalanceAction;
 import org.elasticsearch.action.admin.cluster.node.usage.NodeUsageStatsForThreadPoolsAction;
 import org.elasticsearch.action.admin.cluster.node.usage.TransportNodeUsageStatsForThreadPoolsAction;
@@ -29,14 +27,11 @@ import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
-import org.elasticsearch.cluster.routing.allocation.AllocationDecision;
-import org.elasticsearch.cluster.routing.allocation.Explanations;
 import org.elasticsearch.cluster.routing.allocation.WriteLoadConstraintSettings;
 import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
 import org.elasticsearch.cluster.routing.allocation.allocator.DesiredBalanceMetrics;
 import org.elasticsearch.cluster.routing.allocation.allocator.DesiredBalanceShardsAllocator;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.core.TimeValue;
@@ -273,51 +268,9 @@ public class WriteLoadConstraintDeciderIT extends ESIntegTestCase {
         reason = "track when reconciliation has completed",
         value = "org.elasticsearch.cluster.routing.allocation.allocator.DesiredBalanceShardsAllocator:DEBUG"
     )
-    public void testAllocationExplainMoveShardNotPreferred() {
-        TestHarness harness = setUpThreeTestNodesAndAllIndexShardsOnFirstNode();
-
-        // Running the {@link #runCanRemainNotPreferredIsIgnoredWhenAllOtherNodesReturnNotPreferred} logic should set up a cluster where
-        // shards are all allocated to a {@link AllocationDeciders#canRemain} {@link Decision#NOT_PREFERRED} node, while the other nodes
-        // return {@link AllocationDeciders#canAllocate} {@link Decision#NOT_PREFERRED} responses. This should exercise NOT_PREFERRED in
-        // the allocation/explain paths for remaining on a node AND assignment to other nodes.
-        runCanRemainNotPreferredIsIgnoredWhenAllOtherNodesReturnNotPreferred(harness);
-        int numDataNodes = internalCluster().numDataNodes();
-        assertThat(
-            "test requires at least two nodes, one node for canRemain explanation, one for canAllocation explanation",
-            numDataNodes,
-            greaterThanOrEqualTo(2)
-        );
-
-        ClusterAllocationExplainRequest allocationExplainRequest = new ClusterAllocationExplainRequest(TEST_REQUEST_TIMEOUT).setIndex(
-            harness.indexName
-        ).setShard(0).setPrimary(true);
-        var allocationExplainResponse = safeGet(client().execute(TransportClusterAllocationExplainAction.TYPE, allocationExplainRequest));
-        logger.info("---> Allocation explain response: " + Strings.toString(allocationExplainResponse.getExplanation(), true, true));
-
-        var decision = allocationExplainResponse.getExplanation().getShardAllocationDecision().getMoveDecision();
-        assertThat("Rebalancing should be disabled", decision.canRebalanceCluster(), equalTo(false));
-        assertThat(decision.getCanRemainDecision().type(), equalTo(Decision.NOT_PREFERRED.type()));
-        assertNull(decision.getTargetNode());
-        assertThat(decision.getAllocationDecision(), equalTo(AllocationDecision.NOT_PREFERRED));
-
-        var canAllocateDecisions = allocationExplainResponse.getExplanation()
-            .getShardAllocationDecision()
-            .getMoveDecision()
-            .getNodeDecisions();
-        assertThat(canAllocateDecisions.size(), equalTo(/* number of nodes to which the shard can be relocated = */ numDataNodes - 1));
-        canAllocateDecisions.forEach(nodeDecision -> assertThat(nodeDecision.getNodeDecision(), equalTo(AllocationDecision.NOT_PREFERRED)));
-    }
-
-    @TestLogging(
-        reason = "track when reconciliation has completed",
-        value = "org.elasticsearch.cluster.routing.allocation.allocator.DesiredBalanceShardsAllocator:DEBUG"
-    )
     public void testCanRemainNotPreferredIsIgnoredWhenAllOtherNodesReturnNotPreferred() {
         TestHarness harness = setUpThreeTestNodesAndAllIndexShardsOnFirstNode();
-        runCanRemainNotPreferredIsIgnoredWhenAllOtherNodesReturnNotPreferred(harness);
-    }
 
-    private void runCanRemainNotPreferredIsIgnoredWhenAllOtherNodesReturnNotPreferred(TestHarness harness) {
         /**
          * Override the {@link TransportNodeUsageStatsForThreadPoolsAction} action on the data nodes to supply artificial thread pool write
          * load stats. The stats will show all the nodes above the high utilization threshold, so they do not accept new shards, while the
@@ -500,80 +453,6 @@ public class WriteLoadConstraintDeciderIT extends ESIntegTestCase {
             dumpClusterState();
             throw error;
         }
-    }
-
-    public void testAllocationExplainRebalancingNotPreferred() {
-        var harness = setUpThreeTestNodesAndAllIndexShardsOnFirstNode();
-
-        // Set up all data nodes to report write thread pool usage above the utilization threshold, to stop canAllocate, but no write thread
-        // pool queuing to force a shard relocation. This will leave all the data nodes unable to accept new shards when rebalancing
-        // attempts to redistribute shards more evenly than all shards on a single node.
-
-        final NodeUsageStatsForThreadPools firstNodeAboveUtilizationThresholdNodeStats = createNodeUsageStatsForThreadPools(
-            harness.firstDiscoveryNode,
-            harness.randomNumberOfWritePoolThreads,
-            randomIntBetween(harness.randomUtilizationThresholdPercent, 100) / 100f,
-            0
-        );
-        final NodeUsageStatsForThreadPools secondNodeAboveUtilizationThresholdNodeStats = createNodeUsageStatsForThreadPools(
-            harness.secondDiscoveryNode,
-            harness.randomNumberOfWritePoolThreads,
-            randomIntBetween(harness.randomUtilizationThresholdPercent, 100) / 100f,
-            0
-        );
-        final NodeUsageStatsForThreadPools thirdNodeAboveUtilizationThresholdNodeStats = createNodeUsageStatsForThreadPools(
-            harness.thirdDiscoveryNode,
-            harness.randomNumberOfWritePoolThreads,
-            randomIntBetween(harness.randomUtilizationThresholdPercent, 100) / 100f,
-            0
-        );
-        setUpMockTransportNodeUsageStatsResponse(harness.firstDiscoveryNode, firstNodeAboveUtilizationThresholdNodeStats);
-        setUpMockTransportNodeUsageStatsResponse(harness.secondDiscoveryNode, secondNodeAboveUtilizationThresholdNodeStats);
-        setUpMockTransportNodeUsageStatsResponse(harness.thirdDiscoveryNode, thirdNodeAboveUtilizationThresholdNodeStats);
-
-        // Override the {@link TransportIndicesStatsAction} action on the data nodes to supply artificial shard write load stats. The stats
-        // will show that all shards have non-empty write load stats (so that the WriteLoadDecider will evaluate assigning them to a node).
-        final ClusterState originalClusterState = internalCluster().getCurrentMasterNodeInstance(ClusterService.class).state();
-        final IndexMetadata indexMetadata = originalClusterState.getMetadata().getProject().index(harness.indexName);
-        setUpMockTransportIndicesStatsResponse(
-            harness.firstDiscoveryNode,
-            indexMetadata.getNumberOfShards(),
-            createShardStatsResponseForIndex(indexMetadata, harness.maxShardWriteLoad, harness.firstDataNodeId)
-        );
-        setUpMockTransportIndicesStatsResponse(harness.secondDiscoveryNode, 0, List.of());
-        setUpMockTransportIndicesStatsResponse(harness.thirdDiscoveryNode, 0, List.of());
-
-        logger.info("---> Refreshing the cluster info to pull in the dummy thread pool stats from the data nodes");
-        refreshClusterInfo();
-
-        // Allow rebalancing and clear the exclusion setting that holds the shards on a single node.
-        updateClusterSettings(
-            Settings.builder()
-                .put(EnableAllocationDecider.CLUSTER_ROUTING_REBALANCE_ENABLE_SETTING.getKey(), EnableAllocationDecider.Rebalance.ALL)
-                .putNull("cluster.routing.allocation.exclude._name")
-        );
-
-        logger.info("---> Rebalancing is now allowed");
-
-        ClusterAllocationExplainRequest allocationExplainRequest = new ClusterAllocationExplainRequest(TEST_REQUEST_TIMEOUT).setIndex(
-            harness.indexName
-        ).setShard(0).setPrimary(true);
-        var allocationExplainResponse = safeGet(client().execute(TransportClusterAllocationExplainAction.TYPE, allocationExplainRequest));
-        logger.info("---> Allocation explain response: " + Strings.toString(allocationExplainResponse.getExplanation(), true, true));
-
-        var decision = allocationExplainResponse.getExplanation().getShardAllocationDecision().getMoveDecision();
-        assertThat("Rebalancing should be enabled", decision.canRebalanceCluster(), equalTo(true));
-        assertThat(decision.getCanRemainDecision().type(), equalTo(Decision.YES.type()));
-        assertNull(decision.getTargetNode());
-        assertThat(decision.getAllocationDecision(), equalTo(AllocationDecision.NOT_PREFERRED));
-        assertThat(decision.getExplanation(), equalTo(Explanations.Rebalance.NOT_PREFERRED));
-
-        var canAllocateDecisions = allocationExplainResponse.getExplanation()
-            .getShardAllocationDecision()
-            .getMoveDecision()
-            .getNodeDecisions();
-        assertThat(canAllocateDecisions.size(), equalTo(2));
-        canAllocateDecisions.forEach(nodeDecision -> assertThat(nodeDecision.getNodeDecision(), equalTo(AllocationDecision.NOT_PREFERRED)));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationDecision.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationDecision.java
@@ -154,8 +154,8 @@ public enum AllocationDecision implements Writeable {
      */
     public static AllocationDecision fromDecisionType(Decision.Type type) {
         return switch (type) {
-            case YES -> YES;
-            case NOT_PREFERRED -> NOT_PREFERRED;
+            // TODO: this
+            case YES, NOT_PREFERRED -> YES;
             case THROTTLE -> THROTTLED;
             case NO -> NO;
         };

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/MoveDecision.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/MoveDecision.java
@@ -317,6 +317,7 @@ public final class MoveDecision extends AbstractAllocationDecision {
                 builder.field("rebalance_explanation", getExplanation());
             } else {
                 builder.field("can_move_to_other_node", cannotRemainAndCanMove() ? "yes" : "no");
+                builder.field("move_explanation", getExplanation());
             }
             return builder;
         }), nodeDecisionsToXContentChunked(nodeDecisions));

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/MoveDecision.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/MoveDecision.java
@@ -118,32 +118,13 @@ public final class MoveDecision extends AbstractAllocationDecision {
     ) {
         assert canRemainDecision != null;
         assert canRemainDecision.type() != Type.YES : "create decision with MoveDecision#createRemainYesDecision instead";
-        assert decisionAndTargetAreConsistent(canRemainDecision, moveDecision, targetNode)
-            : "targetNode: " + targetNode + ", move decision: " + moveDecision;
         if (nodeDecisions == null && moveDecision == AllocationDecision.NO) {
             // the final decision is NO (no node to move the shard to) and we are not in explain mode, return a cached version
             return CACHED_CANNOT_MOVE_DECISION;
         } else {
+            assert ((targetNode == null) == (moveDecision != AllocationDecision.YES));
             return new MoveDecision(targetNode, nodeDecisions, moveDecision, canRemainDecision, null, 0);
         }
-    }
-
-    private static boolean decisionAndTargetAreConsistent(
-        Decision canRemainDecision,
-        AllocationDecision moveDecision,
-        DiscoveryNode targetNode
-    ) {
-        return switch (moveDecision) {
-            // YES must always have a target
-            case AllocationDecision.YES -> (targetNode != null);
-            case AllocationDecision.NOT_PREFERRED -> {
-                // If canRemain is not-preferred, then there should be no shard move, and thus no target node.
-                assert (canRemainDecision.type() == Type.NOT_PREFERRED) == (targetNode == null)
-                    : "remain decision: " + canRemainDecision + ", target node: " + targetNode;
-                yield true;
-            }
-            default -> targetNode == null;
-        };
     }
 
     /**
@@ -282,29 +263,23 @@ public final class MoveDecision extends AbstractAllocationDecision {
                     ? Explanations.Rebalance.CANNOT_REBALANCE_CAN_ALLOCATE
                     : Explanations.Rebalance.CANNOT_REBALANCE_CANNOT_ALLOCATE;
                 case THROTTLE -> Explanations.Rebalance.CLUSTER_THROTTLE;
-                case YES -> {
+                case YES, NOT_PREFERRED -> {
                     if (getTargetNode() != null) {
                         yield canMoveDecision == AllocationDecision.THROTTLED
                             ? Explanations.Rebalance.NODE_THROTTLE
                             : Explanations.Rebalance.YES;
                     } else {
-                        yield canMoveDecision == AllocationDecision.NOT_PREFERRED
-                            ? Explanations.Rebalance.NOT_PREFERRED
-                            : Explanations.Rebalance.ALREADY_BALANCED;
+                        yield Explanations.Rebalance.ALREADY_BALANCED;
                     }
                 }
-                case NOT_PREFERRED -> Explanations.Rebalance.NOT_PREFERRED;
             };
         } else {
             // it was a decision by an allocation decider to move the shard
             assert cannotRemain();
             return switch (canMoveDecision) {
-                case YES -> canRemainNotPreferred() ? Explanations.Move.NOT_PREFERRED_TO_YES : Explanations.Move.YES;
-                case NOT_PREFERRED -> canRemainNotPreferred()
-                    ? Explanations.Move.NOT_PREFERRED_TO_NOT_PREFERRED
-                    : Explanations.Move.NOT_PREFERRED;
-                case THROTTLED -> canRemainNotPreferred() ? Explanations.Move.NOT_PREFERRED_TO_THROTTLED : Explanations.Move.THROTTLED;
-                case NO -> canRemainNotPreferred() ? Explanations.Move.NOT_PREFERRED_TO_NO : Explanations.Move.NO;
+                case YES, NOT_PREFERRED -> Explanations.Move.YES;
+                case THROTTLED -> Explanations.Move.THROTTLED;
+                case NO -> Explanations.Move.NO;
                 case WORSE_BALANCE, AWAITING_INFO, ALLOCATION_DELAYED, NO_VALID_SHARD_COPY, NO_ATTEMPT -> {
                     assert false : canMoveDecision;
                     yield canMoveDecision.toString();
@@ -341,14 +316,7 @@ public final class MoveDecision extends AbstractAllocationDecision {
                 builder.field("can_rebalance_to_other_node", canMoveDecision);
                 builder.field("rebalance_explanation", getExplanation());
             } else {
-                if (cannotRemainAndCanMove()) {
-                    builder.field("can_move_to_other_node", "yes");
-                } else if (cannotRemainAndNotPreferredMove()) {
-                    builder.field("can_move_to_other_node", "not-preferred");
-                } else {
-                    builder.field("can_move_to_other_node", "no");
-                }
-                builder.field("move_explanation", getExplanation());
+                builder.field("can_move_to_other_node", cannotRemainAndCanMove() ? "yes" : "no");
             }
             return builder;
         }), nodeDecisionsToXContentChunked(nodeDecisions));

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/Decision.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/Decision.java
@@ -118,10 +118,9 @@ public sealed interface Decision extends ToXContent, Writeable permits Decision.
     enum Type implements Writeable {
         // ordered by positiveness; order matters for serialization and comparison
         NO,
-        NOT_PREFERRED,
-        // Temporarily throttled is a better choice than choosing a not-preferred node,
-        // but NOT_PREFERRED and THROTTLED are generally not comparable.
+        // NOT_PREFERRED and THROTTLED should not be compared.
         THROTTLE,
+        NOT_PREFERRED,
         YES;
 
         private static final TransportVersion ALLOCATION_DECISION_NOT_PREFERRED = TransportVersion.fromName(
@@ -162,6 +161,7 @@ public sealed interface Decision extends ToXContent, Writeable permits Decision.
             }
         }
 
+        // TODO: Remove this method, causes too much headache. THROTTLE and NOT_PREFERRED should not be compared.
         public boolean higherThan(Type other) {
             return this.compareTo(other) > 0;
         }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainActionTests.java
@@ -10,11 +10,8 @@
 package org.elasticsearch.action.admin.cluster.allocation;
 
 import org.elasticsearch.action.support.replication.ClusterStateCreationUtils;
-import org.elasticsearch.cluster.ClusterInfo;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.EmptyClusterInfoService;
 import org.elasticsearch.cluster.TestShardRoutingRoleStrategies;
-import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
@@ -25,19 +22,13 @@ import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.routing.allocation.AllocationDecision;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
-import org.elasticsearch.cluster.routing.allocation.Explanations;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.cluster.routing.allocation.ShardAllocationDecision;
-import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
 import org.elasticsearch.cluster.routing.allocation.allocator.ShardsAllocator;
-import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
-import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.common.xcontent.XContentHelper;
-import org.elasticsearch.snapshots.EmptySnapshotsInfoService;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.gateway.TestGatewayAllocator;
 import org.elasticsearch.xcontent.ToXContent;
@@ -46,7 +37,6 @@ import org.elasticsearch.xcontent.XContentFactory;
 
 import java.time.Instant;
 import java.util.Collections;
-import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -55,7 +45,6 @@ import static org.elasticsearch.action.admin.cluster.allocation.TransportCluster
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
 
 /**
  * Tests for the {@link TransportClusterAllocationExplainAction} class.
@@ -63,284 +52,6 @@ import static org.hamcrest.Matchers.equalTo;
 public class ClusterAllocationExplainActionTests extends ESTestCase {
 
     private static final AllocationDeciders NOOP_DECIDERS = new AllocationDeciders(Collections.emptyList());
-
-    private class CanAllocateNotPreferredAllocationDecider extends AllocationDecider {
-        @Override
-        public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
-            return Decision.single(Decision.Type.NOT_PREFERRED, "CanAllocateNotPreferredAllocationDecider", "Test not-preferred");
-        }
-
-        @Override
-        public Decision canRebalance(RoutingAllocation allocation) {
-            return Decision.NO;
-        }
-    }
-
-    private class CanAllocateThrottledAllocationDecider extends AllocationDecider {
-        @Override
-        public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
-            return Decision.single(Decision.Type.THROTTLE, "CanAllocateThrottledAllocationDecider", "Test throttle");
-        }
-
-        @Override
-        public Decision canRebalance(RoutingAllocation allocation) {
-            return Decision.NO;
-        }
-    }
-
-    private class CanRemainNotPreferredAllocationDecider extends AllocationDecider {
-        @Override
-        public Decision canRemain(IndexMetadata indexMetadata, ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
-            return Decision.single(Decision.Type.NOT_PREFERRED, "CanRemainNotPreferredAllocationDecider", "Test not-preferred");
-        }
-
-        @Override
-        public Decision canRebalance(RoutingAllocation allocation) {
-            return Decision.NO;
-        }
-    }
-
-    private class CanRemainNoAllocationDecider extends AllocationDecider {
-        @Override
-        public Decision canRemain(IndexMetadata indexMetadata, ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
-            return Decision.single(Decision.Type.NO, "CanRemainNoAllocationDecider", "Test no");
-        }
-
-        @Override
-        public Decision canRebalance(RoutingAllocation allocation) {
-            return Decision.NO;
-        }
-    }
-
-    public void testNoToNotPreferredShardAllocationExplanation() {
-        ClusterState clusterState = ClusterStateCreationUtils.state("idx", randomBoolean(), ShardRoutingState.STARTED);
-        logger.info("---> Cluster state: " + clusterState);
-        final ProjectId projectId = clusterState.metadata().projects().keySet().iterator().next();
-        ShardRouting shardRouting = clusterState.globalRoutingTable().routingTable(projectId).index("idx").shard(0).primaryShard();
-        ClusterInfo clusterInfo = ClusterInfo.builder().build();
-        // Set up allocation deciders that will say: 1) shard cannot remain where it is and 2) shard allocation elsewhere is not-preferred.
-        // Relocation should proceed, with a target node for the MoveDecision.
-        AllocationDeciders allocationDeciders = new AllocationDeciders(
-            List.of(new CanRemainNoAllocationDecider(), new CanAllocateNotPreferredAllocationDecider())
-        );
-        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, clusterState, clusterInfo, null, System.nanoTime());
-
-        ClusterAllocationExplanation allocationExplanation = TransportClusterAllocationExplainAction.explainShard(
-            shardRouting,
-            allocation,
-            clusterInfo,
-            randomBoolean(),
-            true,
-            new AllocationService(
-                allocationDeciders,
-                new TestGatewayAllocator(),
-                new BalancedShardsAllocator(Settings.EMPTY),
-                EmptyClusterInfoService.INSTANCE,
-                EmptySnapshotsInfoService.INSTANCE,
-                TestShardRoutingRoleStrategies.DEFAULT_ROLE_ONLY
-            )
-        );
-
-        logger.info("---> Allocation explain response: " + Strings.toString(allocationExplanation, true, true));
-        // canRemain on the current node should be NO.
-        assertThat(allocationExplanation.getShardAllocationDecision().getMoveDecision().canRemain(), equalTo(false));
-        assertThat(
-            allocationExplanation.getShardAllocationDecision().getMoveDecision().getCanRemainDecision().type(),
-            equalTo(Decision.Type.NO)
-        );
-        assertThat(
-            "All other potential nodes should be not-preferred, resulting in an overall not-preferred relocation",
-            allocationExplanation.getShardAllocationDecision().getMoveDecision().getAllocationDecision(),
-            equalTo(AllocationDecision.NOT_PREFERRED)
-        );
-        for (var nodeDecision : allocationExplanation.getShardAllocationDecision().getMoveDecision().getNodeDecisions()) {
-            assertThat(
-                "Each individual node should report not-preferred",
-                nodeDecision.getNodeDecision(),
-                equalTo(AllocationDecision.NOT_PREFERRED)
-            );
-        }
-        assertThat(
-            "This is the explanation expected forcing a move from NO to NOT_PREFERRED, even though not ideal",
-            allocationExplanation.getShardAllocationDecision().getMoveDecision().getExplanation(),
-            equalTo(Explanations.Move.NOT_PREFERRED)
-        );
-        assertNotNull(
-            "A relocation target node should have been selected: canRemain no overrides canAllocate not-preferred",
-            allocationExplanation.getShardAllocationDecision().getMoveDecision().getTargetNode()
-        );
-    }
-
-    public void testNotPreferredToNotPreferredShardAllocationExplanation() {
-        ClusterState clusterState = ClusterStateCreationUtils.state("idx", randomBoolean(), ShardRoutingState.STARTED);
-        logger.info("---> Cluster state: " + clusterState);
-        final ProjectId projectId = clusterState.metadata().projects().keySet().iterator().next();
-        ShardRouting shardRouting = clusterState.globalRoutingTable().routingTable(projectId).index("idx").shard(0).primaryShard();
-        ClusterInfo clusterInfo = ClusterInfo.builder().build();
-        // Set up allocation deciders that will say: 1) shard not-preferred to remain where it is and 2) shard allocation elsewhere is
-        // not-preferred. Relocation should _not_ proceed, no target node for the MoveDecision.
-        AllocationDeciders allocationDeciders = new AllocationDeciders(
-            List.of(new CanRemainNotPreferredAllocationDecider(), new CanAllocateNotPreferredAllocationDecider())
-        );
-        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, clusterState, clusterInfo, null, System.nanoTime());
-
-        ClusterAllocationExplanation allocationExplanation = TransportClusterAllocationExplainAction.explainShard(
-            shardRouting,
-            allocation,
-            clusterInfo,
-            randomBoolean(),
-            true,
-            new AllocationService(
-                allocationDeciders,
-                new TestGatewayAllocator(),
-                new BalancedShardsAllocator(Settings.EMPTY),
-                EmptyClusterInfoService.INSTANCE,
-                EmptySnapshotsInfoService.INSTANCE,
-                TestShardRoutingRoleStrategies.DEFAULT_ROLE_ONLY
-            )
-        );
-
-        logger.info("---> Allocation explain response: " + Strings.toString(allocationExplanation, true, true));
-        // canRemain on the current node should be NOT_PREFERRED.
-        assertThat(allocationExplanation.getShardAllocationDecision().getMoveDecision().canRemainNotPreferred(), equalTo(true));
-        assertThat(
-            allocationExplanation.getShardAllocationDecision().getMoveDecision().getCanRemainDecision().type(),
-            equalTo(Decision.Type.NOT_PREFERRED)
-        );
-        assertThat(
-            "All other potential nodes should be not-preferred, resulting in an overall not-preferred relocation",
-            allocationExplanation.getShardAllocationDecision().getMoveDecision().getAllocationDecision(),
-            equalTo(AllocationDecision.NOT_PREFERRED)
-        );
-        for (var nodeDecision : allocationExplanation.getShardAllocationDecision().getMoveDecision().getNodeDecisions()) {
-            assertThat(
-                "Each individual node should report not-preferred",
-                nodeDecision.getNodeDecision(),
-                equalTo(AllocationDecision.NOT_PREFERRED)
-            );
-        }
-        assertThat(
-            "Expected the explanation for a move from NOT_PREFERRED to NOT_PREFERRED to say the shard won't move",
-            allocationExplanation.getShardAllocationDecision().getMoveDecision().getExplanation(),
-            equalTo(Explanations.Move.NOT_PREFERRED_TO_NOT_PREFERRED)
-        );
-        assertNull(
-            "A relocation target node should not have been selected: canRemain not-preferred does not override canAllocate not-preferred",
-            allocationExplanation.getShardAllocationDecision().getMoveDecision().getTargetNode()
-        );
-    }
-
-    public void testNotPreferredToYesShardAllocationExplanation() {
-        ClusterState clusterState = ClusterStateCreationUtils.state("idx", randomBoolean(), ShardRoutingState.STARTED);
-        logger.info("---> Cluster state: " + clusterState);
-        final ProjectId projectId = clusterState.metadata().projects().keySet().iterator().next();
-        ShardRouting shardRouting = clusterState.globalRoutingTable().routingTable(projectId).index("idx").shard(0).primaryShard();
-        ClusterInfo clusterInfo = ClusterInfo.builder().build();
-        // Set up allocation deciders that will say: 1) shard not-preferred to remain where it is and 2) shard can be allocated elsewhere
-        // (the default without a decider to say no). Relocation should proceed, there should be a target node for the MoveDecision.
-        AllocationDeciders allocationDeciders = new AllocationDeciders(List.of(new CanRemainNotPreferredAllocationDecider()));
-        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, clusterState, clusterInfo, null, System.nanoTime());
-
-        ClusterAllocationExplanation allocationExplanation = TransportClusterAllocationExplainAction.explainShard(
-            shardRouting,
-            allocation,
-            clusterInfo,
-            randomBoolean(),
-            true,
-            new AllocationService(
-                allocationDeciders,
-                new TestGatewayAllocator(),
-                new BalancedShardsAllocator(Settings.EMPTY),
-                EmptyClusterInfoService.INSTANCE,
-                EmptySnapshotsInfoService.INSTANCE,
-                TestShardRoutingRoleStrategies.DEFAULT_ROLE_ONLY
-            )
-        );
-
-        logger.info("---> Allocation explain response: " + Strings.toString(allocationExplanation, true, true));
-        // canRemain on the current node should be NOT_PREFERRED.
-        assertThat(allocationExplanation.getShardAllocationDecision().getMoveDecision().canRemainNotPreferred(), equalTo(true));
-        assertThat(
-            allocationExplanation.getShardAllocationDecision().getMoveDecision().getCanRemainDecision().type(),
-            equalTo(Decision.Type.NOT_PREFERRED)
-        );
-        assertThat(
-            "All other potential nodes should be YES, resulting in an overall YES move decision",
-            allocationExplanation.getShardAllocationDecision().getMoveDecision().getAllocationDecision(),
-            equalTo(AllocationDecision.YES)
-        );
-        for (var nodeDecision : allocationExplanation.getShardAllocationDecision().getMoveDecision().getNodeDecisions()) {
-            assertThat("Each individual node should report YES", nodeDecision.getNodeDecision(), equalTo(AllocationDecision.YES));
-        }
-        assertThat(
-            "Expected the explanation for a move from NOT_PREFERRED to YES to say the shard will move",
-            allocationExplanation.getShardAllocationDecision().getMoveDecision().getExplanation(),
-            equalTo(Explanations.Move.NOT_PREFERRED_TO_YES)
-        );
-        assertNotNull(
-            "A relocation target node should have been selected going from a not-preferred remain node to a yes canAllocate node",
-            allocationExplanation.getShardAllocationDecision().getMoveDecision().getTargetNode()
-        );
-    }
-
-    public void testNotPreferredToThrottleShardAllocationExplanation() {
-        ClusterState clusterState = ClusterStateCreationUtils.state("idx", randomBoolean(), ShardRoutingState.STARTED);
-        logger.info("---> Cluster state: " + clusterState);
-        final ProjectId projectId = clusterState.metadata().projects().keySet().iterator().next();
-        ShardRouting shardRouting = clusterState.globalRoutingTable().routingTable(projectId).index("idx").shard(0).primaryShard();
-        ClusterInfo clusterInfo = ClusterInfo.builder().build();
-        // Set up allocation deciders that will say: 1) shard not-preferred to remain where it is and 2) shard allocation elsewhere is
-        // throttled. Relocation should _not_ proceed, no target node for the MoveDecision. /// TODO DIANNA NOT MERGE
-        AllocationDeciders allocationDeciders = new AllocationDeciders(
-            List.of(new CanRemainNotPreferredAllocationDecider(), new CanAllocateThrottledAllocationDecider())
-        );
-        RoutingAllocation allocation = new RoutingAllocation(allocationDeciders, clusterState, clusterInfo, null, System.nanoTime());
-
-        ClusterAllocationExplanation allocationExplanation = TransportClusterAllocationExplainAction.explainShard(
-            shardRouting,
-            allocation,
-            clusterInfo,
-            randomBoolean(),
-            true,
-            new AllocationService(
-                allocationDeciders,
-                new TestGatewayAllocator(),
-                new BalancedShardsAllocator(Settings.EMPTY),
-                EmptyClusterInfoService.INSTANCE,
-                EmptySnapshotsInfoService.INSTANCE,
-                TestShardRoutingRoleStrategies.DEFAULT_ROLE_ONLY
-            )
-        );
-
-        logger.info("---> Allocation explain response: " + Strings.toString(allocationExplanation, true, true));
-        // canRemain on the current node should be NOT_PREFERRED.
-        assertThat(allocationExplanation.getShardAllocationDecision().getMoveDecision().canRemainNotPreferred(), equalTo(true));
-        assertThat(
-            allocationExplanation.getShardAllocationDecision().getMoveDecision().getCanRemainDecision().type(),
-            equalTo(Decision.Type.NOT_PREFERRED)
-        );
-        assertThat(
-            "All other potential nodes should be throttled, resulting in an overall throttled relocation",
-            allocationExplanation.getShardAllocationDecision().getMoveDecision().getAllocationDecision(),
-            equalTo(AllocationDecision.THROTTLED)
-        );
-        for (var nodeDecision : allocationExplanation.getShardAllocationDecision().getMoveDecision().getNodeDecisions()) {
-            assertThat(
-                "Each individual node should report throttled",
-                nodeDecision.getNodeDecision(),
-                equalTo(AllocationDecision.THROTTLED)
-            );
-        }
-        assertThat(
-            "Expected the explanation for a move from NOT_PREFERRED to THROTTLED to say the shard won't move right now",
-            allocationExplanation.getShardAllocationDecision().getMoveDecision().getExplanation(),
-            equalTo(Explanations.Move.NOT_PREFERRED_TO_THROTTLED)
-        );
-        assertNull(
-            "A relocation target node should have been selected, even though canRemain not-preferred must wait for throttling to cease",
-            allocationExplanation.getShardAllocationDecision().getMoveDecision().getTargetNode()
-        );
-    }
 
     public void testInitializingOrRelocatingShardExplanation() throws Exception {
         ShardRoutingState shardRoutingState = randomFrom(ShardRoutingState.INITIALIZING, ShardRoutingState.RELOCATING);

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationDecisionTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationDecisionTests.java
@@ -109,12 +109,9 @@ public class AllocationDecisionTests extends ESTestCase {
     public void testFromDecisionType() {
         Type type = randomFrom(Type.values());
         AllocationDecision allocationDecision = AllocationDecision.fromDecisionType(type);
-        AllocationDecision expected = switch (type) {
-            case NO -> AllocationDecision.NO;
-            case NOT_PREFERRED -> AllocationDecision.NOT_PREFERRED;
-            case THROTTLE -> AllocationDecision.THROTTLED;
-            case YES -> AllocationDecision.YES;
-        };
+        AllocationDecision expected = type == Type.NO ? AllocationDecision.NO
+            : type == Type.THROTTLE ? AllocationDecision.THROTTLED
+            : AllocationDecision.YES;
 
         assertEquals(expected, allocationDecision);
     }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/MoveDecisionTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/MoveDecisionTests.java
@@ -123,7 +123,6 @@ public class MoveDecisionTests extends ESTestCase {
         assertEquals(moveDecision.getTargetNode(), readDecision.getTargetNode());
         assertEquals(moveDecision.getAllocationDecision(), readDecision.getAllocationDecision());
         // node2 should have the highest sort order
-        assertEquals("node2", moveDecision.getNodeDecisions().iterator().next().getNode().getId());
         assertEquals("node2", readDecision.getNodeDecisions().iterator().next().getNode().getId());
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecidersTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecidersTests.java
@@ -56,11 +56,11 @@ public class AllocationDecidersTests extends ESAllocationTestCase {
     }
 
     public void testCheckAllDecidersBeforeReturningThrottle() {
-        var allDecisions = generateDecisions(Decision.THROTTLE, () -> Decision.YES);
+        var allDecisions = generateDecisions(Decision.THROTTLE, () -> randomFrom(Decision.YES, Decision.NOT_PREFERRED));
         var debugMode = randomFrom(RoutingAllocation.DebugMode.values());
         var expectedDecision = switch (debugMode) {
             case OFF -> Decision.THROTTLE;
-            case EXCLUDE_YES_DECISIONS -> new Decision.Multi().add(Decision.THROTTLE);
+            case EXCLUDE_YES_DECISIONS -> filterAndCollectToMultiDecision(allDecisions, d -> d.type() != Decision.Type.YES);
             case ON -> collectToMultiDecision(allDecisions);
         };
 
@@ -68,7 +68,7 @@ public class AllocationDecidersTests extends ESAllocationTestCase {
     }
 
     public void testCheckAllDecidersBeforeReturningNotPreferred() {
-        var allDecisions = generateDecisions(Decision.NOT_PREFERRED, () -> randomFrom(Decision.YES, Decision.THROTTLE));
+        var allDecisions = generateDecisions(Decision.NOT_PREFERRED, () -> Decision.YES);
         var debugMode = randomFrom(RoutingAllocation.DebugMode.values());
         var expectedDecision = switch (debugMode) {
             case OFF -> Decision.NOT_PREFERRED;

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DecisionTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DecisionTests.java
@@ -25,11 +25,11 @@ import static org.elasticsearch.cluster.routing.allocation.decider.Decision.Type
 public class DecisionTests extends ESTestCase {
 
     public void testTypeEnumOrder() {
-        EnumSerializationTestUtils.assertEnumSerialization(Decision.Type.class, NO, NOT_PREFERRED, THROTTLE, YES);
+        EnumSerializationTestUtils.assertEnumSerialization(Decision.Type.class, NO, THROTTLE, NOT_PREFERRED, YES);
     }
 
     public void testTypeHigherThan() {
-        assertTrue(YES.higherThan(THROTTLE) && THROTTLE.higherThan(NOT_PREFERRED) && NOT_PREFERRED.higherThan(NO));
+        assertTrue(YES.higherThan(NOT_PREFERRED) && NOT_PREFERRED.higherThan(THROTTLE) && THROTTLE.higherThan(NO));
     }
 
     public void testTypeAllowed() {


### PR DESCRIPTION
The work adding not-preferred to the allocation explain output
(#137228) resulted in shards not evacuating a shutting down node
during release testing. There is some unidentified bug in play. Since
a transport version was added with that code change, we wish to
retain the enum changes necessitating the transport version, but
undo / revert all logic changes associated with the commit.

Relates ES-13903
