### PR TITLE
[9.1] Adding dimensions to jina preconfigured endpoint (#139642)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -113,6 +113,12 @@ tests:
 - class: org.elasticsearch.analysis.common.CommonAnalysisClientYamlTestSuiteIT
   method: test {yaml=analysis-common/40_token_filters/stemmer_override file access}
   issue: https://github.com/elastic/elasticsearch/issues/121625
+- class: org.elasticsearch.index.reindex.ReindexClientYamlTestSuiteIT
+  method: test {yaml=delete_by_query/20_validation/Remote indices are not allowed in delete-by-query}
+  issue: https://github.com/elastic/elasticsearch/issues/140472
+- class: org.elasticsearch.index.reindex.ReindexClientYamlTestSuiteIT
+  method: test {yaml=update_by_query/20_validation/Remote indices are not allowed in update-by-query}
+  issue: https://github.com/elastic/elasticsearch/issues/140474
 - class: org.elasticsearch.test.rest.ClientYamlTestSuiteIT
   method: test {yaml=snapshot.delete/10_basic/Delete a snapshot asynchronously}
   issue: https://github.com/elastic/elasticsearch/issues/122102

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceService.java
@@ -203,7 +203,7 @@ public class ElasticInferenceService extends SenderService {
                     new ElasticInferenceServiceDenseTextEmbeddingsServiceSettings(
                         DEFAULT_MULTILINGUAL_EMBED_MODEL_ID,
                         defaultDenseTextEmbeddingsSimilarity(),
-                        null,
+                        DENSE_TEXT_EMBEDDINGS_DIMENSIONS,
                         null,
                         ElasticInferenceServiceDenseTextEmbeddingsServiceSettings.DEFAULT_RATE_LIMIT_SETTINGS
                     ),

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceModel.java
@@ -46,6 +46,20 @@ public abstract class ElasticInferenceServiceModel extends RateLimitGroupingMode
         return Objects.hash(this.getServiceSettings().modelId());
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        if (super.equals(o) == false) return false;
+        ElasticInferenceServiceModel that = (ElasticInferenceServiceModel) o;
+        return Objects.equals(rateLimitServiceSettings, that.rateLimitServiceSettings)
+            && Objects.equals(elasticInferenceServiceComponents, that.elasticInferenceServiceComponents);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), rateLimitServiceSettings, elasticInferenceServiceComponents);
+    }
+
     public RateLimitSettings rateLimitSettings() {
         return rateLimitServiceSettings.rateLimitSettings();
     }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
@@ -11,6 +11,7 @@ import org.apache.http.HttpHeaders;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.action.support.TestPlainActionFuture;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -45,6 +46,7 @@ import org.elasticsearch.xpack.core.inference.results.TextEmbeddingFloatResults;
 import org.elasticsearch.xpack.core.inference.results.UnifiedChatCompletionException;
 import org.elasticsearch.xpack.inference.InferencePlugin;
 import org.elasticsearch.xpack.inference.LocalStateInferencePlugin;
+import org.elasticsearch.xpack.inference.chunking.ChunkingSettingsBuilder;
 import org.elasticsearch.xpack.inference.external.http.HttpClientManager;
 import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSender;
 import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSenderTests;
@@ -58,11 +60,15 @@ import org.elasticsearch.xpack.inference.services.elastic.authorization.ElasticI
 import org.elasticsearch.xpack.inference.services.elastic.authorization.ElasticInferenceServiceAuthorizationRequestHandler;
 import org.elasticsearch.xpack.inference.services.elastic.completion.ElasticInferenceServiceCompletionModel;
 import org.elasticsearch.xpack.inference.services.elastic.completion.ElasticInferenceServiceCompletionServiceSettings;
+import org.elasticsearch.xpack.inference.services.elastic.densetextembeddings.ElasticInferenceServiceDenseTextEmbeddingsModel;
 import org.elasticsearch.xpack.inference.services.elastic.densetextembeddings.ElasticInferenceServiceDenseTextEmbeddingsModelTests;
