### PR TITLE
[9.1] Add debug logging for reindex shutdown test (#140093)

### DIFF
--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexNodeShutdownIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexNodeShutdownIT.java
@@ -18,6 +18,7 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.reindex.ReindexPlugin;
 import org.elasticsearch.tasks.TaskInfo;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -52,6 +53,10 @@ public class ReindexNodeShutdownIT extends ESIntegTestCase {
         return new ReindexRequestBuilder(internalCluster().client(nodeName));
     }
 
+    @TestLogging(
+        value = "org.elasticsearch.index.reindex:DEBUG,org.elasticsearch.node.ShutdownPrepareService:DEBUG",
+        reason = "https://github.com/elastic/elasticsearch/issues/139806"
+    )
     public void testReindexWithShutdown() throws Exception {
         final String masterNodeName = internalCluster().startMasterOnlyNode();
         final String dataNodeName = internalCluster().startDataOnlyNode();

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -346,9 +346,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
   method: testDatafeedTimingStats_DatafeedRecreated
   issue: https://github.com/elastic/elasticsearch/issues/138348
-- class: org.elasticsearch.index.reindex.ReindexNodeShutdownIT
-  method: testReindexWithShutdown
-  issue: https://github.com/elastic/elasticsearch/issues/139806
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=ml/3rd_party_deployment/Test update deployment with low priority to multiple allocations}
   issue: https://github.com/elastic/elasticsearch/issues/140188


### PR DESCRIPTION
# Backport

This will backport the following commits from `9.2` to `9.1`:
 - [Add debug logging for reindex shutdown test (#140093)](https://github.com/elastic/elasticsearch/pull/140093)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)