### PR TITLE
Fix Docker build to use --load for single-platform images

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/docker/DockerBuildTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/docker/DockerBuildTask.java
@@ -227,6 +227,12 @@ public abstract class DockerBuildTask extends DefaultTask {
 
                 if (parameters.getPush().getOrElse(false)) {
                     spec.args("--push");
+                } else if (!isCrossPlatform) {
+                    // For single-platform builds, add --load to ensure the image is loaded into
+                    // the local Docker daemon as a regular image, not a manifest list.
+                    // This prevents issues with newer Docker versions (23.0+) that may create
+                    // manifest lists even for single-platform builds when BuildKit is enabled.
+                    spec.args("--load");
                 }
             });
 


### PR DESCRIPTION
Add --load flag to single-platform Docker builds to ensure images are
loaded into the local Docker daemon as regular images rather than
manifest lists.

This fixes an issue with Docker 23.0+ where BuildKit-enabled builds
can create manifest lists even for single-platform builds, which breaks
the docker manifest create command that expects single-platform images
as input when creating multi-arch manifests.

The --load flag forces the built image to be loaded into the local
Docker image store, preventing it from being stored as a manifest list.