### PR TITLE
allocation: unmute failed decider test that was fixed elsewhere

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -303,9 +303,6 @@ tests:
 - class: org.elasticsearch.xpack.ilm.actions.DownsampleActionIT
   method: testILMWaitsForTimeSeriesEndTimeToLapse
   issue: https://github.com/elastic/elasticsearch/issues/138843
-- class: org.elasticsearch.cluster.routing.allocation.WriteLoadConstraintMonitorTests
-  method: testRerouteIsNotCalledWhenNoNodesAreHotSpotting
-  issue: https://github.com/elastic/elasticsearch/issues/138924
 - class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
   method: testStopLookback_closeJobFalse
   issue: https://github.com/elastic/elasticsearch/issues/139024


### PR DESCRIPTION
The write load constraint decider test, as originally written, had a threshold error when creating a node that was not hotspotting: roughly one in three thousand nodes would accidentally receive a metric that would test as hot. This was already fixed in issue #139161.

Fixes: #138924
