### PR TITLE
Add internal cluster test framework for multi-cluster tests with API key authentication

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/CreateApiKeyResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/CreateApiKeyResponse.java
@@ -85,6 +85,10 @@ public final class CreateApiKeyResponse extends ActionResponse implements ToXCon
         return key;
     }
 
+    public String getEncodedKey() {
+        return Base64.getEncoder().encodeToString((id + ":" + key).getBytes(StandardCharsets.UTF_8));
+    }
+
     @Nullable
     public Instant getExpiration() {
         return expiration;
@@ -149,7 +153,7 @@ public final class CreateApiKeyResponse extends ActionResponse implements ToXCon
         } finally {
             Arrays.fill(charBytes, (byte) 0);
         }
-        builder.field("encoded", Base64.getEncoder().encodeToString((id + ":" + key).getBytes(StandardCharsets.UTF_8)));
+        builder.field("encoded", getEncodedKey());
         return builder.endObject();
     }
 

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/AbstractMultiClustersWithSecurityTestCase.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/AbstractMultiClustersWithSecurityTestCase.java
@@ -13,7 +13,6 @@ import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.KeyStoreWrapper;
-import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.env.Environment;
@@ -24,21 +23,17 @@ import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.NodeConfigurationSource;
 import org.elasticsearch.test.SecuritySettingsSource;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.xpack.core.security.action.ActionTypes;
 import org.elasticsearch.xpack.core.security.action.apikey.CreateCrossClusterApiKeyAction;
 import org.elasticsearch.xpack.core.security.action.apikey.CreateCrossClusterApiKeyRequest;
 import org.elasticsearch.xpack.core.security.action.apikey.CrossClusterApiKeyRoleDescriptorBuilder;
 import org.elasticsearch.xpack.security.LocalStateSecurity;
-import org.elasticsearch.xpack.security.action.settings.TransportReloadRemoteClusterCredentialsAction;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.transport.RemoteClusterPortSettings.REMOTE_CLUSTER_SERVER_ENABLED;
 import static org.hamcrest.CoreMatchers.is;
