### PR TITLE
PromQL: Add PromQL test similar to TS / Batch 3

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-idelta.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-idelta.csv-spec
@@ -17,11 +17,49 @@ null               | 2024-05-10T00:01:00.000Z
 3.5                | 2024-05-10T00:10:00.000Z
 ;
 
+idelta_of_double_no_grouping_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m cost_change=(sum(idelta(network.cost[1m])))
+| SORT cost_change DESC, step DESC | LIMIT 10;
+
+cost_change:double | step:datetime
+null               | 2024-05-10T00:01:00.000Z
+18.625             | 2024-05-10T00:09:00.000Z
+15.25              | 2024-05-10T00:20:00.000Z
+9.75               | 2024-05-10T00:15:00.000Z
+8.0                | 2024-05-10T00:21:00.000Z
+7.125              | 2024-05-10T00:12:00.000Z
+6.625              | 2024-05-10T00:22:00.000Z
+5.375              | 2024-05-10T00:17:00.000Z
+4.375              | 2024-05-10T00:08:00.000Z
+3.5                | 2024-05-10T00:10:00.000Z
+;
+
 idelta_of_integer
 required_capability: ts_command_v0
 TS k8s | STATS clients = avg(idelta(network.eth0.currently_connected_clients)) BY time_bucket = bucket(@timestamp,1minute) | SORT time_bucket | LIMIT 10;
 
 clients:double      | time_bucket:datetime
+-520.0              | 2024-05-10T00:00:00.000Z
+null                | 2024-05-10T00:01:00.000Z
+-248.5              | 2024-05-10T00:02:00.000Z
+-179.0              | 2024-05-10T00:03:00.000Z
+801.0               | 2024-05-10T00:04:00.000Z
+-289.0              | 2024-05-10T00:05:00.000Z
+117.25              | 2024-05-10T00:06:00.000Z
+-214.0              | 2024-05-10T00:07:00.000Z
+-97.33333333333333  | 2024-05-10T00:08:00.000Z
+-20.857142857142858 | 2024-05-10T00:09:00.000Z
+;
+
+idelta_of_integer_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m clients=(avg(idelta(network.eth0.currently_connected_clients[1m])))
+| SORT step | LIMIT 10;
+
+clients:double      | step:datetime
 -520.0              | 2024-05-10T00:00:00.000Z
 null                | 2024-05-10T00:01:00.000Z
 -248.5              | 2024-05-10T00:02:00.000Z
@@ -52,6 +90,25 @@ null           | prod            | 2024-05-10T00:03:00.000Z
 
 ;
 
+idelta_of_integer_grouping_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m clients=(avg by (cluster) (idelta(network.eth0.currently_connected_clients[1m])))
+| SORT step, cluster | LIMIT 10;
+
+clients:double | step:datetime            | cluster:keyword
+-520.0         | 2024-05-10T00:00:00.000Z | prod
+null           | 2024-05-10T00:00:00.000Z | staging
+null           | 2024-05-10T00:01:00.000Z | prod
+null           | 2024-05-10T00:01:00.000Z | qa
+-54.0          | 2024-05-10T00:02:00.000Z | prod
+null           | 2024-05-10T00:02:00.000Z | qa
+-443.0         | 2024-05-10T00:02:00.000Z | staging
+null           | 2024-05-10T00:03:00.000Z | prod
+93.0           | 2024-05-10T00:03:00.000Z | qa
+-315.0         | 2024-05-10T00:03:00.000Z | staging
+;
+
 idelta_with_filtering
 required_capability: ts_command_v0
 // tag::idelta[]
@@ -73,6 +130,24 @@ tx:double | cluster:keyword | time_bucket:datetime
 915.0     | prod            | 2024-05-10T00:20:00.000Z
 9.0       | qa              | 2024-05-10T00:20:00.000Z
 -511.0    | staging         | 2024-05-10T00:20:00.000Z
+;
+
+idelta_with_filtering_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m tx=(sum by (cluster) (idelta(network.bytes_in{pod="one"}[10m])))
+| SORT step, cluster | LIMIT 10;
+
+tx:double | step:datetime            | cluster:keyword
+-224.0    | 2024-05-10T00:00:00.000Z | prod
+791.0     | 2024-05-10T00:00:00.000Z | qa
+534.0     | 2024-05-10T00:00:00.000Z | staging
+-448.0    | 2024-05-10T00:10:00.000Z | prod
+-560.0    | 2024-05-10T00:10:00.000Z | qa
+-512.0    | 2024-05-10T00:10:00.000Z | staging
+915.0     | 2024-05-10T00:20:00.000Z | prod
+9.0       | 2024-05-10T00:20:00.000Z | qa
+-511.0    | 2024-05-10T00:20:00.000Z | staging
 ;
 
 idelta_with_inline_filtering
@@ -109,6 +184,25 @@ avg_bytes:double    | cluster:keyword | time_bucket:datetime     | kb_minus_offs
 -7.0                | qa              | 2024-05-10T00:20:00.000Z | -0.107
 -387.6666666666667  | staging         | 2024-05-10T00:20:00.000Z | -0.4876666666666667
 
+;
+
+eval_on_idelta_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m avg_bytes=(avg by (cluster) (idelta(network.bytes_in[10m])))
+| EVAL kb_minus_offset = (avg_bytes - 100) / 1000.0
+| SORT step, cluster | LIMIT 10;
+
+avg_bytes:double    | step:datetime            | cluster:keyword | kb_minus_offset:double
+-123.0              | 2024-05-10T00:00:00.000Z | prod            | -0.223
+-113.33333333333333 | 2024-05-10T00:00:00.000Z | qa              | -0.21333333333333332
+72.33333333333333   | 2024-05-10T00:00:00.000Z | staging         | -0.027666666666666673
+-459.3333333333333  | 2024-05-10T00:10:00.000Z | prod            | -0.5593333333333332
+-364.0              | 2024-05-10T00:10:00.000Z | qa              | -0.464
+-279.0              | 2024-05-10T00:10:00.000Z | staging         | -0.379
+485.5               | 2024-05-10T00:20:00.000Z | prod            | 0.3855
+-7.0                | 2024-05-10T00:20:00.000Z | qa              | -0.107
+-387.6666666666667  | 2024-05-10T00:20:00.000Z | staging         | -0.4876666666666667
 ;
 
 idelta_multi_values
@@ -169,4 +263,22 @@ events:double | pod:keyword | time_bucket:datetime
 -5.0          | one         | 2024-05-10T00:00:00.000Z
 -6.0          | three       | 2024-05-10T00:00:00.000Z
 
+;
+
+idelta_all_value_types_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m events=(sum by (pod) (idelta(events_received[10m])))
+| SORT events DESC, pod, step | LIMIT 10;
+
+events:double | step:datetime            | pod:keyword
+9.0           | 2024-05-10T00:10:00.000Z | one
+7.0           | 2024-05-10T00:10:00.000Z | three
+3.0           | 2024-05-10T00:00:00.000Z | two
+0.0           | 2024-05-10T00:20:00.000Z | two
+-2.0          | 2024-05-10T00:20:00.000Z | three
+-2.0          | 2024-05-10T00:10:00.000Z | two
+-4.0          | 2024-05-10T00:20:00.000Z | one
+-5.0          | 2024-05-10T00:00:00.000Z | one
+-6.0          | 2024-05-10T00:00:00.000Z | three
 ;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-increase.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-increase.csv-spec
@@ -20,6 +20,25 @@ increase_bytes_in:double | time_bucket:datetime
 764.6877930046035        | 2024-05-10T00:11:00.000Z
 ;
 
