### PR TITLE
PromQL: Add PromQL test similar to TS  / Batch 1

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-rate.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-rate.csv-spec
@@ -20,6 +20,26 @@ rate_bytes_in:double | time_bucket:datetime
 15.515104            | 2024-05-10T00:00:00.000Z
 ;
 
+rate_of_long_no_grouping_promql
+required_capability: promql_pre_tech_preview_v13
+
+PROMQL index=k8s step=1m rate_bytes_in=(avg(rate(network.total_bytes_in[1m])))
+| EVAL rate_bytes_in=ROUND(rate_bytes_in, 6), step=step
+| SORT rate_bytes_in DESC, step DESC | LIMIT 10;
+
+rate_bytes_in:double | step:datetime
+26.69853             | 2024-05-10T00:04:00.000Z
+25.238823            | 2024-05-10T00:20:00.000Z
+22.148003            | 2024-05-10T00:01:00.000Z
+19.281831            | 2024-05-10T00:19:00.000Z
+18.744102            | 2024-05-10T00:11:00.000Z
+17.752681            | 2024-05-10T00:17:00.000Z
+16.945882            | 2024-05-10T00:10:00.000Z
+16.65479             | 2024-05-10T00:07:00.000Z
+15.773894            | 2024-05-10T00:18:00.000Z
+15.515104            | 2024-05-10T00:00:00.000Z
+;
+
 rate_of_long_grouping
 required_capability: rate_with_interpolation_v2
 required_capability: ts_command_v0
@@ -40,6 +60,26 @@ rate_bytes_in:double | cluster:keyword | time_bucket:datetime
 7.169543             | staging         | 2024-05-10T00:05:00.000Z
 6.830557             | staging         | 2024-05-10T00:10:00.000Z
 6.021526             | staging         | 2024-05-10T00:15:00.000Z
+;
+
+rate_of_long_grouping_promql
+required_capability: promql_pre_tech_preview_v13
+
+PROMQL index=k8s step=5m rate_bytes_in=(avg by (cluster) (rate(network.total_bytes_in[5m])))
+| EVAL rate_bytes_in=ROUND(rate_bytes_in, 6), step=step, cluster=cluster
+| SORT rate_bytes_in DESC, step, cluster | LIMIT 10;
+
+rate_bytes_in:double | step:datetime            | cluster:keyword
+25.832433            | 2024-05-10T00:20:00.000Z | prod
+15.4274              | 2024-05-10T00:15:00.000Z | qa
+13.765487            | 2024-05-10T00:05:00.000Z | qa
+12.73738             | 2024-05-10T00:15:00.000Z | prod
+8.152119             | 2024-05-10T00:20:00.000Z | qa
+7.822212             | 2024-05-10T00:10:00.000Z | qa
+7.535957             | 2024-05-10T00:10:00.000Z | prod
+7.169543             | 2024-05-10T00:05:00.000Z | staging
+6.830557             | 2024-05-10T00:10:00.000Z | staging
+6.021526             | 2024-05-10T00:15:00.000Z | staging
 ;
 
 rate_with_window
@@ -97,6 +137,26 @@ rate_cost:double | time_bucket:datetime
 0.913178         | 2024-05-10T00:11:00.000Z
 ;
 
+rate_of_double_no_grouping_promql
+required_capability: promql_pre_tech_preview_v13
+
+PROMQL index=k8s step=1m rate_cost=(sum(rate(network.total_cost[1m])))
+| EVAL rate_cost=ROUND(rate_cost, 6), step=step
+| SORT rate_cost DESC, step | LIMIT 10;
+
+rate_cost:double | step:datetime
+1.986939         | 2024-05-10T00:09:00.000Z
+1.428214         | 2024-05-10T00:17:00.000Z
+1.41077          | 2024-05-10T00:08:00.000Z
+1.011984         | 2024-05-10T00:14:00.000Z
+1.010113         | 2024-05-10T00:18:00.000Z
+0.999404         | 2024-05-10T00:15:00.000Z
+0.954623         | 2024-05-10T00:12:00.000Z
+0.92926          | 2024-05-10T00:05:00.000Z
+0.921813         | 2024-05-10T00:06:00.000Z
+0.913178         | 2024-05-10T00:11:00.000Z
+;
+
 rate_with_filtering
 required_capability: ts_command_v0
 required_capability: rate_with_interpolation
@@ -116,6 +176,25 @@ rate_bytes_in:double | cluster:keyword | time_bucket:datetime
 2.686247             | prod            | 2024-05-10T00:20:00.000Z
 1.589971             | qa              | 2024-05-10T00:20:00.000Z
 1.122634             | staging         | 2024-05-10T00:20:00.000Z
+;
+
+rate_with_filtering_promql
+required_capability: promql_pre_tech_preview_v13
+
+PROMQL index=k8s step=10m rate_bytes_in=(sum by (cluster) (rate(network.total_bytes_in{pod="one"}[10m])))
+| EVAL rate_bytes_in=ROUND(rate_bytes_in, 6), step=step, cluster=cluster
+| SORT step, cluster | LIMIT 10;
+
+rate_bytes_in:double | step:datetime            | cluster:keyword
+4.089167             | 2024-05-10T00:00:00.000Z | prod
+9.714783             | 2024-05-10T00:00:00.000Z | qa
+4.319067             | 2024-05-10T00:00:00.000Z | staging
+11.699031            | 2024-05-10T00:10:00.000Z | prod
+12.156773            | 2024-05-10T00:10:00.000Z | qa
+4.20566              | 2024-05-10T00:10:00.000Z | staging
+2.686247             | 2024-05-10T00:20:00.000Z | prod
+1.589971             | 2024-05-10T00:20:00.000Z | qa
+1.122634             | 2024-05-10T00:20:00.000Z | staging
 ;
 
 rate_with_inline_filtering
