### PR TITLE
[9.3] [Inference API] Fix auth exception listener not called bug (#139966)

### DIFF
--- a/docs/changelog/139966.yaml
+++ b/docs/changelog/139966.yaml
@@ -1,0 +1,5 @@
+pr: 139966
+summary: "[Inference API] Fix auth exception listener not called bug"
+area: Inference
+type: bug
+issues: []

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/authorization/ElasticInferenceServiceAuthorizationRequestHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/authorization/ElasticInferenceServiceAuthorizationRequestHandler.java
@@ -137,6 +137,7 @@ public class ElasticInferenceServiceAuthorizationRequestHandler {
         } catch (Exception e) {
             logger.warn(Strings.format("Retrieving the authorization information encountered an exception: %s", e));
             requestCompleteLatch.countDown();
+            listener.onFailure(e);
         }
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/authorization/ElasticInferenceServiceAuthorizationRequestHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/authorization/ElasticInferenceServiceAuthorizationRequestHandlerTests.java
@@ -54,7 +54,9 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -178,6 +180,36 @@ public class ElasticInferenceServiceAuthorizationRequestHandlerTests extends EST
     private void queueWebServerResponsesForRetries(String responseJson) {
         for (int i = 0; i < MAX_RETRIES; i++) {
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
+        }
+    }
+
+    public void testGetAuthorization_ReturnsFailure_WhenExceptionOccurs() throws IOException {
+        var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
+        var eisGatewayUrl = getUrl(webServer);
+
+        var exceptionToThrow = new IllegalStateException("exception");
+        var logger = mock(Logger.class);
+        doThrow(exceptionToThrow).when(logger).debug(anyString());
+
+        var authHandler = new ElasticInferenceServiceAuthorizationRequestHandler(
+            eisGatewayUrl,
+            threadPool,
+            logger,
+            createNoopApplierFactory()
+        );
+
+        try (var sender = senderFactory.createSender()) {
+            var responseData = getEisAuthorizationResponseWithMultipleEndpoints(eisGatewayUrl);
+
+            webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseData.responseJson()));
+
+            PlainActionFuture<ElasticInferenceServiceAuthorizationModel> listener = new PlainActionFuture<>();
+            authHandler.getAuthorization(listener, sender);
+
+            var exception = expectThrows(IllegalStateException.class, () -> listener.actionGet(TIMEOUT));
+            assertThat(exception, is(exceptionToThrow));
+
+            assertThat(webServer.requests().size(), is(0));
         }
     }
 


### PR DESCRIPTION
Backports the following commits to 9.3:
 - [Inference API] Fix auth exception listener not called bug (#139966)