+increase_of_long_no_grouping_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m increase_bytes_in=(avg(increase(network.total_bytes_in[1m])))
+| SORT increase_bytes_in DESC, step DESC | LIMIT 10;
+
+increase_bytes_in:double | step:datetime
+1156.9098342725822       | 2024-05-10T00:19:00.000Z
+1063.7582541086263       | 2024-05-10T00:17:00.000Z
+999.2874221895291        | 2024-05-10T00:07:00.000Z
+961.1440972222222        | 2024-05-10T00:01:00.000Z
+930.90625                | 2024-05-10T00:00:00.000Z
+914.237233611577         | 2024-05-10T00:18:00.000Z
+839.854243117019         | 2024-05-10T00:20:00.000Z
+838.6380935298255        | 2024-05-10T00:09:00.000Z
+795.8137508015253        | 2024-05-10T00:04:00.000Z
+764.6877930046035        | 2024-05-10T00:11:00.000Z
+;
+
 increase_of_long_grouping
 required_capability: increase
 required_capability: rate_with_interpolation_v2
@@ -32,6 +51,27 @@ TS k8s
 | SORT increase_bytes_in DESC, time_bucket, cluster | LIMIT 10;
 
 increase_bytes_in:double | cluster:keyword | time_bucket:datetime
+4628.220019              | qa              | 2024-05-10T00:15:00.000Z
+4129.646129              | qa              | 2024-05-10T00:05:00.000Z
+3821.213933              | prod            | 2024-05-10T00:15:00.000Z
+2346.663513              | qa              | 2024-05-10T00:10:00.000Z
+2260.78709               | prod            | 2024-05-10T00:10:00.000Z
+2150.862794              | staging         | 2024-05-10T00:05:00.000Z
+2049.166973              | staging         | 2024-05-10T00:10:00.000Z
+1806.457654              | staging         | 2024-05-10T00:15:00.000Z
+1716.559991              | qa              | 2024-05-10T00:00:00.000Z
+1672.349062              | prod            | 2024-05-10T00:00:00.000Z
+;
+
+increase_of_long_grouping_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=5m increase_bytes_in=(avg by (cluster) (increase(network.total_bytes_in[5m])))
+| EVAL increase_bytes_in = ROUND(increase_bytes_in, 6)
+| KEEP increase_bytes_in, cluster, step
+| SORT increase_bytes_in DESC, step, cluster | LIMIT 10;
+
+increase_bytes_in:double | cluster:keyword | step:datetime
 4628.220019              | qa              | 2024-05-10T00:15:00.000Z
 4129.646129              | qa              | 2024-05-10T00:05:00.000Z
 3821.213933              | prod            | 2024-05-10T00:15:00.000Z
@@ -67,6 +107,25 @@ increase_cost:double   | time_bucket:datetime
 
 ;
 
+increase_of_double_no_grouping_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m increase_cost=(sum(increase(network.total_cost[1m])))
+| SORT increase_cost DESC, step | LIMIT 10;
+
+increase_cost:double   | step:datetime
+116.53320614748134   | 2024-05-10T00:09:00.000Z
+84.16558290423815    | 2024-05-10T00:17:00.000Z
+78.41175332832259    | 2024-05-10T00:08:00.000Z
+59.963949716563846   | 2024-05-10T00:18:00.000Z
+58.644766831608926   | 2024-05-10T00:15:00.000Z
+52.48218339839363    | 2024-05-10T00:14:00.000Z
+48.73737443994797    | 2024-05-10T00:06:00.000Z
+47.42165775401069    | 2024-05-10T00:05:00.000Z
+43.7490171990172     | 2024-05-10T00:11:00.000Z
+41.917106313154434   | 2024-05-10T00:13:00.000Z
+;
+
 increase_with_filtering
 required_capability: increase
 required_capability: rate_with_interpolation
@@ -91,6 +150,24 @@ increase_bytes_in:double | cluster:keyword | time_bucket:datetime
 1611.7482269503544       | prod            | 2024-05-10T00:20:00.000Z
 953.982617586912         | qa              | 2024-05-10T00:20:00.000Z
 673.5801687763715        | staging         | 2024-05-10T00:20:00.000Z
+;
+
+increase_with_filtering_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m increase_bytes_in=(sum by (cluster) (increase(network.total_bytes_in{pod="one"}[10m])))
+| SORT step, cluster | LIMIT 10;
+
+increase_bytes_in:double | step:datetime            | cluster:keyword
+2453.5                   | 2024-05-10T00:00:00.000Z | prod
+5828.87                  | 2024-05-10T00:00:00.000Z | qa
+2591.440476190476        | 2024-05-10T00:00:00.000Z | staging
+7019.4184397163135       | 2024-05-10T00:10:00.000Z | prod
+7294.064049079755        | 2024-05-10T00:10:00.000Z | qa
+2523.396021699819        | 2024-05-10T00:10:00.000Z | staging
+1611.7482269503544       | 2024-05-10T00:20:00.000Z | prod
+953.982617586912         | 2024-05-10T00:20:00.000Z | qa
+673.5801687763715        | 2024-05-10T00:20:00.000Z | staging
 ;
 
 increase_with_inline_filtering
@@ -138,6 +215,25 @@ increase_bytes:double | cluster:keyword | time_bucket:datetime     | increase_kb
 
 ;
 
+eval_on_increase_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m increase_bytes=(avg by (cluster) (increase(network.total_bytes_in[10m])))
+| EVAL increase_kb = increase_bytes / 1024.0
+| SORT step, cluster | LIMIT 10;
+
+increase_bytes:double | step:datetime            | cluster:keyword | increase_kb:double
+2735.7690879741726    | 2024-05-10T00:00:00.000Z | prod            | 2.671649499974778
+5897.438804111666     | 2024-05-10T00:00:00.000Z | qa              | 5.759217582140299
+3686.4740884724015    | 2024-05-10T00:00:00.000Z | staging         | 3.6000723520238296
+6082.001022561896     | 2024-05-10T00:10:00.000Z | prod            | 5.939454123595602
+6974.883531451061     | 2024-05-10T00:10:00.000Z | qa              | 6.811409698682676
+3855.6246268438786    | 2024-05-10T00:10:00.000Z | staging         | 3.765258424652225
+1557.7298894639323    | 2024-05-10T00:20:00.000Z | prod            | 1.5212205951796214
+987.1325706421782     | 2024-05-10T00:20:00.000Z | qa              | 0.9639966510177521
+789.2720220707564     | 2024-05-10T00:20:00.000Z | staging         | 0.770773459053473
+;
+
 increase_of_aggregate_metric
 required_capability: increase
 required_capability: ts_command_v0
@@ -173,6 +269,25 @@ increase_bytes_in:double | time_bucket:datetime
 805.8137508015253        | 2024-05-10T00:04:00.000Z
 774.6877930046035        | 2024-05-10T00:11:00.000Z
 
+;
+
+increase_of_expression_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m increase_bytes_in=(avg(increase(network.total_bytes_in[1m]) + 10))
+| SORT increase_bytes_in DESC, step DESC | LIMIT 10;
+
+increase_bytes_in:double | step:datetime
+1166.9098342725822       | 2024-05-10T00:19:00.000Z
+1073.7582541086263       | 2024-05-10T00:17:00.000Z
+1009.2874221895291       | 2024-05-10T00:07:00.000Z
+971.1440972222222        | 2024-05-10T00:01:00.000Z
+940.90625                | 2024-05-10T00:00:00.000Z
+924.237233611577         | 2024-05-10T00:18:00.000Z
+849.854243117019         | 2024-05-10T00:20:00.000Z
+848.6380935298255        | 2024-05-10T00:09:00.000Z
+805.8137508015253        | 2024-05-10T00:04:00.000Z
+774.6877930046035        | 2024-05-10T00:11:00.000Z
 ;
 
 increase_combined_avg
