### PR TITLE
[DOCS]: Add connectors release notes for 9.1.10, 9.2.4

### DIFF
--- a/docs/reference/search-connectors/release-notes.md
+++ b/docs/reference/search-connectors/release-notes.md
@@ -13,6 +13,9 @@ If you are an Enterprise Search user and want to upgrade to Elastic 9.0, refer t
 It includes detailed steps, tooling, and resources to help you transition to supported alternatives in 9.x, such as Elasticsearch, the Open Web Crawler, and self-managed connectors.
 :::
 
+## 9.2.4 [connectors-9.2.4-release-notes]
+There are no new features, enhancements, fixes, known issues, or deprecations associated with this release.
+
 ## 9.2.3 [connectors-9.2.3-release-notes]
 
 ### Fixes [connectors-9.2.3-fixes]
@@ -30,6 +33,9 @@ There are no new features, enhancements, fixes, known issues, or deprecations as
 * Refactored pagination from OFFSET-based to keyset (primary-key) pagination in the MySQL connector. This delivers 3×+ faster syncs on large tables and modest gains on smaller ones. [#3719](https://github.com/elastic/connectors/pull/3719).
 
 * Updated the Jira connector to use the new `/rest/api/3/search/jql` endpoint, ensuring compatibility with Jira’s latest API. [#3710](https://github.com/elastic/connectors/pull/3710).
+
+## 9.1.10 [connectors-9.1.10-release-notes]
+There are no new features, enhancements, fixes, known issues, or deprecations associated with this release.
 
 ## 9.1.9 [connectors-9.1.9-release-notes]
 


### PR DESCRIPTION
This PR adds the search connectors release notes to the documentation for 9.1.10 and 9.2.4.