@@ -177,6 +256,18 @@ TS k8s-downsampled
 
 sum_bytes:double | max_bytes:double | min_bytes:double | avg_bytes:double | time_bucket:datetime
 0.775185         | 0.176944         | 0.025926         | 0.086132         | 2024-05-09T23:30:00.000Z
+;
+
+rate_of_aggregate_metric_promql
+required_capability: promql_pre_tech_preview_v13
+required_capability: aggregate_metric_double_v0
+
+PROMQL index=k8s-downsampled step=30m avg_bytes=(avg(rate(network.total_bytes_in[30m])))
+| EVAL avg_bytes=ROUND(avg_bytes, 6), step=step
+| SORT step | LIMIT 10;
+
+avg_bytes:double | step:datetime
+0.086132         | 2024-05-09T23:30:00.000Z
 ;
 
 rate_of_expression
@@ -336,6 +427,27 @@ rate_bytes_in:double | cluster:keyword | time_bucket:datetime
 9.531694             | qa              | 2024-05-10T00:20:00.000Z
 ;
 
+trange_absolute_with_rate_promql
+required_capability: promql_pre_tech_preview_v13
+
+PROMQL index=k8s step=2m start="2024-05-10T00:15:00.000Z" end="2024-05-10T00:25:00.000Z" rate_bytes_in=(avg by (cluster) (rate(network.total_bytes_in[2m])))
+| EVAL rate_bytes_in=ROUND(rate_bytes_in, 6), step=step, cluster=cluster
+| SORT rate_bytes_in NULLS FIRST, step, cluster
+| LIMIT 10;
+
+rate_bytes_in:double | step:datetime            | cluster:keyword
+1.517381             | 2024-05-10T00:22:00.000Z | staging
+4.428024             | 2024-05-10T00:22:00.000Z | qa
+5.205085             | 2024-05-10T00:20:00.000Z | staging
+5.422222             | 2024-05-10T00:14:00.000Z | staging
+7.347831             | 2024-05-10T00:16:00.000Z | staging
+7.8322               | 2024-05-10T00:18:00.000Z | staging
+8.001423             | 2024-05-10T00:22:00.000Z | prod
+8.155203             | 2024-05-10T00:14:00.000Z | prod
+8.939832             | 2024-05-10T00:14:00.000Z | qa
+9.531694             | 2024-05-10T00:20:00.000Z | qa
+;
+
 bare_rate_outputs_dimensions
 required_capability: ts_command_v0
 required_capability: metrics_group_by_all
@@ -392,5 +504,16 @@ TS k8s
 | EVAL max_rate=ROUND(max_rate, 6) | KEEP max_rate;
 
 max_rate:double 
+13.173725
+;
+
+# Awaits fix: Instant queries are not supported at this time.
+wrapped_rate_promql-Ignore
+required_capability: promql_pre_tech_preview_v13
+
+PROMQL index=k8s max_rate=(max(rate(network.total_bytes_in[1h])))
+| EVAL max_rate=ROUND(max_rate, 6);
+
+max_rate:double
 13.173725
 ;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-rate.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-rate.csv-spec
@@ -21,7 +21,7 @@ rate_bytes_in:double | time_bucket:datetime
 ;
 
 rate_of_long_no_grouping_promql
-required_capability: promql_pre_tech_preview_v13
+required_capability: promql_pre_tech_preview_v12
 
 PROMQL index=k8s step=1m rate_bytes_in=(avg(rate(network.total_bytes_in[1m])))
 | EVAL rate_bytes_in=ROUND(rate_bytes_in, 6), step=step
@@ -63,7 +63,7 @@ rate_bytes_in:double | cluster:keyword | time_bucket:datetime
 ;
 
 rate_of_long_grouping_promql
-required_capability: promql_pre_tech_preview_v13
+required_capability: promql_pre_tech_preview_v12
 
 PROMQL index=k8s step=5m rate_bytes_in=(avg by (cluster) (rate(network.total_bytes_in[5m])))
 | EVAL rate_bytes_in=ROUND(rate_bytes_in, 6), step=step, cluster=cluster
@@ -138,7 +138,7 @@ rate_cost:double | time_bucket:datetime
 ;
 
 rate_of_double_no_grouping_promql
-required_capability: promql_pre_tech_preview_v13
+required_capability: promql_pre_tech_preview_v12
 
 PROMQL index=k8s step=1m rate_cost=(sum(rate(network.total_cost[1m])))
 | EVAL rate_cost=ROUND(rate_cost, 6), step=step
@@ -179,7 +179,7 @@ rate_bytes_in:double | cluster:keyword | time_bucket:datetime
 ;
 
 rate_with_filtering_promql
-required_capability: promql_pre_tech_preview_v13
+required_capability: promql_pre_tech_preview_v12
 
 PROMQL index=k8s step=10m rate_bytes_in=(sum by (cluster) (rate(network.total_bytes_in{pod="one"}[10m])))
 | EVAL rate_bytes_in=ROUND(rate_bytes_in, 6), step=step, cluster=cluster
@@ -259,7 +259,7 @@ sum_bytes:double | max_bytes:double | min_bytes:double | avg_bytes:double | time
 ;
 
 rate_of_aggregate_metric_promql
-required_capability: promql_pre_tech_preview_v13
+required_capability: promql_pre_tech_preview_v12
 required_capability: aggregate_metric_double_v0
 
 PROMQL index=k8s-downsampled step=30m avg_bytes=(avg(rate(network.total_bytes_in[30m])))
