### PR TITLE
[9.3] Remove unused method ElasticInferenceService.translateToChunkedResults (#140442)

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
@@ -7,8 +7,6 @@
 
 package org.elasticsearch.xpack.inference;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.action.support.MappedActionFilter;
 import org.elasticsearch.client.internal.Client;
@@ -208,8 +206,6 @@ public class InferencePlugin extends Plugin
         InternalSearchPlugin,
         ClusterPlugin,
         PersistentTaskPlugin {
-
-    private static final Logger logger = LogManager.getLogger(InferencePlugin.class);
 
     /**
      * When this setting is true the verification check that


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Remove unused method ElasticInferenceService.translateToChunkedResults (#140442)](https://github.com/elastic/elasticsearch/pull/140442)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)