### PR TITLE
[9.3] [Inference API] Fix flaky AuthorizationTaskExecutorIT tests (#139978)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -1,410 +1,404 @@
 tests:
-- class: org.elasticsearch.packaging.test.PackagesSecurityAutoConfigurationTests
-  method: test20SecurityNotAutoConfiguredOnReInstallation
-  issue: https://github.com/elastic/elasticsearch/issues/112635
-- class: org.elasticsearch.xpack.transform.integration.TransformIT
-  method: testStopWaitForCheckpoint
-  issue: https://github.com/elastic/elasticsearch/issues/106113
-- class: org.elasticsearch.xpack.remotecluster.RemoteClusterSecurityWithApmTracingRestIT
-  method: testTracingCrossCluster
-  issue: https://github.com/elastic/elasticsearch/issues/112731
-- class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
-  method: testDeploymentSurvivesRestart {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/115528
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_start_stop/Verify start transform reuses destination index}
-  issue: https://github.com/elastic/elasticsearch/issues/115808
-- class: org.elasticsearch.xpack.application.connector.ConnectorIndexServiceTests
-  issue: https://github.com/elastic/elasticsearch/issues/116087
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_start_stop/Test start already started transform}
-  issue: https://github.com/elastic/elasticsearch/issues/98802
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=snapshot/20_operator_privileges_disabled/Operator only settings can be set and restored by non-operator user when operator privileges is disabled}
-  issue: https://github.com/elastic/elasticsearch/issues/116775
-- class: org.elasticsearch.search.basic.SearchWithRandomIOExceptionsIT
-  method: testRandomDirectoryIOExceptions
-  issue: https://github.com/elastic/elasticsearch/issues/114824
-- class: org.elasticsearch.xpack.apmdata.APMYamlTestSuiteIT
-  method: test {yaml=/10_apm/Test template reinstallation}
-  issue: https://github.com/elastic/elasticsearch/issues/116445
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_reset/Test reset running transform}
-  issue: https://github.com/elastic/elasticsearch/issues/117473
-- class: org.elasticsearch.packaging.test.ArchiveTests
-  method: test44AutoConfigurationNotTriggeredOnNotWriteableConfDir
-  issue: https://github.com/elastic/elasticsearch/issues/118208
-- class: org.elasticsearch.packaging.test.ArchiveTests
-  method: test51AutoConfigurationWithPasswordProtectedKeystore
-  issue: https://github.com/elastic/elasticsearch/issues/118212
-- class: org.elasticsearch.xpack.ccr.rest.ShardChangesRestIT
-  method: testShardChangesNoOperation
-  issue: https://github.com/elastic/elasticsearch/issues/118800
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_start_stop/Test start/stop/start transform}
-  issue: https://github.com/elastic/elasticsearch/issues/119508
-- class: org.elasticsearch.multi_cluster.MultiClusterYamlTestSuiteIT
-  issue: https://github.com/elastic/elasticsearch/issues/119983
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_unattended/Test unattended put and start}
-  issue: https://github.com/elastic/elasticsearch/issues/120019
-- class: org.elasticsearch.xpack.security.QueryableReservedRolesIT
-  method: testConfiguredReservedRolesAfterClosingAndOpeningIndex
-  issue: https://github.com/elastic/elasticsearch/issues/120127
-- class: org.elasticsearch.xpack.ccr.FollowIndexSecurityIT
-  method: testCleanShardFollowTaskAfterDeleteFollower
-  issue: https://github.com/elastic/elasticsearch/issues/120339
-- class: org.elasticsearch.xpack.security.authc.service.ServiceAccountIT
-  method: testAuthenticateShouldNotFallThroughInCaseOfFailure
-  issue: https://github.com/elastic/elasticsearch/issues/120902
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=nodes.stats/11_indices_metrics/indices mappings exact count test for indices level}
-  issue: https://github.com/elastic/elasticsearch/issues/120950
-- class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
-  method: test {yaml=snapshot.delete/10_basic/Delete a snapshot asynchronously}
-  issue: https://github.com/elastic/elasticsearch/issues/122102
-- class: org.elasticsearch.action.admin.cluster.node.tasks.CancellableTasksIT
-  method: testChildrenTasksCancelledOnTimeout
-  issue: https://github.com/elastic/elasticsearch/issues/123568
-- class: org.elasticsearch.xpack.searchablesnapshots.FrozenSearchableSnapshotsIntegTests
-  method: testCreateAndRestorePartialSearchableSnapshot
-  issue: https://github.com/elastic/elasticsearch/issues/123773
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=snapshot/10_basic/Create a source only snapshot and then restore it}
-  issue: https://github.com/elastic/elasticsearch/issues/122755
-- class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
-  method: testDeploymentSurvivesRestart {cluster=OLD}
-  issue: https://github.com/elastic/elasticsearch/issues/124160
-- class: org.elasticsearch.packaging.test.BootstrapCheckTests
-  method: test20RunWithBootstrapChecks
-  issue: https://github.com/elastic/elasticsearch/issues/124940
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_start_stop/Test schedule_now on an already started transform}
-  issue: https://github.com/elastic/elasticsearch/issues/120720
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_start_stop/Verify start transform creates destination index with appropriate mapping}
-  issue: https://github.com/elastic/elasticsearch/issues/125854
-- class: org.elasticsearch.xpack.core.common.notifications.AbstractAuditorTests
-  method: testRecreateTemplateWhenDeleted
-  issue: https://github.com/elastic/elasticsearch/issues/123232
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_reset/Test force reseting a running transform}
-  issue: https://github.com/elastic/elasticsearch/issues/126240
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_start_stop/Test start/stop only starts/stops specified transform}
-  issue: https://github.com/elastic/elasticsearch/issues/126466
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_start_stop/Test start/stop/start continuous transform}
-  issue: https://github.com/elastic/elasticsearch/issues/126755
-- class: org.elasticsearch.index.engine.CompletionStatsCacheTests
-  method: testCompletionStatsCache
-  issue: https://github.com/elastic/elasticsearch/issues/126910
-- class: org.elasticsearch.xpack.ml.integration.ClassificationHousePricingIT
-  method: testFeatureImportanceValues
-  issue: https://github.com/elastic/elasticsearch/issues/124341
-- class: org.elasticsearch.cli.keystore.AddStringKeyStoreCommandTests
-  method: testStdinWithMultipleValues
-  issue: https://github.com/elastic/elasticsearch/issues/126882
-- class: org.elasticsearch.xpack.ccr.action.ShardFollowTaskReplicationTests
-  method: testChangeFollowerHistoryUUID
-  issue: https://github.com/elastic/elasticsearch/issues/127680
-- class: org.elasticsearch.action.admin.indices.diskusage.IndexDiskUsageAnalyzerTests
-  method: testKnnVectors
-  issue: https://github.com/elastic/elasticsearch/issues/127689
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=search/350_point_in_time/point-in-time with index filter}
-  issue: https://github.com/elastic/elasticsearch/issues/127741
-- class: org.elasticsearch.xpack.esql.plugin.DataNodeRequestSenderIT
-  method: testSearchWhileRelocating
-  issue: https://github.com/elastic/elasticsearch/issues/128500
-- class: org.elasticsearch.entitlement.runtime.policy.FileAccessTreeTests
-  method: testWindowsMixedCaseAccess
-  issue: https://github.com/elastic/elasticsearch/issues/129167
-- class: org.elasticsearch.entitlement.runtime.policy.FileAccessTreeTests
-  method: testWindowsAbsolutPathAccess
-  issue: https://github.com/elastic/elasticsearch/issues/129168
-- class: org.elasticsearch.xpack.profiling.action.GetStatusActionIT
-  method: testWaitsUntilResourcesAreCreated
-  issue: https://github.com/elastic/elasticsearch/issues/129486
-- class: org.elasticsearch.search.query.VectorIT
-  method: testFilteredQueryStrategy
-  issue: https://github.com/elastic/elasticsearch/issues/129517
-- class: org.elasticsearch.xpack.security.SecurityRolesMultiProjectIT
-  method: testUpdatingFileBasedRoleAffectsAllProjects
-  issue: https://github.com/elastic/elasticsearch/issues/129775
-- class: org.elasticsearch.action.support.ThreadedActionListenerTests
-  method: testRejectionHandling
-  issue: https://github.com/elastic/elasticsearch/issues/130129
-- class: org.elasticsearch.compute.aggregation.TopIntAggregatorFunctionTests
-  method: testManyInitialManyPartialFinalRunnerThrowing
-  issue: https://github.com/elastic/elasticsearch/issues/130145
-- class: org.elasticsearch.xpack.searchablesnapshots.cache.shared.NodesCachesStatsIntegTests
-  method: testNodesCachesStats
-  issue: https://github.com/elastic/elasticsearch/issues/129863
-- class: org.elasticsearch.index.IndexingPressureIT
-  method: testWriteCanRejectOnPrimaryBasedOnMaxOperationSize
-  issue: https://github.com/elastic/elasticsearch/issues/130281
-- class: org.elasticsearch.indices.stats.IndexStatsIT
-  method: testFilterCacheStats
-  issue: https://github.com/elastic/elasticsearch/issues/124447
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=mtermvectors/10_basic/Tests catching other exceptions per item}
-  issue: https://github.com/elastic/elasticsearch/issues/122414
-- class: org.elasticsearch.packaging.test.DockerTests
-  method: test090SecurityCliPackaging
-  issue: https://github.com/elastic/elasticsearch/issues/131107
-- class: org.elasticsearch.xpack.esql.expression.function.fulltext.ScoreTests
-  method: testSerializationOfSimple {TestCase=<boolean>}
-  issue: https://github.com/elastic/elasticsearch/issues/131334
-- class: org.elasticsearch.packaging.test.DockerTests
-  method: test071BindMountCustomPathWithDifferentUID
-  issue: https://github.com/elastic/elasticsearch/issues/120917
-- class: org.elasticsearch.packaging.test.DockerTests
-  method: test171AdditionalCliOptionsAreForwarded
-  issue: https://github.com/elastic/elasticsearch/issues/120925
-- class: org.elasticsearch.packaging.test.DockerTests
-  method: test050BasicApiTests
-  issue: https://github.com/elastic/elasticsearch/issues/120911
-- class: org.elasticsearch.xpack.restart.FullClusterRestartIT
-  method: testWatcherWithApiKey {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/131964
-- class: org.elasticsearch.xpack.sql.qa.mixed_node.SqlCompatIT
-  method: testNullsOrderWithMissingOrderSupportQueryingNewNode
-  issue: https://github.com/elastic/elasticsearch/issues/132249
-- class: org.elasticsearch.packaging.test.ArchiveGenerateInitialCredentialsTests
-  method: test40VerifyAutogeneratedCredentials
-  issue: https://github.com/elastic/elasticsearch/issues/132877
-- class: org.elasticsearch.packaging.test.ArchiveGenerateInitialCredentialsTests
-  method: test50CredentialAutogenerationOnlyOnce
-  issue: https://github.com/elastic/elasticsearch/issues/132878
-- class: org.elasticsearch.xpack.eql.planner.QueryTranslatorTests
-  method: testMatchOptimization
-  issue: https://github.com/elastic/elasticsearch/issues/132894
-- class: org.elasticsearch.xpack.security.authc.AuthenticationServiceTests
-  method: testInvalidToken
-  issue: https://github.com/elastic/elasticsearch/issues/133328
-- class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
-  method: testCancelViaExpirationOnRemoteResultsWithMinimizeRoundtrips
-  issue: https://github.com/elastic/elasticsearch/issues/127302
-- class: org.elasticsearch.xpack.ml.integration.InferenceIT
-  method: testInferClassificationModel
-  issue: https://github.com/elastic/elasticsearch/issues/133448
-- class: org.elasticsearch.xpack.ml.integration.ClassificationIT
-  method: testWithCustomFeatureProcessors
-  issue: https://github.com/elastic/elasticsearch/issues/134001
-- class: org.elasticsearch.action.admin.cluster.state.TransportClusterStateActionTests
-  method: testGetClusterStateWithDefaultProjectOnly
-  issue: https://github.com/elastic/elasticsearch/issues/134450
-- class: org.elasticsearch.xpack.esql.plugin.CanMatchIT
-  method: testAliasFilters
-  issue: https://github.com/elastic/elasticsearch/issues/134512
-- class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
-  method: testOldRepoAccess
-  issue: https://github.com/elastic/elasticsearch/issues/120148
-- class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
-  method: testOldSourceOnlyRepoAccess
-  issue: https://github.com/elastic/elasticsearch/issues/134646
-- class: org.elasticsearch.oldrepos.OldMappingsIT
-  method: testStandardTokenFilter
-  issue: https://github.com/elastic/elasticsearch/issues/134647
-- class: org.elasticsearch.aggregations.bucket.AggregationReductionCircuitBreakingIT
-  method: testCBTrippingOnReduction
-  issue: https://github.com/elastic/elasticsearch/issues/134667
-- class: org.elasticsearch.xpack.esql.action.CrossClusterCancellationIT
-  method: testCancelSkipUnavailable
-  issue: https://github.com/elastic/elasticsearch/issues/134865
-- class: org.elasticsearch.reservedstate.service.RepositoriesFileSettingsIT
-  method: testSettingsApplied
-  issue: https://github.com/elastic/elasticsearch/issues/126748
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_start_stop/Test stop transform with force and wait_for_checkpoint true}
-  issue: https://github.com/elastic/elasticsearch/issues/135135
-- class: org.elasticsearch.discovery.ClusterDisruptionIT
-  method: testAckedIndexing
-  issue: https://github.com/elastic/elasticsearch/issues/117024
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=analytics/nested_top_metrics_sort/terms order by top metrics numeric not null double values}
-  issue: https://github.com/elastic/elasticsearch/issues/135159
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=analytics/nested_top_metrics_sort/terms order by top metrics numeric not null integer values}
-  issue: https://github.com/elastic/elasticsearch/issues/135162
-- class: org.elasticsearch.gradle.TestClustersPluginFuncTest
-  method: override jdk usage via ES_JAVA_HOME for known jdk os incompatibilities
-  issue: https://github.com/elastic/elasticsearch/issues/135413
-- class: org.elasticsearch.xpack.security.authz.microsoft.MicrosoftGraphAuthzPluginIT
-  method: testConcurrentAuthentication
-  issue: https://github.com/elastic/elasticsearch/issues/135777
-- class: org.elasticsearch.versioning.ConcurrentSeqNoVersioningIT
-  method: testSeqNoCASLinearizability
-  issue: https://github.com/elastic/elasticsearch/issues/117249
-- class: org.elasticsearch.test.rest.yaml.CcsCommonYamlTestSuiteIT
-  method: test {p0=field_caps/10_basic/Field caps for number field with only doc values}
-  issue: https://github.com/elastic/elasticsearch/issues/136244
-- class: org.elasticsearch.test.rest.yaml.RcsCcsCommonYamlTestSuiteIT
-  method: test {p0=search.vectors/200_dense_vector_docvalue_fields/Enable docvalue_fields parameter for dense_vector fields}
-  issue: https://github.com/elastic/elasticsearch/issues/136443
-- class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
-  method: testRemoteClusterOnlyCCSWithFailuresOnAllShards
-  issue: https://github.com/elastic/elasticsearch/issues/136894
-- class: org.elasticsearch.xpack.inference.DefaultEndPointsIT
-  method: testMultipleInferencesTriggeringDownloadAndDeploy
-  issue: https://github.com/elastic/elasticsearch/issues/117208
-- class: org.elasticsearch.readiness.ReadinessClusterIT
-  method: testReadinessDuringRestartsNormalOrder
-  issue: https://github.com/elastic/elasticsearch/issues/136955
-- class: org.elasticsearch.smoketest.SmokeTestIngestWithAllDepsClientYamlTestSuiteIT
-  method: test {yaml=ingest/100_sampling_with_reroute/Test get sample with multiple reroutes}
-  issue: https://github.com/elastic/elasticsearch/issues/137457
-- class: org.elasticsearch.xpack.ilm.CCRIndexLifecycleIT
-  method: testTsdbLeaderIndexRolloverAndSyncAfterWaitUntilEndTime {targetCluster=FOLLOWER}
-  issue: https://github.com/elastic/elasticsearch/issues/137565
-- class: org.elasticsearch.xpack.inference.action.filter.ShardBulkInferenceActionFilterBasicLicenseIT
-  method: testLicenseInvalidForInference {p0=true}
-  issue: https://github.com/elastic/elasticsearch/issues/137690
-- class: org.elasticsearch.xpack.inference.action.filter.ShardBulkInferenceActionFilterBasicLicenseIT
-  method: testLicenseInvalidForInference {p0=false}
-  issue: https://github.com/elastic/elasticsearch/issues/137691
-- class: org.elasticsearch.indices.mapping.UpdateMappingIntegrationIT
-  method: testUpdateMappingConcurrently
-  issue: https://github.com/elastic/elasticsearch/issues/137758
-- class: org.elasticsearch.xpack.inference.integration.AuthorizationTaskExecutorMultipleNodesIT
-  method: testAuthorizationTaskGetsRelocatedToAnotherNode_WhenTheNodeThatIsRunningItShutsDown
-  issue: https://github.com/elastic/elasticsearch/issues/137911
-- class: org.elasticsearch.xpack.ml.integration.ForecastIT
-  method: testOverflowToDisk
-  issue: https://github.com/elastic/elasticsearch/issues/138055
-- class: org.elasticsearch.xpack.inference.integration.AuthorizationTaskExecutorMultipleNodesIT
-  method: testCancellingAuthorizationTaskRestartsIt
-  issue: https://github.com/elastic/elasticsearch/issues/138099
-- class: org.elasticsearch.search.basic.SearchWithRandomDisconnectsIT
-  method: testSearchWithRandomDisconnects
-  issue: https://github.com/elastic/elasticsearch/issues/138128
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeMetricsIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/138311
-- class: org.elasticsearch.xpack.ml.integration.RegressionIT
-  method: testTwoJobsWithSameRandomizeSeedUseSameTrainingSet
-  issue: https://github.com/elastic/elasticsearch/issues/138319
-- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
-  method: test {yaml=termvectors/30_realtime/Realtime Term Vectors}
-  issue: https://github.com/elastic/elasticsearch/issues/138370
-- class: org.elasticsearch.xpack.ml.integration.RevertModelSnapshotIT
-  method: testRevertModelSnapshot_DeleteInterveningResults
-  issue: https://github.com/elastic/elasticsearch/issues/132349
-- class: org.elasticsearch.smoketest.MlWithSecurityIT
-  method: test {yaml=ml/start_data_frame_analytics/Test start classification analysis when the dependent variable cardinality is too low}
-  issue: https://github.com/elastic/elasticsearch/issues/138409
-- class: org.elasticsearch.xpack.ml.integration.RevertModelSnapshotIT
-  method: testRevertModelSnapshot
-  issue: https://github.com/elastic/elasticsearch/issues/132733
-- class: org.elasticsearch.xpack.inference.services.jinaai.JinaAIServiceTests
-  method: test_Embedding_ChunkedInfer_LateChunkingEnabled
-  issue: https://github.com/elastic/elasticsearch/issues/138451
-- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
-  method: test {yaml=index/100_field_name_length_limit/Test field name length limit synthetic source}
-  issue: https://github.com/elastic/elasticsearch/issues/138471
-- class: org.elasticsearch.xpack.esql.heap_attack.HeapAttackLookupJoinIT
-  method: testLookupExplosionBigString
-  issue: https://github.com/elastic/elasticsearch/issues/138510
-- class: org.elasticsearch.xpack.ilm.TimeSeriesLifecycleActionsIT
-  method: testWaitForSnapshot
-  issue: https://github.com/elastic/elasticsearch/issues/138669
-- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
-  method: test {yaml=index/100_field_name_length_limit/Test field name length limit}
-  issue: https://github.com/elastic/elasticsearch/issues/138768
-- class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
-  method: testDatafeedTimingStats_DatafeedRecreated
-  issue: https://github.com/elastic/elasticsearch/issues/138348
-- class: org.elasticsearch.xpack.remotecluster.CrossClusterEsqlRCS1EnrichUnavailableRemotesIT
-  method: testEsqlEnrichWithSkipUnavailable
-  issue: https://github.com/elastic/elasticsearch/issues/138793
-- class: org.elasticsearch.xpack.ilm.actions.DownsampleActionIT
-  method: testILMWaitsForTimeSeriesEndTimeToLapse
-  issue: https://github.com/elastic/elasticsearch/issues/138843
-- class: org.elasticsearch.cluster.routing.allocation.WriteLoadConstraintMonitorTests
-  method: testRerouteIsNotCalledWhenNoNodesAreHotSpotting
-  issue: https://github.com/elastic/elasticsearch/issues/138924
-- class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
-  method: testStopLookback_closeJobFalse
-  issue: https://github.com/elastic/elasticsearch/issues/139024
-- class: org.elasticsearch.xpack.search.AsyncSearchConcurrentStatusIT
-  method: testConcurrentStatusFetchWhileTaskCloses
-  issue: https://github.com/elastic/elasticsearch/issues/138543
-- class: org.elasticsearch.xpack.core.security.authc.AuthenticationTests
-  method: testMaybeRewriteForOlderVersionWithCrossClusterAccessRewritesAuthenticationInMetadata
-  issue: https://github.com/elastic/elasticsearch/issues/139167
-- class: org.elasticsearch.smoketest.MlWithSecurityIT
-  method: test {yaml=ml/sparse_vector_search/Test sparse_vector search with query vector and pruning config}
-  issue: https://github.com/elastic/elasticsearch/issues/139196
-- class: org.elasticsearch.xpack.inference.integration.AuthorizationTaskExecutorIT
-  method: testCreatesEisChatCompletionEndpoint
-  issue: https://github.com/elastic/elasticsearch/issues/138764
-- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
-  method: test {yaml=index/100_field_name_length_limit/Test field name length limit array synthetic source}
-  issue: https://github.com/elastic/elasticsearch/issues/139300
-- class: org.elasticsearch.xpack.inference.integration.AuthorizationTaskExecutorIT
-  method: testCreatesChatCompletion_AndThenCreatesTextEmbedding
-  issue: https://github.com/elastic/elasticsearch/issues/138012
-- class: org.elasticsearch.xpack.unsignedlong.UnsignedLongSyntheticSourceNativeArrayIntegrationTests
-  method: testSynthesizeArrayRandom
-  issue: https://github.com/elastic/elasticsearch/issues/139376
-- class: org.elasticsearch.xpack.esql.optimizer.LocalLogicalPlanOptimizerTests
-  method: testReductionPlanForTopNWithPushedDownFunctionsInOrder
-  issue: https://github.com/elastic/elasticsearch/issues/139490
-- class: org.elasticsearch.xpack.esql.optimizer.LocalLogicalPlanOptimizerTests
-  method: testReductionPlanForTopNWithPushedDownFunctions
-  issue: https://github.com/elastic/elasticsearch/issues/139491
-- class: org.elasticsearch.xpack.esql.optimizer.rules.logical.local.ReplaceDateTruncBucketWithRoundToTests
-  method: testReductionPlanForTopNWithPushedDownFunctionsInOrder
-  issue: https://github.com/elastic/elasticsearch/issues/139492
-- class: org.elasticsearch.xpack.esql.optimizer.rules.logical.local.ReplaceDateTruncBucketWithRoundToTests
-  method: testReductionPlanForTopNWithPushedDownFunctions
-  issue: https://github.com/elastic/elasticsearch/issues/139493
-- class: org.elasticsearch.xpack.security.CoreWithSecurityClientYamlTestSuiteIT
-  method: test {yaml=search.retrievers/result-diversification/10_mmr_result_diversification_retriever/Test MMR result diversification single index float type}
-  issue: https://github.com/elastic/elasticsearch/issues/139527
-- class: org.elasticsearch.repositories.gcs.GoogleCloudStorageBlobStoreRepositoryTests
-  method: testMultipleSnapshotAndRollback
-  issue: https://github.com/elastic/elasticsearch/issues/139556
-- class: org.elasticsearch.index.mapper.LongSyntheticSourceNativeArrayIntegrationTests
-  method: testSynthesizeArrayRandom
-  issue: https://github.com/elastic/elasticsearch/issues/139562
-- class: org.elasticsearch.repositories.gcs.GoogleCloudStorageBlobStoreRepositoryTests
-  method: testDeleteBlobs
-  issue: https://github.com/elastic/elasticsearch/issues/139646
-- class: org.elasticsearch.upgrades.UpgradeClusterClientYamlTestSuiteIT
-  method: test {p0=mixed_cluster/90_ml_data_frame_analytics_crud/Start and stop old regression job}
-  issue: https://github.com/elastic/elasticsearch/issues/139654
-- class: org.elasticsearch.xpack.core.action.XPackUsageResponseTests
-  method: testVersionDependentSerializationWriteToOldStream
-  issue: https://github.com/elastic/elasticsearch/issues/139576
-- class: org.elasticsearch.index.mapper.HalfFloatSyntheticSourceNativeArrayIntegrationTests
-  method: testSynthesizeArrayRandom
-  issue: https://github.com/elastic/elasticsearch/issues/139658
-- class: org.elasticsearch.smoketest.WatcherYamlRestIT
-  method: test {p0=mustache/10_webhook/Test webhook action with mustache integration}
-  issue: https://github.com/elastic/elasticsearch/issues/139663
-- class: org.elasticsearch.repositories.gcs.GoogleCloudStorageBlobStoreRepositoryTests
-  method: testReadNonExistingPath
-  issue: https://github.com/elastic/elasticsearch/issues/139665
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=esql/40_unsupported_types/unsupported}
-  issue: https://github.com/elastic/elasticsearch/issues/139701
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=esql/40_unsupported_types/unsupported with sort}
-  issue: https://github.com/elastic/elasticsearch/issues/139702
-- class: org.elasticsearch.xpack.logsdb.RandomizedRollingUpgradeIT
-  method: testIndexingSyntheticSource
-  issue: https://github.com/elastic/elasticsearch/issues/139482
-- class: org.elasticsearch.persistent.PersistentTasksCustomMetadataTests
-  method: testMinVersionSerialization
-  issue: https://github.com/elastic/elasticsearch/issues/139740
-- class: org.elasticsearch.persistent.ClusterPersistentTasksCustomMetadataTests
-  method: testMinVersionSerialization
-  issue: https://github.com/elastic/elasticsearch/issues/139741
-- class: org.elasticsearch.xpack.esql.session.EsqlResolvedIndexExpressionIT
-  method: testLocalDateMathExpression
-  issue: https://github.com/elastic/elasticsearch/issues/140106
+  - class: org.elasticsearch.packaging.test.PackagesSecurityAutoConfigurationTests
+    method: test20SecurityNotAutoConfiguredOnReInstallation
+    issue: https://github.com/elastic/elasticsearch/issues/112635
+  - class: org.elasticsearch.xpack.transform.integration.TransformIT
+    method: testStopWaitForCheckpoint
+    issue: https://github.com/elastic/elasticsearch/issues/106113
+  - class: org.elasticsearch.xpack.remotecluster.RemoteClusterSecurityWithApmTracingRestIT
+    method: testTracingCrossCluster
+    issue: https://github.com/elastic/elasticsearch/issues/112731
+  - class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
+    method: testDeploymentSurvivesRestart {cluster=UPGRADED}
+    issue: https://github.com/elastic/elasticsearch/issues/115528
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=transform/transforms_start_stop/Verify start transform reuses destination index}
+    issue: https://github.com/elastic/elasticsearch/issues/115808
+  - class: org.elasticsearch.xpack.application.connector.ConnectorIndexServiceTests
+    issue: https://github.com/elastic/elasticsearch/issues/116087
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=transform/transforms_start_stop/Test start already started transform}
+    issue: https://github.com/elastic/elasticsearch/issues/98802
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=snapshot/20_operator_privileges_disabled/Operator only settings can be set and restored by non-operator user when operator privileges is disabled}
+    issue: https://github.com/elastic/elasticsearch/issues/116775
+  - class: org.elasticsearch.search.basic.SearchWithRandomIOExceptionsIT
+    method: testRandomDirectoryIOExceptions
+    issue: https://github.com/elastic/elasticsearch/issues/114824
+  - class: org.elasticsearch.xpack.apmdata.APMYamlTestSuiteIT
+    method: test {yaml=/10_apm/Test template reinstallation}
+    issue: https://github.com/elastic/elasticsearch/issues/116445
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=transform/transforms_reset/Test reset running transform}
+    issue: https://github.com/elastic/elasticsearch/issues/117473
+  - class: org.elasticsearch.packaging.test.ArchiveTests
+    method: test44AutoConfigurationNotTriggeredOnNotWriteableConfDir
+    issue: https://github.com/elastic/elasticsearch/issues/118208
+  - class: org.elasticsearch.packaging.test.ArchiveTests
+    method: test51AutoConfigurationWithPasswordProtectedKeystore
+    issue: https://github.com/elastic/elasticsearch/issues/118212
+  - class: org.elasticsearch.xpack.ccr.rest.ShardChangesRestIT
+    method: testShardChangesNoOperation
+    issue: https://github.com/elastic/elasticsearch/issues/118800
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=transform/transforms_start_stop/Test start/stop/start transform}
+    issue: https://github.com/elastic/elasticsearch/issues/119508
+  - class: org.elasticsearch.multi_cluster.MultiClusterYamlTestSuiteIT
+    issue: https://github.com/elastic/elasticsearch/issues/119983
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=transform/transforms_unattended/Test unattended put and start}
+    issue: https://github.com/elastic/elasticsearch/issues/120019
+  - class: org.elasticsearch.xpack.security.QueryableReservedRolesIT
+    method: testConfiguredReservedRolesAfterClosingAndOpeningIndex
+    issue: https://github.com/elastic/elasticsearch/issues/120127
+  - class: org.elasticsearch.xpack.ccr.FollowIndexSecurityIT
+    method: testCleanShardFollowTaskAfterDeleteFollower
+    issue: https://github.com/elastic/elasticsearch/issues/120339
+  - class: org.elasticsearch.xpack.security.authc.service.ServiceAccountIT
+    method: testAuthenticateShouldNotFallThroughInCaseOfFailure
+    issue: https://github.com/elastic/elasticsearch/issues/120902
+  - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+    method: test {p0=nodes.stats/11_indices_metrics/indices mappings exact count test for indices level}
+    issue: https://github.com/elastic/elasticsearch/issues/120950
+  - class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
+    method: test {yaml=snapshot.delete/10_basic/Delete a snapshot asynchronously}
+    issue: https://github.com/elastic/elasticsearch/issues/122102
+  - class: org.elasticsearch.action.admin.cluster.node.tasks.CancellableTasksIT
+    method: testChildrenTasksCancelledOnTimeout
+    issue: https://github.com/elastic/elasticsearch/issues/123568
+  - class: org.elasticsearch.xpack.searchablesnapshots.FrozenSearchableSnapshotsIntegTests
+    method: testCreateAndRestorePartialSearchableSnapshot
+    issue: https://github.com/elastic/elasticsearch/issues/123773
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=snapshot/10_basic/Create a source only snapshot and then restore it}
+    issue: https://github.com/elastic/elasticsearch/issues/122755
+  - class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
+    method: testDeploymentSurvivesRestart {cluster=OLD}
+    issue: https://github.com/elastic/elasticsearch/issues/124160
+  - class: org.elasticsearch.packaging.test.BootstrapCheckTests
+    method: test20RunWithBootstrapChecks
+    issue: https://github.com/elastic/elasticsearch/issues/124940
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=transform/transforms_start_stop/Test schedule_now on an already started transform}
+    issue: https://github.com/elastic/elasticsearch/issues/120720
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=transform/transforms_start_stop/Verify start transform creates destination index with appropriate mapping}
+    issue: https://github.com/elastic/elasticsearch/issues/125854
+  - class: org.elasticsearch.xpack.core.common.notifications.AbstractAuditorTests
+    method: testRecreateTemplateWhenDeleted
+    issue: https://github.com/elastic/elasticsearch/issues/123232
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=transform/transforms_reset/Test force reseting a running transform}
+    issue: https://github.com/elastic/elasticsearch/issues/126240
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=transform/transforms_start_stop/Test start/stop only starts/stops specified transform}
+    issue: https://github.com/elastic/elasticsearch/issues/126466
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=transform/transforms_start_stop/Test start/stop/start continuous transform}
+    issue: https://github.com/elastic/elasticsearch/issues/126755
+  - class: org.elasticsearch.index.engine.CompletionStatsCacheTests
+    method: testCompletionStatsCache
+    issue: https://github.com/elastic/elasticsearch/issues/126910
+  - class: org.elasticsearch.xpack.ml.integration.ClassificationHousePricingIT
+    method: testFeatureImportanceValues
+    issue: https://github.com/elastic/elasticsearch/issues/124341
+  - class: org.elasticsearch.cli.keystore.AddStringKeyStoreCommandTests
+    method: testStdinWithMultipleValues
+    issue: https://github.com/elastic/elasticsearch/issues/126882
+  - class: org.elasticsearch.xpack.ccr.action.ShardFollowTaskReplicationTests
+    method: testChangeFollowerHistoryUUID
+    issue: https://github.com/elastic/elasticsearch/issues/127680
+  - class: org.elasticsearch.action.admin.indices.diskusage.IndexDiskUsageAnalyzerTests
+    method: testKnnVectors
+    issue: https://github.com/elastic/elasticsearch/issues/127689
+  - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+    method: test {p0=search/350_point_in_time/point-in-time with index filter}
+    issue: https://github.com/elastic/elasticsearch/issues/127741
+  - class: org.elasticsearch.xpack.esql.plugin.DataNodeRequestSenderIT
+    method: testSearchWhileRelocating
+    issue: https://github.com/elastic/elasticsearch/issues/128500
+  - class: org.elasticsearch.entitlement.runtime.policy.FileAccessTreeTests
+    method: testWindowsMixedCaseAccess
+    issue: https://github.com/elastic/elasticsearch/issues/129167
+  - class: org.elasticsearch.entitlement.runtime.policy.FileAccessTreeTests
+    method: testWindowsAbsolutPathAccess
+    issue: https://github.com/elastic/elasticsearch/issues/129168
+  - class: org.elasticsearch.xpack.profiling.action.GetStatusActionIT
+    method: testWaitsUntilResourcesAreCreated
+    issue: https://github.com/elastic/elasticsearch/issues/129486
+  - class: org.elasticsearch.search.query.VectorIT
+    method: testFilteredQueryStrategy
+    issue: https://github.com/elastic/elasticsearch/issues/129517
+  - class: org.elasticsearch.xpack.security.SecurityRolesMultiProjectIT
+    method: testUpdatingFileBasedRoleAffectsAllProjects
+    issue: https://github.com/elastic/elasticsearch/issues/129775
+  - class: org.elasticsearch.action.support.ThreadedActionListenerTests
+    method: testRejectionHandling
+    issue: https://github.com/elastic/elasticsearch/issues/130129
+  - class: org.elasticsearch.compute.aggregation.TopIntAggregatorFunctionTests
+    method: testManyInitialManyPartialFinalRunnerThrowing
+    issue: https://github.com/elastic/elasticsearch/issues/130145
+  - class: org.elasticsearch.xpack.searchablesnapshots.cache.shared.NodesCachesStatsIntegTests
+    method: testNodesCachesStats
+    issue: https://github.com/elastic/elasticsearch/issues/129863
+  - class: org.elasticsearch.index.IndexingPressureIT
+    method: testWriteCanRejectOnPrimaryBasedOnMaxOperationSize
+    issue: https://github.com/elastic/elasticsearch/issues/130281
+  - class: org.elasticsearch.indices.stats.IndexStatsIT
+    method: testFilterCacheStats
+    issue: https://github.com/elastic/elasticsearch/issues/124447
+  - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+    method: test {p0=mtermvectors/10_basic/Tests catching other exceptions per item}
+    issue: https://github.com/elastic/elasticsearch/issues/122414
+  - class: org.elasticsearch.packaging.test.DockerTests
+    method: test090SecurityCliPackaging
+    issue: https://github.com/elastic/elasticsearch/issues/131107
+  - class: org.elasticsearch.xpack.esql.expression.function.fulltext.ScoreTests
+    method: testSerializationOfSimple {TestCase=<boolean>}
+    issue: https://github.com/elastic/elasticsearch/issues/131334
+  - class: org.elasticsearch.packaging.test.DockerTests
+    method: test071BindMountCustomPathWithDifferentUID
+    issue: https://github.com/elastic/elasticsearch/issues/120917
+  - class: org.elasticsearch.packaging.test.DockerTests
+    method: test171AdditionalCliOptionsAreForwarded
+    issue: https://github.com/elastic/elasticsearch/issues/120925
+  - class: org.elasticsearch.packaging.test.DockerTests
+    method: test050BasicApiTests
+    issue: https://github.com/elastic/elasticsearch/issues/120911
+  - class: org.elasticsearch.xpack.restart.FullClusterRestartIT
+    method: testWatcherWithApiKey {cluster=UPGRADED}
+    issue: https://github.com/elastic/elasticsearch/issues/131964
+  - class: org.elasticsearch.xpack.sql.qa.mixed_node.SqlCompatIT
+    method: testNullsOrderWithMissingOrderSupportQueryingNewNode
+    issue: https://github.com/elastic/elasticsearch/issues/132249
+  - class: org.elasticsearch.packaging.test.ArchiveGenerateInitialCredentialsTests
+    method: test40VerifyAutogeneratedCredentials
+    issue: https://github.com/elastic/elasticsearch/issues/132877
+  - class: org.elasticsearch.packaging.test.ArchiveGenerateInitialCredentialsTests
+    method: test50CredentialAutogenerationOnlyOnce
+    issue: https://github.com/elastic/elasticsearch/issues/132878
+  - class: org.elasticsearch.xpack.eql.planner.QueryTranslatorTests
+    method: testMatchOptimization
+    issue: https://github.com/elastic/elasticsearch/issues/132894
+  - class: org.elasticsearch.xpack.security.authc.AuthenticationServiceTests
+    method: testInvalidToken
+    issue: https://github.com/elastic/elasticsearch/issues/133328
+  - class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
+    method: testCancelViaExpirationOnRemoteResultsWithMinimizeRoundtrips
+    issue: https://github.com/elastic/elasticsearch/issues/127302
+  - class: org.elasticsearch.xpack.ml.integration.InferenceIT
+    method: testInferClassificationModel
+    issue: https://github.com/elastic/elasticsearch/issues/133448
+  - class: org.elasticsearch.xpack.ml.integration.ClassificationIT
+    method: testWithCustomFeatureProcessors
+    issue: https://github.com/elastic/elasticsearch/issues/134001
+  - class: org.elasticsearch.action.admin.cluster.state.TransportClusterStateActionTests
+    method: testGetClusterStateWithDefaultProjectOnly
+    issue: https://github.com/elastic/elasticsearch/issues/134450
+  - class: org.elasticsearch.xpack.esql.plugin.CanMatchIT
+    method: testAliasFilters
+    issue: https://github.com/elastic/elasticsearch/issues/134512
+  - class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
+    method: testOldRepoAccess
+    issue: https://github.com/elastic/elasticsearch/issues/120148
+  - class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
+    method: testOldSourceOnlyRepoAccess
+    issue: https://github.com/elastic/elasticsearch/issues/134646
+  - class: org.elasticsearch.oldrepos.OldMappingsIT
+    method: testStandardTokenFilter
+    issue: https://github.com/elastic/elasticsearch/issues/134647
+  - class: org.elasticsearch.aggregations.bucket.AggregationReductionCircuitBreakingIT
+    method: testCBTrippingOnReduction
+    issue: https://github.com/elastic/elasticsearch/issues/134667
+  - class: org.elasticsearch.xpack.esql.action.CrossClusterCancellationIT
+    method: testCancelSkipUnavailable
+    issue: https://github.com/elastic/elasticsearch/issues/134865
+  - class: org.elasticsearch.reservedstate.service.RepositoriesFileSettingsIT
+    method: testSettingsApplied
+    issue: https://github.com/elastic/elasticsearch/issues/126748
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=transform/transforms_start_stop/Test stop transform with force and wait_for_checkpoint true}
+    issue: https://github.com/elastic/elasticsearch/issues/135135
+  - class: org.elasticsearch.discovery.ClusterDisruptionIT
+    method: testAckedIndexing
+    issue: https://github.com/elastic/elasticsearch/issues/117024
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=analytics/nested_top_metrics_sort/terms order by top metrics numeric not null double values}
+    issue: https://github.com/elastic/elasticsearch/issues/135159
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=analytics/nested_top_metrics_sort/terms order by top metrics numeric not null integer values}
+    issue: https://github.com/elastic/elasticsearch/issues/135162
+  - class: org.elasticsearch.gradle.TestClustersPluginFuncTest
+    method: override jdk usage via ES_JAVA_HOME for known jdk os incompatibilities
+    issue: https://github.com/elastic/elasticsearch/issues/135413
+  - class: org.elasticsearch.xpack.security.authz.microsoft.MicrosoftGraphAuthzPluginIT
+    method: testConcurrentAuthentication
+    issue: https://github.com/elastic/elasticsearch/issues/135777
+  - class: org.elasticsearch.versioning.ConcurrentSeqNoVersioningIT
+    method: testSeqNoCASLinearizability
+    issue: https://github.com/elastic/elasticsearch/issues/117249
+  - class: org.elasticsearch.test.rest.yaml.CcsCommonYamlTestSuiteIT
+    method: test {p0=field_caps/10_basic/Field caps for number field with only doc values}
+    issue: https://github.com/elastic/elasticsearch/issues/136244
+  - class: org.elasticsearch.test.rest.yaml.RcsCcsCommonYamlTestSuiteIT
+    method: test {p0=search.vectors/200_dense_vector_docvalue_fields/Enable docvalue_fields parameter for dense_vector fields}
+    issue: https://github.com/elastic/elasticsearch/issues/136443
+  - class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
+    method: testRemoteClusterOnlyCCSWithFailuresOnAllShards
+    issue: https://github.com/elastic/elasticsearch/issues/136894
+  - class: org.elasticsearch.xpack.inference.DefaultEndPointsIT
+    method: testMultipleInferencesTriggeringDownloadAndDeploy
+    issue: https://github.com/elastic/elasticsearch/issues/117208
+  - class: org.elasticsearch.readiness.ReadinessClusterIT
+    method: testReadinessDuringRestartsNormalOrder
+    issue: https://github.com/elastic/elasticsearch/issues/136955
+  - class: org.elasticsearch.smoketest.SmokeTestIngestWithAllDepsClientYamlTestSuiteIT
+    method: test {yaml=ingest/100_sampling_with_reroute/Test get sample with multiple reroutes}
+    issue: https://github.com/elastic/elasticsearch/issues/137457
+  - class: org.elasticsearch.xpack.ilm.CCRIndexLifecycleIT
+    method: testTsdbLeaderIndexRolloverAndSyncAfterWaitUntilEndTime {targetCluster=FOLLOWER}
+    issue: https://github.com/elastic/elasticsearch/issues/137565
+  - class: org.elasticsearch.xpack.inference.action.filter.ShardBulkInferenceActionFilterBasicLicenseIT
+    method: testLicenseInvalidForInference {p0=true}
+    issue: https://github.com/elastic/elasticsearch/issues/137690
+  - class: org.elasticsearch.xpack.inference.action.filter.ShardBulkInferenceActionFilterBasicLicenseIT
+    method: testLicenseInvalidForInference {p0=false}
+    issue: https://github.com/elastic/elasticsearch/issues/137691
+  - class: org.elasticsearch.indices.mapping.UpdateMappingIntegrationIT
+    method: testUpdateMappingConcurrently
+    issue: https://github.com/elastic/elasticsearch/issues/137758
+  - class: org.elasticsearch.xpack.inference.integration.AuthorizationTaskExecutorMultipleNodesIT
+    method: testAuthorizationTaskGetsRelocatedToAnotherNode_WhenTheNodeThatIsRunningItShutsDown
+    issue: https://github.com/elastic/elasticsearch/issues/137911
+  - class: org.elasticsearch.xpack.ml.integration.ForecastIT
+    method: testOverflowToDisk
+    issue: https://github.com/elastic/elasticsearch/issues/138055
+  - class: org.elasticsearch.xpack.inference.integration.AuthorizationTaskExecutorMultipleNodesIT
+    method: testCancellingAuthorizationTaskRestartsIt
+    issue: https://github.com/elastic/elasticsearch/issues/138099
+  - class: org.elasticsearch.search.basic.SearchWithRandomDisconnectsIT
+    method: testSearchWithRandomDisconnects
+    issue: https://github.com/elastic/elasticsearch/issues/138128
+  - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeMetricsIT
+    method: test
+    issue: https://github.com/elastic/elasticsearch/issues/138311
+  - class: org.elasticsearch.xpack.ml.integration.RegressionIT
+    method: testTwoJobsWithSameRandomizeSeedUseSameTrainingSet
+    issue: https://github.com/elastic/elasticsearch/issues/138319
+  - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
+    method: test {yaml=termvectors/30_realtime/Realtime Term Vectors}
+    issue: https://github.com/elastic/elasticsearch/issues/138370
+  - class: org.elasticsearch.xpack.ml.integration.RevertModelSnapshotIT
+    method: testRevertModelSnapshot_DeleteInterveningResults
+    issue: https://github.com/elastic/elasticsearch/issues/132349
+  - class: org.elasticsearch.smoketest.MlWithSecurityIT
+    method: test {yaml=ml/start_data_frame_analytics/Test start classification analysis when the dependent variable cardinality is too low}
+    issue: https://github.com/elastic/elasticsearch/issues/138409
+  - class: org.elasticsearch.xpack.ml.integration.RevertModelSnapshotIT
+    method: testRevertModelSnapshot
+    issue: https://github.com/elastic/elasticsearch/issues/132733
+  - class: org.elasticsearch.xpack.inference.services.jinaai.JinaAIServiceTests
+    method: test_Embedding_ChunkedInfer_LateChunkingEnabled
+    issue: https://github.com/elastic/elasticsearch/issues/138451
+  - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
+    method: test {yaml=index/100_field_name_length_limit/Test field name length limit synthetic source}
+    issue: https://github.com/elastic/elasticsearch/issues/138471
+  - class: org.elasticsearch.xpack.esql.heap_attack.HeapAttackLookupJoinIT
+    method: testLookupExplosionBigString
+    issue: https://github.com/elastic/elasticsearch/issues/138510
+  - class: org.elasticsearch.xpack.ilm.TimeSeriesLifecycleActionsIT
+    method: testWaitForSnapshot
+    issue: https://github.com/elastic/elasticsearch/issues/138669
+  - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
+    method: test {yaml=index/100_field_name_length_limit/Test field name length limit}
+    issue: https://github.com/elastic/elasticsearch/issues/138768
+  - class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
+    method: testDatafeedTimingStats_DatafeedRecreated
+    issue: https://github.com/elastic/elasticsearch/issues/138348
+  - class: org.elasticsearch.xpack.remotecluster.CrossClusterEsqlRCS1EnrichUnavailableRemotesIT
+    method: testEsqlEnrichWithSkipUnavailable
+    issue: https://github.com/elastic/elasticsearch/issues/138793
+  - class: org.elasticsearch.xpack.ilm.actions.DownsampleActionIT
+    method: testILMWaitsForTimeSeriesEndTimeToLapse
+    issue: https://github.com/elastic/elasticsearch/issues/138843
+  - class: org.elasticsearch.cluster.routing.allocation.WriteLoadConstraintMonitorTests
+    method: testRerouteIsNotCalledWhenNoNodesAreHotSpotting
+    issue: https://github.com/elastic/elasticsearch/issues/138924
+  - class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
+    method: testStopLookback_closeJobFalse
+    issue: https://github.com/elastic/elasticsearch/issues/139024
+  - class: org.elasticsearch.xpack.search.AsyncSearchConcurrentStatusIT
+    method: testConcurrentStatusFetchWhileTaskCloses
+    issue: https://github.com/elastic/elasticsearch/issues/138543
+  - class: org.elasticsearch.xpack.core.security.authc.AuthenticationTests
+    method: testMaybeRewriteForOlderVersionWithCrossClusterAccessRewritesAuthenticationInMetadata
+    issue: https://github.com/elastic/elasticsearch/issues/139167
+  - class: org.elasticsearch.smoketest.MlWithSecurityIT
+    method: test {yaml=ml/sparse_vector_search/Test sparse_vector search with query vector and pruning config}
+    issue: https://github.com/elastic/elasticsearch/issues/139196
+  - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
+    method: test {yaml=index/100_field_name_length_limit/Test field name length limit array synthetic source}
+    issue: https://github.com/elastic/elasticsearch/issues/139300
+  - class: org.elasticsearch.xpack.unsignedlong.UnsignedLongSyntheticSourceNativeArrayIntegrationTests
+    method: testSynthesizeArrayRandom
+    issue: https://github.com/elastic/elasticsearch/issues/139376
+  - class: org.elasticsearch.xpack.esql.optimizer.LocalLogicalPlanOptimizerTests
+    method: testReductionPlanForTopNWithPushedDownFunctionsInOrder
+    issue: https://github.com/elastic/elasticsearch/issues/139490
+  - class: org.elasticsearch.xpack.esql.optimizer.LocalLogicalPlanOptimizerTests
+    method: testReductionPlanForTopNWithPushedDownFunctions
+    issue: https://github.com/elastic/elasticsearch/issues/139491
+  - class: org.elasticsearch.xpack.esql.optimizer.rules.logical.local.ReplaceDateTruncBucketWithRoundToTests
+    method: testReductionPlanForTopNWithPushedDownFunctionsInOrder
+    issue: https://github.com/elastic/elasticsearch/issues/139492
+  - class: org.elasticsearch.xpack.esql.optimizer.rules.logical.local.ReplaceDateTruncBucketWithRoundToTests
+    method: testReductionPlanForTopNWithPushedDownFunctions
+    issue: https://github.com/elastic/elasticsearch/issues/139493
+  - class: org.elasticsearch.xpack.security.CoreWithSecurityClientYamlTestSuiteIT
+    method: test {yaml=search.retrievers/result-diversification/10_mmr_result_diversification_retriever/Test MMR result diversification single index float type}
+    issue: https://github.com/elastic/elasticsearch/issues/139527
+  - class: org.elasticsearch.repositories.gcs.GoogleCloudStorageBlobStoreRepositoryTests
+    method: testMultipleSnapshotAndRollback
+    issue: https://github.com/elastic/elasticsearch/issues/139556
+  - class: org.elasticsearch.index.mapper.LongSyntheticSourceNativeArrayIntegrationTests
+    method: testSynthesizeArrayRandom
+    issue: https://github.com/elastic/elasticsearch/issues/139562
+  - class: org.elasticsearch.repositories.gcs.GoogleCloudStorageBlobStoreRepositoryTests
+    method: testDeleteBlobs
+    issue: https://github.com/elastic/elasticsearch/issues/139646
+  - class: org.elasticsearch.upgrades.UpgradeClusterClientYamlTestSuiteIT
+    method: test {p0=mixed_cluster/90_ml_data_frame_analytics_crud/Start and stop old regression job}
+    issue: https://github.com/elastic/elasticsearch/issues/139654
+  - class: org.elasticsearch.xpack.core.action.XPackUsageResponseTests
+    method: testVersionDependentSerializationWriteToOldStream
+    issue: https://github.com/elastic/elasticsearch/issues/139576
+  - class: org.elasticsearch.index.mapper.HalfFloatSyntheticSourceNativeArrayIntegrationTests
+    method: testSynthesizeArrayRandom
+    issue: https://github.com/elastic/elasticsearch/issues/139658
+  - class: org.elasticsearch.smoketest.WatcherYamlRestIT
+    method: test {p0=mustache/10_webhook/Test webhook action with mustache integration}
+    issue: https://github.com/elastic/elasticsearch/issues/139663
+  - class: org.elasticsearch.repositories.gcs.GoogleCloudStorageBlobStoreRepositoryTests
+    method: testReadNonExistingPath
+    issue: https://github.com/elastic/elasticsearch/issues/139665
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=esql/40_unsupported_types/unsupported}
+    issue: https://github.com/elastic/elasticsearch/issues/139701
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=esql/40_unsupported_types/unsupported with sort}
+    issue: https://github.com/elastic/elasticsearch/issues/139702
+  - class: org.elasticsearch.xpack.logsdb.RandomizedRollingUpgradeIT
+    method: testIndexingSyntheticSource
+    issue: https://github.com/elastic/elasticsearch/issues/139482
+  - class: org.elasticsearch.persistent.PersistentTasksCustomMetadataTests
+    method: testMinVersionSerialization
+    issue: https://github.com/elastic/elasticsearch/issues/139740
+  - class: org.elasticsearch.persistent.ClusterPersistentTasksCustomMetadataTests
+    method: testMinVersionSerialization
+    issue: https://github.com/elastic/elasticsearch/issues/139741
+  - class: org.elasticsearch.xpack.esql.session.EsqlResolvedIndexExpressionIT
+    method: testLocalDateMathExpression
+    issue: https://github.com/elastic/elasticsearch/issues/140106
 
 # Examples:
 #

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -1,404 +1,413 @@
 tests:
