### PR TITLE
[9.2] [Inference API] Include rerank in supported tasks for IBM watsonx integration (#140331)

### DIFF
--- a/docs/changelog/140331.yaml
+++ b/docs/changelog/140331.yaml
@@ -1,0 +1,6 @@
+pr: 140331
+summary: "[Inference API] Include rerank in supported tasks for IBM watsonx integration"
+area: Inference
+type: bug
+issues:
+ - 140328

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_watsonx.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_watsonx.json
@@ -28,7 +28,8 @@
               "options": [
                 "text_embedding",
                 "chat_completion",
-                "completion"
+                "completion",
+                "rerank"
               ]
             },
             "watsonx_inference_id": {

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceGetServicesIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceGetServicesIT.java
@@ -141,6 +141,7 @@ public class InferenceGetServicesIT extends BaseMockEISAuthServerTest {
                     "jinaai",
                     "test_reranking_service",
                     "voyageai",
+                    "watsonxai",
                     "hugging_face",
                     "amazon_sagemaker",
                     "elastic"

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxService.java
@@ -25,6 +25,7 @@ import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
+import org.elasticsearch.inference.RerankingInferenceService;
 import org.elasticsearch.inference.SettingsConfiguration;
 import org.elasticsearch.inference.SimilarityMeasure;
 import org.elasticsearch.inference.TaskType;
@@ -69,20 +70,27 @@ import static org.elasticsearch.xpack.inference.services.ibmwatsonx.IbmWatsonxSe
 import static org.elasticsearch.xpack.inference.services.ibmwatsonx.IbmWatsonxServiceFields.EMBEDDING_MAX_BATCH_SIZE;
 import static org.elasticsearch.xpack.inference.services.ibmwatsonx.IbmWatsonxServiceFields.PROJECT_ID;
 
-public class IbmWatsonxService extends SenderService {
-
-    public static final String NAME = "watsonxai";
+public class IbmWatsonxService extends SenderService implements RerankingInferenceService {
 
     private static final String SERVICE_NAME = "IBM watsonx";
     private static final EnumSet<TaskType> supportedTaskTypes = EnumSet.of(
         TaskType.TEXT_EMBEDDING,
         TaskType.COMPLETION,
-        TaskType.CHAT_COMPLETION
+        TaskType.CHAT_COMPLETION,
+        TaskType.RERANK
     );
     private static final ResponseHandler UNIFIED_CHAT_COMPLETION_HANDLER = new IbmWatsonUnifiedChatCompletionResponseHandler(
         "IBM watsonx chat completions",
         OpenAiChatCompletionResponseEntity::fromResponse
     );
+
+    public static final String NAME = "watsonxai";
+
+    // IBM watsonx has a single rerank model with a token limit of 512
+    // (see https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models-embed.html?context=wx#reranker-overview)
+    // Using 1 token = 0.75 words as a rough estimate, we get 384 words
+    // allowing for some headroom, we set the window size below 384 words
+    public static final int RERANK_WINDOW_SIZE = 350;
 
     public IbmWatsonxService(
         HttpRequestSender.Factory factory,
@@ -361,6 +369,11 @@ public class IbmWatsonxService extends SenderService {
 
     protected IbmWatsonxActionCreator getActionCreator(Sender sender, ServiceComponents serviceComponents) {
         return new IbmWatsonxActionCreator(getSender(), getServiceComponents());
+    }
+
+    @Override
+    public int rerankerWindowSize(String modelId) {
+        return RERANK_WINDOW_SIZE;
     }
 
     public static class Configuration {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxServiceTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
 import org.elasticsearch.inference.ModelConfigurations;
+import org.elasticsearch.inference.RerankingInferenceService;
 import org.elasticsearch.inference.SimilarityMeasure;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.test.http.MockResponse;
@@ -82,6 +83,7 @@ import static org.elasticsearch.xpack.inference.external.http.Utils.getUrl;
 import static org.elasticsearch.xpack.inference.services.SenderServiceTests.createMockSender;
 import static org.elasticsearch.xpack.inference.services.ServiceComponentsTests.createWithEmptySettings;
 import static org.elasticsearch.xpack.inference.services.cohere.embeddings.CohereEmbeddingsTaskSettingsTests.getTaskSettingsMapEmpty;
+import static org.elasticsearch.xpack.inference.services.ibmwatsonx.IbmWatsonxService.RERANK_WINDOW_SIZE;
 import static org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettingsTests.getSecretSettingsMap;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -943,7 +945,7 @@ public class IbmWatsonxServiceTests extends InferenceServiceTestCase {
                 {
                        "service": "watsonxai",
                        "name": "IBM watsonx",
-                       "task_types": ["text_embedding", "completion", "chat_completion"],
+                       "task_types": ["text_embedding", "rerank", "completion", "chat_completion"],
                        "configurations": {
                            "project_id": {
                                "description": "",
@@ -952,7 +954,7 @@ public class IbmWatsonxServiceTests extends InferenceServiceTestCase {
                                "sensitive": false,
                                "updatable": false,
                                "type": "str",
-                               "supported_task_types": ["text_embedding", "completion", "chat_completion"]
+                               "supported_task_types": ["text_embedding", "rerank", "completion", "chat_completion"]
                            },
                            "model_id": {
                                "description": "The name of the model to use for the inference task.",
@@ -961,7 +963,7 @@ public class IbmWatsonxServiceTests extends InferenceServiceTestCase {
                                "sensitive": false,
                                "updatable": false,
                                "type": "str",
-                               "supported_task_types": ["text_embedding", "completion", "chat_completion"]
+                               "supported_task_types": ["text_embedding", "rerank", "completion", "chat_completion"]
                            },
                            "api_version": {
                                "description": "The IBM watsonx API version ID to use.",
@@ -970,7 +972,7 @@ public class IbmWatsonxServiceTests extends InferenceServiceTestCase {
                                "sensitive": false,
                                "updatable": false,
                                "type": "str",
-                               "supported_task_types": ["text_embedding", "completion", "chat_completion"]
+                               "supported_task_types": ["text_embedding", "rerank", "completion", "chat_completion"]
                            },
                            "max_input_tokens": {
                                "description": "Allows you to specify the maximum number of tokens per input.",
@@ -988,7 +990,7 @@ public class IbmWatsonxServiceTests extends InferenceServiceTestCase {
                                "sensitive": false,
                                "updatable": false,
                                "type": "str",
-                               "supported_task_types": ["text_embedding", "completion", "chat_completion"]
+                               "supported_task_types": ["text_embedding", "rerank", "completion", "chat_completion"]
                            }
                        }
                    }
@@ -1048,6 +1050,11 @@ public class IbmWatsonxServiceTests extends InferenceServiceTestCase {
     @Override
     public InferenceService createInferenceService() {
         return createIbmWatsonxService();
+    }
+
+    @Override
+    protected void assertRerankerWindowSize(RerankingInferenceService rerankingInferenceService) {
+        assertThat(rerankingInferenceService.rerankerWindowSize("any model"), is(RERANK_WINDOW_SIZE));
     }
 
     private static class IbmWatsonxServiceWithoutAuth extends IbmWatsonxService {


### PR DESCRIPTION
Backports the following commits to 9.2:
 - [Inference API] Include rerank in supported tasks for IBM watsonx integration (#140331)