### PR TITLE
Remove coupling routing and reindex rest test

### DIFF
--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/35_search_failures.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/35_search_failures.yml
@@ -33,7 +33,9 @@
   - match: {error.phase: query}
   - match: {error.root_cause.0.type:   script_exception}
   - match: {error.root_cause.0.reason: runtime error}
-  - match: {error.failed_shards.0.shard: 0}
+  # The shard number can vary based on the shard routing function version. Just check that it's between 0 and 1.
+  - gte: { error.failed_shards.0.shard: 0 }
+  - lte: { error.failed_shards.0.shard: 1 }
   - match: {error.failed_shards.0.index:  source}
   - is_true: error.failed_shards.0.node
   - match: {error.failed_shards.0.reason.type:   script_exception}

--- a/server/src/main/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MultiValuedBinaryDocValuesField.java
@@ -54,7 +54,7 @@ public abstract class MultiValuedBinaryDocValuesField extends CustomDocValuesFie
     protected void writeLenAndValues(BytesStreamOutput out) throws IOException {
         // sort the ArrayList variant of the collection prior to serializing it into a binary array
         if (values instanceof ArrayList<BytesRef> list) {
-           list.sort(Comparator.naturalOrder());
+            list.sort(Comparator.naturalOrder());
         }
 
         for (BytesRef value : values) {


### PR DESCRIPTION
Currently a reindex rest compatibility test depends on specific shard
routing. This is not behavior we guarantee and it should be removed.