### PR TITLE
[DOCS]:Change links to specific pages

### DIFF
--- a/docs/reference/inference/chat-completion-inference.asciidoc
+++ b/docs/reference/inference/chat-completion-inference.asciidoc
@@ -2,6 +2,12 @@
 [[chat-completion-inference-api]]
 === Chat completion inference API
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/operation/operation-inference-chat-completion-unified[Perform chat completion inference].
+--
+
 Streams a chat completion response.
 
 IMPORTANT: The {infer} APIs enable you to use certain services, such as built-in {ml} models (ELSER, E5), models uploaded through Eland, Cohere, OpenAI, Azure, Google AI Studio, Google Vertex AI, Anthropic, Watsonx.ai, or Hugging Face.

--- a/docs/reference/inference/delete-inference.asciidoc
+++ b/docs/reference/inference/delete-inference.asciidoc
@@ -5,7 +5,7 @@
 .New API reference
 [sidebar]
 --
-For the most up-to-date API details, refer to {api-es}/group/endpoint-inference[{infer-cap} APIs].
+For the most up-to-date API details, refer to {api-es}/operation/operation-inference-delete[Delete an inference endpoint].
 --
 
 Deletes an {infer} endpoint.

--- a/docs/reference/inference/get-inference.asciidoc
+++ b/docs/reference/inference/get-inference.asciidoc
@@ -5,7 +5,7 @@
 .New API reference
 [sidebar]
 --
-For the most up-to-date API details, refer to {api-es}/group/endpoint-inference[{infer-cap} APIs].
+For the most up-to-date API details, refer to {api-es}/operation/operation-inference-get[Get an inference endpoint].
 --
 
 Retrieves {infer} endpoint information.

--- a/docs/reference/inference/post-inference.asciidoc
+++ b/docs/reference/inference/post-inference.asciidoc
@@ -5,7 +5,7 @@
 .New API reference
 [sidebar]
 --
-For the most up-to-date API details, refer to {api-es}/group/endpoint-inference[{infer-cap} APIs].
+For the most up-to-date API details, refer to {api-es}/operation/operation-inference-completion[Perform completion inference on the service].
 --
 
 Performs an inference task on an input text by using an {infer} endpoint.

--- a/docs/reference/inference/put-inference.asciidoc
+++ b/docs/reference/inference/put-inference.asciidoc
@@ -5,7 +5,7 @@
 .New API reference
 [sidebar]
 --
-For the most up-to-date API details, refer to {api-es}/group/endpoint-inference[{infer-cap} APIs].
+For the most up-to-date API details, refer to {api-es}/operation/operation-inference-put[Create an inference endpoint].
 --
 
 Creates an {infer} endpoint to perform an {infer} task.

--- a/docs/reference/inference/service-alibabacloud-ai-search.asciidoc
+++ b/docs/reference/inference/service-alibabacloud-ai-search.asciidoc
@@ -4,7 +4,7 @@
 .New API reference
 [sidebar]
 --
-For the most up-to-date API details, refer to {api-es}/group/endpoint-inference[{infer-cap} APIs].
+For the most up-to-date API details, refer to {api-es}/operation/operation-inference-put-alibabacloud[Create an AlibabaCloud AI Search inference endpoint].
 --
 
 Creates an {infer} endpoint to perform an {infer} task with the `alibabacloud-ai-search` service.

--- a/docs/reference/inference/service-amazon-bedrock.asciidoc
+++ b/docs/reference/inference/service-amazon-bedrock.asciidoc
@@ -4,7 +4,7 @@
 .New API reference
 [sidebar]
 --
-For the most up-to-date API details, refer to {api-es}/group/endpoint-inference[{infer-cap} APIs].
+For the most up-to-date API details, refer to {api-es}/operation/operation-inference-put-amazonbedrock[Create an Amazon Bedrock inference endpoint].
 --
 
 Creates an {infer} endpoint to perform an {infer} task with the `amazonbedrock` service.

--- a/docs/reference/inference/service-anthropic.asciidoc
+++ b/docs/reference/inference/service-anthropic.asciidoc
@@ -4,7 +4,7 @@
 .New API reference
 [sidebar]
 --
-For the most up-to-date API details, refer to {api-es}/group/endpoint-inference[{infer-cap} APIs].
+For the most up-to-date API details, refer to {api-es}/operation/operation-inference-put-anthropic[Create an Anthropic inference endpoint].
 --
 
 Creates an {infer} endpoint to perform an {infer} task with the `anthropic` service.

