### PR TITLE
[8.19] Always log connection failure at WARN level for sniffed node (#140149)

### DIFF
--- a/docs/changelog/140149.yaml
+++ b/docs/changelog/140149.yaml
@@ -1,0 +1,5 @@
+pr: 140149
+summary: Always log connection failure at WARN level for sniffed node
+area: Network
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/transport/SniffConnectionStrategy.java
+++ b/server/src/main/java/org/elasticsearch/transport/SniffConnectionStrategy.java
@@ -441,13 +441,12 @@ public class SniffConnectionStrategy extends RemoteConnectionStrategy {
 
                         @Override
                         public void onFailure(Exception e) {
+                            logger.warn(() -> format("[%s] failed to open managed connection to node [%s]", clusterAlias, node), e);
                             if (e instanceof ConnectTransportException || e instanceof IllegalStateException) {
                                 // ISE if we fail the handshake with an version incompatible node
                                 // fair enough we can't connect just move on
-                                logger.debug(() -> format("[%s] failed to open managed connection to node [%s]", clusterAlias, node), e);
                                 handleNodes(nodesIter);
                             } else {
-                                logger.warn(() -> format("[%s] failed to open managed connection to node [%s]", clusterAlias, node), e);
                                 IOUtils.closeWhileHandlingException(connection);
                                 collectRemoteNodes(seedNodes, listener);
                             }

--- a/server/src/test/java/org/elasticsearch/transport/SniffConnectionStrategyTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/SniffConnectionStrategyTests.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.transport;
 
+import org.apache.logging.log4j.Level;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.remote.RemoteClusterNodesAction;
@@ -36,6 +37,7 @@ import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.TransportVersionUtils;
 import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.test.transport.MockTransportService;
@@ -606,6 +608,21 @@ public class SniffConnectionStrategyTests extends ESTestCase {
 
     public void testConnectFailsIfNoConnectionsOpened() {
         List<DiscoveryNode> knownNodes = new CopyOnWriteArrayList<>();
+        final boolean incompatibleDiscoverableNode = randomBoolean();
+        final VersionInformation discoverableNodeVersion;
+        final TransportVersion discoverableNodeTransportVersion;
+        if (incompatibleDiscoverableNode) {
+            discoverableNodeVersion = new VersionInformation(
+                Version.CURRENT.minimumCompatibilityVersion().minimumCompatibilityVersion(),
+                IndexVersions.MINIMUM_COMPATIBLE,
+                IndexVersion.current()
+            );
+            discoverableNodeTransportVersion = TransportVersionUtils.getPreviousVersion(TransportVersion.minimumCompatible(), true);
+        } else {
+            discoverableNodeVersion = VersionInformation.CURRENT;
+            discoverableNodeTransportVersion = TransportVersion.current();
+        }
+
         try (
             MockTransportService seedTransport = startTransport(
                 "seed_node",
@@ -616,14 +633,16 @@ public class SniffConnectionStrategyTests extends ESTestCase {
             MockTransportService closedTransport = startTransport(
                 "discoverable_node",
                 knownNodes,
-                VersionInformation.CURRENT,
-                TransportVersion.current()
+                discoverableNodeVersion,
+                discoverableNodeTransportVersion
             )
         ) {
             DiscoveryNode seedNode = getLocalNode(seedTransport);
             DiscoveryNode discoverableNode = getLocalNode(closedTransport);
             knownNodes.add(discoverableNode);
-            closedTransport.close();
+            if (incompatibleDiscoverableNode == false) {
+                closedTransport.close();
+            }
 
             try (
                 MockTransportService localService = MockTransportService.createNewService(
@@ -659,11 +678,21 @@ public class SniffConnectionStrategyTests extends ESTestCase {
                         seedNodes(seedNode)
                     )
                 ) {
-                    PlainActionFuture<Void> connectFuture = new PlainActionFuture<>();
-                    strategy.connect(connectFuture);
-                    final IllegalStateException ise = expectThrows(IllegalStateException.class, connectFuture::actionGet);
-                    assertEquals("Unable to open any connections to remote cluster [cluster-alias]", ise.getMessage());
-                    assertTrue(strategy.assertNoRunningConnections());
+                    MockLog.assertThatLogger(() -> {
+                        PlainActionFuture<Void> connectFuture = new PlainActionFuture<>();
+                        strategy.connect(connectFuture);
+                        final IllegalStateException ise = expectThrows(IllegalStateException.class, connectFuture::actionGet);
+                        assertEquals("Unable to open any connections to remote cluster [cluster-alias]", ise.getMessage());
+                        assertTrue(strategy.assertNoRunningConnections());
+                    },
+                        SniffConnectionStrategy.class,
+                        new MockLog.SeenEventExpectation(
+                            "warning",
+                            SniffConnectionStrategy.class.getCanonicalName(),
+                            Level.WARN,
+                            "[" + clusterAlias + "] failed to open managed connection to node [{discoverable_node}*"
+                        )
+                    );
                 }
             }
         }

--- a/server/src/test/java/org/elasticsearch/transport/SniffConnectionStrategyTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/SniffConnectionStrategyTests.java
@@ -617,7 +617,7 @@ public class SniffConnectionStrategyTests extends ESTestCase {
                 IndexVersions.MINIMUM_COMPATIBLE,
                 IndexVersion.current()
             );
-            discoverableNodeTransportVersion = TransportVersionUtils.getPreviousVersion(TransportVersion.minimumCompatible(), true);
+            discoverableNodeTransportVersion = TransportVersionUtils.getPreviousVersion(TransportVersion.minimumCompatible());
         } else {
             discoverableNodeVersion = VersionInformation.CURRENT;
             discoverableNodeTransportVersion = TransportVersion.current();


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Always log connection failure at WARN level for sniffed node (#140149)