### PR TITLE
Fixed text block loader tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/blockloader/TextFieldBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/blockloader/TextFieldBlockLoaderTests.java
@@ -106,8 +106,27 @@ public class TextFieldBlockLoaderTests extends BlockLoaderTestCase {
             }
         }
 
+        // Loading from fallback binary doc values, which are sorted by default
+        if (params.syntheticSource()) {
+            return valuesInSortedOrder(value);
+        }
+
         // Loading from stored field, _ignored_source or stored _source
         return valuesInSourceOrder(value);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Object valuesInSortedOrder(Object value) {
+        if (value == null) {
+            return null;
+        }
+
+        if (value instanceof String s) {
+            return new BytesRef(s);
+        }
+
+        var resultList = ((List<String>) value).stream().filter(Objects::nonNull).map(BytesRef::new).sorted().toList();
+        return maybeFoldList(resultList);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Some edge cases weren't caught by the CI in https://github.com/elastic/elasticsearch/pull/140244.

For example:

```
./gradlew ":server:test" --tests "org.elasticsearch.index.mapper.blockloader.TextFieldBlockLoaderTests.testBlockLoader {preference=Params[syntheticSource=true, preference=STORED]}" -Dtests.seed=B6CB6947956FEEB4 -Dtests.locale=os-RU -Dtests.timezone=America/Panama -Druntime.java=25
```