### PR TITLE
Overall Decision for Deciders prioritizes THROTTLE

### DIFF
--- a/docs/changelog/140237.yaml
+++ b/docs/changelog/140237.yaml
@@ -1,0 +1,5 @@
+pr: 140237
+summary: Overall Decision for Deciders prioritizes THROTTLE
+area: Allocation
+type: bug
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/allocator/NonDesiredBalanceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/allocator/NonDesiredBalanceIT.java
@@ -61,7 +61,7 @@ public class NonDesiredBalanceIT extends ESIntegTestCase {
     }
 
     /**
-     * Tests that the Reconciler obeys the THROTTLE decision of a node.
+     * Tests that the non-desired balance allocator obeys the THROTTLE decision of a node.
      */
     @TestLogging(
         reason = "watch for can't move message",

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/allocator/NonDesiredBalanceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/allocator/NonDesiredBalanceIT.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.cluster.routing.allocation.allocator;
+
+import org.apache.logging.log4j.Level;
+import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteRequest;
+import org.elasticsearch.action.admin.cluster.reroute.TransportClusterRerouteAction;
+import org.elasticsearch.cluster.ClusterModule;
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
+import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugins.ClusterPlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ClusterServiceUtils;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.MockLog;
+import org.elasticsearch.test.junit.annotations.TestLogging;
+import org.junit.After;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class NonDesiredBalanceIT extends ESIntegTestCase {
+
+    private static final Set<String> NOT_PREFERRED_NODES = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    private static final Set<String> THROTTLE_NODES = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Arrays.asList(NotPreferredPlugin.class);
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal, otherSettings))
+            .put(ClusterModule.SHARDS_ALLOCATOR_TYPE_SETTING.getKey(), ClusterModule.BALANCED_ALLOCATOR)
+            .build();
+    }
+
+    @After
+    public void clearThrottleAndNotPreferredNodes() {
+        NOT_PREFERRED_NODES.clear();
+        THROTTLE_NODES.clear();
+    }
+
+    /**
+     * Tests that the Reconciler obeys the THROTTLE decision of a node.
+     */
+    @TestLogging(
+        reason = "watch for can't move message",
+        value = "org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator:TRACE"
+    )
+    public void testThrottleVsNotPreferredPriorityInDecisions() {
+        final Settings settings = Settings.builder().build();
+        final var sourceNode = internalCluster().startNode(settings);
+        final var indexName = randomIdentifier();
+        createIndex(indexName, 1, 0);
+        ensureGreen(indexName);
+        final var targetNode = internalCluster().startNode(settings);
+        final var sourceNodeID = getNodeId(sourceNode);
+        final var targetNodeID = getNodeId(targetNode);
+
+        NOT_PREFERRED_NODES.add(targetNodeID);
+        THROTTLE_NODES.add(targetNodeID);
+
+        var mapNodeIdsToNames = nodeIdsToNames();
+        final var sourceNodeName = mapNodeIdsToNames.get(sourceNodeID);
+        final var targetNodeName = mapNodeIdsToNames.get(targetNodeID);
+        assertNotNull(sourceNodeName);
+        assertNotNull(targetNodeName);
+
+        logger.info("--> Verifying the shard did not move because allocation to the target node (ID: " + targetNodeID + ") is throttled.");
+        MockLog.awaitLogger(() -> {
+            logger.info(
+                "--> Excluding shard assignment to node "
+                    + sourceNodeName
+                    + "(ID: "
+                    + sourceNodeID
+                    + ") to force its shard to move to node "
+                    + targetNodeName
+                    + "(ID: "
+                    + targetNodeID
+                    + ")"
+            );
+            updateClusterSettings(Settings.builder().put("cluster.routing.allocation.exclude._name", sourceNodeName));
+        },
+            BalancedShardsAllocator.class,
+            new MockLog.SeenEventExpectation(
+                "unable to relocate shard due to throttling",
+                BalancedShardsAllocator.class.getCanonicalName(),
+                Level.TRACE,
+                "[[*]][0] can't move: [MoveDecision{canMoveDecision=throttled, canRemainDecision=NO(), *}]"
+            )
+        );
+
+        logger.info("--> Clearing THROTTLE decider response and prodding the Reconciler (with a reroute request) to try again");
+        clearThrottleAndNotPreferredNodes();
+
+        safeGet(
+            client().execute(TransportClusterRerouteAction.TYPE, new ClusterRerouteRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT))
+        );
+
+        safeAwait(
+            ClusterServiceUtils.addMasterTemporaryStateListener(
+                state -> state.routingTable(ProjectId.DEFAULT)
+                    .index(indexName)
+                    .allShards()
+                    .flatMap(IndexShardRoutingTable::allShards)
+                    .allMatch(shardRouting -> shardRouting.currentNodeId().equals(targetNodeID) && shardRouting.started())
+            )
+        );
+    }
+
+    public static class NotPreferredPlugin extends Plugin implements ClusterPlugin {
+        @Override
+        public Collection<AllocationDecider> createAllocationDeciders(Settings settings, ClusterSettings clusterSettings) {
+
+            return List.of(new AllocationDecider() {
+                @Override
+                public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+                    return NOT_PREFERRED_NODES.contains(node.nodeId()) ? Decision.NOT_PREFERRED : Decision.YES;
+                }
+            }, new AllocationDecider() {
+                @Override
+                public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+                    // THROTTLING is not returned in simulation, so only THROTTLE for real moves in the Reconciler.
+                    return (THROTTLE_NODES.contains(node.nodeId()) && allocation.isSimulating() == false)
+                        ? Decision.THROTTLE
+                        : Decision.YES;
+                }
+            });
+        }
+    }
+}

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/allocator/ReconcilerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/allocator/ReconcilerIT.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.cluster.routing.allocation.allocator;
+
+import org.apache.logging.log4j.Level;
+import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteRequest;
+import org.elasticsearch.action.admin.cluster.reroute.TransportClusterRerouteAction;
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
+import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugins.ClusterPlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ClusterServiceUtils;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.MockLog;
+import org.elasticsearch.test.junit.annotations.TestLogging;
+import org.junit.After;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class ReconcilerIT extends ESIntegTestCase {
+
+    private static final Set<String> NOT_PREFERRED_NODES = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    private static final Set<String> THROTTLE_NODES = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Arrays.asList(NotPreferredPlugin.class);
+    }
+
+    @After
+    public void clearThrottleAndNotPreferredNodes() {
+        NOT_PREFERRED_NODES.clear();
+        THROTTLE_NODES.clear();
+    }
+
+    /**
+     * Tests that the Reconciler obeys the THROTTLE decision of a node.
+     */
+    @TestLogging(
+        reason = "track when Reconciler decisions",
+        value = "org.elasticsearch.cluster.routing.allocation.allocator.DesiredBalanceReconciler:TRACE"
+    )
+    public void testThrottleVsNotPreferredPriorityInDecisions() {
+        final Settings settings = Settings.builder().build();
+        final var sourceNode = internalCluster().startNode(settings);
+        final var indexName = randomIdentifier();
+        createIndex(indexName, 1, 0);
+        ensureGreen(indexName);
+        final var targetNode = internalCluster().startNode(settings);
+        final var sourceNodeID = getNodeId(sourceNode);
+        final var targetNodeID = getNodeId(targetNode);
+
+        NOT_PREFERRED_NODES.add(targetNodeID);
+        THROTTLE_NODES.add(targetNodeID);
+
+        var mapNodeIdsToNames = nodeIdsToNames();
+        final var sourceNodeName = mapNodeIdsToNames.get(sourceNodeID);
+        final var targetNodeName = mapNodeIdsToNames.get(targetNodeID);
+        assertNotNull(sourceNodeName);
+        assertNotNull(targetNodeName);
+
+        logger.info("--> Verifying the shard did not move because allocation to the target node (ID: " + targetNodeID + ") is throttled.");
+        MockLog.awaitLogger(() -> {
+            logger.info(
+                "--> Excluding shard assignment to node "
+                    + sourceNodeName
+                    + "(ID: "
+                    + sourceNodeID
+                    + ") to force its shard to move to node "
+                    + targetNodeName
+                    + "(ID: "
+                    + targetNodeID
+                    + ")"
+            );
+            updateClusterSettings(Settings.builder().put("cluster.routing.allocation.exclude._name", sourceNodeName));
+        },
+            DesiredBalanceReconciler.class,
+            new MockLog.SeenEventExpectation(
+                "unable to relocate shard that can no longer remain",
+                DesiredBalanceReconciler.class.getCanonicalName(),
+                Level.TRACE,
+                "Cannot move shard * and cannot remain because of [NO()]"
+            )
+        );
+
+        logger.info("--> Clearing THROTTLE decider response and prodding the Reconciler (with a reroute request) to try again");
+        clearThrottleAndNotPreferredNodes();
+
+        safeGet(
+            client().execute(TransportClusterRerouteAction.TYPE, new ClusterRerouteRequest(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT))
+        );
+
+        safeAwait(
+            ClusterServiceUtils.addMasterTemporaryStateListener(
+                state -> state.routingTable(ProjectId.DEFAULT)
+                    .index(indexName)
+                    .allShards()
+                    .flatMap(IndexShardRoutingTable::allShards)
+                    .allMatch(shardRouting -> shardRouting.currentNodeId().equals(targetNodeID) && shardRouting.started())
+            )
+        );
+    }
+
+    public static class NotPreferredPlugin extends Plugin implements ClusterPlugin {
+        @Override
+        public Collection<AllocationDecider> createAllocationDeciders(Settings settings, ClusterSettings clusterSettings) {
+
+            return List.of(new AllocationDecider() {
+                @Override
+                public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+                    return NOT_PREFERRED_NODES.contains(node.nodeId()) ? Decision.NOT_PREFERRED : Decision.YES;
+                }
+            }, new AllocationDecider() {
+                @Override
+                public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
+                    // THROTTLING is not returned in simulation, so only THROTTLE for real moves in the Reconciler.
+                    return (THROTTLE_NODES.contains(node.nodeId()) && allocation.isSimulating() == false)
+                        ? Decision.THROTTLE
+                        : Decision.YES;
+                }
+            });
+        }
+    }
+}

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/allocator/ReconcilerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/allocator/ReconcilerIT.java
@@ -39,18 +39,16 @@ import java.util.concurrent.ConcurrentHashMap;
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
 public class ReconcilerIT extends ESIntegTestCase {
 
-    private static final Set<String> NOT_PREFERRED_NODES = Collections.newSetFromMap(new ConcurrentHashMap<>());
-    private static final Set<String> THROTTLE_NODES = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    private static final Set<String> NOT_PREFERRED_AND_THROTTLED_NODES = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return Arrays.asList(NotPreferredPlugin.class);
+        return Arrays.asList(NotPreferredAndThrottledPlugin.class);
     }
 
     @After
     public void clearThrottleAndNotPreferredNodes() {
-        NOT_PREFERRED_NODES.clear();
-        THROTTLE_NODES.clear();
+        NOT_PREFERRED_AND_THROTTLED_NODES.clear();
     }
 
     /**
@@ -70,8 +68,7 @@ public class ReconcilerIT extends ESIntegTestCase {
         final var sourceNodeID = getNodeId(sourceNode);
         final var targetNodeID = getNodeId(targetNode);
 
-        NOT_PREFERRED_NODES.add(targetNodeID);
-        THROTTLE_NODES.add(targetNodeID);
+        NOT_PREFERRED_AND_THROTTLED_NODES.add(targetNodeID);
 
         var mapNodeIdsToNames = nodeIdsToNames();
         final var sourceNodeName = mapNodeIdsToNames.get(sourceNodeID);
@@ -121,20 +118,20 @@ public class ReconcilerIT extends ESIntegTestCase {
         );
     }
 
-    public static class NotPreferredPlugin extends Plugin implements ClusterPlugin {
+    public static class NotPreferredAndThrottledPlugin extends Plugin implements ClusterPlugin {
         @Override
         public Collection<AllocationDecider> createAllocationDeciders(Settings settings, ClusterSettings clusterSettings) {
 
             return List.of(new AllocationDecider() {
                 @Override
                 public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
-                    return NOT_PREFERRED_NODES.contains(node.nodeId()) ? Decision.NOT_PREFERRED : Decision.YES;
+                    return NOT_PREFERRED_AND_THROTTLED_NODES.contains(node.nodeId()) ? Decision.NOT_PREFERRED : Decision.YES;
                 }
             }, new AllocationDecider() {
                 @Override
                 public Decision canAllocate(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
                     // THROTTLING is not returned in simulation, so only THROTTLE for real moves in the Reconciler.
-                    return (THROTTLE_NODES.contains(node.nodeId()) && allocation.isSimulating() == false)
+                    return (NOT_PREFERRED_AND_THROTTLED_NODES.contains(node.nodeId()) && allocation.isSimulating() == false)
                         ? Decision.THROTTLE
                         : Decision.YES;
                 }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -1570,14 +1570,16 @@ public class BalancedShardsAllocator implements ShardsAllocator {
                         continue;
                     }
 
-                    assert rebalanceDecision.type() != Type.NOT_PREFERRED
-                        : "if this changes, we'll have to consider what comparison to use";
-                    final Decision.Type canAllocateOrRebalance = Decision.Type.min(allocationDecision.type(), rebalanceDecision.type());
+                    assert rebalanceDecision.type() == Type.YES || rebalanceDecision.type() == Type.THROTTLE
+                        : "We should only see YES/THROTTLE decisions here";
+                    assert allocationDecision.type() == Type.YES || allocationDecision.type() == Type.THROTTLE
+                        : "We should only see YES/THROTTLE decisions here";
+                    final Decision.Type canAllocateOrRebalance = allocationDecision.type() == Type.THROTTLE
+                        || rebalanceDecision.type() == Type.THROTTLE ? Type.THROTTLE : Type.YES;
 
                     maxNode.removeShard(projectIndex(shard), shard);
                     long shardSize = allocation.clusterInfo().getShardSize(shard, ShardRouting.UNAVAILABLE_EXPECTED_SHARD_SIZE);
 
-                    assert canAllocateOrRebalance == Type.YES || canAllocateOrRebalance == Type.THROTTLE : canAllocateOrRebalance;
                     logger.debug(
                         "decision [{}]: relocate [{}] from [{}] to [{}]",
                         canAllocateOrRebalance,

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -530,12 +530,12 @@ public class BalancedShardsAllocator implements ShardsAllocator {
                     // if the simulated weight delta with the shard moved away is better than the weight delta
                     // with the shard remaining on the current node, and we are allowed to allocate to the
                     // node in question, then allow the rebalance
-                    if (rebalanceConditionsMet && canAllocate.type().isBetterAcrossNodes(bestRebalanceCanAllocateDecisionType)) {
+                    if (rebalanceConditionsMet && canAllocate.type().compareToBetweenNodes(bestRebalanceCanAllocateDecisionType) > 0) {
                         // Overwrite the best decision since it is better than the last. This means that YES/THROTTLE decisions will replace
                         // NOT_PREFERRED/NO decisions, and a YES decision will replace a THROTTLE decision. NOT_PREFERRED will also replace
                         // NO, even if neither are acted upon for rebalancing, for allocation explain purposes.
                         bestRebalanceCanAllocateDecisionType = canAllocate.type();
-                        if (canAllocate.type().isBetterAcrossNodes(Type.NOT_PREFERRED)) {
+                        if (canAllocate.type().compareToBetweenNodes(Type.NOT_PREFERRED) > 0) {
                             // Movement is only allowed to THROTTLE/YES nodes. NOT_PREFERRED is the same as no for rebalancing, since
                             // rebalancing aims to distribute resource usage and NOT_PREFERRED means the move could cause hot-spots.
                             targetNode = node;
@@ -1053,7 +1053,7 @@ public class BalancedShardsAllocator implements ShardsAllocator {
                         // Relocating a shard from one NOT_PREFERRED node to another NOT_PREFERRED node would not improve the situation.
                         continue;
                     }
-                    if (allocationDecision.type().isBetterAcrossNodes(bestDecision)) {
+                    if (allocationDecision.type().compareToBetweenNodes(bestDecision) > 0) {
                         bestDecision = allocationDecision.type();
                         if (bestDecision == Type.YES) {
                             targetNode = target;

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java
@@ -530,6 +530,14 @@ public class DesiredBalanceReconciler {
                         iterator.dePrioritizeNode(shardRouting.currentNodeId());
                         moveOrdering.recordAllocation(shardRouting.currentNodeId());
                         movedUndesiredShard = true;
+                    } else {
+                        logger.trace(
+                            "Cannot move shard [{}][{}] away from {}, and cannot remain because of [{}]",
+                            shardRouting.index(),
+                            shardRouting.shardId(),
+                            shardRouting.currentNodeId(),
+                            canRemainDecision
+                        );
                     }
                 } finally {
                     if (movedUndesiredShard) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDeciders.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDeciders.java
@@ -208,7 +208,7 @@ public class AllocationDeciders {
             Decision mostNegativeDecision = Decision.YES;
             for (AllocationDecider decider : deciders) {
                 var decision = deciderAction.apply(decider);
-                if (decision.type().isWorseForTheSameNode(mostNegativeDecision.type())) {
+                if (decision.type().compareToBetweenDecisions(mostNegativeDecision.type()) < 0) {
                     mostNegativeDecision = decision;
                     if (mostNegativeDecision.type() == Decision.Type.NO) {
                         traceNoDecisions(decider, decision, logMessageCreator);

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDeciders.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDeciders.java
@@ -205,19 +205,19 @@ public class AllocationDeciders {
         BiFunction<String, Decision, String> logMessageCreator
     ) {
         if (debugMode == RoutingAllocation.DebugMode.OFF) {
-            Decision worstDecision = Decision.YES;
+            Decision mostNegativeDecision = Decision.YES;
             for (AllocationDecider decider : deciders) {
-                var newDecision = deciderAction.apply(decider);
-                if (newDecision.type().isWorseForTheSameNode(worstDecision.type())) {
-                    worstDecision = newDecision;
-                    if (worstDecision.type() == Decision.Type.NO) {
-                        traceNoDecisions(decider, newDecision, logMessageCreator);
+                var decision = deciderAction.apply(decider);
+                if (decision.type().isWorseForTheSameNode(mostNegativeDecision.type())) {
+                    mostNegativeDecision = decision;
+                    if (mostNegativeDecision.type() == Decision.Type.NO) {
+                        traceNoDecisions(decider, decision, logMessageCreator);
                         break;
                     }
                 }
             }
 
-            return worstDecision;
+            return mostNegativeDecision;
         } else {
             final var multiDecision = new Decision.Multi();
             for (AllocationDecider decider : deciders) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDeciders.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDeciders.java
@@ -208,7 +208,7 @@ public class AllocationDeciders {
             Decision mostNegativeDecision = Decision.YES;
             for (AllocationDecider decider : deciders) {
                 var decision = deciderAction.apply(decider);
-                if (decision.type().compareToBetweenDecisions(mostNegativeDecision.type()) < 0) {
+                if (mostNegativeDecision.type().compareToBetweenDecisions(decision.type()) > 0) {
                     mostNegativeDecision = decision;
                     if (mostNegativeDecision.type() == Decision.Type.NO) {
                         traceNoDecisions(decider, decision, logMessageCreator);

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DecisionTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DecisionTests.java
@@ -54,7 +54,9 @@ public class DecisionTests extends ESTestCase {
     }
 
     public void testTypeHigherThan() {
-        assertTrue(YES.higherThan(THROTTLE) && THROTTLE.higherThan(NOT_PREFERRED) && NOT_PREFERRED.higherThan(NO));
+        assertTrue(
+            YES.isBetterAcrossNodes(THROTTLE) && THROTTLE.isBetterAcrossNodes(NOT_PREFERRED) && NOT_PREFERRED.isBetterAcrossNodes(NO)
+        );
     }
 
     public void testTypeAllowed() {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DecisionTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DecisionTests.java
@@ -100,6 +100,19 @@ public class DecisionTests extends ESTestCase {
         testReadWriteEnum(NO, OriginalType.class, OriginalType.NO, TransportVersion.minimumCompatible());
     }
 
+    public void testMultiPrioritisation() {
+        assertEffectiveDecision(NO, Decision.NO, Decision.THROTTLE, Decision.NOT_PREFERRED, Decision.YES);
+        assertEffectiveDecision(THROTTLE, Decision.THROTTLE, Decision.NOT_PREFERRED, Decision.YES);
+        assertEffectiveDecision(NOT_PREFERRED, Decision.NOT_PREFERRED, Decision.YES);
+        assertEffectiveDecision(YES, Decision.YES);
+        assertEffectiveDecision(YES);
+    }
+
+    private void assertEffectiveDecision(Decision.Type effectiveDecision, Decision.Single... decisions) {
+        final var multi = new Decision.Multi(shuffledList(List.of(decisions)));
+        assertEquals(effectiveDecision, multi.type());
+    }
+
     /**
      * Test the reading and writing of an enum to a specific transport version (assuming lossless roundtrip)
      *

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DecisionTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DecisionTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.EnumSerializationTestUtils;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.elasticsearch.cluster.routing.allocation.decider.Decision.Type.ALLOCATION_DECISION_NOT_PREFERRED;
@@ -24,6 +25,7 @@ import static org.elasticsearch.cluster.routing.allocation.decider.Decision.Type
 import static org.elasticsearch.cluster.routing.allocation.decider.Decision.Type.NOT_PREFERRED;
 import static org.elasticsearch.cluster.routing.allocation.decider.Decision.Type.THROTTLE;
 import static org.elasticsearch.cluster.routing.allocation.decider.Decision.Type.YES;
+import static org.hamcrest.Matchers.equalTo;
 
 /**
  * A class for unit testing the {@link Decision} class.
@@ -53,9 +55,14 @@ public class DecisionTests extends ESTestCase {
         EnumSerializationTestUtils.assertEnumSerialization(Type.class, NO, NOT_PREFERRED, THROTTLE, YES);
     }
 
-    public void testTypeHigherThan() {
-        assertTrue(
-            YES.isBetterAcrossNodes(THROTTLE) && THROTTLE.isBetterAcrossNodes(NOT_PREFERRED) && NOT_PREFERRED.isBetterAcrossNodes(NO)
+    public void testTypeComparisonOrder() {
+        assertThat(
+            shuffledList(Arrays.asList(Type.values())).stream().sorted(Type::compareToBetweenDecisions).toList(),
+            equalTo(List.of(NO, THROTTLE, NOT_PREFERRED, YES))
+        );
+        assertThat(
+            shuffledList(Arrays.asList(Type.values())).stream().sorted(Type::compareToBetweenNodes).toList(),
+            equalTo(List.of(NO, NOT_PREFERRED, THROTTLE, YES))
         );
     }
 


### PR DESCRIPTION
Fixing a bug where AllocationDeciders could summarize
AllocationDecider responses as NOT_PREFERRED, which allows shard
movement, when an AllocationDecider responded THROTTLE.

Relates ES-13903