### PR TITLE
PromQL: Add PromQL test similar to TS / Batch 2

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-count-over-time.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-count-over-time.csv-spec
@@ -14,6 +14,24 @@ ip:long | cluster:keyword | time_bucket:datetime
 2       | staging         | 2024-05-10T00:20:00.000Z
 ;
 
+count_over_time_of_ip_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m ip=(min by (cluster) (count_over_time(client.ip[10m])))
+| SORT step, cluster | LIMIT 10;
+
+ip:double | step:datetime            | cluster:keyword
+4.0       | 2024-05-10T00:00:00.000Z | prod
+11.0      | 2024-05-10T00:00:00.000Z | qa
+6.0       | 2024-05-10T00:00:00.000Z | staging
+9.0       | 2024-05-10T00:10:00.000Z | prod
+11.0      | 2024-05-10T00:10:00.000Z | qa
+5.0       | 2024-05-10T00:10:00.000Z | staging
+1.0       | 2024-05-10T00:20:00.000Z | prod
+1.0       | 2024-05-10T00:20:00.000Z | qa
+2.0       | 2024-05-10T00:20:00.000Z | staging
+;
+
 count_over_time_of_long
 required_capability: ts_command_v0
 TS k8s | STATS bytes_in = sum(count_over_time(network.bytes_in)) BY cluster, time_bucket = bucket(@timestamp,10minute) | SORT bytes_in DESC, cluster, time_bucket | LIMIT 10;
@@ -28,6 +46,24 @@ bytes_in:long | cluster:keyword | time_bucket:datetime
 10            | staging         | 2024-05-10T00:20:00.000Z
 7             | prod            | 2024-05-10T00:20:00.000Z
 6             | qa              | 2024-05-10T00:20:00.000Z
+;
+
+count_over_time_of_long_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m bytes_in=(sum by (cluster) (count_over_time(network.bytes_in[10m])))
+| SORT bytes_in DESC, cluster, step | LIMIT 10;
+
+bytes_in:double | step:datetime            | cluster:keyword
+39.0            | 2024-05-10T00:10:00.000Z | qa
+37.0            | 2024-05-10T00:00:00.000Z | qa
+31.0            | 2024-05-10T00:10:00.000Z | prod
+24.0            | 2024-05-10T00:00:00.000Z | staging
+23.0            | 2024-05-10T00:00:00.000Z | prod
+23.0            | 2024-05-10T00:10:00.000Z | staging
+10.0            | 2024-05-10T00:20:00.000Z | staging
+7.0             | 2024-05-10T00:20:00.000Z | prod
+6.0             | 2024-05-10T00:20:00.000Z | qa
 ;
 
 count_over_time_with_window
@@ -62,6 +98,36 @@ bytes_in:long | cluster:keyword | time_bucket:datetime
 35            | qa              | 2024-05-10T00:12:00.000Z
 ;
 
+count_over_time_with_window_promql
+required_capability: promql_pre_tech_preview_v12
+required_capability: time_series_window_v1
+
+PROMQL index=k8s step=2m bytes_in=(sum by (cluster) (count_over_time(network.bytes_in[10m])))
+| SORT step, cluster | LIMIT 20;
+
+bytes_in:double | step:datetime            | cluster:keyword
+23.0            | 2024-05-10T00:00:00.000Z | prod
+37.0            | 2024-05-10T00:00:00.000Z | qa
+24.0            | 2024-05-10T00:00:00.000Z | staging
+21.0            | 2024-05-10T00:02:00.000Z | prod
+43.0            | 2024-05-10T00:02:00.000Z | qa
+24.0            | 2024-05-10T00:02:00.000Z | staging
+22.0            | 2024-05-10T00:04:00.000Z | prod
+42.0            | 2024-05-10T00:04:00.000Z | qa
+25.0            | 2024-05-10T00:04:00.000Z | staging
+25.0            | 2024-05-10T00:06:00.000Z | prod
+41.0            | 2024-05-10T00:06:00.000Z | qa
+30.0            | 2024-05-10T00:06:00.000Z | staging
+32.0            | 2024-05-10T00:08:00.000Z | prod
+41.0            | 2024-05-10T00:08:00.000Z | qa
+30.0            | 2024-05-10T00:08:00.000Z | staging
+31.0            | 2024-05-10T00:10:00.000Z | prod
+39.0            | 2024-05-10T00:10:00.000Z | qa
+23.0            | 2024-05-10T00:10:00.000Z | staging
+33.0            | 2024-05-10T00:12:00.000Z | prod
+35.0            | 2024-05-10T00:12:00.000Z | qa
+;
+
 count_over_time_of_boolean
 required_capability: ts_command_v0
 TS k8s | STATS eth0_up = min(count_over_time(network.eth0.up)) BY cluster, time_bucket = bucket(@timestamp,10minute) | SORT time_bucket, cluster | LIMIT 10;
@@ -76,6 +142,24 @@ eth0_up:long | cluster:keyword | time_bucket:datetime
 1            | prod            | 2024-05-10T00:20:00.000Z
 1            | qa              | 2024-05-10T00:20:00.000Z
 2            | staging         | 2024-05-10T00:20:00.000Z
+;
+
+count_over_time_of_boolean_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m eth0_up=(min by (cluster) (count_over_time(network.eth0.up[10m])))
+| SORT step, cluster | LIMIT 10;
+
+eth0_up:double | step:datetime            | cluster:keyword
+4.0            | 2024-05-10T00:00:00.000Z | prod
+11.0           | 2024-05-10T00:00:00.000Z | qa
+6.0            | 2024-05-10T00:00:00.000Z | staging
+9.0            | 2024-05-10T00:10:00.000Z | prod
+11.0           | 2024-05-10T00:10:00.000Z | qa
+5.0            | 2024-05-10T00:10:00.000Z | staging
+1.0            | 2024-05-10T00:20:00.000Z | prod
+1.0            | 2024-05-10T00:20:00.000Z | qa
+2.0            | 2024-05-10T00:20:00.000Z | staging
 ;
 
 count_over_time_of_date_nanos
@@ -94,6 +178,24 @@ last_up:long | cluster:keyword | time_bucket:datetime
 5            | staging         | 2024-05-10T00:20:00.000Z
 ;
 
+count_over_time_of_date_nanos_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m last_up=(max by (cluster) (count_over_time(network.eth0.last_up[10m])))
+| SORT step, cluster | LIMIT 10;
+
+last_up:double | step:datetime            | cluster:keyword
+10.0           | 2024-05-10T00:00:00.000Z | prod
+14.0           | 2024-05-10T00:00:00.000Z | qa
+10.0           | 2024-05-10T00:00:00.000Z | staging
+11.0           | 2024-05-10T00:10:00.000Z | prod
+14.0           | 2024-05-10T00:10:00.000Z | qa
+11.0           | 2024-05-10T00:10:00.000Z | staging
+3.0            | 2024-05-10T00:20:00.000Z | prod
+3.0            | 2024-05-10T00:20:00.000Z | qa
+5.0            | 2024-05-10T00:20:00.000Z | staging
+;
+
 count_over_time_of_date
 required_capability: ts_command_v0
 TS k8s | STATS last_up = max(count_over_time(to_datetime(network.eth0.last_up))) BY cluster, time_bucket = bucket(@timestamp,10minute) | SORT time_bucket, cluster | LIMIT 10;
@@ -108,6 +210,24 @@ last_up:long | cluster:keyword | time_bucket:datetime
 3            | prod            | 2024-05-10T00:20:00.000Z
 3            | qa              | 2024-05-10T00:20:00.000Z
 5            | staging         | 2024-05-10T00:20:00.000Z
+;
+
+count_over_time_of_date_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m last_up=(max by (cluster) (count_over_time(network.eth0.last_up[10m])))
+| SORT step, cluster | LIMIT 10;
+
+last_up:double | step:datetime            | cluster:keyword
+10.0           | 2024-05-10T00:00:00.000Z | prod
+14.0           | 2024-05-10T00:00:00.000Z | qa
+10.0           | 2024-05-10T00:00:00.000Z | staging
+11.0           | 2024-05-10T00:10:00.000Z | prod
+14.0           | 2024-05-10T00:10:00.000Z | qa
+11.0           | 2024-05-10T00:10:00.000Z | staging
+3.0            | 2024-05-10T00:20:00.000Z | prod
+3.0            | 2024-05-10T00:20:00.000Z | qa
+5.0            | 2024-05-10T00:20:00.000Z | staging
 ;
 
 count_over_time_of_version
@@ -126,6 +246,24 @@ version:long | cluster:keyword | time_bucket:datetime
 5            | staging         | 2024-05-10T00:20:00.000Z
 ;
 
+count_over_time_of_version_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m version=(max by (cluster) (count_over_time(network.eth0.firmware_version[10m])))
+| SORT step, cluster | LIMIT 10;
+
+version:double | step:datetime            | cluster:keyword
+10.0           | 2024-05-10T00:00:00.000Z | prod
+14.0           | 2024-05-10T00:00:00.000Z | qa
+10.0           | 2024-05-10T00:00:00.000Z | staging
+11.0           | 2024-05-10T00:10:00.000Z | prod
+14.0           | 2024-05-10T00:10:00.000Z | qa
+11.0           | 2024-05-10T00:10:00.000Z | staging
+3.0            | 2024-05-10T00:20:00.000Z | prod
+3.0            | 2024-05-10T00:20:00.000Z | qa
+5.0            | 2024-05-10T00:20:00.000Z | staging
+;
+
 count_over_time_of_integer
 required_capability: ts_command_v0
 TS k8s | STATS clients = avg(count_over_time(network.eth0.currently_connected_clients)) BY cluster, time_bucket = bucket(@timestamp,10minute) | SORT time_bucket, cluster | LIMIT 10;
@@ -140,6 +278,24 @@ clients:double     | cluster:keyword | time_bucket:datetime
 2.3333333333333335 | prod            | 2024-05-10T00:20:00.000Z
 2.0                | qa              | 2024-05-10T00:20:00.000Z
 3.3333333333333335 | staging         | 2024-05-10T00:20:00.000Z
+;
+
+count_over_time_of_integer_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m clients=(avg by (cluster) (count_over_time(network.eth0.currently_connected_clients[10m])))
+| SORT step, cluster | LIMIT 10;
+
+clients:double     | step:datetime            | cluster:keyword
+7.666666666666667  | 2024-05-10T00:00:00.000Z | prod
+12.333333333333334 | 2024-05-10T00:00:00.000Z | qa
+8.0                | 2024-05-10T00:00:00.000Z | staging
+10.333333333333334 | 2024-05-10T00:10:00.000Z | prod
+13.0               | 2024-05-10T00:10:00.000Z | qa
+7.666666666666667  | 2024-05-10T00:10:00.000Z | staging
+2.3333333333333335 | 2024-05-10T00:20:00.000Z | prod
+2.0                | 2024-05-10T00:20:00.000Z | qa
+3.3333333333333335 | 2024-05-10T00:20:00.000Z | staging
 ;
 
 count_over_time_of_text
@@ -158,6 +314,24 @@ event_log:long | cluster:keyword | time_bucket:datetime
 14             | qa              | 2024-05-10T00:10:00.000Z
 ;
 
+count_over_time_of_text_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m event_log=(max by (cluster) (count_over_time(event_log[10m])))
+| SORT event_log, cluster, step | LIMIT 10;
+
+event_log:double | step:datetime            | cluster:keyword
+3.0              | 2024-05-10T00:20:00.000Z | prod
+3.0              | 2024-05-10T00:20:00.000Z | qa
+5.0              | 2024-05-10T00:20:00.000Z | staging
+10.0             | 2024-05-10T00:00:00.000Z | prod
+10.0             | 2024-05-10T00:10:00.000Z | prod
+10.0             | 2024-05-10T00:00:00.000Z | staging
+11.0             | 2024-05-10T00:10:00.000Z | staging
+13.0             | 2024-05-10T00:00:00.000Z | qa
+14.0             | 2024-05-10T00:10:00.000Z | qa
+;
+
 count_over_time_of_keyword
 required_capability: ts_command_v0
 TS k8s | STATS pod = min(count_over_time(network.eth0.up)) BY cluster, time_bucket = bucket(@timestamp,10minute) | SORT time_bucket, cluster | LIMIT 10;
@@ -172,6 +346,24 @@ pod:long | cluster:keyword | time_bucket:datetime
 1        | prod            | 2024-05-10T00:20:00.000Z
 1        | qa              | 2024-05-10T00:20:00.000Z
 2        | staging         | 2024-05-10T00:20:00.000Z
+;
+
+count_over_time_of_keyword_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m pod=(min by (cluster) (count_over_time(network.eth0.up[10m])))
+| SORT step, cluster | LIMIT 10;
+
+pod:double | step:datetime            | cluster:keyword
+4.0        | 2024-05-10T00:00:00.000Z | prod
+11.0       | 2024-05-10T00:00:00.000Z | qa
+6.0        | 2024-05-10T00:00:00.000Z | staging
+9.0        | 2024-05-10T00:10:00.000Z | prod
+11.0       | 2024-05-10T00:10:00.000Z | qa
+5.0        | 2024-05-10T00:10:00.000Z | staging
+1.0        | 2024-05-10T00:20:00.000Z | prod
+1.0        | 2024-05-10T00:20:00.000Z | qa
+2.0        | 2024-05-10T00:20:00.000Z | staging
 ;
 
 count_over_time_of_aggregate_metric_double
@@ -191,6 +383,25 @@ tx:long | cluster:keyword | time_bucket:datetime
 19      | staging         | 2024-05-09T23:50:00.000Z
 ;
 
+count_over_time_of_aggregate_metric_double_promql
+required_capability: promql_pre_tech_preview_v12
+required_capability: aggregate_metric_double_v0
+
+PROMQL index=k8s-downsampled step=10m tx=(sum by (cluster) (count_over_time(network.eth0.tx[10m])))
+| SORT step, cluster | LIMIT 10;
+
+tx:double | step:datetime            | cluster:keyword
+26.0      | 2024-05-09T23:30:00.000Z | prod
+16.0      | 2024-05-09T23:30:00.000Z | qa
+22.0      | 2024-05-09T23:30:00.000Z | staging
+14.0      | 2024-05-09T23:40:00.000Z | prod
+20.0      | 2024-05-09T23:40:00.000Z | qa
+16.0      | 2024-05-09T23:40:00.000Z | staging
+20.0      | 2024-05-09T23:50:00.000Z | prod
+25.0      | 2024-05-09T23:50:00.000Z | qa
+19.0      | 2024-05-09T23:50:00.000Z | staging
+;
+
 count_over_time_of_geopoint
 required_capability: ts_command_v0
 TS k8s | STATS min = min(count_over_time(event_city)) BY cluster, time_bucket = bucket(@timestamp,10minute) | SORT time_bucket, cluster | LIMIT 10;
