### PR TITLE
[9.3] Use LongUpDownCounter for Linked Project Error Metrics (#139657)

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
@@ -102,9 +102,13 @@ public final class RemoteClusterService extends RemoteClusterAware
          *  the functionality to do it the right way is not yet ready -- replace this code when it's ready.
          */
         this.crossProjectEnabled = settings.getAsBoolean("serverless.cross_project.enabled", false);
+        // Since this counter may never be incremented we need to force an initial observed value of zero via add(0) so the metric will be
+        // in the mappings of the indices of the APM data stream, otherwise we will encounter 'not found' errors in dashboards and alerts.
+        // See observability-dev issue #3042.
         transportService.getTelemetryProvider()
             .getMeterRegistry()
-            .registerLongCounter(CONNECTION_ATTEMPT_FAILURES_COUNTER_NAME, "linked project connection attempt failure count", "count");
+            .registerLongUpDownCounter(CONNECTION_ATTEMPT_FAILURES_COUNTER_NAME, "linked project connection attempt failure count", "count")
+            .add(0);
     }
 
     public RemoteClusterCredentialsManager getRemoteClusterCredentialsManager() {

--- a/server/src/test/java/org/elasticsearch/transport/RemoteConnectionStrategyTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteConnectionStrategyTests.java
@@ -266,7 +266,7 @@ public class RemoteConnectionStrategyTests extends ESTestCase {
                     if (shouldConnectFail) {
                         metricRecorder.collect();
                         final var counterName = RemoteClusterService.CONNECTION_ATTEMPT_FAILURES_COUNTER_NAME;
-                        final var measurements = metricRecorder.getMeasurements(InstrumentType.LONG_COUNTER, counterName);
+                        final var measurements = metricRecorder.getMeasurements(InstrumentType.LONG_UP_DOWN_COUNTER, counterName);
                         assertFalse(measurements.isEmpty());
                         final var measurement = measurements.getLast();
                         assertThat(measurement.getLong(), equalTo(1L));


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Use LongUpDownCounter for Linked Project Error Metrics (#139657)](https://github.com/elastic/elasticsearch/pull/139657)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)