### PR TITLE
Unmute 350_point_in_time/point-in-time with index filter

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -108,9 +108,6 @@ tests:
 - class: org.elasticsearch.action.admin.indices.diskusage.IndexDiskUsageAnalyzerTests
   method: testKnnVectors
   issue: https://github.com/elastic/elasticsearch/issues/127689
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=search/350_point_in_time/point-in-time with index filter}
-  issue: https://github.com/elastic/elasticsearch/issues/127741
 - class: org.elasticsearch.xpack.esql.plugin.DataNodeRequestSenderIT
   method: testSearchWhileRelocating
   issue: https://github.com/elastic/elasticsearch/issues/128500


### PR DESCRIPTION
Unmute test for https://github.com/elastic/elasticsearch/issues/127741 to check if this is still failing on main/9.1.