### PR TITLE
[8.19] Expose _tier metadata attribute in ESQL (#139894)

### DIFF
--- a/docs/changelog/139894.yaml
+++ b/docs/changelog/139894.yaml
@@ -1,0 +1,5 @@
+pr: 139894
+summary: Expose `_tier` in ESQL
+area: ES|QL
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/query/QueryRewriteContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryRewriteContext.java
@@ -537,16 +537,18 @@ public class QueryRewriteContext {
      */
     @Nullable
     public String getTierPreference() {
-        Settings settings = getIndexSettings().getSettings();
+        return getFirstTierPreference(getIndexSettings().getSettings(), null);
+    }
+
+    public static String getFirstTierPreference(Settings settings, String defaultTierPreference) {
         String value = DataTier.TIER_PREFERENCE_SETTING.get(settings);
-
         if (Strings.hasText(value) == false) {
-            return null;
+            return defaultTierPreference;
         }
-
         // Tier preference can be a comma-delimited list of tiers, ordered by preference
         // It was decided we should only test the first of these potentially multiple preferences.
-        return value.split(",")[0].trim();
+        int separatorPosition = value.indexOf(',');
+        return (separatorPosition != -1 ? value.substring(0, separatorPosition) : value).trim();
     }
 
     public QueryRewriteInterceptor getQueryRewriteInterceptor() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/mapper/DataTierFieldMapper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/routing/allocation/mapper/DataTierFieldMapper.java
@@ -10,8 +10,10 @@ package org.elasticsearch.xpack.cluster.routing.allocation.mapper;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.ConstantFieldType;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
@@ -72,6 +74,12 @@ public class DataTierFieldMapper extends MetadataFieldMapper {
                 return new MatchNoDocsQuery();
             }
             return new MatchAllDocsQuery();
+        }
+
+        @Override
+        public BlockLoader blockLoader(BlockLoaderContext blContext) {
+            final String tierPreference = SearchExecutionContext.getFirstTierPreference(blContext.indexSettings().getSettings(), "");
+            return BlockLoader.constantBytes(new BytesRef(tierPreference));
         }
 
         @Override

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/MetadataAttribute.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/MetadataAttribute.java
@@ -11,11 +11,11 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
-import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.mapper.IgnoredFieldMapper;
 import org.elasticsearch.index.mapper.IndexModeFieldMapper;
 import org.elasticsearch.index.mapper.SourceFieldMapper;
+import org.elasticsearch.xpack.cluster.routing.allocation.mapper.DataTierFieldMapper;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -25,8 +25,6 @@ import org.elasticsearch.xpack.esql.core.util.PlanStreamOutput;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
-
-import static org.elasticsearch.core.Tuple.tuple;
 
 public class MetadataAttribute extends TypedAttribute {
     public static final String TIMESTAMP_FIELD = "@timestamp"; // this is not a true metadata attribute
@@ -40,22 +38,19 @@ public class MetadataAttribute extends TypedAttribute {
         MetadataAttribute::readFrom
     );
 
-    private static final Map<String, Tuple<DataType, Boolean>> ATTRIBUTES_MAP = Map.of(
-        "_version",
-        tuple(DataType.LONG, false), // _version field is not searchable
-        INDEX,
-        tuple(DataType.KEYWORD, true),
-        IdFieldMapper.NAME,
-        tuple(DataType.KEYWORD, false), // actually searchable, but fielddata access on the _id field is disallowed by default
-        IgnoredFieldMapper.NAME,
-        tuple(DataType.KEYWORD, true),
-        SourceFieldMapper.NAME,
-        tuple(DataType.SOURCE, false),
-        IndexModeFieldMapper.NAME,
-        tuple(DataType.KEYWORD, true),
-        SCORE,
-        tuple(DataType.DOUBLE, false)
+    private static final Map<String, MetadataAttributeConfiguration> ATTRIBUTES_MAP = Map.ofEntries(
+        Map.entry("_version", new MetadataAttributeConfiguration(DataType.LONG, false)),
+        Map.entry(INDEX, new MetadataAttributeConfiguration(DataType.KEYWORD, true)),
+        // actually searchable, but fielddata access on the _id field is disallowed by default
+        Map.entry(IdFieldMapper.NAME, new MetadataAttributeConfiguration(DataType.KEYWORD, false)),
+        Map.entry(IgnoredFieldMapper.NAME, new MetadataAttributeConfiguration(DataType.KEYWORD, true)),
+        Map.entry(SourceFieldMapper.NAME, new MetadataAttributeConfiguration(DataType.SOURCE, false)),
+        Map.entry(IndexModeFieldMapper.NAME, new MetadataAttributeConfiguration(DataType.KEYWORD, true)),
+        Map.entry(DataTierFieldMapper.NAME, new MetadataAttributeConfiguration(DataType.KEYWORD, true)),
+        Map.entry(SCORE, new MetadataAttributeConfiguration(DataType.DOUBLE, false))
     );
+
+    private record MetadataAttributeConfiguration(DataType dataType, boolean searchable) {}
 
     private final boolean searchable;
 
@@ -160,12 +155,12 @@ public class MetadataAttribute extends TypedAttribute {
 
     public static MetadataAttribute create(Source source, String name) {
         var t = ATTRIBUTES_MAP.get(name);
-        return t != null ? new MetadataAttribute(source, name, t.v1(), t.v2()) : null;
+        return t != null ? new MetadataAttribute(source, name, t.dataType(), t.searchable()) : null;
     }
 
     public static DataType dataType(String name) {
         var t = ATTRIBUTES_MAP.get(name);
-        return t != null ? t.v1() : null;
+        return t != null ? t.dataType() : null;
     }
 
     public static boolean isSupported(String name) {

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/metadata.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/metadata.csv-spec
@@ -184,3 +184,19 @@ FROM ul_logs, apps METADATA _index, _version
     
 // end::multipleIndices-result[]
 ;
+
+indexMetadata
+required_capability: metadata_tier_field
+FROM employees METADATA _index | KEEP _index | LIMIT 1;
+
+_index:keyword
+employees
+;
+
+tierMetadata
+required_capability: metadata_tier_field
+FROM employees METADATA _tier | KEEP _tier | LIMIT 1;
+
+_tier:keyword
+data_content
+;

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/CanMatchIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/plugin/CanMatchIT.java
@@ -11,18 +11,22 @@ import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.routing.allocation.DataTier;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
+import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.index.query.MatchQueryBuilder;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.cluster.routing.allocation.mapper.DataTierFieldMapper;
 import org.elasticsearch.xpack.esql.action.AbstractEsqlIntegTestCase;
 import org.elasticsearch.xpack.esql.action.EsqlQueryResponse;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -41,7 +45,17 @@ public class CanMatchIT extends AbstractEsqlIntegTestCase {
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return CollectionUtils.appendToCopy(super.nodePlugins(), MockTransportService.TestPlugin.class);
+        List<Class<? extends Plugin>> plugins = new ArrayList<>(super.nodePlugins());
+        plugins.add(MockTransportService.TestPlugin.class);
+        plugins.add(DataTierFieldMapperPlugin.class);
+        return plugins;
+    }
+
+    public static class DataTierFieldMapperPlugin extends Plugin implements MapperPlugin {
+        @Override
+        public Map<String, MetadataFieldMapper.TypeParser> getMetadataMappers() {
+            return Map.of(DataTierFieldMapper.NAME, DataTierFieldMapper.PARSER);
+        }
     }
 
     /**
@@ -69,19 +83,7 @@ public class CanMatchIT extends AbstractEsqlIntegTestCase {
             .add(new IndexRequest().source("@timestamp", "2023-03-25", "uid", "u1"))
             .get();
         try {
-            Set<String> queriedIndices = ConcurrentCollections.newConcurrentSet();
-            for (TransportService transportService : internalCluster().getInstances(TransportService.class)) {
-                as(transportService, MockTransportService.class).addRequestHandlingBehavior(
-                    ComputeService.DATA_ACTION_NAME,
-                    (handler, request, channel, task) -> {
-                        DataNodeRequest dataNodeRequest = (DataNodeRequest) request;
-                        for (ShardId shardId : dataNodeRequest.shardIds()) {
-                            queriedIndices.add(shardId.getIndexName());
-                        }
-                        handler.messageReceived(request, channel, task);
-                    }
-                );
-            }
+            Set<String> queriedIndices = captureQueriedIndices();
             try (EsqlQueryResponse resp = run("from events_*", randomPragmas(), new RangeQueryBuilder("@timestamp").gte("2023-01-01"))) {
                 assertThat(getValuesList(resp), hasSize(4));
                 assertThat(queriedIndices, equalTo(Set.of("events_2023")));
@@ -118,9 +120,7 @@ public class CanMatchIT extends AbstractEsqlIntegTestCase {
                 queriedIndices.clear();
             }
         } finally {
-            for (TransportService transportService : internalCluster().getInstances(TransportService.class)) {
-                as(transportService, MockTransportService.class).clearAllRules();
-            }
+            cleanAllTransportRules();
         }
     }
 
@@ -286,6 +286,48 @@ public class CanMatchIT extends AbstractEsqlIntegTestCase {
             bulk.get();
             indexToNumDocs.put(index, docs);
         }
+        Set<String> queriedIndices = captureQueriedIndices();
+        try {
+            for (int i = 0; i < numIndices; i++) {
+                queriedIndices.clear();
+                String index = "events-" + i;
+                try (EsqlQueryResponse resp = run("from events* METADATA _index | WHERE _index ==  \"" + index + "\" | KEEP timestamp")) {
+                    assertThat(getValuesList(resp), hasSize(indexToNumDocs.get(index)));
+                }
+                assertThat(queriedIndices, equalTo(Set.of(index)));
+            }
+        } finally {
+            cleanAllTransportRules();
+        }
+    }
+
+    public void testSkipOnTierName() {
+        var tiers = List.of("hot", "warm", "cold");
+        for (String tier : tiers) {
+            assertAcked(
+                client().admin()
+                    .indices()
+                    .prepareCreate("index-" + tier)
+                    .setSettings(Settings.builder().put(DataTier.TIER_PREFERENCE, "data_" + tier))
+            );
+            indexRandom(true, "index-" + tier, 1);
+        }
+
+        var queriedIndices = captureQueriedIndices();
+        try {
+            for (String tier : tiers) {
+                queriedIndices.clear();
+                try (EsqlQueryResponse resp = run("from index-* METADATA _tier | WHERE _tier == \"data_" + tier + "\"")) {
+                    assertThat(getValuesList(resp), hasSize(1));
+                    assertThat(queriedIndices, equalTo(Set.of("index-" + tier)));
+                }
+            }
+        } finally {
+            cleanAllTransportRules();
+        }
+    }
+
+    private static Set<String> captureQueriedIndices() {
         Set<String> queriedIndices = ConcurrentCollections.newConcurrentSet();
         for (TransportService transportService : internalCluster().getInstances(TransportService.class)) {
             as(transportService, MockTransportService.class).addRequestHandlingBehavior(
@@ -299,19 +341,12 @@ public class CanMatchIT extends AbstractEsqlIntegTestCase {
                 }
             );
         }
-        try {
-            for (int i = 0; i < numIndices; i++) {
-                queriedIndices.clear();
-                String index = "events-" + i;
-                try (EsqlQueryResponse resp = run("from events* METADATA _index | WHERE _index ==  \"" + index + "\" | KEEP timestamp")) {
-                    assertThat(getValuesList(resp), hasSize(indexToNumDocs.get(index)));
-                }
-                assertThat(queriedIndices, equalTo(Set.of(index)));
-            }
-        } finally {
-            for (TransportService transportService : internalCluster().getInstances(TransportService.class)) {
-                as(transportService, MockTransportService.class).clearAllRules();
-            }
+        return queriedIndices;
+    }
+
+    private static void cleanAllTransportRules() {
+        for (TransportService transportService : internalCluster().getInstances(TransportService.class)) {
+            as(transportService, MockTransportService.class).clearAllRules();
         }
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1088,6 +1088,11 @@ public class EsqlCapabilities {
          */
         FIX_STATS_MV_CONSTANT_FOLD,
 
+        /**
+         * Support for requesting the "_tier" metadata field.
+         */
+        METADATA_TIER_FIELD,
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
@@ -2718,6 +2718,83 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
         }
     }
 
+    /*
+     * LimitExec[1000[INTEGER],...]
+     * \_ExchangeExec[[...],false]
+     *   \_ProjectExec[[...]]
+     *     \_FieldExtractExec[_meta_field{f}#8586, ...]<[],[]>
+     *       \_EsQueryExec[test], query={"term":{"_tier":{"value":"data_hot","boost":0.0}}}
+     */
+    public void testPushDownMetadataTierInEquality() {
+        var plan = physicalPlan("""
+            from test metadata _tier
+            | where _tier == "data_hot"
+            """);
+
+        var optimized = optimizedPlan(plan);
+        var limit = as(optimized, LimitExec.class);
+        var exchange = asRemoteExchange(limit.child());
+        var project = as(exchange.child(), ProjectExec.class);
+        var extract = as(project.child(), FieldExtractExec.class);
+        var source = source(extract.child());
+
+        var tq = as(source.query(), TermQueryBuilder.class);
+        assertThat(tq.fieldName(), is("_tier"));
+        assertThat(tq.value(), is("data_hot"));
+    }
+
+    /*
+     * LimitExec[1000[INTEGER],..]
+     * \_ExchangeExec[[...],false]
+     *   \_ProjectExec[[...]]
+     *     \_FieldExtractExec[_meta_field{f}#9140, ...]<[],[]>
+     *       \_EsQueryExec[test], query={"bool":{"must_not":[{"term":{"_tier":{"value":"data_hot","boost":0.0}}}],"boost":1.0}}
+     */
+    public void testPushDownMetadataTierInNotEquality() {
+        var plan = physicalPlan("""
+            from test metadata _tier
+            | where _tier != "data_hot"
+            """);
+
+        var optimized = optimizedPlan(plan);
+        var limit = as(optimized, LimitExec.class);
+        var exchange = asRemoteExchange(limit.child());
+        var project = as(exchange.child(), ProjectExec.class);
+        var extract = as(project.child(), FieldExtractExec.class);
+        var source = source(extract.child());
+
+        var bq = as(source.query(), BoolQueryBuilder.class);
+        assertThat(bq.mustNot().size(), is(1));
+        var tq = as(bq.mustNot().get(0), TermQueryBuilder.class);
+        assertThat(tq.fieldName(), is("_tier"));
+        assertThat(tq.value(), is("data_hot"));
+    }
+
+    /*
+     * LimitExec[1000[INTEGER],...]
+     * \_ExchangeExec[[...],false]
+     *   \_ProjectExec[[_meta_field{f}#1816, ..., _tier{m}#1808]]
+     *     \_FieldExtractExec[_meta_field{f}#1816, ...]<[],[]>
+     *       \_EsQueryExec[test], query={"wildcard":{"_tier":{"wildcard":"data_*","boost":0.0}}}
+     */
+    public void testPushDownMetadataTierInWildcard() {
+        var plan = physicalPlan("""
+            from test metadata _tier
+            | where _tier like "data_*"
+            """);
+
+        var optimized = optimizedPlan(plan);
+        var limit = as(optimized, LimitExec.class);
+        var exchange = asRemoteExchange(limit.child());
+        var project = as(exchange.child(), ProjectExec.class);
+        var extract = as(project.child(), FieldExtractExec.class);
+        var source = source(extract.child());
+
+        var tq = as(source.query(), WildcardQueryBuilder.class);
+        assertThat(tq.fieldName(), is("_tier"));
+        assertThat(tq.value(), is("data_*"));
+    }
+
     public void testDontPushDownMetadataVersionAndId() {
         for (var t : List.of(tuple("_version", "2"), tuple("_id", "\"2\""))) {
             var plan = physicalPlan("from test metadata " + t.v1() + " | where " + t.v1() + " == " + t.v2());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
@@ -1191,10 +1191,6 @@ public class StatementParserTests extends AbstractStatementParserTests {
         expectError("from test metadata _index, _version, _index", "1:38: metadata field [_index] already declared [@1:20]");
     }
 
-    public void testMetadataFieldUnsupportedPrimitiveType() {
-        expectError("from test metadata _tier", "line 1:20: unsupported metadata field [_tier]");
-    }
-
     public void testMetadataFieldUnsupportedCustomType() {
         expectError("from test metadata _feature", "line 1:20: unsupported metadata field [_feature]");
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/TestPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/TestPhysicalOperationProviders.java
@@ -44,6 +44,7 @@ import org.elasticsearch.index.mapper.MappedFieldType.FieldExtractPreference;
 import org.elasticsearch.indices.analysis.AnalysisModule;
 import org.elasticsearch.lucene.spatial.CoordinateEncoder;
 import org.elasticsearch.plugins.scanners.StablePluginsRegistry;
+import org.elasticsearch.xpack.cluster.routing.allocation.mapper.DataTierFieldMapper;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
@@ -294,14 +295,19 @@ public class TestPhysicalOperationProviders extends AbstractPhysicalOperationPro
     private Block extractBlockForSingleDoc(DocBlock docBlock, String columnName, TestBlockCopier blockCopier) {
         var indexId = docBlock.asVector().shards().getInt(0);
         var indexPage = indexPages.get(indexId);
-        if (MetadataAttribute.INDEX.equals(columnName)) {
-            return docBlock.blockFactory()
+        return switch (columnName) {
+            case MetadataAttribute.INDEX -> docBlock.blockFactory()
                 .newConstantBytesRefBlockWith(new BytesRef(indexPage.index), blockCopier.docIndices.getPositionCount());
-        }
-        int columnIndex = indexPage.columnIndex(columnName)
-            .orElseThrow(() -> new EsqlIllegalArgumentException("Cannot find column named [{}] in {}", columnName, indexPage.columnNames));
-        var originalData = indexPage.page.getBlock(columnIndex);
-        return blockCopier.copyBlock(originalData);
+            case DataTierFieldMapper.NAME -> docBlock.blockFactory()
+                .newConstantBytesRefBlockWith(new BytesRef("data_content"), blockCopier.docIndices.getPositionCount());
+            default -> {
+                int columnIndex = indexPage.columnIndex(columnName)
+                    .orElseThrow(
+                        () -> new EsqlIllegalArgumentException("Cannot find column named [{}] in {}", columnName, indexPage.columnNames)
+                    );
+                yield blockCopier.copyBlock(indexPage.page.getBlock(columnIndex));
+            }
+        };
     }
 
     private static void foreachIndexDoc(DocBlock docBlock, Consumer<DocBlock> indexDocConsumer) {


### PR DESCRIPTION
This backports https://github.com/elastic/elasticsearch/pull/139894 to 8.19