@@ -240,6 +355,24 @@ increase_of_ratio:double | cluster:keyword | time_bucket:datetime
 0.01904697273860459      | prod            | 2024-05-10T00:20:00.000Z
 0.04576556363812584      | qa              | 2024-05-10T00:20:00.000Z
 0.05565157854549939      | staging         | 2024-05-10T00:20:00.000Z
+;
+
+increase_of_ratio_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m increase_of_ratio=(sum by (cluster) (increase(network.total_cost[10m]) / increase(network.total_bytes_in[10m])))
+| SORT step, cluster | LIMIT 10;
+
+increase_of_ratio:double | step:datetime            | cluster:keyword
+0.05584479370760387      | 2024-05-10T00:00:00.000Z | prod
+0.04455589590741875      | 2024-05-10T00:00:00.000Z | qa
+0.041646030613741385     | 2024-05-10T00:00:00.000Z | staging
+0.029899504595540118     | 2024-05-10T00:10:00.000Z | prod
+0.03694009599618049      | 2024-05-10T00:10:00.000Z | qa
+0.0332582444590309       | 2024-05-10T00:10:00.000Z | staging
+0.01904697273860459      | 2024-05-10T00:20:00.000Z | prod
+0.04576556363812584      | 2024-05-10T00:20:00.000Z | qa
+0.05565157854549939      | 2024-05-10T00:20:00.000Z | staging
 ;
 
 increase_of_long_grouping_1min_nulls

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-irate.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-irate.csv-spec
@@ -22,6 +22,25 @@ null                  | 2024-05-10T00:01:00.000Z
 
 ;
 
+irate_of_long_no_grouping_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m irate_bytes_in=(avg(irate(network.total_bytes_in[1m])))
+| SORT irate_bytes_in DESC, step DESC | LIMIT 10;
+
+irate_bytes_in:double | step:datetime
+null                  | 2024-05-10T00:01:00.000Z
+140.58333333333331    | 2024-05-10T00:02:00.000Z
+134.5314713064713     | 2024-05-10T00:09:00.000Z
+116.41911764705883    | 2024-05-10T00:22:00.000Z
+112.83333333333333    | 2024-05-10T00:00:00.000Z
+93.43529411764706     | 2024-05-10T00:14:00.000Z
+88.6875               | 2024-05-10T00:11:00.000Z
+78.83333333333333     | 2024-05-10T00:13:00.000Z
+71.04464285714286     | 2024-05-10T00:15:00.000Z
+51.58823529411765     | 2024-05-10T00:19:00.000Z
+;
+
 irate_of_long_grouping
 required_capability: ts_command_v0
 TS k8s
@@ -43,6 +62,25 @@ irate_bytes_in:double | cluster:keyword | time_bucket:datetime
 
 ;
 
+irate_of_long_grouping_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=5m irate_bytes_in=(avg by (cluster) (irate(network.total_bytes_in[5m])))
+| SORT irate_bytes_in DESC, step, cluster | LIMIT 10;
+
+irate_bytes_in:double | step:datetime            | cluster:keyword
+284.63440860215053    | 2024-05-10T00:05:00.000Z | qa
+119.52228682170542    | 2024-05-10T00:20:00.000Z | prod
+62.32120383036936     | 2024-05-10T00:10:00.000Z | prod
+31.92871485943775     | 2024-05-10T00:00:00.000Z | prod
+30.83898647284474     | 2024-05-10T00:00:00.000Z | staging
+28.57226890756303     | 2024-05-10T00:15:00.000Z | qa
+26.055199430199433    | 2024-05-10T00:05:00.000Z | staging
+21.898989322941418    | 2024-05-10T00:15:00.000Z | staging
+14.23272442880286     | 2024-05-10T00:00:00.000Z | qa
+10.889987485115794    | 2024-05-10T00:10:00.000Z | staging
+;
+
 irate_of_double_no_grouping
 required_capability: ts_command_v0
 TS k8s
@@ -61,6 +99,25 @@ null               | 2024-05-10T00:01:00.000Z
 1.951470588235294  | 2024-05-10T00:14:00.000Z
 1.8680555555555556 | 2024-05-10T00:13:00.000Z
 
+;
+
+irate_of_double_no_grouping_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m irate_cost=(sum(irate(network.total_cost[1m])))
+| SORT irate_cost DESC, step | LIMIT 10;
+
+irate_cost:double  | step:datetime
+null               | 2024-05-10T00:01:00.000Z
+7.836832264957265  | 2024-05-10T00:09:00.000Z
+3.590324074074074  | 2024-05-10T00:17:00.000Z
+2.6708333333333334 | 2024-05-10T00:02:00.000Z
+2.2916666666666665 | 2024-05-10T00:08:00.000Z
+2.265625           | 2024-05-10T00:11:00.000Z
+2.2481617647058822 | 2024-05-10T00:22:00.000Z
+2.020833333333333  | 2024-05-10T00:00:00.000Z
+1.951470588235294  | 2024-05-10T00:14:00.000Z
+1.8680555555555556 | 2024-05-10T00:13:00.000Z
 ;
 
 irate_with_filtering
@@ -87,6 +144,24 @@ irate_bytes_in:double | cluster:keyword | time_bucket:datetime
 
 ;
 
+irate_with_filtering_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m irate_bytes_in=(sum by (cluster) (irate(network.total_bytes_in{pod="one"}[10m])))
+| SORT step, cluster | LIMIT 10;
+
+irate_bytes_in:double | step:datetime            | cluster:keyword
+0.07692307692307693   | 2024-05-10T00:00:00.000Z | prod
+830.0                 | 2024-05-10T00:00:00.000Z | qa
+31.375                | 2024-05-10T00:00:00.000Z | staging
+9.854545454545454     | 2024-05-10T00:10:00.000Z | prod
+18.700000000000003    | 2024-05-10T00:10:00.000Z | qa
+0.023952095808383235  | 2024-05-10T00:10:00.000Z | staging
+232.75                | 2024-05-10T00:20:00.000Z | prod
+3.2698412698412698    | 2024-05-10T00:20:00.000Z | qa
+4.407407407407407     | 2024-05-10T00:20:00.000Z | staging
+;
+
 eval_on_irate
 required_capability: ts_command_v0
 TS k8s
@@ -105,6 +180,25 @@ irate_bytes:double | cluster:keyword | time_bucket:datetime     | irate_kb:doubl
 4.428024083196497  | qa              | 2024-05-10T00:20:00.000Z | 0.0043242422687465795
 1.5050835148874364 | staging         | 2024-05-10T00:20:00.000Z | 0.0014698081200072621
 
+;
+
+eval_on_irate_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m irate_bytes=(avg by (cluster) (irate(network.total_bytes_in[10m])))
+| EVAL irate_kb = irate_bytes / 1024.0
+| SORT step, cluster | LIMIT 10;
+
+irate_bytes:double | step:datetime            | cluster:keyword | irate_kb:double
+4.37482276552044   | 2024-05-10T00:00:00.000Z | prod            | 0.004272287856953555
+284.63440860215053 | 2024-05-10T00:00:00.000Z | qa              | 0.2779632896505376
+26.055199430199433 | 2024-05-10T00:00:00.000Z | staging         | 0.025444530693554134
+9.893214497920377  | 2024-05-10T00:10:00.000Z | prod            | 0.009661342283125368
+28.57226890756303  | 2024-05-10T00:10:00.000Z | qa              | 0.02790260635504202
+21.898989322941418 | 2024-05-10T00:10:00.000Z | staging         | 0.02138573176068498
+119.52228682170542 | 2024-05-10T00:20:00.000Z | prod            | 0.1167209832243217
+4.428024083196497  | 2024-05-10T00:20:00.000Z | qa              | 0.0043242422687465795
+1.5050835148874364 | 2024-05-10T00:20:00.000Z | staging         | 0.0014698081200072621
 ;
 
 irate_of_aggregate_metric
