### PR TITLE
Populate intervals directly for rate calculation

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateDoubleGroupingAggregatorFunction.java
@@ -615,7 +615,13 @@ public final class RateDoubleGroupingAggregatorFunction implements GroupingAggre
             resets += interval.resets;
         }
 
-        void appendIntervalsFromBlocks(LongBlock timestampsBlock, DoubleBlock valuesBlock, DoubleBlock resetsBlock, LongBlock samplesBLock, int position) {
+        void appendIntervalsFromBlocks(
+            LongBlock timestampsBlock,
+            DoubleBlock valuesBlock,
+            DoubleBlock resetsBlock,
+            LongBlock samplesBLock,
+            int position
+        ) {
             int tsFirst = timestampsBlock.getFirstValueIndex(position);
             int vsFirst = valuesBlock.getFirstValueIndex(position);
             int resetsFirst = resetsBlock.getFirstValueIndex(position);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
@@ -201,11 +201,11 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
                 final int groupId = groups.getInt(g);
                 final var value = valueBlock.getInt(valueBlock.getFirstValueIndex(valuePosition));
                 if (lastGroup != groupId) {
-                    buffer = getBuffer(groupId, 1, timestamp);
-                    buffer.appendWithoutResize(timestamp, value);
+                    buffer = getBuffer(groupId);
+                    buffer.append(timestamp, value);
                     lastGroup = groupId;
                 } else {
-                    buffer.maybeResizeAndAppend(bigArrays, timestamp, value);
+                    buffer.append(timestamp, value);
                 }
             }
         }
@@ -252,12 +252,12 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
     }
 
     private void addSubRange(int group, int from, int to, IntVector valueVector, LongVector timestampVector) {
-        var buffer = getBuffer(group, to - from, timestampVector.getLong(from));
+        var buffer = getBuffer(group);
         buffer.appendRange(from, to, valueVector, timestampVector);
     }
 
     private void addSubRange(int group, int from, int to, IntBlock valueBlock, LongVector timestampVector) {
-        var buffer = getBuffer(group, to - from, timestampVector.getLong(from));
+        var buffer = getBuffer(group);
         buffer.appendRange(from, to, valueBlock, timestampVector);
     }
 
@@ -285,8 +285,8 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
         if (values.areAllValuesNull()) {
             return;
         }
-        LongVector sampleCounts = ((LongBlock) page.getBlock(channels.get(2))).asVector();
-        DoubleVector resets = ((DoubleBlock) page.getBlock(channels.get(3))).asVector();
+        var sampleCounts = ((LongBlock) page.getBlock(channels.get(2)));
+        var resets = ((IntBlock) page.getBlock(channels.get(3)));
         for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
             int valuePosition = positionOffset + groupPosition;
             long sampleCount = sampleCounts.getLong(valuePosition);
@@ -300,9 +300,7 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
                 state = new ReducedState();
                 reducedStates.set(groupId, state);
             }
-            state.appendIntervalsFromBlocks(timestamps, values, valuePosition);
-            state.samples += sampleCount;
-            state.resets += resets.getDouble(valuePosition);
+            state.appendIntervalsFromBlocks(timestamps, values, resets, sampleCounts, valuePosition);
         }
     }
 
@@ -314,8 +312,8 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
         if (values.areAllValuesNull()) {
             return;
         }
-        LongVector sampleCounts = ((LongBlock) page.getBlock(channels.get(2))).asVector();
-        DoubleVector resets = ((DoubleBlock) page.getBlock(channels.get(3))).asVector();
+        var sampleCounts = ((LongBlock) page.getBlock(channels.get(2)));
+        var resets = ((IntBlock) page.getBlock(channels.get(3)));
         for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
             int valuePosition = positionOffset + groupPosition;
             long sampleCount = sampleCounts.getLong(valuePosition);
@@ -335,9 +333,7 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
                     state = new ReducedState();
                     reducedStates.set(groupId, state);
                 }
-                state.appendIntervalsFromBlocks(timestamps, values, valuePosition);
-                state.samples += sampleCount;
-                state.resets += resets.getDouble(valuePosition);
+                state.appendIntervalsFromBlocks(timestamps, values, resets, sampleCounts, valuePosition);
             }
         }
     }
@@ -350,7 +346,7 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
             var timestamps = blockFactory.newLongBlockBuilder(positionCount * 2);
             var values = blockFactory.newIntBlockBuilder(positionCount * 2);
             var sampleCounts = blockFactory.newLongVectorFixedBuilder(positionCount);
-            var resets = blockFactory.newDoubleVectorFixedBuilder(positionCount)
+            var resets = blockFactory.newIntVectorFixedBuilder(positionCount)
         ) {
             for (int p = 0; p < positionCount; p++) {
                 int group = selected.getInt(p);
@@ -360,20 +356,20 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
                     timestamps.beginPositionEntry();
                     values.beginPositionEntry();
                     for (Interval interval : state.intervals) {
-                        timestamps.appendLong(interval.t1);
-                        timestamps.appendLong(interval.t2);
-                        values.appendInt(interval.v1);
-                        values.appendInt(interval.v2);
+                        timestamps.appendLong(interval.lastTimestamp);
+                        timestamps.appendLong(interval.firstTimestamp);
+                        values.appendInt(interval.lastValue);
+                        values.appendInt(interval.firstValue);
                     }
                     timestamps.endPositionEntry();
                     values.endPositionEntry();
                     sampleCounts.appendLong(state.samples);
-                    resets.appendDouble(state.resets);
+                    resets.appendInt(state.resets);
                 } else {
                     timestamps.appendLong(0);
                     values.appendInt(0);
                     sampleCounts.appendLong(0);
-                    resets.appendDouble(0);
+                    resets.appendInt(0);
                 }
             }
             blocks[offset] = timestamps.build();
@@ -394,16 +390,55 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
         Releasables.close(reducedStates, buffers);
     }
 
