### PR TITLE
[9.3] [Inference API] Get _services skips EIS authorization call if CCM is not configured (#139964)

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
@@ -478,7 +478,9 @@ public class InferencePlugin extends Plugin
         var authorizationHandler = new ElasticInferenceServiceAuthorizationRequestHandler(
             inferenceServiceSettings.getElasticInferenceServiceUrl(),
             services.threadPool(),
-            ccmAuthApplierFactory
+            ccmAuthApplierFactory,
+            ccmFeature,
+            ccmService
         );
 
         var authTaskExecutor = AuthorizationTaskExecutor.create(

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportGetInferenceServicesAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportGetInferenceServicesAction.java
@@ -158,7 +158,7 @@ public class TransportGetInferenceServicesAction extends HandledTransportAction<
             delegate.onResponse(ElasticInferenceServiceAuthorizationModel.unauthorized());
         });
 
-        eisAuthorizationRequestHandler.getAuthorization(disabledServiceListener, sender);
+        eisAuthorizationRequestHandler.getAuthorizationIfPermittedEnvironment(disabledServiceListener, sender);
     }
 
     private List<InferenceServiceConfiguration> getServiceConfigurationsForServices(

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportPutCCMConfigurationAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportPutCCMConfigurationAction.java
@@ -112,7 +112,9 @@ public class TransportPutCCMConfigurationAction extends TransportMasterNodeActio
             var authRequestHandler = new ElasticInferenceServiceAuthorizationRequestHandler(
                 eisSettings.getElasticInferenceServiceUrl(),
                 threadPool,
-                new ValidationAuthenticationFactory(request.getApiKey())
+                new ValidationAuthenticationFactory(request.getApiKey()),
+                ccmFeature,
+                ccmService
             );
 
             var errorListener = authValidationListener.delegateResponse((delegate, exception) -> {


### PR DESCRIPTION
Backports the following commits to 9.3:
 - [Inference API] Get _services skips EIS authorization call if CCM is not configured (#139964)