@@ -128,6 +222,25 @@ TS k8s
 | SORT irate_bytes_in DESC, time_bucket DESC | LIMIT 10;
 
 irate_bytes_in:double | time_bucket:datetime
+null                  | 2024-05-10T00:01:00.000Z
+150.58333333333331    | 2024-05-10T00:02:00.000Z
+144.5314713064713     | 2024-05-10T00:09:00.000Z
+126.41911764705883    | 2024-05-10T00:22:00.000Z
+122.83333333333333    | 2024-05-10T00:00:00.000Z
+103.43529411764706    | 2024-05-10T00:14:00.000Z
+98.6875               | 2024-05-10T00:11:00.000Z
+88.83333333333333     | 2024-05-10T00:13:00.000Z
+81.04464285714286     | 2024-05-10T00:15:00.000Z
+61.58823529411765     | 2024-05-10T00:19:00.000Z
+;
+
+irate_of_expression_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m irate_bytes_in=(avg(irate(network.total_bytes_in[1m]) + 10))
+| SORT irate_bytes_in DESC, step DESC | LIMIT 10;
+
+irate_bytes_in:double | step:datetime
 null                  | 2024-05-10T00:01:00.000Z
 150.58333333333331    | 2024-05-10T00:02:00.000Z
 144.5314713064713     | 2024-05-10T00:09:00.000Z
@@ -242,6 +355,24 @@ irate_of_ratio:double | cluster:keyword | time_bucket:datetime
 
 ;
 
+irate_of_ratio_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m irate_of_ratio=(sum by (cluster) (irate(network.total_cost[10m]) / irate(network.total_bytes_in[10m])))
+| SORT step, cluster | LIMIT 10;
+
+irate_of_ratio:double | step:datetime            | cluster:keyword
+0.7377812779572093    | 2024-05-10T00:00:00.000Z | prod
+0.15560960316361233   | 2024-05-10T00:00:00.000Z | qa
+0.05581954089819596   | 2024-05-10T00:00:00.000Z | staging
+3.088611728967339     | 2024-05-10T00:10:00.000Z | prod
+0.019280051363230983  | 2024-05-10T00:10:00.000Z | qa
+0.17121614905482155   | 2024-05-10T00:10:00.000Z | staging
+0.021697562872698986  | 2024-05-10T00:20:00.000Z | prod
+0.04152807743018099   | 2024-05-10T00:20:00.000Z | qa
+3.7694327731092434    | 2024-05-10T00:20:00.000Z | staging
+;
+
 irate_of_long_grouping_1min_nulls
 required_capability: ts_command_v0
 TS k8s
@@ -260,5 +391,24 @@ null                  | qa              | 2024-05-10T00:22:00.000Z
 0.875                 | qa              | 2024-05-10T00:12:00.000Z
 4.300925925925926     | qa              | 2024-05-10T00:02:00.000Z
 
+;
+
+irate_of_long_grouping_1min_nulls_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=2m irate_bytes_in=(avg by (cluster) (irate(network.total_bytes_in[2m])))
+| SORT irate_bytes_in NULLS FIRST, step, cluster | LIMIT 10;
+
+irate_bytes_in:double | step:datetime            | cluster:keyword
+null                  | 2024-05-10T00:00:00.000Z | qa
+null                  | 2024-05-10T00:00:00.000Z | staging
+null                  | 2024-05-10T00:06:00.000Z | prod
+null                  | 2024-05-10T00:10:00.000Z | prod
+null                  | 2024-05-10T00:10:00.000Z | staging
+null                  | 2024-05-10T00:22:00.000Z | qa
+0.08823529411764706   | 2024-05-10T00:22:00.000Z | staging
+0.3                   | 2024-05-10T00:04:00.000Z | prod
+0.875                 | 2024-05-10T00:12:00.000Z | qa
+4.300925925925926     | 2024-05-10T00:02:00.000Z | qa
 ;
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-last-over-time.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-last-over-time.csv-spec
@@ -54,7 +54,7 @@ clients:double | cluster:keyword | time_bucket:datetime
 implicit_last_over_time_of_integer_promql
 required_capability: promql_pre_tech_preview_v12
 
-PROMQL index=k8s step=1m clients=(avg by (cluster) (last_over_time(network.eth0.currently_connected_clients[1m])))
+PROMQL index=k8s step=1m clients=(avg by (cluster) (network.eth0.currently_connected_clients[1m]))
 | SORT step, cluster | LIMIT 10;
 
 clients:double | step:datetime            | cluster:keyword
@@ -126,7 +126,7 @@ bytes:double | cluster:keyword | time_bucket:datetime
 implicit_last_over_time_of_long_promql
 required_capability: promql_pre_tech_preview_v12
 
-PROMQL index=k8s step=1m bytes=(avg by (cluster) (last_over_time(network.bytes_in[1m])))
+PROMQL index=k8s step=1m bytes=(avg by (cluster) (network.bytes_in[1m]))
 | SORT step, cluster | LIMIT 10;
 
 bytes:double | step:datetime            | cluster:keyword
@@ -196,7 +196,7 @@ tx:long | cluster:keyword | time_bucket:datetime
 implicit_last_over_time_with_filtering_promql
 required_capability: promql_pre_tech_preview_v12
 
-PROMQL index=k8s step=10m tx=(sum by (cluster) (last_over_time(network.bytes_in{pod="one"}[10m])))
+PROMQL index=k8s step=10m tx=(sum by (cluster) (network.bytes_in{pod="one"}[10m]))
 | SORT step, cluster | LIMIT 10;
 
 tx:double | step:datetime            | cluster:keyword
@@ -230,7 +230,7 @@ tx:long | cluster:keyword | time_bucket:datetime
 implicit_last_over_time_with_inline_filtering_promql
 required_capability: promql_pre_tech_preview_v12
 
-PROMQL index=k8s step=10m tx=(sum by (cluster) (last_over_time(network.bytes_in{pod="one"}[10m])))
+PROMQL index=k8s step=10m tx=(sum by (cluster) (network.bytes_in{pod="one"}[10m]))
 | SORT step, cluster | LIMIT 10;
 
 tx:double | step:datetime            | cluster:keyword

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-last-over-time.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-last-over-time.csv-spec
@@ -322,25 +322,6 @@ max_bytes:double  | cluster:keyword | time_bucket:datetime     | kb_minus_offset
 81.33333333333333 | staging         | 2024-05-10T00:20:00.000Z | -0.01866666666666667
 ;
 
-implicit_eval_on_last_over_time_promql
-required_capability: promql_pre_tech_preview_v12
-
-PROMQL index=k8s step=10m max_bytes=(avg by (cluster) (last_over_time(network.bytes_in[10m])))
-| EVAL kb_minus_offset = (max_bytes - 100) / 1000.0
-| SORT step, cluster | LIMIT 10;
-
-max_bytes:double  | step:datetime            | cluster:keyword | kb_minus_offset:double
-225.0             | 2024-05-10T00:00:00.000Z | prod            | 0.125
-485.6666666666667 | 2024-05-10T00:00:00.000Z | qa              | 0.3856666666666667
-572.6666666666666 | 2024-05-10T00:00:00.000Z | staging         | 0.4726666666666666
-517.6666666666666 | 2024-05-10T00:10:00.000Z | prod            | 0.41766666666666663
-426.6666666666667 | 2024-05-10T00:10:00.000Z | qa              | 0.32666666666666666
-482.3333333333333 | 2024-05-10T00:10:00.000Z | staging         | 0.3823333333333333
-839.0             | 2024-05-10T00:20:00.000Z | prod            | 0.739
-697.0             | 2024-05-10T00:20:00.000Z | qa              | 0.597
-81.33333333333333 | 2024-05-10T00:20:00.000Z | staging         | -0.01866666666666667
-;
-
 last_over_time_multi_values
 required_capability: ts_command_v0
 TS k8s | WHERE @timestamp < "2024-05-10T00:10:00.000Z" | STATS events = sum(last_over_time(events_received)) by pod, time_bucket = bucket(@timestamp, 1minute) | SORT events desc, pod, time_bucket  | LIMIT 10;