-    private Buffer getBuffer(int groupId, int newElements, long firstTimestamp) {
+    private Buffer getBuffer(int groupId) {
         buffers = bigArrays.grow(buffers, groupId + 1);
         Buffer buffer = buffers.get(groupId);
         if (buffer == null) {
-            buffer = new Buffer(bigArrays, newElements);
+            buffer = new Buffer(bigArrays);
             buffers.set(groupId, buffer);
-        } else {
-            buffer.ensureCapacity(bigArrays, newElements, firstTimestamp);
         }
         return buffer;
+    }
+
+    private static class Interval implements Comparable<Interval> {
+
+        private long lastTimestamp;
+        private int lastValue;
+        private long firstTimestamp;
+        private int firstValue;
+        private int resets;
+        private long samples;
+
+        Interval(long timestamp, int value) {
+            this(timestamp, value, timestamp, value, 0, 1);
+        }
+
+        Interval(long lastTimestamp, int lastValue, long firstTimestamp, int firstValue, int resets, long samples) {
+            this.lastTimestamp = lastTimestamp;
+            this.lastValue = lastValue;
+            this.firstTimestamp = firstTimestamp;
+            this.firstValue = firstValue;
+            this.resets = resets;
+            this.samples = samples;
+        }
+
+        boolean maybeAdd(long timestamp, int value) {
+            if (timestamp > firstTimestamp) {
+                return false;
+            }
+            if (value > firstValue) {
+                resets += value;  // Counter reset detected.
+            }
+            firstTimestamp = timestamp;
+            firstValue = value;
+            samples++;
+            return true;
+        }
+
+        @Override
+        public int compareTo(Interval other) {
+            return Long.compare(other.lastTimestamp, lastTimestamp); // want most recent first
+        }
     }
 
     /**
@@ -415,38 +450,26 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
      * the slice with the greatest timestamp.
      */
     static final class Buffer implements Releasable {
-        private LongArray timestamps;
-        private IntArray values;
-        private int pendingCount;
-        int[] sliceOffsets;
-        private static final int[] EMPTY_SLICES = new int[0];
+        private final BigArrays bigArrays;
+        private ObjectArray<Interval> intervals;
+        private int offset = -1;
 
-        Buffer(BigArrays bigArrays, int initialSize) {
-            this.timestamps = bigArrays.newLongArray(Math.max(initialSize, 32), false);
-            this.values = bigArrays.newIntArray(Math.max(initialSize, 32), false);
-            this.sliceOffsets = EMPTY_SLICES;
+        Buffer(BigArrays bigArrays) {
+            this.bigArrays = bigArrays;
+            this.intervals = bigArrays.newObjectArray(32);
         }
 
-        void appendWithoutResize(long timestamp, int value) {
-            timestamps.set(pendingCount, timestamp);
-            values.set(pendingCount, value);
-            pendingCount++;
-        }
-
-        void maybeResizeAndAppend(BigArrays bigArrays, long timestamp, int value) {
-            timestamps = bigArrays.grow(timestamps, pendingCount + 1);
-            values = bigArrays.grow(values, pendingCount + 1);
-
-            timestamps.set(pendingCount, timestamp);
-            values.set(pendingCount, value);
-            pendingCount++;
+        void append(long timestamp, int value) {
+            if (offset < 0 || intervals.get(offset).maybeAdd(timestamp, value) == false) {
+                var nextInterval = new Interval(timestamp, value);
+                bigArrays.grow(intervals, offset + 1);
+                intervals.set(++offset, nextInterval);
+            }
         }
 
         void appendRange(int fromPosition, int toPosition, IntVector valueVector, LongVector timestampVector) {
             for (int p = fromPosition; p < toPosition; p++) {
-                values.set(pendingCount, valueVector.getInt(p));
-                timestamps.set(pendingCount, timestampVector.getLong(p));
-                pendingCount++;
+                append(timestampVector.getLong(p), valueVector.getInt(p));
             }
         }
 
@@ -456,116 +479,54 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
                     continue;
                 }
                 assert valueBlock.getValueCount(p) == 1 : "expected single-valued block " + valueBlock;
-                values.set(pendingCount, valueBlock.getInt(p));
-                timestamps.set(pendingCount, timestampVector.getLong(p));
-                pendingCount++;
-            }
-        }
-
-        void ensureCapacity(BigArrays bigArrays, int count, long firstTimestamp) {
-            int newSize = pendingCount + count;
-            timestamps = bigArrays.grow(timestamps, newSize);
-            values = bigArrays.grow(values, newSize);
-            if (pendingCount > 0 && firstTimestamp > timestamps.get(pendingCount - 1)) {
-                if (sliceOffsets.length == 0 || sliceOffsets[sliceOffsets.length - 1] != pendingCount) {
-                    sliceOffsets = ArrayUtil.growExact(sliceOffsets, sliceOffsets.length + 1);
-                    sliceOffsets[sliceOffsets.length - 1] = pendingCount;
-                }
+                append(timestampVector.getLong(p), valueBlock.getInt(p));
             }
         }
 
         void flush(ReducedState state) {
-            if (pendingCount == 0) {
+            if (offset < 0) {
                 return;
             }
-            if (pendingCount == 1) {
-                state.samples++;
-                long t = timestamps.get(0);
-                int v = values.get(0);
-                state.appendInterval(new Interval(t, v, t, v));
+            if (offset == 0) {
+                state.appendInterval(intervals.get(0));
                 return;
             }
-            PriorityQueue<Slice> pq = mergeQueue();
+            PriorityQueue<Interval> pq = mergeQueue();
+            Interval top = pq.pop();
+
             // first
-            final long lastTimestamp;
-            final int lastValue;
-            {
-                Slice top = pq.top();
-                lastTimestamp = top.timestamp;
-                int position = top.next();
-                lastValue = values.get(position);
-                if (top.exhausted()) {
-                    pq.pop();
-                } else {
-                    pq.updateTop();
-                }
-            }
-            var prevValue = lastValue;
-            int position = -1;
+            final int lastValue = top.lastValue;
+            final long lastTimestamp = top.lastTimestamp;
+            int resets = top.resets;
+            long samples = top.samples;
+            int prevValue = top.firstValue;
             while (pq.size() > 0) {
-                Slice top = pq.top();
-                position = top.next();
-                if (top.exhausted()) {
-                    pq.pop();
-                } else {
-                    pq.updateTop();
+                top = pq.pop();
+                samples += top.samples;
+                resets += top.resets;
+                if (top.lastValue > prevValue) {
+                    resets += prevValue;
                 }
-                var val = values.get(position);
-                if (val > prevValue) {
-                    state.resets += val;
-                }
-                prevValue = val;
             }
-            state.samples += pendingCount;
-            state.appendInterval(new Interval(lastTimestamp, lastValue, timestamps.get(position), prevValue));
+            state.appendInterval(new Interval(lastTimestamp, lastValue, top.firstTimestamp, top.firstValue, resets, samples));
         }
 
-        private PriorityQueue<Slice> mergeQueue() {
-            PriorityQueue<Slice> pq = new PriorityQueue<>(this.sliceOffsets.length + 1) {
+        private PriorityQueue<Interval> mergeQueue() {
+            var pq = new PriorityQueue<Interval>(offset + 1) {
                 @Override
-                protected boolean lessThan(Slice a, Slice b) {
-                    return a.timestamp > b.timestamp; // want the latest timestamp first
+                protected boolean lessThan(Interval a, Interval b) {
+                    return a.lastTimestamp > b.lastTimestamp; // want the latest timestamp first
                 }
             };
-            int startOffset = 0;
-            for (int sliceOffset : sliceOffsets) {
-                pq.add(new Slice(this, startOffset, sliceOffset));
-                startOffset = sliceOffset;
+            for (int i = 0; i <= offset; i++) {
+                pq.add(intervals.get(i));
             }
-            pq.add(new Slice(this, startOffset, pendingCount));
             return pq;
         }
 
         @Override
         public void close() {
-            timestamps.close();
-            values.close();
-        }
-    }
-
-    static final class Slice {
-        int start;
-        long timestamp;
-        final int end;
-        final Buffer buffer;
-
-        Slice(Buffer buffer, int start, int end) {
-            this.buffer = buffer;
-            this.start = start;
-            this.end = end;
-            this.timestamp = buffer.timestamps.get(start);
-        }
-
-        boolean exhausted() {
-            return start >= end;
-        }
-
-        int next() {
-            int index = start++;
-            if (start < end) {
-                timestamp = buffer.timestamps.get(start);
-            }
-            return index;
+            intervals.close();
         }
     }
 
@@ -588,8 +549,8 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
                     for (int i = 1; i < intervals.length; i++) {
                         Interval next = intervals[i - 1]; // reversed
                         Interval prev = intervals[i];
-                        if (prev.v1 > next.v2) {
-                            state.resets += prev.v1;
+                        if (prev.lastValue > next.firstValue) {
+                            state.resets += prev.lastValue;
                         }
                     }
                 }
@@ -640,40 +601,41 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
         return sb.toString();
     }
 
-    record Interval(long t1, int v1, long t2, int v2) implements Comparable<Interval> {
-        @Override
-        public int compareTo(Interval other) {
-            return Long.compare(other.t1, t1); // want most recent first
-        }
-    }
-
     static final class ReducedState {
         private static final Interval[] EMPTY_INTERVALS = new Interval[0];
         long samples;
-        double resets;
+        int resets;
         Interval[] intervals = EMPTY_INTERVALS;
 
         void appendInterval(Interval interval) {
             int currentSize = intervals.length;
-            this.intervals = ArrayUtil.growExact(intervals, currentSize + 1);
-            this.intervals[currentSize] = interval;
+            intervals = ArrayUtil.growExact(intervals, currentSize + 1);
+            intervals[currentSize] = interval;
+            samples += interval.samples;
+            resets += interval.resets;
         }
 
-        void appendIntervalsFromBlocks(LongBlock ts, IntBlock vs, int position) {
-            int tsFirst = ts.getFirstValueIndex(position);
-            int vsFirst = vs.getFirstValueIndex(position);
-            int count = ts.getValueCount(position);
-            assert count % 2 == 0 : "expected even number of values for intervals, got " + count + " in " + ts;
+        void appendIntervalsFromBlocks(LongBlock timestampsBlock, IntBlock valuesBlock, IntBlock resetsBlock, LongBlock samplesBLock, int position) {
+            int tsFirst = timestampsBlock.getFirstValueIndex(position);
+            int vsFirst = valuesBlock.getFirstValueIndex(position);
+            int resetsFirst = resetsBlock.getFirstValueIndex(position);
+            int samplesFirst = samplesBLock.getFirstValueIndex(position);
+            int count = timestampsBlock.getValueCount(position);
+            assert count % 2 == 0 : "expected even number of values for intervals, got " + count + " in " + timestampsBlock;
             int currentSize = intervals.length;
             intervals = ArrayUtil.growExact(intervals, currentSize + (count / 2));
             for (int i = 0; i < count; i += 2) {
                 Interval interval = new Interval(
-                    ts.getLong(tsFirst + i),
-                    vs.getInt(vsFirst + i),
-                    ts.getLong(tsFirst + i + 1),
-                    vs.getInt(vsFirst + i + 1)
+                    timestampsBlock.getLong(tsFirst + i),
+                    valuesBlock.getInt(vsFirst + i),
+                    timestampsBlock.getLong(tsFirst + i + 1),
+                    valuesBlock.getInt(vsFirst + i + 1),
+                    resetsBlock.getInt(resetsFirst + i),
+                    samplesBLock.getLong(samplesFirst + i)
                 );
                 intervals[currentSize++] = interval;
+                samples += interval.samples;
+                resets += interval.resets;
             }
         }
     }
@@ -682,10 +644,10 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
         if (state.samples < 2) {
             return Double.NaN;
         }
-        final long firstTS = state.intervals[state.intervals.length - 1].t2;
-        final long lastTS = state.intervals[0].t1;
-        double firstValue = state.intervals[state.intervals.length - 1].v2;
-        double lastValue = state.intervals[0].v1 + state.resets;
+        final long firstTS = state.intervals[state.intervals.length - 1].firstTimestamp;
+        final long lastTS = state.intervals[0].lastTimestamp;
+        double firstValue = state.intervals[state.intervals.length - 1].firstValue;
+        double lastValue = state.intervals[0].lastValue + state.resets;
         if (isRateOverTime) {
             return (lastValue - firstValue) * dateFactor / (lastTS - firstTS);
         } else {
@@ -716,8 +678,8 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
         var previousState = (previousGroupId >= 0) ? states.get(previousGroupId) : null;
         if (previousState == null || previousState.samples == 0) {
             if (state.samples == 1) {
-                firstTsSec = state.intervals[0].t1 / dateFactor;
-                firstValue = state.intervals[0].v1;
+                firstTsSec = state.intervals[0].lastTimestamp / dateFactor;
+                firstValue = state.intervals[0].lastValue;
             } else {
                 firstValue = extrapolateToBoundary(state, tbucketStart, tbucketEnd, dateFactor, true);
             }
@@ -729,8 +691,8 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
         var nextState = (nextGroupId >= 0) ? states.get(nextGroupId) : null;
         if (nextState == null || nextState.samples == 0) {
             if (state.samples == 1) {
-                lastTsSec = state.intervals[0].t1 / dateFactor;
-                lastValue = state.intervals[0].v1;
+                lastTsSec = state.intervals[0].lastTimestamp / dateFactor;
+                lastValue = state.intervals[0].lastValue;
             } else {
                 lastValue = extrapolateToBoundary(state, tbucketStart, tbucketEnd, dateFactor, false);
             }
@@ -743,14 +705,15 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
             if (state.samples == 1) {
                 if (previousState != null) {
                     assert nextState == null;
-                    assert state.intervals[0].t1 == firstTsSec * dateFactor : firstTsSec + ":" + state.intervals[0].t1;
-                    final double startTs = previousState.intervals[0].t1 / dateFactor;
+                    assert state.intervals[0].lastTimestamp == firstTsSec * dateFactor
+                        : firstTsSec + ":" + state.intervals[0].lastTimestamp;
+                    final double startTs = previousState.intervals[0].lastTimestamp / dateFactor;
                     final double delta = deltaBetweenStates(previousState, state, dateFactor);
                     return isRateOverTime ? delta / (firstTsSec - startTs) : delta;
                 }
                 if (nextState != null) {
-                    assert state.intervals[0].t1 == lastTsSec * dateFactor : lastTsSec + ":" + state.intervals[0].t1;
-                    final double endTs = nextState.intervals[nextState.intervals.length - 1].t2 / dateFactor;
+                    assert state.intervals[0].lastTimestamp == lastTsSec * dateFactor : lastTsSec + ":" + state.intervals[0].lastTimestamp;
+                    final double endTs = nextState.intervals[nextState.intervals.length - 1].firstTimestamp / dateFactor;
                     final double delta = deltaBetweenStates(state, nextState, dateFactor);
                     return isRateOverTime ? delta / (endTs - lastTsSec) : delta;
                 }
@@ -778,10 +741,10 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
         double dateFactor,
         boolean isLowerBoundary
     ) {
-        final double startTs = state.intervals[state.intervals.length - 1].t2 / dateFactor;
-        final double startValue = state.intervals[state.intervals.length - 1].v2;
-        final double endTs = state.intervals[0].t1 / dateFactor;
-        final double endValue = state.intervals[0].v1 + state.resets;
+        final double startTs = state.intervals[state.intervals.length - 1].firstTimestamp / dateFactor;
+        final double startValue = state.intervals[state.intervals.length - 1].firstValue;
+        final double endTs = state.intervals[0].lastTimestamp / dateFactor;
+        final double endValue = state.intervals[0].lastValue + state.resets;
         final double sampleTsSec = endTs - startTs;
         final double averageSampleInterval = sampleTsSec / state.samples;
         final double slope = (endValue - startValue) / sampleTsSec;
@@ -825,10 +788,10 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
         double dateFactor,
         boolean isLowerBoundary
     ) {
-        final double startValue = lowerState.intervals[0].v1;
-        final double startTs = lowerState.intervals[0].t1 / dateFactor;
-        final double endValue = upperState.intervals[upperState.intervals.length - 1].v2;
-        final double endTs = upperState.intervals[upperState.intervals.length - 1].t2 / dateFactor;
+        final double startValue = lowerState.intervals[0].lastValue;
+        final double startTs = lowerState.intervals[0].lastTimestamp / dateFactor;
+        final double endValue = upperState.intervals[upperState.intervals.length - 1].firstValue;
+        final double endTs = upperState.intervals[upperState.intervals.length - 1].firstTimestamp / dateFactor;
         assert startTs < endTs : "expected startTs < endTs, got " + startTs + " < " + endTs;
         final double delta = deltaBetweenStates(lowerState, upperState, dateFactor);
         final double slope = delta / (endTs - startTs);
@@ -845,10 +808,10 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
     }
 
     private static double deltaBetweenStates(ReducedState lowerState, ReducedState upperState, double dateFactor) {
-        final double startValue = lowerState.intervals[0].v1;
-        final double startTs = lowerState.intervals[0].t1 / dateFactor;
-        final double endValue = upperState.intervals[upperState.intervals.length - 1].v2;
-        final double endTs = upperState.intervals[upperState.intervals.length - 1].t2 / dateFactor;
+        final double startValue = lowerState.intervals[0].lastValue;
+        final double startTs = lowerState.intervals[0].lastTimestamp / dateFactor;
+        final double endValue = upperState.intervals[upperState.intervals.length - 1].firstValue;
+        final double endTs = upperState.intervals[upperState.intervals.length - 1].firstTimestamp / dateFactor;
 
         // If the end value is smaller than the start value, a counter reset occurred.
         // In this case, the delta is considered equal to the end value.

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
@@ -615,7 +615,13 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
             resets += interval.resets;
         }
 
-        void appendIntervalsFromBlocks(LongBlock timestampsBlock, IntBlock valuesBlock, IntBlock resetsBlock, LongBlock samplesBLock, int position) {
+        void appendIntervalsFromBlocks(
+            LongBlock timestampsBlock,
+            IntBlock valuesBlock,
+            IntBlock resetsBlock,
+            LongBlock samplesBLock,
+            int position
+        ) {
             int tsFirst = timestampsBlock.getFirstValueIndex(position);
             int vsFirst = valuesBlock.getFirstValueIndex(position);
             int resetsFirst = resetsBlock.getFirstValueIndex(position);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateLongGroupingAggregatorFunction.java
@@ -201,11 +201,11 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
                 final int groupId = groups.getInt(g);
                 final var value = valueBlock.getLong(valueBlock.getFirstValueIndex(valuePosition));
                 if (lastGroup != groupId) {
-                    buffer = getBuffer(groupId, 1, timestamp);
-                    buffer.appendWithoutResize(timestamp, value);
+                    buffer = getBuffer(groupId);
+                    buffer.append(timestamp, value);
                     lastGroup = groupId;
                 } else {
-                    buffer.maybeResizeAndAppend(bigArrays, timestamp, value);
+                    buffer.append(timestamp, value);
                 }
             }
         }
@@ -252,12 +252,12 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
     }
 
     private void addSubRange(int group, int from, int to, LongVector valueVector, LongVector timestampVector) {
-        var buffer = getBuffer(group, to - from, timestampVector.getLong(from));
+        var buffer = getBuffer(group);
         buffer.appendRange(from, to, valueVector, timestampVector);
     }
 
     private void addSubRange(int group, int from, int to, LongBlock valueBlock, LongVector timestampVector) {
-        var buffer = getBuffer(group, to - from, timestampVector.getLong(from));
+        var buffer = getBuffer(group);
         buffer.appendRange(from, to, valueBlock, timestampVector);
     }
 
@@ -285,8 +285,8 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
         if (values.areAllValuesNull()) {
             return;
         }
-        LongVector sampleCounts = ((LongBlock) page.getBlock(channels.get(2))).asVector();
-        DoubleVector resets = ((DoubleBlock) page.getBlock(channels.get(3))).asVector();
+        var sampleCounts = ((LongBlock) page.getBlock(channels.get(2)));
+        var resets = ((LongBlock) page.getBlock(channels.get(3)));
         for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
             int valuePosition = positionOffset + groupPosition;
             long sampleCount = sampleCounts.getLong(valuePosition);
@@ -300,9 +300,7 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
                 state = new ReducedState();
                 reducedStates.set(groupId, state);
             }
-            state.appendIntervalsFromBlocks(timestamps, values, valuePosition);
-            state.samples += sampleCount;
-            state.resets += resets.getDouble(valuePosition);
+            state.appendIntervalsFromBlocks(timestamps, values, resets, sampleCounts, valuePosition);
         }
     }
 
@@ -314,8 +312,8 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
         if (values.areAllValuesNull()) {
             return;
         }
-        LongVector sampleCounts = ((LongBlock) page.getBlock(channels.get(2))).asVector();
-        DoubleVector resets = ((DoubleBlock) page.getBlock(channels.get(3))).asVector();
+        var sampleCounts = ((LongBlock) page.getBlock(channels.get(2)));
+        var resets = ((LongBlock) page.getBlock(channels.get(3)));
         for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
             int valuePosition = positionOffset + groupPosition;
             long sampleCount = sampleCounts.getLong(valuePosition);
@@ -335,9 +333,7 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
                     state = new ReducedState();
                     reducedStates.set(groupId, state);
                 }
-                state.appendIntervalsFromBlocks(timestamps, values, valuePosition);
-                state.samples += sampleCount;
-                state.resets += resets.getDouble(valuePosition);
+                state.appendIntervalsFromBlocks(timestamps, values, resets, sampleCounts, valuePosition);
             }
         }
     }
@@ -350,7 +346,7 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
             var timestamps = blockFactory.newLongBlockBuilder(positionCount * 2);
             var values = blockFactory.newLongBlockBuilder(positionCount * 2);
             var sampleCounts = blockFactory.newLongVectorFixedBuilder(positionCount);
-            var resets = blockFactory.newDoubleVectorFixedBuilder(positionCount)
+            var resets = blockFactory.newLongVectorFixedBuilder(positionCount)
         ) {
             for (int p = 0; p < positionCount; p++) {
                 int group = selected.getInt(p);
@@ -360,20 +356,20 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
                     timestamps.beginPositionEntry();
                     values.beginPositionEntry();
                     for (Interval interval : state.intervals) {
-                        timestamps.appendLong(interval.t1);
-                        timestamps.appendLong(interval.t2);
-                        values.appendLong(interval.v1);
-                        values.appendLong(interval.v2);
+                        timestamps.appendLong(interval.lastTimestamp);
+                        timestamps.appendLong(interval.firstTimestamp);
+                        values.appendLong(interval.lastValue);
+                        values.appendLong(interval.firstValue);
                     }
                     timestamps.endPositionEntry();
                     values.endPositionEntry();
                     sampleCounts.appendLong(state.samples);
-                    resets.appendDouble(state.resets);
+                    resets.appendLong(state.resets);
                 } else {
                     timestamps.appendLong(0);
                     values.appendLong(0);
                     sampleCounts.appendLong(0);
-                    resets.appendDouble(0);
+                    resets.appendLong(0);
                 }
             }
             blocks[offset] = timestamps.build();
@@ -394,16 +390,55 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
         Releasables.close(reducedStates, buffers);
     }
 
