### PR TITLE
ES|QL: Search functions docs cleanup

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/functions/description/top_snippets.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/description/top_snippets.md
@@ -4,6 +4,6 @@
 
 Use `TOP_SNIPPETS` to extract the best snippets for a given query string from a text field.
 
-TopSnippets can be used on fields from the text famiy like [text](/reference/elasticsearch/mapping-reference/text.md) and [semantic_text](/reference/elasticsearch/mapping-reference/semantic-text.md).
-    TopSnippets will extract the best snippets for a given query string.
+`TOP_SNIPPETS` can be used on fields from the text famiy like [text](/reference/elasticsearch/mapping-reference/text.md) and [semantic_text](/reference/elasticsearch/mapping-reference/semantic-text.md).
+    `TOP_SNIPPETS` will extract the best snippets for a given query string.
 

--- a/docs/reference/query-languages/esql/_snippets/functions/parameters/top_snippets.md
+++ b/docs/reference/query-languages/esql/_snippets/functions/parameters/top_snippets.md
@@ -9,5 +9,5 @@
 :   The input text containing only query terms for snippet extraction. Lucene query syntax, operators, and wildcards are not allowed. 
 
 `options`
-:   (Optional) TopSnippets additional options as [function named parameters](/reference/query-languages/esql/esql-syntax.md#esql-function-named-params).
+:   (Optional) `TOP_SNIPPETS` additional options as [function named parameters](/reference/query-languages/esql/esql-syntax.md#esql-function-named-params).
 

--- a/docs/reference/query-languages/esql/functions-operators/search-functions.md
+++ b/docs/reference/query-languages/esql/functions-operators/search-functions.md
@@ -60,9 +60,3 @@ for information on the limitations of full text search.
 
 :::{include} ../_snippets/functions/layout/top_snippets.md
 :::
-
-% TERM is currently a hidden feature
-% To make it visible again, uncomment this and the line in
-lists/search-functions.md
-% :::{include} ../_snippets/functions/layout/term.md
-% :::

--- a/docs/reference/query-languages/esql/kibana/definition/functions/top_snippets.json
+++ b/docs/reference/query-languages/esql/kibana/definition/functions/top_snippets.json
@@ -41,7 +41,7 @@
           "type" : "function_named_parameters",
           "mapParams" : "{name='num_words', values=[300], description='The maximum number of words to return in each snippet.\nThis allows better control of inference costs by limiting the size of tokens per snippet.\n', type=[integer]}, {name='num_snippets', values=[3], description='The maximum number of matching snippets to return.', type=[integer]}",
           "optional" : true,
-          "description" : "(Optional) TopSnippets additional options as [function named parameters](https://www.elastic.co/docs/reference/query-languages/esql/esql-syntax#esql-function-named-params)."
+          "description" : "(Optional) `TOP_SNIPPETS` additional options as [function named parameters](https://www.elastic.co/docs/reference/query-languages/esql/esql-syntax#esql-function-named-params)."
         }
       ],
       "variadic" : false,
@@ -84,7 +84,7 @@
           "type" : "function_named_parameters",
           "mapParams" : "{name='num_words', values=[300], description='The maximum number of words to return in each snippet.\nThis allows better control of inference costs by limiting the size of tokens per snippet.\n', type=[integer]}, {name='num_snippets', values=[3], description='The maximum number of matching snippets to return.', type=[integer]}",
           "optional" : true,
-          "description" : "(Optional) TopSnippets additional options as [function named parameters](https://www.elastic.co/docs/reference/query-languages/esql/esql-syntax#esql-function-named-params)."
+          "description" : "(Optional) `TOP_SNIPPETS` additional options as [function named parameters](https://www.elastic.co/docs/reference/query-languages/esql/esql-syntax#esql-function-named-params)."
         }
       ],
       "variadic" : false,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/TopSnippets.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/TopSnippets.java
@@ -76,8 +76,8 @@ public class TopSnippets extends EsqlScalarFunction implements OptionalArgument 
         preview = true,
         description = "Use `TOP_SNIPPETS` to extract the best snippets for a given query string from a text field.",
         detailedDescription = """
-                TopSnippets can be used on fields from the text famiy like <<text, text>> and <<semantic-text, semantic_text>>.
-                TopSnippets will extract the best snippets for a given query string.
+                `TOP_SNIPPETS` can be used on fields from the text famiy like <<text, text>> and <<semantic-text, semantic_text>>.
+                `TOP_SNIPPETS` will extract the best snippets for a given query string.
             """,
         examples = {
             @Example(file = "top-snippets", tag = "top-snippets-with-field", applies_to = "stack: preview 9.3.0"),
@@ -92,7 +92,7 @@ public class TopSnippets extends EsqlScalarFunction implements OptionalArgument 
             """) Expression query,
         @MapParam(
             name = "options",
-            description = "(Optional) TopSnippets additional options as "
+            description = "(Optional) `TOP_SNIPPETS` additional options as "
                 + "[function named parameters](/reference/query-languages/esql/esql-syntax.md#esql-function-named-params).",
             optional = true,
             params = {


### PR DESCRIPTION
Small cleanups

Noticed that `TOP_SNIPPETS` is referred to as "TopSnippets" in the docs:

<img width="1051" height="851" alt="Screenshot 2026-01-09 at 11 09 33" src="https://github.com/user-attachments/assets/43887e8a-c066-4d01-8e54-9fc53a716ccf" />

We also have a random `lists/search-functions.md` line at the end of the search functions docs page:

<img width="1640" height="1183" alt="Screenshot 2026-01-09 at 11 08 19" src="https://github.com/user-attachments/assets/9b306e4b-ae09-4634-bc08-3828c8d4607a" />

