### PR TITLE
Added cluster feature for sorted binary doc values

### DIFF
--- a/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/match_only_text/10_basic.yml
+++ b/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/match_only_text/10_basic.yml
@@ -438,8 +438,8 @@ synthetic_source match_only_text as multi-field:
 ---
 synthetic_source match_only_text as multi-field with ignored keyword as parent:
   - requires:
-      cluster_features: [ "mapper.source.mode_from_index_setting" ]
-      reason: "Source mode configured through index setting"
+      cluster_features: [ "mapper.source.mode_from_index_setting", "mapper.sorted_binary_doc_values" ]
+      reason: "Source mode configured through index setting. Fallback keyword fields now use sorted binary doc values"
 
   - do:
       indices.create:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/20_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/20_synthetic_source.yml
@@ -1071,6 +1071,10 @@ synthetic_source with disabled doc_values:
 
 ---
 fallback synthetic_source for text field:
+  - requires:
+      cluster_features: ["mapper.sorted_binary_doc_values"]
+      reason: "fallback text fields now use sorted binary doc values"
+
   - do:
       indices.create:
         index: test

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mget/90_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mget/90_synthetic_source.yml
@@ -236,6 +236,10 @@ keyword with non-lowercase normalizer:
 
 ---
 keyword with normalizer and skip store original value:
+  - requires:
+      cluster_features: [ "mapper.sorted_binary_doc_values" ]
+      reason: "fallback keyword fields now use sorted binary doc values"
+
   - do:
       indices.create:
         index: test-keyword-with-normalizer
@@ -325,6 +329,10 @@ keyword with normalizer and skip store original value:
 ---
 
 keyword with built-in normalizer:
+  - requires:
+      cluster_features: [ "mapper.sorted_binary_doc_values" ]
+      reason: "fallback text fields now use sorted binary doc values"
+
   - do:
       indices.create:
         index: test-keyword-with-normalizer

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -69,6 +69,7 @@ public class MapperFeatures implements FeatureSpecification {
         "mapper.keyword.store_high_cardinality_in_binary_doc_values"
     );
     static final NodeFeature TDIGEST_TYPE = new NodeFeature("mapper.tdigest_type");
+    static final NodeFeature SORTED_BINARY_DOC_VALUES = new NodeFeature("mapper.sorted_binary_doc_values");
 
     @Override
     public Set<NodeFeature> getTestFeatures() {
@@ -119,7 +120,8 @@ public class MapperFeatures implements FeatureSpecification {
             GENERIC_VECTOR_FORMAT,
             EXPONENTIAL_HISTOGRAM_TYPE,
             STORE_HIGH_CARDINALITY_KEYWORDS_IN_BINARY_DOC_VALUES,
-            TDIGEST_TYPE
+            TDIGEST_TYPE,
+            SORTED_BINARY_DOC_VALUES
         );
     }
 }


### PR DESCRIPTION
Followed https://github.com/elastic/elasticsearch/blob/8f1a4809da8ab960fd9926d3e98489f97305466d/REST_API_COMPATIBILITY.md to skip rest bwc tests in https://github.com/elastic/elasticsearch/pull/140244. Now making the change in 9.3 so the skips can be removed from 9.4.