### PR TITLE
Overload `randomIdentifier` to accept prefix

### DIFF
--- a/modules/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureBlobStoreRepositoryMetricsTests.java
+++ b/modules/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureBlobStoreRepositoryMetricsTests.java
@@ -99,7 +99,7 @@ public class AzureBlobStoreRepositoryMetricsTests extends AzureBlobStoreReposito
         final BlobContainer blobContainer = getBlobContainer(dataNodeName, repository);
 
         // Create a blob
-        final String blobName = "index-" + randomIdentifier();
+        final String blobName = randomIdentifier("index-");
         final OperationPurpose purpose = randomFrom(OperationPurpose.values());
         blobContainer.writeBlob(purpose, blobName, BytesReference.fromByteBuffer(ByteBuffer.wrap(randomBlobContent())), false);
         clearMetrics(dataNodeName);
@@ -126,7 +126,7 @@ public class AzureBlobStoreRepositoryMetricsTests extends AzureBlobStoreReposito
         final BlobContainer blobContainer = getBlobContainer(dataNodeName, repository);
 
         // Create a blob
-        final String blobName = "index-" + randomIdentifier();
+        final String blobName = randomIdentifier("index-");
         final OperationPurpose purpose = randomFrom(OperationPurpose.values());
         blobContainer.writeBlob(purpose, blobName, BytesReference.fromByteBuffer(ByteBuffer.wrap(randomBlobContent())), false);
         clearMetrics(dataNodeName);
@@ -153,7 +153,7 @@ public class AzureBlobStoreRepositoryMetricsTests extends AzureBlobStoreReposito
         final BlobContainer blobContainer = getBlobContainer(dataNodeName, repository);
 
         // Create a blob
-        final String blobName = "index-" + randomIdentifier();
+        final String blobName = randomIdentifier("index-");
         final OperationPurpose purpose = randomFrom(OperationPurpose.values());
         blobContainer.writeBlob(purpose, blobName, BytesReference.fromByteBuffer(ByteBuffer.wrap(randomBlobContent())), false);
         clearMetrics(dataNodeName);

--- a/modules/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureBlobStoreRepositoryMetricsTests.java
+++ b/modules/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureBlobStoreRepositoryMetricsTests.java
@@ -99,7 +99,7 @@ public class AzureBlobStoreRepositoryMetricsTests extends AzureBlobStoreReposito
         final BlobContainer blobContainer = getBlobContainer(dataNodeName, repository);
 
         // Create a blob
-        final String blobName = randomIdentifier("index-");
+        final String blobName = randomIndexName();
         final OperationPurpose purpose = randomFrom(OperationPurpose.values());
         blobContainer.writeBlob(purpose, blobName, BytesReference.fromByteBuffer(ByteBuffer.wrap(randomBlobContent())), false);
         clearMetrics(dataNodeName);
@@ -126,7 +126,7 @@ public class AzureBlobStoreRepositoryMetricsTests extends AzureBlobStoreReposito
         final BlobContainer blobContainer = getBlobContainer(dataNodeName, repository);
 
         // Create a blob
-        final String blobName = randomIdentifier("index-");
+        final String blobName = randomIndexName();
         final OperationPurpose purpose = randomFrom(OperationPurpose.values());
         blobContainer.writeBlob(purpose, blobName, BytesReference.fromByteBuffer(ByteBuffer.wrap(randomBlobContent())), false);
         clearMetrics(dataNodeName);
@@ -153,7 +153,7 @@ public class AzureBlobStoreRepositoryMetricsTests extends AzureBlobStoreReposito
         final BlobContainer blobContainer = getBlobContainer(dataNodeName, repository);
 
         // Create a blob
-        final String blobName = randomIdentifier("index-");
+        final String blobName = randomIndexName();
         final OperationPurpose purpose = randomFrom(OperationPurpose.values());
         blobContainer.writeBlob(purpose, blobName, BytesReference.fromByteBuffer(ByteBuffer.wrap(randomBlobContent())), false);
         clearMetrics(dataNodeName);

