### PR TITLE
[Inference API] Fixing flaky test for auth integrationt tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -351,9 +351,6 @@ tests:
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test072RunEsAsDifferentUserAndGroup
   issue: https://github.com/elastic/elasticsearch/issues/140127
-- class: org.elasticsearch.xpack.inference.integration.AuthorizationTaskExecutorIT
-  method: testCreatesEisChatCompletion_DoesNotRemoveEndpointWhenNoLongerAuthorized
-  issue: https://github.com/elastic/elasticsearch/issues/138480
 
 # Examples:
 #

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/test/http/MockWebServer.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/test/http/MockWebServer.java
@@ -307,6 +307,13 @@ public class MockWebServer implements Closeable {
     }
 
     /**
+     * Removes all responses from the queue.
+     */
+    public void clearResponses() {
+        responses.clear();
+    }
+
+    /**
      * A utility method to peek into the requests and find out if #MockWebServer.takeRequests will not throw an out of bound exception
      * @return true if more requests are available, false otherwise
      */

--- a/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/AuthorizationTaskExecutorIT.java
+++ b/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/AuthorizationTaskExecutorIT.java
@@ -145,7 +145,7 @@ public class AuthorizationTaskExecutorIT extends ESSingleNodeTestCase {
     public void testCreatesEisChatCompletionEndpoint() throws Exception {
         assertNoAuthorizedEisEndpoints();
 
-        webServer.clearRequests();
+        resetWebServerQueues();
         webServer.enqueue(new MockResponse().setResponseCode(200).setBody(chatCompletionResponseBody));
         restartPollingTaskAndWaitForAuthResponse();
 
@@ -260,20 +260,25 @@ public class AuthorizationTaskExecutorIT extends ESSingleNodeTestCase {
     public void testCreatesEisChatCompletion_DoesNotRemoveEndpointWhenNoLongerAuthorized() throws Exception {
         assertNoAuthorizedEisEndpoints();
 
-        webServer.clearRequests();
+        resetWebServerQueues();
         webServer.enqueue(new MockResponse().setResponseCode(200).setBody(chatCompletionResponseBody));
         restartPollingTaskAndWaitForAuthResponse();
         assertWebServerReceivedRequest();
 
         assertChatCompletionEndpointExists();
 
-        webServer.clearRequests();
+        resetWebServerQueues();
         // Simulate that the model is no longer authorized
         webServer.enqueue(new MockResponse().setResponseCode(200).setBody(EIS_EMPTY_RESPONSE));
         restartPollingTaskAndWaitForAuthResponse();
         assertWebServerReceivedRequest();
 
         assertChatCompletionEndpointExists();
+    }
+
+    private static void resetWebServerQueues() {
+        webServer.clearRequests();
+        webServer.clearResponses();
     }
 
     private void assertChatCompletionEndpointExists() throws Exception {
@@ -300,7 +305,7 @@ public class AuthorizationTaskExecutorIT extends ESSingleNodeTestCase {
     public void testCreatesChatCompletion_AndThenCreatesTextEmbedding() throws Exception {
         assertNoAuthorizedEisEndpoints();
 
-        webServer.clearRequests();
+        resetWebServerQueues();
         webServer.enqueue(new MockResponse().setResponseCode(200).setBody(chatCompletionResponseBody));
         restartPollingTaskAndWaitForAuthResponse();
         assertWebServerReceivedRequest();
@@ -308,14 +313,14 @@ public class AuthorizationTaskExecutorIT extends ESSingleNodeTestCase {
         assertChatCompletionEndpointExists();
 
         // Simulate that the model is no longer authorized
-        webServer.clearRequests();
+        resetWebServerQueues();
         webServer.enqueue(new MockResponse().setResponseCode(200).setBody(EIS_EMPTY_RESPONSE));
         restartPollingTaskAndWaitForAuthResponse();
         assertWebServerReceivedRequest();
 
         assertChatCompletionEndpointExists();
 
-        webServer.clearRequests();
+        resetWebServerQueues();
         // Simulate that a text embedding model is now authorized
         var jinaEmbedResponseBody = ElasticInferenceServiceAuthorizationResponseEntityTests.getEisJinaEmbedAuthorizationResponse(gatewayUrl)
             .responseJson();
@@ -341,7 +346,7 @@ public class AuthorizationTaskExecutorIT extends ESSingleNodeTestCase {
         // Ensure the task is created and we get an initial authorization response
         assertNoAuthorizedEisEndpoints();
 
-        webServer.clearRequests();
+        resetWebServerQueues();
         webServer.enqueue(new MockResponse().setResponseCode(200).setBody(EIS_EMPTY_RESPONSE));
         // Abort the task and ensure it is restarted
         restartPollingTaskAndWaitForAuthResponse();


### PR DESCRIPTION
This is a follow up to: https://github.com/elastic/elasticsearch/pull/139978

The tests were muted for a different reason. The issue was that we're adding an empty response before each test is run. The problem with that is the node some times starts (and the authorization task that would call the mock web server and get the empty response) before the `@Before` method within `AuthorizationTaskExecutorIT` is executed. This means we'd enqueue an empty response after the authorization task has attempted to retrieve the empty response, then when the test runs we'd enqueue another response. The test would retrieve the empty response and cause a failure.

I tried making the mock webserver a member and have it initialized whenever the node was started but that was resulting in null pointers within some of the tests. I'm opting for enqueuing an empty response right before a node is started and then also clearing the response queue within each test prior to enqueuing the response we expect.