@@ -205,6 +416,24 @@ min:long | cluster:keyword | time_bucket:datetime
 1        | prod            | 2024-05-10T00:20:00.000Z
 1        | qa              | 2024-05-10T00:20:00.000Z
 2        | staging         | 2024-05-10T00:20:00.000Z
+;
+
+count_over_time_of_geopoint_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m min=(min by (cluster) (count_over_time(event_city[10m])))
+| SORT step, cluster | LIMIT 10;
+
+min:double | step:datetime            | cluster:keyword
+4.0        | 2024-05-10T00:00:00.000Z | prod
+11.0       | 2024-05-10T00:00:00.000Z | qa
+6.0        | 2024-05-10T00:00:00.000Z | staging
+9.0        | 2024-05-10T00:10:00.000Z | prod
+11.0       | 2024-05-10T00:10:00.000Z | qa
+5.0        | 2024-05-10T00:10:00.000Z | staging
+1.0        | 2024-05-10T00:20:00.000Z | prod
+1.0        | 2024-05-10T00:20:00.000Z | qa
+2.0        | 2024-05-10T00:20:00.000Z | staging
 ;
 
 count_over_time_of_geoshape
@@ -223,6 +452,24 @@ min:long | cluster:keyword | time_bucket:datetime
 2        | staging         | 2024-05-10T00:20:00.000Z
 ;
 
+count_over_time_of_geoshape_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m min=(min by (cluster) (count_over_time(event_city_boundary[10m])))
+| SORT step, cluster | LIMIT 10;
+
+min:double | step:datetime            | cluster:keyword
+4.0        | 2024-05-10T00:00:00.000Z | prod
+11.0       | 2024-05-10T00:00:00.000Z | qa
+6.0        | 2024-05-10T00:00:00.000Z | staging
+9.0        | 2024-05-10T00:10:00.000Z | prod
+11.0       | 2024-05-10T00:10:00.000Z | qa
+5.0        | 2024-05-10T00:10:00.000Z | staging
+1.0        | 2024-05-10T00:20:00.000Z | prod
+1.0        | 2024-05-10T00:20:00.000Z | qa
+2.0        | 2024-05-10T00:20:00.000Z | staging
+;
+
 count_over_time_of_shape
 required_capability: ts_command_v0
 TS k8s | STATS min = min(count_over_time(event_shape)) BY cluster, time_bucket = bucket(@timestamp,10minute) | SORT time_bucket, cluster | LIMIT 10;
@@ -237,6 +484,24 @@ min:long | cluster:keyword | time_bucket:datetime
 1        | prod            | 2024-05-10T00:20:00.000Z
 1        | qa              | 2024-05-10T00:20:00.000Z
 2        | staging         | 2024-05-10T00:20:00.000Z
+;
+
+count_over_time_of_shape_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m min=(min by (cluster) (count_over_time(event_shape[10m])))
+| SORT step, cluster | LIMIT 10;
+
+min:double | step:datetime            | cluster:keyword
+4.0        | 2024-05-10T00:00:00.000Z | prod
+11.0       | 2024-05-10T00:00:00.000Z | qa
+6.0        | 2024-05-10T00:00:00.000Z | staging
+9.0        | 2024-05-10T00:10:00.000Z | prod
+11.0       | 2024-05-10T00:10:00.000Z | qa
+5.0        | 2024-05-10T00:10:00.000Z | staging
+1.0        | 2024-05-10T00:20:00.000Z | prod
+1.0        | 2024-05-10T00:20:00.000Z | qa
+2.0        | 2024-05-10T00:20:00.000Z | staging
 ;
 
 count_over_time_of_point
@@ -255,6 +520,24 @@ min:long | cluster:keyword | time_bucket:datetime
 2        | staging         | 2024-05-10T00:20:00.000Z
 ;
 
+count_over_time_of_point_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m min=(min by (cluster) (count_over_time(event_location[10m])))
+| SORT step, cluster | LIMIT 10;
+
+min:double | step:datetime            | cluster:keyword
+4.0        | 2024-05-10T00:00:00.000Z | prod
+11.0       | 2024-05-10T00:00:00.000Z | qa
+6.0        | 2024-05-10T00:00:00.000Z | staging
+9.0        | 2024-05-10T00:10:00.000Z | prod
+11.0       | 2024-05-10T00:10:00.000Z | qa
+5.0        | 2024-05-10T00:10:00.000Z | staging
+1.0        | 2024-05-10T00:20:00.000Z | prod
+1.0        | 2024-05-10T00:20:00.000Z | qa
+2.0        | 2024-05-10T00:20:00.000Z | staging
+;
+
 count_over_time_with_filtering
 required_capability: ts_command_v0
 TS k8s | WHERE pod != "three" | STATS tx = sum(count_over_time(network.bytes_in)) BY cluster, time_bucket = bucket(@timestamp, 10minute) | SORT time_bucket, cluster | LIMIT 10;
@@ -271,6 +554,24 @@ tx:long | cluster:keyword | time_bucket:datetime
 5       | staging         | 2024-05-10T00:20:00.000Z
 ;
 
+count_over_time_with_filtering_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m tx=(sum by (cluster) (count_over_time(network.bytes_in{pod!="three"}[10m])))
+| SORT step, cluster | LIMIT 10;
+
+tx:double | step:datetime            | cluster:keyword
+13.0      | 2024-05-10T00:00:00.000Z | prod
+26.0      | 2024-05-10T00:00:00.000Z | qa
+16.0      | 2024-05-10T00:00:00.000Z | staging
+20.0      | 2024-05-10T00:10:00.000Z | prod
+28.0      | 2024-05-10T00:10:00.000Z | qa
+12.0      | 2024-05-10T00:10:00.000Z | staging
+6.0       | 2024-05-10T00:20:00.000Z | prod
+4.0       | 2024-05-10T00:20:00.000Z | qa
+5.0       | 2024-05-10T00:20:00.000Z | staging
+;
+
 count_over_time_older_than_10d
 required_capability: ts_command_v0
 required_capability: aggregate_metric_double_v0
@@ -282,6 +583,21 @@ cost:double | pod:keyword | time_bucket:datetime
 9.0         | two         | 2024-05-09T23:30:00.000Z
 10.0        | one         | 2024-05-09T23:40:00.000Z
 10.0        | three       | 2024-05-09T23:40:00.000Z
+;
+
+count_over_time_older_than_10d_promql
+required_capability: promql_pre_tech_preview_v12
+required_capability: aggregate_metric_double_v0
+
+PROMQL index=k8s-downsampled step=10m start="2024-05-09T23:00:00.000Z" end="2024-05-10T00:00:00.000Z" cost=(avg by (pod) (count_over_time(network.eth0.rx{cluster="qa"}[10m])))
+| SORT step, pod | LIMIT 5;
+
+cost:double | step:datetime            | pod:keyword
+9.0         | 2024-05-09T23:30:00.000Z | one
+1.0         | 2024-05-09T23:30:00.000Z | three
+9.0         | 2024-05-09T23:30:00.000Z | two
+10.0        | 2024-05-09T23:40:00.000Z | one
+10.0        | 2024-05-09T23:40:00.000Z | three
 ;
 
 eval_on_count_over_time
@@ -298,6 +614,25 @@ bytes:long | pod:keyword | time_bucket:datetime     | kb:double
 8              | one         | 2024-05-10T00:20:00.000Z | 0.008
 8              | three       | 2024-05-10T00:20:00.000Z | 0.008
 7              | two         | 2024-05-10T00:20:00.000Z | 0.007
+;
+
+eval_on_count_over_time_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m bytes=(sum by (pod) (count_over_time(network.bytes_in[10m])))
+| EVAL kb = bytes / 1000.0
+| SORT step, pod | LIMIT 10;
+
+bytes:double | step:datetime            | pod:keyword | kb:double
+27.0         | 2024-05-10T00:00:00.000Z | one         | 0.027
+29.0         | 2024-05-10T00:00:00.000Z | three       | 0.029
+28.0         | 2024-05-10T00:00:00.000Z | two         | 0.028
+30.0         | 2024-05-10T00:10:00.000Z | one         | 0.03
+33.0         | 2024-05-10T00:10:00.000Z | three       | 0.033
+30.0         | 2024-05-10T00:10:00.000Z | two         | 0.03
+8.0          | 2024-05-10T00:20:00.000Z | one         | 0.008
+8.0          | 2024-05-10T00:20:00.000Z | three       | 0.008
+7.0          | 2024-05-10T00:20:00.000Z | two         | 0.007
 ;
 
 count_over_time_multi_values
@@ -317,6 +652,25 @@ events:double | pod:keyword | time_bucket:datetime
 1.5           | three       | 2024-05-10T00:05:00.000Z
 ;
 
+count_over_time_multi_values_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m start="2024-05-10T00:00:00.000Z" end="2024-05-10T00:09:00.000Z" events=(avg by (pod) (count_over_time(events_received[1m])))
+| SORT events, pod, step | LIMIT 10;
+
+events:double | step:datetime            | pod:keyword
+1.0           | 2024-05-10T00:01:00.000Z | one
+1.0           | 2024-05-10T00:04:00.000Z | one
+1.0           | 2024-05-10T00:01:00.000Z | three
+1.0           | 2024-05-10T00:02:00.000Z | three
+1.0           | 2024-05-10T00:00:00.000Z | two
+1.0           | 2024-05-10T00:01:00.000Z | two
+1.0           | 2024-05-10T00:07:00.000Z | two
+1.5           | 2024-05-10T00:03:00.000Z | one
+1.5           | 2024-05-10T00:00:00.000Z | three
+1.5           | 2024-05-10T00:05:00.000Z | three
+;
+
 count_over_time_null_values
 required_capability: ts_command_v0
 TS k8s | WHERE @timestamp > "2024-05-10T00:10:00.000Z" and @timestamp < "2024-05-10T00:15:00.000Z" | STATS events = sum(count_over_time(events_received)) by pod, time_bucket = bucket(@timestamp, 1minute) | SORT events NULLS FIRST, pod, time_bucket  | LIMIT 10;
@@ -334,6 +688,25 @@ events:long | pod:keyword | time_bucket:datetime
 2           | two         | 2024-05-10T00:14:00.000Z
 ;
 
+count_over_time_null_values_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m start="2024-05-10T00:10:00.000Z" end="2024-05-10T00:14:00.000Z" events=(sum by (pod) (count_over_time(events_received[1m])))
+| SORT events, pod, step | LIMIT 10;
+
+events:double | step:datetime            | pod:keyword
+0.0           | 2024-05-10T00:12:00.000Z | one
+0.0           | 2024-05-10T00:13:00.000Z | two
+1.0           | 2024-05-10T00:11:00.000Z | one
+1.0           | 2024-05-10T00:11:00.000Z | three
+1.0           | 2024-05-10T00:10:00.000Z | two
+1.0           | 2024-05-10T00:11:00.000Z | two
+2.0           | 2024-05-10T00:10:00.000Z | one
+3.0           | 2024-05-10T00:13:00.000Z | one
+3.0           | 2024-05-10T00:12:00.000Z | three
+3.0           | 2024-05-10T00:13:00.000Z | three
+;
+
 count_over_time_all_value_types
 required_capability: ts_command_v0
 TS k8s | STATS events = sum(count_over_time(events_received)) by pod, time_bucket = bucket(@timestamp, 10minute) | SORT events NULLS FIRST, pod, time_bucket | LIMIT 10 ;
@@ -348,6 +721,24 @@ events:long | pod:keyword | time_bucket:datetime
 53          | one         | 2024-05-10T00:00:00.000Z
 53          | three       | 2024-05-10T00:00:00.000Z
 53          | two         | 2024-05-10T00:00:00.000Z
+;
+
+count_over_time_all_value_types_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m events=(sum by (pod) (count_over_time(events_received[10m])))
+| SORT events, pod, step | LIMIT 10;
+
+events:double | step:datetime            | pod:keyword
+4.0           | 2024-05-10T00:20:00.000Z | one
+13.0          | 2024-05-10T00:20:00.000Z | three
+13.0          | 2024-05-10T00:20:00.000Z | two
+23.0          | 2024-05-10T00:10:00.000Z | one
+30.0          | 2024-05-10T00:10:00.000Z | three
+34.0          | 2024-05-10T00:10:00.000Z | two
+53.0          | 2024-05-10T00:00:00.000Z | one
+53.0          | 2024-05-10T00:00:00.000Z | three
+53.0          | 2024-05-10T00:00:00.000Z | two
 ;
 
 
@@ -367,4 +758,25 @@ bytes:long | pod:keyword | time_bucket:datetime
 15         | three       | 2024-05-09T23:40:00.000Z
 19         | two         | 2024-05-09T23:50:00.000Z
 20         | one         | 2024-05-09T23:40:00.000Z
+;
+
+# Awaits fix: Index wildcard selector is not supported at this time.
+count_over_time_aggregate_metric_double_implicit_casting_promql-Ignore
+required_capability: promql_pre_tech_preview_v12
+required_capability: aggregate_metric_double_v0
+
+PROMQL index=k8s* step=10m bytes=(sum by (pod) (count_over_time(network.eth0.rx[10m])))
+| SORT bytes, pod, step | LIMIT 10;
+
+bytes:double | step:datetime            | pod:keyword
+7.0          | 2024-05-10T00:20:00.000Z | two
+8.0          | 2024-05-10T00:20:00.000Z | one
+8.0          | 2024-05-10T00:20:00.000Z | three
+8.0          | 2024-05-09T23:40:00.000Z | two
+10.0         | 2024-05-09T23:30:00.000Z | three
+11.0         | 2024-05-09T23:50:00.000Z | one
+12.0         | 2024-05-09T23:30:00.000Z | two
+15.0         | 2024-05-09T23:40:00.000Z | three
+19.0         | 2024-05-09T23:50:00.000Z | two
+20.0         | 2024-05-09T23:40:00.000Z | one
 ;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-count-over-time.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-count-over-time.csv-spec
