### PR TITLE
[8.19] [Inference API] Include rerank in supported tasks for IBM watsonx integration (#140331)

### DIFF
--- a/docs/changelog/140331.yaml
+++ b/docs/changelog/140331.yaml
@@ -1,0 +1,6 @@
+pr: 140331
+summary: "[Inference API] Include rerank in supported tasks for IBM watsonx integration"
+area: Inference
+type: bug
+issues:
+ - 140328

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_watsonx.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_watsonx.json
@@ -28,7 +28,8 @@
               "options": [
                 "text_embedding",
                 "chat_completion",
-                "completion"
+                "completion",
+                "rerank"
               ]
             },
             "watsonx_inference_id": {

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceGetServicesIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceGetServicesIT.java
@@ -116,6 +116,7 @@ public class InferenceGetServicesIT extends BaseMockEISAuthServerTest {
                     "elastic",
                     "elasticsearch",
                     "googlevertexai",
+                    "watsonxai",
                     "hugging_face",
                     "jinaai",
                     "test_reranking_service",

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxService.java
@@ -68,7 +68,7 @@ public class IbmWatsonxService extends SenderService {
     public static final String NAME = "watsonxai";
 
     private static final String SERVICE_NAME = "IBM Watsonx";
-    private static final EnumSet<TaskType> supportedTaskTypes = EnumSet.of(TaskType.TEXT_EMBEDDING);
+    private static final EnumSet<TaskType> supportedTaskTypes = EnumSet.of(TaskType.TEXT_EMBEDDING, TaskType.RERANK);
 
     public IbmWatsonxService(HttpRequestSender.Factory factory, ServiceComponents serviceComponents) {
         super(factory, serviceComponents);

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxServiceTests.java
@@ -938,59 +938,59 @@ public class IbmWatsonxServiceTests extends ESTestCase {
     public void testGetConfiguration() throws Exception {
         try (var service = createIbmWatsonxService()) {
             String content = XContentHelper.stripWhitespace("""
-                                {
-                                       "service": "watsonxai",
-                                       "name": "IBM Watsonx",
-                                       "task_types": ["text_embedding", "rerank"],
-                                       "configurations": {
-                                           "project_id": {
-                                               "description": "",
-                                               "label": "Project ID",
-                                               "required": true,
-                                               "sensitive": false,
-                                               "updatable": false,
-                                               "type": "str",
-                                               "supported_task_types": ["text_embedding", "rerank"]
-                                           },
-                                           "model_id": {
-                                               "description": "The name of the model to use for the inference task.",
-                                               "label": "Model ID",
-                                               "required": true,
-                                               "sensitive": false,
-                                               "updatable": false,
-                                               "type": "str",
-                                               "supported_task_types": ["text_embedding", "rerank"]
-                                           },
-                                           "api_version": {
-                                               "description": "The IBM Watsonx API version ID to use.",
-                                               "label": "API Version",
-                                               "required": true,
-                                               "sensitive": false,
-                                               "updatable": false,
-                                               "type": "str",
-                                               "supported_task_types": ["text_embedding", "rerank"]
-                                           },
-                                           "max_input_tokens": {
-                                               "description": "Allows you to specify the maximum number of tokens per input.",
-                                               "label": "Maximum Input Tokens",
-                                               "required": false,
-                                               "sensitive": false,
-                                               "updatable": false,
-                                               "type": "int",
-                                               "supported_task_types": ["text_embedding"]
-                                           },
-                                           "url": {
-                                               "description": "",
-                                               "label": "URL",
-                                               "required": true,
-                                               "sensitive": false,
-                                               "updatable": false,
-                                               "type": "str",
-                                               "supported_task_types": ["text_embedding", "rerank"]
-                                           }
-                                       }
-                                   }
-                                """);
+                {
+                       "service": "watsonxai",
+                       "name": "IBM Watsonx",
+                       "task_types": ["text_embedding", "rerank"],
+                       "configurations": {
+                           "project_id": {
+                               "description": "",
+                               "label": "Project ID",
+                               "required": true,
+                               "sensitive": false,
+                               "updatable": false,
+                               "type": "str",
+                               "supported_task_types": ["text_embedding", "rerank"]
+                           },
+                           "model_id": {
+                               "description": "The name of the model to use for the inference task.",
+                               "label": "Model ID",
+                               "required": true,
+                               "sensitive": false,
+                               "updatable": false,
+                               "type": "str",
+                               "supported_task_types": ["text_embedding", "rerank"]
+                           },
+                           "api_version": {
+                               "description": "The IBM Watsonx API version ID to use.",
+                               "label": "API Version",
+                               "required": true,
+                               "sensitive": false,
+                               "updatable": false,
+                               "type": "str",
+                               "supported_task_types": ["text_embedding", "rerank"]
+                           },
+                           "max_input_tokens": {
+                               "description": "Allows you to specify the maximum number of tokens per input.",
+                               "label": "Maximum Input Tokens",
+                               "required": false,
+                               "sensitive": false,
+                               "updatable": false,
+                               "type": "int",
+                               "supported_task_types": ["text_embedding"]
+                           },
+                           "url": {
+                               "description": "",
+                               "label": "URL",
+                               "required": true,
+                               "sensitive": false,
+                               "updatable": false,
+                               "type": "str",
+                               "supported_task_types": ["text_embedding", "rerank"]
+                           }
+                       }
+                   }
+                """);
             InferenceServiceConfiguration configuration = InferenceServiceConfiguration.fromXContentBytes(
                 new BytesArray(content),
                 XContentType.JSON

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ibmwatsonx/IbmWatsonxServiceTests.java
@@ -938,59 +938,59 @@ public class IbmWatsonxServiceTests extends ESTestCase {
     public void testGetConfiguration() throws Exception {
         try (var service = createIbmWatsonxService()) {
             String content = XContentHelper.stripWhitespace("""
-                {
-                       "service": "watsonxai",
-                       "name": "IBM Watsonx",
-                       "task_types": ["text_embedding"],
-                       "configurations": {
-                           "project_id": {
-                               "description": "",
-                               "label": "Project ID",
-                               "required": true,
-                               "sensitive": false,
-                               "updatable": false,
-                               "type": "str",
-                               "supported_task_types": ["text_embedding"]
-                           },
-                           "model_id": {
-                               "description": "The name of the model to use for the inference task.",
-                               "label": "Model ID",
-                               "required": true,
-                               "sensitive": false,
-                               "updatable": false,
-                               "type": "str",
-                               "supported_task_types": ["text_embedding"]
-                           },
-                           "api_version": {
-                               "description": "The IBM Watsonx API version ID to use.",
-                               "label": "API Version",
-                               "required": true,
-                               "sensitive": false,
-                               "updatable": false,
-                               "type": "str",
-                               "supported_task_types": ["text_embedding"]
-                           },
-                           "max_input_tokens": {
-                               "description": "Allows you to specify the maximum number of tokens per input.",
-                               "label": "Maximum Input Tokens",
-                               "required": false,
-                               "sensitive": false,
-                               "updatable": false,
-                               "type": "int",
-                               "supported_task_types": ["text_embedding"]
-                           },
-                           "url": {
-                               "description": "",
-                               "label": "URL",
-                               "required": true,
-                               "sensitive": false,
-                               "updatable": false,
-                               "type": "str",
-                               "supported_task_types": ["text_embedding"]
-                           }
-                       }
-                   }
-                """);
+                                {
+                                       "service": "watsonxai",
+                                       "name": "IBM Watsonx",
+                                       "task_types": ["text_embedding", "rerank"],
+                                       "configurations": {
+                                           "project_id": {
+                                               "description": "",
+                                               "label": "Project ID",
+                                               "required": true,
+                                               "sensitive": false,
+                                               "updatable": false,
+                                               "type": "str",
+                                               "supported_task_types": ["text_embedding", "rerank"]
+                                           },
+                                           "model_id": {
+                                               "description": "The name of the model to use for the inference task.",
+                                               "label": "Model ID",
+                                               "required": true,
+                                               "sensitive": false,
+                                               "updatable": false,
+                                               "type": "str",
+                                               "supported_task_types": ["text_embedding", "rerank"]
+                                           },
+                                           "api_version": {
+                                               "description": "The IBM Watsonx API version ID to use.",
+                                               "label": "API Version",
+                                               "required": true,
+                                               "sensitive": false,
+                                               "updatable": false,
+                                               "type": "str",
+                                               "supported_task_types": ["text_embedding", "rerank"]
+                                           },
+                                           "max_input_tokens": {
+                                               "description": "Allows you to specify the maximum number of tokens per input.",
+                                               "label": "Maximum Input Tokens",
+                                               "required": false,
+                                               "sensitive": false,
+                                               "updatable": false,
+                                               "type": "int",
+                                               "supported_task_types": ["text_embedding"]
+                                           },
+                                           "url": {
+                                               "description": "",
+                                               "label": "URL",
+                                               "required": true,
+                                               "sensitive": false,
+                                               "updatable": false,
+                                               "type": "str",
+                                               "supported_task_types": ["text_embedding", "rerank"]
+                                           }
+                                       }
+                                   }
+                                """);
             InferenceServiceConfiguration configuration = InferenceServiceConfiguration.fromXContentBytes(
                 new BytesArray(content),
                 XContentType.JSON


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [[Inference API] Include rerank in supported tasks for IBM watsonx integration (#140331)](https://github.com/elastic/elasticsearch/pull/140331)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)