@@ -358,26 +339,6 @@ events:long | pod:keyword | time_bucket:datetime
 9           | three       | 2024-05-10T00:02:00.000Z
 ;
 
-last_over_time_multi_values_promql
-required_capability: promql_pre_tech_preview_v12
-
-PROMQL index=k8s step=1m start="2024-05-10T00:00:00.000Z" end="2024-05-10T00:09:00.000Z" events=(sum by (pod) (last_over_time(events_received[1m])))
-| SORT events DESC, pod, step | LIMIT 10;
-
-events:double | step:datetime            | pod:keyword
-18.0          | 2024-05-10T00:01:00.000Z | one
-16.0          | 2024-05-10T00:08:00.000Z | one
-12.0          | 2024-05-10T00:03:00.000Z | one
-12.0          | 2024-05-10T00:00:00.000Z | three
-10.0          | 2024-05-10T00:06:00.000Z | three
-10.0          | 2024-05-10T00:02:00.000Z | two
-10.0          | 2024-05-10T00:04:00.000Z | two
-9.0           | 2024-05-10T00:02:00.000Z | three
-9.0           | 2024-05-10T00:07:00.000Z | three
-9.0           | 2024-05-10T00:00:00.000Z | two
-;
-
-
 implicit_last_over_time_multi_values
 required_capability: ts_command_v0
 TS k8s | WHERE @timestamp < "2024-05-10T00:10:00.000Z" | STATS events = sum(events_received) by pod, time_bucket = bucket(@timestamp, 1minute) | SORT events desc, pod, time_bucket  | LIMIT 10;
@@ -394,26 +355,6 @@ events:long | pod:keyword | time_bucket:datetime
 9           | one         | 2024-05-10T00:09:00.000Z
 9           | three       | 2024-05-10T00:02:00.000Z
 ;
-
-implicit_last_over_time_multi_values_promql
-required_capability: promql_pre_tech_preview_v12
-
-PROMQL index=k8s step=1m start="2024-05-10T00:00:00.000Z" end="2024-05-10T00:09:00.000Z" events=(sum by (pod) (last_over_time(events_received[1m])))
-| SORT events DESC, pod, step | LIMIT 10;
-
-events:double | step:datetime            | pod:keyword
-18.0          | 2024-05-10T00:01:00.000Z | one
-16.0          | 2024-05-10T00:08:00.000Z | one
-12.0          | 2024-05-10T00:03:00.000Z | one
-12.0          | 2024-05-10T00:00:00.000Z | three
-10.0          | 2024-05-10T00:06:00.000Z | three
-10.0          | 2024-05-10T00:02:00.000Z | two
-10.0          | 2024-05-10T00:04:00.000Z | two
-9.0           | 2024-05-10T00:02:00.000Z | three
-9.0           | 2024-05-10T00:07:00.000Z | three
-9.0           | 2024-05-10T00:00:00.000Z | two
-;
-
 
 last_over_time_null_values
 required_capability: ts_command_v0
@@ -468,25 +409,6 @@ null        | two         | 2024-05-10T00:13:00.000Z
 7           | three       | 2024-05-10T00:12:00.000Z
 ;
 
-implicit_last_over_time_null_values_promql
-required_capability: promql_pre_tech_preview_v12
-
-PROMQL index=k8s step=1m start="2024-05-10T00:10:00.000Z" end="2024-05-10T00:15:00.000Z" events=(sum by (pod) (last_over_time(events_received[1m])))
-| SORT events DESC, pod, step | LIMIT 10;
-
-events:double | step:datetime            | pod:keyword
-null          | 2024-05-10T00:12:00.000Z | one
-null          | 2024-05-10T00:13:00.000Z | two
-20.0          | 2024-05-10T00:14:00.000Z | two
-18.0          | 2024-05-10T00:12:00.000Z | two
-16.0          | 2024-05-10T00:13:00.000Z | one
-16.0          | 2024-05-10T00:14:00.000Z | one
-11.0          | 2024-05-10T00:10:00.000Z | one
-9.0           | 2024-05-10T00:11:00.000Z | one
-9.0           | 2024-05-10T00:13:00.000Z | three
-7.0           | 2024-05-10T00:12:00.000Z | three
-;
-
 last_over_time_all_value_types
 required_capability: ts_command_v0
 TS k8s | STATS events = sum(last_over_time(events_received)) by pod, time_bucket = bucket(@timestamp, 10minute) | SORT events desc, pod, time_bucket | LIMIT 10 ;
@@ -536,24 +458,6 @@ events:long | pod:keyword | time_bucket:datetime
 9           | one         | 2024-05-10T00:00:00.000Z
 9           | three       | 2024-05-10T00:00:00.000Z
 5           | two         | 2024-05-10T00:20:00.000Z
-;
-
-implicit_last_over_time_all_value_types_promql
-required_capability: promql_pre_tech_preview_v12
-
-PROMQL index=k8s step=10m events=(sum by (pod) (last_over_time(events_received[10m])))
-| SORT events DESC, pod, step | LIMIT 10;
-
-events:double | step:datetime            | pod:keyword
-21.0          | 2024-05-10T00:10:00.000Z | three
-20.0          | 2024-05-10T00:10:00.000Z | one
-15.0          | 2024-05-10T00:20:00.000Z | one
-15.0          | 2024-05-10T00:20:00.000Z | three
-13.0          | 2024-05-10T00:10:00.000Z | two
-12.0          | 2024-05-10T00:00:00.000Z | two
-9.0           | 2024-05-10T00:00:00.000Z | one
-9.0           | 2024-05-10T00:00:00.000Z | three
-5.0           | 2024-05-10T00:20:00.000Z | two
 ;
 
 last_over_time_counter_double

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-last-over-time.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-last-over-time.csv-spec
@@ -15,6 +15,25 @@ clients:double | cluster:keyword | time_bucket:datetime
 357.0          | staging         | 2024-05-10T00:03:00.000Z
 ;
 
+last_over_time_of_integer_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m clients=(avg by (cluster) (last_over_time(network.eth0.currently_connected_clients[1m])))
+| SORT step, cluster | LIMIT 10;
+
+clients:double | step:datetime            | cluster:keyword
+429.0          | 2024-05-10T00:00:00.000Z | prod
+615.5          | 2024-05-10T00:00:00.000Z | staging
+396.5          | 2024-05-10T00:01:00.000Z | prod
+440.0          | 2024-05-10T00:01:00.000Z | qa
+632.5          | 2024-05-10T00:02:00.000Z | prod
+565.0          | 2024-05-10T00:02:00.000Z | qa
+205.0          | 2024-05-10T00:02:00.000Z | staging
+742.0          | 2024-05-10T00:03:00.000Z | prod
+454.0          | 2024-05-10T00:03:00.000Z | qa
+357.0          | 2024-05-10T00:03:00.000Z | staging
+;
+
 implicit_last_over_time_of_integer
 required_capability: ts_command_v0
 TS k8s | STATS clients = avg(network.eth0.currently_connected_clients) BY cluster, time_bucket = bucket(@timestamp,1minute) | SORT time_bucket, cluster | LIMIT 10;