@@ -93,12 +88,17 @@ public abstract class AbstractMultiClustersWithSecurityTestCase extends Abstract
 
     @Override
     protected TransportAddress getTransportAddress(TransportService transportService) {
-        return apiKeyAuthenticationEnabled() ? transportService.boundRemoteAccessAddress().publishAddress() : super.getTransportAddress(transportService);
+        return apiKeyAuthenticationEnabled()
+            ? transportService.boundRemoteAccessAddress().publishAddress()
+            : super.getTransportAddress(transportService);
     }
 
     private String addCrossClusterApiKey(String clusterAlias) throws Exception {
         Client client = internalClient(clusterAlias);
-        CreateCrossClusterApiKeyRequest request = generateCreateCrossClusterApiKeyRequest("cross_cluster_access_key", crossClusterAccessJson());
+        CreateCrossClusterApiKeyRequest request = generateCreateCrossClusterApiKeyRequest(
+            "cross_cluster_access_key",
+            crossClusterAccessJson()
+        );
         var responseFuture = client.execute(CreateCrossClusterApiKeyAction.INSTANCE, request);
 
         String encodedApiKey;
@@ -182,7 +182,8 @@ public abstract class AbstractMultiClustersWithSecurityTestCase extends Abstract
             }""";
     }
 
-    private static CreateCrossClusterApiKeyRequest generateCreateCrossClusterApiKeyRequest(String name, String accessJson) throws IOException {
+    private static CreateCrossClusterApiKeyRequest generateCreateCrossClusterApiKeyRequest(String name, String accessJson)
+        throws IOException {
         CrossClusterApiKeyRoleDescriptorBuilder roleDescriptorBuilder = CrossClusterApiKeyRoleDescriptorBuilder.parse(accessJson);
         var request = new CreateCrossClusterApiKeyRequest(name, roleDescriptorBuilder, null, null, null);
         request.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/AbstractMultiClustersWithSecurityTestCase.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/AbstractMultiClustersWithSecurityTestCase.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.integration;
+
+import org.elasticsearch.action.admin.cluster.node.reload.NodesReloadSecureSettingsRequest;
+import org.elasticsearch.action.admin.cluster.node.reload.TransportNodesReloadSecureSettingsAction;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.MockSecureSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.AbstractMultiClustersTestCase;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.NodeConfigurationSource;
+import org.elasticsearch.test.SecuritySettingsSource;
+import org.elasticsearch.xpack.core.security.action.apikey.CreateCrossClusterApiKeyAction;
+import org.elasticsearch.xpack.core.security.action.apikey.CreateCrossClusterApiKeyRequest;
+import org.elasticsearch.xpack.core.security.action.apikey.CrossClusterApiKeyRoleDescriptorBuilder;
+import org.elasticsearch.xpack.security.LocalStateSecurity;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
+import static org.elasticsearch.transport.RemoteClusterPortSettings.REMOTE_CLUSTER_SERVER_ENABLED;
+import static org.hamcrest.CoreMatchers.is;
+
+public abstract class AbstractMultiClustersWithSecurityTestCase extends AbstractMultiClustersTestCase {
+    // TODO: Need to clear this? How does this work with different values of reuseCluster?
+    private final Map<String, String> crossClusterApiKeys = new HashMap<>();
+
+    @Override
+    protected Settings nodeSettings(String clusterAlias) {
+        Settings.Builder builder = Settings.builder().put(nodeSettings());
+        if (enableSecurity() && useApiKeyAuthentication()) {
+            if (clusterAlias.equals(LOCAL_CLUSTER)) {
+                builder.put("xpack.security.remote_cluster_client.ssl.enabled", false);
+            } else {
+                builder.put(REMOTE_CLUSTER_SERVER_ENABLED.getKey(), true);
+                builder.put("xpack.security.remote_cluster_server.ssl.enabled", false);
+                builder.put("remote_cluster.port", 0);
+            }
+        }
+
+        return builder.build();
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins(String clusterAlias) {
+        return enableSecurity() ? List.of(LocalStateSecurity.class) : List.of();
+    }
+
+    @Override
+    protected NodeConfigurationSource nodeConfigurationSource() {
+        return enableSecurity() ? new SecuritySettingsSource(false, createTempDir(), ESIntegTestCase.Scope.TEST) : null;
+    }
+
+    @Override
+    protected void customizeRemoteClusterConfig(String clusterAlias) throws Exception {
+        if (enableSecurity() && useApiKeyAuthentication()) {
+            Client client = internalClient(clusterAlias);
+
+            CreateCrossClusterApiKeyRequest request = generateCreateCrossClusterApiKeyRequest("cross_cluster_access_key", crossClusterAccessJson());
+            var responseFuture = client.execute(CreateCrossClusterApiKeyAction.INSTANCE, request);
+            assertResponse(responseFuture, r -> {
+                String encodedKey = r.getEncodedKey();
+                crossClusterApiKeys.put(clusterAlias, encodedKey);
+            });
+        }
+    }
+
+    @Override
+    protected void customizeLocalClusterConfig(String remoteClusterAlias) throws Exception {
+        if (enableSecurity() && useApiKeyAuthentication()) {
+            String crossClusterApiKey = crossClusterApiKeys.get(remoteClusterAlias);
+            if (crossClusterApiKey == null) {
+                throw new IllegalStateException("Cross-cluster API key does not exist for cluster [" + remoteClusterAlias + "]");
+            }
+
+            MockSecureSettings secureSettings = new MockSecureSettings();
+            secureSettings.setString("cluster.remote." + remoteClusterAlias + ".credentials", crossClusterApiKey);
+
+            Client client = internalClient();
+            Settings.Builder settings = Settings.builder().setSecureSettings(secureSettings);
+            assertAcked(client.admin().cluster().prepareUpdateSettings(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT).setPersistentSettings(settings));
+
+            NodesReloadSecureSettingsRequest reloadSecureSettingsRequest = new NodesReloadSecureSettingsRequest(Strings.EMPTY_ARRAY);
+            assertResponse(client.execute(TransportNodesReloadSecureSettingsAction.TYPE, reloadSecureSettingsRequest), r -> {
+                assertThat(r.hasFailures(), is(false));
+            });
+        }
+    }
+
+    protected boolean enableSecurity() {
+        return true;
+    }
+
+    protected boolean useApiKeyAuthentication() {
+        return true;
+    }
+
+    protected String crossClusterAccessJson() {
+        return """
+            {
+              "search": [
+                {
+                  "names": [
+                    "*"
+                  ],
+                  "allow_restricted_indices": false
+                }
+              ],
+              "replication": [
+                {
+                  "names": [
+                    "*"
+                  ],
+                  "allow_restricted_indices": false
+                }
+              ]
+            }""";
+    }
+
+    private static CreateCrossClusterApiKeyRequest generateCreateCrossClusterApiKeyRequest(String name, String accessJson) throws IOException {
+        CrossClusterApiKeyRoleDescriptorBuilder roleDescriptorBuilder = CrossClusterApiKeyRoleDescriptorBuilder.parse(accessJson);
+        var request = new CreateCrossClusterApiKeyRequest(name, roleDescriptorBuilder, null, null, null);
+        request.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+        return request;
+    }
+}

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/QueryRewriteRemoteAsyncActionIT.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/QueryRewriteRemoteAsyncActionIT.java
@@ -196,8 +196,8 @@ public class QueryRewriteRemoteAsyncActionIT extends AbstractMultiClustersWithSe
             assertSearchFailure(
                 r,
                 ElasticsearchSecurityException.class,
-                "action [cluster:internal/test/instrumented] towards remote cluster is unauthorized for user [test_user]" +
-                    " with assigned roles [user]"
+                "action [cluster:internal/test/instrumented] towards remote cluster is unauthorized for user [test_user]"
+                    + " with assigned roles [user]"
             );
             assertInstrumentedActionCalls(0, 0);
         };

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/QueryRewriteRemoteAsyncActionIT.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/QueryRewriteRemoteAsyncActionIT.java
@@ -196,7 +196,8 @@ public class QueryRewriteRemoteAsyncActionIT extends AbstractMultiClustersWithSe
             assertSearchFailure(
                 r,
                 ElasticsearchSecurityException.class,
-                "action [cluster:internal/test/instrumented] towards remote cluster is unauthorized for user [test_user] with assigned roles [user]"
+                "action [cluster:internal/test/instrumented] towards remote cluster is unauthorized for user [test_user]" +
+                    " with assigned roles [user]"
             );
             assertInstrumentedActionCalls(0, 0);
         };

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/QueryRewriteRemoteAsyncActionIT.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/QueryRewriteRemoteAsyncActionIT.java
@@ -51,7 +51,6 @@ import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.tasks.Task;
-import org.elasticsearch.test.AbstractMultiClustersTestCase;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.NodeConfigurationSource;
@@ -66,6 +65,7 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -93,7 +93,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 
 @ESTestCase.WithoutEntitlements
-public class QueryRewriteRemoteAsyncActionIT extends AbstractMultiClustersTestCase {
+public class QueryRewriteRemoteAsyncActionIT extends AbstractMultiClustersWithSecurityTestCase {
     private static final String REMOTE_CLUSTER_A = "cluster-a";
     private static final String REMOTE_CLUSTER_B = "cluster-b";
 
@@ -126,7 +126,9 @@ public class QueryRewriteRemoteAsyncActionIT extends AbstractMultiClustersTestCa
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins(String clusterAlias) {
-        return List.of(TestPlugin.class);
+        List<Class<? extends Plugin>> plugins = new ArrayList<>(super.nodePlugins(clusterAlias));
+        plugins.add(TestPlugin.class);
+        return plugins;
     }
 
     @Override
@@ -137,6 +139,11 @@ public class QueryRewriteRemoteAsyncActionIT extends AbstractMultiClustersTestCa
     @Override
     protected String internalClientOrigin() {
         return MONITORING_ORIGIN;
+    }
+
+    @Override
+    protected boolean enableSecurity() {
+        return securityEnabled;
     }
 
     @Before
@@ -161,6 +168,7 @@ public class QueryRewriteRemoteAsyncActionIT extends AbstractMultiClustersTestCa
         this.securityEnabled = securityEnabled;
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/140193")
     public void testCallRemoteAsyncActionWithOrigin() {
         SearchRequestBuilder allClustersAllIndicesRequest = buildSearchRequest(
             List.of(INDEX_1, INDEX_2),
@@ -188,7 +196,7 @@ public class QueryRewriteRemoteAsyncActionIT extends AbstractMultiClustersTestCa
             assertSearchFailure(
                 r,
                 ElasticsearchSecurityException.class,
-                "action [cluster:internal/test/instrumented] is unauthorized for user [test_user] with effective roles [user]"
+                "action [cluster:internal/test/instrumented] towards remote cluster is unauthorized for user [test_user] with assigned roles [user]"
             );
             assertInstrumentedActionCalls(0, 0);
         };
@@ -614,6 +622,10 @@ public class QueryRewriteRemoteAsyncActionIT extends AbstractMultiClustersTestCa
               indices:
                 - names: 'index-*'
                   allow_restricted_indices: false
+                  privileges: [ ALL ]
+              remote_indices:
+                - names: 'index-*'
+                  clusters: ['cluster-*']
                   privileges: [ ALL ]
             """;
 


### PR DESCRIPTION
Adds `AbstractMultiClustersWithSecurityTestCase`, which extends `AbstractMultiClustersTestCase` to enable API key-based authentication with the security framework. This is useful for scenarios where we want to use an internal cluster test in combination with API key authentication. One such scenario is `QueryRewriteRemoteAsyncActionIT`, which has been updated to use `AbstractMultiClustersWithSecurityTestCase` as part of this PR.