@@ -428,7 +428,7 @@ rate_bytes_in:double | cluster:keyword | time_bucket:datetime
 ;
 
 trange_absolute_with_rate_promql
-required_capability: promql_pre_tech_preview_v13
+required_capability: promql_pre_tech_preview_v12
 
 PROMQL index=k8s step=2m start="2024-05-10T00:15:00.000Z" end="2024-05-10T00:25:00.000Z" rate_bytes_in=(avg by (cluster) (rate(network.total_bytes_in[2m])))
 | EVAL rate_bytes_in=ROUND(rate_bytes_in, 6), step=step, cluster=cluster
@@ -507,13 +507,3 @@ max_rate:double
 13.173725
 ;
 
-# Awaits fix: Instant queries are not supported at this time.
-wrapped_rate_promql-Ignore
-required_capability: promql_pre_tech_preview_v13
-
-PROMQL index=k8s max_rate=(max(rate(network.total_bytes_in[1h])))
-| EVAL max_rate=ROUND(max_rate, 6);
-
-max_rate:double
-13.173725
-;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-sum-over-time.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-sum-over-time.csv-spec
@@ -17,11 +17,49 @@ cost:double | time_bucket:datetime
 54.125      | 2024-05-10T00:03:00.000Z
 ;
 
+sum_over_time_of_double_no_grouping_promql
+required_capability: promql_pre_tech_preview_v13
+
+PROMQL index=k8s step=1m cost=(sum(sum_over_time(network.cost[1m])))
+| SORT cost DESC, step DESC | LIMIT 10;
+
+cost:double | step:datetime
+151.375     | 2024-05-10T00:09:00.000Z
+99.375      | 2024-05-10T00:17:00.000Z
+87.875      | 2024-05-10T00:08:00.000Z
+80.375      | 2024-05-10T00:18:00.000Z
+66.0        | 2024-05-10T00:15:00.000Z
+64.625      | 2024-05-10T00:06:00.000Z
+62.375      | 2024-05-10T00:22:00.000Z
+61.375      | 2024-05-10T00:13:00.000Z
+57.0        | 2024-05-10T00:11:00.000Z
+54.125      | 2024-05-10T00:03:00.000Z
+;
+
 sum_over_time_of_integer
 required_capability: ts_command_v0
 TS k8s | STATS clients = avg(sum_over_time(network.eth0.currently_connected_clients)) BY time_bucket = bucket(@timestamp,1minute) | SORT time_bucket | LIMIT 10;
 
 clients:double     | time_bucket:datetime
+869.6666666666666  | 2024-05-10T00:00:00.000Z
+418.25             | 2024-05-10T00:01:00.000Z
+763.1666666666666  | 2024-05-10T00:02:00.000Z
+868.6              | 2024-05-10T00:03:00.000Z
+769.6666666666666  | 2024-05-10T00:04:00.000Z
+1101.6             | 2024-05-10T00:05:00.000Z
+987.6666666666666  | 2024-05-10T00:06:00.000Z
+1102.6666666666667 | 2024-05-10T00:07:00.000Z
+766.875            | 2024-05-10T00:08:00.000Z
+998.7777777777778  | 2024-05-10T00:09:00.000Z
+;
+
+sum_over_time_of_integer_promql
+required_capability: promql_pre_tech_preview_v13
+
+PROMQL index=k8s step=1m clients=(avg(sum_over_time(network.eth0.currently_connected_clients[1m])))
+| SORT step | LIMIT 10;
+
+clients:double     | step:datetime
 869.6666666666666  | 2024-05-10T00:00:00.000Z
 418.25             | 2024-05-10T00:01:00.000Z
 763.1666666666666  | 2024-05-10T00:02:00.000Z
@@ -51,12 +89,44 @@ clients:double | cluster:keyword | time_bucket:datetime
 1029.0         | staging         | 2024-05-10T00:03:00.000Z
 ;
 
+sum_over_time_of_integer_grouping_promql
+required_capability: promql_pre_tech_preview_v13
+
+PROMQL index=k8s step=1m clients=(avg by (cluster) (sum_over_time(network.eth0.currently_connected_clients[1m])))
+| SORT step, cluster | LIMIT 10;
+
+clients:double | step:datetime            | cluster:keyword
+1378.0         | 2024-05-10T00:00:00.000Z | prod
+615.5          | 2024-05-10T00:00:00.000Z | staging
+396.5          | 2024-05-10T00:01:00.000Z | prod
+440.0          | 2024-05-10T00:01:00.000Z | qa
+1101.0         | 2024-05-10T00:02:00.000Z | prod
+565.0          | 2024-05-10T00:02:00.000Z | qa
+623.5          | 2024-05-10T00:02:00.000Z | staging
+742.0          | 2024-05-10T00:03:00.000Z | prod
+771.5          | 2024-05-10T00:03:00.000Z | qa
+1029.0         | 2024-05-10T00:03:00.000Z | staging
+;
+
 sum_over_time_of_aggregate_metric_double
 required_capability: ts_command_v0
 required_capability: aggregate_metric_double_v0
 TS k8s-downsampled | STATS tx = sum(sum_over_time(network.eth0.tx)) BY time_bucket = bucket(@timestamp, 10minute) | SORT time_bucket | LIMIT 10;
 
 tx:double | time_bucket:datetime
+31610.0   | 2024-05-09T23:30:00.000Z
+39887.0   | 2024-05-09T23:40:00.000Z
+30996.0   | 2024-05-09T23:50:00.000Z
+;
+
+sum_over_time_of_aggregate_metric_double_promql
+required_capability: promql_pre_tech_preview_v13
+required_capability: aggregate_metric_double_v0
+
+PROMQL index=k8s-downsampled step=10m tx=(sum(sum_over_time(network.eth0.tx[10m])))
+| SORT step | LIMIT 10;
+
+tx:double | step:datetime
 31610.0   | 2024-05-09T23:30:00.000Z
 39887.0   | 2024-05-09T23:40:00.000Z
 30996.0   | 2024-05-09T23:50:00.000Z