+import org.elasticsearch.xpack.inference.services.elastic.densetextembeddings.ElasticInferenceServiceDenseTextEmbeddingsServiceSettings;
 import org.elasticsearch.xpack.inference.services.elastic.rerank.ElasticInferenceServiceRerankModel;
 import org.elasticsearch.xpack.inference.services.elastic.rerank.ElasticInferenceServiceRerankModelTests;
+import org.elasticsearch.xpack.inference.services.elastic.rerank.ElasticInferenceServiceRerankServiceSettings;
 import org.elasticsearch.xpack.inference.services.elastic.response.ElasticInferenceServiceAuthorizationResponseEntity;
 import org.elasticsearch.xpack.inference.services.elastic.sparseembeddings.ElasticInferenceServiceSparseEmbeddingsModel;
+import org.elasticsearch.xpack.inference.services.elastic.sparseembeddings.ElasticInferenceServiceSparseEmbeddingsServiceSettings;
 import org.elasticsearch.xpack.inference.services.elasticsearch.ElserModels;
 import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
 import org.hamcrest.MatcherAssert;
@@ -91,8 +97,19 @@ import static org.elasticsearch.xpack.inference.Utils.mockClusterServiceEmpty;
 import static org.elasticsearch.xpack.inference.external.http.Utils.entityAsMap;
 import static org.elasticsearch.xpack.inference.external.http.Utils.getUrl;
 import static org.elasticsearch.xpack.inference.services.ServiceComponentsTests.createWithEmptySettings;