--- a/modules/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTimeoutTests.java
+++ b/modules/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3BlobStoreRepositoryTimeoutTests.java
@@ -131,7 +131,7 @@ public class S3BlobStoreRepositoryTimeoutTests extends ESMockAPIBasedRepositoryI
         s3StallingHttpHandler.setStallLatchRef(latch);
         try {
             final var purpose = randomFrom(OperationPurpose.values());
-            final String blobName = "test-" + randomIdentifier();
+            final String blobName = randomIdentifier("test-");
             assert BlobContainer.assertPurposeConsistency(purpose, blobName);
             final var e = expectThrows(
                 IOException.class,

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/metadata/CreateIndexPriorityIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/metadata/CreateIndexPriorityIT.java
@@ -114,7 +114,7 @@ public class CreateIndexPriorityIT extends ESIntegTestCase {
 
     public void testReducePriorities() {
         final var masterClusterService = internalCluster().getCurrentMasterNodeInstance(ClusterService.class);
-        final var indexName = randomIdentifier("index-");
+        final var indexName = randomIndexName();
 
         // starve all tasks at NORMAL or below
         final var createIndexBlockingTask = new RepeatingTask(masterClusterService);

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/metadata/CreateIndexPriorityIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/metadata/CreateIndexPriorityIT.java
@@ -114,7 +114,7 @@ public class CreateIndexPriorityIT extends ESIntegTestCase {
 
     public void testReducePriorities() {
         final var masterClusterService = internalCluster().getCurrentMasterNodeInstance(ClusterService.class);
-        final var indexName = "index-" + randomIdentifier();
+        final var indexName = randomIdentifier("index-");
 
         // starve all tasks at NORMAL or below
         final var createIndexBlockingTask = new RepeatingTask(masterClusterService);

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/metadata/CreateIndexTimeoutIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/metadata/CreateIndexTimeoutIT.java
@@ -100,7 +100,7 @@ public class CreateIndexTimeoutIT extends ESIntegTestCase {
     public void testReducePriorities() throws Exception {
         final var masterClusterService = internalCluster().getCurrentMasterNodeInstance(ClusterService.class);
         final var restClient = getRestClient();
-        final var indexName = randomIdentifier("index-");
+        final var indexName = randomIndexName();
 
         try (var ignored = withBlockedMasterService(masterClusterService)) {
             final var createIndexRequest = new CreateIndexRequest(indexName);

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/metadata/CreateIndexTimeoutIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/metadata/CreateIndexTimeoutIT.java
@@ -100,7 +100,7 @@ public class CreateIndexTimeoutIT extends ESIntegTestCase {
     public void testReducePriorities() throws Exception {
         final var masterClusterService = internalCluster().getCurrentMasterNodeInstance(ClusterService.class);
         final var restClient = getRestClient();
-        final var indexName = "index-" + randomIdentifier();
+        final var indexName = randomIdentifier("index-");
 
         try (var ignored = withBlockedMasterService(masterClusterService)) {
             final var createIndexRequest = new CreateIndexRequest(indexName);

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
@@ -126,7 +126,7 @@ public class DiskThresholdDeciderIT extends DiskUsageIntegTestCase {
             ClusterInfoServiceUtils.refresh(clusterInfoService);
         });
 
-        final var sourceIndexName = "source-" + randomIdentifier();
+        final var sourceIndexName = randomIdentifier("source-");
         createIndex(sourceIndexName, indexSettings(1, 0).put(INDEX_STORE_STATS_REFRESH_INTERVAL_SETTING.getKey(), "0ms").build());
         final var shardSizes = createReasonableSizedShards(sourceIndexName);
 
@@ -142,7 +142,7 @@ public class DiskThresholdDeciderIT extends DiskUsageIntegTestCase {
         getTestFileStore(dataNodeName).setTotalSpace(totalSpace);
         refreshDiskUsage();
 
-        final var targetIndexName = "target-" + randomIdentifier();
+        final var targetIndexName = randomIdentifier("target-");
         final var resizeRequest = ResizeIndexTestUtils.resizeRequest(
             ResizeType.CLONE,
             sourceIndexName,

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RestoreSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RestoreSnapshotIT.java
@@ -1033,11 +1033,11 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
     }
 
     public void testExplainUnassigableDuringRestore() {
-        final String repoName = "repo-" + randomIdentifier();
+        final String repoName = randomIdentifier("repo-");
         createRepository(repoName, FsRepository.TYPE);
-        final String indexName = "index-" + randomIdentifier();
+        final String indexName = randomIdentifier("index-");
         createIndexWithContent(indexName);
-        final String snapshotName = "snapshot-" + randomIdentifier();
+        final String snapshotName = randomIdentifier("snapshot-");
         createSnapshot(repoName, snapshotName, List.of(indexName));
         assertAcked(indicesAdmin().prepareDelete(indexName));
 
@@ -1050,7 +1050,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
             .setRestoreGlobalState(false)
             .setWaitForCompletion(true)
             .setIndexSettings(
-                Settings.builder().put(IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_PREFIX + "._name", "not-a-node-" + randomIdentifier())
+                Settings.builder().put(IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_PREFIX + "._name", randomIdentifier("not-a-node-"))
             )
             .get();
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RestoreSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RestoreSnapshotIT.java
@@ -1033,11 +1033,11 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
     }
 
     public void testExplainUnassigableDuringRestore() {
-        final String repoName = randomIdentifier("repo-");
+        final String repoName = randomRepoName();
         createRepository(repoName, FsRepository.TYPE);
-        final String indexName = randomIdentifier("index-");
+        final String indexName = randomIndexName();
         createIndexWithContent(indexName);
-        final String snapshotName = randomIdentifier("snapshot-");
+        final String snapshotName = randomSnapshotName();
         createSnapshot(repoName, snapshotName, List.of(indexName));
         assertAcked(indicesAdmin().prepareDelete(indexName));
 

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/get/SnapshotNamePredicateTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/get/SnapshotNamePredicateTests.java
@@ -57,17 +57,17 @@ public class SnapshotNamePredicateTests extends ESTestCase {
 
     public void testMatchWildcard() {
         final var predicates = createPredicate(randomBoolean(), "include-*");
-        assertTrue(predicates.test("include-" + randomIdentifier(), randomBoolean()));
-        assertFalse(predicates.test("exclude-" + randomIdentifier(), randomBoolean()));
+        assertTrue(predicates.test(randomIdentifier("include-"), randomBoolean()));
+        assertFalse(predicates.test(randomIdentifier("exclude-"), randomBoolean()));
         assertThat(predicates.requiredNames(), empty());
     }
 
     public void testMatchWildcardAndName() {
         final var requestName = randomIdentifier();
         final var predicates = createPredicate(true, "include-*", requestName);
-        assertTrue(predicates.test("include-" + randomIdentifier(), randomBoolean()));
+        assertTrue(predicates.test(randomIdentifier("include-"), randomBoolean()));
         assertTrue(predicates.test(requestName, randomBoolean()));
-        assertFalse(predicates.test("exclude-" + randomIdentifier(), randomBoolean()));
+        assertFalse(predicates.test(randomIdentifier("exclude-"), randomBoolean()));
         assertThat(predicates.requiredNames(), empty());
 
         assertEquals(createPredicate(false, "include-*", requestName).requiredNames(), Set.of(requestName));
@@ -83,16 +83,16 @@ public class SnapshotNamePredicateTests extends ESTestCase {
 
     public void testIncludeWildcardExcludeWildcard() {
         final var predicates = createPredicate(randomBoolean(), "include-*", "-include-exclude-*");
-        assertTrue(predicates.test("include-" + randomIdentifier(), randomBoolean()));
-        assertFalse(predicates.test("exclude-" + randomIdentifier(), randomBoolean()));
-        assertFalse(predicates.test("include-exclude-" + randomIdentifier(), randomBoolean()));
+        assertTrue(predicates.test(randomIdentifier("include-"), randomBoolean()));
+        assertFalse(predicates.test(randomIdentifier("exclude-"), randomBoolean()));
+        assertFalse(predicates.test(randomIdentifier("include-exclude-"), randomBoolean()));
         assertThat(predicates.requiredNames(), empty());
     }
 
     public void testIncludeCurrentExcludeWildcard() {
         final var predicates = createPredicate(randomBoolean(), currentSnapshotsSelector(), "-exclude-*");
         assertTrue(predicates.test(randomIdentifier(), true));
-        assertFalse(predicates.test("exclude-" + randomIdentifier(), randomBoolean()));
+        assertFalse(predicates.test(randomIdentifier("exclude-"), randomBoolean()));
         assertFalse(predicates.test(randomIdentifier(), false));
         assertThat(predicates.requiredNames(), empty());
     }
@@ -117,7 +117,7 @@ public class SnapshotNamePredicateTests extends ESTestCase {
     public void testHyphen() {
         // NB current behaviour, but could be considered a bug?
         final var predicates = createPredicate(false, "include-*", "-");
-        assertTrue(predicates.test("include-" + randomIdentifier(), randomBoolean()));
+        assertTrue(predicates.test(randomIdentifier("include-"), randomBoolean()));
         assertTrue(predicates.test("-", randomBoolean()));
         assertThat(predicates.requiredNames(), equalTo(Set.of("-")));
     }

--- a/test/fixtures/aws-fixture-utils/src/main/java/fixture/aws/DynamicRegionSupplier.java
+++ b/test/fixtures/aws-fixture-utils/src/main/java/fixture/aws/DynamicRegionSupplier.java
@@ -29,7 +29,7 @@ public class DynamicRegionSupplier implements Supplier<String> {
     }
 
     private String generateAndGet() {
-        final var newRegion = "DynamicRegionSupplier-" + ESTestCase.randomIdentifier();
+        final var newRegion = ESTestCase.randomIdentifier("DynamicRegionSupplier-");
         return Objects.requireNonNullElse(generatedRegion.compareAndExchange(null, newRegion), newRegion);
     }
 }

--- a/test/fixtures/ec2-imds-fixture/src/main/java/fixture/aws/imds/Ec2ImdsHttpHandler.java
+++ b/test/fixtures/ec2-imds-fixture/src/main/java/fixture/aws/imds/Ec2ImdsHttpHandler.java
@@ -121,7 +121,7 @@ public class Ec2ImdsHttpHandler implements HttpHandler {
 
             if ("GET".equals(requestMethod)) {
                 if (path.equals(IMDS_SECURITY_CREDENTIALS_PATH) && dynamicProfileNames) {
-                    final var profileName = "imds_profile_" + randomIdentifier();
+                    final var profileName = randomIdentifier("imds_profile_");
                     validCredentialsEndpoints.add(IMDS_SECURITY_CREDENTIALS_PATH + profileName);
                     sendStringResponse(exchange, profileName);
                     return;

--- a/test/fixtures/gcs-fixture/src/test/java/fixture/gcs/GoogleCloudStorageHttpHandlerTests.java
+++ b/test/fixtures/gcs-fixture/src/test/java/fixture/gcs/GoogleCloudStorageHttpHandlerTests.java
@@ -146,7 +146,7 @@ public class GoogleCloudStorageHttpHandlerTests extends ESTestCase {
     public void testGetWithBytesRange() {
         final var bucket = randomIdentifier();
         final var handler = new GoogleCloudStorageHttpHandler(bucket);
-        final var blobName = "blob_name_" + randomIdentifier();
+        final var blobName = randomIdentifier("blob_name_");
         final var blobBytes = randomBytesReference(256);
 
         assertEquals(RestStatus.OK, executeUpload(handler, bucket, blobName, blobBytes, 0L).restStatus());
@@ -192,7 +192,7 @@ public class GoogleCloudStorageHttpHandlerTests extends ESTestCase {
     public void testZeroLengthObjectGets() {
         final var bucket = randomIdentifier();
         final var handler = new GoogleCloudStorageHttpHandler(bucket);
-        final var blobName = "blob_name_" + randomIdentifier();
+        final var blobName = randomIdentifier("blob_name_");
         final var blobBytes = BytesArray.EMPTY;
 
         assertEquals(RestStatus.OK, executeMultipartUpload(handler, bucket, blobName, blobBytes, 0L).restStatus());
@@ -219,7 +219,7 @@ public class GoogleCloudStorageHttpHandlerTests extends ESTestCase {
     public void testResumableUpload() {
         final var bucket = randomIdentifier();
         final var handler = new GoogleCloudStorageHttpHandler(bucket);
-        final var blobName = "blob_name_" + randomIdentifier();
+        final var blobName = randomIdentifier("blob_name_");
 
         final var createUploadResponse = handleRequest(
             handler,
@@ -298,7 +298,7 @@ public class GoogleCloudStorageHttpHandlerTests extends ESTestCase {
     public void testIfGenerationMatch_MultipartUpload() {
         final var bucket = randomIdentifier();
         final var handler = new GoogleCloudStorageHttpHandler(bucket);
-        final var blobName = "blob_name_" + randomIdentifier();
+        final var blobName = randomIdentifier("blob_name_");
 
         assertEquals(
             RestStatus.OK,
@@ -364,7 +364,7 @@ public class GoogleCloudStorageHttpHandlerTests extends ESTestCase {
     public void testIfGenerationMatch_ResumableUpload() {
         final var bucket = randomIdentifier();
         final var handler = new GoogleCloudStorageHttpHandler(bucket);
-        final var blobName = "blob_name_" + randomIdentifier();
+        final var blobName = randomIdentifier("blob_name_");
 
         assertEquals(
             RestStatus.OK,
@@ -430,7 +430,7 @@ public class GoogleCloudStorageHttpHandlerTests extends ESTestCase {
     public void testIfGenerationMatch_GetObject() {
         final var bucket = randomIdentifier();
         final var handler = new GoogleCloudStorageHttpHandler(bucket);
-        final var blobName = "blob_name_" + randomIdentifier();
+        final var blobName = randomIdentifier("blob_name_");
 
         assertEquals(
             RestStatus.OK,

--- a/test/fixtures/s3-fixture/src/test/java/fixture/s3/S3HttpHandlerTests.java
+++ b/test/fixtures/s3-fixture/src/test/java/fixture/s3/S3HttpHandlerTests.java
@@ -135,7 +135,7 @@ public class S3HttpHandlerTests extends ESTestCase {
 
     public void testGetWithBytesRange() {
         final var handler = new S3HttpHandler("bucket", "path", S3ConsistencyModel.randomConsistencyModel());
-        final var blobName = "blob_name_" + randomIdentifier();
+        final var blobName = randomIdentifier("blob_name_");
         final var blobPath = "/bucket/path/" + blobName;
         final var blobBytes = randomBytesReference(256);
         assertEquals(RestStatus.OK, handleRequest(handler, "PUT", blobPath, blobBytes).status());

--- a/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -852,7 +852,7 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
         final PlainActionFuture<Collection<CreateSnapshotResponse>> allSnapshotsDone = new PlainActionFuture<>();
         final ActionListener<CreateSnapshotResponse> snapshotsListener = new GroupedActionListener<>(count, allSnapshotsDone);
         final List<String> snapshotNames = new ArrayList<>(count);
-        final String prefix = randomIdentifier("snap-") + "-";
+        final String prefix = randomSnapshotName() + "-";
         for (int i = 0; i < count; i++) {
             final String snapshot = prefix + i;
             snapshotNames.add(snapshot);

--- a/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -102,8 +102,6 @@ import static org.hamcrest.Matchers.oneOf;
 
 public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
 
-    public static final String RANDOM_SNAPSHOT_NAME_PREFIX = "snap-";
-
     public static final String OLD_VERSION_SNAPSHOT_PREFIX = "old-version-snapshot-";
 
     protected static final int LARGE_POOL_SIZE = 10;
@@ -854,7 +852,7 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
         final PlainActionFuture<Collection<CreateSnapshotResponse>> allSnapshotsDone = new PlainActionFuture<>();
         final ActionListener<CreateSnapshotResponse> snapshotsListener = new GroupedActionListener<>(count, allSnapshotsDone);
         final List<String> snapshotNames = new ArrayList<>(count);
-        final String prefix = RANDOM_SNAPSHOT_NAME_PREFIX + randomIdentifier() + "-";
+        final String prefix = randomIdentifier("snap-") + "-";
         for (int i = 0; i < count; i++) {
             final String snapshot = prefix + i;
             snapshotNames.add(snapshot);

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -1299,10 +1299,20 @@ public abstract class ESTestCase extends LuceneTestCase {
     }
 
     /**
-     * Creates a valid random identifier such as node id or index name
+     * @return a valid random identifier, appropriate for use as a node name, index name, repository name or similar.
+     * @see #randomIdentifier(String) randomIdentifier(String) which allows to add a prefix.
      */
     public static String randomIdentifier() {
         return randomAlphaOfLengthBetween(8, 12).toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * @return a valid random identifier with the given prefix. Makes debugging tests easier if you use {@code randomIdentifier("index-")}
+     * for indices and {@code randomIdentifier("repository-")} and so on, keeping the identifiers visually distinct, rather than having to
+     * work out what kind of identifier you're looking at in each log message.
+     */
+    public static String randomIdentifier(String prefix) {
+        return prefix + randomIdentifier();
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -1301,18 +1301,52 @@ public abstract class ESTestCase extends LuceneTestCase {
     /**
      * @return a valid random identifier, appropriate for use as a node name, index name, repository name or similar.
      * @see #randomIdentifier(String) randomIdentifier(String) which allows to add a prefix.
+     * @see #randomIndexName() randomIndexName() which encodes a convention for random index names.
+     * @see #randomRepoName() randomRepoName() which encodes a convention for random repository names.
+     * @see #randomSnapshotName() randomSnapshotName() which encodes a convention for random snapshot names.
      */
     public static String randomIdentifier() {
         return randomAlphaOfLengthBetween(8, 12).toLowerCase(Locale.ROOT);
     }
 
     /**
-     * @return a valid random identifier with the given prefix. Makes debugging tests easier if you use {@code randomIdentifier("index-")}
-     * for indices and {@code randomIdentifier("repository-")} and so on, keeping the identifiers visually distinct, rather than having to
-     * work out what kind of identifier you're looking at in each log message.
+     * @return a valid random identifier with the given prefix. Makes debugging tests easier if you use {@code randomIdentifier("type1-")}
+     * for indices and {@code randomIdentifier("type2-")} and so on, keeping the identifier types visually distinct, rather than having
+     * to work out what kind of identifier you're looking at in each log message.
+     *
+     * @see #randomIndexName() randomIndexName() which encodes a convention for random index names.
+     * @see #randomRepoName() randomRepoName() which encodes a convention for random repository names.
+     * @see #randomSnapshotName() randomSnapshotName() which encodes a convention for random snapshot names.
      */
     public static String randomIdentifier(String prefix) {
         return prefix + randomIdentifier();
+    }
+
+    /**
+     * @return a valid random index name of the form {@code index-${RANDOM_CHARS}}. Makes debugging tests easier if you use this rather
+     * than just a bare {@code randomIdentifier()} since the resulting identifier types are visually distinct, rather than having to
+     * work out what kind of identifier you're looking at in each log message.
+     */
+    public static String randomIndexName() {
+        return randomIdentifier("index-");
+    }
+
+    /**
+     * @return a valid random repository name of the form {@code repo-${RANDOM_CHARS}}. Makes debugging tests easier if you use this rather
+     * than just a bare {@code randomIdentifier()} since the resulting identifier types are visually distinct, rather than having to
+     * work out what kind of identifier you're looking at in each log message.
+     */
+    public static String randomRepoName() {
+        return randomIdentifier("repo-");
+    }
+
+    /**
+     * @return a valid random snapshot name of the form {@code snap-${RANDOM_CHARS}}. Makes debugging tests easier if you use this rather
+     * than just a bare {@code randomIdentifier()} since the resulting identifier types are visually distinct, rather than having to
+     * work out what kind of identifier you're looking at in each log message.
+     */
+    public static String randomSnapshotName() {
+        return randomIdentifier("snap-");
     }
 
     /**

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/slm/SnapshotRetentionConfigurationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/slm/SnapshotRetentionConfigurationTests.java
@@ -313,7 +313,7 @@ public class SnapshotRetentionConfigurationTests extends ESTestCase {
         meta.put(SnapshotsService.POLICY_ID_METADATA_FIELD, REPO);
         final int totalShards = between(1, 20);
         SnapshotInfo snapInfo = new SnapshotInfo(
-            new Snapshot(REPO, new SnapshotId("snap-" + randomIdentifier(), "uuid")),
+            new Snapshot(REPO, new SnapshotId(randomIdentifier("snap-"), "uuid")),
             Collections.singletonList("foo"),
             Collections.singletonList("bar"),
             Collections.emptyList(),

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/slm/SnapshotRetentionConfigurationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/slm/SnapshotRetentionConfigurationTests.java
@@ -313,7 +313,7 @@ public class SnapshotRetentionConfigurationTests extends ESTestCase {
         meta.put(SnapshotsService.POLICY_ID_METADATA_FIELD, REPO);
         final int totalShards = between(1, 20);
         SnapshotInfo snapInfo = new SnapshotInfo(
-            new Snapshot(REPO, new SnapshotId(randomIdentifier("snap-"), "uuid")),
+            new Snapshot(REPO, new SnapshotId(randomSnapshotName(), "uuid")),
             Collections.singletonList("foo"),
             Collections.singletonList("bar"),
             Collections.emptyList(),

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/SharedCacheEvictionTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/SharedCacheEvictionTests.java
@@ -69,7 +69,7 @@ public class SharedCacheEvictionTests extends BaseFrozenSearchableSnapshotsInteg
     }
 
     public void testPartialShardsAreEvictedAsynchronouslyOnDelete() throws Exception {
-        final String mountedSnapshotName = "mounted_" + randomIdentifier();
+        final String mountedSnapshotName = randomIdentifier("mounted_");
         snapshotAndMount(mountedSnapshotName, MountSearchableSnapshotRequest.Storage.SHARED_CACHE);
 
         final Map<String, Integer> allocations = getShardCounts(mountedSnapshotName);
@@ -86,7 +86,7 @@ public class SharedCacheEvictionTests extends BaseFrozenSearchableSnapshotsInteg
      * Fully mounted snapshots don't use the shared blob cache, so we don't need to evict them from it
      */
     public void testFullFullShardsAreNotEvictedOnDelete() throws Exception {
-        final String mountedSnapshotName = "mounted_" + randomIdentifier();
+        final String mountedSnapshotName = randomIdentifier("mounted_");
         snapshotAndMount(mountedSnapshotName, MountSearchableSnapshotRequest.Storage.FULL_COPY);
 
         final Map<String, Integer> allocations = getShardCounts(mountedSnapshotName);
@@ -103,7 +103,7 @@ public class SharedCacheEvictionTests extends BaseFrozenSearchableSnapshotsInteg
      * We let relocated shards age out of the cache, rather than evicting them
      */
     public void testPartialShardsAreNotEvictedOnRelocate() throws Exception {
-        final String mountedSnapshotName = "mounted_" + randomIdentifier();
+        final String mountedSnapshotName = randomIdentifier("mounted_");
         snapshotAndMount(mountedSnapshotName, MountSearchableSnapshotRequest.Storage.SHARED_CACHE);
 
         final Map<String, Integer> allocations = getShardCounts(mountedSnapshotName);
@@ -129,7 +129,7 @@ public class SharedCacheEvictionTests extends BaseFrozenSearchableSnapshotsInteg
     }
 
     public void testPartialShardsAreEvictedSynchronouslyOnFailure() throws Exception {
-        final String mountedSnapshotName = "mounted_" + randomIdentifier();
+        final String mountedSnapshotName = randomIdentifier("mounted_");
 
         snapshotAndMount(mountedSnapshotName, MountSearchableSnapshotRequest.Storage.SHARED_CACHE);
 


### PR DESCRIPTION
If a test creates a named thing then it's useful to capture its name in
a variable so that readers can find all references to the thing using
their IDE. If the name is a fixed literal like `"test-repo"` or
`"test-index"` then it's easy to accidentally use the literal elsewhere
rather than the variable, breaking the find-all-references pattern, but
this can be avoided by including some randomness in the identifier.

However, using a purely random identifier, such as would be generated by
`ESTestCase#randomIdentifier()` can add add quite some cognitive
overhead to reading logs from tests, especially if there's lots of
different kinds of random identifier in play: any given random string
might be an index name or a repository name or all sorts of other
things.

Some more debugging-friendly tests have elected to use a random
identifier with a fixed prefix to get the best of both worlds. This
commit introduces a utility to capture this convention.