@@ -164,9 +164,9 @@ eth0_up:double | step:datetime            | cluster:keyword
 
 count_over_time_of_date_nanos
 required_capability: ts_command_v0
-TS k8s | STATS last_up = max(count_over_time(network.eth0.last_up)) BY cluster, time_bucket = bucket(@timestamp,10minute) | SORT time_bucket, cluster | LIMIT 10;
+TS datenanos-k8s | STATS last_up = max(count_over_time(network.eth0.last_up)) BY cluster, time_bucket = bucket(@timestamp,10minute) | SORT time_bucket, cluster | LIMIT 10;
 
-last_up:long | cluster:keyword | time_bucket:datetime
+last_up:long | cluster:keyword | time_bucket:date_nanos
 10           | prod            | 2024-05-10T00:00:00.000Z
 14           | qa              | 2024-05-10T00:00:00.000Z
 10           | staging         | 2024-05-10T00:00:00.000Z
@@ -180,11 +180,12 @@ last_up:long | cluster:keyword | time_bucket:datetime
 
 count_over_time_of_date_nanos_promql
 required_capability: promql_pre_tech_preview_v12
+required_capability: promql_date_nanos_support_v0
 
-PROMQL index=k8s step=10m last_up=(max by (cluster) (count_over_time(network.eth0.last_up[10m])))
+PROMQL index=datenanos-k8s step=10m last_up=(max by (cluster) (count_over_time(network.eth0.last_up[10m])))
 | SORT step, cluster | LIMIT 10;
 
-last_up:double | step:datetime            | cluster:keyword
+last_up:double | step:date_nanos          | cluster:keyword
 10.0           | 2024-05-10T00:00:00.000Z | prod
 14.0           | 2024-05-10T00:00:00.000Z | qa
 10.0           | 2024-05-10T00:00:00.000Z | staging
@@ -585,21 +586,6 @@ cost:double | pod:keyword | time_bucket:datetime
 10.0        | three       | 2024-05-09T23:40:00.000Z
 ;
 
-count_over_time_older_than_10d_promql
-required_capability: promql_pre_tech_preview_v12
-required_capability: aggregate_metric_double_v0
-
-PROMQL index=k8s-downsampled step=10m start="2024-05-09T23:00:00.000Z" end="2024-05-10T00:00:00.000Z" cost=(avg by (pod) (count_over_time(network.eth0.rx{cluster="qa"}[10m])))
-| SORT step, pod | LIMIT 5;
-
-cost:double | step:datetime            | pod:keyword
-9.0         | 2024-05-09T23:30:00.000Z | one
-1.0         | 2024-05-09T23:30:00.000Z | three
-9.0         | 2024-05-09T23:30:00.000Z | two
-10.0        | 2024-05-09T23:40:00.000Z | one
-10.0        | 2024-05-09T23:40:00.000Z | three
-;
-
 eval_on_count_over_time
 required_capability: ts_command_v0
 TS k8s | STATS bytes = sum(count_over_time(network.bytes_in)) BY pod, time_bucket = bucket(@timestamp, 10minute) | EVAL kb = to_double(bytes) / 1000.0 | LIMIT 10 | SORT time_bucket, pod;
@@ -760,7 +746,7 @@ bytes:long | pod:keyword | time_bucket:datetime
 20         | one         | 2024-05-09T23:40:00.000Z
 ;
 
-# Awaits fix: Index wildcard selector is not supported at this time.
+# Awaits fix: https://github.com/elastic/metrics-program/issues/302
 count_over_time_aggregate_metric_double_implicit_casting_promql-Ignore
 required_capability: promql_pre_tech_preview_v12
 required_capability: aggregate_metric_double_v0

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-max-over-time.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-max-over-time.csv-spec
@@ -752,12 +752,12 @@ bytes:double | time_bucket:datetime
 4290.0       | 2024-05-10T00:00:00.000Z
 ;
 
-# Awaits fix: index wildcard selector not yet available for PromQL.
+# Awaits fix: https://github.com/elastic/metrics-program/issues/302
 max_over_time_aggregate_metric_double_implicit_casting_promql-Ignore
 required_capability: promql_pre_tech_preview_v12
 required_capability: aggregate_metric_double_v0
 
-PROMQL index=k8s* step=10m bytes=sum(max_over_time(network.eth0.rx[10m]))
+PROMQL index=k8s* step=10m bytes=(sum(max_over_time(network.eth0.rx[10m])))
 | SORT bytes DESC, step | LIMIT 10;
 
 bytes:double | step:datetime           
@@ -787,12 +787,12 @@ bytes:double | pod:keyword | time_bucket:datetime
 2478.0       | one         | 2024-05-09T23:50:00.000Z
 ;
 
-# Awaits fix: index wildcard selector not yet available for PromQL.
+# Awaits fix: https://github.com/elastic/metrics-program/issues/302
 max_over_time_aggregate_metric_double_implicit_casting_grouping_promql-Ignore
 required_capability: promql_pre_tech_preview_v12
 required_capability: aggregate_metric_double_v0
 
-PROMQL index=k8s* step=10m bytes=sum by (pod) (max_over_time(network.eth0.rx[10m]))
+PROMQL index=k8s* step=10m bytes=(sum by (pod) (max_over_time(network.eth0.rx[10m])))
 | SORT bytes DESC, pod, step | LIMIT 10;
 
 bytes:double | step:datetime            | pod:keyword

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-max-over-time.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-max-over-time.csv-spec
@@ -598,21 +598,6 @@ cost:double | pod:keyword | time_bucket:datetime
 1237.0      | three       | 2024-05-09T23:40:00.000Z
 ;
 
-max_over_time_older_than_10h_promql
-required_capability: promql_pre_tech_preview_v12
-required_capability: aggregate_metric_double_v0
-
-PROMQL index=k8s-downsampled step=10m start="2024-05-09T23:00:00.000Z" end="2024-05-10T00:00:00.000Z" cost=(avg by (pod) (max_over_time(network.eth0.rx{cluster="qa"}[10m])))
-| SORT step, pod | LIMIT 5;
-
-cost:double | step:datetime            | pod:keyword
-655.0       | 2024-05-09T23:30:00.000Z | one
-1.0         | 2024-05-09T23:30:00.000Z | three
-461.0       | 2024-05-09T23:30:00.000Z | two
-1049.0      | 2024-05-09T23:40:00.000Z | one
-1237.0      | 2024-05-09T23:40:00.000Z | three
-;
-
 eval_on_max_over_time
 required_capability: ts_command_v0
 TS k8s | STATS max_bytes = avg(max_over_time(network.bytes_in)) BY cluster, time_bucket = bucket(@timestamp, 10minute) | EVAL kb_minus_offset = (max_bytes - 100) / 1000.0 | LIMIT 10 | SORT time_bucket, cluster ;
@@ -703,14 +688,15 @@ null        | two         | 2024-05-10T00:13:00.000Z
 7           | two         | 2024-05-10T00:10:00.000Z
 ;
 
-# Awaits fix: PromQL should omit buckets with no samples
-max_over_time_null_values_promql-Ignore
+max_over_time_null_values_promql
 required_capability: promql_pre_tech_preview_v12
 
 PROMQL index=k8s step=1m start="2024-05-10T00:10:00.000Z" end="2024-05-10T00:15:00.000Z" events=(sum by (pod) (max_over_time(events_received[1m])))
 | SORT events DESC, step | LIMIT 10;
 
 events:double | step:datetime            | pod:keyword
+null          | 2024-05-10T00:12:00.000Z | one
+null          | 2024-05-10T00:13:00.000Z | two 
 20.0          | 2024-05-10T00:14:00.000Z | two
 18.0          | 2024-05-10T00:12:00.000Z | two
 17.0          | 2024-05-10T00:13:00.000Z | one

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-max-over-time.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-max-over-time.csv-spec
@@ -17,6 +17,25 @@ cost:double | time_bucket:datetime
 42.25       | 2024-05-10T00:03:00.000Z
 ;
 
+max_over_time_of_double_no_grouping_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m cost=(sum(max_over_time(network.cost[1m])))
+| SORT cost DESC, step DESC | LIMIT 10;
+
+cost:double | step:datetime           
+83.125      | 2024-05-10T00:09:00.000Z
+65.75       | 2024-05-10T00:08:00.000Z
+60.375      | 2024-05-10T00:17:00.000Z
+55.25       | 2024-05-10T00:18:00.000Z
+51.625      | 2024-05-10T00:22:00.000Z
+50.125      | 2024-05-10T00:15:00.000Z
+44.875      | 2024-05-10T00:06:00.000Z
+43.5        | 2024-05-10T00:20:00.000Z
+42.625      | 2024-05-10T00:13:00.000Z
+42.25       | 2024-05-10T00:03:00.000Z
+;
+
 max_over_time_of_ip
 required_capability: ts_command_v0
 TS k8s | STATS ip = max(max_over_time(client.ip)) BY time_bucket = bucket(@timestamp,1minute) | SORT time_bucket | LIMIT 10;
@@ -99,6 +118,25 @@ bytes_in:long | time_bucket:datetime
 3618          | 2024-05-10T00:06:00.000Z
 ;
 
+max_over_time_of_long_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m bytes_in=(sum(max_over_time(network.bytes_in[1m])))
+| SORT bytes_in DESC, step | LIMIT 10;
+
+bytes_in:double | step:datetime           
+6707.0          | 2024-05-10T00:18:00.000Z
+6000.0          | 2024-05-10T00:20:00.000Z
+5899.0          | 2024-05-10T00:17:00.000Z
+4836.0          | 2024-05-10T00:09:00.000Z
+4384.0          | 2024-05-10T00:15:00.000Z
+4115.0          | 2024-05-10T00:08:00.000Z
+4030.0          | 2024-05-10T00:14:00.000Z
+3685.0          | 2024-05-10T00:13:00.000Z
+3623.0          | 2024-05-10T00:02:00.000Z
+3618.0          | 2024-05-10T00:06:00.000Z
+;
+
 max_over_time_of_long_grouping
 required_capability: ts_command_v0
 TS k8s | STATS bytes_in = sum(max_over_time(network.bytes_in)) BY cluster, time_bucket = bucket(@timestamp,1minute) | SORT bytes_in DESC, time_bucket | LIMIT 10;
@@ -114,6 +152,25 @@ bytes_in:long | cluster:keyword | time_bucket:datetime
 1908          | qa              | 2024-05-10T00:20:00.000Z
 1904          | qa              | 2024-05-10T00:06:00.000Z
 1811          | prod            | 2024-05-10T00:13:00.000Z
+;
+
+max_over_time_of_long_grouping_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m bytes_in=(sum by (cluster) (max_over_time(network.bytes_in[1m])))
+| SORT bytes_in DESC, step | LIMIT 10;
+
+bytes_in:double | step:datetime            | cluster:keyword
+3013.0          | 2024-05-10T00:18:00.000Z | prod
+2848.0          | 2024-05-10T00:17:00.000Z | prod
+2483.0          | 2024-05-10T00:20:00.000Z | prod
+2247.0          | 2024-05-10T00:18:00.000Z | qa
+2153.0          | 2024-05-10T00:15:00.000Z | qa
+2087.0          | 2024-05-10T00:17:00.000Z | qa
+2035.0          | 2024-05-10T00:09:00.000Z | staging
+1908.0          | 2024-05-10T00:20:00.000Z | qa
+1904.0          | 2024-05-10T00:06:00.000Z | qa
+1811.0          | 2024-05-10T00:13:00.000Z | prod
 ;
 
 max_over_time_of_boolean
@@ -133,6 +190,25 @@ false           | 2024-05-10T00:08:00.000Z
 false           | 2024-05-10T00:09:00.000Z
 ;
 
+max_over_time_of_boolean_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m eth0_up=(min(max_over_time(network.eth0.up[1m])))
+| SORT step | LIMIT 10;
+
+eth0_up:double | step:datetime           
+0.0            | 2024-05-10T00:00:00.000Z
+0.0            | 2024-05-10T00:01:00.000Z
+1.0            | 2024-05-10T00:02:00.000Z
+0.0            | 2024-05-10T00:03:00.000Z
+0.0            | 2024-05-10T00:04:00.000Z
+0.0            | 2024-05-10T00:05:00.000Z
+0.0            | 2024-05-10T00:06:00.000Z
+0.0            | 2024-05-10T00:07:00.000Z
+0.0            | 2024-05-10T00:08:00.000Z
+0.0            | 2024-05-10T00:09:00.000Z
+;
+
 max_over_time_of_boolean_grouping
 required_capability: ts_command_v0
 TS k8s | STATS eth0_up = min(max_over_time(network.eth0.up)) BY cluster, time_bucket = bucket(@timestamp,1minute) | SORT time_bucket, cluster | LIMIT 10;
@@ -148,6 +224,25 @@ true            | staging         | 2024-05-10T00:02:00.000Z
 false           | prod            | 2024-05-10T00:03:00.000Z
 true            | qa              | 2024-05-10T00:03:00.000Z
 false           | staging         | 2024-05-10T00:03:00.000Z
+;
+
+max_over_time_of_boolean_grouping_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m eth0_up=(min by (cluster) (max_over_time(network.eth0.up[1m])))
+| SORT step, cluster | LIMIT 10;
+
+eth0_up:double | step:datetime            | cluster:keyword
+0.0            | 2024-05-10T00:00:00.000Z | prod
+1.0            | 2024-05-10T00:00:00.000Z | staging
+0.0            | 2024-05-10T00:01:00.000Z | prod
+0.0            | 2024-05-10T00:01:00.000Z | qa
+1.0            | 2024-05-10T00:02:00.000Z | prod
+1.0            | 2024-05-10T00:02:00.000Z | qa
+1.0            | 2024-05-10T00:02:00.000Z | staging
+0.0            | 2024-05-10T00:03:00.000Z | prod
+1.0            | 2024-05-10T00:03:00.000Z | qa
+0.0            | 2024-05-10T00:03:00.000Z | staging
 ;
 
 max_over_time_of_date_nanos
@@ -235,6 +330,25 @@ clients:double    | time_bucket:datetime
 642.1111111111111 | 2024-05-10T00:09:00.000Z
 ;
 
