### PR TITLE
PromQL: support any functions regardless of the metric type

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Increase.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Increase.java
@@ -88,7 +88,7 @@ public class Increase extends TimeSeriesAggregateFunction implements OptionalArg
         this(source, field, filter, window, timestamp, false);
     }
 
-    Increase(Source source, Expression field, Expression filter, Expression window, Expression timestamp, boolean lenientTypeCheck) {
+    public Increase(Source source, Expression field, Expression filter, Expression window, Expression timestamp, boolean lenientTypeCheck) {
         super(source, field, filter, window, List.of(timestamp));
         this.timestamp = timestamp;
         this.lenientTypeCheck = lenientTypeCheck;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Irate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Irate.java
@@ -84,7 +84,7 @@ public class Irate extends TimeSeriesAggregateFunction implements OptionalArgume
         this(source, field, filter, window, timestamp, false);
     }
 
-    Irate(Source source, Expression field, Expression filter, Expression window, Expression timestamp, boolean lenientTypeCheck) {
+    public Irate(Source source, Expression field, Expression filter, Expression window, Expression timestamp, boolean lenientTypeCheck) {
         super(source, field, filter, window, List.of(timestamp));
         this.timestamp = timestamp;
         this.lenientTypeCheck = lenientTypeCheck;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Rate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Rate.java
@@ -88,7 +88,7 @@ public class Rate extends TimeSeriesAggregateFunction implements OptionalArgumen
         this(source, field, filter, window, timestamp, false);
     }
 
-    Rate(Source source, Expression field, Expression filter, Expression window, Expression timestamp, boolean lenientTypeCheck) {
+    public Rate(Source source, Expression field, Expression filter, Expression window, Expression timestamp, boolean lenientTypeCheck) {
         super(source, field, filter, window, List.of(timestamp));
         this.timestamp = timestamp;
         this.lenientTypeCheck = lenientTypeCheck;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Rate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Rate.java
@@ -42,6 +42,12 @@ public class Rate extends TimeSeriesAggregateFunction implements OptionalArgumen
 
     private final Expression timestamp;
 
+    /**
+     * When true, accepts any numeric type (for PromQL compatibility).
+     * When false, requires counter types only (ESQL TS behavior).
+     */
+    private final boolean lenientTypeCheck;
+
     @FunctionInfo(
         type = FunctionType.TIME_SERIES_AGGREGATE,
         returnType = { "double" },
@@ -71,12 +77,21 @@ public class Rate extends TimeSeriesAggregateFunction implements OptionalArgumen
         ) Expression window,
         Expression timestamp
     ) {
-        this(source, field, Literal.TRUE, Objects.requireNonNullElse(window, NO_WINDOW), timestamp);
+        this(source, field, Literal.TRUE, Objects.requireNonNullElse(window, NO_WINDOW), timestamp, false);
+    }
+
+    public Rate(Source source, Expression field, Expression window, Expression timestamp, boolean lenientTypeCheck) {
+        this(source, field, Literal.TRUE, Objects.requireNonNullElse(window, NO_WINDOW), timestamp, lenientTypeCheck);
     }
 
     public Rate(Source source, Expression field, Expression filter, Expression window, Expression timestamp) {
+        this(source, field, filter, window, timestamp, false);
+    }
+
+    Rate(Source source, Expression field, Expression filter, Expression window, Expression timestamp, boolean lenientTypeCheck) {
         super(source, field, filter, window, List.of(timestamp));
         this.timestamp = timestamp;
+        this.lenientTypeCheck = lenientTypeCheck;
     }
 
     public Rate(StreamInput in) throws IOException {
@@ -85,7 +100,8 @@ public class Rate extends TimeSeriesAggregateFunction implements OptionalArgumen
             in.readNamedWriteable(Expression.class),
             in.readNamedWriteable(Expression.class),
             readWindow(in),
-            in.readNamedWriteableCollectionAsList(Expression.class).getFirst()
+            in.readNamedWriteableCollectionAsList(Expression.class).getFirst(),
+            false
         );
     }
 
@@ -96,17 +112,17 @@ public class Rate extends TimeSeriesAggregateFunction implements OptionalArgumen
 
     @Override
     protected NodeInfo<Rate> info() {
-        return NodeInfo.create(this, Rate::new, field(), filter(), window(), timestamp);
+        return NodeInfo.create(this, Rate::new, field(), filter(), window(), timestamp, lenientTypeCheck);
     }
 
     @Override
     public Rate replaceChildren(List<Expression> newChildren) {
-        return new Rate(source(), newChildren.get(0), newChildren.get(1), newChildren.get(2), newChildren.get(3));
+        return new Rate(source(), newChildren.get(0), newChildren.get(1), newChildren.get(2), newChildren.get(3), lenientTypeCheck);
     }
 
     @Override
     public Rate withFilter(Expression filter) {
-        return new Rate(source(), field(), filter, window(), timestamp);
+        return new Rate(source(), field(), filter, window(), timestamp, lenientTypeCheck);
     }
 
     @Override
@@ -116,6 +132,9 @@ public class Rate extends TimeSeriesAggregateFunction implements OptionalArgumen
 
     @Override
     protected TypeResolution resolveType() {
+        if (lenientTypeCheck) {
+            return isType(field(), dt -> dt.isNumeric() || DataType.isCounter(dt), sourceText(), FIRST, "numeric or counter");
+        }
         return isType(field(), dt -> DataType.isCounter(dt), sourceText(), FIRST, "counter_long", "counter_integer", "counter_double");
     }
 
@@ -125,9 +144,9 @@ public class Rate extends TimeSeriesAggregateFunction implements OptionalArgumen
         final DataType tsType = timestamp().dataType();
         final boolean isDateNanos = tsType == DataType.DATE_NANOS;
         return switch (type) {
-            case COUNTER_LONG -> new RateLongGroupingAggregatorFunction.FunctionSupplier(true, isDateNanos);
-            case COUNTER_INTEGER -> new RateIntGroupingAggregatorFunction.FunctionSupplier(true, isDateNanos);
-            case COUNTER_DOUBLE -> new RateDoubleGroupingAggregatorFunction.FunctionSupplier(true, isDateNanos);
+            case COUNTER_LONG, LONG -> new RateLongGroupingAggregatorFunction.FunctionSupplier(true, isDateNanos);
+            case COUNTER_INTEGER, INTEGER -> new RateIntGroupingAggregatorFunction.FunctionSupplier(true, isDateNanos);
+            case COUNTER_DOUBLE, DOUBLE -> new RateDoubleGroupingAggregatorFunction.FunctionSupplier(true, isDateNanos);
             default -> throw EsqlIllegalArgumentException.illegalDataType(type);
         };
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/promql/function/PromqlFunctionRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/promql/function/PromqlFunctionRegistry.java
@@ -202,9 +202,7 @@ public class PromqlFunctionRegistry {
             name,
             FunctionType.WITHIN_SERIES_AGGREGATION,
             Arity.ONE,
-            (source, target, timestamp, window, extraParams) -> {
-                return builder.build(source, target, window, timestamp, true);  // lenient=true for PromQL
-            }
+            (source, target, timestamp, window, extraParams) -> builder.build(source, target, window, timestamp, true)
         );
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlLogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlLogicalPlanOptimizerTests.java
@@ -336,7 +336,6 @@ public class PromqlLogicalPlanOptimizerTests extends AbstractLogicalPlanOptimize
 
     }
 
-    @AwaitsFix(bugUrl = "Invalid call to dataType on an unresolved object ?RATE_$1")
     public void testRate() {
         // TS metrics-hostmetricsreceiver.otel-default
         // | WHERE @timestamp >= \"{{from | minus .benchmark.duration}}\" AND @timestamp <= \"{{from}}\"

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlLogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlLogicalPlanOptimizerTests.java
@@ -654,6 +654,36 @@ public class PromqlLogicalPlanOptimizerTests extends AbstractLogicalPlanOptimize
         assertThat(plan.output().stream().map(Attribute::name).toList(), equalTo(List.of("rate", "step", "_timeseries")));
     }
 
+    public void testIncreaseLenientTypes() {
+        // gauge integer field
+        var gaugePlan = planPromql("PROMQL index=k8s step=1m increase=(increase(network.eth0.tx[1m]))");
+        assertThat(gaugePlan.output().stream().map(Attribute::name).toList(), equalTo(List.of("increase", "step", "_timeseries")));
+
+        // counter long field
+        var counterPlan = planPromql("PROMQL index=k8s step=1m increase=(increase(network.total_bytes_in[1m]))");
+        assertThat(counterPlan.output().stream().map(Attribute::name).toList(), equalTo(List.of("increase", "step", "_timeseries")));
+    }
+
+    public void testIrateLenientTypes() {
+        // gauge integer field
+        var gaugePlan = planPromql("PROMQL index=k8s step=1m irate=(irate(network.eth0.rx[1m]))");
+        assertThat(gaugePlan.output().stream().map(Attribute::name).toList(), equalTo(List.of("irate", "step", "_timeseries")));
+
+        // counter long field
+        var counterPlan = planPromql("PROMQL index=k8s step=1m irate=(irate(network.total_bytes_in[1m]))");
+        assertThat(counterPlan.output().stream().map(Attribute::name).toList(), equalTo(List.of("irate", "step", "_timeseries")));
+    }
+
+    public void testRateLenientTypes() {
+        // gauge integer field
+        var gaugePlan = planPromql("PROMQL index=k8s step=1m rate=(rate(network.eth0.tx[1m]))");
+        assertThat(gaugePlan.output().stream().map(Attribute::name).toList(), equalTo(List.of("rate", "step", "_timeseries")));
+
+        // counter long field
+        var counterPlan = planPromql("PROMQL index=k8s step=1m rate=(rate(network.total_bytes_in[1m]))");
+        assertThat(counterPlan.output().stream().map(Attribute::name).toList(), equalTo(List.of("rate", "step", "_timeseries")));
+    }
+
     protected LogicalPlan planPromql(String query) {
         return planPromql(query, false);
     }


### PR DESCRIPTION
**Summary:**

This change relaxes metric type checks for PromQL counter aggregate functions to match PromQL semantics. It avoids relying on metric metadata, which is not available when using [Prometheus Remote Write v1](https://github.com/vectordotdev/vector/issues/22825).

It uses a non serialized `lenientTypeCheck` flag which makes it fragile since data nodes wouldn't see it. But given type checking is done on the coordinator node, it may be ok for the initial version. LMK.


**Alternatives considered:**

This would allow custom type resolution, but would increase plan complexity and affect serialization.

**Test plan:**
```
./gradlew :x-pack:plugin:esql:qa:server:single-node:javaRestTest --tests "org.elasticsearch.xpack.esql.q
a.single_node.EsqlSpecIT" -Dtests.method="test {csv-spec:k8s-timeseries.*}"
```


**Issue:** [#140035](https://github.com/elastic/elasticsearch/issues/140035)