### PR TITLE
feat(slo): add slo-observability.health index privileges

### DIFF
--- a/docs/changelog/140392.yml
+++ b/docs/changelog/140392.yml
@@ -1,0 +1,5 @@
+pr: 140392
+summary: "Configure `slo-observability.health` index permissions for reserved roles and kibana internal user"
+area: Authentication
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -649,7 +649,10 @@ class KibanaOwnedReservedRoleDescriptors {
                     .build(),
                 // SLO observability solution internal indices
                 // Kibana system user uses them to read / write slo data.
-                RoleDescriptor.IndicesPrivileges.builder().indices(".slo-observability.*", "slo-observability.health").privileges("all").build(),
+                RoleDescriptor.IndicesPrivileges.builder()
+                    .indices(".slo-observability.*", "slo-observability.health")
+                    .privileges("all")
+                    .build(),
                 // Endpoint heartbeat. Kibana reads from these to determine metering/billing for
                 // endpoints.
                 RoleDescriptor.IndicesPrivileges.builder().indices(".logs-endpoint.heartbeat-*").privileges("read", "create_index").build(),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -649,7 +649,7 @@ class KibanaOwnedReservedRoleDescriptors {
                     .build(),
                 // SLO observability solution internal indices
                 // Kibana system user uses them to read / write slo data.
-                RoleDescriptor.IndicesPrivileges.builder().indices(".slo-observability.*").privileges("all").build(),
+                RoleDescriptor.IndicesPrivileges.builder().indices(".slo-observability.*", "slo-observability.health").privileges("all").build(),
                 // Endpoint heartbeat. Kibana reads from these to determine metering/billing for
                 // endpoints.
                 RoleDescriptor.IndicesPrivileges.builder().indices(".logs-endpoint.heartbeat-*").privileges("read", "create_index").build(),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -769,7 +769,7 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                     .build(),
                 // Observability
                 RoleDescriptor.IndicesPrivileges.builder()
-                    .indices(".slo-observability.*")
+                    .indices(".slo-observability.*", "slo-observability.health")
                     .privileges("read", "view_index_metadata")
                     .build(),
                 // Security
@@ -835,7 +835,7 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                     .privileges("read", "view_index_metadata", "write")
                     .build(),
                 RoleDescriptor.IndicesPrivileges.builder()
-                    .indices(".slo-observability.*")
+                    .indices(".slo-observability.*", "slo-observability.health")
                     .privileges("read", "view_index_metadata", "write", "manage")
                     .build(),
                 // Security

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -629,7 +629,8 @@ public class ReservedRolesStoreTests extends ESTestCase {
             ReservedRolesStore.LISTS_INDEX_REINDEXED_V8 + randomAlphaOfLength(randomIntBetween(0, 13)),
             ReservedRolesStore.LISTS_ITEMS_INDEX + randomAlphaOfLength(randomIntBetween(0, 13)),
             ReservedRolesStore.LISTS_ITEMS_INDEX_REINDEXED_V8 + randomAlphaOfLength(randomIntBetween(0, 13)),
-            ".slo-observability." + randomAlphaOfLength(randomIntBetween(0, 13))
+            ".slo-observability." + randomAlphaOfLength(randomIntBetween(0, 13)),
+            "slo-observability.health"
         ).forEach(index -> assertAllIndicesAccessAllowed(kibanaRole, index));
 
         Arrays.asList(
@@ -3860,6 +3861,8 @@ public class ReservedRolesStoreTests extends ESTestCase {
 
         assertOnlyReadAllowed(role, ".slo-observability." + randomIntBetween(0, 5));
         assertViewIndexMetadata(role, ".slo-observability." + randomIntBetween(0, 5));
+        assertOnlyReadAllowed(role, "slo-observability.health");
+        assertViewIndexMetadata(role, "slo-observability.health");
 
         assertNoAccessAllowed(role, TestRestrictedIndices.SAMPLE_RESTRICTED_NAMES);
         assertNoAccessAllowed(role, "." + randomAlphaOfLengthBetween(6, 10));
@@ -3944,6 +3947,8 @@ public class ReservedRolesStoreTests extends ESTestCase {
 
         assertViewIndexMetadata(role, ".slo-observability." + randomIntBetween(0, 5));
         assertReadWriteAndManage(role, ".slo-observability." + randomIntBetween(0, 5));
+        assertViewIndexMetadata(role, "slo-observability.health");
+        assertReadWriteAndManage(role, "slo-observability.health");
 
         assertNoAccessAllowed(role, TestRestrictedIndices.SAMPLE_RESTRICTED_NAMES);
         assertNoAccessAllowed(role, "." + randomAlphaOfLengthBetween(6, 10));


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/248348

## Summary

This PR updates the kibana internal user privileges for the `slo-observability.health` index (datastream), as well as the custom roles (editor, viewer) privileges.