--- a/docs/reference/inference/service-azure-ai-studio.asciidoc
+++ b/docs/reference/inference/service-azure-ai-studio.asciidoc
@@ -4,7 +4,8 @@
 .New API reference
 [sidebar]
 --
-For the most up-to-date API details, refer to {api-es}/group/endpoint-inference[{infer-cap} APIs].
+For the most up-to-date API details, refer to {api-es}/operation/operation-inference-put-azureaistudio[Create an Azure AI studio inference endpoint
+].
 --
 
 Creates an {infer} endpoint to perform an {infer} task with the `azureaistudio` service.

--- a/docs/reference/inference/service-azure-openai.asciidoc
+++ b/docs/reference/inference/service-azure-openai.asciidoc
@@ -4,7 +4,7 @@
 .New API reference
 [sidebar]
 --
-For the most up-to-date API details, refer to {api-es}/group/endpoint-inference[{infer-cap} APIs].
+For the most up-to-date API details, refer to {api-es}/operation/operation-inference-put-azureopenai[Create an Azure OpenAI inference endpoint].
 --
 
 Creates an {infer} endpoint to perform an {infer} task with the `azureopenai` service.

--- a/docs/reference/inference/service-cohere.asciidoc
+++ b/docs/reference/inference/service-cohere.asciidoc
@@ -4,7 +4,7 @@
 .New API reference
 [sidebar]
 --
-For the most up-to-date API details, refer to {api-es}/group/endpoint-inference[{infer-cap} APIs].
+For the most up-to-date API details, refer to {api-es}/operation/operation-inference-put-cohere[Create a Cohere inference endpoint].
 --
 
 Creates an {infer} endpoint to perform an {infer} task with the `cohere` service.

--- a/docs/reference/inference/service-elasticsearch.asciidoc
+++ b/docs/reference/inference/service-elasticsearch.asciidoc
@@ -4,7 +4,7 @@
 .New API reference
 [sidebar]
 --
-For the most up-to-date API details, refer to {api-es}/group/endpoint-inference[{infer-cap} APIs].
+For the most up-to-date API details, refer to {api-es}/operation/operation-inference-put-elasticsearch[Create an Elasticsearch inference endpoint].
 --
 
 Creates an {infer} endpoint to perform an {infer} task with the `elasticsearch` service.

--- a/docs/reference/inference/service-elser.asciidoc
+++ b/docs/reference/inference/service-elser.asciidoc
@@ -4,7 +4,7 @@
 .New API reference
 [sidebar]
 --
-For the most up-to-date API details, refer to {api-es}/group/endpoint-inference[{infer-cap} APIs].
+For the most up-to-date API details, refer to {api-es}/operation/operation-inference-put-elser[Create an ELSER inference endpoint].
 --
 
 Creates an {infer} endpoint to perform an {infer} task with the `elser` service.

--- a/docs/reference/inference/service-google-ai-studio.asciidoc
+++ b/docs/reference/inference/service-google-ai-studio.asciidoc
@@ -4,7 +4,7 @@
 .New API reference
 [sidebar]
 --
-For the most up-to-date API details, refer to {api-es}/group/endpoint-inference[{infer-cap} APIs].
+For the most up-to-date API details, refer to {api-es}/operation/operation-inference-put-googleaistudio[Create an Google AI Studio inference endpoint].
 --
 
 Creates an {infer} endpoint to perform an {infer} task with the `googleaistudio` service.

--- a/docs/reference/inference/service-google-vertex-ai.asciidoc
+++ b/docs/reference/inference/service-google-vertex-ai.asciidoc
@@ -4,7 +4,8 @@
 .New API reference
 [sidebar]
 --
-For the most up-to-date API details, refer to {api-es}/group/endpoint-inference[{infer-cap} APIs].
+For the most up-to-date API details, refer to {api-es}/operation/operation-inference-put-googlevertexai[Create a Google Vertex AI inference endpoint
+].
 --
 
 Creates an {infer} endpoint to perform an {infer} task with the `googlevertexai` service.

--- a/docs/reference/inference/service-hugging-face.asciidoc
+++ b/docs/reference/inference/service-hugging-face.asciidoc
@@ -4,7 +4,7 @@
 .New API reference
 [sidebar]
 --