+max_over_time_of_integer_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m clients=(avg(max_over_time(network.eth0.currently_connected_clients[1m])))
+| SORT step | LIMIT 10;
+
+clients:double    | step:datetime           
+726.6666666666666 | 2024-05-10T00:00:00.000Z
+418.25            | 2024-05-10T00:01:00.000Z
+550.3333333333334 | 2024-05-10T00:02:00.000Z
+598.8             | 2024-05-10T00:03:00.000Z
+546.3333333333334 | 2024-05-10T00:04:00.000Z
+809.8             | 2024-05-10T00:05:00.000Z
+656.8333333333334 | 2024-05-10T00:06:00.000Z
+822.6666666666666 | 2024-05-10T00:07:00.000Z
+605.25            | 2024-05-10T00:08:00.000Z
+642.1111111111111 | 2024-05-10T00:09:00.000Z
+;
+
 max_over_time_of_integer_grouping
 required_capability: ts_command_v0
 TS k8s | STATS clients = avg(max_over_time(network.eth0.currently_connected_clients)) BY cluster, time_bucket = bucket(@timestamp,1minute) | SORT time_bucket, cluster | LIMIT 10;
@@ -250,6 +364,25 @@ clients:double | cluster:keyword | time_bucket:datetime
 742.0          | prod            | 2024-05-10T00:03:00.000Z
 454.0          | qa              | 2024-05-10T00:03:00.000Z
 672.0          | staging         | 2024-05-10T00:03:00.000Z
+;
+
+max_over_time_of_integer_grouping_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m clients=(avg by (cluster) (max_over_time(network.eth0.currently_connected_clients[1m])))
+| SORT step, cluster | LIMIT 10;
+
+clients:double | step:datetime            | cluster:keyword
+949.0          | 2024-05-10T00:00:00.000Z | prod
+615.5          | 2024-05-10T00:00:00.000Z | staging
+396.5          | 2024-05-10T00:01:00.000Z | prod
+440.0          | 2024-05-10T00:01:00.000Z | qa
+659.5          | 2024-05-10T00:02:00.000Z | prod
+565.0          | 2024-05-10T00:02:00.000Z | qa
+426.5          | 2024-05-10T00:02:00.000Z | staging
+742.0          | 2024-05-10T00:03:00.000Z | prod
+454.0          | 2024-05-10T00:03:00.000Z | qa
+672.0          | 2024-05-10T00:03:00.000Z | staging
 ;
 
 max_over_time_of_text
@@ -304,6 +437,25 @@ false       | 2024-05-10T00:09:00.000Z
 
 ;
 
+max_over_time_of_keyword_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m pod=(min(max_over_time(network.eth0.up[1m])))
+| SORT step | LIMIT 10;
+
+pod:double | step:datetime           
+0.0        | 2024-05-10T00:00:00.000Z
+0.0        | 2024-05-10T00:01:00.000Z
+1.0        | 2024-05-10T00:02:00.000Z
+0.0        | 2024-05-10T00:03:00.000Z
+0.0        | 2024-05-10T00:04:00.000Z
+0.0        | 2024-05-10T00:05:00.000Z
+0.0        | 2024-05-10T00:06:00.000Z
+0.0        | 2024-05-10T00:07:00.000Z
+0.0        | 2024-05-10T00:08:00.000Z
+0.0        | 2024-05-10T00:09:00.000Z
+;
+
 max_over_time_of_keyword_grouping
 required_capability: ts_command_v0
 TS k8s | STATS pod = min(max_over_time(network.eth0.up)) BY cluster, time_bucket = bucket(@timestamp,1minute) | SORT time_bucket, cluster | LIMIT 10;
@@ -321,11 +473,43 @@ true        | qa              | 2024-05-10T00:03:00.000Z
 false       | staging         | 2024-05-10T00:03:00.000Z
 ;
 
+max_over_time_of_keyword_grouping_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m pod=(min by (cluster) (max_over_time(network.eth0.up[1m])))
+| SORT step, cluster | LIMIT 10;
+
+pod:double | step:datetime            | cluster:keyword
+0.0        | 2024-05-10T00:00:00.000Z | prod
+1.0        | 2024-05-10T00:00:00.000Z | staging
+0.0        | 2024-05-10T00:01:00.000Z | prod
+0.0        | 2024-05-10T00:01:00.000Z | qa
+1.0        | 2024-05-10T00:02:00.000Z | prod
+1.0        | 2024-05-10T00:02:00.000Z | qa
+1.0        | 2024-05-10T00:02:00.000Z | staging
+0.0        | 2024-05-10T00:03:00.000Z | prod
+1.0        | 2024-05-10T00:03:00.000Z | qa
+0.0        | 2024-05-10T00:03:00.000Z | staging
+;
+
 max_over_time_of_aggregate_metric_double
 required_capability: ts_command_v0
 required_capability: aggregate_metric_double_v0
 TS k8s-downsampled | STATS tx = sum(max_over_time(network.eth0.tx)) BY time_bucket = bucket(@timestamp, 10minute) | SORT time_bucket | LIMIT 10;
 tx:double | time_bucket:datetime
+6053.0    | 2024-05-09T23:30:00.000Z
+6699.0    | 2024-05-09T23:40:00.000Z
+5895.0    | 2024-05-09T23:50:00.000Z
+;
+
+max_over_time_of_aggregate_metric_double_promql
+required_capability: promql_pre_tech_preview_v12
+required_capability: aggregate_metric_double_v0
+
+PROMQL index=k8s-downsampled step=10m tx=(sum(max_over_time(network.eth0.tx[10m])))
+| SORT step | LIMIT 10;
+
+tx:double | step:datetime           
 6053.0    | 2024-05-09T23:30:00.000Z
 6699.0    | 2024-05-09T23:40:00.000Z
 5895.0    | 2024-05-09T23:50:00.000Z
@@ -348,6 +532,25 @@ tx:double | cluster:keyword | time_bucket:datetime
 1832.0    | staging         | 2024-05-09T23:50:00.000Z
 ;
 
+max_over_time_of_aggregate_metric_double_grouping_promql
+required_capability: promql_pre_tech_preview_v12
+required_capability: aggregate_metric_double_v0
+
+PROMQL index=k8s-downsampled step=10m tx=(sum by (cluster) (max_over_time(network.eth0.tx[10m])))
+| SORT step, cluster | LIMIT 10;
+
+tx:double | step:datetime            | cluster:keyword
+1601.0    | 2024-05-09T23:30:00.000Z | prod
+2109.0    | 2024-05-09T23:30:00.000Z | qa
+2343.0    | 2024-05-09T23:30:00.000Z | staging
+1854.0    | 2024-05-09T23:40:00.000Z | prod
+2975.0    | 2024-05-09T23:40:00.000Z | qa
+1870.0    | 2024-05-09T23:40:00.000Z | staging
+2377.0    | 2024-05-09T23:50:00.000Z | prod
+1686.0    | 2024-05-09T23:50:00.000Z | qa
+1832.0    | 2024-05-09T23:50:00.000Z | staging
+;
+
 max_over_time_with_filtering
 required_capability: ts_command_v0
 TS k8s | WHERE pod == "one" | STATS tx = sum(max_over_time(network.bytes_in)) BY cluster, time_bucket = bucket(@timestamp, 10minute) | SORT time_bucket, cluster | LIMIT 10;
@@ -364,6 +567,24 @@ tx:long | cluster:keyword | time_bucket:datetime
 749     | staging         | 2024-05-10T00:20:00.000Z
 ;
 
+max_over_time_with_filtering_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m tx=(sum by (cluster) (max_over_time(network.bytes_in{pod="one"}[10m])))
+| SORT step, cluster | LIMIT 10;
+
+tx:double | step:datetime            | cluster:keyword
+970.0     | 2024-05-10T00:00:00.000Z | prod
+842.0     | 2024-05-10T00:00:00.000Z | qa
+753.0     | 2024-05-10T00:00:00.000Z | staging
+990.0     | 2024-05-10T00:10:00.000Z | prod
+1006.0    | 2024-05-10T00:10:00.000Z | qa
+947.0     | 2024-05-10T00:10:00.000Z | staging
+953.0     | 2024-05-10T00:20:00.000Z | prod
+917.0     | 2024-05-10T00:20:00.000Z | qa
+749.0     | 2024-05-10T00:20:00.000Z | staging
+;
+
 max_over_time_older_than_10h
 required_capability: ts_command_v0
 required_capability: aggregate_metric_double_v0
@@ -375,6 +596,21 @@ cost:double | pod:keyword | time_bucket:datetime
 461.0       | two         | 2024-05-09T23:30:00.000Z
 1049.0      | one         | 2024-05-09T23:40:00.000Z
 1237.0      | three       | 2024-05-09T23:40:00.000Z
+;
+
+max_over_time_older_than_10h_promql
+required_capability: promql_pre_tech_preview_v12
+required_capability: aggregate_metric_double_v0
+
+PROMQL index=k8s-downsampled step=10m start="2024-05-09T23:00:00.000Z" end="2024-05-10T00:00:00.000Z" cost=(avg by (pod) (max_over_time(network.eth0.rx{cluster="qa"}[10m])))
+| SORT step, pod | LIMIT 5;
+
+cost:double | step:datetime            | pod:keyword
+655.0       | 2024-05-09T23:30:00.000Z | one
+1.0         | 2024-05-09T23:30:00.000Z | three
+461.0       | 2024-05-09T23:30:00.000Z | two
+1049.0      | 2024-05-09T23:40:00.000Z | one
+1237.0      | 2024-05-09T23:40:00.000Z | three
 ;
 
 eval_on_max_over_time
@@ -391,6 +627,25 @@ max_bytes:double  | cluster:keyword | time_bucket:datetime     | kb_minus_offset
 846.3333333333334 | prod            | 2024-05-10T00:20:00.000Z | 0.7463333333333334
 941.6666666666666 | qa              | 2024-05-10T00:20:00.000Z | 0.8416666666666667
 786.0             | staging         | 2024-05-10T00:20:00.000Z | 0.686
+;
+
+eval_on_max_over_time_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m max_bytes=(avg by (cluster) (max_over_time(network.bytes_in[10m])))
+| EVAL kb_minus_offset = (max_bytes - 100) / 1000.0
+| LIMIT 10 | SORT step, cluster;
+
+max_bytes:double  | step:datetime            | cluster:keyword | kb_minus_offset:double
+909.3333333333334 | 2024-05-10T00:00:00.000Z | prod            | 0.8093333333333333
+908.6666666666666 | 2024-05-10T00:00:00.000Z | qa              | 0.8086666666666666
+794.0             | 2024-05-10T00:00:00.000Z | staging         | 0.694
+1005.0            | 2024-05-10T00:10:00.000Z | prod            | 0.905
+980.0             | 2024-05-10T00:10:00.000Z | qa              | 0.88
+917.6666666666666 | 2024-05-10T00:10:00.000Z | staging         | 0.8176666666666667
+846.3333333333334 | 2024-05-10T00:20:00.000Z | prod            | 0.7463333333333334
+941.6666666666666 | 2024-05-10T00:20:00.000Z | qa              | 0.8416666666666667
+786.0             | 2024-05-10T00:20:00.000Z | staging         | 0.686
 ;
 
 max_over_time_multi_values
@@ -410,21 +665,25 @@ events:long | pod:keyword | time_bucket:datetime
 14          | three       | 2024-05-10T00:00:00.000Z
 ;
 
-max_over_time_null_values
-required_capability: ts_command_v0
-TS k8s | WHERE @timestamp > "2024-05-10T00:10:00.000Z" and @timestamp < "2024-05-10T00:15:00.000Z" | STATS events = sum(max_over_time(events_received)) by pod, time_bucket = bucket(@timestamp, 1minute) | SORT events desc, time_bucket  | LIMIT 10;
+# PromQL omits buckets with no samples:
+# https://github.com/prometheus/prometheus/blob/14de1eb043f2b264056a9d1426d5db8c068c3b32/promql/functions.go#L1052
+max_over_time_multi_values_promql
+required_capability: promql_pre_tech_preview_v12
 
-events:long | pod:keyword | time_bucket:datetime
-null        | one         | 2024-05-10T00:12:00.000Z
-null        | two         | 2024-05-10T00:13:00.000Z
-20          | two         | 2024-05-10T00:14:00.000Z
-18          | two         | 2024-05-10T00:12:00.000Z
-17          | one         | 2024-05-10T00:13:00.000Z
-16          | one         | 2024-05-10T00:14:00.000Z
-11          | one         | 2024-05-10T00:10:00.000Z
-9           | one         | 2024-05-10T00:11:00.000Z
-9           | three       | 2024-05-10T00:13:00.000Z
-7           | two         | 2024-05-10T00:10:00.000Z
+PROMQL index=k8s step=1m start="2024-05-10T00:00:00.000Z" end="2024-05-10T00:09:00.000Z" events=(sum by (pod) (max_over_time(events_received[1m])))
+| SORT events DESC, step | LIMIT 10;
+
+events:double | step:datetime            | pod:keyword
+27.0          | 2024-05-10T00:08:00.000Z | two
+26.0          | 2024-05-10T00:08:00.000Z | one
+24.0          | 2024-05-10T00:06:00.000Z | three
+21.0          | 2024-05-10T00:02:00.000Z | two
+18.0          | 2024-05-10T00:01:00.000Z | one
+17.0          | 2024-05-10T00:05:00.000Z | one
+14.0          | 2024-05-10T00:00:00.000Z | three
+12.0          | 2024-05-10T00:03:00.000Z | one
+12.0          | 2024-05-10T00:06:00.000Z | two
+12.0          | 2024-05-10T00:08:00.000Z | three
 ;
 
 max_over_time_null_values
@@ -444,6 +703,24 @@ null        | two         | 2024-05-10T00:13:00.000Z
 7           | two         | 2024-05-10T00:10:00.000Z
 ;
 
