### PR TITLE
[Test Unmute] Unmute tests that failed due to transient version mismatch

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -506,18 +506,6 @@ tests:
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test070BindMountCustomPathConfAndJvmOptions
   issue: https://github.com/elastic/elasticsearch/issues/131366
-- class: org.elasticsearch.xpack.restart.FullClusterRestartIT
-  method: testNodeShutdown {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/140414
-- class: org.elasticsearch.upgrades.RunningSnapshotIT
-  method: testRunningSnapshotCompleteAfterUpgrade {upgradedNodes=1}
-  issue: https://github.com/elastic/elasticsearch/issues/140415
-- class: org.elasticsearch.upgrades.RunningSnapshotIT
-  method: testRunningSnapshotCompleteAfterUpgrade {upgradedNodes=2}
-  issue: https://github.com/elastic/elasticsearch/issues/140416
-- class: org.elasticsearch.upgrades.RunningSnapshotIT
-  method: testRunningSnapshotCompleteAfterUpgrade {upgradedNodes=3}
-  issue: https://github.com/elastic/elasticsearch/issues/140417
 
 # Examples:
 #


### PR DESCRIPTION
See justification at
https://github.com/elastic/elasticsearch/issues/140415#issuecomment-3726954968

Depends on https://github.com/elastic/elasticsearch/pull/140286

Resolves: #140414
Resolves: #140415
Resolves: #140416
Resolves: #140417

