### PR TITLE
[9.2] Unmute tests after landing #139569 (#140300)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -1,502 +1,487 @@
 tests:
-- class: "org.elasticsearch.client.RestClientSingleHostIntegTests"
-  issue: "https://github.com/elastic/elasticsearch/issues/102717"
-  method: "testRequestResetAndAbort"
-- class: org.elasticsearch.packaging.test.PackagesSecurityAutoConfigurationTests
-  method: test20SecurityNotAutoConfiguredOnReInstallation
-  issue: https://github.com/elastic/elasticsearch/issues/112635
-- class: org.elasticsearch.packaging.test.WindowsServiceTests
-  method: test30StartStop
-  issue: https://github.com/elastic/elasticsearch/issues/113160
-- class: org.elasticsearch.packaging.test.WindowsServiceTests
-  method: test33JavaChanged
-  issue: https://github.com/elastic/elasticsearch/issues/113177
-- class: org.elasticsearch.packaging.test.WindowsServiceTests
-  method: test80JavaOptsInEnvVar
-  issue: https://github.com/elastic/elasticsearch/issues/113219
-- class: org.elasticsearch.packaging.test.WindowsServiceTests
-  method: test81JavaOptsInJvmOptions
-  issue: https://github.com/elastic/elasticsearch/issues/113313
-- class: org.elasticsearch.xpack.transform.integration.TransformIT
-  method: testStopWaitForCheckpoint
-  issue: https://github.com/elastic/elasticsearch/issues/106113
-- class: org.elasticsearch.xpack.remotecluster.RemoteClusterSecurityWithApmTracingRestIT
-  method: testTracingCrossCluster
-  issue: https://github.com/elastic/elasticsearch/issues/112731
-- class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
-  method: testDeploymentSurvivesRestart {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/115528
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_start_stop/Verify start transform reuses destination index}
-  issue: https://github.com/elastic/elasticsearch/issues/115808
-- class: org.elasticsearch.xpack.application.connector.ConnectorIndexServiceTests
-  issue: https://github.com/elastic/elasticsearch/issues/116087
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_start_stop/Test start already started transform}
-  issue: https://github.com/elastic/elasticsearch/issues/98802
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=snapshot/20_operator_privileges_disabled/Operator only settings can be set and restored by non-operator user when operator privileges is disabled}
-  issue: https://github.com/elastic/elasticsearch/issues/116775
-- class: org.elasticsearch.search.basic.SearchWithRandomIOExceptionsIT
-  method: testRandomDirectoryIOExceptions
-  issue: https://github.com/elastic/elasticsearch/issues/114824
-- class: org.elasticsearch.xpack.apmdata.APMYamlTestSuiteIT
-  method: test {yaml=/10_apm/Test template reinstallation}
-  issue: https://github.com/elastic/elasticsearch/issues/116445
-- class: org.elasticsearch.xpack.inference.InferenceRestIT
-  method: test {p0=inference/40_semantic_text_query/Query a field that uses the default ELSER 2 endpoint}
-  issue: https://github.com/elastic/elasticsearch/issues/117027
-- class: org.elasticsearch.xpack.inference.InferenceRestIT
-  method: test {p0=inference/30_semantic_text_inference/Calculates embeddings using the default ELSER 2 endpoint}
-  issue: https://github.com/elastic/elasticsearch/issues/117349
-- class: org.elasticsearch.xpack.inference.InferenceRestIT
-  method: test {p0=inference/30_semantic_text_inference_bwc/Calculates embeddings using the default ELSER 2 endpoint}
-  issue: https://github.com/elastic/elasticsearch/issues/117349
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_reset/Test reset running transform}
-  issue: https://github.com/elastic/elasticsearch/issues/117473
-- class: org.elasticsearch.xpack.ml.integration.RegressionIT
-  method: testTwoJobsWithSameRandomizeSeedUseSameTrainingSet
-  issue: https://github.com/elastic/elasticsearch/issues/117805
-- class: org.elasticsearch.packaging.test.ArchiveTests
-  method: test44AutoConfigurationNotTriggeredOnNotWriteableConfDir
-  issue: https://github.com/elastic/elasticsearch/issues/118208
-- class: org.elasticsearch.packaging.test.ArchiveTests
-  method: test51AutoConfigurationWithPasswordProtectedKeystore
-  issue: https://github.com/elastic/elasticsearch/issues/118212
-- class: org.elasticsearch.xpack.ccr.rest.ShardChangesRestIT
-  method: testShardChangesNoOperation
-  issue: https://github.com/elastic/elasticsearch/issues/118800
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_start_stop/Test start/stop/start transform}
-  issue: https://github.com/elastic/elasticsearch/issues/119508
-- class: org.elasticsearch.xpack.ml.integration.ForecastIT
-  method: testOverflowToDisk
-  issue: https://github.com/elastic/elasticsearch/issues/117740
-- class: org.elasticsearch.multi_cluster.MultiClusterYamlTestSuiteIT
-  issue: https://github.com/elastic/elasticsearch/issues/119983
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_unattended/Test unattended put and start}
-  issue: https://github.com/elastic/elasticsearch/issues/120019
-- class: org.elasticsearch.xpack.security.QueryableReservedRolesIT
-  method: testConfiguredReservedRolesAfterClosingAndOpeningIndex
-  issue: https://github.com/elastic/elasticsearch/issues/120127
-- class: org.elasticsearch.xpack.ccr.FollowIndexSecurityIT
-  method: testCleanShardFollowTaskAfterDeleteFollower
-  issue: https://github.com/elastic/elasticsearch/issues/120339
-- class: org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeToCharProcessorTests
-  issue: https://github.com/elastic/elasticsearch/issues/120575
-- class: org.elasticsearch.xpack.inference.DefaultEndPointsIT
-  method: testMultipleInferencesTriggeringDownloadAndDeploy
-  issue: https://github.com/elastic/elasticsearch/issues/120668
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=ml/3rd_party_deployment/Test start deployment fails while model download in progress}
-  issue: https://github.com/elastic/elasticsearch/issues/120810
-- class: org.elasticsearch.xpack.security.authc.service.ServiceAccountIT
-  method: testAuthenticateShouldNotFallThroughInCaseOfFailure
-  issue: https://github.com/elastic/elasticsearch/issues/120902
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=nodes.stats/11_indices_metrics/indices mappings exact count test for indices level}
-  issue: https://github.com/elastic/elasticsearch/issues/120950
-- class: org.elasticsearch.analysis.common.CommonAnalysisClientYamlTestSuiteIT
-  method: test {yaml=analysis-common/40_token_filters/stemmer_override file access}
-  issue: https://github.com/elastic/elasticsearch/issues/121625
-- class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
-  method: test {yaml=snapshot.delete/10_basic/Delete a snapshot asynchronously}
-  issue: https://github.com/elastic/elasticsearch/issues/122102
-- class: org.elasticsearch.action.admin.cluster.node.tasks.CancellableTasksIT
-  method: testChildrenTasksCancelledOnTimeout
-  issue: https://github.com/elastic/elasticsearch/issues/123568
-- class: org.elasticsearch.xpack.searchablesnapshots.FrozenSearchableSnapshotsIntegTests
-  method: testCreateAndRestorePartialSearchableSnapshot
-  issue: https://github.com/elastic/elasticsearch/issues/123773
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=snapshot/10_basic/Create a source only snapshot and then restore it}
-  issue: https://github.com/elastic/elasticsearch/issues/122755
-- class: org.elasticsearch.indices.recovery.IndexRecoveryIT
-  method: testSourceThrottling
-  issue: https://github.com/elastic/elasticsearch/issues/123680
-- class: org.elasticsearch.smoketest.MlWithSecurityIT
-  method: test {yaml=ml/3rd_party_deployment/Test start deployment fails while model download in progress}
-  issue: https://github.com/elastic/elasticsearch/issues/120814
-- class: org.elasticsearch.smoketest.MlWithSecurityIT
-  method: test {yaml=ml/3rd_party_deployment/Test start and stop multiple deployments}
-  issue: https://github.com/elastic/elasticsearch/issues/124315
-- class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
-  method: testDeploymentSurvivesRestart {cluster=OLD}
-  issue: https://github.com/elastic/elasticsearch/issues/124160
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_start_stop/Test schedule_now on an already started transform}
-  issue: https://github.com/elastic/elasticsearch/issues/120720
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_start_stop/Verify start transform creates destination index with appropriate mapping}
-  issue: https://github.com/elastic/elasticsearch/issues/125854
-- class: org.elasticsearch.xpack.core.common.notifications.AbstractAuditorTests
-  method: testRecreateTemplateWhenDeleted
-  issue: https://github.com/elastic/elasticsearch/issues/123232
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_stats/Test get transform stats with timeout}
-  issue: https://github.com/elastic/elasticsearch/issues/125975
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_reset/Test force reseting a running transform}
-  issue: https://github.com/elastic/elasticsearch/issues/126240
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_stats/Test get transform stats}
-  issue: https://github.com/elastic/elasticsearch/issues/126270
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_start_stop/Test start/stop only starts/stops specified transform}
-  issue: https://github.com/elastic/elasticsearch/issues/126466
-- class: org.elasticsearch.smoketest.MlWithSecurityIT
-  method: test {yaml=ml/get_trained_model_stats/Test get stats given trained models}
-  issue: https://github.com/elastic/elasticsearch/issues/126510
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_stats/Test get multiple transform stats}
-  issue: https://github.com/elastic/elasticsearch/issues/126567
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_stats/Test get single transform stats when it does not have a task}
-  issue: https://github.com/elastic/elasticsearch/issues/126568
-- class: org.elasticsearch.repositories.blobstore.testkit.rest.SnapshotRepoTestKitClientYamlTestSuiteIT
-  method: test {p0=/10_analyze/Analysis without details}
-  issue: https://github.com/elastic/elasticsearch/issues/126569
-- class: org.elasticsearch.xpack.esql.action.EsqlActionIT
-  method: testQueryOnEmptyDataIndex
-  issue: https://github.com/elastic/elasticsearch/issues/126580
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_start_stop/Test start/stop/start continuous transform}
-  issue: https://github.com/elastic/elasticsearch/issues/126755
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_stats/Test get multiple transform stats where one does not have a task}
-  issue: https://github.com/elastic/elasticsearch/issues/126863
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=ml/inference_crud/Test delete given unused trained model}
-  issue: https://github.com/elastic/elasticsearch/issues/126881
-- class: org.elasticsearch.index.engine.CompletionStatsCacheTests
-  method: testCompletionStatsCache
-  issue: https://github.com/elastic/elasticsearch/issues/126910
-- class: org.elasticsearch.xpack.ml.integration.ClassificationHousePricingIT
-  method: testFeatureImportanceValues
-  issue: https://github.com/elastic/elasticsearch/issues/124341
-- class: org.elasticsearch.cli.keystore.AddStringKeyStoreCommandTests
-  method: testStdinWithMultipleValues
-  issue: https://github.com/elastic/elasticsearch/issues/126882
-- class: org.elasticsearch.xpack.ccr.action.ShardFollowTaskReplicationTests
-  method: testChangeFollowerHistoryUUID
-  issue: https://github.com/elastic/elasticsearch/issues/127680
-- class: org.elasticsearch.action.admin.indices.diskusage.IndexDiskUsageAnalyzerTests
-  method: testKnnVectors
-  issue: https://github.com/elastic/elasticsearch/issues/127689
-- class: org.elasticsearch.xpack.esql.plugin.DataNodeRequestSenderIT
-  method: testSearchWhileRelocating
-  issue: https://github.com/elastic/elasticsearch/issues/128500
-- class: org.elasticsearch.entitlement.runtime.policy.FileAccessTreeTests
-  method: testWindowsMixedCaseAccess
-  issue: https://github.com/elastic/elasticsearch/issues/129167
-- class: org.elasticsearch.entitlement.runtime.policy.FileAccessTreeTests
-  method: testWindowsAbsolutPathAccess
-  issue: https://github.com/elastic/elasticsearch/issues/129168
-- class: org.elasticsearch.xpack.ml.integration.ClassificationIT
-  method: testWithDatastreams
-  issue: https://github.com/elastic/elasticsearch/issues/129457
-- class: org.elasticsearch.xpack.profiling.action.GetStatusActionIT
-  method: testWaitsUntilResourcesAreCreated
-  issue: https://github.com/elastic/elasticsearch/issues/129486
-- class: org.elasticsearch.search.query.VectorIT
-  method: testFilteredQueryStrategy
-  issue: https://github.com/elastic/elasticsearch/issues/129517
-- class: org.elasticsearch.xpack.security.SecurityRolesMultiProjectIT
-  method: testUpdatingFileBasedRoleAffectsAllProjects
-  issue: https://github.com/elastic/elasticsearch/issues/129775
-- class: org.elasticsearch.action.support.ThreadedActionListenerTests
-  method: testRejectionHandling
-  issue: https://github.com/elastic/elasticsearch/issues/130129
-- class: org.elasticsearch.compute.aggregation.TopIntAggregatorFunctionTests
-  method: testManyInitialManyPartialFinalRunnerThrowing
-  issue: https://github.com/elastic/elasticsearch/issues/130145
-- class: org.elasticsearch.xpack.searchablesnapshots.cache.shared.NodesCachesStatsIntegTests
-  method: testNodesCachesStats
-  issue: https://github.com/elastic/elasticsearch/issues/129863
-- class: org.elasticsearch.index.IndexingPressureIT
-  method: testWriteCanRejectOnPrimaryBasedOnMaxOperationSize
-  issue: https://github.com/elastic/elasticsearch/issues/130281
-- class: org.elasticsearch.xpack.esql.inference.bulk.BulkInferenceExecutorTests
-  method: testSuccessfulExecution
-  issue: https://github.com/elastic/elasticsearch/issues/130306
-- class: org.elasticsearch.indices.stats.IndexStatsIT
-  method: testFilterCacheStats
-  issue: https://github.com/elastic/elasticsearch/issues/124447
-- class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
-  method: test {p0=mtermvectors/10_basic/Tests catching other exceptions per item}
-  issue: https://github.com/elastic/elasticsearch/issues/122414
-- class: org.elasticsearch.packaging.test.DockerTests
-  method: test090SecurityCliPackaging
-  issue: https://github.com/elastic/elasticsearch/issues/131107
-- class: org.elasticsearch.xpack.esql.expression.function.fulltext.ScoreTests
-  method: testSerializationOfSimple {TestCase=<boolean>}
-  issue: https://github.com/elastic/elasticsearch/issues/131334
-- class: org.elasticsearch.xpack.esql.analysis.VerifierTests
-  method: testMatchInsideEval
-  issue: https://github.com/elastic/elasticsearch/issues/131336
-- class: org.elasticsearch.packaging.test.DockerTests
-  method: test071BindMountCustomPathWithDifferentUID
-  issue: https://github.com/elastic/elasticsearch/issues/120917
-- class: org.elasticsearch.packaging.test.DockerTests
-  method: test171AdditionalCliOptionsAreForwarded
-  issue: https://github.com/elastic/elasticsearch/issues/120925
-- class: org.elasticsearch.packaging.test.DockerTests
-  method: test050BasicApiTests
-  issue: https://github.com/elastic/elasticsearch/issues/120911
-- class: org.elasticsearch.xpack.restart.FullClusterRestartIT
-  method: testWatcherWithApiKey {cluster=UPGRADED}
-  issue: https://github.com/elastic/elasticsearch/issues/131964
-- class: org.elasticsearch.test.rest.yaml.MDPYamlTestSuiteIT
-  method: test {yaml=mdp/10_basic/Index using shared data path}
-  issue: https://github.com/elastic/elasticsearch/issues/132223
-- class: org.elasticsearch.xpack.sql.qa.mixed_node.SqlCompatIT
-  method: testNullsOrderWithMissingOrderSupportQueryingNewNode
-  issue: https://github.com/elastic/elasticsearch/issues/132249
-- class: org.elasticsearch.xpack.ml.integration.AutodetectMemoryLimitIT
-  method: testManyDistinctOverFields
-  issue: https://github.com/elastic/elasticsearch/issues/132308
-- class: org.elasticsearch.xpack.ml.integration.AutodetectMemoryLimitIT
-  method: testTooManyByAndOverFields
-  issue: https://github.com/elastic/elasticsearch/issues/132310
-- class: org.elasticsearch.xpack.esql.inference.completion.CompletionOperatorTests
-  method: testSimpleCircuitBreaking
-  issue: https://github.com/elastic/elasticsearch/issues/132382
-- class: org.elasticsearch.xpack.ml.integration.RevertModelSnapshotIT
-  method: testRevertModelSnapshot_DeleteInterveningResults
-  issue: https://github.com/elastic/elasticsearch/issues/132349
-- class: org.elasticsearch.xpack.ml.integration.RevertModelSnapshotIT
-  method: testRevertModelSnapshot
-  issue: https://github.com/elastic/elasticsearch/issues/132733
-- class: org.elasticsearch.packaging.test.ArchiveGenerateInitialCredentialsTests
-  method: test40VerifyAutogeneratedCredentials
-  issue: https://github.com/elastic/elasticsearch/issues/132877
-- class: org.elasticsearch.packaging.test.ArchiveGenerateInitialCredentialsTests
-  method: test50CredentialAutogenerationOnlyOnce
-  issue: https://github.com/elastic/elasticsearch/issues/132878
-- class: org.elasticsearch.xpack.eql.planner.QueryTranslatorTests
-  method: testMatchOptimization
-  issue: https://github.com/elastic/elasticsearch/issues/132894
-- class: org.elasticsearch.xpack.deprecation.DeprecationHttpIT
-  method: testUniqueDeprecationResponsesMergedTogether
-  issue: https://github.com/elastic/elasticsearch/issues/132895
-- class: org.elasticsearch.search.CCSDuelIT
-  method: testTermsAggs
-  issue: https://github.com/elastic/elasticsearch/issues/132879
-- class: org.elasticsearch.search.CCSDuelIT
-  method: testTermsAggsWithProfile
-  issue: https://github.com/elastic/elasticsearch/issues/132880
-- class: org.elasticsearch.xpack.security.authc.AuthenticationServiceTests
-  method: testInvalidToken
-  issue: https://github.com/elastic/elasticsearch/issues/133328
-- class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
-  method: testCancelViaExpirationOnRemoteResultsWithMinimizeRoundtrips
-  issue: https://github.com/elastic/elasticsearch/issues/127302
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlClientYamlIT
-  method: test {p0=esql/60_usage/*}
-  issue: https://github.com/elastic/elasticsearch/issues/133461
-- class: org.elasticsearch.xpack.esql.inference.rerank.RerankOperatorTests
-  method: testSimpleCircuitBreaking
-  issue: https://github.com/elastic/elasticsearch/issues/133619
-- class: org.elasticsearch.xpack.ml.integration.InferenceIT
-  method: testInferClassificationModel
-  issue: https://github.com/elastic/elasticsearch/issues/133448
-- class: org.elasticsearch.xpack.ml.integration.ClassificationIT
-  method: testWithCustomFeatureProcessors
-  issue: https://github.com/elastic/elasticsearch/issues/134001
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
-  method: test {csv-spec:fork.ForkBeforeStats}
-  issue: https://github.com/elastic/elasticsearch/issues/134100
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
-  method: test {csv-spec:fork.ForkWithMixOfCommands}
-  issue: https://github.com/elastic/elasticsearch/issues/134135
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeForkIT
-  method: test {csv-spec:inlinestats.MultiIndexInlinestatsOfMultiTypedField}
-  issue: https://github.com/elastic/elasticsearch/issues/133973
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.score.DecayTests
-  method: "testEvaluateBlockWithNulls {TestCase=<double>, <double>, <double>, <_source> #11}"
-  issue: https://github.com/elastic/elasticsearch/issues/134447
-- class: org.elasticsearch.cluster.ClusterInfoServiceIT
-  method: testMaxQueueLatenciesInClusterInfo
-  issue: https://github.com/elastic/elasticsearch/issues/134500
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.score.DecayTests
-  method: "testEvaluateBlockWithNulls {TestCase=<date_nanos>, <date_nanos>, <time_duration>, <_source> #11}"
-  issue: https://github.com/elastic/elasticsearch/issues/134509
-- class: org.elasticsearch.xpack.esql.plugin.CanMatchIT
-  method: testAliasFilters
-  issue: https://github.com/elastic/elasticsearch/issues/134512
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
-  method: test {csv-spec:fork.FiveFork}
-  issue: https://github.com/elastic/elasticsearch/issues/134560
-- class: org.elasticsearch.xpack.esql.analysis.AnalyzerTests
-  method: testDenseVectorImplicitCastingKnnQueryParams
-  issue: https://github.com/elastic/elasticsearch/issues/134639
-- class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
-  method: testOldRepoAccess
-  issue: https://github.com/elastic/elasticsearch/issues/120148
-- class: org.elasticsearch.oldrepos.OldRepositoryAccessIT
-  method: testOldSourceOnlyRepoAccess
-  issue: https://github.com/elastic/elasticsearch/issues/134646
-- class: org.elasticsearch.oldrepos.OldMappingsIT
-  method: testStandardTokenFilter
-  issue: https://github.com/elastic/elasticsearch/issues/134647
-- class: org.elasticsearch.aggregations.bucket.AggregationReductionCircuitBreakingIT
-  method: testCBTrippingOnReduction
-  issue: https://github.com/elastic/elasticsearch/issues/134667
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.score.DecayTests
-  method: "testEvaluateBlockWithNulls {TestCase=<integer>, <integer>, <integer>, <_source> #2}"
-  issue: https://github.com/elastic/elasticsearch/issues/134679
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
-  method: test {csv-spec:fork.ForkBeforeStatsByWithWhere}
-  issue: https://github.com/elastic/elasticsearch/issues/134817
-- class: org.elasticsearch.repositories.blobstore.testkit.analyze.MinioRepositoryAnalysisRestIT
-  method: testRepositoryAnalysis
-  issue: https://github.com/elastic/elasticsearch/issues/134853
-- class: org.elasticsearch.xpack.esql.action.CrossClusterCancellationIT
-  method: testCancelSkipUnavailable
-  issue: https://github.com/elastic/elasticsearch/issues/134865
-- class: org.elasticsearch.xpack.ml.integration.InferenceIT
-  method: testInferRegressionModel
-  issue: https://github.com/elastic/elasticsearch/issues/133603
-- class: org.elasticsearch.reservedstate.service.RepositoriesFileSettingsIT
-  method: testSettingsApplied
-  issue: https://github.com/elastic/elasticsearch/issues/126748
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
-  method: test {csv-spec:stats.CountDistinctWithConditions}
-  issue: https://github.com/elastic/elasticsearch/issues/134984
-- class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
-  method: test {csv-spec:stats.CountDistinctWithConditions}
-  issue: https://github.com/elastic/elasticsearch/issues/134993
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
-  method: test {csv-spec:fork.ForkBeforeStatsWithWhere}
-  issue: https://github.com/elastic/elasticsearch/issues/135041
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeMetricsIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/135055
-- class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
-  method: test {csv-spec:fork.ForkWithStats}
-  issue: https://github.com/elastic/elasticsearch/issues/135116
-- class: org.elasticsearch.xpack.esql.heap_attack.HeapAttackIT
-  method: testLookupExplosionBigString
-  issue: https://github.com/elastic/elasticsearch/issues/135122
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=transform/transforms_start_stop/Test stop transform with force and wait_for_checkpoint true}
-  issue: https://github.com/elastic/elasticsearch/issues/135135
-- class: org.elasticsearch.discovery.ClusterDisruptionIT
-  method: testAckedIndexing
-  issue: https://github.com/elastic/elasticsearch/issues/117024
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=analytics/nested_top_metrics_sort/terms order by top metrics numeric not null double values}
-  issue: https://github.com/elastic/elasticsearch/issues/135159
-- class: org.elasticsearch.xpack.test.rest.XPackRestIT
-  method: test {p0=analytics/nested_top_metrics_sort/terms order by top metrics numeric not null integer values}
-  issue: https://github.com/elastic/elasticsearch/issues/135162
-- class: org.elasticsearch.xpack.esql.qa.single_node.PushQueriesIT
-  method: testEqualityAndOther {SEMANTIC_TEXT_WITH_KEYWORD}
-  issue: https://github.com/elastic/elasticsearch/issues/135333
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.score.DecayTests
-  method: "testEvaluateInManyThreads {TestCase=<double>, <double>, <double>, <_source> #17}"
-  issue: https://github.com/elastic/elasticsearch/issues/135357
-- class: org.elasticsearch.xpack.esql.expression.function.scalar.score.DecayTests
-  method: "testEvaluateBlockWithoutNulls {TestCase=<date_nanos>, <date_nanos>, <time_duration>, <_source> #12}"
-  issue: https://github.com/elastic/elasticsearch/issues/135394
-- class: org.elasticsearch.gradle.TestClustersPluginFuncTest
-  method: override jdk usage via ES_JAVA_HOME for known jdk os incompatibilities
-  issue: https://github.com/elastic/elasticsearch/issues/135413
-- class: org.elasticsearch.xpack.esql.inference.textembedding.TextEmbeddingOperatorTests
-  method: testSimpleCircuitBreaking
-  issue: https://github.com/elastic/elasticsearch/issues/135569
-- class: org.elasticsearch.multiproject.test.XpackWithMultipleProjectsClientYamlTestSuiteIT
-  method: test {yaml=esql/60_usage/Basic ESQL usage output (telemetry) snapshot version}
-  issue: https://github.com/elastic/elasticsearch/issues/135579
-- class: org.elasticsearch.xpack.esql.heap_attack.HeapAttackIT
-  method: testAggTooManyMvLongs
-  issue: https://github.com/elastic/elasticsearch/issues/135585
-- class: org.elasticsearch.indices.recovery.IndexRecoveryIT
-  method: testUsesFileBasedRecoveryIfOperationsBasedRecoveryWouldBeUnreasonable
-  issue: https://github.com/elastic/elasticsearch/issues/135737
-- class: org.elasticsearch.datastreams.TSDBIndexingIT
-  method: testTsdbTemplatesNoKeywordFieldType
-  issue: https://github.com/elastic/elasticsearch/issues/135746
-- class: org.elasticsearch.xpack.esql.expression.function.aggregate.IncreaseTests
-  method: testGroupingAggregate {TestCase=<small positive doubles>}
-  issue: https://github.com/elastic/elasticsearch/issues/135752
-- class: org.elasticsearch.xpack.esql.expression.function.aggregate.IncreaseTests
-  method: testGroupingAggregate {TestCase=<positive ints>}
-  issue: https://github.com/elastic/elasticsearch/issues/135753
-- class: org.elasticsearch.xpack.esql.expression.function.aggregate.IncreaseTests
-  method: testGroupingAggregate {TestCase=<positive longs>}
-  issue: https://github.com/elastic/elasticsearch/issues/135754
-- class: org.elasticsearch.xpack.esql.expression.function.aggregate.IncreaseTests
-  method: testGroupingAggregate {TestCase=<big positive doubles>}
-  issue: https://github.com/elastic/elasticsearch/issues/135755
-- class: org.elasticsearch.xpack.esql.ccq.AllSupportedFieldsIT
-  method: testFetchDenseVector {pref=null mode=time_series}
-  issue: https://github.com/elastic/elasticsearch/issues/135762
-- class: org.elasticsearch.xpack.esql.expression.function.aggregate.IrateTests
-  method: testGroupingAggregate {TestCase=<positive longs>}
-  issue: https://github.com/elastic/elasticsearch/issues/135775
-- class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/135787
-- class: org.elasticsearch.ingest.SamplingServiceTests
-  method: testMaybeSampleWithLowRate
-  issue: https://github.com/elastic/elasticsearch/issues/135808
-- class: org.elasticsearch.ingest.SamplingServiceTests
-  method: testMaybeSample
-  issue: https://github.com/elastic/elasticsearch/issues/135809
-- class: org.elasticsearch.ingest.SamplingServiceTests
-  method: testMaybeSampleWithCondition
-  issue: https://github.com/elastic/elasticsearch/issues/135810
-- class: org.elasticsearch.ingest.SamplingServiceTests
-  method: testMaybeSampleMaxSamples
-  issue: https://github.com/elastic/elasticsearch/issues/135811
-- class: org.elasticsearch.xpack.esql.expression.function.aggregate.IrateTests
-  method: testGroupingAggregate {TestCase=<positive ints>}
-  issue: https://github.com/elastic/elasticsearch/issues/135814
-- class: org.elasticsearch.xpack.esql.expression.function.aggregate.IrateTests
-  method: testGroupingAggregate {TestCase=<small positive doubles>}
-  issue: https://github.com/elastic/elasticsearch/issues/135757
-- class: org.elasticsearch.xpack.esql.expression.function.aggregate.IrateTests
-  method: testGroupingAggregate {TestCase=<big positive doubles>}
-  issue: https://github.com/elastic/elasticsearch/issues/135756
-- class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
-  method: test
-  issue: https://github.com/elastic/elasticsearch/issues/135787
-- class: org.elasticsearch.xpack.logsdb.qa.BulkDynamicMappingChallengeRestIT
-  method: testMatchAllQuery
-  issue: https://github.com/elastic/elasticsearch/issues/135820
-- class: org.elasticsearch.datastreams.DataStreamIndexSettingsProviderTests
-  method: testGetAdditionalIndexSettingsMappingsMerging
-  issue: https://github.com/elastic/elasticsearch/issues/135884
-- class: org.elasticsearch.datastreams.DataStreamIndexSettingsProviderTests
-  method: testGetAdditionalIndexSettings
-  issue: https://github.com/elastic/elasticsearch/issues/135972
-- class: org.elasticsearch.search.basic.SearchWithRandomDisconnectsIT
-  method: testSearchWithRandomDisconnects
-  issue: https://github.com/elastic/elasticsearch/issues/138128
-- class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
-  method: testDatafeedTimingStats_DatafeedRecreated
-  issue: https://github.com/elastic/elasticsearch/issues/138348
-- class: org.elasticsearch.versioning.ConcurrentSeqNoVersioningIT
-  method: testSeqNoCASLinearizability
-  issue: https://github.com/elastic/elasticsearch/issues/117249
-- class: org.elasticsearch.xpack.logsdb.qa.BulkDynamicMappingChallengeRestIT
-  method: testEsqlTermsAggregation
-  issue: https://github.com/elastic/elasticsearch/issues/138717
-- class: org.elasticsearch.readiness.ReadinessClusterIT
-  method: testReadinessDuringRestartsNormalOrder
-  issue: https://github.com/elastic/elasticsearch/issues/136955
-- class: org.elasticsearch.packaging.test.DockerTests
-  method: test140CgroupOsStatsAreAvailable
-  issue: https://github.com/elastic/elasticsearch/issues/131372
-- class: org.elasticsearch.packaging.test.DockerTests
-  method: test070BindMountCustomPathConfAndJvmOptions
-  issue: https://github.com/elastic/elasticsearch/issues/131366
-- class: org.elasticsearch.index.reindex.ReindexNodeShutdownIT
-  method: testReindexWithShutdown
-  issue: https://github.com/elastic/elasticsearch/issues/139806
+  - class: "org.elasticsearch.client.RestClientSingleHostIntegTests"
+    issue: "https://github.com/elastic/elasticsearch/issues/102717"
+    method: "testRequestResetAndAbort"
+  - class: org.elasticsearch.packaging.test.PackagesSecurityAutoConfigurationTests
+    method: test20SecurityNotAutoConfiguredOnReInstallation
+    issue: https://github.com/elastic/elasticsearch/issues/112635
+  - class: org.elasticsearch.packaging.test.WindowsServiceTests
+    method: test30StartStop
+    issue: https://github.com/elastic/elasticsearch/issues/113160
+  - class: org.elasticsearch.packaging.test.WindowsServiceTests
+    method: test33JavaChanged
+    issue: https://github.com/elastic/elasticsearch/issues/113177
+  - class: org.elasticsearch.packaging.test.WindowsServiceTests
+    method: test80JavaOptsInEnvVar
+    issue: https://github.com/elastic/elasticsearch/issues/113219
+  - class: org.elasticsearch.packaging.test.WindowsServiceTests
+    method: test81JavaOptsInJvmOptions
+    issue: https://github.com/elastic/elasticsearch/issues/113313
+  - class: org.elasticsearch.xpack.transform.integration.TransformIT
+    method: testStopWaitForCheckpoint
+    issue: https://github.com/elastic/elasticsearch/issues/106113
+  - class: org.elasticsearch.xpack.remotecluster.RemoteClusterSecurityWithApmTracingRestIT
+    method: testTracingCrossCluster
+    issue: https://github.com/elastic/elasticsearch/issues/112731
+  - class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
+    method: testDeploymentSurvivesRestart {cluster=UPGRADED}
+    issue: https://github.com/elastic/elasticsearch/issues/115528
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=transform/transforms_start_stop/Verify start transform reuses destination index}
+    issue: https://github.com/elastic/elasticsearch/issues/115808
+  - class: org.elasticsearch.xpack.application.connector.ConnectorIndexServiceTests
+    issue: https://github.com/elastic/elasticsearch/issues/116087
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=transform/transforms_start_stop/Test start already started transform}
+    issue: https://github.com/elastic/elasticsearch/issues/98802
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=snapshot/20_operator_privileges_disabled/Operator only settings can be set and restored by non-operator user when operator privileges is disabled}
+    issue: https://github.com/elastic/elasticsearch/issues/116775
+  - class: org.elasticsearch.search.basic.SearchWithRandomIOExceptionsIT
+    method: testRandomDirectoryIOExceptions
+    issue: https://github.com/elastic/elasticsearch/issues/114824
+  - class: org.elasticsearch.xpack.apmdata.APMYamlTestSuiteIT
+    method: test {yaml=/10_apm/Test template reinstallation}
+    issue: https://github.com/elastic/elasticsearch/issues/116445
+  - class: org.elasticsearch.xpack.inference.InferenceRestIT
+    method: test {p0=inference/40_semantic_text_query/Query a field that uses the default ELSER 2 endpoint}
+    issue: https://github.com/elastic/elasticsearch/issues/117027
+  - class: org.elasticsearch.xpack.inference.InferenceRestIT
+    method: test {p0=inference/30_semantic_text_inference/Calculates embeddings using the default ELSER 2 endpoint}
+    issue: https://github.com/elastic/elasticsearch/issues/117349
+  - class: org.elasticsearch.xpack.inference.InferenceRestIT
+    method: test {p0=inference/30_semantic_text_inference_bwc/Calculates embeddings using the default ELSER 2 endpoint}
+    issue: https://github.com/elastic/elasticsearch/issues/117349
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=transform/transforms_reset/Test reset running transform}
+    issue: https://github.com/elastic/elasticsearch/issues/117473
+  - class: org.elasticsearch.xpack.ml.integration.RegressionIT
+    method: testTwoJobsWithSameRandomizeSeedUseSameTrainingSet
+    issue: https://github.com/elastic/elasticsearch/issues/117805
+  - class: org.elasticsearch.packaging.test.ArchiveTests
+    method: test44AutoConfigurationNotTriggeredOnNotWriteableConfDir
+    issue: https://github.com/elastic/elasticsearch/issues/118208
+  - class: org.elasticsearch.packaging.test.ArchiveTests
+    method: test51AutoConfigurationWithPasswordProtectedKeystore
+    issue: https://github.com/elastic/elasticsearch/issues/118212
+  - class: org.elasticsearch.xpack.ccr.rest.ShardChangesRestIT
+    method: testShardChangesNoOperation
+    issue: https://github.com/elastic/elasticsearch/issues/118800
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=transform/transforms_start_stop/Test start/stop/start transform}
+    issue: https://github.com/elastic/elasticsearch/issues/119508
+  - class: org.elasticsearch.xpack.ml.integration.ForecastIT
+    method: testOverflowToDisk
+    issue: https://github.com/elastic/elasticsearch/issues/117740
+  - class: org.elasticsearch.multi_cluster.MultiClusterYamlTestSuiteIT
+    issue: https://github.com/elastic/elasticsearch/issues/119983
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=transform/transforms_unattended/Test unattended put and start}
+    issue: https://github.com/elastic/elasticsearch/issues/120019
+  - class: org.elasticsearch.xpack.security.QueryableReservedRolesIT
+    method: testConfiguredReservedRolesAfterClosingAndOpeningIndex
+    issue: https://github.com/elastic/elasticsearch/issues/120127
+  - class: org.elasticsearch.xpack.ccr.FollowIndexSecurityIT
+    method: testCleanShardFollowTaskAfterDeleteFollower
+    issue: https://github.com/elastic/elasticsearch/issues/120339
+  - class: org.elasticsearch.xpack.sql.expression.function.scalar.datetime.DateTimeToCharProcessorTests
+    issue: https://github.com/elastic/elasticsearch/issues/120575
+  - class: org.elasticsearch.xpack.inference.DefaultEndPointsIT
+    method: testMultipleInferencesTriggeringDownloadAndDeploy
+    issue: https://github.com/elastic/elasticsearch/issues/120668
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=ml/3rd_party_deployment/Test start deployment fails while model download in progress}
+    issue: https://github.com/elastic/elasticsearch/issues/120810
+  - class: org.elasticsearch.xpack.security.authc.service.ServiceAccountIT
+    method: testAuthenticateShouldNotFallThroughInCaseOfFailure
+    issue: https://github.com/elastic/elasticsearch/issues/120902
+  - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+    method: test {p0=nodes.stats/11_indices_metrics/indices mappings exact count test for indices level}
+    issue: https://github.com/elastic/elasticsearch/issues/120950
+  - class: org.elasticsearch.analysis.common.CommonAnalysisClientYamlTestSuiteIT
+    method: test {yaml=analysis-common/40_token_filters/stemmer_override file access}
+    issue: https://github.com/elastic/elasticsearch/issues/121625
+  - class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
+    method: test {yaml=snapshot.delete/10_basic/Delete a snapshot asynchronously}
+    issue: https://github.com/elastic/elasticsearch/issues/122102
+  - class: org.elasticsearch.action.admin.cluster.node.tasks.CancellableTasksIT
+    method: testChildrenTasksCancelledOnTimeout
+    issue: https://github.com/elastic/elasticsearch/issues/123568
+  - class: org.elasticsearch.xpack.searchablesnapshots.FrozenSearchableSnapshotsIntegTests
+    method: testCreateAndRestorePartialSearchableSnapshot
+    issue: https://github.com/elastic/elasticsearch/issues/123773
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=snapshot/10_basic/Create a source only snapshot and then restore it}
+    issue: https://github.com/elastic/elasticsearch/issues/122755
+  - class: org.elasticsearch.indices.recovery.IndexRecoveryIT
+    method: testSourceThrottling
+    issue: https://github.com/elastic/elasticsearch/issues/123680
+  - class: org.elasticsearch.smoketest.MlWithSecurityIT
+    method: test {yaml=ml/3rd_party_deployment/Test start deployment fails while model download in progress}
+    issue: https://github.com/elastic/elasticsearch/issues/120814
+  - class: org.elasticsearch.smoketest.MlWithSecurityIT
+    method: test {yaml=ml/3rd_party_deployment/Test start and stop multiple deployments}
+    issue: https://github.com/elastic/elasticsearch/issues/124315
+  - class: org.elasticsearch.xpack.restart.MLModelDeploymentFullClusterRestartIT
+    method: testDeploymentSurvivesRestart {cluster=OLD}
+    issue: https://github.com/elastic/elasticsearch/issues/124160
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=transform/transforms_start_stop/Test schedule_now on an already started transform}
+    issue: https://github.com/elastic/elasticsearch/issues/120720
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=transform/transforms_start_stop/Verify start transform creates destination index with appropriate mapping}
+    issue: https://github.com/elastic/elasticsearch/issues/125854
+  - class: org.elasticsearch.xpack.core.common.notifications.AbstractAuditorTests
+    method: testRecreateTemplateWhenDeleted
+    issue: https://github.com/elastic/elasticsearch/issues/123232
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=transform/transforms_stats/Test get transform stats with timeout}
+    issue: https://github.com/elastic/elasticsearch/issues/125975
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=transform/transforms_reset/Test force reseting a running transform}
+    issue: https://github.com/elastic/elasticsearch/issues/126240
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=transform/transforms_stats/Test get transform stats}
+    issue: https://github.com/elastic/elasticsearch/issues/126270
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=transform/transforms_start_stop/Test start/stop only starts/stops specified transform}
+    issue: https://github.com/elastic/elasticsearch/issues/126466
+  - class: org.elasticsearch.smoketest.MlWithSecurityIT
+    method: test {yaml=ml/get_trained_model_stats/Test get stats given trained models}
+    issue: https://github.com/elastic/elasticsearch/issues/126510
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=transform/transforms_stats/Test get multiple transform stats}
+    issue: https://github.com/elastic/elasticsearch/issues/126567
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=transform/transforms_stats/Test get single transform stats when it does not have a task}
+    issue: https://github.com/elastic/elasticsearch/issues/126568
+  - class: org.elasticsearch.repositories.blobstore.testkit.rest.SnapshotRepoTestKitClientYamlTestSuiteIT
+    method: test {p0=/10_analyze/Analysis without details}
+    issue: https://github.com/elastic/elasticsearch/issues/126569
+  - class: org.elasticsearch.xpack.esql.action.EsqlActionIT
+    method: testQueryOnEmptyDataIndex
+    issue: https://github.com/elastic/elasticsearch/issues/126580
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=transform/transforms_start_stop/Test start/stop/start continuous transform}
+    issue: https://github.com/elastic/elasticsearch/issues/126755
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=transform/transforms_stats/Test get multiple transform stats where one does not have a task}
+    issue: https://github.com/elastic/elasticsearch/issues/126863
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=ml/inference_crud/Test delete given unused trained model}
+    issue: https://github.com/elastic/elasticsearch/issues/126881
+  - class: org.elasticsearch.index.engine.CompletionStatsCacheTests
+    method: testCompletionStatsCache
+    issue: https://github.com/elastic/elasticsearch/issues/126910
+  - class: org.elasticsearch.xpack.ml.integration.ClassificationHousePricingIT
+    method: testFeatureImportanceValues
+    issue: https://github.com/elastic/elasticsearch/issues/124341
+  - class: org.elasticsearch.cli.keystore.AddStringKeyStoreCommandTests
+    method: testStdinWithMultipleValues
+    issue: https://github.com/elastic/elasticsearch/issues/126882
+  - class: org.elasticsearch.xpack.ccr.action.ShardFollowTaskReplicationTests
+    method: testChangeFollowerHistoryUUID
+    issue: https://github.com/elastic/elasticsearch/issues/127680
+  - class: org.elasticsearch.action.admin.indices.diskusage.IndexDiskUsageAnalyzerTests
+    method: testKnnVectors
+    issue: https://github.com/elastic/elasticsearch/issues/127689
+  - class: org.elasticsearch.xpack.esql.plugin.DataNodeRequestSenderIT
+    method: testSearchWhileRelocating
+    issue: https://github.com/elastic/elasticsearch/issues/128500
+  - class: org.elasticsearch.entitlement.runtime.policy.FileAccessTreeTests
+    method: testWindowsMixedCaseAccess
+    issue: https://github.com/elastic/elasticsearch/issues/129167
+  - class: org.elasticsearch.entitlement.runtime.policy.FileAccessTreeTests
+    method: testWindowsAbsolutPathAccess
+    issue: https://github.com/elastic/elasticsearch/issues/129168
+  - class: org.elasticsearch.xpack.ml.integration.ClassificationIT
+    method: testWithDatastreams
+    issue: https://github.com/elastic/elasticsearch/issues/129457
+  - class: org.elasticsearch.xpack.profiling.action.GetStatusActionIT
+    method: testWaitsUntilResourcesAreCreated
+    issue: https://github.com/elastic/elasticsearch/issues/129486
+  - class: org.elasticsearch.search.query.VectorIT
+    method: testFilteredQueryStrategy
+    issue: https://github.com/elastic/elasticsearch/issues/129517
+  - class: org.elasticsearch.xpack.security.SecurityRolesMultiProjectIT
+    method: testUpdatingFileBasedRoleAffectsAllProjects
+    issue: https://github.com/elastic/elasticsearch/issues/129775
+  - class: org.elasticsearch.action.support.ThreadedActionListenerTests
+    method: testRejectionHandling
+    issue: https://github.com/elastic/elasticsearch/issues/130129
+  - class: org.elasticsearch.compute.aggregation.TopIntAggregatorFunctionTests
+    method: testManyInitialManyPartialFinalRunnerThrowing
+    issue: https://github.com/elastic/elasticsearch/issues/130145
+  - class: org.elasticsearch.xpack.searchablesnapshots.cache.shared.NodesCachesStatsIntegTests
+    method: testNodesCachesStats
+    issue: https://github.com/elastic/elasticsearch/issues/129863
+  - class: org.elasticsearch.index.IndexingPressureIT
+    method: testWriteCanRejectOnPrimaryBasedOnMaxOperationSize
+    issue: https://github.com/elastic/elasticsearch/issues/130281
+  - class: org.elasticsearch.xpack.esql.inference.bulk.BulkInferenceExecutorTests
+    method: testSuccessfulExecution
+    issue: https://github.com/elastic/elasticsearch/issues/130306
+  - class: org.elasticsearch.indices.stats.IndexStatsIT
+    method: testFilterCacheStats
+    issue: https://github.com/elastic/elasticsearch/issues/124447
+  - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
+    method: test {p0=mtermvectors/10_basic/Tests catching other exceptions per item}
+    issue: https://github.com/elastic/elasticsearch/issues/122414
+  - class: org.elasticsearch.packaging.test.DockerTests
+    method: test090SecurityCliPackaging
+    issue: https://github.com/elastic/elasticsearch/issues/131107
+  - class: org.elasticsearch.xpack.esql.expression.function.fulltext.ScoreTests
+    method: testSerializationOfSimple {TestCase=<boolean>}
+    issue: https://github.com/elastic/elasticsearch/issues/131334
+  - class: org.elasticsearch.xpack.esql.analysis.VerifierTests
+    method: testMatchInsideEval
+    issue: https://github.com/elastic/elasticsearch/issues/131336
+  - class: org.elasticsearch.packaging.test.DockerTests
+    method: test071BindMountCustomPathWithDifferentUID
+    issue: https://github.com/elastic/elasticsearch/issues/120917
+  - class: org.elasticsearch.packaging.test.DockerTests
+    method: test171AdditionalCliOptionsAreForwarded
+    issue: https://github.com/elastic/elasticsearch/issues/120925
+  - class: org.elasticsearch.packaging.test.DockerTests
+    method: test050BasicApiTests
+    issue: https://github.com/elastic/elasticsearch/issues/120911
+  - class: org.elasticsearch.xpack.restart.FullClusterRestartIT
+    method: testWatcherWithApiKey {cluster=UPGRADED}
+    issue: https://github.com/elastic/elasticsearch/issues/131964
+  - class: org.elasticsearch.test.rest.yaml.MDPYamlTestSuiteIT
+    method: test {yaml=mdp/10_basic/Index using shared data path}
+    issue: https://github.com/elastic/elasticsearch/issues/132223
+  - class: org.elasticsearch.xpack.sql.qa.mixed_node.SqlCompatIT
+    method: testNullsOrderWithMissingOrderSupportQueryingNewNode
+    issue: https://github.com/elastic/elasticsearch/issues/132249
+  - class: org.elasticsearch.xpack.ml.integration.AutodetectMemoryLimitIT
+    method: testManyDistinctOverFields
+    issue: https://github.com/elastic/elasticsearch/issues/132308
+  - class: org.elasticsearch.xpack.ml.integration.AutodetectMemoryLimitIT
+    method: testTooManyByAndOverFields
+    issue: https://github.com/elastic/elasticsearch/issues/132310
+  - class: org.elasticsearch.xpack.esql.inference.completion.CompletionOperatorTests
+    method: testSimpleCircuitBreaking
+    issue: https://github.com/elastic/elasticsearch/issues/132382
+  - class: org.elasticsearch.xpack.ml.integration.RevertModelSnapshotIT
+    method: testRevertModelSnapshot_DeleteInterveningResults
+    issue: https://github.com/elastic/elasticsearch/issues/132349
+  - class: org.elasticsearch.xpack.ml.integration.RevertModelSnapshotIT
+    method: testRevertModelSnapshot
+    issue: https://github.com/elastic/elasticsearch/issues/132733
+  - class: org.elasticsearch.packaging.test.ArchiveGenerateInitialCredentialsTests
+    method: test40VerifyAutogeneratedCredentials
+    issue: https://github.com/elastic/elasticsearch/issues/132877
+  - class: org.elasticsearch.packaging.test.ArchiveGenerateInitialCredentialsTests
+    method: test50CredentialAutogenerationOnlyOnce
+    issue: https://github.com/elastic/elasticsearch/issues/132878
+  - class: org.elasticsearch.xpack.eql.planner.QueryTranslatorTests
+    method: testMatchOptimization
+    issue: https://github.com/elastic/elasticsearch/issues/132894
+  - class: org.elasticsearch.xpack.deprecation.DeprecationHttpIT
+    method: testUniqueDeprecationResponsesMergedTogether
+    issue: https://github.com/elastic/elasticsearch/issues/132895
+  - class: org.elasticsearch.search.CCSDuelIT
+    method: testTermsAggs
+    issue: https://github.com/elastic/elasticsearch/issues/132879
+  - class: org.elasticsearch.search.CCSDuelIT
+    method: testTermsAggsWithProfile
+    issue: https://github.com/elastic/elasticsearch/issues/132880
+  - class: org.elasticsearch.xpack.security.authc.AuthenticationServiceTests
+    method: testInvalidToken
+    issue: https://github.com/elastic/elasticsearch/issues/133328
+  - class: org.elasticsearch.xpack.search.CrossClusterAsyncSearchIT
+    method: testCancelViaExpirationOnRemoteResultsWithMinimizeRoundtrips
+    issue: https://github.com/elastic/elasticsearch/issues/127302
+  - class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlClientYamlIT
+    method: test {p0=esql/60_usage/*}
+    issue: https://github.com/elastic/elasticsearch/issues/133461
+  - class: org.elasticsearch.xpack.esql.inference.rerank.RerankOperatorTests
+    method: testSimpleCircuitBreaking
+    issue: https://github.com/elastic/elasticsearch/issues/133619
+  - class: org.elasticsearch.xpack.ml.integration.InferenceIT
+    method: testInferClassificationModel
+    issue: https://github.com/elastic/elasticsearch/issues/133448
+  - class: org.elasticsearch.xpack.ml.integration.ClassificationIT
+    method: testWithCustomFeatureProcessors
+    issue: https://github.com/elastic/elasticsearch/issues/134001
+  - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
+    method: test {csv-spec:fork.ForkBeforeStats}
+    issue: https://github.com/elastic/elasticsearch/issues/134100
+  - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
+    method: test {csv-spec:fork.ForkWithMixOfCommands}
+    issue: https://github.com/elastic/elasticsearch/issues/134135
+  - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeForkIT
+    method: test {csv-spec:inlinestats.MultiIndexInlinestatsOfMultiTypedField}
+    issue: https://github.com/elastic/elasticsearch/issues/133973
+  - class: org.elasticsearch.xpack.esql.expression.function.scalar.score.DecayTests
+    method: "testEvaluateBlockWithNulls {TestCase=<double>, <double>, <double>, <_source> #11}"
+    issue: https://github.com/elastic/elasticsearch/issues/134447
+  - class: org.elasticsearch.cluster.ClusterInfoServiceIT
+    method: testMaxQueueLatenciesInClusterInfo
+    issue: https://github.com/elastic/elasticsearch/issues/134500
+  - class: org.elasticsearch.xpack.esql.expression.function.scalar.score.DecayTests
+    method: "testEvaluateBlockWithNulls {TestCase=<date_nanos>, <date_nanos>, <time_duration>, <_source> #11}"
+    issue: https://github.com/elastic/elasticsearch/issues/134509
+  - class: org.elasticsearch.xpack.esql.plugin.CanMatchIT
+    method: testAliasFilters
+    issue: https://github.com/elastic/elasticsearch/issues/134512
+  - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
+    method: test {csv-spec:fork.FiveFork}
+    issue: https://github.com/elastic/elasticsearch/issues/134560
+  - class: org.elasticsearch.xpack.esql.analysis.AnalyzerTests
+    method: testDenseVectorImplicitCastingKnnQueryParams
+    issue: https://github.com/elastic/elasticsearch/issues/134639
+  - class: org.elasticsearch.aggregations.bucket.AggregationReductionCircuitBreakingIT
+    method: testCBTrippingOnReduction
+    issue: https://github.com/elastic/elasticsearch/issues/134667
+  - class: org.elasticsearch.xpack.esql.expression.function.scalar.score.DecayTests
+    method: "testEvaluateBlockWithNulls {TestCase=<integer>, <integer>, <integer>, <_source> #2}"
+    issue: https://github.com/elastic/elasticsearch/issues/134679
+  - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
+    method: test {csv-spec:fork.ForkBeforeStatsByWithWhere}
+    issue: https://github.com/elastic/elasticsearch/issues/134817
+  - class: org.elasticsearch.repositories.blobstore.testkit.analyze.MinioRepositoryAnalysisRestIT
+    method: testRepositoryAnalysis
+    issue: https://github.com/elastic/elasticsearch/issues/134853
+  - class: org.elasticsearch.xpack.esql.action.CrossClusterCancellationIT
+    method: testCancelSkipUnavailable
+    issue: https://github.com/elastic/elasticsearch/issues/134865
+  - class: org.elasticsearch.xpack.ml.integration.InferenceIT
+    method: testInferRegressionModel
+    issue: https://github.com/elastic/elasticsearch/issues/133603
+  - class: org.elasticsearch.reservedstate.service.RepositoriesFileSettingsIT
+    method: testSettingsApplied
+    issue: https://github.com/elastic/elasticsearch/issues/126748
+  - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
+    method: test {csv-spec:stats.CountDistinctWithConditions}
+    issue: https://github.com/elastic/elasticsearch/issues/134984
+  - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
+    method: test {csv-spec:stats.CountDistinctWithConditions}
+    issue: https://github.com/elastic/elasticsearch/issues/134993
+  - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
+    method: test {csv-spec:fork.ForkBeforeStatsWithWhere}
+    issue: https://github.com/elastic/elasticsearch/issues/135041
+  - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeMetricsIT
+    method: test
+    issue: https://github.com/elastic/elasticsearch/issues/135055
+  - class: org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT
+    method: test {csv-spec:fork.ForkWithStats}
+    issue: https://github.com/elastic/elasticsearch/issues/135116
+  - class: org.elasticsearch.xpack.esql.heap_attack.HeapAttackIT
+    method: testLookupExplosionBigString
+    issue: https://github.com/elastic/elasticsearch/issues/135122
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=transform/transforms_start_stop/Test stop transform with force and wait_for_checkpoint true}
+    issue: https://github.com/elastic/elasticsearch/issues/135135
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=analytics/nested_top_metrics_sort/terms order by top metrics numeric not null double values}
+    issue: https://github.com/elastic/elasticsearch/issues/135159
+  - class: org.elasticsearch.xpack.test.rest.XPackRestIT
+    method: test {p0=analytics/nested_top_metrics_sort/terms order by top metrics numeric not null integer values}
+    issue: https://github.com/elastic/elasticsearch/issues/135162
+  - class: org.elasticsearch.xpack.esql.qa.single_node.PushQueriesIT
+    method: testEqualityAndOther {SEMANTIC_TEXT_WITH_KEYWORD}
+    issue: https://github.com/elastic/elasticsearch/issues/135333
+  - class: org.elasticsearch.xpack.esql.expression.function.scalar.score.DecayTests
+    method: "testEvaluateInManyThreads {TestCase=<double>, <double>, <double>, <_source> #17}"
+    issue: https://github.com/elastic/elasticsearch/issues/135357
+  - class: org.elasticsearch.xpack.esql.expression.function.scalar.score.DecayTests
+    method: "testEvaluateBlockWithoutNulls {TestCase=<date_nanos>, <date_nanos>, <time_duration>, <_source> #12}"
+    issue: https://github.com/elastic/elasticsearch/issues/135394
+  - class: org.elasticsearch.gradle.TestClustersPluginFuncTest
+    method: override jdk usage via ES_JAVA_HOME for known jdk os incompatibilities
+    issue: https://github.com/elastic/elasticsearch/issues/135413
+  - class: org.elasticsearch.xpack.esql.inference.textembedding.TextEmbeddingOperatorTests
+    method: testSimpleCircuitBreaking
+    issue: https://github.com/elastic/elasticsearch/issues/135569
+  - class: org.elasticsearch.multiproject.test.XpackWithMultipleProjectsClientYamlTestSuiteIT
+    method: test {yaml=esql/60_usage/Basic ESQL usage output (telemetry) snapshot version}
+    issue: https://github.com/elastic/elasticsearch/issues/135579
+  - class: org.elasticsearch.xpack.esql.heap_attack.HeapAttackIT
+    method: testAggTooManyMvLongs
+    issue: https://github.com/elastic/elasticsearch/issues/135585
+  - class: org.elasticsearch.indices.recovery.IndexRecoveryIT
+    method: testUsesFileBasedRecoveryIfOperationsBasedRecoveryWouldBeUnreasonable
+    issue: https://github.com/elastic/elasticsearch/issues/135737
+  - class: org.elasticsearch.datastreams.TSDBIndexingIT
+    method: testTsdbTemplatesNoKeywordFieldType
+    issue: https://github.com/elastic/elasticsearch/issues/135746
+  - class: org.elasticsearch.xpack.esql.expression.function.aggregate.IncreaseTests
+    method: testGroupingAggregate {TestCase=<small positive doubles>}
+    issue: https://github.com/elastic/elasticsearch/issues/135752
+  - class: org.elasticsearch.xpack.esql.expression.function.aggregate.IncreaseTests
+    method: testGroupingAggregate {TestCase=<positive ints>}
+    issue: https://github.com/elastic/elasticsearch/issues/135753
+  - class: org.elasticsearch.xpack.esql.expression.function.aggregate.IncreaseTests
+    method: testGroupingAggregate {TestCase=<positive longs>}
+    issue: https://github.com/elastic/elasticsearch/issues/135754
+  - class: org.elasticsearch.xpack.esql.expression.function.aggregate.IncreaseTests
+    method: testGroupingAggregate {TestCase=<big positive doubles>}
+    issue: https://github.com/elastic/elasticsearch/issues/135755
+  - class: org.elasticsearch.xpack.esql.ccq.AllSupportedFieldsIT
+    method: testFetchDenseVector {pref=null mode=time_series}
+    issue: https://github.com/elastic/elasticsearch/issues/135762
+  - class: org.elasticsearch.xpack.esql.expression.function.aggregate.IrateTests
+    method: testGroupingAggregate {TestCase=<positive longs>}
+    issue: https://github.com/elastic/elasticsearch/issues/135775
+  - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeIT
+    method: test
+    issue: https://github.com/elastic/elasticsearch/issues/135787
+  - class: org.elasticsearch.ingest.SamplingServiceTests
+    method: testMaybeSampleWithLowRate
+    issue: https://github.com/elastic/elasticsearch/issues/135808
+  - class: org.elasticsearch.ingest.SamplingServiceTests
+    method: testMaybeSample
+    issue: https://github.com/elastic/elasticsearch/issues/135809
+  - class: org.elasticsearch.ingest.SamplingServiceTests
+    method: testMaybeSampleWithCondition
+    issue: https://github.com/elastic/elasticsearch/issues/135810
+  - class: org.elasticsearch.ingest.SamplingServiceTests
+    method: testMaybeSampleMaxSamples
+    issue: https://github.com/elastic/elasticsearch/issues/135811
+  - class: org.elasticsearch.xpack.esql.expression.function.aggregate.IrateTests
+    method: testGroupingAggregate {TestCase=<positive ints>}
+    issue: https://github.com/elastic/elasticsearch/issues/135814
+  - class: org.elasticsearch.xpack.esql.expression.function.aggregate.IrateTests
+    method: testGroupingAggregate {TestCase=<small positive doubles>}
+    issue: https://github.com/elastic/elasticsearch/issues/135757
+  - class: org.elasticsearch.xpack.esql.expression.function.aggregate.IrateTests
+    method: testGroupingAggregate {TestCase=<big positive doubles>}
+    issue: https://github.com/elastic/elasticsearch/issues/135756
+  - class: org.elasticsearch.xpack.esql.qa.multi_node.GenerativeIT
+    method: test
+    issue: https://github.com/elastic/elasticsearch/issues/135787
+  - class: org.elasticsearch.xpack.logsdb.qa.BulkDynamicMappingChallengeRestIT
+    method: testMatchAllQuery
+    issue: https://github.com/elastic/elasticsearch/issues/135820
+  - class: org.elasticsearch.datastreams.DataStreamIndexSettingsProviderTests
+    method: testGetAdditionalIndexSettingsMappingsMerging
+    issue: https://github.com/elastic/elasticsearch/issues/135884
+  - class: org.elasticsearch.datastreams.DataStreamIndexSettingsProviderTests
+    method: testGetAdditionalIndexSettings
+    issue: https://github.com/elastic/elasticsearch/issues/135972
+  - class: org.elasticsearch.search.basic.SearchWithRandomDisconnectsIT
+    method: testSearchWithRandomDisconnects
+    issue: https://github.com/elastic/elasticsearch/issues/138128
+  - class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
+    method: testDatafeedTimingStats_DatafeedRecreated
+    issue: https://github.com/elastic/elasticsearch/issues/138348
+  - class: org.elasticsearch.xpack.logsdb.qa.BulkDynamicMappingChallengeRestIT
+    method: testEsqlTermsAggregation
+    issue: https://github.com/elastic/elasticsearch/issues/138717
+  - class: org.elasticsearch.readiness.ReadinessClusterIT
+    method: testReadinessDuringRestartsNormalOrder
+    issue: https://github.com/elastic/elasticsearch/issues/136955
+  - class: org.elasticsearch.packaging.test.DockerTests
+    method: test140CgroupOsStatsAreAvailable
+    issue: https://github.com/elastic/elasticsearch/issues/131372
+  - class: org.elasticsearch.packaging.test.DockerTests
+    method: test070BindMountCustomPathConfAndJvmOptions
+    issue: https://github.com/elastic/elasticsearch/issues/131366
+  - class: org.elasticsearch.index.reindex.ReindexNodeShutdownIT
+    method: testReindexWithShutdown
+    issue: https://github.com/elastic/elasticsearch/issues/139806
 
 # Examples:
 #


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Unmute tests after landing #139569 (#140300)](https://github.com/elastic/elasticsearch/pull/140300)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)