+# Awaits fix: PromQL should omit buckets with no samples
+max_over_time_null_values_promql-Ignore
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m start="2024-05-10T00:10:00.000Z" end="2024-05-10T00:15:00.000Z" events=(sum by (pod) (max_over_time(events_received[1m])))
+| SORT events DESC, step | LIMIT 10;
+
+events:double | step:datetime            | pod:keyword
+20.0          | 2024-05-10T00:14:00.000Z | two
+18.0          | 2024-05-10T00:12:00.000Z | two
+17.0          | 2024-05-10T00:13:00.000Z | one
+16.0          | 2024-05-10T00:14:00.000Z | one
+11.0          | 2024-05-10T00:10:00.000Z | one
+9.0           | 2024-05-10T00:11:00.000Z | one
+9.0           | 2024-05-10T00:13:00.000Z | three
+7.0           | 2024-05-10T00:10:00.000Z | two
+;
+
 max_over_time_all_value_types
 required_capability: ts_command_v0
 TS k8s | STATS events = sum(max_over_time(events_received)) by pod, time_bucket = bucket(@timestamp, 10minute) | SORT events desc, pod, time_bucket | LIMIT 10 ;
@@ -460,12 +737,44 @@ events:long | pod:keyword | time_bucket:datetime
 19          | one         | 2024-05-10T00:20:00.000Z
 ;
 
+max_over_time_all_value_types_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m start="2024-05-09T23:20:00.000Z" end="2024-05-10T00:20:00.000Z" events=(sum by (pod) (max_over_time(events_received[10m])))
+| SORT step, pod | LIMIT 10;
+
+events:double | step:datetime            | pod:keyword
+29.0          | 2024-05-10T00:00:00.000Z | one
+29.0          | 2024-05-10T00:00:00.000Z | three
+29.0          | 2024-05-10T00:00:00.000Z | two
+30.0          | 2024-05-10T00:10:00.000Z | one
+28.0          | 2024-05-10T00:10:00.000Z | three
+30.0          | 2024-05-10T00:10:00.000Z | two
+20.0          | 2024-05-10T00:20:00.000Z | three
+;
 max_over_time_aggregate_metric_double_implicit_casting
 required_capability: ts_command_v0
 required_capability: aggregate_metric_double_v0
 TS k8s* | STATS bytes = sum(max_over_time(network.eth0.rx)) by time_bucket = bucket(@timestamp, 10minute) | SORT bytes desc, time_bucket | LIMIT 10 ;
 
 bytes:double | time_bucket:datetime
+9058.0       | 2024-05-10T00:20:00.000Z
+8070.0       | 2024-05-10T00:10:00.000Z
+7088.0       | 2024-05-09T23:50:00.000Z
+6380.0       | 2024-05-09T23:30:00.000Z
+6095.0       | 2024-05-09T23:40:00.000Z
+4290.0       | 2024-05-10T00:00:00.000Z
+;
+
+# Awaits fix: index wildcard selector not yet available for PromQL.
+max_over_time_aggregate_metric_double_implicit_casting_promql-Ignore
+required_capability: promql_pre_tech_preview_v12
+required_capability: aggregate_metric_double_v0
+
+PROMQL index=k8s* step=10m bytes=sum(max_over_time(network.eth0.rx[10m]))
+| SORT bytes DESC, step | LIMIT 10;
+
+bytes:double | step:datetime           
 9058.0       | 2024-05-10T00:20:00.000Z
 8070.0       | 2024-05-10T00:10:00.000Z
 7088.0       | 2024-05-09T23:50:00.000Z
@@ -490,4 +799,25 @@ bytes:double | pod:keyword | time_bucket:datetime
 2570.0       | one         | 2024-05-09T23:30:00.000Z
 2535.0       | two         | 2024-05-10T00:10:00.000Z
 2478.0       | one         | 2024-05-09T23:50:00.000Z
+;
+
+# Awaits fix: index wildcard selector not yet available for PromQL.
+max_over_time_aggregate_metric_double_implicit_casting_grouping_promql-Ignore
+required_capability: promql_pre_tech_preview_v12
+required_capability: aggregate_metric_double_v0
+
+PROMQL index=k8s* step=10m bytes=sum by (pod) (max_over_time(network.eth0.rx[10m]))
+| SORT bytes DESC, pod, step | LIMIT 10;
+
+bytes:double | step:datetime            | pod:keyword
+3156.0       | 2024-05-10T00:20:00.000Z | one
+3028.0       | 2024-05-10T00:20:00.000Z | three
+2874.0       | 2024-05-10T00:20:00.000Z | two
+2825.0       | 2024-05-10T00:10:00.000Z | one
+2810.0       | 2024-05-09T23:40:00.000Z | three
+2710.0       | 2024-05-10T00:10:00.000Z | three
+2653.0       | 2024-05-09T23:50:00.000Z | three
+2570.0       | 2024-05-09T23:30:00.000Z | one
+2535.0       | 2024-05-10T00:10:00.000Z | two
+2478.0       | 2024-05-09T23:50:00.000Z | one
 ;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-min-over-time.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-min-over-time.csv-spec
@@ -16,6 +16,25 @@ cost:double | time_bucket:datetime
 33.75       | 2024-05-10T00:11:00.000Z
 ;
 
+min_over_time_of_double_no_grouping_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m cost=(sum(min_over_time(network.cost[1m])))
+| SORT cost DESC, step DESC | LIMIT 10;
+
+cost:double | step:datetime           
+53.625      | 2024-05-10T00:09:00.000Z
+47.875      | 2024-05-10T00:08:00.000Z
+45.0        | 2024-05-10T00:22:00.000Z
+40.375      | 2024-05-10T00:15:00.000Z
+36.0        | 2024-05-10T00:06:00.000Z
+35.75       | 2024-05-10T00:19:00.000Z
+35.125      | 2024-05-10T00:17:00.000Z
+34.0        | 2024-05-10T00:13:00.000Z
+33.875      | 2024-05-10T00:12:00.000Z
+33.75       | 2024-05-10T00:11:00.000Z
+;
+
 min_over_time_of_ip
 required_capability: ts_command_v0
 TS k8s | STATS ip = max(min_over_time(client.ip)) BY time_bucket = bucket(@timestamp,1minute) | SORT time_bucket | LIMIT 10;
@@ -67,6 +86,25 @@ bytes_in:long | time_bucket:datetime
 2430          | 2024-05-10T00:19:00.000Z
 ;
 
+min_over_time_of_long_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m bytes_in=(sum(min_over_time(network.bytes_in[1m])))
+| SORT bytes_in DESC, step | LIMIT 10;
+
+bytes_in:double | step:datetime           
+4903.0          | 2024-05-10T00:20:00.000Z
+3734.0          | 2024-05-10T00:18:00.000Z
+3655.0          | 2024-05-10T00:14:00.000Z
+3519.0          | 2024-05-10T00:15:00.000Z
+3439.0          | 2024-05-10T00:02:00.000Z
+2937.0          | 2024-05-10T00:08:00.000Z
+2909.0          | 2024-05-10T00:03:00.000Z
+2873.0          | 2024-05-10T00:13:00.000Z
+2584.0          | 2024-05-10T00:17:00.000Z
+2430.0          | 2024-05-10T00:19:00.000Z
+;
+
 min_over_time_with_window
 required_capability: ts_command_v0
 required_capability: time_series_window_v1
@@ -99,6 +137,36 @@ bytes_in:long | time_bucket:datetime
 4632          | 2024-05-10T00:19:00.000Z
 ;
 
+min_over_time_with_window_promql
+required_capability: promql_pre_tech_preview_v12
+required_capability: time_series_window_v1
+
+PROMQL index=k8s step=1m bytes_in=(sum(min_over_time(network.bytes_in[3m])))
+| SORT step | LIMIT 20;
+
+bytes_in:double | step:datetime           
+3701.0          | 2024-05-10T00:00:00.000Z
+3925.0          | 2024-05-10T00:01:00.000Z
+3243.0          | 2024-05-10T00:02:00.000Z
+2074.0          | 2024-05-10T00:03:00.000Z
+801.0           | 2024-05-10T00:04:00.000Z
+513.0           | 2024-05-10T00:05:00.000Z
+1569.0          | 2024-05-10T00:06:00.000Z
+1582.0          | 2024-05-10T00:07:00.000Z
+1637.0          | 2024-05-10T00:08:00.000Z
+1226.0          | 2024-05-10T00:09:00.000Z
+2238.0          | 2024-05-10T00:10:00.000Z
+2640.0          | 2024-05-10T00:11:00.000Z
+1517.0          | 2024-05-10T00:12:00.000Z
+2774.0          | 2024-05-10T00:13:00.000Z
+2732.0          | 2024-05-10T00:14:00.000Z
+1665.0          | 2024-05-10T00:15:00.000Z
+779.0           | 2024-05-10T00:16:00.000Z
+1760.0          | 2024-05-10T00:17:00.000Z
+2103.0          | 2024-05-10T00:18:00.000Z
+4632.0          | 2024-05-10T00:19:00.000Z
+;
+
 min_over_time_of_long_grouping
 required_capability: ts_command_v0
 TS k8s | STATS bytes_in = sum(min_over_time(network.bytes_in)) BY cluster, time_bucket = bucket(@timestamp,1minute) | SORT bytes_in DESC, time_bucket | LIMIT 10;
@@ -116,6 +184,25 @@ bytes_in:long | cluster:keyword | time_bucket:datetime
 1409          | staging         | 2024-05-10T00:18:00.000Z
 ;
 
+min_over_time_of_long_grouping_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m bytes_in=(sum by (cluster) (min_over_time(network.bytes_in[1m])))
+| SORT bytes_in DESC, step | LIMIT 10;
+
+bytes_in:double | step:datetime            | cluster:keyword
+2405.0          | 2024-05-10T00:20:00.000Z | prod
+2040.0          | 2024-05-10T00:18:00.000Z | prod
+1908.0          | 2024-05-10T00:20:00.000Z | qa
+1664.0          | 2024-05-10T00:13:00.000Z | prod
+1560.0          | 2024-05-10T00:12:00.000Z | staging
+1553.0          | 2024-05-10T00:19:00.000Z | prod
+1509.0          | 2024-05-10T00:14:00.000Z | staging
+1506.0          | 2024-05-10T00:08:00.000Z | staging
+1498.0          | 2024-05-10T00:02:00.000Z | qa
+1409.0          | 2024-05-10T00:18:00.000Z | staging
+;
+
 min_over_time_of_boolean
 required_capability: ts_command_v0
 TS k8s | STATS eth0_up = max(min_over_time(network.eth0.up)) BY time_bucket = bucket(@timestamp,10minute) | SORT time_bucket | LIMIT 10;
@@ -124,6 +211,18 @@ eth0_up:boolean | time_bucket:datetime
 false           | 2024-05-10T00:00:00.000Z
 true            | 2024-05-10T00:10:00.000Z
 true            | 2024-05-10T00:20:00.000Z
+;
+
+min_over_time_of_boolean_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m eth0_up=(max(min_over_time(network.eth0.up[10m])))
+| SORT step | LIMIT 10;
+
+eth0_up:double | step:datetime           
+0.0            | 2024-05-10T00:00:00.000Z
+1.0            | 2024-05-10T00:10:00.000Z
+1.0            | 2024-05-10T00:20:00.000Z
 ;
 
 min_over_time_of_boolean_grouping
@@ -141,6 +240,25 @@ false           | staging         | 2024-05-10T00:02:00.000Z
 false           | prod            | 2024-05-10T00:03:00.000Z
 true            | qa              | 2024-05-10T00:03:00.000Z
 false           | staging         | 2024-05-10T00:03:00.000Z
+;
+
+min_over_time_of_boolean_grouping_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m eth0_up=(min by (cluster) (min_over_time(network.eth0.up[1m])))
+| SORT step, cluster | LIMIT 10;
+
+eth0_up:double | step:datetime            | cluster:keyword
+0.0            | 2024-05-10T00:00:00.000Z | prod
+1.0            | 2024-05-10T00:00:00.000Z | staging
+0.0            | 2024-05-10T00:01:00.000Z | prod
+0.0            | 2024-05-10T00:01:00.000Z | qa
+0.0            | 2024-05-10T00:02:00.000Z | prod
+1.0            | 2024-05-10T00:02:00.000Z | qa
+0.0            | 2024-05-10T00:02:00.000Z | staging
+0.0            | 2024-05-10T00:03:00.000Z | prod
+1.0            | 2024-05-10T00:03:00.000Z | qa
+0.0            | 2024-05-10T00:03:00.000Z | staging
 ;
 
 min_over_time_of_date_nanos
@@ -228,6 +346,25 @@ clients:double     | time_bucket:datetime
 244.77777777777777 | 2024-05-10T00:09:00.000Z
 ;
 
+min_over_time_of_integer_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m clients=(avg(min_over_time(network.eth0.currently_connected_clients[1m])))
+| SORT step | LIMIT 10;
+
+clients:double     | step:datetime           
+553.3333333333334  | 2024-05-10T00:00:00.000Z
+418.25             | 2024-05-10T00:01:00.000Z
+467.5              | 2024-05-10T00:02:00.000Z
+454.2              | 2024-05-10T00:03:00.000Z
+279.3333333333333  | 2024-05-10T00:04:00.000Z
+590.6              | 2024-05-10T00:05:00.000Z
+578.6666666666666  | 2024-05-10T00:06:00.000Z
+454.6666666666667  | 2024-05-10T00:07:00.000Z
+512.25             | 2024-05-10T00:08:00.000Z
+244.77777777777777 | 2024-05-10T00:09:00.000Z
+;
+
 min_over_time_of_integer_grouping
 required_capability: ts_command_v0
 TS k8s | STATS clients = avg(min_over_time(network.eth0.currently_connected_clients)) BY cluster, time_bucket = bucket(@timestamp,1minute) | SORT time_bucket, cluster | LIMIT 10;
@@ -243,6 +380,25 @@ clients:double | cluster:keyword | time_bucket:datetime
 742.0          | prod            | 2024-05-10T00:03:00.000Z
 407.5          | qa              | 2024-05-10T00:03:00.000Z
 357.0          | staging         | 2024-05-10T00:03:00.000Z
