### PR TITLE
[8.19] Add busy assertion to avoid race condition for testStalledShardMigrationProperlyDetected (#140230)

### DIFF
--- a/x-pack/plugin/shutdown/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownIT.java
+++ b/x-pack/plugin/shutdown/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownIT.java
@@ -325,7 +325,7 @@ public class NodeShutdownIT extends ESRestTestCase {
 
         // Mark the node for shutdown
         putNodeShutdown(nodeIdToShutdown, "remove");
-        {
+        assertBusy(() -> {
             // Now check the shard migration status
             Request getStatusRequest = new Request("GET", "_nodes/" + nodeIdToShutdown + "/shutdown");
             Response statusResponse = client().performRequest(getStatusRequest);
@@ -340,7 +340,7 @@ public class NodeShutdownIT extends ESRestTestCase {
                 )
             );
             assertThat(ObjectPath.eval("nodes.0.shard_migration.node_allocation_decision", status), notNullValue());
-        }
+        });
 
         // Now update the allocation requirements to unblock shard relocation
         Request updateSettingsRequest = new Request("PUT", indexName + "/_settings");


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Add busy assertion to avoid race condition for testStalledShardMigrationProperlyDetected (#140230)