### PR TITLE
Unmute TextFieldBlockLoaderTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -324,15 +324,6 @@ tests:
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test072RunEsAsDifferentUserAndGroup
   issue: https://github.com/elastic/elasticsearch/issues/140127
-- class: org.elasticsearch.index.mapper.blockloader.TextFieldBlockLoaderTests
-  method: testBlockLoaderForFieldInObject {preference=Params[syntheticSource=true, preference=NONE]}
-  issue: https://github.com/elastic/elasticsearch/issues/140411
-- class: org.elasticsearch.index.mapper.blockloader.TextFieldBlockLoaderTests
-  method: testBlockLoaderForFieldInObject {preference=Params[syntheticSource=true, preference=STORED]}
-  issue: https://github.com/elastic/elasticsearch/issues/140412
-- class: org.elasticsearch.index.mapper.blockloader.TextFieldBlockLoaderTests
-  method: testBlockLoaderForFieldInObject {preference=Params[syntheticSource=true, preference=DOC_VALUES]}
-  issue: https://github.com/elastic/elasticsearch/issues/140413
 
 # Examples:
 #


### PR DESCRIPTION
I got the [fix](https://github.com/elastic/elasticsearch/pull/140408) in before these were muted, but somehow they were muted anyway.

This addresses:
- https://github.com/elastic/elasticsearch/issues/140413
- https://github.com/elastic/elasticsearch/issues/140411
- https://github.com/elastic/elasticsearch/issues/140412