### PR TITLE
[9.3] Disable _delete_by_query and _update_by_query for CCS/stateful (#140301)

### DIFF
--- a/docs/changelog/140301.yaml
+++ b/docs/changelog/140301.yaml
@@ -1,0 +1,5 @@
+pr: 140301
+summary: Disable `_delete_by_query` and `_update_by_query` for CCS/stateful
+area: Reindex
+type: bug
+issues: []

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/delete_by_query/20_validation.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/delete_by_query/20_validation.yml
@@ -161,3 +161,15 @@
         body:
           query:
             match_all: {}
+---
+"Remote indices are not allowed in delete-by-query":
+  - do:
+      catch: bad_request
+      delete_by_query:
+        index: "remote:test"
+        body:
+          query:
+            match_all: {}
+  - match: { status: 400 }
+  - match: { error.type: "action_request_validation_exception" }
+  - match: { error.reason: "Validation Failed: 1: Cross-cluster calls are not supported in this context but remote indices were requested: [remote:test];" }

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/update_by_query/20_validation.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/update_by_query/20_validation.yml
@@ -176,3 +176,15 @@
       update_by_query:
         slices: 0
         index: test
+---
+"Remote indices are not allowed in update-by-query":
+  - do:
+      catch: bad_request
+      update_by_query:
+        index: "remote:test"
+        body:
+          query:
+            match_all: {}
+  - match: { status: 400 }
+  - match: { error.type: "action_request_validation_exception" }
+  - match: { error.reason: "Validation Failed: 1: Cross-cluster calls are not supported in this context but remote indices were requested: [remote:test];" }

--- a/server/src/test/java/org/elasticsearch/index/reindex/DeleteByQueryRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/DeleteByQueryRequestTests.java
@@ -94,6 +94,21 @@ public class DeleteByQueryRequestTests extends AbstractBulkByScrollRequestTestCa
         assertThat(e, is(nullValue()));
     }
 
+    public void testValidateGivenRemoteIndex() {
+        SearchRequest searchRequest = new SearchRequest();
+        DeleteByQueryRequest deleteByQueryRequest = new DeleteByQueryRequest(searchRequest);
+        deleteByQueryRequest.indices("remote:index");
+        searchRequest.source().query(QueryBuilders.matchAllQuery());
+
+        ActionRequestValidationException e = deleteByQueryRequest.validate();
+
+        assertThat(e, is(not(nullValue())));
+        assertThat(
+            e.getMessage(),
+            containsString("Cross-cluster calls are not supported in this context but remote indices were requested")
+        );
+    }
+
     // TODO: Implement standard to/from x-content parsing tests
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/reindex/ReindexRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/ReindexRequestTests.java
@@ -518,6 +518,13 @@ public class ReindexRequestTests extends AbstractBulkByScrollRequestTestCase<Rei
         assertEquals(List.of("use _all if you really want to copy from all existing indexes"), validationException.validationErrors());
     }
 
+    public void testValidateGivenRemoteIndex() throws IOException {
+        ReindexRequest r = parseRequestWithSourceIndices("remote:index");
+        assertArrayEquals(new String[] { "remote:index" }, r.getSearchRequest().indices());
+        ActionRequestValidationException validationException = r.validate();
+        assertNull(validationException);
+    }
+
     private ReindexRequest parseRequestWithSourceIndices(Object sourceIndices) throws IOException {
         BytesReference request;
         try (XContentBuilder b = JsonXContent.contentBuilder()) {

--- a/server/src/test/java/org/elasticsearch/index/reindex/UpdateByQueryRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/UpdateByQueryRequestTests.java
@@ -9,12 +9,19 @@
 
 package org.elasticsearch.index.reindex;
 
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 
 import static org.apache.lucene.tests.util.TestUtil.randomSimpleString;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 
 public class UpdateByQueryRequestTests extends AbstractBulkByScrollRequestTestCase<UpdateByQueryRequest> {
     public void testUpdateByQueryRequestImplementsIndicesRequestReplaceable() {
@@ -48,6 +55,21 @@ public class UpdateByQueryRequestTests extends AbstractBulkByScrollRequestTestCa
         for (int i = 0; i < numNewIndices; i++) {
             assertEquals(newIndices[i], request.getSearchRequest().indices()[i]);
         }
+    }
+
+    public void testValidateGivenRemoteIndex() {
+        SearchRequest searchRequest = new SearchRequest();
+        UpdateByQueryRequest updateByQueryRequest = new UpdateByQueryRequest(searchRequest);
+        updateByQueryRequest.indices("remote:index");
+        searchRequest.source().query(QueryBuilders.matchAllQuery());
+
+        ActionRequestValidationException e = updateByQueryRequest.validate();
+
+        assertThat(e, is(not(nullValue())));
+        assertThat(
+            e.getMessage(),
+            containsString("Cross-cluster calls are not supported in this context but remote indices were requested")
+        );
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Disable _delete_by_query and _update_by_query for CCS/stateful (#140301)