### PR TITLE
[9.2] [CI] Fix test fixture caching in ci image baking (#140358)

### DIFF
--- a/test/fixtures/testcontainer-utils/src/main/java/org/elasticsearch/test/fixtures/testcontainers/DockerEnvironmentAwareTestContainer.java
+++ b/test/fixtures/testcontainer-utils/src/main/java/org/elasticsearch/test/fixtures/testcontainers/DockerEnvironmentAwareTestContainer.java
@@ -23,7 +23,7 @@ import java.util.concurrent.Future;
 
 import static org.elasticsearch.test.fixtures.testcontainers.DockerAvailability.assumeDockerIsAvailable;
 
-public class DockerEnvironmentAwareTestContainer extends GenericContainer<DockerEnvironmentAwareTestContainer>
+public abstract class DockerEnvironmentAwareTestContainer extends GenericContainer<DockerEnvironmentAwareTestContainer>
     implements
         TestRule,
         CacheableTestFixture {


### PR DESCRIPTION
Backports the following commits to 9.2:
 - [CI] Fix test fixture caching in ci image baking (#140358)