-  - class: org.elasticsearch.packaging.test.PackagesSecurityAutoConfigurationTests
-    method: test20SecurityNotAutoConfiguredOnReInstallation
-    issue: https://github.com/elastic/elasticsearch/issues/112635
-  - class: org.elasticsearch.xpack.transform.integration.TransformIT
-    method: testStopWaitForCheckpoint
-    issue: https://github.com/elastic/elasticsearch/issues/106113
-  - class: org.elasticsearch.xpack.remotecluster.RemoteClusterSecurityWithApmTracingRestIT
-    method: testTracingCrossCluster
-    issue: https://github.com/elastic/elasticsearch/issues/112731
-  - class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
-    method: testDeploymentSurvivesRestart {cluster=UPGRADED}
-    issue: https://github.com/elastic/elasticsearch/issues/115528
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_start_stop/Verify start transform reuses destination index}
-    issue: https://github.com/elastic/elasticsearch/issues/115808
-  - class: org.elasticsearch.xpack.application.connector.ConnectorIndexServiceTests
-    issue: https://github.com/elastic/elasticsearch/issues/116087
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_start_stop/Test start already started transform}
-    issue: https://github.com/elastic/elasticsearch/issues/98802
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=snapshot/20_operator_privileges_disabled/Operator only settings can be set and restored by non-operator user when operator privileges is disabled}
-    issue: https://github.com/elastic/elasticsearch/issues/116775
-  - class: org.elasticsearch.search.basic.SearchWithRandomIOExceptionsIT
-    method: testRandomDirectoryIOExceptions
-    issue: https://github.com/elastic/elasticsearch/issues/114824
-  - class: org.elasticsearch.xpack.apmdata.APMYamlTestSuiteIT
-    method: test {yaml=/10_apm/Test template reinstallation}
-    issue: https://github.com/elastic/elasticsearch/issues/116445
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_reset/Test reset running transform}
-    issue: https://github.com/elastic/elasticsearch/issues/117473
-  - class: org.elasticsearch.packaging.test.ArchiveTests
-    method: test44AutoConfigurationNotTriggeredOnNotWriteableConfDir
-    issue: https://github.com/elastic/elasticsearch/issues/118208
-  - class: org.elasticsearch.packaging.test.ArchiveTests
-    method: test51AutoConfigurationWithPasswordProtectedKeystore
-    issue: https://github.com/elastic/elasticsearch/issues/118212
-  - class: org.elasticsearch.xpack.ccr.rest.ShardChangesRestIT
-    method: testShardChangesNoOperation
-    issue: https://github.com/elastic/elasticsearch/issues/118800
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_start_stop/Test start/stop/start transform}
-    issue: https://github.com/elastic/elasticsearch/issues/119508
-  - class: org.elasticsearch.multi_cluster.MultiClusterYamlTestSuiteIT
-    issue: https://github.com/elastic/elasticsearch/issues/119983
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_unattended/Test unattended put and start}
-    issue: https://github.com/elastic/elasticsearch/issues/120019
-  - class: org.elasticsearch.xpack.security.QueryableReservedRolesIT
-    method: testConfiguredReservedRolesAfterClosingAndOpeningIndex
-    issue: https://github.com/elastic/elasticsearch/issues/120127
-  - class: org.elasticsearch.xpack.ccr.FollowIndexSecurityIT
-    method: testCleanShardFollowTaskAfterDeleteFollower
-    issue: https://github.com/elastic/elasticsearch/issues/120339
-  - class: org.elasticsearch.xpack.security.authc.service.ServiceAccountIT
-    method: testAuthenticateShouldNotFallThroughInCaseOfFailure
-    issue: https://github.com/elastic/elasticsearch/issues/120902
-  - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-    method: test {p0=nodes.stats/11_indices_metrics/indices mappings exact count test for indices level}
-    issue: https://github.com/elastic/elasticsearch/issues/120950
-  - class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
-    method: test {yaml=snapshot.delete/10_basic/Delete a snapshot asynchronously}
-    issue: https://github.com/elastic/elasticsearch/issues/122102
-  - class: org.elasticsearch.action.admin.cluster.node.tasks.CancellableTasksIT
-    method: testChildrenTasksCancelledOnTimeout
-    issue: https://github.com/elastic/elasticsearch/issues/123568
-  - class: org.elasticsearch.xpack.searchablesnapshots.FrozenSearchableSnapshotsIntegTests
-    method: testCreateAndRestorePartialSearchableSnapshot
-    issue: https://github.com/elastic/elasticsearch/issues/123773
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=snapshot/10_basic/Create a source only snapshot and then restore it}
-    issue: https://github.com/elastic/elasticsearch/issues/122755
-  - class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
-    method: testDeploymentSurvivesRestart {cluster=OLD}
-    issue: https://github.com/elastic/elasticsearch/issues/124160
-  - class: org.elasticsearch.packaging.test.BootstrapCheckTests
-    method: test20RunWithBootstrapChecks
-    issue: https://github.com/elastic/elasticsearch/issues/124940
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_start_stop/Test schedule_now on an already started transform}
-    issue: https://github.com/elastic/elasticsearch/issues/120720
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_start_stop/Verify start transform creates destination index with appropriate mapping}
-    issue: https://github.com/elastic/elasticsearch/issues/125854
-  - class: org.elasticsearch.xpack.core.common.notifications.AbstractAuditorTests
-    method: testRecreateTemplateWhenDeleted
-    issue: https://github.com/elastic/elasticsearch/issues/123232
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_reset/Test force reseting a running transform}
-    issue: https://github.com/elastic/elasticsearch/issues/126240
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_start_stop/Test start/stop only starts/stops specified transform}
-    issue: https://github.com/elastic/elasticsearch/issues/126466
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_start_stop/Test start/stop/start continuous transform}
-    issue: https://github.com/elastic/elasticsearch/issues/126755
-  - class: org.elasticsearch.index.engine.CompletionStatsCacheTests
-    method: testCompletionStatsCache
-    issue: https://github.com/elastic/elasticsearch/issues/126910
-  - class: org.elasticsearch.xpack.ml.integration.ClassificationHousePricingIT
-    method: testFeatureImportanceValues
-    issue: https://github.com/elastic/elasticsearch/issues/124341
-  - class: org.elasticsearch.cli.keystore.AddStringKeyStoreCommandTests
-    method: testStdinWithMultipleValues
-    issue: https://github.com/elastic/elasticsearch/issues/126882
-  - class: org.elasticsearch.xpack.ccr.action.ShardFollowTaskReplicationTests
-    method: testChangeFollowerHistoryUUID
-    issue: https://github.com/elastic/elasticsearch/issues/127680
-  - class: org.elasticsearch.action.admin.indices.diskusage.IndexDiskUsageAnalyzerTests
-    method: testKnnVectors
-    issue: https://github.com/elastic/elasticsearch/issues/127689
-  - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-    method: test {p0=search/350_point_in_time/point-in-time with index filter}
-    issue: https://github.com/elastic/elasticsearch/issues/127741
-  - class: org.elasticsearch.xpack.esql.plugin.DataNodeRequestSenderIT
-    method: testSearchWhileRelocating
-    issue: https://github.com/elastic/elasticsearch/issues/128500
-  - class: org.elasticsearch.entitlement.runtime.policy.FileAccessTreeTests
-    method: testWindowsMixedCaseAccess
-    issue: https://github.com/elastic/elasticsearch/issues/129167
-  - class: org.elasticsearch.entitlement.runtime.policy.FileAccessTreeTests
-    method: testWindowsAbsolutPathAccess
-    issue: https://github.com/elastic/elasticsearch/issues/129168
-  - class: org.elasticsearch.xpack.profiling.action.GetStatusActionIT
-    method: testWaitsUntilResourcesAreCreated
-    issue: https://github.com/elastic/elasticsearch/issues/129486
-  - class: org.elasticsearch.search.query.VectorIT
-    method: testFilteredQueryStrategy
-    issue: https://github.com/elastic/elasticsearch/issues/129517
-  - class: org.elasticsearch.xpack.security.SecurityRolesMultiProjectIT
-    method: testUpdatingFileBasedRoleAffectsAllProjects
-    issue: https://github.com/elastic/elasticsearch/issues/129775
-  - class: org.elasticsearch.action.support.ThreadedActionListenerTests
-    method: testRejectionHandling
-    issue: https://github.com/elastic/elasticsearch/issues/130129
-  - class: org.elasticsearch.compute.aggregation.TopIntAggregatorFunctionTests
-    method: testManyInitialManyPartialFinalRunnerThrowing
-    issue: https://github.com/elastic/elasticsearch/issues/130145
-  - class: org.elasticsearch.xpack.searchablesnapshots.cache.shared.NodesCachesStatsIntegTests
-    method: testNodesCachesStats
-    issue: https://github.com/elastic/elasticsearch/issues/129863
-  - class: org.elasticsearch.index.IndexingPressureIT
-    method: testWriteCanRejectOnPrimaryBasedOnMaxOperationSize
-    issue: https://github.com/elastic/elasticsearch/issues/130281
-  - class: org.elasticsearch.indices.stats.IndexStatsIT
-    method: testFilterCacheStats
-    issue: https://github.com/elastic/elasticsearch/issues/124447
-  - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-    method: test {p0=mtermvectors/10_basic/Tests catching other exceptions per item}
-    issue: https://github.com/elastic/elasticsearch/issues/122414
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test090SecurityCliPackaging
-    issue: https://github.com/elastic/elasticsearch/issues/131107
-  - class: org.elasticsearch.xpack.esql.expression.function.fulltext.ScoreTests
-    method: testSerializationOfSimple {TestCase=<boolean>}
-    issue: https://github.com/elastic/elasticsearch/issues/131334
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test071BindMountCustomPathWithDifferentUID
-    issue: https://github.com/elastic/elasticsearch/issues/120917
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test171AdditionalCliOptionsAreForwarded
-    issue: https://github.com/elastic/elasticsearch/issues/120925
-  - class: org.elasticsearch.packaging.test.DockerTests
-    method: test050BasicApiTests
-    issue: https://github.com/elastic/elasticsearch/issues/120911
-  - class: org.elasticsearch.xpack.restart.FullClusterRestartIT
-    method: testWatcherWithApiKey {cluster=UPGRADED}
-    issue: https://github.com/elastic/elasticsearch/issues/131964
-  - class: org.elasticsearch.xpack.sql.qa.mixed_node.SqlCompatIT
-    method: testNullsOrderWithMissingOrderSupportQueryingNewNode
-    issue: https://github.com/elastic/elasticsearch/issues/132249
-  - class: org.elasticsearch.packaging.test.ArchiveGenerateInitialCredentialsTests
-    method: test40VerifyAutogeneratedCredentials
-    issue: https://github.com/elastic/elasticsearch/issues/132877
-  - class: org.elasticsearch.packaging.test.ArchiveGenerateInitialCredentialsTests
-    method: test50CredentialAutogenerationOnlyOnce
-    issue: https://github.com/elastic/elasticsearch/issues/132878
-  - class: org.elasticsearch.xpack.eql.planner.QueryTranslatorTests
-    method: testMatchOptimization
-    issue: https://github.com/elastic/elasticsearch/issues/132894
-  - class: org.elasticsearch.xpack.security.authc.AuthenticationServiceTests
-    method: testInvalidToken
-    issue: https://github.com/elastic/elasticsearch/issues/133328
-  - class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
-    method: testCancelViaExpirationOnRemoteResultsWithMinimizeRoundtrips
-    issue: https://github.com/elastic/elasticsearch/issues/127302
-  - class: org.elasticsearch.xpack.ml.integration.InferenceIT
-    method: testInferClassificationModel
-    issue: https://github.com/elastic/elasticsearch/issues/133448
-  - class: org.elasticsearch.xpack.ml.integration.ClassificationIT
-    method: testWithCustomFeatureProcessors
-    issue: https://github.com/elastic/elasticsearch/issues/134001
-  - class: org.elasticsearch.action.admin.cluster.state.TransportClusterStateActionTests
-    method: testGetClusterStateWithDefaultProjectOnly
-    issue: https://github.com/elastic/elasticsearch/issues/134450
-  - class: org.elasticsearch.xpack.esql.plugin.CanMatchIT
-    method: testAliasFilters
-    issue: https://github.com/elastic/elasticsearch/issues/134512
-  - class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
-    method: testOldRepoAccess
-    issue: https://github.com/elastic/elasticsearch/issues/120148
-  - class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
-    method: testOldSourceOnlyRepoAccess
-    issue: https://github.com/elastic/elasticsearch/issues/134646
-  - class: org.elasticsearch.oldrepos.OldMappingsIT
-    method: testStandardTokenFilter
-    issue: https://github.com/elastic/elasticsearch/issues/134647
-  - class: org.elasticsearch.aggregations.bucket.AggregationReductionCircuitBreakingIT
-    method: testCBTrippingOnReduction
-    issue: https://github.com/elastic/elasticsearch/issues/134667
-  - class: org.elasticsearch.xpack.esql.action.CrossClusterCancellationIT
-    method: testCancelSkipUnavailable
-    issue: https://github.com/elastic/elasticsearch/issues/134865
-  - class: org.elasticsearch.reservedstate.service.RepositoriesFileSettingsIT
-    method: testSettingsApplied
-    issue: https://github.com/elastic/elasticsearch/issues/126748
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=transform/transforms_start_stop/Test stop transform with force and wait_for_checkpoint true}
-    issue: https://github.com/elastic/elasticsearch/issues/135135
-  - class: org.elasticsearch.discovery.ClusterDisruptionIT
-    method: testAckedIndexing
-    issue: https://github.com/elastic/elasticsearch/issues/117024
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=analytics/nested_top_metrics_sort/terms order by top metrics numeric not null double values}
-    issue: https://github.com/elastic/elasticsearch/issues/135159
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=analytics/nested_top_metrics_sort/terms order by top metrics numeric not null integer values}
-    issue: https://github.com/elastic/elasticsearch/issues/135162
-  - class: org.elasticsearch.gradle.TestClustersPluginFuncTest
-    method: override jdk usage via ES_JAVA_HOME for known jdk os incompatibilities
-    issue: https://github.com/elastic/elasticsearch/issues/135413
-  - class: org.elasticsearch.xpack.security.authz.microsoft.MicrosoftGraphAuthzPluginIT
-    method: testConcurrentAuthentication
-    issue: https://github.com/elastic/elasticsearch/issues/135777
-  - class: org.elasticsearch.versioning.ConcurrentSeqNoVersioningIT
-    method: testSeqNoCASLinearizability
-    issue: https://github.com/elastic/elasticsearch/issues/117249
-  - class: org.elasticsearch.test.rest.yaml.CcsCommonYamlTestSuiteIT
-    method: test {p0=field_caps/10_basic/Field caps for number field with only doc values}
-    issue: https://github.com/elastic/elasticsearch/issues/136244
-  - class: org.elasticsearch.test.rest.yaml.RcsCcsCommonYamlTestSuiteIT
-    method: test {p0=search.vectors/200_dense_vector_docvalue_fields/Enable docvalue_fields parameter for dense_vector fields}
-    issue: https://github.com/elastic/elasticsearch/issues/136443
-  - class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
-    method: testRemoteClusterOnlyCCSWithFailuresOnAllShards
-    issue: https://github.com/elastic/elasticsearch/issues/136894
-  - class: org.elasticsearch.xpack.inference.DefaultEndPointsIT
-    method: testMultipleInferencesTriggeringDownloadAndDeploy
-    issue: https://github.com/elastic/elasticsearch/issues/117208
-  - class: org.elasticsearch.readiness.ReadinessClusterIT
-    method: testReadinessDuringRestartsNormalOrder
-    issue: https://github.com/elastic/elasticsearch/issues/136955
-  - class: org.elasticsearch.smoketest.SmokeTestIngestWithAllDepsClientYamlTestSuiteIT
-    method: test {yaml=ingest/100_sampling_with_reroute/Test get sample with multiple reroutes}
-    issue: https://github.com/elastic/elasticsearch/issues/137457
-  - class: org.elasticsearch.xpack.ilm.CCRIndexLifecycleIT
-    method: testTsdbLeaderIndexRolloverAndSyncAfterWaitUntilEndTime {targetCluster=FOLLOWER}
-    issue: https://github.com/elastic/elasticsearch/issues/137565
-  - class: org.elasticsearch.xpack.inference.action.filter.ShardBulkInferenceActionFilterBasicLicenseIT
-    method: testLicenseInvalidForInference {p0=true}
-    issue: https://github.com/elastic/elasticsearch/issues/137690
-  - class: org.elasticsearch.xpack.inference.action.filter.ShardBulkInferenceActionFilterBasicLicenseIT
-    method: testLicenseInvalidForInference {p0=false}
-    issue: https://github.com/elastic/elasticsearch/issues/137691
-  - class: org.elasticsearch.indices.mapping.UpdateMappingIntegrationIT
-    method: testUpdateMappingConcurrently
-    issue: https://github.com/elastic/elasticsearch/issues/137758
-  - class: org.elasticsearch.xpack.inference.integration.AuthorizationTaskExecutorMultipleNodesIT
-    method: testAuthorizationTaskGetsRelocatedToAnotherNode_WhenTheNodeThatIsRunningItShutsDown
-    issue: https://github.com/elastic/elasticsearch/issues/137911
-  - class: org.elasticsearch.xpack.ml.integration.ForecastIT
-    method: testOverflowToDisk
-    issue: https://github.com/elastic/elasticsearch/issues/138055
-  - class: org.elasticsearch.xpack.inference.integration.AuthorizationTaskExecutorMultipleNodesIT
-    method: testCancellingAuthorizationTaskRestartsIt
-    issue: https://github.com/elastic/elasticsearch/issues/138099
-  - class: org.elasticsearch.search.basic.SearchWithRandomDisconnectsIT
-    method: testSearchWithRandomDisconnects
-    issue: https://github.com/elastic/elasticsearch/issues/138128
-  - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeMetricsIT
-    method: test
-    issue: https://github.com/elastic/elasticsearch/issues/138311
-  - class: org.elasticsearch.xpack.ml.integration.RegressionIT
-    method: testTwoJobsWithSameRandomizeSeedUseSameTrainingSet
-    issue: https://github.com/elastic/elasticsearch/issues/138319
-  - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
-    method: test {yaml=termvectors/30_realtime/Realtime Term Vectors}
-    issue: https://github.com/elastic/elasticsearch/issues/138370
-  - class: org.elasticsearch.xpack.ml.integration.RevertModelSnapshotIT
-    method: testRevertModelSnapshot_DeleteInterveningResults
-    issue: https://github.com/elastic/elasticsearch/issues/132349
-  - class: org.elasticsearch.smoketest.MlWithSecurityIT
-    method: test {yaml=ml/start_data_frame_analytics/Test start classification analysis when the dependent variable cardinality is too low}
-    issue: https://github.com/elastic/elasticsearch/issues/138409
-  - class: org.elasticsearch.xpack.ml.integration.RevertModelSnapshotIT
-    method: testRevertModelSnapshot
-    issue: https://github.com/elastic/elasticsearch/issues/132733
-  - class: org.elasticsearch.xpack.inference.services.jinaai.JinaAIServiceTests
-    method: test_Embedding_ChunkedInfer_LateChunkingEnabled
-    issue: https://github.com/elastic/elasticsearch/issues/138451
-  - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
-    method: test {yaml=index/100_field_name_length_limit/Test field name length limit synthetic source}
-    issue: https://github.com/elastic/elasticsearch/issues/138471
-  - class: org.elasticsearch.xpack.esql.heap_attack.HeapAttackLookupJoinIT
-    method: testLookupExplosionBigString
-    issue: https://github.com/elastic/elasticsearch/issues/138510
-  - class: org.elasticsearch.xpack.ilm.TimeSeriesLifecycleActionsIT
-    method: testWaitForSnapshot
-    issue: https://github.com/elastic/elasticsearch/issues/138669
-  - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
-    method: test {yaml=index/100_field_name_length_limit/Test field name length limit}
-    issue: https://github.com/elastic/elasticsearch/issues/138768
-  - class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
-    method: testDatafeedTimingStats_DatafeedRecreated
-    issue: https://github.com/elastic/elasticsearch/issues/138348
-  - class: org.elasticsearch.xpack.remotecluster.CrossClusterEsqlRCS1EnrichUnavailableRemotesIT
-    method: testEsqlEnrichWithSkipUnavailable
-    issue: https://github.com/elastic/elasticsearch/issues/138793
-  - class: org.elasticsearch.xpack.ilm.actions.DownsampleActionIT
-    method: testILMWaitsForTimeSeriesEndTimeToLapse
-    issue: https://github.com/elastic/elasticsearch/issues/138843
-  - class: org.elasticsearch.cluster.routing.allocation.WriteLoadConstraintMonitorTests
-    method: testRerouteIsNotCalledWhenNoNodesAreHotSpotting
-    issue: https://github.com/elastic/elasticsearch/issues/138924
-  - class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
-    method: testStopLookback_closeJobFalse
-    issue: https://github.com/elastic/elasticsearch/issues/139024
-  - class: org.elasticsearch.xpack.search.AsyncSearchConcurrentStatusIT
-    method: testConcurrentStatusFetchWhileTaskCloses
-    issue: https://github.com/elastic/elasticsearch/issues/138543
-  - class: org.elasticsearch.xpack.core.security.authc.AuthenticationTests
-    method: testMaybeRewriteForOlderVersionWithCrossClusterAccessRewritesAuthenticationInMetadata
-    issue: https://github.com/elastic/elasticsearch/issues/139167
-  - class: org.elasticsearch.smoketest.MlWithSecurityIT
-    method: test {yaml=ml/sparse_vector_search/Test sparse_vector search with query vector and pruning config}
-    issue: https://github.com/elastic/elasticsearch/issues/139196
-  - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
-    method: test {yaml=index/100_field_name_length_limit/Test field name length limit array synthetic source}
-    issue: https://github.com/elastic/elasticsearch/issues/139300
-  - class: org.elasticsearch.xpack.unsignedlong.UnsignedLongSyntheticSourceNativeArrayIntegrationTests
-    method: testSynthesizeArrayRandom
-    issue: https://github.com/elastic/elasticsearch/issues/139376
-  - class: org.elasticsearch.xpack.esql.optimizer.LocalLogicalPlanOptimizerTests
-    method: testReductionPlanForTopNWithPushedDownFunctionsInOrder
-    issue: https://github.com/elastic/elasticsearch/issues/139490
-  - class: org.elasticsearch.xpack.esql.optimizer.LocalLogicalPlanOptimizerTests
-    method: testReductionPlanForTopNWithPushedDownFunctions
-    issue: https://github.com/elastic/elasticsearch/issues/139491
-  - class: org.elasticsearch.xpack.esql.optimizer.rules.logical.local.ReplaceDateTruncBucketWithRoundToTests
-    method: testReductionPlanForTopNWithPushedDownFunctionsInOrder
-    issue: https://github.com/elastic/elasticsearch/issues/139492
-  - class: org.elasticsearch.xpack.esql.optimizer.rules.logical.local.ReplaceDateTruncBucketWithRoundToTests
-    method: testReductionPlanForTopNWithPushedDownFunctions
-    issue: https://github.com/elastic/elasticsearch/issues/139493
-  - class: org.elasticsearch.xpack.security.CoreWithSecurityClientYamlTestSuiteIT
-    method: test {yaml=search.retrievers/result-diversification/10_mmr_result_diversification_retriever/Test MMR result diversification single index float type}
-    issue: https://github.com/elastic/elasticsearch/issues/139527
-  - class: org.elasticsearch.repositories.gcs.GoogleCloudStorageBlobStoreRepositoryTests
-    method: testMultipleSnapshotAndRollback
-    issue: https://github.com/elastic/elasticsearch/issues/139556
-  - class: org.elasticsearch.index.mapper.LongSyntheticSourceNativeArrayIntegrationTests
-    method: testSynthesizeArrayRandom
-    issue: https://github.com/elastic/elasticsearch/issues/139562
-  - class: org.elasticsearch.repositories.gcs.GoogleCloudStorageBlobStoreRepositoryTests
-    method: testDeleteBlobs
-    issue: https://github.com/elastic/elasticsearch/issues/139646
-  - class: org.elasticsearch.upgrades.UpgradeClusterClientYamlTestSuiteIT
-    method: test {p0=mixed_cluster/90_ml_data_frame_analytics_crud/Start and stop old regression job}
-    issue: https://github.com/elastic/elasticsearch/issues/139654
-  - class: org.elasticsearch.xpack.core.action.XPackUsageResponseTests
-    method: testVersionDependentSerializationWriteToOldStream
-    issue: https://github.com/elastic/elasticsearch/issues/139576
-  - class: org.elasticsearch.index.mapper.HalfFloatSyntheticSourceNativeArrayIntegrationTests
-    method: testSynthesizeArrayRandom
-    issue: https://github.com/elastic/elasticsearch/issues/139658
-  - class: org.elasticsearch.smoketest.WatcherYamlRestIT
-    method: test {p0=mustache/10_webhook/Test webhook action with mustache integration}
-    issue: https://github.com/elastic/elasticsearch/issues/139663
-  - class: org.elasticsearch.repositories.gcs.GoogleCloudStorageBlobStoreRepositoryTests
-    method: testReadNonExistingPath
-    issue: https://github.com/elastic/elasticsearch/issues/139665
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=esql/40_unsupported_types/unsupported}
-    issue: https://github.com/elastic/elasticsearch/issues/139701
-  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
-    method: test {p0=esql/40_unsupported_types/unsupported with sort}
-    issue: https://github.com/elastic/elasticsearch/issues/139702
-  - class: org.elasticsearch.xpack.logsdb.RandomizedRollingUpgradeIT
-    method: testIndexingSyntheticSource
-    issue: https://github.com/elastic/elasticsearch/issues/139482
-  - class: org.elasticsearch.persistent.PersistentTasksCustomMetadataTests
-    method: testMinVersionSerialization
-    issue: https://github.com/elastic/elasticsearch/issues/139740
-  - class: org.elasticsearch.persistent.ClusterPersistentTasksCustomMetadataTests
-    method: testMinVersionSerialization
-    issue: https://github.com/elastic/elasticsearch/issues/139741
-  - class: org.elasticsearch.xpack.esql.session.EsqlResolvedIndexExpressionIT
-    method: testLocalDateMathExpression
-    issue: https://github.com/elastic/elasticsearch/issues/140106
+- class: org.elasticsearch.packaging.test.PackagesSecurityAutoConfigurationTests
+  method: test20SecurityNotAutoConfiguredOnReInstallation
+  issue: https://github.com/elastic/elasticsearch/issues/112635
+- class: org.elasticsearch.xpack.transform.integration.TransformIT
+  method: testStopWaitForCheckpoint
+  issue: https://github.com/elastic/elasticsearch/issues/106113
+- class: org.elasticsearch.xpack.remotecluster.RemoteClusterSecurityWithApmTracingRestIT
+  method: testTracingCrossCluster
+  issue: https://github.com/elastic/elasticsearch/issues/112731
+- class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
+  method: testDeploymentSurvivesRestart {cluster=UPGRADED}
+  issue: https://github.com/elastic/elasticsearch/issues/115528
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_start_stop/Verify start transform reuses destination index}
+  issue: https://github.com/elastic/elasticsearch/issues/115808
+- class: org.elasticsearch.xpack.application.connector.ConnectorIndexServiceTests
+  issue: https://github.com/elastic/elasticsearch/issues/116087
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_start_stop/Test start already started transform}
+  issue: https://github.com/elastic/elasticsearch/issues/98802
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=snapshot/20_operator_privileges_disabled/Operator only settings can be set and restored by non-operator user when operator privileges is disabled}
+  issue: https://github.com/elastic/elasticsearch/issues/116775
+- class: org.elasticsearch.search.basic.SearchWithRandomIOExceptionsIT
+  method: testRandomDirectoryIOExceptions
+  issue: https://github.com/elastic/elasticsearch/issues/114824
+- class: org.elasticsearch.xpack.apmdata.APMYamlTestSuiteIT
+  method: test {yaml=/10_apm/Test template reinstallation}
+  issue: https://github.com/elastic/elasticsearch/issues/116445
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_reset/Test reset running transform}
+  issue: https://github.com/elastic/elasticsearch/issues/117473
+- class: org.elasticsearch.packaging.test.ArchiveTests
+  method: test44AutoConfigurationNotTriggeredOnNotWriteableConfDir
+  issue: https://github.com/elastic/elasticsearch/issues/118208
+- class: org.elasticsearch.packaging.test.ArchiveTests
+  method: test51AutoConfigurationWithPasswordProtectedKeystore
+  issue: https://github.com/elastic/elasticsearch/issues/118212
+- class: org.elasticsearch.xpack.ccr.rest.ShardChangesRestIT
+  method: testShardChangesNoOperation
+  issue: https://github.com/elastic/elasticsearch/issues/118800
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_start_stop/Test start/stop/start transform}
+  issue: https://github.com/elastic/elasticsearch/issues/119508
+- class: org.elasticsearch.multi_cluster.MultiClusterYamlTestSuiteIT
+  issue: https://github.com/elastic/elasticsearch/issues/119983
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_unattended/Test unattended put and start}
+  issue: https://github.com/elastic/elasticsearch/issues/120019
+- class: org.elasticsearch.xpack.security.QueryableReservedRolesIT
+  method: testConfiguredReservedRolesAfterClosingAndOpeningIndex
+  issue: https://github.com/elastic/elasticsearch/issues/120127
+- class: org.elasticsearch.xpack.ccr.FollowIndexSecurityIT
+  method: testCleanShardFollowTaskAfterDeleteFollower
+  issue: https://github.com/elastic/elasticsearch/issues/120339
+- class: org.elasticsearch.xpack.security.authc.service.ServiceAccountIT
+  method: testAuthenticateShouldNotFallThroughInCaseOfFailure
+  issue: https://github.com/elastic/elasticsearch/issues/120902
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  method: test {p0=nodes.stats/11_indices_metrics/indices mappings exact count test for indices level}
+  issue: https://github.com/elastic/elasticsearch/issues/120950
+- class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
+  method: test {yaml=snapshot.delete/10_basic/Delete a snapshot asynchronously}
+  issue: https://github.com/elastic/elasticsearch/issues/122102
+- class: org.elasticsearch.action.admin.cluster.node.tasks.CancellableTasksIT
+  method: testChildrenTasksCancelledOnTimeout
+  issue: https://github.com/elastic/elasticsearch/issues/123568
+- class: org.elasticsearch.xpack.searchablesnapshots.FrozenSearchableSnapshotsIntegTests
+  method: testCreateAndRestorePartialSearchableSnapshot
+  issue: https://github.com/elastic/elasticsearch/issues/123773
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=snapshot/10_basic/Create a source only snapshot and then restore it}
+  issue: https://github.com/elastic/elasticsearch/issues/122755
+- class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
+  method: testDeploymentSurvivesRestart {cluster=OLD}
+  issue: https://github.com/elastic/elasticsearch/issues/124160
+- class: org.elasticsearch.packaging.test.BootstrapCheckTests
+  method: test20RunWithBootstrapChecks
+  issue: https://github.com/elastic/elasticsearch/issues/124940
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_start_stop/Test schedule_now on an already started transform}
+  issue: https://github.com/elastic/elasticsearch/issues/120720
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_start_stop/Verify start transform creates destination index with appropriate mapping}
+  issue: https://github.com/elastic/elasticsearch/issues/125854
+- class: org.elasticsearch.xpack.core.common.notifications.AbstractAuditorTests
+  method: testRecreateTemplateWhenDeleted
+  issue: https://github.com/elastic/elasticsearch/issues/123232
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_reset/Test force reseting a running transform}
+  issue: https://github.com/elastic/elasticsearch/issues/126240
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_start_stop/Test start/stop only starts/stops specified transform}
+  issue: https://github.com/elastic/elasticsearch/issues/126466
+- class: org.elasticsearch.repositories.blobstore.testkit.rest.SnapshotRepoTestKitClientYamlTestSuiteIT
+  method: test {p0=/10_analyze/Analysis without details}
+  issue: https://github.com/elastic/elasticsearch/issues/126569
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_start_stop/Test start/stop/start continuous transform}
+  issue: https://github.com/elastic/elasticsearch/issues/126755
+- class: org.elasticsearch.index.engine.CompletionStatsCacheTests
+  method: testCompletionStatsCache
+  issue: https://github.com/elastic/elasticsearch/issues/126910
+- class: org.elasticsearch.xpack.ml.integration.ClassificationHousePricingIT
+  method: testFeatureImportanceValues
+  issue: https://github.com/elastic/elasticsearch/issues/124341
+- class: org.elasticsearch.cli.keystore.AddStringKeyStoreCommandTests
+  method: testStdinWithMultipleValues
+  issue: https://github.com/elastic/elasticsearch/issues/126882
+- class: org.elasticsearch.xpack.ccr.action.ShardFollowTaskReplicationTests
+  method: testChangeFollowerHistoryUUID
+  issue: https://github.com/elastic/elasticsearch/issues/127680
+- class: org.elasticsearch.action.admin.indices.diskusage.IndexDiskUsageAnalyzerTests
+  method: testKnnVectors
+  issue: https://github.com/elastic/elasticsearch/issues/127689
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  method: test {p0=search/350_point_in_time/point-in-time with index filter}
+  issue: https://github.com/elastic/elasticsearch/issues/127741
+- class: org.elasticsearch.xpack.esql.plugin.DataNodeRequestSenderIT
+  method: testSearchWhileRelocating
+  issue: https://github.com/elastic/elasticsearch/issues/128500
+- class: org.elasticsearch.entitlement.runtime.policy.FileAccessTreeTests
+  method: testWindowsMixedCaseAccess
+  issue: https://github.com/elastic/elasticsearch/issues/129167
+- class: org.elasticsearch.entitlement.runtime.policy.FileAccessTreeTests
+  method: testWindowsAbsolutPathAccess
+  issue: https://github.com/elastic/elasticsearch/issues/129168
+- class: org.elasticsearch.xpack.profiling.action.GetStatusActionIT
+  method: testWaitsUntilResourcesAreCreated
+  issue: https://github.com/elastic/elasticsearch/issues/129486
+- class: org.elasticsearch.search.query.VectorIT
+  method: testFilteredQueryStrategy
+  issue: https://github.com/elastic/elasticsearch/issues/129517
+- class: org.elasticsearch.xpack.security.SecurityRolesMultiProjectIT
+  method: testUpdatingFileBasedRoleAffectsAllProjects
+  issue: https://github.com/elastic/elasticsearch/issues/129775
+- class: org.elasticsearch.action.support.ThreadedActionListenerTests
+  method: testRejectionHandling
+  issue: https://github.com/elastic/elasticsearch/issues/130129
+- class: org.elasticsearch.compute.aggregation.TopIntAggregatorFunctionTests
+  method: testManyInitialManyPartialFinalRunnerThrowing
+  issue: https://github.com/elastic/elasticsearch/issues/130145
+- class: org.elasticsearch.xpack.searchablesnapshots.cache.shared.NodesCachesStatsIntegTests
+  method: testNodesCachesStats
+  issue: https://github.com/elastic/elasticsearch/issues/129863
+- class: org.elasticsearch.index.IndexingPressureIT
+  method: testWriteCanRejectOnPrimaryBasedOnMaxOperationSize
+  issue: https://github.com/elastic/elasticsearch/issues/130281
+- class: org.elasticsearch.indices.stats.IndexStatsIT
+  method: testFilterCacheStats
+  issue: https://github.com/elastic/elasticsearch/issues/124447
+- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+  method: test {p0=mtermvectors/10_basic/Tests catching other exceptions per item}
+  issue: https://github.com/elastic/elasticsearch/issues/122414
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test090SecurityCliPackaging
+  issue: https://github.com/elastic/elasticsearch/issues/131107
+- class: org.elasticsearch.xpack.esql.expression.function.fulltext.ScoreTests
+  method: testSerializationOfSimple {TestCase=<boolean>}
+  issue: https://github.com/elastic/elasticsearch/issues/131334
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test071BindMountCustomPathWithDifferentUID
+  issue: https://github.com/elastic/elasticsearch/issues/120917
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test171AdditionalCliOptionsAreForwarded
+  issue: https://github.com/elastic/elasticsearch/issues/120925
+- class: org.elasticsearch.packaging.test.DockerTests
+  method: test050BasicApiTests
+  issue: https://github.com/elastic/elasticsearch/issues/120911
+- class: org.elasticsearch.xpack.restart.FullClusterRestartIT
+  method: testWatcherWithApiKey {cluster=UPGRADED}
+  issue: https://github.com/elastic/elasticsearch/issues/131964
+- class: org.elasticsearch.xpack.sql.qa.mixed_node.SqlCompatIT
+  method: testNullsOrderWithMissingOrderSupportQueryingNewNode
+  issue: https://github.com/elastic/elasticsearch/issues/132249
+- class: org.elasticsearch.packaging.test.ArchiveGenerateInitialCredentialsTests
+  method: test40VerifyAutogeneratedCredentials
+  issue: https://github.com/elastic/elasticsearch/issues/132877
+- class: org.elasticsearch.packaging.test.ArchiveGenerateInitialCredentialsTests
+  method: test50CredentialAutogenerationOnlyOnce
+  issue: https://github.com/elastic/elasticsearch/issues/132878
+- class: org.elasticsearch.xpack.eql.planner.QueryTranslatorTests
+  method: testMatchOptimization
+  issue: https://github.com/elastic/elasticsearch/issues/132894
+- class: org.elasticsearch.xpack.security.authc.AuthenticationServiceTests
+  method: testInvalidToken
+  issue: https://github.com/elastic/elasticsearch/issues/133328
+- class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
+  method: testCancelViaExpirationOnRemoteResultsWithMinimizeRoundtrips
+  issue: https://github.com/elastic/elasticsearch/issues/127302
+- class: org.elasticsearch.xpack.ml.integration.InferenceIT
+  method: testInferClassificationModel
+  issue: https://github.com/elastic/elasticsearch/issues/133448
+- class: org.elasticsearch.xpack.ml.integration.ClassificationIT
+  method: testWithCustomFeatureProcessors
+  issue: https://github.com/elastic/elasticsearch/issues/134001
+- class: org.elasticsearch.action.admin.cluster.state.TransportClusterStateActionTests
+  method: testGetClusterStateWithDefaultProjectOnly
+  issue: https://github.com/elastic/elasticsearch/issues/134450
+- class: org.elasticsearch.xpack.esql.plugin.CanMatchIT
+  method: testAliasFilters
+  issue: https://github.com/elastic/elasticsearch/issues/134512
+- class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
+  method: testOldRepoAccess
+  issue: https://github.com/elastic/elasticsearch/issues/120148
+- class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
+  method: testOldSourceOnlyRepoAccess
+  issue: https://github.com/elastic/elasticsearch/issues/134646
+- class: org.elasticsearch.oldrepos.OldMappingsIT
+  method: testStandardTokenFilter
+  issue: https://github.com/elastic/elasticsearch/issues/134647
+- class: org.elasticsearch.aggregations.bucket.AggregationReductionCircuitBreakingIT
+  method: testCBTrippingOnReduction
+  issue: https://github.com/elastic/elasticsearch/issues/134667
+- class: org.elasticsearch.xpack.esql.action.CrossClusterCancellationIT
+  method: testCancelSkipUnavailable
+  issue: https://github.com/elastic/elasticsearch/issues/134865
+- class: org.elasticsearch.reservedstate.service.RepositoriesFileSettingsIT
+  method: testSettingsApplied
+  issue: https://github.com/elastic/elasticsearch/issues/126748
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=transform/transforms_start_stop/Test stop transform with force and wait_for_checkpoint true}
+  issue: https://github.com/elastic/elasticsearch/issues/135135
+- class: org.elasticsearch.discovery.ClusterDisruptionIT
+  method: testAckedIndexing
+  issue: https://github.com/elastic/elasticsearch/issues/117024
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=analytics/nested_top_metrics_sort/terms order by top metrics numeric not null double values}
+  issue: https://github.com/elastic/elasticsearch/issues/135159
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=analytics/nested_top_metrics_sort/terms order by top metrics numeric not null integer values}
+  issue: https://github.com/elastic/elasticsearch/issues/135162
+- class: org.elasticsearch.gradle.TestClustersPluginFuncTest
+  method: override jdk usage via ES_JAVA_HOME for known jdk os incompatibilities
+  issue: https://github.com/elastic/elasticsearch/issues/135413
+- class: org.elasticsearch.xpack.security.authz.microsoft.MicrosoftGraphAuthzPluginIT
+  method: testConcurrentAuthentication
+  issue: https://github.com/elastic/elasticsearch/issues/135777
+- class: org.elasticsearch.versioning.ConcurrentSeqNoVersioningIT
+  method: testSeqNoCASLinearizability
+  issue: https://github.com/elastic/elasticsearch/issues/117249
+- class: org.elasticsearch.test.rest.yaml.CcsCommonYamlTestSuiteIT
+  method: test {p0=field_caps/10_basic/Field caps for number field with only doc values}
+  issue: https://github.com/elastic/elasticsearch/issues/136244
+- class: org.elasticsearch.test.rest.yaml.RcsCcsCommonYamlTestSuiteIT
+  method: test {p0=search.vectors/200_dense_vector_docvalue_fields/Enable docvalue_fields parameter for dense_vector fields}
+  issue: https://github.com/elastic/elasticsearch/issues/136443
+- class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
+  method: testRemoteClusterOnlyCCSWithFailuresOnAllShards
+  issue: https://github.com/elastic/elasticsearch/issues/136894
+- class: org.elasticsearch.xpack.inference.DefaultEndPointsIT
+  method: testMultipleInferencesTriggeringDownloadAndDeploy
+  issue: https://github.com/elastic/elasticsearch/issues/117208
+- class: org.elasticsearch.readiness.ReadinessClusterIT
+  method: testReadinessDuringRestartsNormalOrder
+  issue: https://github.com/elastic/elasticsearch/issues/136955
+- class: org.elasticsearch.smoketest.SmokeTestIngestWithAllDepsClientYamlTestSuiteIT
+  method: test {yaml=ingest/100_sampling_with_reroute/Test get sample with multiple reroutes}
+  issue: https://github.com/elastic/elasticsearch/issues/137457
+- class: org.elasticsearch.xpack.ilm.CCRIndexLifecycleIT
+  method: testTsdbLeaderIndexRolloverAndSyncAfterWaitUntilEndTime {targetCluster=FOLLOWER}
+  issue: https://github.com/elastic/elasticsearch/issues/137565
+- class: org.elasticsearch.xpack.inference.action.filter.ShardBulkInferenceActionFilterBasicLicenseIT
+  method: testLicenseInvalidForInference {p0=true}
+  issue: https://github.com/elastic/elasticsearch/issues/137690
+- class: org.elasticsearch.xpack.inference.action.filter.ShardBulkInferenceActionFilterBasicLicenseIT
+  method: testLicenseInvalidForInference {p0=false}
+  issue: https://github.com/elastic/elasticsearch/issues/137691
+- class: org.elasticsearch.xpack.inference.InferenceRestIT
+  method: test {p0=inference/70_text_similarity_rank_retriever/Text similarity reranker with min_score zero includes all docs}
+  issue: https://github.com/elastic/elasticsearch/issues/137732
+- class: org.elasticsearch.indices.mapping.UpdateMappingIntegrationIT
+  method: testUpdateMappingConcurrently
+  issue: https://github.com/elastic/elasticsearch/issues/137758
+- class: org.elasticsearch.xpack.inference.external.http.sender.RequestExecutorServiceTests
+  method: testChangingCapacity_DoesNotRejectsOverflowTasks_BecauseOfQueueFull
+  issue: https://github.com/elastic/elasticsearch/issues/137823
+- class: org.elasticsearch.xpack.inference.integration.AuthorizationTaskExecutorMultipleNodesIT
+  method: testAuthorizationTaskGetsRelocatedToAnotherNode_WhenTheNodeThatIsRunningItShutsDown
+  issue: https://github.com/elastic/elasticsearch/issues/137911
+- class: org.elasticsearch.xpack.ml.integration.ForecastIT
+  method: testOverflowToDisk
+  issue: https://github.com/elastic/elasticsearch/issues/138055
+- class: org.elasticsearch.xpack.inference.integration.AuthorizationTaskExecutorMultipleNodesIT
+  method: testCancellingAuthorizationTaskRestartsIt
+  issue: https://github.com/elastic/elasticsearch/issues/138099
+- class: org.elasticsearch.search.basic.SearchWithRandomDisconnectsIT
+  method: testSearchWithRandomDisconnects
+  issue: https://github.com/elastic/elasticsearch/issues/138128
+- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeMetricsIT
+  method: test
+  issue: https://github.com/elastic/elasticsearch/issues/138311
+- class: org.elasticsearch.xpack.ml.integration.RegressionIT
+  method: testTwoJobsWithSameRandomizeSeedUseSameTrainingSet
+  issue: https://github.com/elastic/elasticsearch/issues/138319
+- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
+  method: test {yaml=termvectors/30_realtime/Realtime Term Vectors}
+  issue: https://github.com/elastic/elasticsearch/issues/138370
+- class: org.elasticsearch.xpack.ml.integration.RevertModelSnapshotIT
+  method: testRevertModelSnapshot_DeleteInterveningResults
+  issue: https://github.com/elastic/elasticsearch/issues/132349
+- class: org.elasticsearch.smoketest.MlWithSecurityIT
+  method: test {yaml=ml/start_data_frame_analytics/Test start classification analysis when the dependent variable cardinality is too low}
+  issue: https://github.com/elastic/elasticsearch/issues/138409
+- class: org.elasticsearch.xpack.ml.integration.RevertModelSnapshotIT
+  method: testRevertModelSnapshot
+  issue: https://github.com/elastic/elasticsearch/issues/132733
+- class: org.elasticsearch.xpack.inference.services.jinaai.JinaAIServiceTests
+  method: test_Embedding_ChunkedInfer_LateChunkingEnabled
+  issue: https://github.com/elastic/elasticsearch/issues/138451
+- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
+  method: test {yaml=index/100_field_name_length_limit/Test field name length limit synthetic source}
+  issue: https://github.com/elastic/elasticsearch/issues/138471
+- class: org.elasticsearch.xpack.esql.heap_attack.HeapAttackLookupJoinIT
+  method: testLookupExplosionBigString
+  issue: https://github.com/elastic/elasticsearch/issues/138510
+- class: org.elasticsearch.xpack.ilm.TimeSeriesLifecycleActionsIT
+  method: testWaitForSnapshot
+  issue: https://github.com/elastic/elasticsearch/issues/138669
+- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
+  method: test {yaml=index/100_field_name_length_limit/Test field name length limit}
+  issue: https://github.com/elastic/elasticsearch/issues/138768
+- class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
+  method: testDatafeedTimingStats_DatafeedRecreated
+  issue: https://github.com/elastic/elasticsearch/issues/138348
+- class: org.elasticsearch.xpack.remotecluster.CrossClusterEsqlRCS1EnrichUnavailableRemotesIT
+  method: testEsqlEnrichWithSkipUnavailable
+  issue: https://github.com/elastic/elasticsearch/issues/138793
+- class: org.elasticsearch.xpack.ilm.actions.DownsampleActionIT
+  method: testILMWaitsForTimeSeriesEndTimeToLapse
+  issue: https://github.com/elastic/elasticsearch/issues/138843
+- class: org.elasticsearch.cluster.routing.allocation.WriteLoadConstraintMonitorTests
+  method: testRerouteIsNotCalledWhenNoNodesAreHotSpotting
+  issue: https://github.com/elastic/elasticsearch/issues/138924
+- class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
+  method: testStopLookback_closeJobFalse
+  issue: https://github.com/elastic/elasticsearch/issues/139024
+- class: org.elasticsearch.xpack.search.AsyncSearchConcurrentStatusIT
+  method: testConcurrentStatusFetchWhileTaskCloses
+  issue: https://github.com/elastic/elasticsearch/issues/138543
+- class: org.elasticsearch.xpack.core.security.authc.AuthenticationTests
+  method: testMaybeRewriteForOlderVersionWithCrossClusterAccessRewritesAuthenticationInMetadata
+  issue: https://github.com/elastic/elasticsearch/issues/139167
+- class: org.elasticsearch.smoketest.MlWithSecurityIT
+  method: test {yaml=ml/sparse_vector_search/Test sparse_vector search with query vector and pruning config}
+  issue: https://github.com/elastic/elasticsearch/issues/139196
+- class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
+  method: test {yaml=index/100_field_name_length_limit/Test field name length limit array synthetic source}
+  issue: https://github.com/elastic/elasticsearch/issues/139300
+- class: org.elasticsearch.xpack.unsignedlong.UnsignedLongSyntheticSourceNativeArrayIntegrationTests
+  method: testSynthesizeArrayRandom
+  issue: https://github.com/elastic/elasticsearch/issues/139376
+- class: org.elasticsearch.xpack.esql.optimizer.LocalLogicalPlanOptimizerTests
+  method: testReductionPlanForTopNWithPushedDownFunctionsInOrder
+  issue: https://github.com/elastic/elasticsearch/issues/139490
+- class: org.elasticsearch.xpack.esql.optimizer.LocalLogicalPlanOptimizerTests
+  method: testReductionPlanForTopNWithPushedDownFunctions
+  issue: https://github.com/elastic/elasticsearch/issues/139491
+- class: org.elasticsearch.xpack.esql.optimizer.rules.logical.local.ReplaceDateTruncBucketWithRoundToTests
+  method: testReductionPlanForTopNWithPushedDownFunctionsInOrder
+  issue: https://github.com/elastic/elasticsearch/issues/139492
+- class: org.elasticsearch.xpack.esql.optimizer.rules.logical.local.ReplaceDateTruncBucketWithRoundToTests
+  method: testReductionPlanForTopNWithPushedDownFunctions
+  issue: https://github.com/elastic/elasticsearch/issues/139493
+- class: org.elasticsearch.xpack.security.CoreWithSecurityClientYamlTestSuiteIT
+  method: test {yaml=search.retrievers/result-diversification/10_mmr_result_diversification_retriever/Test MMR result diversification single index float type}
+  issue: https://github.com/elastic/elasticsearch/issues/139527
+- class: org.elasticsearch.repositories.gcs.GoogleCloudStorageBlobStoreRepositoryTests
+  method: testMultipleSnapshotAndRollback
+  issue: https://github.com/elastic/elasticsearch/issues/139556
+- class: org.elasticsearch.index.mapper.LongSyntheticSourceNativeArrayIntegrationTests
+  method: testSynthesizeArrayRandom
+  issue: https://github.com/elastic/elasticsearch/issues/139562
+- class: org.elasticsearch.repositories.gcs.GoogleCloudStorageBlobStoreRepositoryTests
+  method: testDeleteBlobs
+  issue: https://github.com/elastic/elasticsearch/issues/139646
+- class: org.elasticsearch.upgrades.UpgradeClusterClientYamlTestSuiteIT
+  method: test {p0=mixed_cluster/90_ml_data_frame_analytics_crud/Start and stop old regression job}
+  issue: https://github.com/elastic/elasticsearch/issues/139654
+- class: org.elasticsearch.xpack.core.action.XPackUsageResponseTests
+  method: testVersionDependentSerializationWriteToOldStream
+  issue: https://github.com/elastic/elasticsearch/issues/139576
+- class: org.elasticsearch.index.mapper.HalfFloatSyntheticSourceNativeArrayIntegrationTests
+  method: testSynthesizeArrayRandom
+  issue: https://github.com/elastic/elasticsearch/issues/139658
+- class: org.elasticsearch.smoketest.WatcherYamlRestIT
+  method: test {p0=mustache/10_webhook/Test webhook action with mustache integration}
+  issue: https://github.com/elastic/elasticsearch/issues/139663
+- class: org.elasticsearch.repositories.gcs.GoogleCloudStorageBlobStoreRepositoryTests
+  method: testReadNonExistingPath
+  issue: https://github.com/elastic/elasticsearch/issues/139665
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=esql/40_unsupported_types/unsupported}
+  issue: https://github.com/elastic/elasticsearch/issues/139701
+- class: org.elasticsearch.xpack.test.rest.XPackRestIT
+  method: test {p0=esql/40_unsupported_types/unsupported with sort}
+  issue: https://github.com/elastic/elasticsearch/issues/139702
+- class: org.elasticsearch.xpack.logsdb.RandomizedRollingUpgradeIT
+  method: testIndexingSyntheticSource
+  issue: https://github.com/elastic/elasticsearch/issues/139482
+- class: org.elasticsearch.persistent.PersistentTasksCustomMetadataTests
+  method: testMinVersionSerialization
+  issue: https://github.com/elastic/elasticsearch/issues/139740
+- class: org.elasticsearch.persistent.ClusterPersistentTasksCustomMetadataTests
+  method: testMinVersionSerialization
+  issue: https://github.com/elastic/elasticsearch/issues/139741
+- class: org.elasticsearch.xpack.esql.session.EsqlResolvedIndexExpressionIT
+  method: testLocalDateMathExpression
+  issue: https://github.com/elastic/elasticsearch/issues/140106
 
 # Examples:
 #

