### PR TITLE
[Stack Monitoring] mapping for total node shards in .monitoring-es-mb

### DIFF
--- a/docs/changelog/140302.yaml
+++ b/docs/changelog/140302.yaml
@@ -1,0 +1,5 @@
+pr: 140302
+summary: "[Stack Monitoring] mapping for total node shards in .monitoring-es-mb"
+area: Monitoring
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/template-resources/src/main/resources/monitoring-es-mb.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/monitoring-es-mb.json
@@ -93,6 +93,13 @@
                             }
                           }
                         },
+                        "shard_stats": {
+                          "properties": {
+                            "total_count": {
+                              "type": "long"
+                            }
+                          }
+                        },
                         "store": {
                           "properties": {
                             "size": {

--- a/x-pack/plugin/core/template-resources/src/main/resources/monitoring-es-mb.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/monitoring-es-mb.json
@@ -93,13 +93,6 @@
                             }
                           }
                         },
-                        "shard_stats": {
-                          "properties": {
-                            "total_count": {
-                              "type": "long"
-                            }
-                          }
-                        },
                         "store": {
                           "properties": {
                             "size": {
@@ -690,6 +683,13 @@
                                   "type": "long"
                                 }
                               }
+                            }
+                          }
+                        },
+                        "shard_stats": {
+                          "properties": {
+                            "total_count": {
+                              "type": "long"
                             }
                           }
                         },

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
@@ -77,7 +77,7 @@ public class MonitoringTemplateRegistry extends IndexTemplateRegistry {
      * writes monitoring data in ECS format as of 8.0. These templates define the ECS schema as well as alias fields for the old monitoring
      * mappings that point to the corresponding ECS fields.
      */
-    public static final int STACK_MONITORING_REGISTRY_VERSION = 8_00_00_99 + 22;
+    public static final int STACK_MONITORING_REGISTRY_VERSION = 8_00_00_99 + 23;
     private static final String STACK_MONITORING_REGISTRY_VERSION_VARIABLE = "xpack.stack.monitoring.template.release.version";
     private static final String STACK_TEMPLATE_VERSION = "8";
     private static final String STACK_TEMPLATE_VERSION_VARIABLE = "xpack.stack.monitoring.template.version";


### PR DESCRIPTION
Proposing adding mapping for `elasticsearch.node.stats.indices.shard_stats.total_count` to `.monitoring-es-mb` template.
This field is part of the `node_stats` metricset. 
Can be useful for users' custom alerting/visualizations.

I see we currently use this aggregation approach to compute the same metric in the stack monitoring UI: https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/private/monitoring/server/lib/elasticsearch/shards/get_nodes_shard_count.ts

---

Used PR https://github.com/elastic/elasticsearch/pull/121062 as a reference for the changes here