### PR TITLE
Rename reindex API

### DIFF
--- a/modules/reindex-management/build.gradle
+++ b/modules/reindex-management/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 
 restResources {
   restApi {
-    include '_common', 'index', 'bulk', 'reindex', 'reindex.get', 'reindex.list', 'reindex_rethrottle', 'delete_by_query', 'tasks', 'capabilities'
+    include '_common', 'index', 'bulk', 'reindex', 'reindex_get', 'reindex_list', 'reindex_rethrottle', 'delete_by_query', 'tasks', 'capabilities'
   }
 }
 

--- a/modules/reindex-management/src/yamlRestTest/resources/rest-api-spec/test/reindex/10_get_reindex.yml
+++ b/modules/reindex-management/src/yamlRestTest/resources/rest-api-spec/test/reindex/10_get_reindex.yml
@@ -27,7 +27,7 @@ setup:
   - set: { task: taskId }
 
   - do:
-      reindex.get:
+      reindex_get:
         task_id: $taskId
         # wait for task to complete to ensure we get consistent result
         wait_for_completion: true
@@ -49,7 +49,7 @@ setup:
 ---
 "Invalid task id":
     - do:
-        reindex.get:
+        reindex_get:
             task_id: invalid_task_id
         catch: bad_request
     - is_true: error
@@ -58,7 +58,7 @@ setup:
 ---
 "Task does not exist":
   - do:
-      reindex.get:
+      reindex_get:
         task_id: "node0:123"
       catch: missing
   - is_true: error
@@ -84,7 +84,7 @@ setup:
 
   # verify the reindex does not exist
   - do:
-      reindex.get:
+      reindex_get:
           task_id: $task
       catch: missing
   - is_true: error

--- a/modules/reindex-management/src/yamlRestTest/resources/rest-api-spec/test/reindex/20_list_reindex.yml
+++ b/modules/reindex-management/src/yamlRestTest/resources/rest-api-spec/test/reindex/20_list_reindex.yml
@@ -55,7 +55,7 @@ setup:
 ---
 "List returns empty when no tasks":
   - do:
-      reindex.list: {}
+      reindex_list: {}
   - match: { reindex: [] }
 ---
 "List returns running reindex task":
@@ -73,7 +73,7 @@ setup:
   - set: { task: taskId }
 
   - do:
-      reindex.list:
+      reindex_list:
         human: true
         detailed: true
   - is_true: reindex
@@ -94,12 +94,12 @@ setup:
 
   # Wait for reindex to complete
   - do:
-      reindex.get:
+      reindex_get:
         task_id: $taskId
         wait_for_completion: true
 
   - do:
-      reindex.list: {}
+      reindex_list: {}
   - match: { reindex: [] }
 ---
 "List returns multiple reindex tasks":
@@ -132,7 +132,7 @@ setup:
   - set: { task: taskId2 }
 
   - do:
-      reindex.list:
+      reindex_list:
         human: true
   - is_true: reindex
   - length: { reindex: 2 }
@@ -157,16 +157,16 @@ setup:
 
   # Wait for reindex to complete
   - do:
-      reindex.get:
+      reindex_get:
         task_id: $taskId1
         wait_for_completion: true
   - do:
-      reindex.get:
+      reindex_get:
         task_id: $taskId2
         wait_for_completion: true
 
   - do:
-      reindex.list: {}
+      reindex_list: {}
   - match: { reindex: [] }
 ---
 "List returns only parent reindex tasks":
@@ -185,7 +185,7 @@ setup:
   - set: { task: taskId }
 
   - do:
-      reindex.list:
+      reindex_list:
         human: true
   - is_true: reindex
   - length: { reindex: 1 }
@@ -205,10 +205,10 @@ setup:
 
   # Wait for reindex to complete
   - do:
-      reindex.get:
+      reindex_get:
         task_id: $taskId
         wait_for_completion: true
 
   - do:
-      reindex.list: {}
+      reindex_list: {}
   - match: { reindex: [] }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/reindex_get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/reindex_get.json
@@ -1,5 +1,5 @@
 {
-  "reindex.get": {
+  "reindex_get": {
     "documentation": {
       "url": "https://www.elastic.co/docs/api/doc/elasticsearch#TODO",
       "description": "Get information for a reindex operation"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/reindex_list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/reindex_list.json
@@ -1,5 +1,5 @@
 {
-  "reindex.list": {
+  "reindex_list": {
     "documentation": {
       "url": "https://www.elastic.co/docs/api/doc/elasticsearch#TODO",
       "description": "List all running reindex operations"


### PR DESCRIPTION
Rename reindex management API according to recommendation, due to namespace conflicts with the existing `reindex` API.