### PR TITLE
Drop `project_routing` from query params in rest-api-spec

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.count.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.count.json
@@ -54,10 +54,6 @@
         "description": "Return help information",
         "default": false
       },
-      "project_routing": {
-        "type": "string",
-        "description": "A Lucene query using project metadata tags to limit which projects to search, such as _alias:_origin or _alias:*pr*. Only supported in serverless."
-      },
       "s": {
         "type": "list",
         "description": "Comma-separated list of column names or column aliases to sort by"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/count.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/count.json
@@ -78,10 +78,6 @@
         "type": "string",
         "description": "Specify the node or shard the operation should be performed on (default: random)"
       },
-      "project_routing": {
-        "type": "string",
-        "description": "A Lucene query using project metadata tags to limit which projects to search, such as _alias:_origin or _alias:*pr*. Only supported in serverless."
-      },
       "routing": {
         "type": "list",
         "description": "A comma-separated list of specific routing values"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/eql.search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/eql.search.json
@@ -82,10 +82,6 @@
         ],
         "default": "open",
         "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both."
-      },
-      "project_routing": {
-        "type": "string",
-        "description": "A Lucene query using project metadata tags to limit which projects to search, such as _alias:_origin or _alias:*pr*. Only supported in serverless."
       }
     },
     "body": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/field_caps.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/field_caps.json
@@ -82,10 +82,6 @@
         "type": "boolean",
         "default": true,
         "description": "Include empty fields in result"
-      },
-      "project_routing": {
-        "type": "string",
-        "description": "A Lucene query using project metadata tags to limit which projects to search, such as _alias:_origin or _alias:*pr*. Only supported in serverless."
       }
     },
     "body": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.resolve_index.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.resolve_index.json
@@ -59,10 +59,6 @@
           "lookup"
         ],
         "description": "Filter indices by index mode. Comma-separated list of IndexMode. Empty means no filter."
-      },
-      "project_routing": {
-        "type": "string",
-        "description": "A Lucene query using project metadata tags to limit which projects to search, such as _alias:_origin or _alias:*pr*. Only supported in serverless."
       }
     }
   }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/open_point_in_time.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/open_point_in_time.json
@@ -70,10 +70,6 @@
         "type": "int",
         "description": "The number of concurrent shard requests per node executed concurrently when opening this point-in-time. This value should be used to limit the impact of opening the point-in-time on the cluster",
         "default": 5
-      },
-      "project_routing": {
-        "type": "string",
-        "description": "A Lucene query using project metadata tags to limit which projects to search, such as _alias:_origin or _alias:*pr*. Only supported in serverless."
       }
     },
     "body": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_mvt.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_mvt.json
@@ -82,10 +82,6 @@
         "description": "Aggregation used to create a grid for `field`.",
         "default": "geotile"
       },
-      "project_routing": {
-        "type": "string",
-        "description": "A Lucene query using project metadata tags to limit which projects to search, such as _alias:_origin or _alias:*pr*. Only supported in serverless."
-      },
       "size": {
         "type": "int",
         "description": "Maximum number of features to return in the hits layer. Accepts 0-10000.",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_template.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_template.json
@@ -114,10 +114,6 @@
         "type": "boolean",
         "description": "Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution",
         "default": true
-      },
-      "project_routing": {
-        "type": "string",
-        "description": "A Lucene query using project metadata tags to limit which projects to search, such as _alias:_origin or _alias:*pr*. Only supported in serverless."
       }
     },
     "body": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/sql.query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/sql.query.json
@@ -38,10 +38,6 @@
           "cbor",
           "smile"
         ]
-      },
-      "project_routing": {
-        "type": "string",
-        "description": "A Lucene query using project metadata tags to limit which projects to search, such as _alias:_origin or _alias:*pr*. Only supported in serverless."
       }
     },
     "body": {


### PR DESCRIPTION
`project_routing` was previously added in https://github.com/elastic/elasticsearch/pull/134741. Later, the decision was made not to allow it as a query parameter (except for multisearch requests), and its corresponding ES-side changes were implemented. However, these REST API specifications were never updated. This PR fixes it.