@@ -79,6 +149,25 @@ tx:double | cluster:keyword | time_bucket:datetime
 8488.0    | staging         | 2024-05-09T23:50:00.000Z
 ;
 
+sum_over_time_of_aggregate_metric_double_grouping_promql
+required_capability: promql_pre_tech_preview_v13
+required_capability: aggregate_metric_double_v0
+
+PROMQL index=k8s-downsampled step=10m tx=(sum by (cluster) (sum_over_time(network.eth0.tx[10m])))
+| SORT step, cluster | LIMIT 10;
+
+tx:double | step:datetime            | cluster:keyword
+9454.0    | 2024-05-09T23:30:00.000Z | prod
+10960.0   | 2024-05-09T23:30:00.000Z | qa
+11196.0   | 2024-05-09T23:30:00.000Z | staging
+12465.0   | 2024-05-09T23:40:00.000Z | prod
+19471.0   | 2024-05-09T23:40:00.000Z | qa
+7951.0    | 2024-05-09T23:40:00.000Z | staging
+11088.0   | 2024-05-09T23:50:00.000Z | prod
+11420.0   | 2024-05-09T23:50:00.000Z | qa
+8488.0    | 2024-05-09T23:50:00.000Z | staging
+;
+
 sum_over_time_with_filtering
 required_capability: ts_command_v0
 TS k8s | WHERE pod == "one" | STATS tx = sum(sum_over_time(network.bytes_in)) BY cluster, time_bucket = bucket(@timestamp, 10minute) | SORT time_bucket, cluster | LIMIT 10;
@@ -93,6 +182,24 @@ tx:long | cluster:keyword | time_bucket:datetime
 1900    | prod            | 2024-05-10T00:20:00.000Z
 1320    | qa              | 2024-05-10T00:20:00.000Z
 987     | staging         | 2024-05-10T00:20:00.000Z
+;
+
+sum_over_time_with_filtering_promql
+required_capability: promql_pre_tech_preview_v13
+
+PROMQL index=k8s step=10m tx=(sum by (cluster) (sum_over_time(network.bytes_in{pod="one"}[10m])))
+| SORT step, cluster | LIMIT 10;
+
+tx:double | step:datetime            | cluster:keyword
+2637.0    | 2024-05-10T00:00:00.000Z | prod
+5792.0    | 2024-05-10T00:00:00.000Z | qa
+2965.0    | 2024-05-10T00:00:00.000Z | staging
+6617.0    | 2024-05-10T00:10:00.000Z | prod
+6946.0    | 2024-05-10T00:10:00.000Z | qa
+2208.0    | 2024-05-10T00:10:00.000Z | staging
+1900.0    | 2024-05-10T00:20:00.000Z | prod
+1320.0    | 2024-05-10T00:20:00.000Z | qa
+987.0     | 2024-05-10T00:20:00.000Z | staging
 ;
 
 sum_over_time_with_window
@@ -123,6 +230,32 @@ tx:long | cluster:keyword | time_bucket:datetime
 987     | staging         | 2024-05-10T00:20:00.000Z
 ;
 
+
+sum_over_time_with_window_promql
+required_capability: promql_pre_tech_preview_v13
+
+PROMQL index=k8s step=5m tx=(sum by (cluster) (sum_over_time(network.bytes_in{pod="one"}[10m])))
+| SORT step, cluster
+| LIMIT 20;
+
+tx:double | step:datetime            | cluster:keyword
+2637.0    | 2024-05-10T00:00:00.000Z | prod
+5792.0    | 2024-05-10T00:00:00.000Z | qa
+2965.0    | 2024-05-10T00:00:00.000Z | staging
+4613.0    | 2024-05-10T00:05:00.000Z | prod
+8912.0    | 2024-05-10T00:05:00.000Z | qa
+3369.0    | 2024-05-10T00:05:00.000Z | staging
+6617.0    | 2024-05-10T00:10:00.000Z | prod
+6946.0    | 2024-05-10T00:10:00.000Z | qa
+2208.0    | 2024-05-10T00:10:00.000Z | staging
+5214.0    | 2024-05-10T00:15:00.000Z | prod
+4292.0    | 2024-05-10T00:15:00.000Z | qa
+1507.0    | 2024-05-10T00:15:00.000Z | staging
+1900.0    | 2024-05-10T00:20:00.000Z | prod
+1320.0    | 2024-05-10T00:20:00.000Z | qa
+987.0     | 2024-05-10T00:20:00.000Z | staging
+;
+
 sum_over_time_older_than_10d
 required_capability: ts_command_v0
 required_capability: aggregate_metric_double_v0
@@ -134,6 +267,21 @@ cost:double | pod:keyword | time_bucket:datetime
 3825.0      | two         | 2024-05-09T23:30:00.000Z
 8850.0      | one         | 2024-05-09T23:40:00.000Z
 7447.0      | three       | 2024-05-09T23:40:00.000Z
+;
+
+sum_over_time_older_than_10d_promql
+required_capability: promql_pre_tech_preview_v13
+required_capability: aggregate_metric_double_v0
+
+PROMQL index=k8s-downsampled step=10m start="2024-05-09T23:00:00.000Z" end="2024-05-10T00:00:00.000Z" cost=(avg by (pod) (sum_over_time(network.eth0.rx{cluster="qa"}[10m])))
+| SORT step, pod | LIMIT 5;
+
+cost:double | step:datetime            | pod:keyword
+3780.0      | 2024-05-09T23:30:00.000Z | one
+1.0         | 2024-05-09T23:30:00.000Z | three
+3825.0      | 2024-05-09T23:30:00.000Z | two
+8850.0      | 2024-05-09T23:40:00.000Z | one
+7447.0      | 2024-05-09T23:40:00.000Z | three
 ;
 
 eval_on_sum_over_time