+;
+
+min_over_time_of_integer_grouping_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m clients=(avg by (cluster) (min_over_time(network.eth0.currently_connected_clients[1m])))
+| SORT step, cluster | LIMIT 10;
+
+clients:double | step:datetime            | cluster:keyword
+429.0          | 2024-05-10T00:00:00.000Z | prod
+615.5          | 2024-05-10T00:00:00.000Z | staging
+396.5          | 2024-05-10T00:01:00.000Z | prod
+440.0          | 2024-05-10T00:01:00.000Z | qa
+632.5          | 2024-05-10T00:02:00.000Z | prod
+565.0          | 2024-05-10T00:02:00.000Z | qa
+205.0          | 2024-05-10T00:02:00.000Z | staging
+742.0          | 2024-05-10T00:03:00.000Z | prod
+407.5          | 2024-05-10T00:03:00.000Z | qa
+357.0          | 2024-05-10T00:03:00.000Z | staging
 ;
 
 min_over_time_of_text
@@ -294,7 +450,25 @@ false       | 2024-05-10T00:06:00.000Z
 false       | 2024-05-10T00:07:00.000Z
 false       | 2024-05-10T00:08:00.000Z
 false       | 2024-05-10T00:09:00.000Z
+;
 
+min_over_time_of_keyword_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m pod=(min(min_over_time(network.eth0.up[1m])))
+| SORT step | LIMIT 10;
+
+pod:double | step:datetime           
+0.0        | 2024-05-10T00:00:00.000Z
+0.0        | 2024-05-10T00:01:00.000Z
+0.0        | 2024-05-10T00:02:00.000Z
+0.0        | 2024-05-10T00:03:00.000Z
+0.0        | 2024-05-10T00:04:00.000Z
+0.0        | 2024-05-10T00:05:00.000Z
+0.0        | 2024-05-10T00:06:00.000Z
+0.0        | 2024-05-10T00:07:00.000Z
+0.0        | 2024-05-10T00:08:00.000Z
+0.0        | 2024-05-10T00:09:00.000Z
 ;
 
 min_over_time_of_keyword_grouping
@@ -312,7 +486,25 @@ false       | staging         | 2024-05-10T00:02:00.000Z
 false       | prod            | 2024-05-10T00:03:00.000Z
 true        | qa              | 2024-05-10T00:03:00.000Z
 false       | staging         | 2024-05-10T00:03:00.000Z
+;
 
+min_over_time_of_keyword_grouping_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m pod=(min by (cluster) (min_over_time(network.eth0.up[1m])))
+| SORT step, cluster | LIMIT 10;
+
+pod:double | step:datetime            | cluster:keyword
+0.0        | 2024-05-10T00:00:00.000Z | prod
+1.0        | 2024-05-10T00:00:00.000Z | staging
+0.0        | 2024-05-10T00:01:00.000Z | prod
+0.0        | 2024-05-10T00:01:00.000Z | qa
+0.0        | 2024-05-10T00:02:00.000Z | prod
+1.0        | 2024-05-10T00:02:00.000Z | qa
+0.0        | 2024-05-10T00:02:00.000Z | staging
+0.0        | 2024-05-10T00:03:00.000Z | prod
+1.0        | 2024-05-10T00:03:00.000Z | qa
+0.0        | 2024-05-10T00:03:00.000Z | staging
 ;
 
 min_over_time_of_aggregate_metric_double
@@ -321,6 +513,19 @@ required_capability: aggregate_metric_double_v0
 TS k8s-downsampled | STATS tx = sum(min_over_time(network.eth0.tx)) BY time_bucket = bucket(@timestamp, 10minute) | SORT time_bucket | LIMIT 10;
 
 tx:double | time_bucket:datetime
+3087.0    | 2024-05-09T23:30:00.000Z
+2815.0    | 2024-05-09T23:40:00.000Z
+3085.0    | 2024-05-09T23:50:00.000Z
+;
+
+min_over_time_of_aggregate_metric_double_promql
+required_capability: promql_pre_tech_preview_v12
+required_capability: aggregate_metric_double_v0
+
+PROMQL index=k8s-downsampled step=10m tx=(sum(min_over_time(network.eth0.tx[10m])))
+| SORT step | LIMIT 10;
+
+tx:double | step:datetime           
 3087.0    | 2024-05-09T23:30:00.000Z
 2815.0    | 2024-05-09T23:40:00.000Z
 3085.0    | 2024-05-09T23:50:00.000Z
@@ -343,6 +548,25 @@ tx:double | cluster:keyword | time_bucket:datetime
 1162.0    | staging         | 2024-05-09T23:50:00.000Z
 ;
 
+min_over_time_of_aggregate_metric_double_grouping_promql
+required_capability: promql_pre_tech_preview_v12
+required_capability: aggregate_metric_double_v0
+
+PROMQL index=k8s-downsampled step=10m tx=(sum by (cluster) (min_over_time(network.eth0.tx[10m])))
+| SORT step, cluster | LIMIT 10;
+
+tx:double | step:datetime            | cluster:keyword
+786.0     | 2024-05-09T23:30:00.000Z | prod
+1255.0    | 2024-05-09T23:30:00.000Z | qa
+1046.0    | 2024-05-09T23:30:00.000Z | staging
+870.0     | 2024-05-09T23:40:00.000Z | prod
+938.0     | 2024-05-09T23:40:00.000Z | qa
+1007.0    | 2024-05-09T23:40:00.000Z | staging
+1137.0    | 2024-05-09T23:50:00.000Z | prod
+786.0     | 2024-05-09T23:50:00.000Z | qa
+1162.0    | 2024-05-09T23:50:00.000Z | staging
+;
+
 min_over_time_with_filtering
 required_capability: ts_command_v0
 TS k8s | WHERE pod != "three" | STATS tx = sum(min_over_time(network.bytes_in)) BY cluster, time_bucket = bucket(@timestamp, 10minute) | SORT time_bucket, cluster | LIMIT 10;
@@ -359,6 +583,24 @@ tx:long | cluster:keyword | time_bucket:datetime
 241     | staging         | 2024-05-10T00:20:00.000Z
 ;
 
+min_over_time_with_filtering_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m tx=(sum by (cluster) (min_over_time(network.bytes_in{pod!="three"}[10m])))
+| SORT step, cluster | LIMIT 10;
+
+tx:double | step:datetime            | cluster:keyword
+181.0     | 2024-05-10T00:00:00.000Z | prod
+4.0       | 2024-05-10T00:00:00.000Z | qa
+32.0      | 2024-05-10T00:00:00.000Z | staging
+4.0       | 2024-05-10T00:10:00.000Z | prod
+6.0       | 2024-05-10T00:10:00.000Z | qa
+7.0       | 2024-05-10T00:10:00.000Z | staging
+694.0     | 2024-05-10T00:20:00.000Z | prod
+1110.0    | 2024-05-10T00:20:00.000Z | qa
+241.0     | 2024-05-10T00:20:00.000Z | staging
+;
+
 min_over_time_older_than_10h
 required_capability: ts_command_v0
 required_capability: aggregate_metric_double_v0
@@ -370,6 +612,21 @@ cost:double | pod:keyword | time_bucket:datetime
 382.0       | two         | 2024-05-09T23:30:00.000Z
 684.0       | one         | 2024-05-09T23:40:00.000Z
 690.0       | three       | 2024-05-09T23:40:00.000Z
+;
+
+min_over_time_older_than_10h_promql
+required_capability: promql_pre_tech_preview_v12
+required_capability: aggregate_metric_double_v0
+
+PROMQL index=k8s-downsampled step=10m start="2024-05-09T23:00:00.000Z" end="2024-05-10T00:00:00.000Z" cost=(avg by (pod) (min_over_time(network.eth0.rx{cluster="qa"}[10m])))
+| SORT step, pod | LIMIT 5;
+
+cost:double | step:datetime            | pod:keyword
+329.0       | 2024-05-09T23:30:00.000Z | one
+1.0         | 2024-05-09T23:30:00.000Z | three
+382.0       | 2024-05-09T23:30:00.000Z | two
+684.0       | 2024-05-09T23:40:00.000Z | one
+690.0       | 2024-05-09T23:40:00.000Z | three
 ;
 
 eval_on_min_over_time
@@ -386,6 +643,25 @@ min_bytes:long | pod:keyword | time_bucket:datetime     | kb:double
 451            | one         | 2024-05-10T00:20:00.000Z | 0.451
 1747           | three       | 2024-05-10T00:20:00.000Z | 1.747
 1594           | two         | 2024-05-10T00:20:00.000Z | 1.594
+;
+
+eval_on_min_over_time_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m min_bytes=(sum by (pod) (min_over_time(network.bytes_in[10m])))
+| EVAL kb = min_bytes / 1000.0
+| SORT step, pod | LIMIT 10;
+
+min_bytes:double | step:datetime            | pod:keyword | kb:double
+35.0             | 2024-05-10T00:00:00.000Z | one         | 0.035
+293.0            | 2024-05-10T00:00:00.000Z | three       | 0.293
+182.0            | 2024-05-10T00:00:00.000Z | two         | 0.182
+6.0              | 2024-05-10T00:10:00.000Z | one         | 0.006
+200.0            | 2024-05-10T00:10:00.000Z | three       | 0.2
+11.0             | 2024-05-10T00:10:00.000Z | two         | 0.011
+451.0            | 2024-05-10T00:20:00.000Z | one         | 0.451
+1747.0           | 2024-05-10T00:20:00.000Z | three       | 1.747
+1594.0           | 2024-05-10T00:20:00.000Z | two         | 1.594
 ;
 
 min_over_time_multi_values
@@ -405,6 +681,25 @@ events:long | pod:keyword | time_bucket:datetime
 4           | one         | 2024-05-10T00:06:00.000Z
 ;
 
+min_over_time_multi_values_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m start="2024-05-10T00:00:00.000Z" end="2024-05-10T00:09:00.000Z" events=(sum by (pod) (min_over_time(events_received[1m])))
+| SORT events, step | LIMIT 10;
+
+events:double | step:datetime            | pod:keyword
+0.0           | 2024-05-10T00:07:00.000Z | two
+1.0           | 2024-05-10T00:05:00.000Z | two
+1.0           | 2024-05-10T00:07:00.000Z | one
+2.0           | 2024-05-10T00:04:00.000Z | two
+2.0           | 2024-05-10T00:05:00.000Z | one
+3.0           | 2024-05-10T00:03:00.000Z | one
+3.0           | 2024-05-10T00:04:00.000Z | one
+3.0           | 2024-05-10T00:06:00.000Z | two
+4.0           | 2024-05-10T00:06:00.000Z | one
+4.0           | 2024-05-10T00:08:00.000Z | two
+;
+
 min_over_time_null_values
 required_capability: ts_command_v0
 TS k8s | WHERE @timestamp > "2024-05-10T00:10:00.000Z" and @timestamp < "2024-05-10T00:15:00.000Z" | STATS events = sum(min_over_time(events_received)) by pod, time_bucket = bucket(@timestamp, 1minute) | SORT events NULLS FIRST, time_bucket  | LIMIT 10;
@@ -420,6 +715,27 @@ null        | two         | 2024-05-10T00:13:00.000Z
 7           | three       | 2024-05-10T00:12:00.000Z
 9           | one         | 2024-05-10T00:11:00.000Z
 11          | one         | 2024-05-10T00:10:00.000Z
+;
+
+# PromQL omits buckets with no samples:
+# https://github.com/prometheus/prometheus/blob/14de1eb043f2b264056a9d1426d5db8c068c3b32/promql/functions.go#L1052
+min_over_time_null_values_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m start="2024-05-10T00:10:00.000Z" end="2024-05-10T00:15:00.000Z" events=(sum by (pod) (min_over_time(events_received[1m])))
+| SORT events, step | LIMIT 10;
+
+events:double | step:datetime            | pod:keyword
+2.0           | 2024-05-10T00:11:00.000Z | three
+3.0           | 2024-05-10T00:13:00.000Z | three
+3.0           | 2024-05-10T00:14:00.000Z | three
+5.0           | 2024-05-10T00:11:00.000Z | two
+7.0           | 2024-05-10T00:10:00.000Z | two
+7.0           | 2024-05-10T00:12:00.000Z | three
+9.0           | 2024-05-10T00:11:00.000Z | one
+11.0          | 2024-05-10T00:10:00.000Z | one
+16.0          | 2024-05-10T00:12:00.000Z | two
+16.0          | 2024-05-10T00:13:00.000Z | one
 ;
 
 min_over_time_all_value_types
@@ -438,6 +754,24 @@ events:long | pod:keyword | time_bucket:datetime
 15          | one         | 2024-05-10T00:20:00.000Z
 ;
 
+min_over_time_all_value_types_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m events=(sum by (pod) (min_over_time(events_received[10m])))
+| SORT events, pod, step | LIMIT 10;
+
+events:double | step:datetime            | pod:keyword
+0.0           | 2024-05-10T00:00:00.000Z | one
+2.0           | 2024-05-10T00:00:00.000Z | three
+2.0           | 2024-05-10T00:00:00.000Z | two
+3.0           | 2024-05-10T00:20:00.000Z | two
+4.0           | 2024-05-10T00:10:00.000Z | three
+4.0           | 2024-05-10T00:10:00.000Z | two
+5.0           | 2024-05-10T00:10:00.000Z | one
+13.0          | 2024-05-10T00:20:00.000Z | three
+15.0          | 2024-05-10T00:20:00.000Z | one
+;
+
 min_over_time_aggregate_metric_double_implicit_casting
 required_capability: ts_command_v0
 required_capability: aggregate_metric_double_v0
@@ -450,6 +784,27 @@ bytes:double | time_bucket:datetime
 3111.0       | 2024-05-09T23:50:00.000Z
 4552.0       | 2024-05-10T00:10:00.000Z
 8465.0       | 2024-05-10T00:20:00.000Z
+;
+
+# Awaits fix: index wildcard selector not yet available for PromQL.
+min_over_time_aggregate_metric_double_implicit_casting_promql-Ignore
+required_capability: promql_pre_tech_preview_v12
+required_capability: aggregate_metric_double_v0
+
+PROMQL index=k8s* step=10m bytes=(sum by (pod) (min_over_time(network.eth0.rx[10m])))
+| SORT bytes, pod, step | LIMIT 10;
+
+bytes:double | step:datetime            | pod:keyword
+114.0        | 2024-05-10T00:00:00.000Z | two
+196.0        | 2024-05-10T00:00:00.000Z | three
+225.0        | 2024-05-10T00:00:00.000Z | one
+742.0        | 2024-05-09T23:30:00.000Z | three
+781.0        | 2024-05-09T23:40:00.000Z | two
+947.0        | 2024-05-09T23:30:00.000Z | one
+974.0        | 2024-05-09T23:50:00.000Z | three
+1035.0       | 2024-05-09T23:50:00.000Z | two
+1086.0       | 2024-05-09T23:30:00.000Z | two
+1102.0       | 2024-05-09T23:50:00.000Z | one
 ;
 
 min_over_time_aggregate_metric_double_implicit_casting_grouping
