### PR TITLE
[8.19] Backporting Fix flaky test: Text similarity reranker with min_score zero includes all docs  (#139687)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -330,9 +330,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.plugin.DataNodeRequestSenderIT
   method: testSearchWhileRelocating
   issue: https://github.com/elastic/elasticsearch/issues/128500
-- class: org.elasticsearch.xpack.inference.InferenceRestIT
-  method: test {p0=inference/70_text_similarity_rank_retriever/Text similarity reranker with min_score zero includes all docs}
-  issue: https://github.com/elastic/elasticsearch/issues/137732
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test050BasicApiTests
   issue: https://github.com/elastic/elasticsearch/issues/120911

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/70_text_similarity_rank_retriever.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/70_text_similarity_rank_retriever.yml
@@ -439,9 +439,59 @@ setup:
       cluster_features: "text_similarity_reranker_minscore_fix"
       reason: test min score functionality
 
+  # Created a dedicated index for deterministic score testing.
+  # The mock reranker parses string values in 'inference_text_field' as numbers to determine the reranked score.
+  # This ensures scores are positive and avoids unexpected filtering when min_score is 0.
+  - do:
+      indices.create:
+        index: test-index-deterministic
+        body:
+          mappings:
+            properties:
+              text:
+                type: text
+              topic:
+                type: keyword
+              subtopic:
+                type: keyword
+              inference_text_field:
+                type: keyword
+
+  - do:
+      index:
+        index: test-index-deterministic
+        id: doc_1
+        body:
+          text: "As seen from Earth, a solar eclipse happens when the Moon is directly between the Earth and the Sun."
+          topic: ["science"]
+          subtopic: ["technology"]
+          inference_text_field: "1"
+        refresh: true
+
+  - do:
+      index:
+        index: test-index-deterministic
+        id: doc_2
+        body:
+          text: "The phases of the Moon come from the position of the Moon relative to the Earth and Sun."
+          topic: [ "science" ]
+          subtopic: [ "astronomy" ]
+          inference_text_field: "2"
+        refresh: true
+
+  - do:
+      index:
+        index: test-index-deterministic
+        id: doc_3
+        body:
+          text: "Sun Moon Lake is a lake in Nantou County, Taiwan. It is the largest lake in Taiwan."
+          topic: [ "geography" ]
+          inference_text_field: "3"
+        refresh: true
+
   - do:
       search:
-        index: test-index
+        index: test-index-deterministic
         body:
           track_total_hits: true
           fields: [ "text", "topic" ]
@@ -454,7 +504,7 @@ setup:
               rank_window_size: 10
               inference_id: my-rerank-model
               inference_text: "How often does the moon hide the sun?"
-              field: text
+              field: inference_text_field
               min_score: 0
           size: 10
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix flaky test: Text similarity reranker with min_score zero includes all docs](https://github.com/elastic/elasticsearch/pull/140176)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)