@@ -150,6 +298,25 @@ max_bytes:double   | cluster:keyword | time_bucket:datetime     | kb_minus_offse
 1640.0             | prod            | 2024-05-10T00:20:00.000Z | 1.54
 1400.0             | qa              | 2024-05-10T00:20:00.000Z | 1.3
 1153.0             | staging         | 2024-05-10T00:20:00.000Z | 1.053
+;
+
+# Awaits fix: Arithmetic on instant vector is not supported at this time.
+eval_on_sum_over_time_promql-Ignore
+required_capability: promql_pre_tech_preview_v13
+
+PROMQL index=k8s step=10m kb_minus_offset=((avg by (cluster) (sum_over_time(network.bytes_in[10m])) - 100) / 1000)
+| SORT step, cluster | LIMIT 10;
+
+kb_minus_offset:double | step:datetime            | cluster:keyword
+2.7973333333333334     | 2024-05-10T00:00:00.000Z | prod
+6.094                  | 2024-05-10T00:00:00.000Z | qa
+3.9456666666666664     | 2024-05-10T00:00:00.000Z | staging
+5.578333333333333      | 2024-05-10T00:10:00.000Z | prod
+6.388333333333333      | 2024-05-10T00:10:00.000Z | qa
+3.3393333333333333     | 2024-05-10T00:10:00.000Z | staging
+1.54                   | 2024-05-10T00:20:00.000Z | prod
+1.3                    | 2024-05-10T00:20:00.000Z | qa
+1.053                  | 2024-05-10T00:20:00.000Z | staging
 ;
 
 sum_over_time_multi_values
@@ -169,6 +336,25 @@ events:long | pod:keyword | time_bucket:datetime
 26          | one         | 2024-05-10T00:07:00.000Z
 ;
 
+sum_over_time_multi_values_promql
+required_capability: promql_pre_tech_preview_v13
+
+PROMQL index=k8s step=1m start="2024-05-10T00:00:00.000Z" end="2024-05-10T00:10:00.000Z" events=(sum by (pod) (sum_over_time(events_received[1m])))
+| SORT events desc, step, pod | LIMIT 10;
+
+events:double | step:datetime            | pod:keyword
+102.0         | 2024-05-10T00:09:00.000Z | one
+101.0         | 2024-05-10T00:09:00.000Z | three
+74.0          | 2024-05-10T00:08:00.000Z | two
+67.0          | 2024-05-10T00:06:00.000Z | three
+66.0          | 2024-05-10T00:08:00.000Z | one
+45.0          | 2024-05-10T00:09:00.000Z | two
+37.0          | 2024-05-10T00:05:00.000Z | two
+34.0          | 2024-05-10T00:05:00.000Z | one
+34.0          | 2024-05-10T00:06:00.000Z | one
+26.0          | 2024-05-10T00:07:00.000Z | one
+;
+
 sum_over_time_null_values
 required_capability: ts_command_v0
 TS k8s | WHERE @timestamp > "2024-05-10T00:10:00.000Z" and @timestamp < "2024-05-10T00:15:00.000Z" | STATS events = sum(sum_over_time(events_received)) by pod, time_bucket = bucket(@timestamp, 1minute) | SORT events desc, time_bucket, pod  | LIMIT 10;
@@ -184,6 +370,25 @@ null        | two         | 2024-05-10T00:13:00.000Z
 11          | one         | 2024-05-10T00:10:00.000Z
 9           | one         | 2024-05-10T00:11:00.000Z
 7           | two         | 2024-05-10T00:10:00.000Z
+;
+
+sum_over_time_null_values_promql
+required_capability: promql_pre_tech_preview_v13
+
+PROMQL index=k8s step=1m start="2024-05-10T00:10:00.000Z" end="2024-05-10T00:15:00.000Z" events=(sum by (pod) (sum_over_time(events_received[1m])))
+| SORT events desc, step, pod | LIMIT 10;
+
+events:double | step:datetime            | pod:keyword
+null          | 2024-05-10T00:12:00.000Z | one
+null          | 2024-05-10T00:13:00.000Z | two
+25.0          | 2024-05-10T00:12:00.000Z | two
+23.0          | 2024-05-10T00:13:00.000Z | one
+21.0          | 2024-05-10T00:13:00.000Z | three
+20.0          | 2024-05-10T00:14:00.000Z | two
+16.0          | 2024-05-10T00:14:00.000Z | one
+11.0          | 2024-05-10T00:10:00.000Z | one
+9.0           | 2024-05-10T00:11:00.000Z | one
+7.0           | 2024-05-10T00:10:00.000Z | two
 ;
 
 sum_over_time_all_value_types
@@ -202,12 +407,47 @@ events:long | pod:keyword | time_bucket:datetime
 25          | one         | 2024-05-10T00:20:00.000Z
 ;
 
