### PR TITLE
[9.3] Always use ssl settings for elastic service (#140173)

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
@@ -357,12 +357,7 @@ public class InferencePlugin extends Plugin
         var inferenceServiceSettings = new CCMInformedSettings(settings, ccmFeature.get());
         inferenceServiceSettings.init(services.clusterService());
 
-        var eisRequestSenderFactoryComponents = createEisRequestSenderFactory(
-            services,
-            throttlerManager,
-            inferenceServiceSettings,
-            ccmFeature.get()
-        );
+        var eisRequestSenderFactoryComponents = createEisRequestSenderComponents(services, throttlerManager, inferenceServiceSettings);
         var elasticInferenceServiceHttpClientManager = eisRequestSenderFactoryComponents.httpClientManager();
         elasticInferenceServiceFactory.set(eisRequestSenderFactoryComponents.factory());
 
@@ -517,33 +512,21 @@ public class InferencePlugin extends Plugin
 
     private record EisRequestSenderComponents(HttpRequestSender.Factory factory, HttpClientManager httpClientManager) {}
 
-    private EisRequestSenderComponents createEisRequestSenderFactory(
+    private EisRequestSenderComponents createEisRequestSenderComponents(
         PluginServices services,
         ThrottlerManager throttlerManager,
-        ElasticInferenceServiceSettings inferenceServiceSettings,
-        CCMFeature ccmFeature
+        ElasticInferenceServiceSettings inferenceServiceSettings
     ) {
-        // Create a separate instance of HTTPClientManager with its own SSL configuration (`xpack.inference.elastic.http.ssl.*`).
-        HttpClientManager manager;
-        if (ccmFeature.isCcmSupportedEnvironment()) {
-            // If ccm is configurable then we aren't using mTLS so ignore the ssl service
-            manager = HttpClientManager.create(
-                settings,
-                services.threadPool(),
-                services.clusterService(),
-                throttlerManager,
-                inferenceServiceSettings.getConnectionTtl()
-            );
-        } else {
-            manager = HttpClientManager.create(
-                settings,
-                services.threadPool(),
-                services.clusterService(),
-                throttlerManager,
-                getSslService(),
-                inferenceServiceSettings.getConnectionTtl()
-            );
-        }
+        // Always use the SSL service to respect SSL settings like verification_mode even in CCM mode.
+        // This allows local development with self-signed certificates when verification_mode=none.
+        var manager = HttpClientManager.create(
+            settings,
+            services.threadPool(),
+            services.clusterService(),
+            throttlerManager,
+            getSslService(),
+            inferenceServiceSettings.getConnectionTtl()
+        );
 
         return new EisRequestSenderComponents(
             new HttpRequestSender.Factory(serviceComponents.get(), manager, services.clusterService()),


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Always use ssl settings for elastic service (#140173)