--- a/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/AuthorizationTaskExecutorIT.java
+++ b/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/AuthorizationTaskExecutorIT.java
@@ -75,12 +75,13 @@ public class AuthorizationTaskExecutorIT extends ESSingleNodeTestCase {
     public static void initClass() throws IOException {
         webServer.start();
         gatewayUrl = getUrl(webServer);
-        webServer.enqueue(new MockResponse().setResponseCode(200).setBody(EIS_EMPTY_RESPONSE));
         chatCompletionResponseBody = getEisRainbowSprinklesAuthorizationResponse(gatewayUrl).responseJson();
     }
 
     @Before
     public void createComponents() {
+        // Adding an empty response to ensure that the initial authorization polling request does not fail
+        webServer.enqueue(new MockResponse().setResponseCode(200).setBody(EIS_EMPTY_RESPONSE));
         modelRegistry = node().injector().getInstance(ModelRegistry.class);
         authorizationTaskExecutor = node().injector().getInstance(AuthorizationTaskExecutor.class);
     }
@@ -195,7 +196,7 @@ public class AuthorizationTaskExecutorIT extends ESSingleNodeTestCase {
 
     static List<UnparsedModel> getEisEndpoints(ModelRegistry modelRegistry) {
         var listener = new PlainActionFuture<List<UnparsedModel>>();
-        modelRegistry.getAllModels(false, listener);
+        modelRegistry.getAllModels(true, listener);
 
         var endpoints = listener.actionGet(TimeValue.THIRTY_SECONDS);
         return endpoints.stream().filter(m -> m.service().equals(ElasticInferenceService.NAME)).toList();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Inference API] Fix flaky AuthorizationTaskExecutorIT tests (#139978)](https://github.com/elastic/elasticsearch/pull/139978)

<!--- Backport version: 9.2.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)