+sum_over_time_all_value_types_promql
+required_capability: promql_pre_tech_preview_v13
+
+PROMQL index=k8s step=10m events=(sum by (pod) (sum_over_time(events_received[10m])))
+| SORT events desc, pod, step | LIMIT 10;
+
+events:double | step:datetime            | pod:keyword
+295.0         | 2024-05-10T00:00:00.000Z | one
+271.0         | 2024-05-10T00:00:00.000Z | three
+242.0         | 2024-05-10T00:00:00.000Z | two
+195.0         | 2024-05-10T00:10:00.000Z | two
+149.0         | 2024-05-10T00:10:00.000Z | three
+136.0         | 2024-05-10T00:10:00.000Z | one
+89.0          | 2024-05-10T00:20:00.000Z | three
+50.0          | 2024-05-10T00:20:00.000Z | two
+25.0          | 2024-05-10T00:20:00.000Z | one
+;
+
 sum_over_time_aggregate_metric_double_implicit_casting
 required_capability: ts_command_v0
 required_capability: aggregate_metric_double_v0
 TS k8s* | STATS bytes = sum(sum_over_time(network.eth0.rx)) by time_bucket = bucket(@timestamp, 10minute) | SORT bytes desc, time_bucket | LIMIT 10 ;
 
 bytes:double | time_bucket:datetime
+69195.0      | 2024-05-10T00:10:00.000Z
+34512.0      | 2024-05-09T23:50:00.000Z
+27115.0      | 2024-05-09T23:30:00.000Z
+24000.0      | 2024-05-10T00:00:00.000Z
+23469.0      | 2024-05-09T23:40:00.000Z
+22780.0      | 2024-05-10T00:20:00.000Z
+;
+
+# Awaits fix: Index wildcard selector is not supported at this time.
+sum_over_time_aggregate_metric_double_implicit_casting_promql-Ignore
+required_capability: promql_pre_tech_preview_v13
+required_capability: aggregate_metric_double_v0
+
+PROMQL index=k8s* step=10m bytes=(sum(sum_over_time(network.eth0.rx[10m])))
+| SORT bytes desc, step | LIMIT 10;
+
+bytes:double | step:datetime
 69195.0      | 2024-05-10T00:10:00.000Z
 34512.0      | 2024-05-09T23:50:00.000Z
 27115.0      | 2024-05-09T23:30:00.000Z
@@ -234,6 +474,27 @@ bytes:double | pod:keyword | time_bucket:datetime
 8624.0       | one         | 2024-05-10T00:20:00.000Z
 ;
 
+# Awaits fix: Index wildcard selector is not supported at this time.
+sum_over_time_aggregate_metric_double_implicit_casting_grouping_promql-Ignore
+required_capability: promql_pre_tech_preview_v13
+required_capability: aggregate_metric_double_v0
+
+PROMQL index=k8s* step=10m bytes=(sum by (pod) (sum_over_time(network.eth0.rx[10m])))
+| SORT bytes desc, pod, step | LIMIT 10;
+
+bytes:double | step:datetime            | pod:keyword
+25245.0      | 2024-05-10T00:10:00.000Z | one
+22560.0      | 2024-05-10T00:10:00.000Z | three
+21390.0      | 2024-05-10T00:10:00.000Z | two
+17692.0      | 2024-05-09T23:50:00.000Z | three
+16824.0      | 2024-05-09T23:30:00.000Z | one
+11652.0      | 2024-05-09T23:40:00.000Z | one
+11211.0      | 2024-05-09T23:50:00.000Z | two
+9618.0       | 2024-05-09T23:40:00.000Z | three
+8692.0       | 2024-05-10T00:00:00.000Z | one
+8624.0       | 2024-05-10T00:20:00.000Z | one
+;
+
 sum_over_time_nested_expression
 required_capability: ts_command_v0
 TS k8s | STATS sum = sum(sum_over_time(network.eth0.rx % 2)) by pod, time_bucket = bucket(@timestamp, 1minute) | SORT sum desc, time_bucket, pod | LIMIT 5;
@@ -244,6 +505,21 @@ sum:long | pod:keyword | time_bucket:datetime
 3        | one         | 2024-05-10T00:08:00.000Z
 3        | three       | 2024-05-10T00:12:00.000Z
 3        | three       | 2024-05-10T00:14:00.000Z
+;
+
+# Awaits fix: Subqueries are not supported at this time.
+sum_over_time_nested_expression_promql-Ignore
+required_capability: promql_pre_tech_preview_v13
+
+PROMQL index=k8s step=1m sum=(sum by (pod) (sum_over_time((network.eth0.rx % 2)[1m:])))
+| SORT sum desc, step, pod | LIMIT 5;
+
+sum:double | step:datetime            | pod:keyword
+6.0        | 2024-05-10T00:09:00.000Z | three
+4.0        | 2024-05-10T00:17:00.000Z | three
+3.0        | 2024-05-10T00:08:00.000Z | one
+3.0        | 2024-05-10T00:12:00.000Z | three
+3.0        | 2024-05-10T00:14:00.000Z | three
 ;
 
 sum_over_time_nested_expression_in_grouping_with_alias
@@ -257,4 +533,18 @@ min:long | time_bucket:datetime
 187      | 2024-05-10T00:10:00.000Z
 520      | 2024-05-10T00:15:00.000Z
 774      | 2024-05-10T00:20:00.000Z
+;
+
+sum_over_time_nested_expression_in_grouping_with_alias_promql
+required_capability: promql_pre_tech_preview_v13
+
+PROMQL index=k8s step=5m min=(min(sum_over_time(network.bytes_in[5m])))
+| SORT step | LIMIT 10;
+
+min:double | step:datetime
+651.0      | 2024-05-10T00:00:00.000Z
+389.0      | 2024-05-10T00:05:00.000Z
+187.0      | 2024-05-10T00:10:00.000Z
+520.0      | 2024-05-10T00:15:00.000Z
+774.0      | 2024-05-10T00:20:00.000Z
 ;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-sum-over-time.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-sum-over-time.csv-spec
@@ -18,7 +18,7 @@ cost:double | time_bucket:datetime
 ;
 
 sum_over_time_of_double_no_grouping_promql
