### PR TITLE
Fix TransportClusterStateActionTests.testGetClusterStateWithDefaultProjectOnly

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -186,9 +186,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.ClassificationIT
   method: testWithCustomFeatureProcessors
   issue: https://github.com/elastic/elasticsearch/issues/134001
-- class: org.elasticsearch.action.admin.cluster.state.TransportClusterStateActionTests
-  method: testGetClusterStateWithDefaultProjectOnly
-  issue: https://github.com/elastic/elasticsearch/issues/134450
 - class: org.elasticsearch.xpack.esql.plugin.CanMatchIT
   method: testAliasFilters
   issue: https://github.com/elastic/elasticsearch/issues/134512


### PR DESCRIPTION
This change introduces additional checks to TransportClusterStateActionTests.testGetClusterStateWithDefaultProjectOnly to ensure that multi-project customs are not present in the cluster state when multiproject is disabled.

Closes: https://github.com/elastic/elasticsearch/issues/134450