### PR TITLE
[9.3] Take snapshot build status into account in SkipperSettingsTests (#139839)

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/SkipperSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/SkipperSettingsTests.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.elasticsearch.Build;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexMode;
@@ -41,23 +42,44 @@ public class SkipperSettingsTests extends ESTestCase {
             });
             assertTrue(indexSettings.useDocValuesSkipper());
         }
-        {
-            IndexSettings indexSettings = settings(IndexVersions.SKIPPERS_ENABLED_BY_DEFAULT, b -> {
-                b.put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES.getName());
-                b.put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "path");
-            });
-            assertTrue(indexSettings.useDocValuesSkipper());
-        }
-        {
-            IndexVersion nonSkipperVersion = IndexVersionUtils.randomPreviousCompatibleVersion(
-                random(),
-                IndexVersions.SKIPPERS_ENABLED_BY_DEFAULT
-            );
-            IndexSettings indexSettings = settings(nonSkipperVersion, b -> {
-                b.put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES.getName());
-                b.put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "path");
-            });
-            assertFalse(indexSettings.useDocValuesSkipper());
+        if (Build.current().isSnapshot()) {
+            {
+                IndexSettings indexSettings = settings(IndexVersions.SKIPPERS_ENABLED_BY_DEFAULT, b -> {
+                    b.put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES.getName());
+                    b.put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "path");
+                });
+                assertTrue(indexSettings.useDocValuesSkipper());
+            }
+            {
+                IndexVersion nonSkipperVersion = IndexVersionUtils.randomPreviousCompatibleVersion(
+                    random(),
+                    IndexVersions.SKIPPERS_ENABLED_BY_DEFAULT
+                );
+                IndexSettings indexSettings = settings(nonSkipperVersion, b -> {
+                    b.put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES.getName());
+                    b.put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "path");
+                });
+                assertFalse(indexSettings.useDocValuesSkipper());
+            }
+        } else {
+            {
+                IndexSettings indexSettings = settings(IndexVersions.STATELESS_SKIPPERS_ENABLED_FOR_TSDB, b -> {
+                    b.put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES.getName());
+                    b.put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "path");
+                });
+                assertTrue(indexSettings.useDocValuesSkipper());
+            }
+            {
+                IndexVersion nonSkipperVersion = IndexVersionUtils.randomPreviousCompatibleVersion(
+                    random(),
+                    IndexVersions.STATELESS_SKIPPERS_ENABLED_FOR_TSDB
+                );
+                IndexSettings indexSettings = settings(nonSkipperVersion, b -> {
+                    b.put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES.getName());
+                    b.put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "path");
+                });
+                assertFalse(indexSettings.useDocValuesSkipper());
+            }
         }
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Take snapshot build status into account in SkipperSettingsTests (#139839)](https://github.com/elastic/elasticsearch/pull/139839)
 
 Resolves https://github.com/elastic/elasticsearch/issues/140015

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)