-required_capability: promql_pre_tech_preview_v13
+required_capability: promql_pre_tech_preview_v12
 
 PROMQL index=k8s step=1m cost=(sum(sum_over_time(network.cost[1m])))
 | SORT cost DESC, step DESC | LIMIT 10;
@@ -54,7 +54,7 @@ clients:double     | time_bucket:datetime
 ;
 
 sum_over_time_of_integer_promql
-required_capability: promql_pre_tech_preview_v13
+required_capability: promql_pre_tech_preview_v12
 
 PROMQL index=k8s step=1m clients=(avg(sum_over_time(network.eth0.currently_connected_clients[1m])))
 | SORT step | LIMIT 10;
@@ -90,7 +90,7 @@ clients:double | cluster:keyword | time_bucket:datetime
 ;
 
 sum_over_time_of_integer_grouping_promql
-required_capability: promql_pre_tech_preview_v13
+required_capability: promql_pre_tech_preview_v12
 
 PROMQL index=k8s step=1m clients=(avg by (cluster) (sum_over_time(network.eth0.currently_connected_clients[1m])))
 | SORT step, cluster | LIMIT 10;
@@ -120,7 +120,7 @@ tx:double | time_bucket:datetime
 ;
 
 sum_over_time_of_aggregate_metric_double_promql
-required_capability: promql_pre_tech_preview_v13
+required_capability: promql_pre_tech_preview_v12
 required_capability: aggregate_metric_double_v0
 
 PROMQL index=k8s-downsampled step=10m tx=(sum(sum_over_time(network.eth0.tx[10m])))
@@ -150,7 +150,7 @@ tx:double | cluster:keyword | time_bucket:datetime
 ;
 
 sum_over_time_of_aggregate_metric_double_grouping_promql
-required_capability: promql_pre_tech_preview_v13
+required_capability: promql_pre_tech_preview_v12
 required_capability: aggregate_metric_double_v0
 
 PROMQL index=k8s-downsampled step=10m tx=(sum by (cluster) (sum_over_time(network.eth0.tx[10m])))
@@ -185,7 +185,7 @@ tx:long | cluster:keyword | time_bucket:datetime
 ;
 
 sum_over_time_with_filtering_promql
-required_capability: promql_pre_tech_preview_v13
+required_capability: promql_pre_tech_preview_v12
 
 PROMQL index=k8s step=10m tx=(sum by (cluster) (sum_over_time(network.bytes_in{pod="one"}[10m])))
 | SORT step, cluster | LIMIT 10;
@@ -232,7 +232,7 @@ tx:long | cluster:keyword | time_bucket:datetime
 
 
 sum_over_time_with_window_promql
-required_capability: promql_pre_tech_preview_v13
+required_capability: promql_pre_tech_preview_v12
 
 PROMQL index=k8s step=5m tx=(sum by (cluster) (sum_over_time(network.bytes_in{pod="one"}[10m])))
 | SORT step, cluster
@@ -270,7 +270,7 @@ cost:double | pod:keyword | time_bucket:datetime
 ;
 
 sum_over_time_older_than_10d_promql
-required_capability: promql_pre_tech_preview_v13
+required_capability: promql_pre_tech_preview_v12
 required_capability: aggregate_metric_double_v0
 
 PROMQL index=k8s-downsampled step=10m start="2024-05-09T23:00:00.000Z" end="2024-05-10T00:00:00.000Z" cost=(avg by (pod) (sum_over_time(network.eth0.rx{cluster="qa"}[10m])))
@@ -301,22 +301,23 @@ max_bytes:double   | cluster:keyword | time_bucket:datetime     | kb_minus_offse
 ;
 
 # Awaits fix: Arithmetic on instant vector is not supported at this time.
-eval_on_sum_over_time_promql-Ignore
-required_capability: promql_pre_tech_preview_v13
+eval_on_sum_over_time_promql
+required_capability: promql_pre_tech_preview_v12
 
-PROMQL index=k8s step=10m kb_minus_offset=((avg by (cluster) (sum_over_time(network.bytes_in[10m])) - 100) / 1000)
+PROMQL index=k8s step=10m max_bytes=(avg by (cluster) (sum_over_time(network.bytes_in[10m])))
+| EVAL kb_minus_offset = (max_bytes - 100) / 1000.0
 | SORT step, cluster | LIMIT 10;
 
-kb_minus_offset:double | step:datetime            | cluster:keyword
-2.7973333333333334     | 2024-05-10T00:00:00.000Z | prod
-6.094                  | 2024-05-10T00:00:00.000Z | qa
-3.9456666666666664     | 2024-05-10T00:00:00.000Z | staging
-5.578333333333333      | 2024-05-10T00:10:00.000Z | prod
-6.388333333333333      | 2024-05-10T00:10:00.000Z | qa
-3.3393333333333333     | 2024-05-10T00:10:00.000Z | staging
-1.54                   | 2024-05-10T00:20:00.000Z | prod
-1.3                    | 2024-05-10T00:20:00.000Z | qa
-1.053                  | 2024-05-10T00:20:00.000Z | staging
+max_bytes:double   | step:datetime            | cluster:keyword  | kb_minus_offset:double
+2897.3333333333335 | 2024-05-10T00:00:00.000Z | prod             | 2.7973333333333334
+6194.0             | 2024-05-10T00:00:00.000Z | qa               | 6.094
+4045.6666666666665 | 2024-05-10T00:00:00.000Z | staging          | 3.9456666666666664
+5678.333333333333  | 2024-05-10T00:10:00.000Z | prod             | 5.578333333333333
+6488.333333333333  | 2024-05-10T00:10:00.000Z | qa               | 6.388333333333333
+3439.3333333333335 | 2024-05-10T00:10:00.000Z | staging          | 3.3393333333333333
+1640.0             | 2024-05-10T00:20:00.000Z | prod             | 1.54
+1400.0             | 2024-05-10T00:20:00.000Z | qa               | 1.3
+1153.0             | 2024-05-10T00:20:00.000Z | staging          | 1.053
 ;
 
 sum_over_time_multi_values
