### PR TITLE
Use stored fallback fields when time series doc values format is not used

### DIFF
--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -89,9 +89,6 @@ tasks.named("yamlRestCompatTestTransform").configure ({ task ->
   task.skipTest("indices.create/20_synthetic_source/subobjects auto", "subobjects auto removed")
   task.skipTest("indices.create/20_synthetic_source/synthetic_source with copy_to inside nested object", "temporary until backported")
   task.skipTest("indices.create/20_synthetic_source/synthetic_source with copy_to pointing to ambiguous field and subobjects auto", "subobjects auto removed")
-  task.skipTest("indices.create/20_synthetic_source/fallback synthetic_source for text field", "fallback text fields now use sorted binary doc values")
-  task.skipTest("mget/90_synthetic_source/keyword with normalizer and skip store original value", "ignore_above now uses sorted binary doc values")
-  task.skipTest("mget/90_synthetic_source/keyword with built-in normalizer", "ignore_above now uses sorted binary doc values")
   task.skipTest("indices.put_index_template/15_composition/Composable index templates that include subobjects: auto on arbitrary field", "subobjects auto removed")
   task.skipTest("indices.put_index_template/15_composition/Composable index templates that include subobjects: auto at root", "subobjects auto removed")
   task.skipTest(

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/20_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/20_synthetic_source.yml
@@ -1098,8 +1098,7 @@ fallback synthetic_source for text field:
 
   - match:
       hits.hits.0._source:
-        # fallback text fields use binary doc values, which are sorted, so we expect the output to be sorted as well
-        text: [ "hello", "world", "world" ]
+        text: [ "world", "hello", "world" ]
 
 ---
 synthetic_source with copy_to and ignored values:

--- a/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java
@@ -331,14 +331,9 @@ final class DynamicFieldsBuilder {
             } else {
                 var indexSettings = context.indexSettings();
                 return createDynamicField(
-                    new TextFieldMapper.Builder(
-                        name,
-                        indexSettings.getIndexVersionCreated(),
-                        indexSettings.getMode(),
-                        context.indexAnalyzers(),
-                        SourceFieldMapper.isSynthetic(indexSettings),
-                        false
-                    ).addMultiField(new KeywordFieldMapper.Builder("keyword", context.indexSettings(), true).ignoreAbove(256)),
+                    new TextFieldMapper.Builder(name, indexSettings, context.indexAnalyzers(), false).addMultiField(
+                        new KeywordFieldMapper.Builder("keyword", context.indexSettings(), true).ignoreAbove(256)
+                    ),
                     context
                 );
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -57,6 +57,7 @@ import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.analysis.AnalyzerScope;
@@ -290,9 +291,10 @@ public final class TextFieldMapper extends FieldMapper {
         private final Parameter<Map<String, String>> meta = Parameter.metaParam();
 
         final TextParams.Analyzers analyzers;
+        private final boolean usesBinaryDocValues;
 
         public Builder(String name, IndexAnalyzers indexAnalyzers) {
-            this(name, IndexVersion.current(), null, indexAnalyzers, false, false);
+            this(name, IndexVersion.current(), null, indexAnalyzers, false, false, false);
         }
 
         public Builder(
@@ -301,11 +303,13 @@ public final class TextFieldMapper extends FieldMapper {
             IndexMode indexMode,
             IndexAnalyzers indexAnalyzers,
             boolean isSyntheticSourceEnabled,
-            boolean isWithinMultiField
+            boolean isWithinMultiField,
+            boolean usesBinaryDocValues
         ) {
             super(name, indexCreatedVersion, isWithinMultiField);
 
             this.indexMode = indexMode;
+            this.usesBinaryDocValues = usesBinaryDocValues;
             this.analyzers = new TextParams.Analyzers(
                 indexAnalyzers,
                 m -> ((TextFieldMapper) m).indexAnalyzer,
@@ -337,6 +341,27 @@ public final class TextFieldMapper extends FieldMapper {
                     return isSyntheticSourceEnabled && multiFieldsBuilder.hasSyntheticSourceCompatibleKeywordField() == false;
                 }
             });
+        }
+
+        public Builder(String name, IndexSettings indexSettings, IndexAnalyzers indexAnalyzers, boolean isWithinMultiField) {
+            this(
+                name,
+                indexSettings.getIndexVersionCreated(),
+                indexSettings.getMode(),
+                indexAnalyzers,
+                SourceFieldMapper.isSynthetic(indexSettings),
+                isWithinMultiField,
+                usesBinaryDocValues(indexSettings)
+            );
+        }
+
+        private Builder(String name, MappingParserContext context) {
+            this(name, context.getIndexSettings(), context.getIndexAnalyzers(), context.isWithinMultiField());
+        }
+
+        private static boolean usesBinaryDocValues(final IndexSettings indexSettings) {
+            return indexSettings.getIndexVersionCreated().onOrAfter(IndexVersions.STORE_FALLBACK_TEXT_FIELDS_IN_BINARY_DOC_VALUES)
+                && indexSettings.useTimeSeriesDocValuesFormat();
         }
 
         public Builder index(boolean index) {
@@ -417,7 +442,8 @@ public final class TextFieldMapper extends FieldMapper {
                     meta.getValue(),
                     eagerGlobalOrdinals.getValue(),
                     indexPhrases.getValue(),
-                    indexCreatedVersion
+                    indexCreatedVersion,
+                    usesBinaryDocValues
                 );
                 if (fieldData.getValue()) {
                     ft.setFielddata(true, freqFilter.getValue());
@@ -508,16 +534,7 @@ public final class TextFieldMapper extends FieldMapper {
         }
     }
 
-    public static final TypeParser PARSER = createTypeParserWithLegacySupport(
-        (n, c) -> new Builder(
-            n,
-            c.indexVersionCreated(),
-            c.getIndexSettings().getMode(),
-            c.getIndexAnalyzers(),
-            SourceFieldMapper.isSynthetic(c.getIndexSettings()),
-            c.isWithinMultiField()
-        )
-    );
+    public static final TypeParser PARSER = createTypeParserWithLegacySupport(Builder::new);
 
     private static class PhraseWrappedAnalyzer extends AnalyzerWrapper {
 
@@ -698,6 +715,8 @@ public final class TextFieldMapper extends FieldMapper {
         private final boolean indexPhrases;
         private final boolean eagerGlobalOrdinals;
         private final IndexVersion indexCreatedVersion;
+        private final boolean usesBinaryDocValues;
+
         /**
          * In some configurations text fields use a sub-keyword field to provide
          * their values for synthetic source. This is that field. Or empty if we're
@@ -716,15 +735,17 @@ public final class TextFieldMapper extends FieldMapper {
             Map<String, String> meta,
             boolean eagerGlobalOrdinals,
             boolean indexPhrases,
-            IndexVersion indexCreatedVersion
+            IndexVersion indexCreatedVersion,
+            boolean usesBinaryDocValues
         ) {
             super(name, indexed ? IndexType.terms(true, false) : IndexType.NONE, stored, tsi, meta, isSyntheticSource, isWithinMultiField);
-            fielddata = false;
+            this.fielddata = false;
             // TODO block loader could use a "fast loading" delegate which isn't always the same - but frequently is.
             this.syntheticSourceDelegate = Optional.ofNullable(syntheticSourceDelegate);
             this.eagerGlobalOrdinals = eagerGlobalOrdinals;
             this.indexPhrases = indexPhrases;
             this.indexCreatedVersion = indexCreatedVersion;
+            this.usesBinaryDocValues = usesBinaryDocValues;
         }
 
         public TextFieldType(
@@ -750,7 +771,8 @@ public final class TextFieldMapper extends FieldMapper {
                 meta,
                 eagerGlobalOrdinals,
                 indexPhrases,
-                IndexVersion.current()
+                IndexVersion.current(),
+                false
             );
         }
 
@@ -764,11 +786,12 @@ public final class TextFieldMapper extends FieldMapper {
                 false,
                 false
             );
-            fielddata = false;
-            syntheticSourceDelegate = null;
-            eagerGlobalOrdinals = false;
-            indexPhrases = false;
-            indexCreatedVersion = IndexVersion.current();
+            this.fielddata = false;
+            this.syntheticSourceDelegate = null;
+            this.eagerGlobalOrdinals = false;
+            this.indexPhrases = false;
+            this.indexCreatedVersion = IndexVersion.current();
+            this.usesBinaryDocValues = false;
         }
 
         public TextFieldType(String name, boolean isSyntheticSource, boolean isWithinMultiField) {
@@ -782,8 +805,7 @@ public final class TextFieldMapper extends FieldMapper {
                 null,
                 Collections.emptyMap(),
                 false,
-                false,
-                IndexVersion.current()
+                false
             );
         }
 
@@ -803,8 +825,7 @@ public final class TextFieldMapper extends FieldMapper {
                 syntheticSourceDelegate,
                 Collections.emptyMap(),
                 false,
-                false,
-                IndexVersion.current()
+                false
             );
         }
 
@@ -1162,7 +1183,7 @@ public final class TextFieldMapper extends FieldMapper {
 
             // 5. check if we can load from a fallback field
             if (isSyntheticSourceEnabled() && syntheticSourceDelegate.isEmpty() && parentField == null) {
-                if (storeFallbackFieldsInBinaryDocValues(indexCreatedVersion)) {
+                if (usesBinaryDocValues) {
                     return new BytesRefsFromCustomBinaryBlockLoader(syntheticSourceFallbackFieldName());
                 }
                 return new BlockStoredFieldsReader.BytesFromStringsBlockLoader(syntheticSourceFallbackFieldName());
@@ -1322,7 +1343,7 @@ public final class TextFieldMapper extends FieldMapper {
     public static class ConstantScoreTextFieldType extends TextFieldType {
 
         public ConstantScoreTextFieldType(String name, boolean indexed, boolean stored, TextSearchInfo tsi, Map<String, String> meta) {
-            super(name, indexed, stored, tsi, false, false, null, meta, false, false, IndexVersion.current());
+            super(name, indexed, stored, tsi, false, false, null, meta, false, false, IndexVersion.current(), false);
         }
 
         public ConstantScoreTextFieldType(String name) {
@@ -1438,6 +1459,7 @@ public final class TextFieldMapper extends FieldMapper {
     private final FieldType fieldType;
     private final SubFieldInfo prefixFieldInfo;
     private final SubFieldInfo phraseFieldInfo;
+    private final boolean usesBinaryDocValues;
 
     private TextFieldMapper(
         String simpleName,
@@ -1475,6 +1497,7 @@ public final class TextFieldMapper extends FieldMapper {
         this.indexPrefixes = builder.indexPrefixes.getValue();
         this.freqFilter = builder.freqFilter.getValue();
         this.fieldData = builder.fieldData.get();
+        this.usesBinaryDocValues = builder.usesBinaryDocValues;
     }
 
     @Override
@@ -1504,7 +1527,8 @@ public final class TextFieldMapper extends FieldMapper {
             indexMode,
             indexAnalyzers,
             fieldType().isSyntheticSourceEnabled(),
-            fieldType().isWithinMultiField()
+            fieldType().isWithinMultiField(),
+            usesBinaryDocValues
         ).init(this);
     }
 
@@ -1541,7 +1565,7 @@ public final class TextFieldMapper extends FieldMapper {
             final String fallbackFieldName = fieldType().syntheticSourceFallbackFieldName();
             final BytesRef bytesRef = new BytesRef(value);
 
-            if (storeFallbackFieldsInBinaryDocValues()) {
+            if (usesBinaryDocValues) {
                 // store the value in a binary doc values field, create one if it doesn't exist
                 MultiValuedBinaryDocValuesField field = (MultiValuedBinaryDocValuesField) context.doc().getByKey(fallbackFieldName);
                 if (field == null) {
@@ -1554,14 +1578,6 @@ public final class TextFieldMapper extends FieldMapper {
                 context.doc().add(new StoredField(fallbackFieldName, value));
             }
         }
-    }
-
-    private boolean storeFallbackFieldsInBinaryDocValues() {
-        return storeFallbackFieldsInBinaryDocValues(indexCreatedVersion);
-    }
-
-    private static boolean storeFallbackFieldsInBinaryDocValues(final IndexVersion indexCreatedVersion) {
-        return indexCreatedVersion.onOrAfter(IndexVersions.STORE_FALLBACK_TEXT_FIELDS_IN_BINARY_DOC_VALUES);
     }
 
     /**
@@ -1772,7 +1788,7 @@ public final class TextFieldMapper extends FieldMapper {
 
         // layer for loading from a fallback field created during indexing by this text field mapper
         final String fallbackFieldName = fieldType().syntheticSourceFallbackFieldName();
-        if (storeFallbackFieldsInBinaryDocValues()) {
+        if (usesBinaryDocValues) {
             layers.add(new BinaryDocValuesSyntheticFieldLoaderLayer(fallbackFieldName));
         } else {
             // for bwc - fallback fields were originally stored in StoredFields

--- a/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperTests.java
@@ -579,6 +579,7 @@ public class ObjectMapperTests extends MapperServiceTestCase {
                             null,
                             createDefaultIndexAnalyzers(),
                             false,
+                            true,
                             true
                         ).addMultiField(new KeywordFieldMapper.Builder("multi_field_of_multi_field_size_6", defaultIndexSettings(), true))
                     )

--- a/server/src/test/java/org/elasticsearch/index/mapper/blockloader/TextFieldBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/blockloader/TextFieldBlockLoaderTests.java
@@ -9,10 +9,18 @@
 
 package org.elasticsearch.index.mapper.blockloader;
 
-import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.datageneration.FieldType;
-import org.elasticsearch.index.mapper.BlockLoaderTestCase;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.datageneration.FieldType;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.mapper.BlockLoaderTestCase;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -21,8 +29,29 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class TextFieldBlockLoaderTests extends BlockLoaderTestCase {
-    public TextFieldBlockLoaderTests(Params params) {
-        super(FieldType.TEXT.toString(), params);
+
+    private final boolean useBinaryDocValues;
+
+    public TextFieldBlockLoaderTests(
+        boolean syntheticSource,
+        MappedFieldType.FieldExtractPreference preference,
+        boolean useBinaryDocValues
+    ) {
+        super(FieldType.TEXT.toString(), new Params(syntheticSource, preference));
+        this.useBinaryDocValues = useBinaryDocValues;
+    }
+
+    @ParametersFactory(argumentFormatting = "syntheticSource=%s, preference=%s, useBinaryDocValues=%s")
+    public static List<Object[]> args() {
+        List<Object[]> args = new ArrayList<>();
+        for (var preference : PREFERENCES) {
+            for (boolean syntheticSource : new boolean[] { false, true }) {
+                for (boolean useBinaryDocValues : new boolean[] { false, true }) {
+                    args.add(new Object[] { syntheticSource, preference, useBinaryDocValues });
+                }
+            }
+        }
+        return args;
     }
 
     @Override
@@ -30,11 +59,17 @@ public class TextFieldBlockLoaderTests extends BlockLoaderTestCase {
         logger.info("field mapping={}", fieldMapping);
         logger.info("value={}", value);
         logger.info("params={}", params.toString());
-        return expectedValue(fieldMapping, value, params, testContext);
+        return expectedValue(fieldMapping, value, params, testContext, useBinaryDocValues);
     }
 
     @SuppressWarnings("unchecked")
-    public static Object expectedValue(Map<String, Object> fieldMapping, Object value, Params params, TestContext testContext) {
+    public static Object expectedValue(
+        Map<String, Object> fieldMapping,
+        Object value,
+        Params params,
+        TestContext testContext,
+        boolean useBinaryDocValues
+    ) {
         if (fieldMapping.getOrDefault("store", false).equals(true)) {
             return valuesInSourceOrder(value);
         }
@@ -106,8 +141,8 @@ public class TextFieldBlockLoaderTests extends BlockLoaderTestCase {
             }
         }
 
-        // Loading from fallback binary doc values, which are sorted by default
-        if (params.syntheticSource()) {
+        // Loading from binary doc values
+        if (params.syntheticSource() && useBinaryDocValues) {
             return valuesInSortedOrder(value);
         }
 
@@ -141,5 +176,24 @@ public class TextFieldBlockLoaderTests extends BlockLoaderTestCase {
 
         var resultList = ((List<String>) value).stream().filter(Objects::nonNull).map(BytesRef::new).toList();
         return maybeFoldList(resultList);
+    }
+
+    @Override
+    protected MapperService createMapperServiceForParams(XContentBuilder mappings) throws IOException {
+        if (params.syntheticSource()) {
+            if (useBinaryDocValues) {
+                // enable time series doc values format whenever binary doc values are to be used. TextFieldMapper will switch to using
+                // binary doc values when this format is enabled
+                Settings settings = Settings.builder()
+                    .put(IndexSettings.USE_TIME_SERIES_DOC_VALUES_FORMAT_SETTING.getKey(), true)
+                    .put("index.mapping.source.mode", "synthetic")
+                    .build();
+                return createMapperService(settings, mappings);
+            } else {
+                return createSytheticSourceMapperService(mappings);
+            }
+        } else {
+            return createMapperService(mappings);
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/blockloader/TextFieldWithParentBlockLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/blockloader/TextFieldWithParentBlockLoaderTests.java
@@ -79,6 +79,6 @@ public class TextFieldWithParentBlockLoaderTests extends MapperServiceTestCase {
 
         // we are using block loader of the text field itself
         var textFieldMapping = (Map<String, Object>) ((Map<String, Object>) fieldMapping.get("fields")).get("subfield_text");
-        return TextFieldBlockLoaderTests.expectedValue(textFieldMapping, value, params, testContext);
+        return TextFieldBlockLoaderTests.expectedValue(textFieldMapping, value, params, testContext, false);
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/BlockLoaderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/BlockLoaderTestCase.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 public abstract class BlockLoaderTestCase extends MapperServiceTestCase {
-    private static final MappedFieldType.FieldExtractPreference[] PREFERENCES = new MappedFieldType.FieldExtractPreference[] {
+    protected static final MappedFieldType.FieldExtractPreference[] PREFERENCES = new MappedFieldType.FieldExtractPreference[] {
         MappedFieldType.FieldExtractPreference.NONE,
         MappedFieldType.FieldExtractPreference.DOC_VALUES,
         MappedFieldType.FieldExtractPreference.STORED };
@@ -90,9 +90,7 @@ public abstract class BlockLoaderTestCase extends MapperServiceTestCase {
         Object expected = expected(mapping.lookup().get(fieldName), getFieldValue(document, fieldName), new TestContext(false, false));
 
         var mappingXContent = XContentBuilder.builder(XContentType.JSON.xContent()).map(mapping.raw());
-        var mapperService = params.syntheticSource
-            ? createSytheticSourceMapperService(mappingXContent)
-            : createMapperService(mappingXContent);
+        var mapperService = createMapperServiceForParams(mappingXContent);
 
         runner.runTest(mapperService, document, expected, fieldName);
     }
@@ -134,9 +132,7 @@ public abstract class BlockLoaderTestCase extends MapperServiceTestCase {
         }
 
         var mappingXContent = XContentBuilder.builder(XContentType.JSON.xContent()).map(mapping.raw());
-        var mapperService = params.syntheticSource
-            ? createSytheticSourceMapperService(mappingXContent)
-            : createMapperService(mappingXContent);
+        var mapperService = createMapperServiceForParams(mappingXContent);
 
         Object expected = expected(
             mapping.lookup().get(fullFieldName.toString()),
@@ -201,11 +197,16 @@ public abstract class BlockLoaderTestCase extends MapperServiceTestCase {
 
         Object expected = expected(fieldMapping, getFieldValue(document, "parent"), new TestContext(false, true));
         var mappingXContent = XContentBuilder.builder(XContentType.JSON.xContent()).map(mapping.raw());
-        var mapperService = params.syntheticSource
-            ? createSytheticSourceMapperService(mappingXContent)
-            : createMapperService(mappingXContent);
+        var mapperService = createMapperServiceForParams(mappingXContent);
 
         runner.runTest(mapperService, document, expected, "parent.mf");
+    }
+
+    protected MapperService createMapperServiceForParams(XContentBuilder mappings) throws IOException {
+        if (params.syntheticSource) {
+            return createSytheticSourceMapperService(mappings);
+        }
+        return createMapperService(mappings);
     }
 
     public static DataGeneratorSpecification buildSpecification(Collection<DataSourceHandler> customHandlers) {


### PR DESCRIPTION
We only want to use fallback binary doc values when time series format is enabled, otherwise storing values in a `StoredField` is more efficient.

This PR reintroduces using `StoredFields` for fallback text fields based on the value of `useBinaryDocValues`.