### PR TITLE
Improve downsampling mixed cluster test

### DIFF
--- a/x-pack/plugin/downsample/qa/mixed-cluster/build.gradle
+++ b/x-pack/plugin/downsample/qa/mixed-cluster/build.gradle
@@ -8,6 +8,7 @@
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
+apply plugin: 'elasticsearch.internal-test-artifact'
 apply plugin: 'elasticsearch.internal-yaml-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 

--- a/x-pack/plugin/downsample/qa/mixed-cluster/src/yamlRestTest/java/org/elasticsearch/xpack/downsample/Clusters.java
+++ b/x-pack/plugin/downsample/qa/mixed-cluster/src/yamlRestTest/java/org/elasticsearch/xpack/downsample/Clusters.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.downsample;
+
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+import org.elasticsearch.test.cluster.util.Version;
+
+public class Clusters {
+
+    static ElasticsearchCluster mixedVersionsCluster() {
+        Version oldVersion = getOldVersion();
+        var cluster = ElasticsearchCluster.local()
+            .distribution(DistributionType.DEFAULT)
+            .withNode(node -> node.version(oldVersion))
+            .withNode(node -> node.version(Version.CURRENT))
+            .setting("xpack.security.enabled", "false")
+            .setting("xpack.license.self_generated.type", "trial");
+
+        if (oldVersion.before(Version.fromString("8.18.0"))) {
+            cluster.jvmArg("-da:org.elasticsearch.index.mapper.DocumentMapper");
+            cluster.jvmArg("-da:org.elasticsearch.index.mapper.MapperService");
+        }
+        return cluster.build();
+    }
+
+    private static Version getOldVersion() {
+        return Version.fromString(System.getProperty("tests.old_cluster_version"));
+    }
+}

--- a/x-pack/plugin/downsample/qa/mixed-cluster/src/yamlRestTest/java/org/elasticsearch/xpack/downsample/Clusters.java
+++ b/x-pack/plugin/downsample/qa/mixed-cluster/src/yamlRestTest/java/org/elasticsearch/xpack/downsample/Clusters.java
@@ -14,22 +14,13 @@ import org.elasticsearch.test.cluster.util.Version;
 public class Clusters {
 
     static ElasticsearchCluster mixedVersionsCluster() {
-        Version oldVersion = getOldVersion();
-        var cluster = ElasticsearchCluster.local()
+        Version oldVersion = Version.fromString(System.getProperty("tests.old_cluster_version"));
+        return ElasticsearchCluster.local()
             .distribution(DistributionType.DEFAULT)
             .withNode(node -> node.version(oldVersion))
             .withNode(node -> node.version(Version.CURRENT))
             .setting("xpack.security.enabled", "false")
-            .setting("xpack.license.self_generated.type", "trial");
-
-        if (oldVersion.before(Version.fromString("8.18.0"))) {
-            cluster.jvmArg("-da:org.elasticsearch.index.mapper.DocumentMapper");
-            cluster.jvmArg("-da:org.elasticsearch.index.mapper.MapperService");
-        }
-        return cluster.build();
-    }
-
-    private static Version getOldVersion() {
-        return Version.fromString(System.getProperty("tests.old_cluster_version"));
+            .setting("xpack.license.self_generated.type", "trial")
+            .build();
     }
 }

--- a/x-pack/plugin/downsample/qa/mixed-cluster/src/yamlRestTest/java/org/elasticsearch/xpack/downsample/MixedClusterDownsampleRestIT.java
+++ b/x-pack/plugin/downsample/qa/mixed-cluster/src/yamlRestTest/java/org/elasticsearch/xpack/downsample/MixedClusterDownsampleRestIT.java
@@ -10,8 +10,6 @@ package org.elasticsearch.xpack.downsample;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
-import org.elasticsearch.test.cluster.local.distribution.DistributionType;
-import org.elasticsearch.test.cluster.util.Version;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
 import org.junit.ClassRule;