@@ -468,4 +823,25 @@ bytes:double | pod:keyword | time_bucket:datetime
 1035.0       | two         | 2024-05-09T23:50:00.000Z
 1086.0       | two         | 2024-05-09T23:30:00.000Z
 1102.0       | one         | 2024-05-09T23:50:00.000Z
+;
+
+# Awaits fix: index wildcard selector not yet available for PromQL.
+min_over_time_aggregate_metric_double_implicit_casting_grouping_promql-Ignore
+required_capability: promql_pre_tech_preview_v12
+required_capability: aggregate_metric_double_v0
+
+PROMQL index=k8s* step=10m bytes=(sum by (pod) (min_over_time(network.eth0.rx[10m])))
+| SORT bytes, pod, step | LIMIT 10;
+
+bytes:double | step:datetime            | pod:keyword
+114.0        | 2024-05-10T00:00:00.000Z | two
+196.0        | 2024-05-10T00:00:00.000Z | three
+225.0        | 2024-05-10T00:00:00.000Z | one
+742.0        | 2024-05-09T23:30:00.000Z | three
+781.0        | 2024-05-09T23:40:00.000Z | two
+947.0        | 2024-05-09T23:30:00.000Z | one
+974.0        | 2024-05-09T23:50:00.000Z | three
+1035.0       | 2024-05-09T23:50:00.000Z | two
+1086.0       | 2024-05-09T23:30:00.000Z | two
+1102.0       | 2024-05-09T23:50:00.000Z | one
 ;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-min-over-time.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-min-over-time.csv-spec
@@ -614,21 +614,6 @@ cost:double | pod:keyword | time_bucket:datetime
 690.0       | three       | 2024-05-09T23:40:00.000Z
 ;
 
-min_over_time_older_than_10h_promql
-required_capability: promql_pre_tech_preview_v12
-required_capability: aggregate_metric_double_v0
-
-PROMQL index=k8s-downsampled step=10m start="2024-05-09T23:00:00.000Z" end="2024-05-10T00:00:00.000Z" cost=(avg by (pod) (min_over_time(network.eth0.rx{cluster="qa"}[10m])))
-| SORT step, pod | LIMIT 5;
-
-cost:double | step:datetime            | pod:keyword
-329.0       | 2024-05-09T23:30:00.000Z | one
-1.0         | 2024-05-09T23:30:00.000Z | three
-382.0       | 2024-05-09T23:30:00.000Z | two
-684.0       | 2024-05-09T23:40:00.000Z | one
-690.0       | 2024-05-09T23:40:00.000Z | three
-;
-
 eval_on_min_over_time
 required_capability: ts_command_v0
 TS k8s | STATS min_bytes = sum(min_over_time(network.bytes_in)) BY pod, time_bucket = bucket(@timestamp, 10minute) | EVAL kb = to_double(min_bytes) / 1000.0 | LIMIT 10 | SORT time_bucket, pod;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-present-over-time.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-present-over-time.csv-spec
@@ -530,21 +530,6 @@ true       | one         | 2024-05-09T23:40:00.000Z
 true       | three       | 2024-05-09T23:40:00.000Z
 ;
 
-present_over_time_older_than_10d_promql
-required_capability: promql_pre_tech_preview_v12
-required_capability: aggregate_metric_double_v0
-
-PROMQL index=k8s-downsampled step=10m start="2024-05-09T23:00:00.000Z" end="2024-05-10T00:00:00.000Z" is_present=(max by (pod) (present_over_time(network.eth0.rx{cluster="qa"}[10m])))
-| SORT step, pod | LIMIT 5;
-
-is_present:double | step:datetime            | pod:keyword
-1.0               | 2024-05-09T23:30:00.000Z | one
-1.0               | 2024-05-09T23:30:00.000Z | three
-1.0               | 2024-05-09T23:30:00.000Z | two
-1.0               | 2024-05-09T23:40:00.000Z | one
-1.0               | 2024-05-09T23:40:00.000Z | three
-;
-
 eval_on_present_over_time
 required_capability: ts_command_v0
 TS k8s | STATS is_present = max(present_over_time(network.bytes_in)) BY pod, time_bucket = tbucket(10 minute) | EVAL int = to_integer(is_present) | LIMIT 10 | SORT time_bucket, pod;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-present-over-time.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-present-over-time.csv-spec
@@ -20,6 +20,25 @@ true                    | two         | 2024-05-10T00:20:00.000Z
 true                    | two         | 2024-05-10T00:22:00.000Z
 ;
 
+present_over_time_events_received_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=2m start="2024-05-10T00:02:00.000Z" end="2024-05-10T00:22:00.000Z" events_received=(max by (pod) (present_over_time(events_received{cluster="prod",pod="two"}[2m])))
+| SORT step;
+
+ignoreOrder:true
+
+events_received:double | step:datetime            | pod:keyword
+1.0                    | 2024-05-10T00:02:00.000Z | two
+1.0                    | 2024-05-10T00:08:00.000Z | two
+0.0                    | 2024-05-10T00:10:00.000Z | two
+0.0                    | 2024-05-10T00:12:00.000Z | two
+1.0                    | 2024-05-10T00:14:00.000Z | two
+1.0                    | 2024-05-10T00:16:00.000Z | two
+0.0                    | 2024-05-10T00:18:00.000Z | two
+1.0                    | 2024-05-10T00:20:00.000Z | two
+;
+
 present_over_time_of_long
 required_capability: ts_command_v0
 TS k8s | STATS is_present = max(present_over_time(network.bytes_in)) BY cluster, time_bucket = tbucket(10minute) | SORT cluster, time_bucket | LIMIT 10;
@@ -34,6 +53,24 @@ true               | qa              | 2024-05-10T00:20:00.000Z
 true               | staging         | 2024-05-10T00:00:00.000Z
 true               | staging         | 2024-05-10T00:10:00.000Z
 true               | staging         | 2024-05-10T00:20:00.000Z
+;
+
+present_over_time_of_long_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m is_present=(max by (cluster) (present_over_time(network.bytes_in[10m])))
+| SORT cluster, step | LIMIT 10;
+
+is_present:double | step:datetime            | cluster:keyword
+1.0               | 2024-05-10T00:00:00.000Z | prod
+1.0               | 2024-05-10T00:10:00.000Z | prod
+1.0               | 2024-05-10T00:20:00.000Z | prod
+1.0               | 2024-05-10T00:00:00.000Z | qa
+1.0               | 2024-05-10T00:10:00.000Z | qa
+1.0               | 2024-05-10T00:20:00.000Z | qa
+1.0               | 2024-05-10T00:00:00.000Z | staging
+1.0               | 2024-05-10T00:10:00.000Z | staging
+1.0               | 2024-05-10T00:20:00.000Z | staging
 ;
 
 present_over_time_of_boolean
@@ -52,6 +89,24 @@ true          | qa              | 2024-05-10T00:20:00.000Z
 true          | staging         | 2024-05-10T00:20:00.000Z
 ;
 
+present_over_time_of_boolean_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m is_present=(max by (cluster) (present_over_time(network.eth0.up[10m])))
+| SORT step, cluster | LIMIT 10;
+
+is_present:double | step:datetime            | cluster:keyword
+1.0               | 2024-05-10T00:00:00.000Z | prod
+1.0               | 2024-05-10T00:00:00.000Z | qa
+1.0               | 2024-05-10T00:00:00.000Z | staging
+1.0               | 2024-05-10T00:10:00.000Z | prod
+1.0               | 2024-05-10T00:10:00.000Z | qa
+1.0               | 2024-05-10T00:10:00.000Z | staging
+1.0               | 2024-05-10T00:20:00.000Z | prod
+1.0               | 2024-05-10T00:20:00.000Z | qa
+1.0               | 2024-05-10T00:20:00.000Z | staging
+;
+
 present_over_time_of_date_nanos
 required_capability: ts_command_v0
 TS k8s | STATS is_present = max(present_over_time(network.eth0.last_up)) BY cluster, time_bucket = tbucket(10minute) | SORT time_bucket, cluster | LIMIT 10;
@@ -66,6 +121,24 @@ true           | staging         | 2024-05-10T00:10:00.000Z
 true           | prod            | 2024-05-10T00:20:00.000Z
 true           | qa              | 2024-05-10T00:20:00.000Z
 true           | staging         | 2024-05-10T00:20:00.000Z
+;
+
+present_over_time_of_date_nanos_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m is_present=(max by (cluster) (present_over_time(network.eth0.last_up[10m])))
+| SORT step, cluster | LIMIT 10;
+
+is_present:double | step:datetime            | cluster:keyword
+1.0               | 2024-05-10T00:00:00.000Z | prod
+1.0               | 2024-05-10T00:00:00.000Z | qa
+1.0               | 2024-05-10T00:00:00.000Z | staging
+1.0               | 2024-05-10T00:10:00.000Z | prod
+1.0               | 2024-05-10T00:10:00.000Z | qa
+1.0               | 2024-05-10T00:10:00.000Z | staging
+1.0               | 2024-05-10T00:20:00.000Z | prod
+1.0               | 2024-05-10T00:20:00.000Z | qa
+1.0               | 2024-05-10T00:20:00.000Z | staging
 ;
 
 present_over_time_of_date
@@ -84,6 +157,24 @@ true           | qa              | 2024-05-10T00:20:00.000Z
 true           | staging         | 2024-05-10T00:20:00.000Z
 ;
 
+present_over_time_of_date_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m is_present=(max by (cluster) (present_over_time(network.eth0.last_up[10m])))
+| SORT step, cluster | LIMIT 10;
+
+is_present:double | step:datetime            | cluster:keyword
+1.0               | 2024-05-10T00:00:00.000Z | prod
+1.0               | 2024-05-10T00:00:00.000Z | qa
+1.0               | 2024-05-10T00:00:00.000Z | staging
+1.0               | 2024-05-10T00:10:00.000Z | prod
+1.0               | 2024-05-10T00:10:00.000Z | qa
+1.0               | 2024-05-10T00:10:00.000Z | staging
+1.0               | 2024-05-10T00:20:00.000Z | prod
+1.0               | 2024-05-10T00:20:00.000Z | qa
+1.0               | 2024-05-10T00:20:00.000Z | staging
+;
+
 present_over_time_of_version
 required_capability: ts_command_v0
 TS k8s | STATS is_present = max(present_over_time(network.eth0.firmware_version)) BY cluster, time_bucket = tbucket(10minute) | SORT time_bucket, cluster | LIMIT 10;
@@ -98,6 +189,24 @@ true           | staging         | 2024-05-10T00:10:00.000Z
 true           | prod            | 2024-05-10T00:20:00.000Z
 true           | qa              | 2024-05-10T00:20:00.000Z
 true           | staging         | 2024-05-10T00:20:00.000Z
+;
+
+present_over_time_of_version_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m is_present=(max by (cluster) (present_over_time(network.eth0.firmware_version[10m])))
+| SORT step, cluster | LIMIT 10;
+
+is_present:double | step:datetime            | cluster:keyword
+1.0               | 2024-05-10T00:00:00.000Z | prod
+1.0               | 2024-05-10T00:00:00.000Z | qa
+1.0               | 2024-05-10T00:00:00.000Z | staging
+1.0               | 2024-05-10T00:10:00.000Z | prod
+1.0               | 2024-05-10T00:10:00.000Z | qa
+1.0               | 2024-05-10T00:10:00.000Z | staging
+1.0               | 2024-05-10T00:20:00.000Z | prod
+1.0               | 2024-05-10T00:20:00.000Z | qa
+1.0               | 2024-05-10T00:20:00.000Z | staging
 ;
 
 present_over_time_of_integer
@@ -116,6 +225,24 @@ true                | qa              | 2024-05-10T00:20:00.000Z
 true | staging         | 2024-05-10T00:20:00.000Z
 ;
 
+present_over_time_of_integer_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m is_present=(max by (cluster) (present_over_time(network.eth0.currently_connected_clients[10m])))
+| SORT step, cluster | LIMIT 10;
+
+is_present:double | step:datetime            | cluster:keyword
+1.0               | 2024-05-10T00:00:00.000Z | prod
+1.0               | 2024-05-10T00:00:00.000Z | qa
+1.0               | 2024-05-10T00:00:00.000Z | staging
+1.0               | 2024-05-10T00:10:00.000Z | prod
+1.0               | 2024-05-10T00:10:00.000Z | qa
+1.0               | 2024-05-10T00:10:00.000Z | staging
+1.0               | 2024-05-10T00:20:00.000Z | prod
+1.0               | 2024-05-10T00:20:00.000Z | qa
+1.0               | 2024-05-10T00:20:00.000Z | staging
+;
+
 present_over_time_of_text
 required_capability: ts_command_v0
 TS k8s | STATS is_present = max(present_over_time(event_log)) BY cluster, time_bucket = tbucket(10minute) | SORT cluster, time_bucket | LIMIT 10;
@@ -132,6 +259,24 @@ true               | staging         | 2024-05-10T00:10:00.000Z
 true               | staging         | 2024-05-10T00:20:00.000Z
 ;
 
+present_over_time_of_text_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m is_present=(max by (cluster) (present_over_time(event_log[10m])))
+| SORT cluster, step | LIMIT 10;
+
+is_present:double | step:datetime            | cluster:keyword
+1.0               | 2024-05-10T00:00:00.000Z | prod
+1.0               | 2024-05-10T00:10:00.000Z | prod
+1.0               | 2024-05-10T00:20:00.000Z | prod
+1.0               | 2024-05-10T00:00:00.000Z | qa
+1.0               | 2024-05-10T00:10:00.000Z | qa
+1.0               | 2024-05-10T00:20:00.000Z | qa
+1.0               | 2024-05-10T00:00:00.000Z | staging
+1.0               | 2024-05-10T00:10:00.000Z | staging
+1.0               | 2024-05-10T00:20:00.000Z | staging
+;
+
 present_over_time_of_keyword
 required_capability: ts_command_v0
 TS k8s | STATS is_present = max(present_over_time(network.eth0.up)) BY cluster, time_bucket = tbucket(10minute) | SORT time_bucket, cluster | LIMIT 10;
