### PR TITLE
[8.19] Dump log files on packaging test failure (#140245)

### DIFF
--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -1217,7 +1217,6 @@ public class DockerTests extends PackagingTestCase {
             builder().envVar("readiness.port", "9399").envVar("xpack.security.enabled", "false").envVar("discovery.type", "single-node")
         );
         waitForElasticsearch(installation);
-        dumpDebug();
         // readiness may still take time as file settings are applied into cluster state (even non-existent file settings)
         assertBusy(() -> assertTrue(readinessProbe(9399)));
     }

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
@@ -145,7 +145,7 @@ public abstract class PackagingTestCase extends Assert {
         @Override
         protected void failed(Throwable e, Description description) {
             failed = true;
-            if (installation != null && installation.distribution.isDocker()) {
+            if (installation != null) {
                 logger.warn("Test {} failed. Printing logs for failed test...", description.getMethodName());
                 dumpDebug();
             }
@@ -292,19 +292,8 @@ public abstract class PackagingTestCase extends Assert {
      * Starts and stops elasticsearch, and performs assertions while it is running.
      */
     protected void assertWhileRunning(Platforms.PlatformAction assertions) throws Exception {
-        try {
-            awaitElasticsearchStartup(runElasticsearchStartCommand(null, true, false));
-        } catch (AssertionError | Exception e) {
-            dumpDebug();
-            throw e;
-        }
-
-        try {
-            assertions.run();
-        } catch (AssertionError | Exception e) {
-            dumpDebug();
-            throw e;
-        }
+        awaitElasticsearchStartup(runElasticsearchStartCommand(null, true, false));
+        assertions.run();
         stopElasticsearch();
     }
 
@@ -395,12 +384,7 @@ public abstract class PackagingTestCase extends Assert {
      * @throws Exception if Elasticsearch can't start
      */
     public void startElasticsearch() throws Exception {
-        try {
-            awaitElasticsearchStartup(runElasticsearchStartCommand(null, true, false));
-        } catch (AssertionError | Exception e) {
-            dumpDebug();
-            throw e;
-        }
+        awaitElasticsearchStartup(runElasticsearchStartCommand(null, true, false));
     }
 
     public void assertElasticsearchFailure(Shell.Result result, String expectedMessage, Packages.JournaldWrapper journaldWrapper) {

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/WindowsServiceTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/WindowsServiceTests.java
@@ -91,7 +91,6 @@ public class WindowsServiceTests extends PackagingTestCase {
             logger.error("---- Unexpected exit code (expected " + exitCode + ", got " + result.exitCode() + ") for script: " + script);
             logger.error(result);
             logger.error("Dumping log files\n");
-            dumpDebug();
             fail();
         } else {
             logger.info("\nscript: " + script + "\nstdout: " + result.stdout() + "\nstderr: " + result.stderr());


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Dump log files on packaging test failure (#140245)