### PR TITLE
[9.2] Fix ST_DISTANCE handling of invalid geometry literals that fold to null (#140116) (#140265)

### DIFF
--- a/docs/changelog/140116.yaml
+++ b/docs/changelog/140116.yaml
@@ -1,0 +1,6 @@
+pr: 140116
+summary: Fix ST_DISTANCE handling of invalid geometry literals that fold to null
+area: ES|QL
+type: bug
+issues:
+ - 138594

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial.csv-spec
@@ -1922,6 +1922,167 @@ wkt:keyword                               |pt:geo_point
 ;
 
 ###############################################
+# Tests for bug with literals that evaluate to null
+# (due to inner geometry parsing errors)
+# in ST_DISTANCE, ST_INTERSECTS, ST_DISJOINT, ST_CONTAINS, ST_WITHIN
+# Reported in https://github.com/elastic/elasticsearch/issues/138594
+#
+
+airportsDistanceGreaterThanInvalidPoint3
+required_capability: geo_null_literals_folding
+
+FROM airports
+| EVAL distance = ST_DISTANCE(TO_GEOPOINT(MV_SLICE(["POINT(-28.6359 153.5906)"], 0, 0)), location)
+| KEEP distance, location, name, scalerank
+| WHERE distance > 500 AND scalerank < 6
+| STATS count = COUNT()
+;
+
+warning:Line 2:31: evaluation of [TO_GEOPOINT(MV_SLICE([\"POINT(-28.6359 153.5906)\"], 0, 0))] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:31: java.lang.IllegalArgumentException: Failed to parse WKT: invalid latitude 153.5906; must be between -90.0 and 90.0
+
+count:l
+0
+;
+
+distancePointsLiteralMvSlice
+required_capability: st_distance
+
+ROW point = MV_SLICE(["POINT(0 0)"], 0, 0)::geo_point
+| EVAL distance = ST_DISTANCE(point, point)
+;
+
+point:geo_point | distance:double
+POINT(0 0)      | 0.0
+;
+
+distancePointsLiteralMvSliceInvalid
+required_capability: geo_null_literals_folding
+
+ROW point = MV_SLICE(["POINT(0)"], 0, 0)::geo_point
+| EVAL d1 = ST_DISTANCE(point, point)
+| EVAL d2 = ST_DISTANCE(point, "POINT(0 0)"::geo_point)
+| EVAL d3 = ST_DISTANCE("POINT(0 0)"::geo_point, point)
+| EVAL d4 = ST_DISTANCE("POINT(0 0)"::geo_point, "POINT(0 0)"::geo_point)
+;
+
+warning:Line 1:13: evaluation of [MV_SLICE([\"POINT(0)\"], 0, 0)::geo_point] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 1:13: java.lang.IllegalArgumentException: Failed to parse WKT: expected number but found: ')'
+
+point:geo_point | d1:double | d2:double | d3:double | d4:double
+null            | null      | null      | null      | 0.0
+;
+
+airportsIntersectsInvalidShapeLiteralMvSlice
+required_capability: geo_null_literals_folding
+
+FROM airports
+| WHERE ST_INTERSECTS(TO_GEOSHAPE(MV_SLICE(["POINT(-28.6359 153.5906)"], 0, 0)), location)
+| STATS count = COUNT()
+;
+
+warning:Line 2:23: evaluation of [TO_GEOSHAPE(MV_SLICE([\"POINT(-28.6359 153.5906)\"], 0, 0))] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:23: java.lang.IllegalArgumentException: Failed to parse WKT: invalid latitude 153.5906; must be between -90.0 and 90.0
+
+count:l
+0
+;
+
+airportsEvalIntersectsInvalidShapeLiteralMvSlice
+required_capability: geo_null_literals_folding
+
+FROM airports
+| EVAL intersects = ST_INTERSECTS(TO_GEOSHAPE(MV_SLICE(["POINT(-28.6359 153.5906)"], 0, 0)), location)
+| STATS count = COUNT() BY intersects
+;
+
+warning:Line 2:35: evaluation of [TO_GEOSHAPE(MV_SLICE([\"POINT(-28.6359 153.5906)\"], 0, 0))] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 2:35: java.lang.IllegalArgumentException: Failed to parse WKT: invalid latitude 153.5906; must be between -90.0 and 90.0
+
+count:l | intersects:boolean
+891     | null
+;
+
+intersectsPointsLiteralMvSlice
+required_capability: st_intersects
+
+ROW point = MV_SLICE(["POINT(0 0)"], 0, 0)::geo_point
+| EVAL intersects = ST_INTERSECTS(point, point)
+;
+
+point:geo_point | intersects:boolean
+POINT(0 0)      | true
+;
+
+intersectsPointsLiteralMvSliceInvalid
+required_capability: geo_null_literals_folding
+
+ROW point = MV_SLICE(["POINT(0)"], 0, 0)::geo_point
+| EVAL a = ST_INTERSECTS(point, point)
+| EVAL b = ST_INTERSECTS(point, "POINT(0 0)"::geo_point)
+| EVAL c = ST_INTERSECTS("POINT(0 0)"::geo_point, point)
+| EVAL d = ST_INTERSECTS("POINT(0 0)"::geo_point, "POINT(0 0)"::geo_point)
+;
+
+warning:Line 1:13: evaluation of [MV_SLICE([\"POINT(0)\"], 0, 0)::geo_point] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 1:13: java.lang.IllegalArgumentException: Failed to parse WKT: expected number but found: ')'
+
+point:geo_point | a:boolean | b:boolean | c:boolean | d:boolean
+null            | null      | null      | null      | true
+;
+
+disjointPointsLiteralMvSliceInvalid
+required_capability: geo_null_literals_folding
+
+ROW point = MV_SLICE(["POINT(0)"], 0, 0)::geo_point
+| EVAL a = ST_DISJOINT(point, point)
+| EVAL b = ST_DISJOINT(point, "POINT(0 0)"::geo_point)
+| EVAL c = ST_DISJOINT("POINT(0 0)"::geo_point, point)
+| EVAL d = ST_DISJOINT("POINT(0 0)"::geo_point, "POINT(0 0)"::geo_point)
+;
+
+warning:Line 1:13: evaluation of [MV_SLICE([\"POINT(0)\"], 0, 0)::geo_point] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 1:13: java.lang.IllegalArgumentException: Failed to parse WKT: expected number but found: ')'
+
+point:geo_point | a:boolean | b:boolean | c:boolean | d:boolean
+null            | null      | null      | null      | false
+;
+
+containsPointsLiteralMvSliceInvalid
+required_capability: geo_null_literals_folding
+
+ROW point = MV_SLICE(["POINT(0)"], 0, 0)::geo_point
+| EVAL a = ST_CONTAINS(point, point)
+| EVAL b = ST_CONTAINS(point, "POINT(0 0)"::geo_point)
+| EVAL c = ST_CONTAINS("POINT(0 0)"::geo_point, point)
+| EVAL d = ST_CONTAINS("POINT(0 0)"::geo_point, "POINT(0 0)"::geo_point)
+;
+
+warning:Line 1:13: evaluation of [MV_SLICE([\"POINT(0)\"], 0, 0)::geo_point] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 1:13: java.lang.IllegalArgumentException: Failed to parse WKT: expected number but found: ')'
+
+point:geo_point | a:boolean | b:boolean | c:boolean | d:boolean
+null            | null      | null      | null      | true
+;
+
+withinPointsLiteralMvSliceInvalid
+required_capability: geo_null_literals_folding
+
+ROW point = MV_SLICE(["POINT(0)"], 0, 0)::geo_point
+| EVAL a = ST_WITHIN(point, point)
+| EVAL b = ST_WITHIN(point, "POINT(0 0)"::geo_point)
+| EVAL c = ST_WITHIN("POINT(0 0)"::geo_point, point)
+| EVAL d = ST_WITHIN("POINT(0 0)"::geo_point, "POINT(0 0)"::geo_point)
+;
+
+warning:Line 1:13: evaluation of [MV_SLICE([\"POINT(0)\"], 0, 0)::geo_point] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 1:13: java.lang.IllegalArgumentException: Failed to parse WKT: expected number but found: ')'
+
+point:geo_point | a:boolean | b:boolean | c:boolean | d:boolean
+null            | null      | null      | null      | true
+;
+
+###############################################
 # Tests for CARTESIAN_POINT type
 ###############################################
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -59,6 +59,11 @@ public class EsqlCapabilities {
         GEO_VALIDATION,
 
         /**
+         * Fold in spatial functions should return null for null input.
+         */
+        GEO_NULL_LITERALS_FOLDING,
+
+        /**
          * Support for spatial aggregation {@code ST_CENTROID}. Done in #104269.
          */
         ST_CENTROID_AGG,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialContains.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialContains.java
@@ -78,7 +78,7 @@ public class SpatialContains extends SpatialRelatesFunction {
      * We override the normal behaviour for CONTAINS because we need to test each component separately.
      * This applies to multi-component geometries (MultiPolygon, etc.) as well as polygons that cross the dateline.
      */
-    static final class SpatialRelationsContains extends SpatialRelations {
+    protected static final class SpatialRelationsContains extends SpatialRelations {
 
         SpatialRelationsContains(SpatialCoordinateTypes spatialCoordinateType, CoordinateEncoder encoder, ShapeIndexer shapeIndexer) {
             super(ShapeField.QueryRelation.CONTAINS, spatialCoordinateType, encoder, shapeIndexer);
@@ -216,14 +216,24 @@ public class SpatialContains extends SpatialRelatesFunction {
     }
 
     @Override
+    protected SpatialRelationsContains getSpatialRelations() {
+        return crsType() == SpatialCrsType.GEO ? GEO : CARTESIAN;
+    }
+
+    /**
+     * Contains needs to evaluate each component of the right geometry separately,
+     * so we override the fold method from the parent SpatialRelatesFunction.
+     */
+    @Override
     public Object fold(FoldContext ctx) {
         try {
             GeometryDocValueReader docValueReader = asGeometryDocValueReader(ctx, crsType(), left());
             Geometry rightGeom = makeGeometryFromLiteral(ctx, right());
             Component2D[] components = asLuceneComponent2Ds(crsType(), rightGeom);
-            return (crsType() == SpatialCrsType.GEO)
-                ? GEO.geometryRelatesGeometries(docValueReader, components)
-                : CARTESIAN.geometryRelatesGeometries(docValueReader, components);
+            if (docValueReader == null || components == null) {
+                return null;
+            }
+            return getSpatialRelations().geometryRelatesGeometries(docValueReader, components);
         } catch (IOException e) {
             throw new IllegalArgumentException("Failed to fold constant fields: " + e.getMessage(), e);
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialDisjoint.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialDisjoint.java
@@ -22,9 +22,7 @@ import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.index.mapper.GeoShapeIndexer;
 import org.elasticsearch.lucene.spatial.CartesianShapeIndexer;
 import org.elasticsearch.lucene.spatial.CoordinateEncoder;
-import org.elasticsearch.lucene.spatial.GeometryDocValueReader;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
-import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -44,10 +42,6 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.GEOHEX;
 import static org.elasticsearch.xpack.esql.core.type.DataType.GEOTILE;
 import static org.elasticsearch.xpack.esql.core.type.DataType.GEO_POINT;
 import static org.elasticsearch.xpack.esql.core.type.DataType.GEO_SHAPE;
-import static org.elasticsearch.xpack.esql.expression.Foldables.valueOf;
-import static org.elasticsearch.xpack.esql.expression.function.scalar.spatial.SpatialRelatesUtils.asGeometryDocValueReader;
-import static org.elasticsearch.xpack.esql.expression.function.scalar.spatial.SpatialRelatesUtils.asLuceneComponent2D;
-import static org.elasticsearch.xpack.esql.expression.function.scalar.spatial.SpatialRelatesUtils.makeGeometryFromLiteral;
 
 /**
  * This is the primary class for supporting the function ST_DISJOINT.
@@ -146,26 +140,8 @@ public class SpatialDisjoint extends SpatialRelatesFunction {
     }
 
     @Override
-    public Object fold(FoldContext ctx) {
-        try {
-            if (DataType.isGeoGrid(left().dataType())) {
-                return foldGeoGrid(ctx, right(), left(), left().dataType());
-            } else if (DataType.isGeoGrid(right().dataType())) {
-                return foldGeoGrid(ctx, left(), right(), right().dataType());
-            }
-            GeometryDocValueReader docValueReader = asGeometryDocValueReader(ctx, crsType(), left());
-            Component2D component2D = asLuceneComponent2D(ctx, crsType(), right());
-            return (crsType() == SpatialCrsType.GEO)
-                ? GEO.geometryRelatesGeometry(docValueReader, component2D)
-                : CARTESIAN.geometryRelatesGeometry(docValueReader, component2D);
-        } catch (IOException e) {
-            throw new IllegalArgumentException("Failed to fold constant fields: " + e.getMessage(), e);
-        }
-    }
-
-    private Object foldGeoGrid(FoldContext ctx, Expression spatialExp, Expression gridExp, DataType gridType) throws IOException {
-        long gridId = (Long) valueOf(ctx, gridExp);
-        return GEO.compareGeometryAndGrid(makeGeometryFromLiteral(ctx, spatialExp), gridId, gridType);
+    protected SpatialRelations getSpatialRelations() {
+        return crsType() == SpatialCrsType.GEO ? GEO : CARTESIAN;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialIntersects.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialIntersects.java
@@ -22,9 +22,7 @@ import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.index.mapper.GeoShapeIndexer;
 import org.elasticsearch.lucene.spatial.CartesianShapeIndexer;
 import org.elasticsearch.lucene.spatial.CoordinateEncoder;
-import org.elasticsearch.lucene.spatial.GeometryDocValueReader;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
-import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -44,10 +42,6 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.GEOHEX;
 import static org.elasticsearch.xpack.esql.core.type.DataType.GEOTILE;
 import static org.elasticsearch.xpack.esql.core.type.DataType.GEO_POINT;
 import static org.elasticsearch.xpack.esql.core.type.DataType.GEO_SHAPE;
-import static org.elasticsearch.xpack.esql.expression.Foldables.valueOf;
-import static org.elasticsearch.xpack.esql.expression.function.scalar.spatial.SpatialRelatesUtils.asGeometryDocValueReader;
-import static org.elasticsearch.xpack.esql.expression.function.scalar.spatial.SpatialRelatesUtils.asLuceneComponent2D;
-import static org.elasticsearch.xpack.esql.expression.function.scalar.spatial.SpatialRelatesUtils.makeGeometryFromLiteral;
 
 /**
  * This is the primary class for supporting the function ST_INTERSECTS.
@@ -144,26 +138,8 @@ public class SpatialIntersects extends SpatialRelatesFunction {
     }
 
     @Override
-    public Object fold(FoldContext ctx) {
-        try {
-            if (DataType.isGeoGrid(left().dataType())) {
-                return foldGeoGrid(ctx, right(), left(), left().dataType());
-            } else if (DataType.isGeoGrid(right().dataType())) {
-                return foldGeoGrid(ctx, left(), right(), right().dataType());
-            }
-            GeometryDocValueReader docValueReader = asGeometryDocValueReader(ctx, crsType(), left());
-            Component2D component2D = asLuceneComponent2D(ctx, crsType(), right());
-            return (crsType() == SpatialCrsType.GEO)
-                ? GEO.geometryRelatesGeometry(docValueReader, component2D)
-                : CARTESIAN.geometryRelatesGeometry(docValueReader, component2D);
-        } catch (IOException e) {
-            throw new IllegalArgumentException("Failed to fold constant fields: " + e.getMessage(), e);
-        }
-    }
-
-    private Object foldGeoGrid(FoldContext ctx, Expression spatialExp, Expression gridExp, DataType gridType) throws IOException {
-        long gridId = (Long) valueOf(ctx, gridExp);
-        return GEO.compareGeometryAndGrid(makeGeometryFromLiteral(ctx, spatialExp), gridId, gridType);
+    protected SpatialRelations getSpatialRelations() {
+        return crsType() == SpatialCrsType.GEO ? GEO : CARTESIAN;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialRelatesUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialRelatesUtils.java
@@ -64,6 +64,9 @@ public class SpatialRelatesUtils {
 
     /** Converts a {@link Geometry} into a {@link Component2D}. */
     static Component2D asLuceneComponent2D(BinarySpatialFunction.SpatialCrsType crsType, Geometry geometry) {
+        if (geometry == null) {
+            return null;
+        }
         if (crsType == BinarySpatialFunction.SpatialCrsType.GEO) {
             var luceneGeometries = LuceneGeometriesUtils.toLatLonGeometry(geometry, true, t -> {});
             return LatLonGeometry.create(luceneGeometries);
@@ -91,6 +94,9 @@ public class SpatialRelatesUtils {
      * The reason for generating an array instead of a single component is for multi-shape support with ST_CONTAINS.
      */
     static Component2D[] asLuceneComponent2Ds(BinarySpatialFunction.SpatialCrsType crsType, Geometry geometry) {
+        if (geometry == null) {
+            return null;
+        }
         if (crsType == BinarySpatialFunction.SpatialCrsType.GEO) {
             var luceneGeometries = LuceneGeometriesUtils.toLatLonGeometry(geometry, true, t -> {});
             return LuceneComponent2DUtils.createLatLonComponents(luceneGeometries);
@@ -127,6 +133,9 @@ public class SpatialRelatesUtils {
     /** Converts a {@link Geometry} into a {@link GeometryDocValueReader} */
     static GeometryDocValueReader asGeometryDocValueReader(CoordinateEncoder encoder, ShapeIndexer shapeIndexer, Geometry geometry)
         throws IOException {
+        if (geometry == null) {
+            return null;
+        }
         GeometryDocValueReader reader = new GeometryDocValueReader();
         CentroidCalculator centroidCalculator = new CentroidCalculator();
         if (geometry instanceof Circle) {
@@ -198,7 +207,9 @@ public class SpatialRelatesUtils {
     }
 
     private static Geometry makeGeometryFromLiteralValue(Object value, DataType dataType) {
-        if (value instanceof BytesRef bytesRef) {
+        if (value == null) {
+            return null;
+        } else if (value instanceof BytesRef bytesRef) {
             // Single value expression
             return SpatialCoordinateTypes.UNSPECIFIED.wkbToGeometry(bytesRef);
         } else if (value instanceof List<?> bytesRefList) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialWithin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialWithin.java
@@ -22,9 +22,7 @@ import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.index.mapper.GeoShapeIndexer;
 import org.elasticsearch.lucene.spatial.CartesianShapeIndexer;
 import org.elasticsearch.lucene.spatial.CoordinateEncoder;
-import org.elasticsearch.lucene.spatial.GeometryDocValueReader;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
-import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -42,8 +40,6 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.CARTESIAN_POINT;
 import static org.elasticsearch.xpack.esql.core.type.DataType.CARTESIAN_SHAPE;
 import static org.elasticsearch.xpack.esql.core.type.DataType.GEO_POINT;
 import static org.elasticsearch.xpack.esql.core.type.DataType.GEO_SHAPE;
-import static org.elasticsearch.xpack.esql.expression.function.scalar.spatial.SpatialRelatesUtils.asGeometryDocValueReader;
-import static org.elasticsearch.xpack.esql.expression.function.scalar.spatial.SpatialRelatesUtils.asLuceneComponent2D;
 
 /**
  * This is the primary class for supporting the function ST_WITHIN.
@@ -131,16 +127,8 @@ public class SpatialWithin extends SpatialRelatesFunction implements SurrogateEx
     }
 
     @Override
-    public Object fold(FoldContext ctx) {
-        try {
-            GeometryDocValueReader docValueReader = asGeometryDocValueReader(ctx, crsType(), left());
-            Component2D component2D = asLuceneComponent2D(ctx, crsType(), right());
-            return (crsType() == SpatialCrsType.GEO)
-                ? GEO.geometryRelatesGeometry(docValueReader, component2D)
-                : CARTESIAN.geometryRelatesGeometry(docValueReader, component2D);
-        } catch (IOException e) {
-            throw new IllegalArgumentException("Failed to fold constant fields: " + e.getMessage(), e);
-        }
+    protected SpatialRelations getSpatialRelations() {
+        return crsType() == SpatialCrsType.GEO ? GEO : CARTESIAN;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StDistance.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StDistance.java
@@ -24,7 +24,6 @@ import org.elasticsearch.geometry.Point;
 import org.elasticsearch.lucene.spatial.CoordinateEncoder;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
-import org.elasticsearch.xpack.esql.core.expression.FoldContext;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -282,9 +281,7 @@ public class StDistance extends BinarySpatialFunction implements EvaluatorMapper
     }
 
     @Override
-    public Object fold(FoldContext ctx) {
-        var leftGeom = makeGeometryFromLiteral(ctx, left());
-        var rightGeom = makeGeometryFromLiteral(ctx, right());
+    protected Object fold(Geometry leftGeom, Geometry rightGeom) {
         return (crsType() == SpatialCrsType.GEO) ? GEO.distance(leftGeom, rightGeom) : CARTESIAN.distance(leftGeom, rightGeom);
     }
 


### PR DESCRIPTION
Manual backport of https://github.com/elastic/elasticsearch/pull/140265