@@ -19,27 +17,7 @@ import org.junit.ClassRule;
 public class MixedClusterDownsampleRestIT extends ESClientYamlSuiteTestCase {
 
     @ClassRule
-    public static ElasticsearchCluster cluster = buildCluster();
-
-    private static ElasticsearchCluster buildCluster() {
-        Version oldVersion = getOldVersion();
-        var cluster = ElasticsearchCluster.local()
-            .distribution(DistributionType.DEFAULT)
-            .withNode(node -> node.version(getOldVersion()))
-            .withNode(node -> node.version(Version.CURRENT))
-            .setting("xpack.security.enabled", "false")
-            .setting("xpack.license.self_generated.type", "trial");
-
-        if (oldVersion.before(Version.fromString("8.18.0"))) {
-            cluster.jvmArg("-da:org.elasticsearch.index.mapper.DocumentMapper");
-            cluster.jvmArg("-da:org.elasticsearch.index.mapper.MapperService");
-        }
-        return cluster.build();
-    }
-
-    static Version getOldVersion() {
-        return Version.fromString(System.getProperty("tests.old_cluster_version"));
-    }
+    public static ElasticsearchCluster cluster = Clusters.mixedVersionsCluster();
 
     @Override
     protected String getTestRestCluster() {

--- a/x-pack/plugin/downsample/qa/mixed-cluster/src/yamlRestTest/resources/rest-api-spec/test/downsample/10_basic.yml
+++ b/x-pack/plugin/downsample/qa/mixed-cluster/src/yamlRestTest/resources/rest-api-spec/test/downsample/10_basic.yml
@@ -1,8 +1,4 @@
 setup:
-  - requires:
-      cluster_features: ["gte_v8.10.0"]
-      reason: "Downsampling executed using persistent task framework from version 8.10"
-
   - do:
       indices.create:
         index: test

--- a/x-pack/plugin/downsample/qa/mixed-cluster/src/yamlRestTest/resources/rest-api-spec/test/downsample/10_basic.yml
+++ b/x-pack/plugin/downsample/qa/mixed-cluster/src/yamlRestTest/resources/rest-api-spec/test/downsample/10_basic.yml
@@ -8,7 +8,6 @@ setup:
         index: test
         body:
           settings:
-            number_of_shards: 1
             index:
               mode: time_series
               routing_path: [metricset, k8s.pod.uid]
@@ -105,11 +104,30 @@ setup:
       search:
         index: test-downsample
         body:
-          sort: [ "@timestamp" ]
+          sort: [ "_tsid", "@timestamp" ]
 
   - length: { hits.hits: 4 }
   - match:  { hits.hits.0._source._doc_count: 2 }
+  # Verify dimensions & time
   - match:  { hits.hits.0._source.metricset: pod }
+  - match:  { hits.hits.0._source.k8s.pod.uid: df3145b3-0563-4d3b-a0f7-897eb2876ea9 }
+  - match:  { hits.hits.0._source.@timestamp: 2021-04-28T18:00:00.000Z }
+
+  # Verify metrics
+  - match:  { hits.hits.0._source.k8s.pod.multi-gauge.min: 100 }
+  - match:  { hits.hits.0._source.k8s.pod.multi-gauge.max: 102 }
+  - match:  { hits.hits.0._source.k8s.pod.multi-gauge.sum: 607 }
+  - match:  { hits.hits.0._source.k8s.pod.multi-gauge.value_count: 6 }
+  - match:  { hits.hits.0._source.k8s.pod.multi-counter: 0 }
+  - match:  { hits.hits.0._source.k8s.pod.network.tx.min: 1434521831 }
+  - match:  { hits.hits.0._source.k8s.pod.network.tx.max: 1434577921 }
+  - match:  { hits.hits.0._source.k8s.pod.network.tx.value_count: 2 }
+  - match:  { hits.hits.0._source.k8s.pod.ip: "10.10.55.56" }
+  - match:  { hits.hits.0._source.k8s.pod.created_at: "2021-04-28T19:43:00.000Z" }
+  - match:  { hits.hits.0._source.k8s.pod.number_of_containers: 1 }
+  - match:  { hits.hits.0._source.k8s.pod.tags: [ "backend", "test", "us-west2" ] }
+  - match:  { hits.hits.0._source.k8s.pod.values: [ 1, 1, 2 ] }
+  - is_false: hits.hits.0._source.k8s.pod.running
 
   # Assert rollup index settings
   - do:
@@ -120,7 +138,6 @@ setup:
   - match: { test-downsample.settings.index.time_series.end_time:   2021-04-29T00:00:00Z }
   - match: { test-downsample.settings.index.time_series.start_time: 2021-04-28T00:00:00Z }
   - match: { test-downsample.settings.index.routing_path: [ "metricset", "k8s.pod.uid"] }
-  - match: { test-downsample.settings.index.downsample.source.name: test }
 
   # Assert rollup index mapping
   - do:


### PR DESCRIPTION
Small improvements to the mixed cluster downsampling test:

- Extract cluster configuration to a separate class so it can be overwritten in serverless.
- Assert the a downsampled document to ensure not only that the downsampling happened but it the fields were downsampled correctly.