### PR TITLE
Decouple rest bwc test from shard number

### DIFF
--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/update_by_query/35_search_failure.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/update_by_query/35_search_failure.yml
@@ -30,7 +30,9 @@
   - match: {error.phase: query}
   - match: {error.root_cause.0.type:   script_exception}
   - match: {error.root_cause.0.reason: runtime error}
-  - match: {error.failed_shards.0.shard: 0}
+  # The shard number can vary based on the shard routing function version. Just check that it's between 0 and 1.
+  - gte: { error.failed_shards.0.shard: 0 }
+  - lte: { error.failed_shards.0.shard: 1 }
   - match: {error.failed_shards.0.index:  source}
   - is_true: error.failed_shards.0.node
   - match: {error.failed_shards.0.reason.type:   script_exception}


### PR DESCRIPTION
Currently the rest compatibility test tightly couples the validation to
the shard number returned. This will cause issues when we change the
shard routing and is not really something our rest compatibility should
validate.