-For the most up-to-date API details, refer to {api-es}/group/endpoint-inference[{infer-cap} APIs].
+For the most up-to-date API details, refer to {api-es}/operation/operation-inference-put-hugging-face[Create a Hugging Face inference endpoint].
 --
 
 Creates an {infer} endpoint to perform an {infer} task with the `hugging_face` service.

--- a/docs/reference/inference/service-jinaai.asciidoc
+++ b/docs/reference/inference/service-jinaai.asciidoc
@@ -1,6 +1,12 @@
 [[infer-service-jinaai]]
 === JinaAI {infer} integration
 
+.New API reference
+[sidebar]
+--
+For the most up-to-date API details, refer to {api-es}/operation/operation-inference-put-jinaai[Create an JinaAI inference endpoint].
+--
+
 Creates an {infer} endpoint to perform an {infer} task with the `jinaai` service.
 
 

--- a/docs/reference/inference/service-mistral.asciidoc
+++ b/docs/reference/inference/service-mistral.asciidoc
@@ -4,7 +4,8 @@
 .New API reference
 [sidebar]
 --
-For the most up-to-date API details, refer to {api-es}/group/endpoint-inference[{infer-cap} APIs].
+For the most up-to-date API details, refer to {api-es}/operation/operation-inference-put-mistral[Create a Mistral inference endpoint
+].
 --
 
 Creates an {infer} endpoint to perform an {infer} task with the `mistral` service.

--- a/docs/reference/inference/service-openai.asciidoc
+++ b/docs/reference/inference/service-openai.asciidoc
@@ -4,7 +4,7 @@
 .New API reference
 [sidebar]
 --
-For the most up-to-date API details, refer to {api-es}/group/endpoint-inference[{infer-cap} APIs].
+For the most up-to-date API details, refer to {api-es}/operation/operation-inference-put-openai[Create an OpenAI inference endpoint].
 --
 
 Creates an {infer} endpoint to perform an {infer} task with the `openai` service or `openai` compatible APIs. 

--- a/docs/reference/inference/service-voyageai.asciidoc
+++ b/docs/reference/inference/service-voyageai.asciidoc
@@ -4,7 +4,7 @@
 .New API reference
 [sidebar]
 --
-For the most up-to-date API details, refer to {api-es}/group/endpoint-inference[{infer-cap} APIs].
+For the most up-to-date API details, refer to {api-es}/operation/operation-inference-put-voyageai[Create a VoyageAI inference endpoint].
 --
 
 Creates an {infer} endpoint to perform an {infer} task with the `voyageai` service.

--- a/docs/reference/inference/service-watsonx-ai.asciidoc
+++ b/docs/reference/inference/service-watsonx-ai.asciidoc
@@ -4,7 +4,7 @@
 .New API reference
 [sidebar]
 --
-For the most up-to-date API details, refer to {api-es}/group/endpoint-inference[{infer-cap} APIs].
+For the most up-to-date API details, refer to {api-es}/operation/operation-inference-put-watsonx[Create a Watsonx inference endpoint].
 --
 
 Creates an {infer} endpoint to perform an {infer} task with the `watsonxai` service.

--- a/docs/reference/inference/stream-inference.asciidoc
+++ b/docs/reference/inference/stream-inference.asciidoc
@@ -5,7 +5,8 @@
 .New API reference
 [sidebar]
 --
-For the most up-to-date API details, refer to {api-es}/group/endpoint-inference[{infer-cap} APIs].
+For the most up-to-date API details, refer to {api-es}/operation/operation-inference-stream-completion[Perform streaming inference
+].
 --
 
 Streams a chat completion response.

--- a/docs/reference/inference/update-inference.asciidoc
+++ b/docs/reference/inference/update-inference.asciidoc
@@ -5,7 +5,7 @@
 .New API reference
 [sidebar]
 --
-For the most up-to-date API details, refer to {api-es}/group/endpoint-inference[{infer-cap} APIs].
+For the most up-to-date API details, refer to {api-es}/operation/operation-inference-update[Update an inference endpoint].
 --
 
 Updates an {infer} endpoint.


### PR DESCRIPTION
This PR updates the links on the 8.19 version inference pages pointing to the new API documentation.
Connected issue: https://github.com/elastic/docs-content/issues/1103
