### PR TITLE
[9.1] Unmuting test to check it's status (#140226)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -152,9 +152,6 @@ tests:
 - class: org.elasticsearch.multiproject.test.CoreWithMultipleProjectsClientYamlTestSuiteIT
   method: test {yaml=search.vectors/41_knn_search_byte_quantized/kNN search plus query}
   issue: https://github.com/elastic/elasticsearch/issues/124687
-- class: org.elasticsearch.packaging.test.BootstrapCheckTests
-  method: test20RunWithBootstrapChecks
-  issue: https://github.com/elastic/elasticsearch/issues/124940
 - class: org.elasticsearch.index.shard.StoreRecoveryTests
   method: testAddIndices
   issue: https://github.com/elastic/elasticsearch/issues/124104


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Unmuting test to check it's status (#140226)](https://github.com/elastic/elasticsearch/pull/140226)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)