@@ -337,7 +338,7 @@ events:long | pod:keyword | time_bucket:datetime
 ;
 
 sum_over_time_multi_values_promql
-required_capability: promql_pre_tech_preview_v13
+required_capability: promql_pre_tech_preview_v12
 
 PROMQL index=k8s step=1m start="2024-05-10T00:00:00.000Z" end="2024-05-10T00:10:00.000Z" events=(sum by (pod) (sum_over_time(events_received[1m])))
 | SORT events desc, step, pod | LIMIT 10;
@@ -373,7 +374,7 @@ null        | two         | 2024-05-10T00:13:00.000Z
 ;
 
 sum_over_time_null_values_promql
-required_capability: promql_pre_tech_preview_v13
+required_capability: promql_pre_tech_preview_v12
 
 PROMQL index=k8s step=1m start="2024-05-10T00:10:00.000Z" end="2024-05-10T00:15:00.000Z" events=(sum by (pod) (sum_over_time(events_received[1m])))
 | SORT events desc, step, pod | LIMIT 10;
@@ -408,7 +409,7 @@ events:long | pod:keyword | time_bucket:datetime
 ;
 
 sum_over_time_all_value_types_promql
-required_capability: promql_pre_tech_preview_v13
+required_capability: promql_pre_tech_preview_v12
 
 PROMQL index=k8s step=10m events=(sum by (pod) (sum_over_time(events_received[10m])))
 | SORT events desc, pod, step | LIMIT 10;
@@ -441,7 +442,7 @@ bytes:double | time_bucket:datetime
 
 # Awaits fix: Index wildcard selector is not supported at this time.
 sum_over_time_aggregate_metric_double_implicit_casting_promql-Ignore
-required_capability: promql_pre_tech_preview_v13
+required_capability: promql_pre_tech_preview_v12
 required_capability: aggregate_metric_double_v0
 
 PROMQL index=k8s* step=10m bytes=(sum(sum_over_time(network.eth0.rx[10m])))
@@ -476,7 +477,7 @@ bytes:double | pod:keyword | time_bucket:datetime
 
 # Awaits fix: Index wildcard selector is not supported at this time.
 sum_over_time_aggregate_metric_double_implicit_casting_grouping_promql-Ignore
-required_capability: promql_pre_tech_preview_v13
+required_capability: promql_pre_tech_preview_v12
 required_capability: aggregate_metric_double_v0
 
 PROMQL index=k8s* step=10m bytes=(sum by (pod) (sum_over_time(network.eth0.rx[10m])))
@@ -509,7 +510,7 @@ sum:long | pod:keyword | time_bucket:datetime
 
 # Awaits fix: Subqueries are not supported at this time.
 sum_over_time_nested_expression_promql-Ignore
-required_capability: promql_pre_tech_preview_v13
+required_capability: promql_pre_tech_preview_v12
 
 PROMQL index=k8s step=1m sum=(sum by (pod) (sum_over_time((network.eth0.rx % 2)[1m:])))
 | SORT sum desc, step, pod | LIMIT 5;
@@ -536,7 +537,7 @@ min:long | time_bucket:datetime
 ;
 
 sum_over_time_nested_expression_in_grouping_with_alias_promql
-required_capability: promql_pre_tech_preview_v13
+required_capability: promql_pre_tech_preview_v12
 
 PROMQL index=k8s step=5m min=(min(sum_over_time(network.bytes_in[5m])))
 | SORT step | LIMIT 10;


### PR DESCRIPTION
Summary:

PromQL currently has lower integration test coverage compared to ESQL.
This change adds initial PromQL integration tests for the `sum_over_time()` and `rate()` functions.

NOTE: Some test cases defined in the specs are not yet supported by the PromQL implementation. Those cases are intentionally left **disabled** and annotated with an `Awaits-fix` comment.


Plan:

As part of issue [#260](https://github.com/elastic/metrics-program/issues/260), the planned work includes adding coverage across multiple test types.

CSV-spec test files

* [x] `k8s-timeseries-sum-over-time.csv-spec`
* [x] `k8s-timeseries-rate.csv-spec`
* [ ] `k8s-timeseries-present-over-time.csv-spec`
* [ ] `k8s-timeseries-min-over-time.csv-spec`
* [ ] `k8s-timeseries-max-over-time.csv-spec`
* [ ] `k8s-timeseries-last-over-time.csv-spec`
* [ ] `k8s-timeseries-irate.csv-spec`
* [ ] `k8s-timeseries-increase.csv-spec`
* [ ] `k8s-timeseries-idelta.csv-spec`
* [ ] `k8s-timeseries-first-over-time.csv-spec`
* [ ] `k8s-timeseries-delta.csv-spec`
* [ ] `k8s-timeseries-count-over-time.csv-spec`
* [ ] `k8s-timeseries-clamp.csv-spec`
* [ ] `k8s-timeseries-absent-over-time.csv-spec`

Other test types

* [ ] **YAML REST tests**
  `x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_tsdb.yml`
* [ ] **Java integration tests**
  `RandomizedTimeSeriesIT.java`
* [ ] **Generative tests**
  `GenerativeMetricsIT.java` (handled separately by @limotova)


Test Plan:

```bash
./gradlew :x-pack:plugin:esql:qa:server:single-node:javaRestTest \
  --tests "org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecIT"
```