+import static org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceService.DEFAULT_CHAT_COMPLETION_ENDPOINT_ID_V1;
+import static org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceService.DEFAULT_CHAT_COMPLETION_MODEL_ID_V1;
+import static org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceService.DEFAULT_ELSER_2_MODEL_ID;
+import static org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceService.DEFAULT_ELSER_ENDPOINT_ID_V2;
+import static org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceService.DEFAULT_MULTILINGUAL_EMBED_ENDPOINT_ID;
+import static org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceService.DEFAULT_MULTILINGUAL_EMBED_MODEL_ID;
+import static org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceService.DEFAULT_RERANK_ENDPOINT_ID_V1;
+import static org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceService.DEFAULT_RERANK_MODEL_ID_V1;
+import static org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceService.DENSE_TEXT_EMBEDDINGS_DIMENSIONS;
+import static org.elasticsearch.xpack.inference.services.elastic.ElasticInferenceService.defaultDenseTextEmbeddingsSimilarity;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -1302,8 +1319,8 @@ public class ElasticInferenceServiceTests extends ESSingleNodeTestCase {
                             ".multilingual-embed-v1-elastic",
                             MinimalServiceSettings.textEmbedding(
                                 ElasticInferenceService.NAME,
-                                ElasticInferenceService.DENSE_TEXT_EMBEDDINGS_DIMENSIONS,
-                                ElasticInferenceService.defaultDenseTextEmbeddingsSimilarity(),
+                                DENSE_TEXT_EMBEDDINGS_DIMENSIONS,
+                                defaultDenseTextEmbeddingsSimilarity(),
                                 DenseVectorFieldMapper.ElementType.FLOAT
                             ),
                             service
@@ -1334,6 +1351,94 @@ public class ElasticInferenceServiceTests extends ESSingleNodeTestCase {
             assertThat(models.get(1).getConfigurations().getInferenceEntityId(), is(".multilingual-embed-v1-elastic"));
             assertThat(models.get(2).getConfigurations().getInferenceEntityId(), is(".rainbow-sprinkles-elastic"));
             assertThat(models.get(3).getConfigurations().getInferenceEntityId(), is(".rerank-v1-elastic"));
+        }
+    }
+
+    public void testDefaultConfigs_Returns_DefaultEndpointsModels() throws Exception {
+        String responseJson = """
+            {
+                "models": [
+                    {
+                      "model_name": "rainbow-sprinkles",
+                      "task_types": ["chat"]
+                    },
+                    {
+                      "model_name": "elser_model_2",
+                      "task_types": ["embed/text/sparse"]
+                    },
+                    {
+                      "model_name": "jina-embeddings-v3",
+                      "task_types": ["embed/text/dense"]
+                    },
+                    {
+                      "model_name": "elastic-rerank-v1",
+                      "task_types": ["rerank/text/text-similarity"]
+                    }
+                ]
+            }
+            """;
+
+        webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
+
+        var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
+        try (var service = createServiceWithAuthHandler(senderFactory, getUrl(webServer))) {
+            ensureAuthorizationCallFinished(service);
+            var listener = new TestPlainActionFuture<List<Model>>();
+
+            service.defaultConfigs(listener);
+            var models = listener.actionGet(TIMEOUT);
+
+            var elasticInferenceServiceComponents = new ElasticInferenceServiceComponents(getUrl(webServer));
+
+            assertThat(
+                models,
+                containsInAnyOrder(
+                    new ElasticInferenceServiceCompletionModel(
+                        DEFAULT_CHAT_COMPLETION_ENDPOINT_ID_V1,
+                        TaskType.CHAT_COMPLETION,
+                        ElasticInferenceService.NAME,
+                        new ElasticInferenceServiceCompletionServiceSettings(DEFAULT_CHAT_COMPLETION_MODEL_ID_V1, null),
+                        EmptyTaskSettings.INSTANCE,
+                        EmptySecretSettings.INSTANCE,
+                        elasticInferenceServiceComponents
+                    ),
+                    new ElasticInferenceServiceSparseEmbeddingsModel(
+                        DEFAULT_ELSER_ENDPOINT_ID_V2,
+                        TaskType.SPARSE_EMBEDDING,
+                        ElasticInferenceService.NAME,
+                        new ElasticInferenceServiceSparseEmbeddingsServiceSettings(DEFAULT_ELSER_2_MODEL_ID, null, null),
+                        EmptyTaskSettings.INSTANCE,
+                        EmptySecretSettings.INSTANCE,
+                        elasticInferenceServiceComponents,
+                        ChunkingSettingsBuilder.DEFAULT_SETTINGS
+                    ),
+                    new ElasticInferenceServiceDenseTextEmbeddingsModel(
+                        DEFAULT_MULTILINGUAL_EMBED_ENDPOINT_ID,
+                        TaskType.TEXT_EMBEDDING,
+                        ElasticInferenceService.NAME,
+                        new ElasticInferenceServiceDenseTextEmbeddingsServiceSettings(
+                            DEFAULT_MULTILINGUAL_EMBED_MODEL_ID,
+                            defaultDenseTextEmbeddingsSimilarity(),
+                            DENSE_TEXT_EMBEDDINGS_DIMENSIONS,
+                            null,
+                            null
+                        ),
+                        EmptyTaskSettings.INSTANCE,
+                        EmptySecretSettings.INSTANCE,
+                        elasticInferenceServiceComponents,
+                        ChunkingSettingsBuilder.DEFAULT_SETTINGS
+                    ),
+                    new ElasticInferenceServiceRerankModel(
+                        DEFAULT_RERANK_ENDPOINT_ID_V1,
+                        TaskType.RERANK,
+                        ElasticInferenceService.NAME,
+                        new ElasticInferenceServiceRerankServiceSettings(DEFAULT_RERANK_MODEL_ID_V1, null),
+                        EmptyTaskSettings.INSTANCE,
+                        EmptySecretSettings.INSTANCE,
+                        elasticInferenceServiceComponents
+                    )
+                )
+            );
         }
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceTests.java
@@ -1367,11 +1367,11 @@ public class ElasticInferenceServiceTests extends ESSingleNodeTestCase {
                       "task_types": ["embed/text/sparse"]
                     },
                     {
-                      "model_name": "jina-embeddings-v3",
+                      "model_name": "multilingual-embed-v1",
                       "task_types": ["embed/text/dense"]
                     },
                     {
-                      "model_name": "elastic-rerank-v1",
+                      "model_name": "rerank-v1",
                       "task_types": ["rerank/text/text-similarity"]
                     }
                 ]


### PR DESCRIPTION
# Backport

This will backport the following commits from `9.2` to `9.1`:
 - [Adding dimensions to jina preconfigured endpoint (#139642)](https://github.com/elastic/elasticsearch/pull/139642)

<!--- Backport version: 9.2.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)