### PR TITLE
[8.19] [Inference API] Fix auth exception listener not called bug (#139966)

### DIFF
--- a/docs/changelog/139966.yaml
+++ b/docs/changelog/139966.yaml
@@ -1,0 +1,5 @@
+pr: 139966
+summary: "[Inference API] Fix auth exception listener not called bug"
+area: Inference
+type: bug
+issues: []

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/authorization/ElasticInferenceServiceAuthorizationRequestHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/authorization/ElasticInferenceServiceAuthorizationRequestHandler.java
@@ -116,6 +116,7 @@ public class ElasticInferenceServiceAuthorizationRequestHandler {
         } catch (Exception e) {
             logger.warn(Strings.format("Retrieving the authorization information encountered an exception: %s", e));
             requestCompleteLatch.countDown();
+            listener.onFailure(e);
         }
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/authorization/ElasticInferenceServiceAuthorizationRequestHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/authorization/ElasticInferenceServiceAuthorizationRequestHandlerTests.java
@@ -171,17 +171,25 @@ public class ElasticInferenceServiceAuthorizationRequestHandlerTests extends EST
         var logger = mock(Logger.class);
         doThrow(exceptionToThrow).when(logger).debug(anyString());
 
-        var authHandler = new ElasticInferenceServiceAuthorizationRequestHandler(
-            eisGatewayUrl,
-            threadPool,
-            logger,
-            createNoopApplierFactory()
-        );
+        var authHandler = new ElasticInferenceServiceAuthorizationRequestHandler(eisGatewayUrl, threadPool, logger);
 
         try (var sender = senderFactory.createSender()) {
-            var responseData = getEisAuthorizationResponseWithMultipleEndpoints(eisGatewayUrl);
+            String responseJson = """
+                {
+                    "models": [
+                        {
+                          "model_name": "model-a",
+                          "task_types": ["embed/text/sparse", "chat"]
+                        },
+                        {
+                          "model_name": "model-b",
+                          "task_types": ["embed/text/dense"]
+                        }
+                    ]
+                }
+                """;
 
-            webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseData.responseJson()));
+            webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
 
             PlainActionFuture<ElasticInferenceServiceAuthorizationModel> listener = new PlainActionFuture<>();
             authHandler.getAuthorization(listener, sender);


### PR DESCRIPTION
Backports the following commits to 8.19:
 - [Inference API] Fix auth exception listener not called bug (#139966)