### PR TITLE
[CI] Fix test fixture caching in ci image baking

### DIFF
--- a/test/fixtures/testcontainer-utils/src/main/java/org/elasticsearch/test/fixtures/testcontainers/DockerEnvironmentAwareTestContainer.java
+++ b/test/fixtures/testcontainer-utils/src/main/java/org/elasticsearch/test/fixtures/testcontainers/DockerEnvironmentAwareTestContainer.java
@@ -23,7 +23,7 @@ import java.util.concurrent.Future;
 
 import static org.elasticsearch.test.fixtures.testcontainers.DockerAvailability.assumeDockerIsAvailable;
 
-public class DockerEnvironmentAwareTestContainer extends GenericContainer<DockerEnvironmentAwareTestContainer>
+public abstract class DockerEnvironmentAwareTestContainer extends GenericContainer<DockerEnvironmentAwareTestContainer>
     implements
         TestRule,
         CacheableTestFixture {


### PR DESCRIPTION
This should fix the vm image jobs for baking our ci images that broken due to unability to cache docker
test fixtures. We dont want to instantiate that fixture directly and enforce having dedicated implementations that are then cached in vm image building process