### PR TITLE
Remove coupling routing and reindex rest test (#140393)

### DIFF
--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/35_search_failures.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/35_search_failures.yml
@@ -33,7 +33,9 @@
   - match: {error.phase: query}
   - match: {error.root_cause.0.type:   script_exception}
   - match: {error.root_cause.0.reason: runtime error}
-  - match: {error.failed_shards.0.shard: 0}
+  # The shard number can vary based on the shard routing function version. Just check that it's between 0 and 1.
+  - gte: { error.failed_shards.0.shard: 0 }
+  - lte: { error.failed_shards.0.shard: 1 }
   - match: {error.failed_shards.0.index:  source}
   - is_true: error.failed_shards.0.node
   - match: {error.failed_shards.0.reason.type:   script_exception}


### PR DESCRIPTION
Currently a reindex rest compatibility test depends on specific shard
routing. This is not behavior we guarantee and it should be removed.