### PR TITLE
Relax `SnapshotRepoTestKitClientYamlTestSuiteIT`

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -93,9 +93,6 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=transform/transforms_start_stop/Test start/stop only starts/stops specified transform}
   issue: https://github.com/elastic/elasticsearch/issues/126466
-- class: org.elasticsearch.repositories.blobstore.testkit.rest.SnapshotRepoTestKitClientYamlTestSuiteIT
-  method: test {p0=/10_analyze/Analysis without details}
-  issue: https://github.com/elastic/elasticsearch/issues/126569
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=transform/transforms_start_stop/Test start/stop/start continuous transform}
   issue: https://github.com/elastic/elasticsearch/issues/126755

--- a/x-pack/plugin/snapshot-repo-test-kit/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/10_analyze.yml
+++ b/x-pack/plugin/snapshot-repo-test-kit/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/10_analyze.yml
@@ -79,14 +79,19 @@ setup:
   - is_true: delete_elapsed
   - gte: { listing_elapsed_nanos: 0}
   - gte: { delete_elapsed_nanos:  0}
-  - match: { summary.write.count: 10}
+
+  # We rarely perform a copy instead of a proper write and copies are not counted here so we cannot expect to see ≥10.
+  # In theory every blob could be copied, halving the total to 5 (although that would be extraordinarily unlikely)
+  # This is a bug, fixed by #140086 from 9.4 onwards, but in earlier branches we just weaken the test:
+  - gte: { summary.write.count: 5 }
+  - gte: { summary.read.count: 5 }
+
   - gte: { summary.write.total_size_bytes: 0}
   - is_true: summary.write.total_size
   - gte: { summary.write.total_throttled_nanos: 0}
   - is_true: summary.write.total_throttled
   - gte: { summary.write.total_elapsed_nanos: 0}
   - is_true: summary.write.total_elapsed
-  - gte: { summary.read.count: 10}
   - gte: { summary.read.total_size_bytes: 0}
   - is_true: summary.read.total_size
   - gte: { summary.read.total_wait_nanos: 0}


### PR DESCRIPTION
We introduced a bug in #125737 where the repo analyzer didn't count
copies as writes, leading to an occasional under-count in this test.
Fixed properly in #140086 but this depends on other bigger changes to
the analyzer. In earlier branches we relax the test.

Closes #126569