### PR TITLE
[9.3] [Inference API] Fixing flaky test for auth integrationt tests (#140321)

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/test/http/MockWebServer.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/test/http/MockWebServer.java
@@ -307,6 +307,13 @@ public class MockWebServer implements Closeable {
     }
 
     /**
+     * Removes all responses from the queue.
+     */
+    public void clearResponses() {
+        responses.clear();
+    }
+
+    /**
      * A utility method to peek into the requests and find out if #MockWebServer.takeRequests will not throw an out of bound exception
      * @return true if more requests are available, false otherwise
      */

--- a/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/AuthorizationTaskExecutorIT.java
+++ b/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/AuthorizationTaskExecutorIT.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.inference.integration;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.admin.cluster.node.tasks.cancel.CancelTasksRequestBuilder;
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksRequestBuilder;
 import org.elasticsearch.action.support.PlainActionFuture;
@@ -19,6 +21,7 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.reindex.ReindexPlugin;
 import org.elasticsearch.tasks.TaskInfo;
 import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.http.MockResponse;
 import org.elasticsearch.test.http.MockWebServer;
 import org.elasticsearch.xpack.inference.LocalStateInferencePlugin;
@@ -64,6 +67,7 @@ public class AuthorizationTaskExecutorIT extends ESSingleNodeTestCase {
 
     public static final String AUTH_TASK_ACTION = AuthorizationPoller.TASK_NAME + "[c]";
 
+    private static final Logger logger = LogManager.getLogger(AuthorizationTaskExecutorIT.class);
     private static final MockWebServer webServer = new MockWebServer();
     private static String gatewayUrl;
     private static String chatCompletionResponseBody;
@@ -80,8 +84,6 @@ public class AuthorizationTaskExecutorIT extends ESSingleNodeTestCase {
 
     @Before
     public void createComponents() {
-        // Adding an empty response to ensure that the initial authorization polling request does not fail
-        webServer.enqueue(new MockResponse().setResponseCode(200).setBody(EIS_EMPTY_RESPONSE));
         modelRegistry = node().injector().getInstance(ModelRegistry.class);
         authorizationTaskExecutor = node().injector().getInstance(AuthorizationTaskExecutor.class);
     }
@@ -95,12 +97,24 @@ public class AuthorizationTaskExecutorIT extends ESSingleNodeTestCase {
         // Delete all the eis preconfigured endpoints
         var listener = new PlainActionFuture<Boolean>();
         modelRegistry.deleteModels(EIS_PRECONFIGURED_ENDPOINT_IDS, listener);
-        listener.actionGet(TimeValue.THIRTY_SECONDS);
+        try {
+            listener.actionGet(ESTestCase.TEST_REQUEST_TIMEOUT);
+        } catch (Exception e) {
+            logger.atWarn().withThrowable(e).log("Failed to delete eis preconfigured endpoints");
+        }
     }
 
     @AfterClass
     public static void cleanUpClass() {
         webServer.close();
+    }
+
+    @Override
+    protected void startNode(long seed) throws Exception {
+        // Adding an empty response to ensure that the initial authorization polling request does not fail
+        // We're doing this before the node is started to ensure that the authorization task isn't created yet
+        webServer.enqueue(new MockResponse().setResponseCode(200).setBody(EIS_EMPTY_RESPONSE));
+        super.startNode(seed);
     }
 
     @Override
@@ -131,7 +145,7 @@ public class AuthorizationTaskExecutorIT extends ESSingleNodeTestCase {
     public void testCreatesEisChatCompletionEndpoint() throws Exception {
         assertNoAuthorizedEisEndpoints();
 
-        webServer.clearRequests();
+        resetWebServerQueues();
         webServer.enqueue(new MockResponse().setResponseCode(200).setBody(chatCompletionResponseBody));
         restartPollingTaskAndWaitForAuthResponse();
 
@@ -246,20 +260,25 @@ public class AuthorizationTaskExecutorIT extends ESSingleNodeTestCase {
     public void testCreatesEisChatCompletion_DoesNotRemoveEndpointWhenNoLongerAuthorized() throws Exception {
         assertNoAuthorizedEisEndpoints();
 
-        webServer.clearRequests();
+        resetWebServerQueues();
         webServer.enqueue(new MockResponse().setResponseCode(200).setBody(chatCompletionResponseBody));
         restartPollingTaskAndWaitForAuthResponse();
         assertWebServerReceivedRequest();
 
         assertChatCompletionEndpointExists();
 
-        webServer.clearRequests();
+        resetWebServerQueues();
         // Simulate that the model is no longer authorized
         webServer.enqueue(new MockResponse().setResponseCode(200).setBody(EIS_EMPTY_RESPONSE));
         restartPollingTaskAndWaitForAuthResponse();
         assertWebServerReceivedRequest();
 
         assertChatCompletionEndpointExists();
+    }
+
+    private static void resetWebServerQueues() {
+        webServer.clearRequests();
+        webServer.clearResponses();
     }
 
     private void assertChatCompletionEndpointExists() throws Exception {
@@ -286,7 +305,7 @@ public class AuthorizationTaskExecutorIT extends ESSingleNodeTestCase {
     public void testCreatesChatCompletion_AndThenCreatesTextEmbedding() throws Exception {
         assertNoAuthorizedEisEndpoints();
 
-        webServer.clearRequests();
+        resetWebServerQueues();
         webServer.enqueue(new MockResponse().setResponseCode(200).setBody(chatCompletionResponseBody));
         restartPollingTaskAndWaitForAuthResponse();
         assertWebServerReceivedRequest();
@@ -294,14 +313,14 @@ public class AuthorizationTaskExecutorIT extends ESSingleNodeTestCase {
         assertChatCompletionEndpointExists();
 
         // Simulate that the model is no longer authorized
-        webServer.clearRequests();
+        resetWebServerQueues();
         webServer.enqueue(new MockResponse().setResponseCode(200).setBody(EIS_EMPTY_RESPONSE));
         restartPollingTaskAndWaitForAuthResponse();
         assertWebServerReceivedRequest();
 
         assertChatCompletionEndpointExists();
 
-        webServer.clearRequests();
+        resetWebServerQueues();
         // Simulate that a text embedding model is now authorized
         var jinaEmbedResponseBody = ElasticInferenceServiceAuthorizationResponseEntityTests.getEisJinaEmbedAuthorizationResponse(gatewayUrl)
             .responseJson();
@@ -327,7 +346,7 @@ public class AuthorizationTaskExecutorIT extends ESSingleNodeTestCase {
         // Ensure the task is created and we get an initial authorization response
         assertNoAuthorizedEisEndpoints();
 
-        webServer.clearRequests();
+        resetWebServerQueues();
         webServer.enqueue(new MockResponse().setResponseCode(200).setBody(EIS_EMPTY_RESPONSE));
         // Abort the task and ensure it is restarted
         restartPollingTaskAndWaitForAuthResponse();


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [[Inference API] Fixing flaky test for auth integrationt tests (#140321)](https://github.com/elastic/elasticsearch/pull/140321)

<!--- Backport version: 9.2.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)