@@ -30,6 +49,25 @@ clients:double | cluster:keyword | time_bucket:datetime
 742.0          | prod            | 2024-05-10T00:03:00.000Z
 454.0          | qa              | 2024-05-10T00:03:00.000Z
 357.0          | staging         | 2024-05-10T00:03:00.000Z
+;
+
+implicit_last_over_time_of_integer_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m clients=(avg by (cluster) (last_over_time(network.eth0.currently_connected_clients[1m])))
+| SORT step, cluster | LIMIT 10;
+
+clients:double | step:datetime            | cluster:keyword
+429.0          | 2024-05-10T00:00:00.000Z | prod
+615.5          | 2024-05-10T00:00:00.000Z | staging
+396.5          | 2024-05-10T00:01:00.000Z | prod
+440.0          | 2024-05-10T00:01:00.000Z | qa
+632.5          | 2024-05-10T00:02:00.000Z | prod
+565.0          | 2024-05-10T00:02:00.000Z | qa
+205.0          | 2024-05-10T00:02:00.000Z | staging
+742.0          | 2024-05-10T00:03:00.000Z | prod
+454.0          | 2024-05-10T00:03:00.000Z | qa
+357.0          | 2024-05-10T00:03:00.000Z | staging
 ;
 
 last_over_time_of_long
@@ -49,6 +87,25 @@ bytes:double | cluster:keyword | time_bucket:datetime
 612.5        | staging         | 2024-05-10T00:03:00.000Z
 ;
 
+last_over_time_of_long_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m bytes=(avg by (cluster) (last_over_time(network.bytes_in[1m])))
+| SORT step, cluster | LIMIT 10;
+
+bytes:double | step:datetime            | cluster:keyword
+677.0        | 2024-05-10T00:00:00.000Z | prod
+586.0        | 2024-05-10T00:00:00.000Z | staging
+628.5        | 2024-05-10T00:01:00.000Z | prod
+538.5        | 2024-05-10T00:01:00.000Z | qa
+612.0        | 2024-05-10T00:02:00.000Z | prod
+749.0        | 2024-05-10T00:02:00.000Z | qa
+382.5        | 2024-05-10T00:02:00.000Z | staging
+970.0        | 2024-05-10T00:03:00.000Z | prod
+373.0        | 2024-05-10T00:03:00.000Z | qa
+612.5        | 2024-05-10T00:03:00.000Z | staging
+;
+
 implicit_last_over_time_of_long
 required_capability: ts_command_v0
 TS k8s | STATS bytes = avg(network.bytes_in) BY cluster, time_bucket = bucket(@timestamp,1minute) | SORT time_bucket, cluster | LIMIT 10;
@@ -66,6 +123,25 @@ bytes:double | cluster:keyword | time_bucket:datetime
 612.5        | staging         | 2024-05-10T00:03:00.000Z
 ;
 
+implicit_last_over_time_of_long_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m bytes=(avg by (cluster) (last_over_time(network.bytes_in[1m])))
+| SORT step, cluster | LIMIT 10;
+
+bytes:double | step:datetime            | cluster:keyword
+677.0        | 2024-05-10T00:00:00.000Z | prod
+586.0        | 2024-05-10T00:00:00.000Z | staging
+628.5        | 2024-05-10T00:01:00.000Z | prod
+538.5        | 2024-05-10T00:01:00.000Z | qa
+612.0        | 2024-05-10T00:02:00.000Z | prod
+749.0        | 2024-05-10T00:02:00.000Z | qa
+382.5        | 2024-05-10T00:02:00.000Z | staging
+970.0        | 2024-05-10T00:03:00.000Z | prod
+373.0        | 2024-05-10T00:03:00.000Z | qa
+612.5        | 2024-05-10T00:03:00.000Z | staging
+;
+
 last_over_time_with_filtering
 required_capability: ts_command_v0
 TS k8s | WHERE pod == "one" | STATS tx = sum(last_over_time(network.bytes_in)) BY cluster, time_bucket = bucket(@timestamp, 10minute) | SORT time_bucket, cluster | LIMIT 10;
@@ -80,6 +156,24 @@ tx:long | cluster:keyword | time_bucket:datetime
 931     | prod            | 2024-05-10T00:20:00.000Z
 206     | qa              | 2024-05-10T00:20:00.000Z
 238     | staging         | 2024-05-10T00:20:00.000Z
+;
+
+last_over_time_with_filtering_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m tx=(sum by (cluster) (last_over_time(network.bytes_in{pod="one"}[10m])))
+| SORT step, cluster | LIMIT 10;
+
+tx:double | step:datetime            | cluster:keyword
+3.0       | 2024-05-10T00:00:00.000Z | prod
+830.0     | 2024-05-10T00:00:00.000Z | qa
+753.0     | 2024-05-10T00:00:00.000Z | staging
+542.0     | 2024-05-10T00:10:00.000Z | prod
+187.0     | 2024-05-10T00:10:00.000Z | qa
+4.0       | 2024-05-10T00:10:00.000Z | staging
+931.0     | 2024-05-10T00:20:00.000Z | prod
+206.0     | 2024-05-10T00:20:00.000Z | qa
+238.0     | 2024-05-10T00:20:00.000Z | staging
 ;
 
 
@@ -99,6 +193,24 @@ tx:long | cluster:keyword | time_bucket:datetime
 238     | staging         | 2024-05-10T00:20:00.000Z
 ;
 
+implicit_last_over_time_with_filtering_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m tx=(sum by (cluster) (last_over_time(network.bytes_in{pod="one"}[10m])))
+| SORT step, cluster | LIMIT 10;
+
+tx:double | step:datetime            | cluster:keyword
+3.0       | 2024-05-10T00:00:00.000Z | prod
+830.0     | 2024-05-10T00:00:00.000Z | qa
+753.0     | 2024-05-10T00:00:00.000Z | staging
+542.0     | 2024-05-10T00:10:00.000Z | prod
+187.0     | 2024-05-10T00:10:00.000Z | qa
+4.0       | 2024-05-10T00:10:00.000Z | staging
+931.0     | 2024-05-10T00:20:00.000Z | prod
+206.0     | 2024-05-10T00:20:00.000Z | qa
+238.0     | 2024-05-10T00:20:00.000Z | staging
+;
+
 implicit_last_over_time_with_inline_filtering
 required_capability: ts_command_v0
 TS k8s  | STATS tx = sum(network.bytes_in) WHERE pod == "one" BY cluster, time_bucket = bucket(@timestamp, 10minute) | SORT time_bucket, cluster | LIMIT 10;
@@ -113,6 +225,24 @@ tx:long | cluster:keyword | time_bucket:datetime
 931     | prod            | 2024-05-10T00:20:00.000Z
 206     | qa              | 2024-05-10T00:20:00.000Z
 238     | staging         | 2024-05-10T00:20:00.000Z
+;
+
+implicit_last_over_time_with_inline_filtering_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m tx=(sum by (cluster) (last_over_time(network.bytes_in{pod="one"}[10m])))
+| SORT step, cluster | LIMIT 10;
+
+tx:double | step:datetime            | cluster:keyword
+3.0       | 2024-05-10T00:00:00.000Z | prod
+830.0     | 2024-05-10T00:00:00.000Z | qa
+753.0     | 2024-05-10T00:00:00.000Z | staging
+542.0     | 2024-05-10T00:10:00.000Z | prod
+187.0     | 2024-05-10T00:10:00.000Z | qa
+4.0       | 2024-05-10T00:10:00.000Z | staging
+931.0     | 2024-05-10T00:20:00.000Z | prod
+206.0     | 2024-05-10T00:20:00.000Z | qa
+238.0     | 2024-05-10T00:20:00.000Z | staging
 ;
 
 