-    private Buffer getBuffer(int groupId, int newElements, long firstTimestamp) {
+    private Buffer getBuffer(int groupId) {
         buffers = bigArrays.grow(buffers, groupId + 1);
         Buffer buffer = buffers.get(groupId);
         if (buffer == null) {
-            buffer = new Buffer(bigArrays, newElements);
+            buffer = new Buffer(bigArrays);
             buffers.set(groupId, buffer);
-        } else {
-            buffer.ensureCapacity(bigArrays, newElements, firstTimestamp);
         }
         return buffer;
+    }
+
+    private static class Interval implements Comparable<Interval> {
+
+        private long lastTimestamp;
+        private long lastValue;
+        private long firstTimestamp;
+        private long firstValue;
+        private long resets;
+        private long samples;
+
+        Interval(long timestamp, long value) {
+            this(timestamp, value, timestamp, value, 0, 1);
+        }
+
+        Interval(long lastTimestamp, long lastValue, long firstTimestamp, long firstValue, long resets, long samples) {
+            this.lastTimestamp = lastTimestamp;
+            this.lastValue = lastValue;
+            this.firstTimestamp = firstTimestamp;
+            this.firstValue = firstValue;
+            this.resets = resets;
+            this.samples = samples;
+        }
+
+        boolean maybeAdd(long timestamp, long value) {
+            if (timestamp > firstTimestamp) {
+                return false;
+            }
+            if (value > firstValue) {
+                resets += value;  // Counter reset detected.
+            }
+            firstTimestamp = timestamp;
+            firstValue = value;
+            samples++;
+            return true;
+        }
+
+        @Override
+        public int compareTo(Interval other) {
+            return Long.compare(other.lastTimestamp, lastTimestamp); // want most recent first
+        }
     }
 
     /**
@@ -415,38 +450,26 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
      * the slice with the greatest timestamp.
      */
     static final class Buffer implements Releasable {
-        private LongArray timestamps;
-        private LongArray values;
-        private int pendingCount;
-        int[] sliceOffsets;
-        private static final int[] EMPTY_SLICES = new int[0];
+        private final BigArrays bigArrays;
+        private ObjectArray<Interval> intervals;
+        private int offset = -1;
 
-        Buffer(BigArrays bigArrays, int initialSize) {
-            this.timestamps = bigArrays.newLongArray(Math.max(initialSize, 32), false);
-            this.values = bigArrays.newLongArray(Math.max(initialSize, 32), false);
-            this.sliceOffsets = EMPTY_SLICES;
+        Buffer(BigArrays bigArrays) {
+            this.bigArrays = bigArrays;
+            this.intervals = bigArrays.newObjectArray(32);
         }
 
-        void appendWithoutResize(long timestamp, long value) {
-            timestamps.set(pendingCount, timestamp);
-            values.set(pendingCount, value);
-            pendingCount++;
-        }
-
-        void maybeResizeAndAppend(BigArrays bigArrays, long timestamp, long value) {
-            timestamps = bigArrays.grow(timestamps, pendingCount + 1);
-            values = bigArrays.grow(values, pendingCount + 1);
-
-            timestamps.set(pendingCount, timestamp);
-            values.set(pendingCount, value);
-            pendingCount++;
+        void append(long timestamp, long value) {
+            if (offset < 0 || intervals.get(offset).maybeAdd(timestamp, value) == false) {
+                var nextInterval = new Interval(timestamp, value);
+                bigArrays.grow(intervals, offset + 1);
+                intervals.set(++offset, nextInterval);
+            }
         }
 
         void appendRange(int fromPosition, int toPosition, LongVector valueVector, LongVector timestampVector) {
             for (int p = fromPosition; p < toPosition; p++) {
-                values.set(pendingCount, valueVector.getLong(p));
-                timestamps.set(pendingCount, timestampVector.getLong(p));
-                pendingCount++;
+                append(timestampVector.getLong(p), valueVector.getLong(p));
             }
         }
 
@@ -456,116 +479,54 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
                     continue;
                 }
                 assert valueBlock.getValueCount(p) == 1 : "expected single-valued block " + valueBlock;
-                values.set(pendingCount, valueBlock.getLong(p));
-                timestamps.set(pendingCount, timestampVector.getLong(p));
-                pendingCount++;
-            }
-        }
-
-        void ensureCapacity(BigArrays bigArrays, int count, long firstTimestamp) {
-            int newSize = pendingCount + count;
-            timestamps = bigArrays.grow(timestamps, newSize);
-            values = bigArrays.grow(values, newSize);
-            if (pendingCount > 0 && firstTimestamp > timestamps.get(pendingCount - 1)) {
-                if (sliceOffsets.length == 0 || sliceOffsets[sliceOffsets.length - 1] != pendingCount) {
-                    sliceOffsets = ArrayUtil.growExact(sliceOffsets, sliceOffsets.length + 1);
-                    sliceOffsets[sliceOffsets.length - 1] = pendingCount;
-                }
+                append(timestampVector.getLong(p), valueBlock.getLong(p));
             }
         }
 
         void flush(ReducedState state) {
-            if (pendingCount == 0) {
+            if (offset < 0) {
                 return;
             }
-            if (pendingCount == 1) {
-                state.samples++;
-                long t = timestamps.get(0);
-                long v = values.get(0);
-                state.appendInterval(new Interval(t, v, t, v));
+            if (offset == 0) {
+                state.appendInterval(intervals.get(0));
                 return;
             }
-            PriorityQueue<Slice> pq = mergeQueue();
+            PriorityQueue<Interval> pq = mergeQueue();
+            Interval top = pq.pop();
+
             // first
-            final long lastTimestamp;
-            final long lastValue;
-            {
-                Slice top = pq.top();
-                lastTimestamp = top.timestamp;
-                int position = top.next();
-                lastValue = values.get(position);
-                if (top.exhausted()) {
-                    pq.pop();
-                } else {
-                    pq.updateTop();
-                }
-            }
-            var prevValue = lastValue;
-            int position = -1;
+            final long lastValue = top.lastValue;
+            final long lastTimestamp = top.lastTimestamp;
+            long resets = top.resets;
+            long samples = top.samples;
+            long prevValue = top.firstValue;
             while (pq.size() > 0) {
-                Slice top = pq.top();
-                position = top.next();
-                if (top.exhausted()) {
-                    pq.pop();
-                } else {
-                    pq.updateTop();
+                top = pq.pop();
+                samples += top.samples;
+                resets += top.resets;
+                if (top.lastValue > prevValue) {
+                    resets += prevValue;
                 }
-                var val = values.get(position);
-                if (val > prevValue) {
-                    state.resets += val;
-                }
-                prevValue = val;
             }
-            state.samples += pendingCount;
-            state.appendInterval(new Interval(lastTimestamp, lastValue, timestamps.get(position), prevValue));
+            state.appendInterval(new Interval(lastTimestamp, lastValue, top.firstTimestamp, top.firstValue, resets, samples));
         }
 
-        private PriorityQueue<Slice> mergeQueue() {
-            PriorityQueue<Slice> pq = new PriorityQueue<>(this.sliceOffsets.length + 1) {
+        private PriorityQueue<Interval> mergeQueue() {
+            var pq = new PriorityQueue<Interval>(offset + 1) {
                 @Override
-                protected boolean lessThan(Slice a, Slice b) {
-                    return a.timestamp > b.timestamp; // want the latest timestamp first
+                protected boolean lessThan(Interval a, Interval b) {
+                    return a.lastTimestamp > b.lastTimestamp; // want the latest timestamp first
                 }
             };
-            int startOffset = 0;
-            for (int sliceOffset : sliceOffsets) {
-                pq.add(new Slice(this, startOffset, sliceOffset));
-                startOffset = sliceOffset;
+            for (int i = 0; i <= offset; i++) {
+                pq.add(intervals.get(i));
             }
-            pq.add(new Slice(this, startOffset, pendingCount));
             return pq;
         }
 
         @Override
         public void close() {
-            timestamps.close();
-            values.close();
-        }
-    }
-
-    static final class Slice {
-        int start;
-        long timestamp;
-        final int end;
-        final Buffer buffer;
-
-        Slice(Buffer buffer, int start, int end) {
-            this.buffer = buffer;
-            this.start = start;
-            this.end = end;
-            this.timestamp = buffer.timestamps.get(start);
-        }
-
-        boolean exhausted() {
-            return start >= end;
-        }
-
-        int next() {
-            int index = start++;
-            if (start < end) {
-                timestamp = buffer.timestamps.get(start);
-            }
-            return index;
+            intervals.close();
         }
     }
 
@@ -588,8 +549,8 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
                     for (int i = 1; i < intervals.length; i++) {
                         Interval next = intervals[i - 1]; // reversed
                         Interval prev = intervals[i];
-                        if (prev.v1 > next.v2) {
-                            state.resets += prev.v1;
+                        if (prev.lastValue > next.firstValue) {
+                            state.resets += prev.lastValue;
                         }
                     }
                 }
@@ -640,40 +601,41 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
         return sb.toString();
     }
 
-    record Interval(long t1, long v1, long t2, long v2) implements Comparable<Interval> {
-        @Override
-        public int compareTo(Interval other) {
-            return Long.compare(other.t1, t1); // want most recent first
-        }
-    }
-
     static final class ReducedState {
         private static final Interval[] EMPTY_INTERVALS = new Interval[0];
         long samples;
-        double resets;
+        long resets;
         Interval[] intervals = EMPTY_INTERVALS;
 
         void appendInterval(Interval interval) {
             int currentSize = intervals.length;
-            this.intervals = ArrayUtil.growExact(intervals, currentSize + 1);
-            this.intervals[currentSize] = interval;
+            intervals = ArrayUtil.growExact(intervals, currentSize + 1);
+            intervals[currentSize] = interval;
+            samples += interval.samples;
+            resets += interval.resets;
         }
 
-        void appendIntervalsFromBlocks(LongBlock ts, LongBlock vs, int position) {
-            int tsFirst = ts.getFirstValueIndex(position);
-            int vsFirst = vs.getFirstValueIndex(position);
-            int count = ts.getValueCount(position);
-            assert count % 2 == 0 : "expected even number of values for intervals, got " + count + " in " + ts;
+        void appendIntervalsFromBlocks(LongBlock timestampsBlock, LongBlock valuesBlock, LongBlock resetsBlock, LongBlock samplesBLock, int position) {
+            int tsFirst = timestampsBlock.getFirstValueIndex(position);
+            int vsFirst = valuesBlock.getFirstValueIndex(position);
+            int resetsFirst = resetsBlock.getFirstValueIndex(position);
+            int samplesFirst = samplesBLock.getFirstValueIndex(position);
+            int count = timestampsBlock.getValueCount(position);
+            assert count % 2 == 0 : "expected even number of values for intervals, got " + count + " in " + timestampsBlock;
             int currentSize = intervals.length;
             intervals = ArrayUtil.growExact(intervals, currentSize + (count / 2));
             for (int i = 0; i < count; i += 2) {
                 Interval interval = new Interval(
-                    ts.getLong(tsFirst + i),
-                    vs.getLong(vsFirst + i),
-                    ts.getLong(tsFirst + i + 1),
-                    vs.getLong(vsFirst + i + 1)
+                    timestampsBlock.getLong(tsFirst + i),
+                    valuesBlock.getLong(vsFirst + i),
+                    timestampsBlock.getLong(tsFirst + i + 1),
+                    valuesBlock.getLong(vsFirst + i + 1),
+                    resetsBlock.getLong(resetsFirst + i),
+                    samplesBLock.getLong(samplesFirst + i)
                 );
                 intervals[currentSize++] = interval;
+                samples += interval.samples;
+                resets += interval.resets;
             }
         }
     }
@@ -682,10 +644,10 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
         if (state.samples < 2) {
             return Double.NaN;
         }
-        final long firstTS = state.intervals[state.intervals.length - 1].t2;
-        final long lastTS = state.intervals[0].t1;
-        double firstValue = state.intervals[state.intervals.length - 1].v2;
-        double lastValue = state.intervals[0].v1 + state.resets;
+        final long firstTS = state.intervals[state.intervals.length - 1].firstTimestamp;
+        final long lastTS = state.intervals[0].lastTimestamp;
+        double firstValue = state.intervals[state.intervals.length - 1].firstValue;
+        double lastValue = state.intervals[0].lastValue + state.resets;
         if (isRateOverTime) {
             return (lastValue - firstValue) * dateFactor / (lastTS - firstTS);
         } else {
@@ -716,8 +678,8 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
         var previousState = (previousGroupId >= 0) ? states.get(previousGroupId) : null;
         if (previousState == null || previousState.samples == 0) {
             if (state.samples == 1) {
-                firstTsSec = state.intervals[0].t1 / dateFactor;
-                firstValue = state.intervals[0].v1;
+                firstTsSec = state.intervals[0].lastTimestamp / dateFactor;
+                firstValue = state.intervals[0].lastValue;
             } else {
                 firstValue = extrapolateToBoundary(state, tbucketStart, tbucketEnd, dateFactor, true);
             }
@@ -729,8 +691,8 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
         var nextState = (nextGroupId >= 0) ? states.get(nextGroupId) : null;
         if (nextState == null || nextState.samples == 0) {
             if (state.samples == 1) {
-                lastTsSec = state.intervals[0].t1 / dateFactor;
-                lastValue = state.intervals[0].v1;
+                lastTsSec = state.intervals[0].lastTimestamp / dateFactor;
+                lastValue = state.intervals[0].lastValue;
             } else {
                 lastValue = extrapolateToBoundary(state, tbucketStart, tbucketEnd, dateFactor, false);
             }
@@ -743,14 +705,15 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
             if (state.samples == 1) {
                 if (previousState != null) {
                     assert nextState == null;
-                    assert state.intervals[0].t1 == firstTsSec * dateFactor : firstTsSec + ":" + state.intervals[0].t1;
-                    final double startTs = previousState.intervals[0].t1 / dateFactor;
+                    assert state.intervals[0].lastTimestamp == firstTsSec * dateFactor
+                        : firstTsSec + ":" + state.intervals[0].lastTimestamp;
+                    final double startTs = previousState.intervals[0].lastTimestamp / dateFactor;
                     final double delta = deltaBetweenStates(previousState, state, dateFactor);
                     return isRateOverTime ? delta / (firstTsSec - startTs) : delta;
                 }
                 if (nextState != null) {
-                    assert state.intervals[0].t1 == lastTsSec * dateFactor : lastTsSec + ":" + state.intervals[0].t1;
-                    final double endTs = nextState.intervals[nextState.intervals.length - 1].t2 / dateFactor;
+                    assert state.intervals[0].lastTimestamp == lastTsSec * dateFactor : lastTsSec + ":" + state.intervals[0].lastTimestamp;
+                    final double endTs = nextState.intervals[nextState.intervals.length - 1].firstTimestamp / dateFactor;
                     final double delta = deltaBetweenStates(state, nextState, dateFactor);
                     return isRateOverTime ? delta / (endTs - lastTsSec) : delta;
                 }
@@ -778,10 +741,10 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
         double dateFactor,
         boolean isLowerBoundary
     ) {
-        final double startTs = state.intervals[state.intervals.length - 1].t2 / dateFactor;
-        final double startValue = state.intervals[state.intervals.length - 1].v2;
-        final double endTs = state.intervals[0].t1 / dateFactor;
-        final double endValue = state.intervals[0].v1 + state.resets;
+        final double startTs = state.intervals[state.intervals.length - 1].firstTimestamp / dateFactor;
+        final double startValue = state.intervals[state.intervals.length - 1].firstValue;
+        final double endTs = state.intervals[0].lastTimestamp / dateFactor;
+        final double endValue = state.intervals[0].lastValue + state.resets;
         final double sampleTsSec = endTs - startTs;
         final double averageSampleInterval = sampleTsSec / state.samples;
         final double slope = (endValue - startValue) / sampleTsSec;
@@ -825,10 +788,10 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
         double dateFactor,
         boolean isLowerBoundary
     ) {
-        final double startValue = lowerState.intervals[0].v1;
-        final double startTs = lowerState.intervals[0].t1 / dateFactor;
-        final double endValue = upperState.intervals[upperState.intervals.length - 1].v2;
-        final double endTs = upperState.intervals[upperState.intervals.length - 1].t2 / dateFactor;
+        final double startValue = lowerState.intervals[0].lastValue;
+        final double startTs = lowerState.intervals[0].lastTimestamp / dateFactor;
+        final double endValue = upperState.intervals[upperState.intervals.length - 1].firstValue;
+        final double endTs = upperState.intervals[upperState.intervals.length - 1].firstTimestamp / dateFactor;
         assert startTs < endTs : "expected startTs < endTs, got " + startTs + " < " + endTs;
         final double delta = deltaBetweenStates(lowerState, upperState, dateFactor);
         final double slope = delta / (endTs - startTs);
@@ -845,10 +808,10 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
     }
 
     private static double deltaBetweenStates(ReducedState lowerState, ReducedState upperState, double dateFactor) {
-        final double startValue = lowerState.intervals[0].v1;
-        final double startTs = lowerState.intervals[0].t1 / dateFactor;
-        final double endValue = upperState.intervals[upperState.intervals.length - 1].v2;
-        final double endTs = upperState.intervals[upperState.intervals.length - 1].t2 / dateFactor;
+        final double startValue = lowerState.intervals[0].lastValue;
+        final double startTs = lowerState.intervals[0].lastTimestamp / dateFactor;
+        final double endValue = upperState.intervals[upperState.intervals.length - 1].firstValue;
+        final double endTs = upperState.intervals[upperState.intervals.length - 1].firstTimestamp / dateFactor;
 
         // If the end value is smaller than the start value, a counter reset occurred.
         // In this case, the delta is considered equal to the end value.

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateLongGroupingAggregatorFunction.java
@@ -615,7 +615,13 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
             resets += interval.resets;
         }
 
-        void appendIntervalsFromBlocks(LongBlock timestampsBlock, LongBlock valuesBlock, LongBlock resetsBlock, LongBlock samplesBLock, int position) {
+        void appendIntervalsFromBlocks(
+            LongBlock timestampsBlock,
+            LongBlock valuesBlock,
+            LongBlock resetsBlock,
+            LongBlock samplesBLock,
+            int position
+        ) {
             int tsFirst = timestampsBlock.getFirstValueIndex(position);
             int vsFirst = valuesBlock.getFirstValueIndex(position);
             int resetsFirst = resetsBlock.getFirstValueIndex(position);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-RateGroupingAggregatorFunction.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-RateGroupingAggregatorFunction.java.st
@@ -201,11 +201,11 @@ public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggre
                 final int groupId = groups.getInt(g);
                 final var value = valueBlock.get$Type$(valueBlock.getFirstValueIndex(valuePosition));
                 if (lastGroup != groupId) {
-                    buffer = getBuffer(groupId, 1, timestamp);
-                    buffer.appendWithoutResize(timestamp, value);
+                    buffer = getBuffer(groupId);
+                    buffer.append(timestamp, value);
                     lastGroup = groupId;
                 } else {
-                    buffer.maybeResizeAndAppend(bigArrays, timestamp, value);
+                    buffer.append(timestamp, value);
                 }
             }
         }
@@ -252,12 +252,12 @@ public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggre
     }
 
     private void addSubRange(int group, int from, int to, $Type$Vector valueVector, LongVector timestampVector) {
-        var buffer = getBuffer(group, to - from, timestampVector.getLong(from));
+        var buffer = getBuffer(group);
         buffer.appendRange(from, to, valueVector, timestampVector);
     }
 
     private void addSubRange(int group, int from, int to, $Type$Block valueBlock, LongVector timestampVector) {
-        var buffer = getBuffer(group, to - from, timestampVector.getLong(from));
+        var buffer = getBuffer(group);
         buffer.appendRange(from, to, valueBlock, timestampVector);
     }
 
@@ -285,8 +285,8 @@ public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggre
         if (values.areAllValuesNull()) {
             return;
         }
-        LongVector sampleCounts = ((LongBlock) page.getBlock(channels.get(2))).asVector();
-        DoubleVector resets = ((DoubleBlock) page.getBlock(channels.get(3))).asVector();
+        var sampleCounts = ((LongBlock) page.getBlock(channels.get(2)));
+        var resets = (($Type$Block) page.getBlock(channels.get(3)));
         for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
             int valuePosition = positionOffset + groupPosition;
             long sampleCount = sampleCounts.getLong(valuePosition);
@@ -300,9 +300,7 @@ public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggre
                 state = new ReducedState();
                 reducedStates.set(groupId, state);
             }
-            state.appendIntervalsFromBlocks(timestamps, values, valuePosition);
-            state.samples += sampleCount;
-            state.resets += resets.getDouble(valuePosition);
+            state.appendIntervalsFromBlocks(timestamps, values, resets, sampleCounts, valuePosition);
         }
     }
 
@@ -314,8 +312,8 @@ public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggre
         if (values.areAllValuesNull()) {
             return;
         }
-        LongVector sampleCounts = ((LongBlock) page.getBlock(channels.get(2))).asVector();
-        DoubleVector resets = ((DoubleBlock) page.getBlock(channels.get(3))).asVector();
+        var sampleCounts = ((LongBlock) page.getBlock(channels.get(2)));
+        var resets = (($Type$Block) page.getBlock(channels.get(3)));
         for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
             int valuePosition = positionOffset + groupPosition;
             long sampleCount = sampleCounts.getLong(valuePosition);
@@ -335,9 +333,7 @@ public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggre
                     state = new ReducedState();
                     reducedStates.set(groupId, state);
                 }
-                state.appendIntervalsFromBlocks(timestamps, values, valuePosition);
-                state.samples += sampleCount;
-                state.resets += resets.getDouble(valuePosition);
+                state.appendIntervalsFromBlocks(timestamps, values, resets, sampleCounts, valuePosition);
             }
         }
     }
@@ -350,7 +346,7 @@ public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggre
             var timestamps = blockFactory.newLongBlockBuilder(positionCount * 2);
             var values = blockFactory.new$Type$BlockBuilder(positionCount * 2);
             var sampleCounts = blockFactory.newLongVectorFixedBuilder(positionCount);
-            var resets = blockFactory.newDoubleVectorFixedBuilder(positionCount)
+            var resets = blockFactory.new$Type$VectorFixedBuilder(positionCount)
         ) {
             for (int p = 0; p < positionCount; p++) {
                 int group = selected.getInt(p);
@@ -360,20 +356,20 @@ public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggre
                     timestamps.beginPositionEntry();
                     values.beginPositionEntry();
                     for (Interval interval : state.intervals) {
-                        timestamps.appendLong(interval.t1);
-                        timestamps.appendLong(interval.t2);
-                        values.append$Type$(interval.v1);
-                        values.append$Type$(interval.v2);
+                        timestamps.appendLong(interval.lastTimestamp);
+                        timestamps.appendLong(interval.firstTimestamp);
+                        values.append$Type$(interval.lastValue);
+                        values.append$Type$(interval.firstValue);
                     }
                     timestamps.endPositionEntry();
                     values.endPositionEntry();
                     sampleCounts.appendLong(state.samples);
-                    resets.appendDouble(state.resets);
+                    resets.append$Type$(state.resets);
                 } else {
                     timestamps.appendLong(0);
                     values.append$Type$(0);
                     sampleCounts.appendLong(0);
-                    resets.appendDouble(0);
+                    resets.append$Type$(0);
                 }
             }
             blocks[offset] = timestamps.build();
@@ -394,16 +390,55 @@ public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggre
         Releasables.close(reducedStates, buffers);
     }
 
