### PR TITLE
Update network.asciidoc

### DIFF
--- a/docs/reference/modules/network.asciidoc
+++ b/docs/reference/modules/network.asciidoc
@@ -290,8 +290,6 @@ include::network/threading.asciidoc[]
 [[readiness-tcp-port]]
 ==== TCP readiness port
 
-preview::[]
-
 If configured, a node can open a TCP port when the node is in a ready state. A node is deemed
 ready when it has successfully joined a cluster. In a single node configuration, the node is
 said to be ready, when it's able to accept requests.


### PR DESCRIPTION
TCP readiness port has been implemented in ECK since version 2.14.0 an since v8.2.0,  the warning about tech preview is out of sync and incorrect.

See ref 
- [TCP readiness port](https://www.elastic.co/docs/reference/elasticsearch/configuration-reference/networking-settings)
- [2.14.0 release highlights ECK](https://www.elastic.co/guide/en/cloud-on-k8s/2.16/release-highlights-2.14.0.html#k8s-2140-advanced-readiness-probe)
- [ECK docs readiness probe](https://www.elastic.co/docs/deploy-manage/deploy/cloud-on-k8s/readiness-probe#k8s_elasticsearch_versions_8_2_0_and_later)