@@ -157,6 +287,25 @@ max_bytes:double  | cluster:keyword | time_bucket:datetime     | kb_minus_offset
 81.33333333333333 | staging         | 2024-05-10T00:20:00.000Z | -0.01866666666666667
 ;
 
+eval_on_last_over_time_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m max_bytes=(avg by (cluster) (last_over_time(network.bytes_in[10m])))
+| EVAL kb_minus_offset = (max_bytes - 100) / 1000.0
+| SORT step, cluster | LIMIT 10;
+
+max_bytes:double  | step:datetime            | cluster:keyword | kb_minus_offset:double
+225.0             | 2024-05-10T00:00:00.000Z | prod            | 0.125
+485.6666666666667 | 2024-05-10T00:00:00.000Z | qa              | 0.3856666666666667
+572.6666666666666 | 2024-05-10T00:00:00.000Z | staging         | 0.4726666666666666
+517.6666666666666 | 2024-05-10T00:10:00.000Z | prod            | 0.41766666666666663
+426.6666666666667 | 2024-05-10T00:10:00.000Z | qa              | 0.32666666666666666
+482.3333333333333 | 2024-05-10T00:10:00.000Z | staging         | 0.3823333333333333
+839.0             | 2024-05-10T00:20:00.000Z | prod            | 0.739
+697.0             | 2024-05-10T00:20:00.000Z | qa              | 0.597
+81.33333333333333 | 2024-05-10T00:20:00.000Z | staging         | -0.01866666666666667
+;
+
 implicit_eval_on_last_over_time
 required_capability: ts_command_v0
 TS k8s | STATS max_bytes = avg(network.bytes_in) BY cluster, time_bucket = bucket(@timestamp, 10minute) | EVAL kb_minus_offset = (max_bytes - 100) / 1000.0 | LIMIT 10 | SORT time_bucket, cluster ;
@@ -171,6 +320,25 @@ max_bytes:double  | cluster:keyword | time_bucket:datetime     | kb_minus_offset
 839.0             | prod            | 2024-05-10T00:20:00.000Z | 0.739
 697.0             | qa              | 2024-05-10T00:20:00.000Z | 0.597
 81.33333333333333 | staging         | 2024-05-10T00:20:00.000Z | -0.01866666666666667
+;
+
+implicit_eval_on_last_over_time_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m max_bytes=(avg by (cluster) (last_over_time(network.bytes_in[10m])))
+| EVAL kb_minus_offset = (max_bytes - 100) / 1000.0
+| SORT step, cluster | LIMIT 10;
+
+max_bytes:double  | step:datetime            | cluster:keyword | kb_minus_offset:double
+225.0             | 2024-05-10T00:00:00.000Z | prod            | 0.125
+485.6666666666667 | 2024-05-10T00:00:00.000Z | qa              | 0.3856666666666667
+572.6666666666666 | 2024-05-10T00:00:00.000Z | staging         | 0.4726666666666666
+517.6666666666666 | 2024-05-10T00:10:00.000Z | prod            | 0.41766666666666663
+426.6666666666667 | 2024-05-10T00:10:00.000Z | qa              | 0.32666666666666666
+482.3333333333333 | 2024-05-10T00:10:00.000Z | staging         | 0.3823333333333333
+839.0             | 2024-05-10T00:20:00.000Z | prod            | 0.739
+697.0             | 2024-05-10T00:20:00.000Z | qa              | 0.597
+81.33333333333333 | 2024-05-10T00:20:00.000Z | staging         | -0.01866666666666667
 ;
 
 last_over_time_multi_values
@@ -188,6 +356,25 @@ events:long | pod:keyword | time_bucket:datetime
 10          | two         | 2024-05-10T00:04:00.000Z
 9           | one         | 2024-05-10T00:09:00.000Z
 9           | three       | 2024-05-10T00:02:00.000Z
+;
+
+last_over_time_multi_values_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m start="2024-05-10T00:00:00.000Z" end="2024-05-10T00:09:00.000Z" events=(sum by (pod) (last_over_time(events_received[1m])))
+| SORT events DESC, pod, step | LIMIT 10;
+
+events:double | step:datetime            | pod:keyword
+18.0          | 2024-05-10T00:01:00.000Z | one
+16.0          | 2024-05-10T00:08:00.000Z | one
+12.0          | 2024-05-10T00:03:00.000Z | one
+12.0          | 2024-05-10T00:00:00.000Z | three
+10.0          | 2024-05-10T00:06:00.000Z | three
+10.0          | 2024-05-10T00:02:00.000Z | two
+10.0          | 2024-05-10T00:04:00.000Z | two
+9.0           | 2024-05-10T00:02:00.000Z | three
+9.0           | 2024-05-10T00:07:00.000Z | three
+9.0           | 2024-05-10T00:00:00.000Z | two
 ;
 
 
@@ -208,6 +395,25 @@ events:long | pod:keyword | time_bucket:datetime
 9           | three       | 2024-05-10T00:02:00.000Z
 ;
 
+implicit_last_over_time_multi_values_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m start="2024-05-10T00:00:00.000Z" end="2024-05-10T00:09:00.000Z" events=(sum by (pod) (last_over_time(events_received[1m])))
+| SORT events DESC, pod, step | LIMIT 10;
+
+events:double | step:datetime            | pod:keyword
+18.0          | 2024-05-10T00:01:00.000Z | one
+16.0          | 2024-05-10T00:08:00.000Z | one
+12.0          | 2024-05-10T00:03:00.000Z | one
+12.0          | 2024-05-10T00:00:00.000Z | three
+10.0          | 2024-05-10T00:06:00.000Z | three
+10.0          | 2024-05-10T00:02:00.000Z | two
+10.0          | 2024-05-10T00:04:00.000Z | two
+9.0           | 2024-05-10T00:02:00.000Z | three
+9.0           | 2024-05-10T00:07:00.000Z | three
+9.0           | 2024-05-10T00:00:00.000Z | two
+;
+
 
 last_over_time_null_values
 required_capability: ts_command_v0
@@ -224,6 +430,25 @@ null        | two         | 2024-05-10T00:13:00.000Z
 9           | one         | 2024-05-10T00:11:00.000Z
 9           | three       | 2024-05-10T00:13:00.000Z
 7           | three       | 2024-05-10T00:12:00.000Z
+;
+
+last_over_time_null_values_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m start="2024-05-10T00:10:00.000Z" end="2024-05-10T00:15:00.000Z" events=(sum by (pod) (last_over_time(events_received[1m])))
+| SORT events DESC, pod, step | LIMIT 10;
+
+events:double | step:datetime            | pod:keyword
+null          | 2024-05-10T00:12:00.000Z | one
+null          | 2024-05-10T00:13:00.000Z | two
+20.0          | 2024-05-10T00:14:00.000Z | two
+18.0          | 2024-05-10T00:12:00.000Z | two
+16.0          | 2024-05-10T00:13:00.000Z | one
+16.0          | 2024-05-10T00:14:00.000Z | one
+11.0          | 2024-05-10T00:10:00.000Z | one
+9.0           | 2024-05-10T00:11:00.000Z | one
+9.0           | 2024-05-10T00:13:00.000Z | three
+7.0           | 2024-05-10T00:12:00.000Z | three
 ;
 
 implicit_last_over_time_null_values
@@ -243,6 +468,25 @@ null        | two         | 2024-05-10T00:13:00.000Z
 7           | three       | 2024-05-10T00:12:00.000Z
 ;
 