-    private Buffer getBuffer(int groupId, int newElements, long firstTimestamp) {
+    private Buffer getBuffer(int groupId) {
         buffers = bigArrays.grow(buffers, groupId + 1);
         Buffer buffer = buffers.get(groupId);
         if (buffer == null) {
-            buffer = new Buffer(bigArrays, newElements);
+            buffer = new Buffer(bigArrays);
             buffers.set(groupId, buffer);
-        } else {
-            buffer.ensureCapacity(bigArrays, newElements, firstTimestamp);
         }
         return buffer;
+    }
+
+    private static class Interval implements Comparable<Interval> {
+
+        private long lastTimestamp;
+        private $type$ lastValue;
+        private long firstTimestamp;
+        private $type$ firstValue;
+        private $type$ resets;
+        private long samples;
+
+        Interval(long timestamp, $type$ value) {
+            this(timestamp, value, timestamp, value, 0, 1);
+        }
+
+        Interval(long lastTimestamp, $type$ lastValue, long firstTimestamp, $type$ firstValue, $type$ resets, long samples) {
+            this.lastTimestamp = lastTimestamp;
+            this.lastValue = lastValue;
+            this.firstTimestamp = firstTimestamp;
+            this.firstValue = firstValue;
+            this.resets = resets;
+            this.samples = samples;
+        }
+
+        boolean maybeAdd(long timestamp, $type$ value) {
+            if (timestamp > firstTimestamp) {
+                return false;
+            }
+            if (value > firstValue) {
+                resets += value;  // Counter reset detected.
+            }
+            firstTimestamp = timestamp;
+            firstValue = value;
+            samples++;
+            return true;
+        }
+
+        @Override
+        public int compareTo(Interval other) {
+            return Long.compare(other.lastTimestamp, lastTimestamp); // want most recent first
+        }
     }
 
     /**
@@ -415,38 +450,26 @@ public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggre
      * the slice with the greatest timestamp.
      */
     static final class Buffer implements Releasable {
-        private LongArray timestamps;
-        private $Type$Array values;
-        private int pendingCount;
-        int[] sliceOffsets;
-        private static final int[] EMPTY_SLICES = new int[0];
+        private final BigArrays bigArrays;
+        private ObjectArray<Interval> intervals;
+        private int offset = -1;
 
-        Buffer(BigArrays bigArrays, int initialSize) {
-            this.timestamps = bigArrays.newLongArray(Math.max(initialSize, 32), false);
-            this.values = bigArrays.new$Type$Array(Math.max(initialSize, 32), false);
-            this.sliceOffsets = EMPTY_SLICES;
+        Buffer(BigArrays bigArrays) {
+            this.bigArrays = bigArrays;
+            this.intervals = bigArrays.newObjectArray(32);
         }
 
-        void appendWithoutResize(long timestamp, $type$ value) {
-            timestamps.set(pendingCount, timestamp);
-            values.set(pendingCount, value);
-            pendingCount++;
-        }
-
-        void maybeResizeAndAppend(BigArrays bigArrays, long timestamp, $type$ value) {
-            timestamps = bigArrays.grow(timestamps, pendingCount + 1);
-            values = bigArrays.grow(values, pendingCount + 1);
-
-            timestamps.set(pendingCount, timestamp);
-            values.set(pendingCount, value);
-            pendingCount++;
+        void append(long timestamp, $type$ value) {
+            if (offset < 0 || intervals.get(offset).maybeAdd(timestamp, value) == false) {
+                var nextInterval = new Interval(timestamp, value);
+                bigArrays.grow(intervals, offset + 1);
+                intervals.set(++offset, nextInterval);
+            }
         }
 
         void appendRange(int fromPosition, int toPosition, $Type$Vector valueVector, LongVector timestampVector) {
             for (int p = fromPosition; p < toPosition; p++) {
-                values.set(pendingCount, valueVector.get$Type$(p));
-                timestamps.set(pendingCount, timestampVector.getLong(p));
-                pendingCount++;
+                append(timestampVector.getLong(p), valueVector.get$Type$(p));
             }
         }
 
@@ -456,116 +479,54 @@ public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggre
                     continue;
                 }
                 assert valueBlock.getValueCount(p) == 1 : "expected single-valued block " + valueBlock;
-                values.set(pendingCount, valueBlock.get$Type$(p));
-                timestamps.set(pendingCount, timestampVector.getLong(p));
-                pendingCount++;
-            }
-        }
-
-        void ensureCapacity(BigArrays bigArrays, int count, long firstTimestamp) {
-            int newSize = pendingCount + count;
-            timestamps = bigArrays.grow(timestamps, newSize);
-            values = bigArrays.grow(values, newSize);
-            if (pendingCount > 0 && firstTimestamp > timestamps.get(pendingCount - 1)) {
-                if (sliceOffsets.length == 0 || sliceOffsets[sliceOffsets.length - 1] != pendingCount) {
-                    sliceOffsets = ArrayUtil.growExact(sliceOffsets, sliceOffsets.length + 1);
-                    sliceOffsets[sliceOffsets.length - 1] = pendingCount;
-                }
+                append(timestampVector.getLong(p), valueBlock.get$Type$(p));
             }
         }
 
         void flush(ReducedState state) {
-            if (pendingCount == 0) {
+            if (offset < 0) {
                 return;
             }
-            if (pendingCount == 1) {
-                state.samples++;
-                long t = timestamps.get(0);
-                $type$ v = values.get(0);
-                state.appendInterval(new Interval(t, v, t, v));
+            if (offset == 0) {
+                state.appendInterval(intervals.get(0));
                 return;
             }
-            PriorityQueue<Slice> pq = mergeQueue();
+            PriorityQueue<Interval> pq = mergeQueue();
+            Interval top = pq.pop();
+
             // first
-            final long lastTimestamp;
-            final $type$ lastValue;
-            {
-                Slice top = pq.top();
-                lastTimestamp = top.timestamp;
-                int position = top.next();
-                lastValue = values.get(position);
-                if (top.exhausted()) {
-                    pq.pop();
-                } else {
-                    pq.updateTop();
-                }
-            }
-            var prevValue = lastValue;
-            int position = -1;
+            final $type$ lastValue = top.lastValue;
+            final long lastTimestamp = top.lastTimestamp;
+            $type$ resets = top.resets;
+            long samples = top.samples;
+            $type$ prevValue = top.firstValue;
             while (pq.size() > 0) {
-                Slice top = pq.top();
-                position = top.next();
-                if (top.exhausted()) {
-                    pq.pop();
-                } else {
-                    pq.updateTop();
+                top = pq.pop();
+                samples += top.samples;
+                resets += top.resets;
+                if (top.lastValue > prevValue) {
+                    resets += prevValue;
                 }
-                var val = values.get(position);
-                if (val > prevValue) {
-                    state.resets += val;
-                }
-                prevValue = val;
             }
-            state.samples += pendingCount;
-            state.appendInterval(new Interval(lastTimestamp, lastValue, timestamps.get(position), prevValue));
+            state.appendInterval(new Interval(lastTimestamp, lastValue, top.firstTimestamp, top.firstValue, resets, samples));
         }
 
-        private PriorityQueue<Slice> mergeQueue() {
-            PriorityQueue<Slice> pq = new PriorityQueue<>(this.sliceOffsets.length + 1) {
+        private PriorityQueue<Interval> mergeQueue() {
+            var pq = new PriorityQueue<Interval>(offset + 1) {
                 @Override
-                protected boolean lessThan(Slice a, Slice b) {
-                    return a.timestamp > b.timestamp; // want the latest timestamp first
+                protected boolean lessThan(Interval a, Interval b) {
+                    return a.lastTimestamp > b.lastTimestamp; // want the latest timestamp first
                 }
             };
-            int startOffset = 0;
-            for (int sliceOffset : sliceOffsets) {
-                pq.add(new Slice(this, startOffset, sliceOffset));
-                startOffset = sliceOffset;
+            for (int i = 0; i <= offset; i++) {
+                pq.add(intervals.get(i));
             }
-            pq.add(new Slice(this, startOffset, pendingCount));
             return pq;
         }
 
         @Override
         public void close() {
-            timestamps.close();
-            values.close();
-        }
-    }
-
-    static final class Slice {
-        int start;
-        long timestamp;
-        final int end;
-        final Buffer buffer;
-
-        Slice(Buffer buffer, int start, int end) {
-            this.buffer = buffer;
-            this.start = start;
-            this.end = end;
-            this.timestamp = buffer.timestamps.get(start);
-        }
-
-        boolean exhausted() {
-            return start >= end;
-        }
-
-        int next() {
-            int index = start++;
-            if (start < end) {
-                timestamp = buffer.timestamps.get(start);
-            }
-            return index;
+            intervals.close();
         }
     }
 
@@ -588,8 +549,8 @@ public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggre
                     for (int i = 1; i < intervals.length; i++) {
                         Interval next = intervals[i - 1]; // reversed
                         Interval prev = intervals[i];
-                        if (prev.v1 > next.v2) {
-                            state.resets += prev.v1;
+                        if (prev.lastValue > next.firstValue) {
+                            state.resets += prev.lastValue;
                         }
                     }
                 }
@@ -640,40 +601,41 @@ public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggre
         return sb.toString();
     }
 
-    record Interval(long t1, $type$ v1, long t2, $type$ v2) implements Comparable<Interval> {
-        @Override
-        public int compareTo(Interval other) {
-            return Long.compare(other.t1, t1); // want most recent first
-        }
-    }
-
     static final class ReducedState {
         private static final Interval[] EMPTY_INTERVALS = new Interval[0];
         long samples;
-        double resets;
+        $type$ resets;
         Interval[] intervals = EMPTY_INTERVALS;
 
         void appendInterval(Interval interval) {
             int currentSize = intervals.length;
-            this.intervals = ArrayUtil.growExact(intervals, currentSize + 1);
-            this.intervals[currentSize] = interval;
+            intervals = ArrayUtil.growExact(intervals, currentSize + 1);
+            intervals[currentSize] = interval;
+            samples += interval.samples;
+            resets += interval.resets;
         }
 
-        void appendIntervalsFromBlocks(LongBlock ts, $Type$Block vs, int position) {
-            int tsFirst = ts.getFirstValueIndex(position);
-            int vsFirst = vs.getFirstValueIndex(position);
-            int count = ts.getValueCount(position);
-            assert count % 2 == 0 : "expected even number of values for intervals, got " + count + " in " + ts;
+        void appendIntervalsFromBlocks(LongBlock timestampsBlock, $Type$Block valuesBlock, $Type$Block resetsBlock, LongBlock samplesBLock, int position) {
+            int tsFirst = timestampsBlock.getFirstValueIndex(position);
+            int vsFirst = valuesBlock.getFirstValueIndex(position);
+            int resetsFirst = resetsBlock.getFirstValueIndex(position);
+            int samplesFirst = samplesBLock.getFirstValueIndex(position);
+            int count = timestampsBlock.getValueCount(position);
+            assert count % 2 == 0 : "expected even number of values for intervals, got " + count + " in " + timestampsBlock;
             int currentSize = intervals.length;
             intervals = ArrayUtil.growExact(intervals, currentSize + (count / 2));
             for (int i = 0; i < count; i += 2) {
                 Interval interval = new Interval(
-                    ts.getLong(tsFirst + i),
-                    vs.get$Type$(vsFirst + i),
-                    ts.getLong(tsFirst + i + 1),
-                    vs.get$Type$(vsFirst + i + 1)
+                    timestampsBlock.getLong(tsFirst + i),
+                    valuesBlock.get$Type$(vsFirst + i),
+                    timestampsBlock.getLong(tsFirst + i + 1),
+                    valuesBlock.get$Type$(vsFirst + i + 1),
+                    resetsBlock.get$Type$(resetsFirst + i),
+                    samplesBLock.getLong(samplesFirst + i)
                 );
                 intervals[currentSize++] = interval;
+                samples += interval.samples;
+                resets += interval.resets;
             }
         }
     }
@@ -682,10 +644,10 @@ public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggre
         if (state.samples < 2) {
             return Double.NaN;
         }
-        final long firstTS = state.intervals[state.intervals.length - 1].t2;
-        final long lastTS = state.intervals[0].t1;
-        double firstValue = state.intervals[state.intervals.length - 1].v2;
-        double lastValue = state.intervals[0].v1 + state.resets;
+        final long firstTS = state.intervals[state.intervals.length - 1].firstTimestamp;
+        final long lastTS = state.intervals[0].lastTimestamp;
+        double firstValue = state.intervals[state.intervals.length - 1].firstValue;
+        double lastValue = state.intervals[0].lastValue + state.resets;
         if (isRateOverTime) {
             return (lastValue - firstValue) * dateFactor / (lastTS - firstTS);
         } else {
@@ -716,8 +678,8 @@ public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggre
         var previousState = (previousGroupId >= 0) ? states.get(previousGroupId) : null;
         if (previousState == null || previousState.samples == 0) {
             if (state.samples == 1) {
-                firstTsSec = state.intervals[0].t1 / dateFactor;
-                firstValue = state.intervals[0].v1;
+                firstTsSec = state.intervals[0].lastTimestamp / dateFactor;
+                firstValue = state.intervals[0].lastValue;
             } else {
                 firstValue = extrapolateToBoundary(state, tbucketStart, tbucketEnd, dateFactor, true);
             }
@@ -729,8 +691,8 @@ public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggre
         var nextState = (nextGroupId >= 0) ? states.get(nextGroupId) : null;
         if (nextState == null || nextState.samples == 0) {
             if (state.samples == 1) {
-                lastTsSec = state.intervals[0].t1 / dateFactor;
-                lastValue = state.intervals[0].v1;
+                lastTsSec = state.intervals[0].lastTimestamp / dateFactor;
+                lastValue = state.intervals[0].lastValue;
             } else {
                 lastValue = extrapolateToBoundary(state, tbucketStart, tbucketEnd, dateFactor, false);
             }
@@ -743,14 +705,15 @@ public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggre
             if (state.samples == 1) {
                 if (previousState != null) {
                     assert nextState == null;
-                    assert state.intervals[0].t1 == firstTsSec * dateFactor : firstTsSec + ":" + state.intervals[0].t1;
-                    final double startTs = previousState.intervals[0].t1 / dateFactor;
+                    assert state.intervals[0].lastTimestamp == firstTsSec * dateFactor
+                        : firstTsSec + ":" + state.intervals[0].lastTimestamp;
+                    final double startTs = previousState.intervals[0].lastTimestamp / dateFactor;
                     final double delta = deltaBetweenStates(previousState, state, dateFactor);
                     return isRateOverTime ? delta / (firstTsSec - startTs) : delta;
                 }
                 if (nextState != null) {
-                    assert state.intervals[0].t1 == lastTsSec * dateFactor : lastTsSec + ":" + state.intervals[0].t1;
-                    final double endTs = nextState.intervals[nextState.intervals.length - 1].t2 / dateFactor;
+                    assert state.intervals[0].lastTimestamp == lastTsSec * dateFactor : lastTsSec + ":" + state.intervals[0].lastTimestamp;
+                    final double endTs = nextState.intervals[nextState.intervals.length - 1].firstTimestamp / dateFactor;
                     final double delta = deltaBetweenStates(state, nextState, dateFactor);
                     return isRateOverTime ? delta / (endTs - lastTsSec) : delta;
                 }
@@ -778,10 +741,10 @@ public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggre
         double dateFactor,
         boolean isLowerBoundary
     ) {
-        final double startTs = state.intervals[state.intervals.length - 1].t2 / dateFactor;
-        final double startValue = state.intervals[state.intervals.length - 1].v2;
-        final double endTs = state.intervals[0].t1 / dateFactor;
-        final double endValue = state.intervals[0].v1 + state.resets;
+        final double startTs = state.intervals[state.intervals.length - 1].firstTimestamp / dateFactor;
+        final double startValue = state.intervals[state.intervals.length - 1].firstValue;
+        final double endTs = state.intervals[0].lastTimestamp / dateFactor;
+        final double endValue = state.intervals[0].lastValue + state.resets;
         final double sampleTsSec = endTs - startTs;
         final double averageSampleInterval = sampleTsSec / state.samples;
         final double slope = (endValue - startValue) / sampleTsSec;
@@ -825,10 +788,10 @@ public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggre
         double dateFactor,
         boolean isLowerBoundary
     ) {
-        final double startValue = lowerState.intervals[0].v1;
-        final double startTs = lowerState.intervals[0].t1 / dateFactor;
-        final double endValue = upperState.intervals[upperState.intervals.length - 1].v2;
-        final double endTs = upperState.intervals[upperState.intervals.length - 1].t2 / dateFactor;
+        final double startValue = lowerState.intervals[0].lastValue;
+        final double startTs = lowerState.intervals[0].lastTimestamp / dateFactor;
+        final double endValue = upperState.intervals[upperState.intervals.length - 1].firstValue;
+        final double endTs = upperState.intervals[upperState.intervals.length - 1].firstTimestamp / dateFactor;
         assert startTs < endTs : "expected startTs < endTs, got " + startTs + " < " + endTs;
         final double delta = deltaBetweenStates(lowerState, upperState, dateFactor);
         final double slope = delta / (endTs - startTs);
@@ -845,10 +808,10 @@ public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggre
     }
 
     private static double deltaBetweenStates(ReducedState lowerState, ReducedState upperState, double dateFactor) {
-        final double startValue = lowerState.intervals[0].v1;
-        final double startTs = lowerState.intervals[0].t1 / dateFactor;
-        final double endValue = upperState.intervals[upperState.intervals.length - 1].v2;
-        final double endTs = upperState.intervals[upperState.intervals.length - 1].t2 / dateFactor;
+        final double startValue = lowerState.intervals[0].lastValue;
+        final double startTs = lowerState.intervals[0].lastTimestamp / dateFactor;
+        final double endValue = upperState.intervals[upperState.intervals.length - 1].firstValue;
+        final double endTs = upperState.intervals[upperState.intervals.length - 1].firstTimestamp / dateFactor;
 
         // If the end value is smaller than the start value, a counter reset occurred.
         // In this case, the delta is considered equal to the end value.


### PR DESCRIPTION
Prototype for updating intervals directly, instead of copying and sorting all counter data points. 