### PR TITLE
Use CrossProjectModeDecider in RemoteClusterService

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
@@ -229,7 +229,7 @@ public final class RemoteClusterService extends RemoteClusterAware
      * it returns an empty value where we default/fall back to true.
      */
     public Optional<Boolean> isSkipUnavailable(String clusterAlias) {
-        if (crossProjectModeDecider.crossProjectEnabled()) {
+        if (crossProjectEnabled()) {
             return Optional.empty();
         } else {
             return Optional.of(getRemoteClusterConnection(clusterAlias).isSkipUnavailable());
@@ -365,7 +365,6 @@ public final class RemoteClusterService extends RemoteClusterAware
         boolean forceRebuild,
         ActionListener<RemoteClusterConnectionStatus> listener
     ) {
-        final var crossProjectEnabled = crossProjectModeDecider.crossProjectEnabled();
         final var projectId = config.originProjectId();
         final var clusterAlias = config.linkedProjectAlias();
         final var connectionMap = getConnectionsMapForProject(projectId);
@@ -373,7 +372,7 @@ public final class RemoteClusterService extends RemoteClusterAware
 
         if (remote == null) {
             // this is a new cluster we have to add a new representation
-            remote = new RemoteClusterConnection(config, transportService, remoteClusterCredentialsManager, crossProjectEnabled);
+            remote = new RemoteClusterConnection(config, transportService, remoteClusterCredentialsManager, crossProjectEnabled());
             connectionMap.put(clusterAlias, remote);
             remote.ensureConnected(listener.map(ignored -> RemoteClusterConnectionStatus.CONNECTED));
         } else if (forceRebuild || remote.shouldRebuildConnection(config)) {
@@ -384,7 +383,7 @@ public final class RemoteClusterService extends RemoteClusterAware
                 logger.warn("project [" + projectId + "] failed to close remote cluster connections for cluster: " + clusterAlias, e);
             }
             connectionMap.remove(clusterAlias);
-            remote = new RemoteClusterConnection(config, transportService, remoteClusterCredentialsManager, crossProjectEnabled);
+            remote = new RemoteClusterConnection(config, transportService, remoteClusterCredentialsManager, crossProjectEnabled());
             connectionMap.put(clusterAlias, remote);
             remote.ensureConnected(listener.map(ignored -> RemoteClusterConnectionStatus.RECONNECTED));
         } else if (remote.isSkipUnavailable() != config.skipUnavailable()) {


### PR DESCRIPTION
Addresses a `TODO` in `RemoteClusterService` by using the `CrossProjectModeDecider` which handles the details of the settings lookup.  This is the class used throughout the codebase now to test if CPS is enabled.