### PR TITLE
Fix block channel in dimension values aggregation

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/DimensionValuesByteRefGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/DimensionValuesByteRefGroupingAggregatorFunction.java
@@ -73,7 +73,7 @@ public final class DimensionValuesByteRefGroupingAggregatorFunction implements G
 
     @Override
     public AddInput prepareProcessRawInputPage(SeenGroupIds seenGroupIds, Page page) {
-        BytesRefBlock valuesBlock = page.getBlock(0);
+        BytesRefBlock valuesBlock = page.getBlock(channel);
         if (valuesBlock.areAllValuesNull()) {
             return new AddInput() {
                 @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/DimensionValuesByteRefGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/DimensionValuesByteRefGroupingAggregatorFunctionTests.java
@@ -11,6 +11,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.aggregation.AggregatorMode;
 import org.elasticsearch.compute.aggregation.DimensionValuesByteRefGroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
+import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.ElementType;
@@ -23,6 +24,7 @@ import org.elasticsearch.compute.operator.PageConsumerOperator;
 import org.elasticsearch.compute.test.CannedSourceOperator;
 import org.elasticsearch.compute.test.ComputeTestCase;
 import org.elasticsearch.compute.test.OperatorTestCase;
+import org.elasticsearch.compute.test.RandomBlock;
 import org.elasticsearch.compute.test.TestDriverFactory;
 import org.hamcrest.Matchers;
 
@@ -43,6 +45,8 @@ public class DimensionValuesByteRefGroupingAggregatorFunctionTests extends Compu
         int numPages = between(1, 10);
         List<Page> pages = new ArrayList<>(numPages);
         Map<Integer, List<BytesRef>> expectedValues = new HashMap<>();
+        int prefixBlocks = between(0, 2);
+        int suffixBlocks = between(0, 2);
         for (int i = 0; i < numPages; i++) {
             int positions = between(1, 100);
             try (
@@ -70,20 +74,35 @@ public class DimensionValuesByteRefGroupingAggregatorFunctionTests extends Compu
                     groups.appendInt(group);
                     expectedValues.putIfAbsent(group, values);
                 }
-                pages.add(new Page(valuesBuilder.build(), groups.build().asBlock()));
+                BytesRefBlock valuesBlock = valuesBuilder.build();
+                IntBlock groupsBlock = groups.build().asBlock();
+                Block[] blocks = new Block[prefixBlocks + 2 + suffixBlocks];
+                for (int b = 0; b < prefixBlocks; b++) {
+                    blocks[b] = RandomBlock.randomBlock(RandomBlock.randomElementType(), positions, false, 1, 1, 0, 0).block();
+                }
+                blocks[prefixBlocks] = valuesBlock;
+                blocks[prefixBlocks + 1] = groupsBlock;
+                for (int b = 0; b < suffixBlocks; b++) {
+                    blocks[prefixBlocks + 2 + b] = RandomBlock.randomBlock(RandomBlock.randomElementType(), positions, false, 1, 1, 0, 0)
+                        .block();
+                }
+                pages.add(new Page(blocks));
             }
         }
         var aggregatorFactory = new DimensionValuesByteRefGroupingAggregatorFunction.FunctionSupplier().groupingAggregatorFactory(
-            randomFrom(AggregatorMode.INITIAL, AggregatorMode.SINGLE),
-            List.of(0)
+            randomFrom(AggregatorMode.INITIAL, AggregatorMode.SINGLE, AggregatorMode.FINAL),
+            List.of(prefixBlocks)
         );
         final List<BlockHash.GroupSpec> groupSpecs;
         if (randomBoolean()) {
             // Use IntBlockHash; reserves 0 for null values
-            groupSpecs = List.of(new BlockHash.GroupSpec(1, ElementType.INT));
+            groupSpecs = List.of(new BlockHash.GroupSpec(prefixBlocks + 1, ElementType.INT));
         } else {
             // Use PackedValuesBlockHash; does not reserve 0 for null values
-            groupSpecs = List.of(new BlockHash.GroupSpec(1, ElementType.INT), new BlockHash.GroupSpec(1, ElementType.INT));
+            groupSpecs = List.of(
+                new BlockHash.GroupSpec(prefixBlocks + 1, ElementType.INT),
+                new BlockHash.GroupSpec(prefixBlocks + 1, ElementType.INT)
+            );
         }
         HashAggregationOperator hashAggregationOperator = new HashAggregationOperator(
             List.of(aggregatorFactory),


### PR DESCRIPTION
We don't catch this because we do not inject random blocks before the values block in the unit tests.

Closes #139780