+implicit_last_over_time_null_values_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=1m start="2024-05-10T00:10:00.000Z" end="2024-05-10T00:15:00.000Z" events=(sum by (pod) (last_over_time(events_received[1m])))
+| SORT events DESC, pod, step | LIMIT 10;
+
+events:double | step:datetime            | pod:keyword
+null          | 2024-05-10T00:12:00.000Z | one
+null          | 2024-05-10T00:13:00.000Z | two
+20.0          | 2024-05-10T00:14:00.000Z | two
+18.0          | 2024-05-10T00:12:00.000Z | two
+16.0          | 2024-05-10T00:13:00.000Z | one
+16.0          | 2024-05-10T00:14:00.000Z | one
+11.0          | 2024-05-10T00:10:00.000Z | one
+9.0           | 2024-05-10T00:11:00.000Z | one
+9.0           | 2024-05-10T00:13:00.000Z | three
+7.0           | 2024-05-10T00:12:00.000Z | three
+;
+
 last_over_time_all_value_types
 required_capability: ts_command_v0
 TS k8s | STATS events = sum(last_over_time(events_received)) by pod, time_bucket = bucket(@timestamp, 10minute) | SORT events desc, pod, time_bucket | LIMIT 10 ;
@@ -257,6 +501,24 @@ events:long | pod:keyword | time_bucket:datetime
 9           | one         | 2024-05-10T00:00:00.000Z
 9           | three       | 2024-05-10T00:00:00.000Z
 5           | two         | 2024-05-10T00:20:00.000Z
+;
+
+last_over_time_all_value_types_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m events=(sum by (pod) (last_over_time(events_received[10m])))
+| SORT events DESC, pod, step | LIMIT 10;
+
+events:double | step:datetime            | pod:keyword
+21.0          | 2024-05-10T00:10:00.000Z | three
+20.0          | 2024-05-10T00:10:00.000Z | one
+15.0          | 2024-05-10T00:20:00.000Z | one
+15.0          | 2024-05-10T00:20:00.000Z | three
+13.0          | 2024-05-10T00:10:00.000Z | two
+12.0          | 2024-05-10T00:00:00.000Z | two
+9.0           | 2024-05-10T00:00:00.000Z | one
+9.0           | 2024-05-10T00:00:00.000Z | three
+5.0           | 2024-05-10T00:20:00.000Z | two
 ;
 
 
@@ -274,6 +536,24 @@ events:long | pod:keyword | time_bucket:datetime
 9           | one         | 2024-05-10T00:00:00.000Z
 9           | three       | 2024-05-10T00:00:00.000Z
 5           | two         | 2024-05-10T00:20:00.000Z
+;
+
+implicit_last_over_time_all_value_types_promql
+required_capability: promql_pre_tech_preview_v12
+
+PROMQL index=k8s step=10m events=(sum by (pod) (last_over_time(events_received[10m])))
+| SORT events DESC, pod, step | LIMIT 10;
+
+events:double | step:datetime            | pod:keyword
+21.0          | 2024-05-10T00:10:00.000Z | three
+20.0          | 2024-05-10T00:10:00.000Z | one
+15.0          | 2024-05-10T00:20:00.000Z | one
+15.0          | 2024-05-10T00:20:00.000Z | three
+13.0          | 2024-05-10T00:10:00.000Z | two
+12.0          | 2024-05-10T00:00:00.000Z | two
+9.0           | 2024-05-10T00:00:00.000Z | one
+9.0           | 2024-05-10T00:00:00.000Z | three
+5.0           | 2024-05-10T00:20:00.000Z | two
 ;
 
 last_over_time_counter_double
@@ -296,6 +576,25 @@ sum:double | pod:keyword | time_bucket:datetime
 191.0      | two         | 2024-05-10T00:20:00.000Z
 ;
 
+last_over_time_counter_double_promql
+required_capability: promql_pre_tech_preview_v12
+required_capability: first_last_over_time_counter_support
+
+PROMQL index=k8s step=10m sum=(sum by (pod) (last_over_time(network.total_cost[10m])))
+| SORT step, pod | LIMIT 10;
+
+sum:double | step:datetime            | pod:keyword
+190.125    | 2024-05-10T00:00:00.000Z | one
+158.75     | 2024-05-10T00:00:00.000Z | three
+148.25     | 2024-05-10T00:00:00.000Z | two
+220.125    | 2024-05-10T00:10:00.000Z | one
+271.75     | 2024-05-10T00:10:00.000Z | three
+160.75     | 2024-05-10T00:10:00.000Z | two
+190.625    | 2024-05-10T00:20:00.000Z | one
+180.375    | 2024-05-10T00:20:00.000Z | three
+191.0      | 2024-05-10T00:20:00.000Z | two
+;
+
 last_over_time_counter_long
 required_capability: ts_command_v0
 required_capability: first_last_over_time_counter_support
@@ -314,4 +613,23 @@ max:long | pod:keyword | time_bucket:datetime
 7286     | one         | 2024-05-10T00:20:00.000Z
 10797    | three       | 2024-05-10T00:20:00.000Z
 10277    | two         | 2024-05-10T00:20:00.000Z
+;
+
+last_over_time_counter_long_promql
+required_capability: promql_pre_tech_preview_v12
+required_capability: first_last_over_time_counter_support
+
+PROMQL index=k8s step=10m max=(max by (pod) (last_over_time(network.total_bytes_in[10m])))
+| SORT step, pod | LIMIT 10;
+
+max:double | step:datetime            | pod:keyword
+5963.0     | 2024-05-10T00:00:00.000Z | one
+4169.0     | 2024-05-10T00:00:00.000Z | three
+7900.0     | 2024-05-10T00:00:00.000Z | two
+9254.0     | 2024-05-10T00:10:00.000Z | one
+9195.0     | 2024-05-10T00:10:00.000Z | three
+8031.0     | 2024-05-10T00:10:00.000Z | two
+7286.0     | 2024-05-10T00:20:00.000Z | one
+10797.0    | 2024-05-10T00:20:00.000Z | three
+10277.0    | 2024-05-10T00:20:00.000Z | two
 ;


### PR DESCRIPTION
Summary:

PromQL currently has lower integration test coverage compared to ESQL.
This change adds initial PromQL integration tests for the `sum_over_time()` and `rate()` functions.

NOTE: Some test cases defined in the specs are not yet supported by the PromQL implementation. Those cases are intentionally left **disabled** and annotated with an `Awaits-fix` comment.


Plan:

As part of issue [#260](https://github.com/elastic/metrics-program/issues/260), the planned work includes adding coverage across multiple test types.

CSV-spec test files

* [x] `k8s-timeseries-sum-over-time.csv-spec` (#140204)
* [x] `k8s-timeseries-rate.csv-spec` (#140204)
* [x] `k8s-timeseries-present-over-time.csv-spec`(#140387)
* [x] `k8s-timeseries-min-over-time.csv-spec` (#140387)
* [x] `k8s-timeseries-count-over-time.csv-spec` (#140387)
* [x] `k8s-timeseries-max-over-time.csv-spec` (#140387)
* [x] `k8s-timeseries-last-over-time.csv-spec` (this change)
* [x] `k8s-timeseries-irate.csv-spec` (this change)
* [x] `k8s-timeseries-increase.csv-spec` (this change)
* [x] `k8s-timeseries-idelta.csv-spec` (this change)
* [ ] `k8s-timeseries-first-over-time.csv-spec`
* [ ] `k8s-timeseries-delta.csv-spec`
* [ ] `k8s-timeseries-clamp.csv-spec`
* [ ] `k8s-timeseries-absent-over-time.csv-spec`

Other test types

* [ ] **YAML REST tests**
  `x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_tsdb.yml`
* [ ] **Java integration tests**
  `RandomizedTimeSeriesIT.java`
* [ ] **Generative tests**
  `GenerativeMetricsIT.java` (handled separately by @limotova)


Test Plan:

```bash
./gradlew :x-pack:plugin:esql:qa:server:single-node:javaRestTest \
  --tests "org.elasticsearch.xpack.esql.qa.single_node.EsqlSpecIT"
```
