### PR TITLE
ES|QL Completion command doc GA

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/commands/layout/completion.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/completion.md
@@ -1,7 +1,7 @@
 
 ```yaml {applies_to}
-serverless: preview
-stack: preview 9.1.0
+serverless: ga
+stack: preview 9.1.0, ga 9.3.0
 ```
 
 The `COMPLETION` command allows you to send prompts and context to a Large Language Model (LLM) directly within your ES|QL queries, to perform text generation tasks.


### PR DESCRIPTION
ES|QL completion command is GA in serverless and stack release 9.3.0. Update the doc accordingly.