### PR TITLE
[9.3] ES|QL reenable SampleGenerator (#140249)

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneSourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneSourceOperator.java
@@ -296,7 +296,6 @@ public class LuceneSourceOperator extends LuceneOperator {
     @Override
     public Page getCheckedOutput() throws IOException {
         if (isFinished()) {
-            assert currentPagePos == 0 : currentPagePos;
             return null;
         }
         long start = System.nanoTime();

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/generator/EsqlQueryGenerator.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/generator/EsqlQueryGenerator.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xpack.esql.generator.command.pipe.LimitGenerator;
 import org.elasticsearch.xpack.esql.generator.command.pipe.LookupJoinGenerator;
 import org.elasticsearch.xpack.esql.generator.command.pipe.MvExpandGenerator;
 import org.elasticsearch.xpack.esql.generator.command.pipe.RenameGenerator;
+import org.elasticsearch.xpack.esql.generator.command.pipe.SampleGenerator;
 import org.elasticsearch.xpack.esql.generator.command.pipe.SortGenerator;
 import org.elasticsearch.xpack.esql.generator.command.pipe.StatsGenerator;
 import org.elasticsearch.xpack.esql.generator.command.pipe.TimeSeriesStatsGenerator;
@@ -75,8 +76,7 @@ public class EsqlQueryGenerator {
         LookupJoinGenerator.INSTANCE,
         MvExpandGenerator.INSTANCE,
         RenameGenerator.INSTANCE,
-        // awaits fix for https://github.com/elastic/elasticsearch/issues/135336
-        // SampleGenerator.INSTANCE,
+        SampleGenerator.INSTANCE,
         SortGenerator.INSTANCE,
         StatsGenerator.INSTANCE,
         WhereGenerator.INSTANCE


### PR DESCRIPTION
Backports the following commits to 9.3:
 - ES|QL reenable SampleGenerator (#140249)