@@ -146,6 +291,24 @@ true     | staging         | 2024-05-10T00:10:00.000Z
 true     | prod            | 2024-05-10T00:20:00.000Z
 true     | qa              | 2024-05-10T00:20:00.000Z
 true     | staging         | 2024-05-10T00:20:00.000Z
+;
+
+present_over_time_of_keyword_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m is_present=(max by (cluster) (present_over_time(network.eth0.up[10m])))
+| SORT step, cluster | LIMIT 10;
+
+is_present:double | step:datetime            | cluster:keyword
+1.0               | 2024-05-10T00:00:00.000Z | prod
+1.0               | 2024-05-10T00:00:00.000Z | qa
+1.0               | 2024-05-10T00:00:00.000Z | staging
+1.0               | 2024-05-10T00:10:00.000Z | prod
+1.0               | 2024-05-10T00:10:00.000Z | qa
+1.0               | 2024-05-10T00:10:00.000Z | staging
+1.0               | 2024-05-10T00:20:00.000Z | prod
+1.0               | 2024-05-10T00:20:00.000Z | qa
+1.0               | 2024-05-10T00:20:00.000Z | staging
 ;
 
 present_over_time_of_aggregate_metric_double
@@ -165,6 +328,25 @@ true      | qa              | 2024-05-09T23:50:00.000Z
 true      | staging         | 2024-05-09T23:50:00.000Z
 ;
 
+present_over_time_of_aggregate_metric_double_promql
+required_capability: promql_pre_tech_preview_v12
+required_capability: aggregate_metric_double_v0
+
+PROMQL index=k8s-downsampled step=10m is_present=(max by (cluster) (present_over_time(network.eth0.tx[10m])))
+| SORT step, cluster | LIMIT 10;
+
+is_present:double | step:datetime            | cluster:keyword
+1.0               | 2024-05-09T23:30:00.000Z | prod
+1.0               | 2024-05-09T23:30:00.000Z | qa
+1.0               | 2024-05-09T23:30:00.000Z | staging
+1.0               | 2024-05-09T23:40:00.000Z | prod
+1.0               | 2024-05-09T23:40:00.000Z | qa
+1.0               | 2024-05-09T23:40:00.000Z | staging
+1.0               | 2024-05-09T23:50:00.000Z | prod
+1.0               | 2024-05-09T23:50:00.000Z | qa
+1.0               | 2024-05-09T23:50:00.000Z | staging
+;
+
 present_over_time_of_geopoint
 required_capability: ts_command_v0
 TS k8s | STATS is_present = max(present_over_time(event_city)) BY cluster, time_bucket = tbucket(10minute) | SORT time_bucket, cluster | LIMIT 10;
@@ -179,6 +361,24 @@ true       | staging         | 2024-05-10T00:10:00.000Z
 true       | prod            | 2024-05-10T00:20:00.000Z
 true       | qa              | 2024-05-10T00:20:00.000Z
 true       | staging         | 2024-05-10T00:20:00.000Z
+;
+
+present_over_time_of_geopoint_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m is_present=(max by (cluster) (present_over_time(event_city[10m])))
+| SORT step, cluster | LIMIT 10;
+
+is_present:double | step:datetime            | cluster:keyword
+1.0               | 2024-05-10T00:00:00.000Z | prod
+1.0               | 2024-05-10T00:00:00.000Z | qa
+1.0               | 2024-05-10T00:00:00.000Z | staging
+1.0               | 2024-05-10T00:10:00.000Z | prod
+1.0               | 2024-05-10T00:10:00.000Z | qa
+1.0               | 2024-05-10T00:10:00.000Z | staging
+1.0               | 2024-05-10T00:20:00.000Z | prod
+1.0               | 2024-05-10T00:20:00.000Z | qa
+1.0               | 2024-05-10T00:20:00.000Z | staging
 ;
 
 present_over_time_of_geoshape
@@ -197,6 +397,24 @@ true       | qa              | 2024-05-10T00:20:00.000Z
 true       | staging         | 2024-05-10T00:20:00.000Z
 ;
 
+present_over_time_of_geoshape_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m is_present=(max by (cluster) (present_over_time(event_city_boundary[10m])))
+| SORT step, cluster | LIMIT 10;
+
+is_present:double | step:datetime            | cluster:keyword
+1.0               | 2024-05-10T00:00:00.000Z | prod
+1.0               | 2024-05-10T00:00:00.000Z | qa
+1.0               | 2024-05-10T00:00:00.000Z | staging
+1.0               | 2024-05-10T00:10:00.000Z | prod
+1.0               | 2024-05-10T00:10:00.000Z | qa
+1.0               | 2024-05-10T00:10:00.000Z | staging
+1.0               | 2024-05-10T00:20:00.000Z | prod
+1.0               | 2024-05-10T00:20:00.000Z | qa
+1.0               | 2024-05-10T00:20:00.000Z | staging
+;
+
 present_over_time_of_shape
 required_capability: ts_command_v0
 TS k8s | STATS is_present = max(present_over_time(event_shape)) BY cluster, time_bucket = tbucket(10minute) | SORT time_bucket, cluster | LIMIT 10;
@@ -211,6 +429,24 @@ true       | staging         | 2024-05-10T00:10:00.000Z
 true       | prod            | 2024-05-10T00:20:00.000Z
 true       | qa              | 2024-05-10T00:20:00.000Z
 true       | staging         | 2024-05-10T00:20:00.000Z
+;
+
+present_over_time_of_shape_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m is_present=(max by (cluster) (present_over_time(event_shape[10m])))
+| SORT step, cluster | LIMIT 10;
+
+is_present:double | step:datetime            | cluster:keyword
+1.0               | 2024-05-10T00:00:00.000Z | prod
+1.0               | 2024-05-10T00:00:00.000Z | qa
+1.0               | 2024-05-10T00:00:00.000Z | staging
+1.0               | 2024-05-10T00:10:00.000Z | prod
+1.0               | 2024-05-10T00:10:00.000Z | qa
+1.0               | 2024-05-10T00:10:00.000Z | staging
+1.0               | 2024-05-10T00:20:00.000Z | prod
+1.0               | 2024-05-10T00:20:00.000Z | qa
+1.0               | 2024-05-10T00:20:00.000Z | staging
 ;
 
 present_over_time_of_point
@@ -229,6 +465,24 @@ true       | qa              | 2024-05-10T00:20:00.000Z
 true       | staging         | 2024-05-10T00:20:00.000Z
 ;
 
+present_over_time_of_point_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m is_present=(max by (cluster) (present_over_time(event_location[10m])))
+| SORT step, cluster | LIMIT 10;
+
+is_present:double | step:datetime            | cluster:keyword
+1.0               | 2024-05-10T00:00:00.000Z | prod
+1.0               | 2024-05-10T00:00:00.000Z | qa
+1.0               | 2024-05-10T00:00:00.000Z | staging
+1.0               | 2024-05-10T00:10:00.000Z | prod
+1.0               | 2024-05-10T00:10:00.000Z | qa
+1.0               | 2024-05-10T00:10:00.000Z | staging
+1.0               | 2024-05-10T00:20:00.000Z | prod
+1.0               | 2024-05-10T00:20:00.000Z | qa
+1.0               | 2024-05-10T00:20:00.000Z | staging
+;
+
 present_over_time_with_filtering
 required_capability: ts_command_v0
 TS k8s | WHERE pod != "three" | STATS is_present = max(present_over_time(network.bytes_in)) BY cluster, time_bucket = tbucket(10 minute) | SORT time_bucket, cluster | LIMIT 10;
@@ -245,6 +499,24 @@ true      | qa              | 2024-05-10T00:20:00.000Z
 true      | staging         | 2024-05-10T00:20:00.000Z
 ;
 
+present_over_time_with_filtering_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m is_present=(max by (cluster) (present_over_time(network.bytes_in{pod!="three"}[10m])))
+| SORT step, cluster | LIMIT 10;
+
+is_present:double | step:datetime            | cluster:keyword
+1.0               | 2024-05-10T00:00:00.000Z | prod
+1.0               | 2024-05-10T00:00:00.000Z | qa
+1.0               | 2024-05-10T00:00:00.000Z | staging
+1.0               | 2024-05-10T00:10:00.000Z | prod
+1.0               | 2024-05-10T00:10:00.000Z | qa
+1.0               | 2024-05-10T00:10:00.000Z | staging
+1.0               | 2024-05-10T00:20:00.000Z | prod
+1.0               | 2024-05-10T00:20:00.000Z | qa
+1.0               | 2024-05-10T00:20:00.000Z | staging
+;
+
 present_over_time_older_than_10d
 required_capability: ts_command_v0
 required_capability: aggregate_metric_double_v0
@@ -256,6 +528,21 @@ true       | three       | 2024-05-09T23:30:00.000Z
 true       | two         | 2024-05-09T23:30:00.000Z
 true       | one         | 2024-05-09T23:40:00.000Z
 true       | three       | 2024-05-09T23:40:00.000Z
+;
+
+present_over_time_older_than_10d_promql
+required_capability: promql_pre_tech_preview_v12
+required_capability: aggregate_metric_double_v0
+
+PROMQL index=k8s-downsampled step=10m start="2024-05-09T23:00:00.000Z" end="2024-05-10T00:00:00.000Z" is_present=(max by (pod) (present_over_time(network.eth0.rx{cluster="qa"}[10m])))
+| SORT step, pod | LIMIT 5;
+
+is_present:double | step:datetime            | pod:keyword
+1.0               | 2024-05-09T23:30:00.000Z | one
+1.0               | 2024-05-09T23:30:00.000Z | three
+1.0               | 2024-05-09T23:30:00.000Z | two
+1.0               | 2024-05-09T23:40:00.000Z | one
+1.0               | 2024-05-09T23:40:00.000Z | three
 ;
 
 eval_on_present_over_time
@@ -272,6 +559,25 @@ true             | two         | 2024-05-10T00:10:00.000Z | 1
 true             | one         | 2024-05-10T00:20:00.000Z | 1
 true             | three       | 2024-05-10T00:20:00.000Z | 1
 true             | two         | 2024-05-10T00:20:00.000Z | 1
+;
+
+eval_on_present_over_time_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m is_present=(max by (pod) (present_over_time(network.bytes_in[10m])))
+| EVAL int = to_integer(is_present)
+| SORT step, pod | LIMIT 10;
+
+is_present:double | step:datetime            | pod:keyword | int:integer
+1.0               | 2024-05-10T00:00:00.000Z | one         | 1
+1.0               | 2024-05-10T00:00:00.000Z | three       | 1
+1.0               | 2024-05-10T00:00:00.000Z | two         | 1
+1.0               | 2024-05-10T00:10:00.000Z | one         | 1
+1.0               | 2024-05-10T00:10:00.000Z | three       | 1
+1.0               | 2024-05-10T00:10:00.000Z | two         | 1
+1.0               | 2024-05-10T00:20:00.000Z | one         | 1
+1.0               | 2024-05-10T00:20:00.000Z | three       | 1
+1.0               | 2024-05-10T00:20:00.000Z | two         | 1
 ;
 
 present_over_time_events_received_as_integer
@@ -294,4 +600,23 @@ events_received:integer | pod:keyword | time_bucket:datetime
 0                       | two         | 2024-05-10T00:18:00.000Z
 1                       | two         | 2024-05-10T00:20:00.000Z
 1                       | two         | 2024-05-10T00:22:00.000Z
+;
+
+present_over_time_events_received_as_integer_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=2m start="2024-05-10T00:02:00.000Z" end="2024-05-10T00:22:00.000Z" events_received=(max by (pod) (present_over_time(events_received{cluster="prod",pod="two"}[2m])))
+| SORT step;
+
+ignoreOrder:true
+
+events_received:double | step:datetime            | pod:keyword
+1.0                    | 2024-05-10T00:02:00.000Z | two
+1.0                    | 2024-05-10T00:08:00.000Z | two
+0.0                    | 2024-05-10T00:10:00.000Z | two
+0.0                    | 2024-05-10T00:12:00.000Z | two
+1.0                    | 2024-05-10T00:14:00.000Z | two
+1.0                    | 2024-05-10T00:16:00.000Z | two
+0.0                    | 2024-05-10T00:18:00.000Z | two
+1.0                    | 2024-05-10T00:20:00.000Z | two
 ;


### PR DESCRIPTION
Summary:

PromQL currently has lower integration test coverage compared to ESQL.
This change adds initial PromQL integration tests for the `sum_over_time()` and `rate()` functions.

NOTE: Some test cases defined in the specs are not yet supported by the PromQL implementation. Those cases are intentionally left **disabled** and annotated with an `Awaits-fix` comment.


Plan:

As part of issue [#260](https://github.com/elastic/metrics-program/issues/260), the planned work includes adding coverage across multiple test types.

CSV-spec test files

* [x] `k8s-timeseries-sum-over-time.csv-spec` (#140204)
* [x] `k8s-timeseries-rate.csv-spec` (#140204)
* [x] `k8s-timeseries-present-over-time.csv-spec`(this change)
* [x] `k8s-timeseries-min-over-time.csv-spec` (this change)
* [x] `k8s-timeseries-count-over-time.csv-spec` (this change)
* [x] `k8s-timeseries-max-over-time.csv-spec` (this change)
* [ ] `k8s-timeseries-last-over-time.csv-spec`
* [ ] `k8s-timeseries-irate.csv-spec`
* [ ] `k8s-timeseries-increase.csv-spec`
* [ ] `k8s-timeseries-idelta.csv-spec`
* [ ] `k8s-timeseries-first-over-time.csv-spec`
* [ ] `k8s-timeseries-delta.csv-spec`
* [ ] `k8s-timeseries-clamp.csv-spec`
* [ ] `k8s-timeseries-absent-over-time.csv-spec`

Other test types

* [ ] **YAML REST tests**
  `x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_tsdb.yml`
* [ ] **Java integration tests**
  `RandomizedTimeSeriesIT.java`
* [ ] **Generative tests**
  `GenerativeMetricsIT.java` (handled separately by @limotova)


Test Plan:

```bash
./gradlew :x-pack:plugin:esql:qa:server:single-node:javaRestTest \
  --tests "org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecIT"
```
