### PR TITLE
Add a randomVersionBetween overload to utils classes

### DIFF
--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/CommonAnalysisPluginTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/CommonAnalysisPluginTests.java
@@ -34,7 +34,7 @@ public class CommonAnalysisPluginTests extends ESTestCase {
             .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
             .put(
                 IndexMetadata.SETTING_VERSION_CREATED,
-                IndexVersionUtils.randomVersionBetween(random(), IndexVersions.V_8_0_0, IndexVersion.current())
+                IndexVersionUtils.randomVersionBetween(IndexVersions.V_8_0_0, IndexVersion.current())
             )
             .put("index.analysis.analyzer.custom_analyzer.type", "custom")
             .put("index.analysis.analyzer.custom_analyzer.tokenizer", "standard")
@@ -58,7 +58,7 @@ public class CommonAnalysisPluginTests extends ESTestCase {
             .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
             .put(
                 IndexMetadata.SETTING_VERSION_CREATED,
-                IndexVersionUtils.randomVersionBetween(random(), IndexVersions.MINIMUM_READONLY_COMPATIBLE, IndexVersions.V_7_6_0)
+                IndexVersionUtils.randomVersionBetween(IndexVersions.MINIMUM_READONLY_COMPATIBLE, IndexVersions.V_7_6_0)
             )
             .put("index.analysis.analyzer.custom_analyzer.type", "custom")
             .put("index.analysis.analyzer.custom_analyzer.tokenizer", "standard")
@@ -83,7 +83,7 @@ public class CommonAnalysisPluginTests extends ESTestCase {
             .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
             .put(
                 IndexMetadata.SETTING_VERSION_CREATED,
-                IndexVersionUtils.randomVersionBetween(random(), IndexVersions.V_8_0_0, IndexVersion.current())
+                IndexVersionUtils.randomVersionBetween(IndexVersions.V_8_0_0, IndexVersion.current())
             )
             .put("index.analysis.analyzer.custom_analyzer.type", "custom")
             .put("index.analysis.analyzer.custom_analyzer.tokenizer", "standard")
@@ -107,7 +107,7 @@ public class CommonAnalysisPluginTests extends ESTestCase {
             .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir())
             .put(
                 IndexMetadata.SETTING_VERSION_CREATED,
-                IndexVersionUtils.randomVersionBetween(random(), IndexVersions.MINIMUM_READONLY_COMPATIBLE, IndexVersions.V_7_6_0)
+                IndexVersionUtils.randomVersionBetween(IndexVersions.MINIMUM_READONLY_COMPATIBLE, IndexVersions.V_7_6_0)
             )
             .put("index.analysis.analyzer.custom_analyzer.type", "custom")
             .put("index.analysis.analyzer.custom_analyzer.tokenizer", "standard")
@@ -133,20 +133,19 @@ public class CommonAnalysisPluginTests extends ESTestCase {
         doTestPrebuiltTokenizerDeprecation(
             "nGram",
             "ngram",
-            IndexVersionUtils.randomVersionBetween(random(), IndexVersions.MINIMUM_READONLY_COMPATIBLE, IndexVersions.V_7_5_2),
+            IndexVersionUtils.randomVersionBetween(IndexVersions.MINIMUM_READONLY_COMPATIBLE, IndexVersions.V_7_5_2),
             false
         );
         doTestPrebuiltTokenizerDeprecation(
             "edgeNGram",
             "edge_ngram",
-            IndexVersionUtils.randomVersionBetween(random(), IndexVersions.MINIMUM_READONLY_COMPATIBLE, IndexVersions.V_7_5_2),
+            IndexVersionUtils.randomVersionBetween(IndexVersions.MINIMUM_READONLY_COMPATIBLE, IndexVersions.V_7_5_2),
             false
         );
         doTestPrebuiltTokenizerDeprecation(
             "nGram",
             "ngram",
             IndexVersionUtils.randomVersionBetween(
-                random(),
                 IndexVersions.V_7_6_0,
                 IndexVersion.max(IndexVersions.V_7_6_0, IndexVersionUtils.getPreviousVersion(IndexVersions.V_8_0_0))
             ),
@@ -156,7 +155,6 @@ public class CommonAnalysisPluginTests extends ESTestCase {
             "edgeNGram",
             "edge_ngram",
             IndexVersionUtils.randomVersionBetween(
-                random(),
                 IndexVersions.V_7_6_0,
                 IndexVersion.max(IndexVersions.V_7_6_0, IndexVersionUtils.getPreviousVersion(IndexVersions.V_8_0_0))
             ),
@@ -167,7 +165,7 @@ public class CommonAnalysisPluginTests extends ESTestCase {
             () -> doTestPrebuiltTokenizerDeprecation(
                 "nGram",
                 "ngram",
-                IndexVersionUtils.randomVersionBetween(random(), IndexVersions.V_8_0_0, IndexVersion.current()),
+                IndexVersionUtils.randomVersionBetween(IndexVersions.V_8_0_0, IndexVersion.current()),
                 true
             )
         );
@@ -176,7 +174,7 @@ public class CommonAnalysisPluginTests extends ESTestCase {
             () -> doTestPrebuiltTokenizerDeprecation(
                 "edgeNGram",
                 "edge_ngram",
-                IndexVersionUtils.randomVersionBetween(random(), IndexVersions.V_8_0_0, IndexVersion.current()),
+                IndexVersionUtils.randomVersionBetween(IndexVersions.V_8_0_0, IndexVersion.current()),
                 true
             )
         );
@@ -185,20 +183,19 @@ public class CommonAnalysisPluginTests extends ESTestCase {
         doTestCustomTokenizerDeprecation(
             "nGram",
             "ngram",
-            IndexVersionUtils.randomVersionBetween(random(), IndexVersions.MINIMUM_READONLY_COMPATIBLE, IndexVersions.V_7_5_2),
+            IndexVersionUtils.randomVersionBetween(IndexVersions.MINIMUM_READONLY_COMPATIBLE, IndexVersions.V_7_5_2),
             false
         );
         doTestCustomTokenizerDeprecation(
             "edgeNGram",
             "edge_ngram",
-            IndexVersionUtils.randomVersionBetween(random(), IndexVersions.MINIMUM_READONLY_COMPATIBLE, IndexVersions.V_7_5_2),
+            IndexVersionUtils.randomVersionBetween(IndexVersions.MINIMUM_READONLY_COMPATIBLE, IndexVersions.V_7_5_2),
             false
         );
         doTestCustomTokenizerDeprecation(
             "nGram",
             "ngram",
             IndexVersionUtils.randomVersionBetween(
-                random(),
                 IndexVersions.V_7_6_0,
                 IndexVersion.max(IndexVersions.V_7_6_0, IndexVersionUtils.getPreviousVersion(IndexVersions.V_8_0_0))
             ),
@@ -208,7 +205,6 @@ public class CommonAnalysisPluginTests extends ESTestCase {
             "edgeNGram",
             "edge_ngram",
             IndexVersionUtils.randomVersionBetween(
-                random(),
                 IndexVersions.V_7_6_0,
                 IndexVersion.max(IndexVersions.V_7_6_0, IndexVersionUtils.getPreviousVersion(IndexVersions.V_8_0_0))
             ),
@@ -219,7 +215,7 @@ public class CommonAnalysisPluginTests extends ESTestCase {
             () -> doTestCustomTokenizerDeprecation(
                 "nGram",
                 "ngram",
-                IndexVersionUtils.randomVersionBetween(random(), IndexVersions.V_8_0_0, IndexVersion.current()),
+                IndexVersionUtils.randomVersionBetween(IndexVersions.V_8_0_0, IndexVersion.current()),
                 true
             )
         );
@@ -228,7 +224,7 @@ public class CommonAnalysisPluginTests extends ESTestCase {
             () -> doTestCustomTokenizerDeprecation(
                 "edgeNGram",
                 "edge_ngram",
-                IndexVersionUtils.randomVersionBetween(random(), IndexVersions.V_8_0_0, IndexVersion.current()),
+                IndexVersionUtils.randomVersionBetween(IndexVersions.V_8_0_0, IndexVersion.current()),
                 true
             )
         );

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/EdgeNGramTokenizerTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/EdgeNGramTokenizerTests.java
@@ -54,7 +54,6 @@ public class EdgeNGramTokenizerTests extends ESTokenStreamTestCase {
         // Before 7.3 we return ngrams of length 1 only
         {
             IndexVersion version = IndexVersionUtils.randomVersionBetween(
-                random(),
                 IndexVersions.MINIMUM_READONLY_COMPATIBLE,
                 IndexVersionUtils.getPreviousVersion(IndexVersions.V_7_3_0)
             );
@@ -68,7 +67,6 @@ public class EdgeNGramTokenizerTests extends ESTokenStreamTestCase {
         // Check deprecated name as well
         {
             IndexVersion version = IndexVersionUtils.randomVersionBetween(
-                random(),
                 IndexVersions.MINIMUM_READONLY_COMPATIBLE,
                 IndexVersionUtils.getPreviousVersion(IndexVersions.V_7_3_0)
             );
@@ -91,7 +89,6 @@ public class EdgeNGramTokenizerTests extends ESTokenStreamTestCase {
         // Check deprecated name as well, needs version before 8.0 because throws IAE after that
         {
             IndexVersion version = IndexVersionUtils.randomVersionBetween(
-                random(),
                 IndexVersions.V_7_3_0,
                 IndexVersionUtils.getPreviousVersion(IndexVersions.V_8_0_0)
             );

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/PersianAnalyzerProviderTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/PersianAnalyzerProviderTests.java
@@ -32,7 +32,6 @@ public class PersianAnalyzerProviderTests extends ESTokenStreamTestCase {
 
     public void testPersianAnalyzerPostLucene10() throws IOException {
         IndexVersion postLucene10Version = IndexVersionUtils.randomVersionBetween(
-            random(),
             IndexVersions.UPGRADE_TO_LUCENE_10_0_0,
             IndexVersion.current()
         );
@@ -55,7 +54,6 @@ public class PersianAnalyzerProviderTests extends ESTokenStreamTestCase {
 
     public void testPersianAnalyzerPreLucene10() throws IOException {
         IndexVersion preLucene10Version = IndexVersionUtils.randomVersionBetween(
-            random(),
             IndexVersionUtils.getLowestReadCompatibleVersion(),
             IndexVersionUtils.getPreviousVersion(IndexVersions.UPGRADE_TO_LUCENE_10_0_0)
         );

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/RomanianAnalyzerTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/RomanianAnalyzerTests.java
@@ -32,7 +32,6 @@ public class RomanianAnalyzerTests extends ESTokenStreamTestCase {
 
     public void testRomanianAnalyzerPostLucene10() throws IOException {
         IndexVersion postLucene10Version = IndexVersionUtils.randomVersionBetween(
-            random(),
             IndexVersions.UPGRADE_TO_LUCENE_10_0_0,
             IndexVersion.current()
         );
@@ -56,7 +55,6 @@ public class RomanianAnalyzerTests extends ESTokenStreamTestCase {
 
     public void testRomanianAnalyzerPreLucene10() throws IOException {
         IndexVersion preLucene10Version = IndexVersionUtils.randomVersionBetween(
-            random(),
             IndexVersionUtils.getLowestReadCompatibleVersion(),
             IndexVersionUtils.getPreviousVersion(IndexVersions.UPGRADE_TO_LUCENE_10_0_0)
         );

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/StemmerTokenFilterFactoryTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/StemmerTokenFilterFactoryTests.java
@@ -106,7 +106,7 @@ public class StemmerTokenFilterFactoryTests extends ESTokenStreamTestCase {
     }
 
     public void testGermanAndGerman2Stemmer() throws IOException {
-        IndexVersion v = IndexVersionUtils.randomVersionBetween(random(), IndexVersions.UPGRADE_TO_LUCENE_10_0_0, IndexVersion.current());
+        IndexVersion v = IndexVersionUtils.randomVersionBetween(IndexVersions.UPGRADE_TO_LUCENE_10_0_0, IndexVersion.current());
         Analyzer analyzer = createGermanStemmer("german", v);
         assertAnalyzesTo(analyzer, "Buecher Bücher", new String[] { "Buch", "Buch" });
 

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/SynonymsAnalysisTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/SynonymsAnalysisTests.java
@@ -119,7 +119,6 @@ public class SynonymsAnalysisTests extends ESTestCase {
 
         // Test with an index version where lenient should always be false by default
         IndexVersion randomNonLenientIndexVersion = IndexVersionUtils.randomVersionBetween(
-            random(),
             IndexVersions.MINIMUM_READONLY_COMPATIBLE,
             IndexVersions.INDEX_SORTING_ON_NESTED
         );
@@ -128,7 +127,6 @@ public class SynonymsAnalysisTests extends ESTestCase {
 
         // Test with an index version where the default lenient value is based on updateable
         IndexVersion randomLenientIndexVersion = IndexVersionUtils.randomVersionBetween(
-            random(),
             IndexVersions.LENIENT_UPDATEABLE_SYNONYMS,
             IndexVersion.current()
         );
@@ -178,7 +176,6 @@ public class SynonymsAnalysisTests extends ESTestCase {
 
         // Test with an index version where lenient should always be false by default
         IndexVersion randomNonLenientIndexVersion = IndexVersionUtils.randomVersionBetween(
-            random(),
             IndexVersions.MINIMUM_READONLY_COMPATIBLE,
             IndexVersions.INDEX_SORTING_ON_NESTED
         );
@@ -187,7 +184,6 @@ public class SynonymsAnalysisTests extends ESTestCase {
 
         // Test with an index version where the default lenient value is based on updateable
         IndexVersion randomLenientIndexVersion = IndexVersionUtils.randomVersionBetween(
-            random(),
             IndexVersions.LENIENT_UPDATEABLE_SYNONYMS,
             IndexVersion.current()
         );
@@ -232,7 +228,6 @@ public class SynonymsAnalysisTests extends ESTestCase {
 
         // Test with an index version where lenient should always be false by default
         IndexVersion randomNonLenientIndexVersion = IndexVersionUtils.randomVersionBetween(
-            random(),
             IndexVersions.MINIMUM_READONLY_COMPATIBLE,
             IndexVersions.INDEX_SORTING_ON_NESTED
         );
@@ -241,7 +236,6 @@ public class SynonymsAnalysisTests extends ESTestCase {
 
         // Test with an index version where the default lenient value is based on updateable
         IndexVersion randomLenientIndexVersion = IndexVersionUtils.randomVersionBetween(
-            random(),
             IndexVersions.LENIENT_UPDATEABLE_SYNONYMS,
             IndexVersion.current()
         );
@@ -443,7 +437,7 @@ public class SynonymsAnalysisTests extends ESTestCase {
         Settings settings = Settings.builder()
             .put(
                 IndexMetadata.SETTING_VERSION_CREATED,
-                IndexVersionUtils.randomVersionBetween(random(), IndexVersions.MINIMUM_READONLY_COMPATIBLE, IndexVersion.current())
+                IndexVersionUtils.randomVersionBetween(IndexVersions.MINIMUM_READONLY_COMPATIBLE, IndexVersion.current())
             )
             .put("path.home", createTempDir().toString())
             .put("index.analysis.filter.synonyms.type", "synonym")
@@ -497,7 +491,7 @@ public class SynonymsAnalysisTests extends ESTestCase {
         Settings settings = Settings.builder()
             .put(
                 IndexMetadata.SETTING_VERSION_CREATED,
-                IndexVersionUtils.randomVersionBetween(random(), IndexVersions.MINIMUM_READONLY_COMPATIBLE, IndexVersion.current())
+                IndexVersionUtils.randomVersionBetween(IndexVersions.MINIMUM_READONLY_COMPATIBLE, IndexVersion.current())
             )
             .put("path.home", createTempDir().toString())
             .build();
@@ -529,7 +523,7 @@ public class SynonymsAnalysisTests extends ESTestCase {
         Settings settings = Settings.builder()
             .put(
                 IndexMetadata.SETTING_VERSION_CREATED,
-                IndexVersionUtils.randomVersionBetween(random(), IndexVersions.MINIMUM_READONLY_COMPATIBLE, IndexVersion.current())
+                IndexVersionUtils.randomVersionBetween(IndexVersions.MINIMUM_READONLY_COMPATIBLE, IndexVersion.current())
             )
             .put("path.home", createTempDir().toString())
             .putList("common_words", "a", "b")

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/UniqueTokenFilterTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/UniqueTokenFilterTests.java
@@ -147,7 +147,7 @@ public class UniqueTokenFilterTests extends ESTestCase {
         Settings settings = Settings.builder()
             .put(
                 IndexMetadata.SETTING_VERSION_CREATED,
-                IndexVersionUtils.randomVersionBetween(random(), IndexVersions.UNIQUE_TOKEN_FILTER_POS_FIX, IndexVersion.current())
+                IndexVersionUtils.randomVersionBetween(IndexVersions.UNIQUE_TOKEN_FILTER_POS_FIX, IndexVersion.current())
             )
             .build();
         IndexSettings idxSettings = IndexSettingsModule.newIndexSettings("index", settings);

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/WordDelimiterGraphTokenFilterFactoryTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/WordDelimiterGraphTokenFilterFactoryTests.java
@@ -191,7 +191,6 @@ public class WordDelimiterGraphTokenFilterFactoryTests extends BaseWordDelimiter
                 .put(
                     IndexMetadata.SETTING_VERSION_CREATED,
                     IndexVersionUtils.randomVersionBetween(
-                        random(),
                         IndexVersions.MINIMUM_READONLY_COMPATIBLE,
                         IndexVersionUtils.getPreviousVersion(IndexVersions.V_7_3_0)
                     )

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProviderTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProviderTests.java
@@ -60,7 +60,7 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
         );
         indexVersion = randomBoolean()
             ? IndexVersionUtils.randomPreviousCompatibleVersion(random(), IndexVersions.TSID_CREATED_DURING_ROUTING)
-            : IndexVersionUtils.randomVersionBetween(random(), IndexVersions.TSID_CREATED_DURING_ROUTING, IndexVersion.current());
+            : IndexVersionUtils.randomVersionBetween(IndexVersions.TSID_CREATED_DURING_ROUTING, IndexVersion.current());
         indexDimensionsTsidStrategyEnabledSetting = usually();
         expectedIndexDimensionsTsidOptimizationEnabled = indexDimensionsTsidStrategyEnabledSetting
             && indexVersion.onOrAfter(IndexVersions.TSID_CREATED_DURING_ROUTING);

--- a/plugins/analysis-phonetic/src/test/java/org/elasticsearch/plugin/analysis/phonetic/AnalysisPhoneticFactoryTests.java
+++ b/plugins/analysis-phonetic/src/test/java/org/elasticsearch/plugin/analysis/phonetic/AnalysisPhoneticFactoryTests.java
@@ -44,7 +44,7 @@ public class AnalysisPhoneticFactoryTests extends AnalysisFactoryTestCase {
         Settings settings = Settings.builder()
             .put(
                 IndexMetadata.SETTING_VERSION_CREATED,
-                IndexVersionUtils.randomVersionBetween(random(), IndexVersions.MINIMUM_READONLY_COMPATIBLE, IndexVersion.current())
+                IndexVersionUtils.randomVersionBetween(IndexVersions.MINIMUM_READONLY_COMPATIBLE, IndexVersion.current())
             )
             .put("path.home", createTempDir().toString())
             .build();

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/CloneIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/CloneIndexIT.java
@@ -157,11 +157,7 @@ public class CloneIndexIT extends ESIntegTestCase {
             indexSettings(between(1, 5), 0).put("index.mode", "logsdb")
                 .put(
                     "index.version.created",
-                    IndexVersionUtils.randomVersionBetween(
-                        random(),
-                        IndexVersions.USE_SYNTHETIC_SOURCE_FOR_RECOVERY,
-                        IndexVersion.current()
-                    )
+                    IndexVersionUtils.randomVersionBetween(IndexVersions.USE_SYNTHETIC_SOURCE_FOR_RECOVERY, IndexVersion.current())
                 )
         ).setMapping("@timestamp", "type=date", "host.name", "type=keyword").get();
         updateIndexSettings(Settings.builder().put("index.blocks.write", true), "source");
@@ -174,11 +170,7 @@ public class CloneIndexIT extends ESIntegTestCase {
                 Settings.builder()
                     .put(
                         "index.version.created",
-                        IndexVersionUtils.randomVersionBetween(
-                            random(),
-                            IndexVersions.USE_SYNTHETIC_SOURCE_FOR_RECOVERY,
-                            IndexVersion.current()
-                        )
+                        IndexVersionUtils.randomVersionBetween(IndexVersions.USE_SYNTHETIC_SOURCE_FOR_RECOVERY, IndexVersion.current())
                     )
                     .put("index.recovery.use_synthetic_source", true)
                     .put("index.mode", "logsdb")

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -1979,7 +1979,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         if (randomBoolean()) {
             indexSettingsBuilder.put(
                 IndexMetadata.SETTING_VERSION_CREATED,
-                IndexVersionUtils.randomVersionBetween(random(), IndexVersions.UPGRADE_TO_LUCENE_10_0_0, IndexVersion.current())
+                IndexVersionUtils.randomVersionBetween(IndexVersions.UPGRADE_TO_LUCENE_10_0_0, IndexVersion.current())
             );
         }
         createIndex(indexName, indexSettingsBuilder.build());
@@ -2064,7 +2064,6 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
                 .put(
                     IndexMetadata.SETTING_VERSION_CREATED,
                     IndexVersionUtils.randomVersionBetween(
-                        random(),
                         IndexVersionUtils.getLowestWriteCompatibleVersion(),
                         IndexVersionUtils.getPreviousVersion(IndexVersions.UPGRADE_TO_LUCENE_10_0_0)
                     )

--- a/server/src/internalClusterTest/java/org/elasticsearch/repositories/IndexSnapshotsServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/repositories/IndexSnapshotsServiceIT.java
@@ -115,7 +115,7 @@ public class IndexSnapshotsServiceIT extends AbstractSnapshotIntegTestCase {
 
         final boolean useBwCFormat = randomBoolean();
         if (useBwCFormat) {
-            final IndexVersion version = randomVersionBetween(random(), IndexVersions.V_7_5_0, IndexVersion.current());
+            final IndexVersion version = randomVersionBetween(IndexVersions.V_7_5_0, IndexVersion.current());
             initWithSnapshotVersion(repoName, repoPath, version);
         }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequestTests.java
@@ -39,7 +39,6 @@ public class ClusterStateRequestTests extends ESTestCase {
                 .indicesOptions(indicesOptions);
 
             TransportVersion testVersion = TransportVersionUtils.randomVersionBetween(
-                random(),
                 TransportVersion.minimumCompatible(),
                 TransportVersion.current()
             );

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeResponseTests.java
@@ -112,7 +112,6 @@ public class FieldCapabilitiesNodeResponseTests extends AbstractWireSerializingT
         Randomness.shuffle(indexResponses);
         FieldCapabilitiesNodeResponse inNode = randomNodeResponse(indexResponses);
         final TransportVersion version = TransportVersionUtils.randomVersionBetween(
-            random(),
             TransportVersion.minimumCompatible(),
             TransportVersion.current()
         );

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponseTests.java
@@ -165,7 +165,6 @@ public class FieldCapabilitiesResponseTests extends AbstractWireSerializingTestC
         Randomness.shuffle(indexResponses);
         FieldCapabilitiesResponse inResponse = randomCCSResponse(indexResponses);
         final TransportVersion version = TransportVersionUtils.randomVersionBetween(
-            random(),
             TransportVersion.minimumCompatible(),
             TransportVersion.current()
         );

--- a/server/src/test/java/org/elasticsearch/action/index/IndexRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/index/IndexRequestTests.java
@@ -284,7 +284,6 @@ public class IndexRequestTests extends ESTestCase {
         {
             indexRequest.setDynamicTemplateParams(createRandomDynamicTemplateParams(1, 10));
             TransportVersion ver = TransportVersionUtils.randomVersionBetween(
-                random(),
                 TransportVersion.minimumCompatible(),
                 TransportVersionUtils.getPreviousVersion(IndexRequest.INGEST_REQUEST_DYNAMIC_TEMPLATE_PARAMS)
             );
@@ -301,7 +300,6 @@ public class IndexRequestTests extends ESTestCase {
             Map<String, Map<String, String>> dynamicTemplateParams = createRandomDynamicTemplateParams(0, 10);
             indexRequest.setDynamicTemplateParams(dynamicTemplateParams);
             TransportVersion ver = TransportVersionUtils.randomVersionBetween(
-                random(),
                 IndexRequest.INGEST_REQUEST_DYNAMIC_TEMPLATE_PARAMS,
                 TransportVersion.current()
             );

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinExecutorTests.java
@@ -236,7 +236,6 @@ public class NodeJoinExecutorTests extends ESTestCase {
             );
         }
         var indexCreated = IndexVersionUtils.randomVersionBetween(
-            random(),
             IndexVersions.MINIMUM_READONLY_COMPATIBLE,
             getPreviousVersion(IndexVersions.MINIMUM_COMPATIBLE)
         );
@@ -343,7 +342,7 @@ public class NodeJoinExecutorTests extends ESTestCase {
         final Version minGoodVersion = maxNodeVersion.major == minNodeVersion.major ?
         // we have to stick with the same major
             minNodeVersion : maxNodeVersion.minimumCompatibilityVersion();
-        final Version justGood = randomVersionBetween(random(), minGoodVersion, maxCompatibleVersion(minNodeVersion));
+        final Version justGood = randomVersionBetween(minGoodVersion, maxCompatibleVersion(minNodeVersion));
 
         if (randomBoolean()) {
             NodeJoinExecutor.ensureNodesCompatibility(justGood, nodes);
@@ -676,7 +675,7 @@ public class NodeJoinExecutorTests extends ESTestCase {
             if (randomBoolean()) {
                 builder.put(
                     IndexMetadata.SETTING_VERSION_COMPATIBILITY,
-                    IndexVersionUtils.randomVersionBetween(random(), createdVersion, IndexVersion.current())
+                    IndexVersionUtils.randomVersionBetween(createdVersion, IndexVersion.current())
                 );
             }
         } else {

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
@@ -235,7 +235,7 @@ public class PublicationTransportHandlerTests extends ESTestCase {
                 allNodes.add(node);
                 nodeTransports.put(
                     node,
-                    TransportVersionUtils.randomVersionBetween(random(), TransportVersion.minimumCompatible(), TransportVersion.current())
+                    TransportVersionUtils.randomVersionBetween(TransportVersion.minimumCompatible(), TransportVersion.current())
                 );
             }
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataVerifierTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataVerifierTests.java
@@ -135,7 +135,7 @@ public class IndexMetadataVerifierTests extends ESTestCase {
             )
         );
 
-        indexCreated = randomVersionBetween(random(), IndexVersions.MINIMUM_COMPATIBLE, IndexVersion.current());
+        indexCreated = randomVersionBetween(IndexVersions.MINIMUM_COMPATIBLE, IndexVersion.current());
         IndexMetadata goodMeta = newIndexMeta("foo", Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, indexCreated).build());
         service.verifyIndexMetadata(goodMeta, IndexVersions.MINIMUM_COMPATIBLE, IndexVersions.MINIMUM_READONLY_COMPATIBLE);
     }
@@ -172,7 +172,6 @@ public class IndexMetadataVerifierTests extends ESTestCase {
             );
         }
         var indexCreated = randomVersionBetween(
-            random(),
             IndexVersions.MINIMUM_READONLY_COMPATIBLE,
             getPreviousVersion(IndexVersions.MINIMUM_COMPATIBLE)
         );

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -1575,10 +1575,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
             settings.put(IndexSettings.INDEX_TRANSLOG_RETENTION_SIZE_SETTING.getKey(), between(1, 128) + "mb");
         }
         if (randomBoolean()) {
-            settings.put(
-                SETTING_VERSION_CREATED,
-                IndexVersionUtils.randomVersionBetween(random(), IndexVersions.V_8_0_0, IndexVersion.current())
-            );
+            settings.put(SETTING_VERSION_CREATED, IndexVersionUtils.randomVersionBetween(IndexVersions.V_8_0_0, IndexVersion.current()));
         }
         request.settings(settings.build());
         IllegalArgumentException error = expectThrows(

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/ProjectMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/ProjectMetadataTests.java
@@ -1817,7 +1817,6 @@ public class ProjectMetadataTests extends ESTestCase {
 
     public void testSystemAliasValidationMixedVersionSystemAndRegularFails() {
         final IndexVersion random7xVersion = IndexVersionUtils.randomVersionBetween(
-            random(),
             IndexVersions.V_7_0_0,
             IndexVersionUtils.getPreviousVersion(IndexVersions.V_8_0_0)
         );
@@ -1867,7 +1866,6 @@ public class ProjectMetadataTests extends ESTestCase {
 
     public void testSystemAliasOldSystemAndNewRegular() {
         final IndexVersion random7xVersion = IndexVersionUtils.randomVersionBetween(
-            random(),
             IndexVersions.V_7_0_0,
             IndexVersionUtils.getPreviousVersion(IndexVersions.V_8_0_0)
         );
@@ -1880,7 +1878,6 @@ public class ProjectMetadataTests extends ESTestCase {
 
     public void testSystemIndexValidationAllRegular() {
         final IndexVersion random7xVersion = IndexVersionUtils.randomVersionBetween(
-            random(),
             IndexVersions.V_7_0_0,
             IndexVersionUtils.getPreviousVersion(IndexVersions.V_8_0_0)
         );
@@ -1894,7 +1891,6 @@ public class ProjectMetadataTests extends ESTestCase {
 
     public void testSystemAliasValidationAllSystemSomeOld() {
         final IndexVersion random7xVersion = IndexVersionUtils.randomVersionBetween(
-            random(),
             IndexVersions.V_7_0_0,
             IndexVersionUtils.getPreviousVersion(IndexVersions.V_8_0_0)
         );

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/FailedShardsRoutingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/FailedShardsRoutingTests.java
@@ -767,15 +767,15 @@ public class FailedShardsRoutingTests extends ESAllocationTestCase {
                     .add(
                         newNode(
                             "node3-old",
-                            VersionUtils.randomVersionBetween(random(), Version.CURRENT.minimumCompatibilityVersion(), null),
-                            IndexVersionUtils.randomVersionBetween(random(), IndexVersions.MINIMUM_COMPATIBLE, null)
+                            VersionUtils.randomVersionBetween(Version.CURRENT.minimumCompatibilityVersion(), null),
+                            IndexVersionUtils.randomVersionBetween(IndexVersions.MINIMUM_COMPATIBLE, null)
                         )
                     )
                     .add(
                         newNode(
                             "node4-old",
-                            VersionUtils.randomVersionBetween(random(), Version.CURRENT.minimumCompatibilityVersion(), null),
-                            IndexVersionUtils.randomVersionBetween(random(), IndexVersions.MINIMUM_COMPATIBLE, null)
+                            VersionUtils.randomVersionBetween(Version.CURRENT.minimumCompatibilityVersion(), null),
+                            IndexVersionUtils.randomVersionBetween(IndexVersions.MINIMUM_COMPATIBLE, null)
                         )
                     )
             )

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/NodeBalanceStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/NodeBalanceStatsTests.java
@@ -62,7 +62,6 @@ public class NodeBalanceStatsTests extends AbstractWireSerializingTestCase<Clust
         ClusterBalanceStats.NodeBalanceStats instance = createTestInstance();
         // Serialization changes based on this version
         final var oldVersion = TransportVersionUtils.randomVersionBetween(
-            random(),
             NODE_WEIGHTS_ADDED_TO_NODE_BALANCE_STATS,
             TransportVersion.current()
         );

--- a/server/src/test/java/org/elasticsearch/cluster/serialization/ClusterSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/serialization/ClusterSerializationTests.java
@@ -174,7 +174,6 @@ public class ClusterSerializationTests extends ESAllocationTestCase {
 
     public void testSnapshotDeletionsInProgressSerialization() throws Exception {
         TransportVersion version = TransportVersionUtils.randomVersionBetween(
-            random(),
             TransportVersion.minimumCompatible(),
             TransportVersion.current()
         );

--- a/server/src/test/java/org/elasticsearch/cluster/version/CompatibilityVersionsTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/version/CompatibilityVersionsTests.java
@@ -34,7 +34,6 @@ public class CompatibilityVersionsTests extends ESTestCase {
     public void testMinimumTransportVersions() {
         TransportVersion version1 = TransportVersionUtils.getNextVersion(TransportVersion.minimumCompatible(), true);
         TransportVersion version2 = TransportVersionUtils.randomVersionBetween(
-            random(),
             TransportVersionUtils.getNextVersion(version1, true),
             TransportVersion.current()
         );
@@ -81,7 +80,6 @@ public class CompatibilityVersionsTests extends ESTestCase {
     public void testMinimumsAreMerged() {
         TransportVersion version1 = TransportVersionUtils.getNextVersion(TransportVersion.minimumCompatible(), true);
         TransportVersion version2 = TransportVersionUtils.randomVersionBetween(
-            random(),
             TransportVersionUtils.getNextVersion(version1, true),
             TransportVersion.current()
         );
@@ -110,7 +108,7 @@ public class CompatibilityVersionsTests extends ESTestCase {
 
         // should not throw
         CompatibilityVersions.ensureVersionsCompatibility(
-            new CompatibilityVersions(TransportVersionUtils.randomVersionBetween(random(), min, TransportVersion.current()), Map.of()),
+            new CompatibilityVersions(TransportVersionUtils.randomVersionBetween(min, TransportVersion.current()), Map.of()),
             compatibilityVersions
         );
 

--- a/server/src/test/java/org/elasticsearch/common/io/stream/DelayableWriteableTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/DelayableWriteableTests.java
@@ -203,7 +203,6 @@ public class DelayableWriteableTests extends ESTestCase {
 
     private static TransportVersion randomOldVersion() {
         return TransportVersionUtils.randomVersionBetween(
-            random(),
             TransportVersion.minimumCompatible(),
             TransportVersionUtils.getPreviousVersion(TransportVersion.current())
         );

--- a/server/src/test/java/org/elasticsearch/common/io/stream/VersionCheckingStreamOutputTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/VersionCheckingStreamOutputTests.java
@@ -36,7 +36,6 @@ public class VersionCheckingStreamOutputTests extends ESTestCase {
 
     public void testCheckVersionCompatibility() throws IOException {
         TransportVersion streamVersion = TransportVersionUtils.randomVersionBetween(
-            random(),
             TransportVersion.minimumCompatible(),
             TransportVersionUtils.getPreviousVersion(TransportVersion.current())
         );

--- a/server/src/test/java/org/elasticsearch/env/NodeMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeMetadataTests.java
@@ -155,7 +155,7 @@ public class NodeMetadataTests extends ESTestCase {
 
     public void testUpgradeMarksPreviousVersion() {
         final String nodeId = randomAlphaOfLength(10);
-        final Version version = VersionUtils.randomVersionBetween(random(), Version.CURRENT.minimumCompatibilityVersion(), Version.V_9_0_0);
+        final Version version = VersionUtils.randomVersionBetween(Version.CURRENT.minimumCompatibilityVersion(), Version.V_9_0_0);
         final BuildVersion buildVersion = BuildVersion.fromVersionId(version.id());
 
         final NodeMetadata nodeMetadata = new NodeMetadata(nodeId, buildVersion, IndexVersion.current()).upgradeToCurrentVersion();

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
@@ -768,7 +768,6 @@ public class DateFieldMapperTests extends MapperTestCase {
 
         // BWC compatible index, e.g 7.x
         IndexVersion indexVersion = IndexVersionUtils.randomVersionBetween(
-            random(),
             IndexVersions.V_7_0_0,
             IndexVersionUtils.getPreviousVersion(IndexVersions.V_8_0_0)
         );

--- a/server/src/test/java/org/elasticsearch/index/mapper/IgnoredFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IgnoredFieldMapperTests.java
@@ -89,11 +89,7 @@ public class IgnoredFieldMapperTests extends MetadataMapperTestCase {
     }
 
     public void testIgnoredFieldType() throws IOException {
-        IndexVersion version = IndexVersionUtils.randomVersionBetween(
-            random(),
-            IndexVersions.FIRST_DETACHED_INDEX_VERSION,
-            IndexVersion.current()
-        );
+        IndexVersion version = IndexVersionUtils.randomVersionBetween(IndexVersions.FIRST_DETACHED_INDEX_VERSION, IndexVersion.current());
         boolean afterIntroducingDocValues = version.onOrAfter(IndexVersions.DOC_VALUES_FOR_IGNORED_META_FIELD);
         boolean beforeRemovingStoredField = version.before(IndexVersions.DOC_VALUES_FOR_IGNORED_META_FIELD);
         MapperService mapperService = createMapperService(version, fieldMapping(b -> b.field("type", "keyword").field("ignore_above", 3)));

--- a/server/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
@@ -2004,7 +2004,7 @@ public class NestedObjectMapperTests extends MapperServiceTestCase {
     public void testNestedLimitDefaults() throws IOException {
         // current defaults
         {
-            var version = IndexVersionUtils.randomVersionBetween(random(), IndexVersions.NESTED_PATH_LIMIT, IndexVersion.current());
+            var version = IndexVersionUtils.randomVersionBetween(IndexVersions.NESTED_PATH_LIMIT, IndexVersion.current());
             var mapperService = createMapperService(version, Settings.builder().build(), mapping(b -> {}));
             assertThat(
                 MapperService.INDEX_MAPPING_NESTED_FIELDS_LIMIT_SETTING.get(mapperService.getIndexSettings().getSettings()),

--- a/server/src/test/java/org/elasticsearch/index/mapper/TimeSeriesIdFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TimeSeriesIdFieldMapperTests.java
@@ -59,7 +59,6 @@ public class TimeSeriesIdFieldMapperTests extends MetadataMapperTestCase {
     @Override
     protected IndexVersion getVersion() {
         return IndexVersionUtils.randomVersionBetween(
-            random(),
             IndexVersions.V_8_8_0,
             IndexVersionUtils.getPreviousVersion(IndexVersions.TIME_SERIES_ID_HASHING)
         );

--- a/server/src/test/java/org/elasticsearch/index/mapper/TypeParsersTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TypeParsersTests.java
@@ -86,7 +86,7 @@ public class TypeParsersTests extends ESTestCase {
         // For indices created in 8.0 or later, we should throw an error.
         Map<String, Object> fieldNodeCopy = XContentHelper.convertToMap(BytesReference.bytes(mapping), true, mapping.contentType()).v2();
 
-        IndexVersion version = IndexVersionUtils.randomVersionBetween(random(), IndexVersions.V_8_0_0, IndexVersion.current());
+        IndexVersion version = IndexVersionUtils.randomVersionBetween(IndexVersions.V_8_0_0, IndexVersion.current());
         TransportVersion transportVersion = TransportVersionUtils.randomCompatibleVersion(random());
         MappingParserContext context = new MappingParserContext(
             null,

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
@@ -711,12 +711,10 @@ public class DenseVectorFieldMapperTests extends SyntheticVectorsMapperTestCase 
     public void testRescoreVectorOldIndexVersion() {
         IndexVersion incompatibleVersion = randomFrom(
             IndexVersionUtils.randomVersionBetween(
-                random(),
                 IndexVersionUtils.getLowestReadCompatibleVersion(),
                 IndexVersionUtils.getPreviousVersion(IndexVersions.ADD_RESCORE_PARAMS_TO_QUANTIZED_VECTORS_BACKPORT_8_X)
             ),
             IndexVersionUtils.randomVersionBetween(
-                random(),
                 IndexVersions.UPGRADE_TO_LUCENE_10_0_0,
                 IndexVersionUtils.getPreviousVersion(IndexVersions.ADD_RESCORE_PARAMS_TO_QUANTIZED_VECTORS)
             )
@@ -742,12 +740,10 @@ public class DenseVectorFieldMapperTests extends SyntheticVectorsMapperTestCase 
     public void testRescoreZeroVectorOldIndexVersion() {
         IndexVersion incompatibleVersion = randomFrom(
             IndexVersionUtils.randomVersionBetween(
-                random(),
                 IndexVersionUtils.getLowestReadCompatibleVersion(),
                 IndexVersionUtils.getPreviousVersion(IndexVersions.RESCORE_PARAMS_ALLOW_ZERO_TO_QUANTIZED_VECTORS_BACKPORT_8_X)
             ),
             IndexVersionUtils.randomVersionBetween(
-                random(),
                 IndexVersions.UPGRADE_TO_LUCENE_10_0_0,
                 IndexVersionUtils.getPreviousVersion(IndexVersions.RESCORE_PARAMS_ALLOW_ZERO_TO_QUANTIZED_VECTORS)
             )
@@ -1427,7 +1423,7 @@ public class DenseVectorFieldMapperTests extends SyntheticVectorsMapperTestCase 
         final int dims = randomIntBetween(64, 2048);
         VectorSimilarity similarity = VectorSimilarity.COSINE;
         DocumentMapper mapper = createDocumentMapper(
-            IndexVersionUtils.randomVersionBetween(random(), IndexVersions.V_8_0_0, IndexVersions.NEW_SPARSE_VECTOR),
+            IndexVersionUtils.randomVersionBetween(IndexVersions.V_8_0_0, IndexVersions.NEW_SPARSE_VECTOR),
             fieldMapping(b -> b.field("type", "dense_vector").field("dims", dims).field("index", true).field("similarity", similarity))
         );
         float[] vector = new float[dims];
@@ -1519,7 +1515,6 @@ public class DenseVectorFieldMapperTests extends SyntheticVectorsMapperTestCase 
             VectorSimilarityFunction.COSINE,
             VectorSimilarity.COSINE.vectorSimilarityFunction(
                 IndexVersionUtils.randomVersionBetween(
-                    random(),
                     IndexVersions.V_8_0_0,
                     IndexVersionUtils.getPreviousVersion(DenseVectorFieldMapper.NORMALIZE_COSINE)
                 ),
@@ -1529,7 +1524,7 @@ public class DenseVectorFieldMapperTests extends SyntheticVectorsMapperTestCase 
         assertEquals(
             VectorSimilarityFunction.DOT_PRODUCT,
             VectorSimilarity.COSINE.vectorSimilarityFunction(
-                IndexVersionUtils.randomVersionBetween(random(), DenseVectorFieldMapper.NORMALIZE_COSINE, IndexVersion.current()),
+                IndexVersionUtils.randomVersionBetween(DenseVectorFieldMapper.NORMALIZE_COSINE, IndexVersion.current()),
                 ElementType.FLOAT
             )
         );

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/SparseVectorFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/SparseVectorFieldMapperTests.java
@@ -300,7 +300,6 @@ public class SparseVectorFieldMapperTests extends SyntheticVectorsMapperTestCase
 
     public void testDefaultsWithAndWithoutIncludeDefaultsOlderIndexVersion() throws Exception {
         IndexVersion indexVersion = IndexVersionUtils.randomVersionBetween(
-            random(),
             UPGRADE_TO_LUCENE_10_0_0,
             IndexVersionUtils.getPreviousVersion(SPARSE_VECTOR_PRUNING_INDEX_OPTIONS_SUPPORT)
         );
@@ -529,11 +528,7 @@ public class SparseVectorFieldMapperTests extends SyntheticVectorsMapperTestCase
     }
 
     public void testSparseVectorUnsupportedIndex() {
-        IndexVersion version = IndexVersionUtils.randomVersionBetween(
-            random(),
-            IndexVersions.V_8_0_0,
-            IndexVersions.FIRST_DETACHED_INDEX_VERSION
-        );
+        IndexVersion version = IndexVersionUtils.randomVersionBetween(IndexVersions.V_8_0_0, IndexVersions.FIRST_DETACHED_INDEX_VERSION);
         Exception e = expectThrows(MapperParsingException.class, () -> createMapperService(version, fieldMapping(b -> {
             b.field("type", "sparse_vector");
         })));
@@ -926,6 +921,6 @@ public class SparseVectorFieldMapperTests extends SyntheticVectorsMapperTestCase
     }
 
     public static IndexVersion getIndexOptionsCompatibleIndexVersion() {
-        return IndexVersionUtils.randomVersionBetween(random(), SPARSE_VECTOR_PRUNING_INDEX_OPTIONS_SUPPORT, IndexVersion.current());
+        return IndexVersionUtils.randomVersionBetween(SPARSE_VECTOR_PRUNING_INDEX_OPTIONS_SUPPORT, IndexVersion.current());
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/SparseVectorFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/SparseVectorFieldTypeTests.java
@@ -21,22 +21,14 @@ import java.util.Collections;
 public class SparseVectorFieldTypeTests extends FieldTypeTestCase {
 
     public void testDocValuesDisabled() {
-        IndexVersion indexVersion = IndexVersionUtils.randomVersionBetween(
-            random(),
-            IndexVersions.NEW_SPARSE_VECTOR,
-            IndexVersion.current()
-        );
+        IndexVersion indexVersion = IndexVersionUtils.randomVersionBetween(IndexVersions.NEW_SPARSE_VECTOR, IndexVersion.current());
         MappedFieldType fieldType = new SparseVectorFieldMapper.SparseVectorFieldType(indexVersion, "field", false, Collections.emptyMap());
         assertFalse(fieldType.hasDocValues());
         expectThrows(IllegalArgumentException.class, () -> fieldType.fielddataBuilder(FieldDataContext.noRuntimeFields("index", "test")));
     }
 
     public void testIsNotAggregatable() {
-        IndexVersion indexVersion = IndexVersionUtils.randomVersionBetween(
-            random(),
-            IndexVersions.NEW_SPARSE_VECTOR,
-            IndexVersion.current()
-        );
+        IndexVersion indexVersion = IndexVersionUtils.randomVersionBetween(IndexVersions.NEW_SPARSE_VECTOR, IndexVersion.current());
         MappedFieldType fieldType = new SparseVectorFieldMapper.SparseVectorFieldType(indexVersion, "field", false, Collections.emptyMap());
         assertFalse(fieldType.isAggregatable());
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/VectorEncoderDecoderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/VectorEncoderDecoderTests.java
@@ -28,7 +28,6 @@ public class VectorEncoderDecoderTests extends ESTestCase {
         int dims = 3;
         for (IndexVersion version : List.of(
             IndexVersionUtils.randomVersionBetween(
-                random(),
                 IndexVersions.MINIMUM_COMPATIBLE,
                 IndexVersionUtils.getPreviousVersion(DenseVectorFieldMapper.LITTLE_ENDIAN_FLOAT_STORED_INDEX_VERSION)
             ),

--- a/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -3472,7 +3472,6 @@ public class TranslogTests extends ESTestCase {
         Translog.Index index = new Translog.Index(eIndex, eIndexResult);
 
         TransportVersion wireVersion = TransportVersionUtils.randomVersionBetween(
-            random(),
             TransportVersion.minimumCompatible(),
             TransportVersion.current()
         );

--- a/server/src/test/java/org/elasticsearch/indices/IndicesModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesModuleTests.java
@@ -100,7 +100,7 @@ public class IndicesModuleTests extends ESTestCase {
     public void testBuiltinMappers() {
         IndicesModule module = new IndicesModule(Collections.emptyList());
         {
-            IndexVersion version = IndexVersionUtils.randomVersionBetween(random(), IndexVersions.V_8_0_0, IndexVersion.current());
+            IndexVersion version = IndexVersionUtils.randomVersionBetween(IndexVersions.V_8_0_0, IndexVersion.current());
             assertThat(
                 module.getMapperRegistry().getMapperParser("object", IndexVersion.current()),
                 instanceOf(ObjectMapper.TypeParser.class)
@@ -116,7 +116,6 @@ public class IndicesModuleTests extends ESTestCase {
         }
         {
             IndexVersion version = IndexVersionUtils.randomVersionBetween(
-                random(),
                 IndexVersions.V_7_0_0,
                 IndexVersionUtils.getPreviousVersion(IndexVersions.V_8_0_0)
             );

--- a/server/src/test/java/org/elasticsearch/indices/analysis/AnalysisModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/analysis/AnalysisModuleTests.java
@@ -192,7 +192,7 @@ public class AnalysisModuleTests extends ESTestCase {
         // cacheing bug meant that it was still possible to create indexes using a standard
         // filter until 7.6
         {
-            IndexVersion version = IndexVersionUtils.randomVersionBetween(random(), IndexVersions.V_7_6_0, IndexVersion.current());
+            IndexVersion version = IndexVersionUtils.randomVersionBetween(IndexVersions.V_7_6_0, IndexVersion.current());
             final Settings settings = Settings.builder()
                 .put("index.analysis.analyzer.my_standard.tokenizer", "standard")
                 .put("index.analysis.analyzer.my_standard.filter", "standard")
@@ -203,7 +203,7 @@ public class AnalysisModuleTests extends ESTestCase {
             assertThat(exc.getMessage(), equalTo("The [standard] token filter has been removed."));
         }
         {
-            IndexVersion version = IndexVersionUtils.randomVersionBetween(random(), IndexVersions.V_7_0_0, IndexVersions.V_7_5_2);
+            IndexVersion version = IndexVersionUtils.randomVersionBetween(IndexVersions.V_7_0_0, IndexVersions.V_7_5_2);
             final Settings settings = Settings.builder()
                 .put("index.analysis.analyzer.my_standard.tokenizer", "standard")
                 .put("index.analysis.analyzer.my_standard.filter", "standard")

--- a/server/src/test/java/org/elasticsearch/persistent/BasePersistentTasksCustomMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/persistent/BasePersistentTasksCustomMetadataTests.java
@@ -201,13 +201,13 @@ public abstract class BasePersistentTasksCustomMetadataTests<T extends Metadata.
         PersistentTasks.Builder<?> tasks = builder();
 
         TransportVersion minVersion = TransportVersion.minimumCompatible();
-        TransportVersion streamVersion = randomVersionBetween(random(), minVersion, getPreviousVersion(TransportVersion.current()));
+        TransportVersion streamVersion = randomVersionBetween(minVersion, getPreviousVersion(TransportVersion.current()));
         tasks.addTask(
             "test_compatible_version",
             TestPersistentTasksPlugin.TestPersistentTasksExecutor.NAME,
             new TestPersistentTasksPlugin.TestParams(
                 null,
-                randomVersionBetween(random(), minVersion, streamVersion),
+                randomVersionBetween(minVersion, streamVersion),
                 randomBoolean() ? Optional.empty() : Optional.of("test")
             ),
             randomAssignment()
@@ -217,7 +217,7 @@ public abstract class BasePersistentTasksCustomMetadataTests<T extends Metadata.
             TestPersistentTasksPlugin.TestPersistentTasksExecutor.NAME,
             new TestPersistentTasksPlugin.TestParams(
                 null,
-                randomVersionBetween(random(), getNextVersion(streamVersion), TransportVersion.current()),
+                randomVersionBetween(getNextVersion(streamVersion), TransportVersion.current()),
                 randomBoolean() ? Optional.empty() : Optional.of("test")
             ),
             randomAssignment()

--- a/server/src/test/java/org/elasticsearch/search/internal/ShardSearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/search/internal/ShardSearchRequestTests.java
@@ -230,11 +230,7 @@ public class ShardSearchRequestTests extends AbstractSearchTestCase {
         for (int i = 0; i < iterations; i++) {
             TransportVersion version = TransportVersionUtils.randomCompatibleVersion(random());
             if (Optional.ofNullable(request.source()).map(SearchSourceBuilder::knnSearch).map(List::size).orElse(0) > 1) {
-                version = TransportVersionUtils.randomVersionBetween(
-                    random(),
-                    TransportVersion.minimumCompatible(),
-                    TransportVersion.current()
-                );
+                version = TransportVersionUtils.randomVersionBetween(TransportVersion.minimumCompatible(), TransportVersion.current());
             }
             request = copyWriteable(request, namedWriteableRegistry, ShardSearchRequest::new, version);
             channelVersion = TransportVersion.min(channelVersion, version);

--- a/server/src/test/java/org/elasticsearch/search/sort/FieldSortBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/FieldSortBuilderTests.java
@@ -697,7 +697,6 @@ public class FieldSortBuilderTests extends AbstractSortTestCase<FieldSortBuilder
         );
         assertIntegerSortRewrite(
             IndexVersionUtils.randomVersionBetween(
-                random(),
                 IndexVersions.INDEX_INT_SORT_INT_TYPE_8_19,
                 IndexVersionUtils.getPreviousVersion(IndexVersions.UPGRADE_TO_LUCENE_10_0_0)
             ),
@@ -705,14 +704,13 @@ public class FieldSortBuilderTests extends AbstractSortTestCase<FieldSortBuilder
         );
         assertIntegerSortRewrite(
             IndexVersionUtils.randomVersionBetween(
-                random(),
                 IndexVersions.UPGRADE_TO_LUCENE_10_0_0,
                 IndexVersionUtils.getPreviousVersion(IndexVersions.INDEX_INT_SORT_INT_TYPE)
             ),
             SortField.Type.LONG
         );
         assertIntegerSortRewrite(
-            IndexVersionUtils.randomVersionBetween(random(), IndexVersions.INDEX_INT_SORT_INT_TYPE, IndexVersion.current()),
+            IndexVersionUtils.randomVersionBetween(IndexVersions.INDEX_INT_SORT_INT_TYPE, IndexVersion.current()),
             SortField.Type.INT
         );
         assertIntegerSortRewrite(IndexVersion.current(), SortField.Type.INT);

--- a/server/src/test/java/org/elasticsearch/search/suggest/SuggestTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/SuggestTests.java
@@ -294,7 +294,6 @@ public class SuggestTests extends ESTestCase {
 
     public void testSerialization() throws IOException {
         TransportVersion bwcVersion = TransportVersionUtils.randomVersionBetween(
-            random(),
             TransportVersion.minimumCompatible(),
             TransportVersion.current()
         );

--- a/server/src/test/java/org/elasticsearch/transport/InboundDecoderTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundDecoderTests.java
@@ -368,7 +368,7 @@ public class InboundDecoderTests extends ESTestCase {
     public void testCheckVersionCompatibility() {
         try {
             InboundDecoder.checkVersionCompatibility(
-                TransportVersionUtils.randomVersionBetween(random(), TransportVersion.minimumCompatible(), TransportVersion.current())
+                TransportVersionUtils.randomVersionBetween(TransportVersion.minimumCompatible(), TransportVersion.current())
             );
         } catch (IllegalStateException e) {
             throw new AssertionError(e);

--- a/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
@@ -128,7 +128,7 @@ public class TransportServiceHandshakeTests extends ESTestCase {
             settings,
             TransportVersionUtils.randomCompatibleVersion(random()),
             new VersionInformation(
-                VersionUtils.randomVersionBetween(random(), Version.CURRENT.minimumCompatibilityVersion(), Version.CURRENT),
+                VersionUtils.randomVersionBetween(Version.CURRENT.minimumCompatibilityVersion(), Version.CURRENT),
                 IndexVersions.MINIMUM_COMPATIBLE,
                 IndexVersion.current()
             ),

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MetadataMapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MetadataMapperTestCase.java
@@ -148,11 +148,7 @@ public abstract class MetadataMapperTestCase extends MapperServiceTestCase {
         assumeTrue("Metadata field " + fieldName() + " isn't configurable", isConfigurable());
         IndexVersion previousVersion = IndexVersionUtils.getPreviousVersion(IndexVersions.V_8_6_0);
         // we randomly also pick read-only versions to test that we can still parse the parameters for them
-        IndexVersion version = IndexVersionUtils.randomVersionBetween(
-            random(),
-            IndexVersionUtils.getLowestReadCompatibleVersion(),
-            previousVersion
-        );
+        IndexVersion version = IndexVersionUtils.randomVersionBetween(IndexVersionUtils.getLowestReadCompatibleVersion(), previousVersion);
         assumeTrue("Metadata field " + fieldName() + " is not supported on version " + version, isSupportedOn(version));
         MapperService mapperService = createMapperService(version, mapping(b -> {}));
         // these parameters were previously silently ignored, they will still be ignored in existing indices
@@ -176,7 +172,7 @@ public abstract class MetadataMapperTestCase extends MapperServiceTestCase {
     public void testTypeAndFriendsAreDeprecatedFrom_8_6_0_TO_9_0_0() throws IOException {
         assumeTrue("Metadata field " + fieldName() + " isn't configurable", isConfigurable());
         IndexVersion previousVersion = IndexVersionUtils.getPreviousVersion(IndexVersions.UPGRADE_TO_LUCENE_10_0_0);
-        IndexVersion version = IndexVersionUtils.randomVersionBetween(random(), IndexVersions.V_8_6_0, previousVersion);
+        IndexVersion version = IndexVersionUtils.randomVersionBetween(IndexVersions.V_8_6_0, previousVersion);
         assumeTrue("Metadata field " + fieldName() + " is not supported on version " + version, isSupportedOn(version));
         MapperService mapperService = createMapperService(version, mapping(b -> {}));
         // these parameters were deprecated, they now should throw an error in new indices
@@ -200,11 +196,7 @@ public abstract class MetadataMapperTestCase extends MapperServiceTestCase {
 
     public void testTypeAndFriendsThrow_After_9_0_0() throws IOException {
         assumeTrue("Metadata field " + fieldName() + " isn't configurable", isConfigurable());
-        IndexVersion version = IndexVersionUtils.randomVersionBetween(
-            random(),
-            IndexVersions.UPGRADE_TO_LUCENE_10_0_0,
-            IndexVersion.current()
-        );
+        IndexVersion version = IndexVersionUtils.randomVersionBetween(IndexVersions.UPGRADE_TO_LUCENE_10_0_0, IndexVersion.current());
         assumeTrue("Metadata field " + fieldName() + " is not supported on version " + version, isSupportedOn(version));
         MapperService mapperService = createMapperService(version, mapping(b -> {}));
         // these parameters were previously silently ignored, they are now deprecated in new indices

--- a/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -381,7 +381,7 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
             initWithSnapshotVersion(
                 repoName,
                 repoPath,
-                IndexVersionUtils.randomVersionBetween(random(), IndexVersions.V_7_0_0, IndexVersions.V_8_9_0)
+                IndexVersionUtils.randomVersionBetween(IndexVersions.V_7_0_0, IndexVersions.V_8_9_0)
             );
         }
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/TransportVersionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TransportVersionUtils.java
@@ -63,6 +63,11 @@ public class TransportVersionUtils {
     }
 
     /** Returns a random {@link TransportVersion} between <code>minVersion</code> and <code>maxVersion</code> (inclusive). */
+    public static TransportVersion randomVersionBetween(@Nullable TransportVersion minVersion, @Nullable TransportVersion maxVersion) {
+        return randomVersionBetween(random(), minVersion, maxVersion);
+    }
+
+    /** Returns a random {@link TransportVersion} between <code>minVersion</code> and <code>maxVersion</code> (inclusive). */
     public static TransportVersion randomVersionBetween(
         Random random,
         @Nullable TransportVersion minVersion,

--- a/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/VersionUtils.java
@@ -22,6 +22,8 @@ import java.util.NavigableSet;
 import java.util.Random;
 import java.util.TreeSet;
 
+import static org.apache.lucene.tests.util.LuceneTestCase.random;
+
 /** Utilities for selecting versions in tests */
 public class VersionUtils {
 
@@ -83,6 +85,11 @@ public class VersionUtils {
     public static Version randomCompatibleVersion(Random random, Version version) {
         final List<Version> compatible = ALL_VERSIONS.stream().filter(version::isCompatible).toList();
         return compatible.get(random.nextInt(compatible.size()));
+    }
+
+    /** Returns a random {@link Version} between <code>minVersion</code> and <code>maxVersion</code> (inclusive). */
+    public static Version randomVersionBetween(@Nullable Version minVersion, @Nullable Version maxVersion) {
+        return randomVersionBetween(random(), minVersion, maxVersion);
     }
 
     /** Returns a random {@link Version} between <code>minVersion</code> and <code>maxVersion</code> (inclusive). */

--- a/test/framework/src/main/java/org/elasticsearch/test/index/IndexVersionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/index/IndexVersionUtils.java
@@ -59,6 +59,11 @@ public class IndexVersionUtils {
     }
 
     /** Returns a random {@link IndexVersion} between <code>minVersion</code> and <code>maxVersion</code> (inclusive). */
+    public static IndexVersion randomVersionBetween(@Nullable IndexVersion minVersion, @Nullable IndexVersion maxVersion) {
+        return randomVersionBetween(random(), minVersion, maxVersion);
+    }
+
+    /** Returns a random {@link IndexVersion} between <code>minVersion</code> and <code>maxVersion</code> (inclusive). */
     public static IndexVersion randomVersionBetween(Random random, @Nullable IndexVersion minVersion, @Nullable IndexVersion maxVersion) {
         if (minVersion != null && maxVersion != null && maxVersion.before(minVersion)) {
             throw new IllegalArgumentException("maxVersion [" + maxVersion + "] cannot be less than minVersion [" + minVersion + "]");

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -2340,10 +2340,9 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         }
     }
 
-    public void testHandshakeUpdatesVersion() throws IOException {
+    public void testHandshakeUpdatesVersion() {
         assumeTrue("only tcp transport has a handshake method", serviceA.getOriginalTransport() instanceof TcpTransport);
         TransportVersion transportVersion = TransportVersionUtils.randomVersionBetween(
-            random(),
             TransportVersion.minimumCompatible(),
             TransportVersion.current()
         );

--- a/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/VersionUtilsTests.java
@@ -24,49 +24,49 @@ public class VersionUtilsTests extends ESTestCase {
     public void testRandomVersionBetween() {
         // TODO: rework this test to use a dummy Version class so these don't need to change with each release
         // full range
-        Version got = VersionUtils.randomVersionBetween(random(), VersionUtils.getFirstVersion(), Version.CURRENT);
+        Version got = VersionUtils.randomVersionBetween(VersionUtils.getFirstVersion(), Version.CURRENT);
         assertTrue(got.onOrAfter(VersionUtils.getFirstVersion()));
         assertTrue(got.onOrBefore(Version.CURRENT));
-        got = VersionUtils.randomVersionBetween(random(), null, Version.CURRENT);
+        got = VersionUtils.randomVersionBetween(null, Version.CURRENT);
         assertTrue(got.onOrAfter(VersionUtils.getFirstVersion()));
         assertTrue(got.onOrBefore(Version.CURRENT));
-        got = VersionUtils.randomVersionBetween(random(), VersionUtils.getFirstVersion(), null);
+        got = VersionUtils.randomVersionBetween(VersionUtils.getFirstVersion(), null);
         assertTrue(got.onOrAfter(VersionUtils.getFirstVersion()));
         assertTrue(got.onOrBefore(Version.CURRENT));
 
         // sub range
-        got = VersionUtils.randomVersionBetween(random(), fromId(7000099), fromId(7010099));
+        got = VersionUtils.randomVersionBetween(fromId(7000099), fromId(7010099));
         assertTrue(got.onOrAfter(fromId(7000099)));
         assertTrue(got.onOrBefore(fromId(7010099)));
 
         // unbounded lower
-        got = VersionUtils.randomVersionBetween(random(), null, fromId(7000099));
+        got = VersionUtils.randomVersionBetween(null, fromId(7000099));
         assertTrue(got.onOrAfter(VersionUtils.getFirstVersion()));
         assertTrue(got.onOrBefore(fromId(7000099)));
-        got = VersionUtils.randomVersionBetween(random(), null, VersionUtils.allVersions().getFirst());
+        got = VersionUtils.randomVersionBetween(null, VersionUtils.allVersions().getFirst());
         assertTrue(got.onOrAfter(VersionUtils.getFirstVersion()));
         assertTrue(got.onOrBefore(VersionUtils.allVersions().getFirst()));
 
         // unbounded upper
-        got = VersionUtils.randomVersionBetween(random(), VersionUtils.getFirstVersion(), null);
+        got = VersionUtils.randomVersionBetween(VersionUtils.getFirstVersion(), null);
         assertTrue(got.onOrAfter(VersionUtils.getFirstVersion()));
         assertTrue(got.onOrBefore(Version.CURRENT));
-        got = VersionUtils.randomVersionBetween(random(), VersionUtils.getPreviousVersion(), null);
+        got = VersionUtils.randomVersionBetween(VersionUtils.getPreviousVersion(), null);
         assertTrue(got.onOrAfter(VersionUtils.getPreviousVersion()));
         assertTrue(got.onOrBefore(Version.CURRENT));
 
         // range of one
-        got = VersionUtils.randomVersionBetween(random(), VersionUtils.getFirstVersion(), VersionUtils.getFirstVersion());
+        got = VersionUtils.randomVersionBetween(VersionUtils.getFirstVersion(), VersionUtils.getFirstVersion());
         assertEquals(got, VersionUtils.getFirstVersion());
-        got = VersionUtils.randomVersionBetween(random(), Version.CURRENT, Version.CURRENT);
+        got = VersionUtils.randomVersionBetween(Version.CURRENT, Version.CURRENT);
         assertEquals(got, Version.CURRENT);
-        got = VersionUtils.randomVersionBetween(random(), fromId(7000099), fromId(7000099));
+        got = VersionUtils.randomVersionBetween(fromId(7000099), fromId(7000099));
         assertEquals(got, fromId(7000099));
 
         // implicit range of one
-        got = VersionUtils.randomVersionBetween(random(), null, VersionUtils.getFirstVersion());
+        got = VersionUtils.randomVersionBetween(null, VersionUtils.getFirstVersion());
         assertEquals(got, VersionUtils.getFirstVersion());
-        got = VersionUtils.randomVersionBetween(random(), Version.CURRENT, null);
+        got = VersionUtils.randomVersionBetween(Version.CURRENT, null);
         assertEquals(got, Version.CURRENT);
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ClientHelperTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ClientHelperTests.java
@@ -423,7 +423,6 @@ public class ClientHelperTests extends ESTestCase {
 
         // Rewritten for older version
         final TransportVersion previousVersion = TransportVersionUtils.randomVersionBetween(
-            random(),
             TransportVersion.minimumCompatible(),
             TransportVersionUtils.getPreviousVersion()
         );

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SetSingleNodeAllocateStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SetSingleNodeAllocateStepTests.java
@@ -595,7 +595,7 @@ public class SetSingleNodeAllocateStepTests extends AbstractStepTestCase<SetSing
 
     private VersionInformation randomOldVersionInformation() {
         final var previousVersion = VersionUtils.getPreviousVersion();
-        final var version = VersionUtils.randomVersionBetween(random(), previousVersion.minimumCompatibilityVersion(), previousVersion);
+        final var version = VersionUtils.randomVersionBetween(previousVersion.minimumCompatibilityVersion(), previousVersion);
         return new VersionInformation(
             BuildVersion.fromVersionId(version.id()),
             version,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/search/SparseVectorQueryBuilderTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/search/SparseVectorQueryBuilderTests.java
@@ -111,7 +111,7 @@ public class SparseVectorQueryBuilderTests extends AbstractQueryTestCase<SparseV
         // index versions after its reintroduction.
         final IndexVersion indexVersionCreated = randomBoolean()
             ? IndexVersion.current()
-            : IndexVersionUtils.randomVersionBetween(random(), IndexVersions.NEW_SPARSE_VECTOR, IndexVersion.current());
+            : IndexVersionUtils.randomVersionBetween(IndexVersions.NEW_SPARSE_VECTOR, IndexVersion.current());
         return Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, indexVersionCreated).build();
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationSerializationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationSerializationTests.java
@@ -114,7 +114,6 @@ public class AuthenticationSerializationTests extends ESTestCase {
 
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             final TransportVersion version = TransportVersionUtils.randomVersionBetween(
-                random(),
                 TransportVersion.minimumCompatible(),
                 TransportVersionUtils.getPreviousVersion(SECURITY_CLOUD_API_KEY_REALM_AND_TYPE)
             );

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTests.java
@@ -904,7 +904,6 @@ public class AuthenticationTests extends ESTestCase {
             .build();
         // pick a version before that of the authentication instance to force a rewrite
         final TransportVersion olderVersion = TransportVersionUtils.randomVersionBetween(
-            random(),
             TransportVersion.minimumCompatible(),
             TransportVersionUtils.getPreviousVersion(authentication.getEffectiveSubject().getTransportVersion())
         );
@@ -947,12 +946,11 @@ public class AuthenticationTests extends ESTestCase {
 
     public void testMaybeRewriteForOlderVersionDoesNotEraseDomainForVersionsAfterDomains() {
         final TransportVersion olderVersion = TransportVersionUtils.randomVersionBetween(
-            random(),
             TransportVersion.minimumCompatible(),
             // Don't include CURRENT, so we always have at least one newer version available below
             TransportVersionUtils.getPreviousVersion()
         );
-        TransportVersion transportVersion = TransportVersionUtils.randomVersionBetween(random(), olderVersion, null);
+        TransportVersion transportVersion = TransportVersionUtils.randomVersionBetween(olderVersion, null);
         final Authentication authentication = AuthenticationTestHelper.builder()
             .realm() // randomize to test both when realm is null on the original auth and non-null, instead of setting `underDomain`
             // Use CURRENT to force newer version in case randomVersionBetween above picks olderVersion

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/utils/TransformConfigVersionUtils.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/utils/TransformConfigVersionUtils.java
@@ -53,7 +53,7 @@ public class TransformConfigVersionUtils {
         @Nullable TransformConfigVersion minVersion,
         @Nullable TransformConfigVersion maxVersion
     ) {
-        return randomVersionBetween(minVersion, maxVersion);
+        return randomVersionBetween(random(), minVersion, maxVersion);
     }
 
     /** Returns a random {@link TransformConfigVersion} between <code>minVersion</code> and <code>maxVersion</code> (inclusive). */

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/utils/TransformConfigVersionUtils.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/utils/TransformConfigVersionUtils.java
@@ -18,6 +18,8 @@ import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.apache.lucene.tests.util.LuceneTestCase.random;
+
 public class TransformConfigVersionUtils {
     private static final List<TransformConfigVersion> ALL_VERSIONS = KnownTransformConfigVersions.ALL_VERSIONS;
 
@@ -44,6 +46,14 @@ public class TransformConfigVersionUtils {
     /** Returns a random {@link TransformConfigVersion} from all available versions. */
     public static TransformConfigVersion randomVersion(Random random) {
         return ALL_VERSIONS.get(random.nextInt(ALL_VERSIONS.size()));
+    }
+
+    /** Returns a random {@link TransformConfigVersion} between <code>minVersion</code> and <code>maxVersion</code> (inclusive). */
+    public static TransformConfigVersion randomVersionBetween(
+        @Nullable TransformConfigVersion minVersion,
+        @Nullable TransformConfigVersion maxVersion
+    ) {
+        return randomVersionBetween(minVersion, maxVersion);
     }
 
     /** Returns a random {@link TransformConfigVersion} between <code>minVersion</code> and <code>maxVersion</code> (inclusive). */

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockSerializationTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockSerializationTests.java
@@ -424,11 +424,7 @@ public class BlockSerializationTests extends SerializationTestCase {
             try (
                 CompositeBlock deserBlock = serializeDeserializeBlockWithVersion(
                     origBlock,
-                    TransportVersionUtils.randomVersionBetween(
-                        random(),
-                        Block.ESQL_AGGREGATE_METRIC_DOUBLE_BLOCK,
-                        TransportVersion.current()
-                    )
+                    TransportVersionUtils.randomVersionBetween(Block.ESQL_AGGREGATE_METRIC_DOUBLE_BLOCK, TransportVersion.current())
                 )
             ) {
                 assertThat(deserBlock.getBlockCount(), equalTo(numBlocks));
@@ -490,11 +486,7 @@ public class BlockSerializationTests extends SerializationTestCase {
             try (
                 AggregateMetricDoubleBlock deserBlock = serializeDeserializeBlockWithVersion(
                     origBlock,
-                    TransportVersionUtils.randomVersionBetween(
-                        random(),
-                        Block.ESQL_AGGREGATE_METRIC_DOUBLE_BLOCK,
-                        TransportVersion.current()
-                    )
+                    TransportVersionUtils.randomVersionBetween(Block.ESQL_AGGREGATE_METRIC_DOUBLE_BLOCK, TransportVersion.current())
                 )
             ) {
                 assertThat(deserBlock, equalTo(origBlock));

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/analysis/MutableAnalyzerContext.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/analysis/MutableAnalyzerContext.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.esql.analysis;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.TransportVersionUtils;
 import org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry;
 import org.elasticsearch.xpack.esql.index.IndexResolution;
@@ -52,7 +51,7 @@ public class MutableAnalyzerContext extends AnalyzerContext {
     public RestoreTransportVersion setTemporaryTransportVersionOnOrAfter(TransportVersion minVersion) {
         TransportVersion oldVersion = this.currentVersion;
         // Set to a random version between minVersion and current
-        this.currentVersion = TransportVersionUtils.randomVersionBetween(ESTestCase.random(), minVersion, TransportVersion.current());
+        this.currentVersion = TransportVersionUtils.randomVersionBetween(minVersion, TransportVersion.current());
         return new RestoreTransportVersion(oldVersion);
     }
 

--- a/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/action/SamlInitiateSingleSignOnRequestTests.java
+++ b/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/action/SamlInitiateSingleSignOnRequestTests.java
@@ -44,9 +44,7 @@ public class SamlInitiateSingleSignOnRequestTests extends ESTestCase {
         assertThat("An invalid request is not guaranteed to serialize correctly", request.validate(), nullValue());
         final BytesStreamOutput out = new BytesStreamOutput();
         if (randomBoolean()) {
-            out.setTransportVersion(
-                TransportVersionUtils.randomVersionBetween(random(), IDP_CUSTOM_SAML_ATTRIBUTES, TransportVersion.current())
-            );
+            out.setTransportVersion(TransportVersionUtils.randomVersionBetween(IDP_CUSTOM_SAML_ATTRIBUTES, TransportVersion.current()));
         }
         request.writeTo(out);
 

--- a/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderDocumentTests.java
+++ b/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderDocumentTests.java
@@ -181,7 +181,6 @@ public class SamlServiceProviderDocumentTests extends IdpSamlTestCase {
 
     private SamlServiceProviderDocument assertSerializationRoundTrip(SamlServiceProviderDocument doc) throws IOException {
         final TransportVersion version = TransportVersionUtils.randomVersionBetween(
-            random(),
             IDP_CUSTOM_SAML_ATTRIBUTES_ALLOW_LIST,
             TransportVersion.current()
         );

--- a/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/SemanticTextInferenceFieldsIT.java
+++ b/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/SemanticTextInferenceFieldsIT.java
@@ -113,7 +113,7 @@ public class SemanticTextInferenceFieldsIT extends ESIntegTestCase {
         final String textEmbeddingField = randomIdentifier();
 
         for (int i = 0; i < iterations; i++) {
-            final IndexVersion indexVersion = IndexVersionUtils.randomVersionBetween(random(), minIndexVersion, maxIndexVersion);
+            final IndexVersion indexVersion = IndexVersionUtils.randomVersionBetween(minIndexVersion, maxIndexVersion);
             final Settings indexSettings = generateIndexSettings(indexVersion);
             XContentBuilder mappings = IntegrationTestUtils.generateSemanticTextMapping(
                 Map.of(sparseEmbeddingField, sparseEmbeddingInferenceId, textEmbeddingField, textEmbeddingInferenceId)

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticInferenceMetadataFieldsMapperTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticInferenceMetadataFieldsMapperTests.java
@@ -54,7 +54,6 @@ public class SemanticInferenceMetadataFieldsMapperTests extends MapperServiceTes
             .put(
                 IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(),
                 IndexVersionUtils.randomVersionBetween(
-                    random(),
                     IndexVersions.SEMANTIC_TEXT_FIELD_TYPE,
                     IndexVersionUtils.getPreviousVersion(IndexVersions.INFERENCE_METADATA_FIELDS_BACKPORT)
                 )  // 8.x version range prior to the introduction of the new format
@@ -67,7 +66,6 @@ public class SemanticInferenceMetadataFieldsMapperTests extends MapperServiceTes
             .put(
                 IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(),
                 IndexVersionUtils.randomVersionBetween(
-                    random(),
                     IndexVersions.UPGRADE_TO_LUCENE_10_0_0,
                     IndexVersionUtils.getPreviousVersion(IndexVersions.INFERENCE_METADATA_FIELDS)
                 )  // 9.x version range prior to the introduction of the new format
@@ -107,7 +105,6 @@ public class SemanticInferenceMetadataFieldsMapperTests extends MapperServiceTes
             .put(
                 IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(),
                 IndexVersionUtils.randomVersionBetween(
-                    random(),
                     IndexVersions.INFERENCE_METADATA_FIELDS_BACKPORT,
                     IndexVersionUtils.getPreviousVersion(IndexVersions.UPGRADE_TO_LUCENE_10_0_0)
                 )
@@ -140,12 +137,11 @@ public class SemanticInferenceMetadataFieldsMapperTests extends MapperServiceTes
             // Randomly choose an index version compatible with the legacy semantic text format
             if (randomBoolean()) {
                 // 9.x+ version
-                return IndexVersionUtils.randomVersionBetween(random(), IndexVersions.UPGRADE_TO_LUCENE_10_0_0, IndexVersion.current());
+                return IndexVersionUtils.randomVersionBetween(IndexVersions.UPGRADE_TO_LUCENE_10_0_0, IndexVersion.current());
             }
 
             // 8.x version
             return IndexVersionUtils.randomVersionBetween(
-                random(),
                 IndexVersions.SEMANTIC_TEXT_FIELD_TYPE,
                 IndexVersionUtils.getPreviousVersion(IndexVersions.UPGRADE_TO_LUCENE_10_0_0)
             );
@@ -153,12 +149,11 @@ public class SemanticInferenceMetadataFieldsMapperTests extends MapperServiceTes
             // Randomly choose an index version compatible with the new semantic text format
             if (randomBoolean()) {
                 // 9.x+ version
-                return IndexVersionUtils.randomVersionBetween(random(), IndexVersions.INFERENCE_METADATA_FIELDS, IndexVersion.current());
+                return IndexVersionUtils.randomVersionBetween(IndexVersions.INFERENCE_METADATA_FIELDS, IndexVersion.current());
             }
 
             // 8.x version
             return IndexVersionUtils.randomVersionBetween(
-                random(),
                 IndexVersions.INFERENCE_METADATA_FIELDS_BACKPORT,
                 IndexVersionUtils.getPreviousVersion(IndexVersions.UPGRADE_TO_LUCENE_10_0_0)
             );

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapperTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapperTests.java
@@ -205,7 +205,7 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
         IndexVersion maxIndexVersion
     ) throws IOException {
         validateIndexVersion(minIndexVersion, useLegacyFormat);
-        IndexVersion indexVersion = IndexVersionUtils.randomVersionBetween(random(), minIndexVersion, maxIndexVersion);
+        IndexVersion indexVersion = IndexVersionUtils.randomVersionBetween(minIndexVersion, maxIndexVersion);
         return createMapperServiceWithIndexVersion(mappings, useLegacyFormat, indexVersion);
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/queries/AbstractInterceptedInferenceQueryBuilderTestCase.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/queries/AbstractInterceptedInferenceQueryBuilderTestCase.java
@@ -166,7 +166,6 @@ public abstract class AbstractInterceptedInferenceQueryBuilderTestCase<T extends
         TransportVersion minTransportVersion = TransportVersion.max(getMinimalSupportedVersion(), TransportVersion.minimumCompatible());
         for (int i = 0; i < 100; i++) {
             TransportVersion transportVersion = TransportVersionUtils.randomVersionBetween(
-                random(),
                 minTransportVersion,
                 TransportVersionUtils.getPreviousVersion(TransportVersion.current())
             );
@@ -243,7 +242,6 @@ public abstract class AbstractInterceptedInferenceQueryBuilderTestCase<T extends
                 remoteInferenceEndpoints,
                 remoteIndexConfigs,
                 TransportVersionUtils.randomVersionBetween(
-                    random(),
                     SEMANTIC_SEARCH_CCS_SUPPORT,
                     TransportVersionUtils.getPreviousVersion(GET_INFERENCE_FIELDS_ACTION_TV)
                 )
@@ -277,7 +275,6 @@ public abstract class AbstractInterceptedInferenceQueryBuilderTestCase<T extends
 
         for (int i = 0; i < 100; i++) {
             TransportVersion transportVersion = TransportVersionUtils.randomVersionBetween(
-                random(),
                 TransportVersion.minimumCompatible(),
                 TransportVersionUtils.getPreviousVersion(TransportVersion.current())
             );
@@ -358,7 +355,6 @@ public abstract class AbstractInterceptedInferenceQueryBuilderTestCase<T extends
 
         // Test with a transport version prior to cluster alias support, which should fail
         TransportVersion transportVersion = TransportVersionUtils.randomVersionBetween(
-            random(),
             NEW_SEMANTIC_QUERY_INTERCEPTORS,
             TransportVersionUtils.getPreviousVersion(INFERENCE_RESULTS_MAP_WITH_CLUSTER_ALIAS)
         );

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/queries/SemanticQueryBuilderTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/queries/SemanticQueryBuilderTests.java
@@ -440,7 +440,6 @@ public class SemanticQueryBuilderTests extends AbstractQueryTestCase<SemanticQue
 
         for (int i = 0; i < 100; i++) {
             TransportVersion transportVersion = TransportVersionUtils.randomVersionBetween(
-                random(),
                 TransportVersion.minimumCompatible(),
                 TransportVersion.current()
             );
@@ -491,7 +490,6 @@ public class SemanticQueryBuilderTests extends AbstractQueryTestCase<SemanticQue
 
         for (int i = 0; i < 100; i++) {
             TransportVersion transportVersion = TransportVersionUtils.randomVersionBetween(
-                random(),
                 TransportVersion.minimumCompatible(),
                 TransportVersion.current()
             );
@@ -510,7 +508,6 @@ public class SemanticQueryBuilderTests extends AbstractQueryTestCase<SemanticQue
 
         for (int i = 0; i < 100; i++) {
             TransportVersion transportVersion = TransportVersionUtils.randomVersionBetween(
-                random(),
                 originalQuery.getMinimalSupportedVersion(),
                 TransportVersionUtils.getPreviousVersion(TransportVersion.current())
             );

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/QueryableBuiltInRolesSynchronizerTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/QueryableBuiltInRolesSynchronizerTests.java
@@ -590,7 +590,7 @@ public class QueryableBuiltInRolesSynchronizerTests extends ESTestCase {
 
     private DiscoveryNodes mixedVersionNodes() {
         VersionInformation oldVersion = new VersionInformation(
-            VersionUtils.randomVersionBetween(random(), null, VersionUtils.getPreviousVersion()),
+            VersionUtils.randomVersionBetween(null, VersionUtils.getPreviousVersion()),
             IndexVersions.MINIMUM_COMPATIBLE,
             IndexVersionUtils.randomCompatibleVersion(random())
         );

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapperTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapperTests.java
@@ -109,7 +109,7 @@ public class GeoShapeWithDocValuesFieldMapperTests extends GeoFieldMapperTests {
     }
 
     public void testDefaultDocValueConfigurationOnPre7_8() throws IOException {
-        IndexVersion oldVersion = IndexVersionUtils.randomVersionBetween(random(), IndexVersions.V_7_0_0, IndexVersions.V_7_7_0);
+        IndexVersion oldVersion = IndexVersionUtils.randomVersionBetween(IndexVersions.V_7_0_0, IndexVersions.V_7_7_0);
         DocumentMapper defaultMapper = createDocumentMapper(oldVersion, fieldMapping(this::minimalMapping));
         Mapper fieldMapper = defaultMapper.mappers().getMapper(FIELD_NAME);
         assertThat(fieldMapper, instanceOf(fieldMapperClass()));

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapperTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapperTests.java
@@ -107,11 +107,7 @@ public class ShapeFieldMapperTests extends CartesianFieldMapperTests {
     }
 
     public void testDefaultDocValueConfigurationOnPre8_4() throws IOException {
-        IndexVersion oldVersion = IndexVersionUtils.randomVersionBetween(
-            random(),
-            IndexVersions.MINIMUM_READONLY_COMPATIBLE,
-            IndexVersions.V_8_3_0
-        );
+        IndexVersion oldVersion = IndexVersionUtils.randomVersionBetween(IndexVersions.MINIMUM_READONLY_COMPATIBLE, IndexVersions.V_8_3_0);
         DocumentMapper defaultMapper = createDocumentMapper(oldVersion, fieldMapping(this::minimalMapping));
         Mapper fieldMapper = defaultMapper.mappers().getMapper(FIELD_NAME);
         assertThat(fieldMapper, instanceOf(fieldMapperClass()));

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/integration/TransformOldTransformsIT.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/integration/TransformOldTransformsIT.java
@@ -68,7 +68,6 @@ public class TransformOldTransformsIT extends TransformSingleNodeTestCase {
         createSourceIndex(transformIndex);
         String transformId = "transform-throws-for-old-config";
         TransformConfigVersion transformVersion = TransformConfigVersionUtils.randomVersionBetween(
-            random(),
             TransformConfigVersion.V_7_2_0,
             TransformConfigVersionUtils.getPreviousVersion(TransformDeprecations.MIN_TRANSFORM_VERSION)
         );

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransformUpdaterTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransformUpdaterTests.java
@@ -216,7 +216,6 @@ public class TransformUpdaterTests extends ESTestCase {
         TransformConfig oldConfig = TransformConfigTests.randomTransformConfig(
             randomAlphaOfLengthBetween(1, 10),
             TransformConfigVersionUtils.randomVersionBetween(
-                random(),
                 TransformConfigVersion.V_7_2_0,
                 TransformConfigVersionUtils.getPreviousVersion(TransformConfig.CONFIG_VERSION_LAST_DEFAULTS_CHANGED)
             )
@@ -307,7 +306,6 @@ public class TransformUpdaterTests extends ESTestCase {
         TransformConfig oldConfigForDryRunUpdate = TransformConfigTests.randomTransformConfig(
             randomAlphaOfLengthBetween(1, 10),
             TransformConfigVersionUtils.randomVersionBetween(
-                random(),
                 TransformConfigVersion.V_7_2_0,
                 TransformConfigVersionUtils.getPreviousVersion(TransformConfig.CONFIG_VERSION_LAST_DEFAULTS_CHANGED)
             )
@@ -361,7 +359,6 @@ public class TransformUpdaterTests extends ESTestCase {
         TransformConfig oldConfig = TransformConfigTests.randomTransformConfig(
             randomAlphaOfLengthBetween(1, 10),
             TransformConfigVersionUtils.randomVersionBetween(
-                random(),
                 TransformConfigVersion.V_7_2_0,
                 TransformConfigVersionUtils.getPreviousVersion(TransformConfig.CONFIG_VERSION_LAST_DEFAULTS_CHANGED)
             )
@@ -404,7 +401,6 @@ public class TransformUpdaterTests extends ESTestCase {
         TransformConfig oldConfig = TransformConfigTests.randomTransformConfig(
             randomAlphaOfLengthBetween(1, 10),
             TransformConfigVersionUtils.randomVersionBetween(
-                random(),
                 TransformConfigVersion.V_7_2_0,
                 TransformConfigVersionUtils.getPreviousVersion(TransformConfig.CONFIG_VERSION_LAST_DEFAULTS_CHANGED)
             )

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/TimeBasedCheckpointProviderTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/TimeBasedCheckpointProviderTests.java
@@ -94,7 +94,7 @@ public class TimeBasedCheckpointProviderTests extends ESTestCase {
             0,
             false,
             TransformCheckpoint.EMPTY,
-            TransformConfigVersionUtils.randomVersionBetween(random(), TransformConfigVersion.V_7_15_0, TransformConfigVersion.CURRENT),
+            TransformConfigVersionUtils.randomVersionBetween(TransformConfigVersion.V_7_15_0, TransformConfigVersion.CURRENT),
             TIMESTAMP_FIELD,
             TimeValue.timeValueMinutes(10),
             TimeValue.ZERO,


### PR DESCRIPTION
Adds an overload for `VersionUtils`, `IndexVersionUtils` and `TransportVersionUtils` for the function `randomVersionBetween` so that `random()` does not need to be explicitly passed in as a parameter