### PR TITLE
[8.19] Disable _delete_by_query and _update_by_query for CCS/stateful (#140301)

### DIFF
--- a/docs/changelog/140301.yaml
+++ b/docs/changelog/140301.yaml
@@ -1,0 +1,5 @@
+pr: 140301
+summary: Disable `_delete_by_query` and `_update_by_query` for CCS/stateful
+area: Reindex
+type: bug
+issues: []

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractBaseReindexRestHandler.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractBaseReindexRestHandler.java
@@ -44,6 +44,10 @@ public abstract class AbstractBaseReindexRestHandler<
         // Build the internal request
         Request internal = setCommonOptions(request, buildRequest(request));
 
+        // Only requests supporting remote indices can have IndicesOptions allowing cross-project index expressions
+        assert internal.supportsRemoteIndicesSearch()
+            || internal.getSearchRequest().indicesOptions().resolveCrossProjectIndexExpression() == false;
+
         // Executes the request and waits for completion
         if (request.paramAsBoolean("wait_for_completion", true)) {
             Map<String, String> params = new HashMap<>();

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractBaseReindexRestHandler.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractBaseReindexRestHandler.java
@@ -44,10 +44,6 @@ public abstract class AbstractBaseReindexRestHandler<
         // Build the internal request
         Request internal = setCommonOptions(request, buildRequest(request));
 
-        // Only requests supporting remote indices can have IndicesOptions allowing cross-project index expressions
-        assert internal.supportsRemoteIndicesSearch()
-            || internal.getSearchRequest().indicesOptions().resolveCrossProjectIndexExpression() == false;
-
         // Executes the request and waits for completion
         if (request.paramAsBoolean("wait_for_completion", true)) {
             Map<String, String> params = new HashMap<>();

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/delete_by_query/20_validation.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/delete_by_query/20_validation.yml
@@ -161,3 +161,15 @@
         body:
           query:
             match_all: {}
+---
+"Remote indices are not allowed in delete-by-query":
+  - do:
+      catch: bad_request
+      delete_by_query:
+        index: "remote:test"
+        body:
+          query:
+            match_all: {}
+  - match: { status: 400 }
+  - match: { error.type: "action_request_validation_exception" }
+  - match: { error.reason: "Validation Failed: 1: Cross-cluster calls are not supported in this context but remote indices were requested: [remote:test];" }

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/update_by_query/20_validation.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/update_by_query/20_validation.yml
@@ -176,3 +176,15 @@
       update_by_query:
         slices: 0
         index: test
+---
+"Remote indices are not allowed in update-by-query":
+  - do:
+      catch: bad_request
+      update_by_query:
+        index: "remote:test"
+        body:
+          query:
+            match_all: {}
+  - match: { status: 400 }
+  - match: { error.type: "action_request_validation_exception" }
+  - match: { error.reason: "Validation Failed: 1: Cross-cluster calls are not supported in this context but remote indices were requested: [remote:test];" }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -412,12 +412,7 @@ public class IndexNameExpressionResolver {
             return;
         }
         if (RemoteClusterAware.isRemoteIndexName(current)) {
-            List<String> crossClusterIndices = new ArrayList<>();
-            for (int i = 0; i < expressions.length; i++) {
-                if (RemoteClusterAware.isRemoteIndexName(expressions[i])) {
-                    crossClusterIndices.add(expressions[i]);
-                }
-            }
+            List<String> crossClusterIndices = RemoteClusterAware.getRemoteIndexExpressions(expressions);
             throw new IllegalArgumentException(
                 "Cross-cluster calls are not supported in this context but remote indices were requested: " + crossClusterIndices
             );

--- a/server/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java
@@ -21,9 +21,11 @@ import org.elasticsearch.search.Scroll;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.transport.RemoteClusterAware;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -160,6 +162,15 @@ public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScr
         }
         if (searchRequest.source().slice() != null && slices != DEFAULT_SLICES) {
             e = addValidationError("can't specify both manual and automatic slicing at the same time", e);
+        }
+        if (supportsRemoteIndicesSearch() == false) {
+            List<String> remoteIndices = RemoteClusterAware.getRemoteIndexExpressions(searchRequest.indices());
+            if (remoteIndices.isEmpty() == false) {
+                e = addValidationError(
+                    "Cross-cluster calls are not supported in this context but remote indices were requested: " + remoteIndices,
+                    e
+                );
+            }
         }
         return e;
     }

--- a/server/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java
@@ -140,6 +140,13 @@ public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScr
      */
     protected abstract Self self();
 
+    /**
+     * Whether the request supports remote indices in the search request.
+     */
+    public boolean supportsRemoteIndicesSearch() {
+        return false;
+    }
+
     @Override
     public ActionRequestValidationException validate() {
         ActionRequestValidationException e = searchRequest.validate();

--- a/server/src/main/java/org/elasticsearch/index/reindex/ReindexRequest.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/ReindexRequest.java
@@ -84,6 +84,11 @@ public class ReindexRequest extends AbstractBulkIndexByScrollRequest<ReindexRequ
     }
 
     @Override
+    public boolean supportsRemoteIndicesSearch() {
+        return true;
+    }
+
+    @Override
     public ActionRequestValidationException validate() {
         ActionRequestValidationException e = super.validate();
         if (getSearchRequest().indices() == null || getSearchRequest().indices().length == 0) {

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterAware.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterAware.java
@@ -75,6 +75,19 @@ public abstract class RemoteClusterAware {
     }
 
     /**
+     * Extracts the list of remote index expressions from the given array of index expressions
+     */
+    public static List<String> getRemoteIndexExpressions(String... expressions) {
+        List<String> crossClusterIndices = new ArrayList<>();
+        for (int i = 0; i < expressions.length; i++) {
+            if (isRemoteIndexName(expressions[i])) {
+                crossClusterIndices.add(expressions[i]);
+            }
+        }
+        return crossClusterIndices;
+    }
+
+    /**
      * @param indexExpression expects a single index expression at a time (not a csv list of expression)
      * @return cluster alias in the index expression. If none is present, returns RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY
      */

--- a/server/src/test/java/org/elasticsearch/index/reindex/DeleteByQueryRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/DeleteByQueryRequestTests.java
@@ -94,6 +94,21 @@ public class DeleteByQueryRequestTests extends AbstractBulkByScrollRequestTestCa
         assertThat(e, is(nullValue()));
     }
 
+    public void testValidateGivenRemoteIndex() {
+        SearchRequest searchRequest = new SearchRequest();
+        DeleteByQueryRequest deleteByQueryRequest = new DeleteByQueryRequest(searchRequest);
+        deleteByQueryRequest.indices("remote:index");
+        searchRequest.source().query(QueryBuilders.matchAllQuery());
+
+        ActionRequestValidationException e = deleteByQueryRequest.validate();
+
+        assertThat(e, is(not(nullValue())));
+        assertThat(
+            e.getMessage(),
+            containsString("Cross-cluster calls are not supported in this context but remote indices were requested")
+        );
+    }
+
     // TODO: Implement standard to/from x-content parsing tests
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/reindex/ReindexRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/ReindexRequestTests.java
@@ -479,6 +479,13 @@ public class ReindexRequestTests extends AbstractBulkByScrollRequestTestCase<Rei
         assertEquals(List.of("use _all if you really want to copy from all existing indexes"), validationException.validationErrors());
     }
 
+    public void testValidateGivenRemoteIndex() throws IOException {
+        ReindexRequest r = parseRequestWithSourceIndices("remote:index");
+        assertArrayEquals(new String[] { "remote:index" }, r.getSearchRequest().indices());
+        ActionRequestValidationException validationException = r.validate();
+        assertNull(validationException);
+    }
+
     private ReindexRequest parseRequestWithSourceIndices(Object sourceIndices) throws IOException {
         BytesReference request;
         try (XContentBuilder b = JsonXContent.contentBuilder()) {

--- a/server/src/test/java/org/elasticsearch/index/reindex/UpdateByQueryRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/UpdateByQueryRequestTests.java
@@ -9,12 +9,19 @@
 
 package org.elasticsearch.index.reindex;
 
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 
 import static org.apache.lucene.tests.util.TestUtil.randomSimpleString;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 
 public class UpdateByQueryRequestTests extends AbstractBulkByScrollRequestTestCase<UpdateByQueryRequest> {
     public void testUpdateByQueryRequestImplementsIndicesRequestReplaceable() {
@@ -48,6 +55,21 @@ public class UpdateByQueryRequestTests extends AbstractBulkByScrollRequestTestCa
         for (int i = 0; i < numNewIndices; i++) {
             assertEquals(newIndices[i], request.getSearchRequest().indices()[i]);
         }
+    }
+
+    public void testValidateGivenRemoteIndex() {
+        SearchRequest searchRequest = new SearchRequest();
+        UpdateByQueryRequest updateByQueryRequest = new UpdateByQueryRequest(searchRequest);
+        updateByQueryRequest.indices("remote:index");
+        searchRequest.source().query(QueryBuilders.matchAllQuery());
+
+        ActionRequestValidationException e = updateByQueryRequest.validate();
+
+        assertThat(e, is(not(nullValue())));
+        assertThat(
+            e.getMessage(),
+            containsString("Cross-cluster calls are not supported in this context but remote indices were requested")
+        );
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterAwareTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterAwareTests.java
@@ -16,10 +16,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 
 public class RemoteClusterAwareTests extends ESTestCase {
@@ -156,6 +159,23 @@ public class RemoteClusterAwareTests extends ESTestCase {
             "The '-' exclusions in the index expression list excludes all indexes"
         );
 
+    }
+
+    public void testGetRemoteIndexExpressions() {
+        {
+            List<String> remoteIndexExpressions = RemoteClusterAware.getRemoteIndexExpressions("index-1");
+            assertThat(remoteIndexExpressions, empty());
+        }
+        {
+            List<String> remoteIndexExpressions = RemoteClusterAware.getRemoteIndexExpressions(
+                "index-1",
+                "remote:index-1",
+                "idx-*",
+                "remote-2:idx-5"
+            );
+            assertThat(remoteIndexExpressions, hasSize(2));
+            assertThat(remoteIndexExpressions, contains("remote:index-1", "remote-2:idx-5"));
+        }
     }
 
     private static class RemoteClusterAwareTest extends RemoteClusterAware {


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Disable _delete_by_query and _update_by_query for CCS/stateful (#140301)