### PR TITLE
Directly compressing `StreamOutput`

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinValidationService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinValidationService.java
@@ -24,7 +24,6 @@ import org.elasticsearch.common.compress.CompressorFactory;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
-import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
@@ -392,11 +391,7 @@ public class JoinValidationService {
         assert clusterState.nodes().isLocalNodeElectedMaster();
 
         try (var bytesStream = transportService.newNetworkBytesStream()) {
-            try (
-                var stream = new OutputStreamStreamOutput(
-                    CompressorFactory.COMPRESSOR.threadLocalOutputStream(Streams.flushOnCloseStream(bytesStream))
-                )
-            ) {
+            try (var stream = CompressorFactory.COMPRESSOR.threadLocalStreamOutput(Streams.flushOnCloseStream(bytesStream))) {
                 stream.setTransportVersion(version);
                 clusterState.writeTo(stream);
             } catch (IOException e) {

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.compress.CompressorFactory;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
-import org.elasticsearch.common.io.stream.PositionTrackingOutputStreamStreamOutput;
 import org.elasticsearch.common.io.stream.RecyclerBytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -252,11 +251,7 @@ public class PublicationTransportHandler {
     private ReleasableBytesReference serializeFullClusterState(ClusterState clusterState, DiscoveryNode node, TransportVersion version) {
         try (RecyclerBytesStreamOutput bytesStream = transportService.newNetworkBytesStream()) {
             final long uncompressedBytes;
-            try (
-                StreamOutput stream = new PositionTrackingOutputStreamStreamOutput(
-                    CompressorFactory.COMPRESSOR.threadLocalOutputStream(Streams.flushOnCloseStream(bytesStream))
-                )
-            ) {
+            try (StreamOutput stream = CompressorFactory.COMPRESSOR.threadLocalStreamOutput(Streams.flushOnCloseStream(bytesStream))) {
                 stream.setTransportVersion(version);
                 stream.writeBoolean(true);
                 clusterState.writeTo(stream);
@@ -285,11 +280,7 @@ public class PublicationTransportHandler {
         final long clusterStateVersion = newState.version();
         try (RecyclerBytesStreamOutput bytesStream = transportService.newNetworkBytesStream()) {
             final long uncompressedBytes;
-            try (
-                StreamOutput stream = new PositionTrackingOutputStreamStreamOutput(
-                    CompressorFactory.COMPRESSOR.threadLocalOutputStream(Streams.flushOnCloseStream(bytesStream))
-                )
-            ) {
+            try (StreamOutput stream = CompressorFactory.COMPRESSOR.threadLocalStreamOutput(Streams.flushOnCloseStream(bytesStream))) {
                 stream.setTransportVersion(version);
                 stream.writeBoolean(false);
                 diff.writeTo(stream);

--- a/server/src/main/java/org/elasticsearch/common/compress/CompressedXContent.java
+++ b/server/src/main/java/org/elasticsearch/common/compress/CompressedXContent.java
@@ -109,7 +109,7 @@ public final class CompressedXContent implements Writeable {
         BytesStreamOutput bStream = baos.get();
         try {
             OutputStream checkedStream = new DigestOutputStream(
-                CompressorFactory.COMPRESSOR.threadLocalOutputStream(bStream),
+                CompressorFactory.COMPRESSOR.threadLocalStreamOutput(bStream),
                 messageDigest
             );
             try (XContentBuilder builder = XContentFactory.jsonBuilder(checkedStream)) {

--- a/server/src/main/java/org/elasticsearch/common/compress/Compressor.java
+++ b/server/src/main/java/org/elasticsearch/common/compress/Compressor.java
@@ -12,6 +12,7 @@ package org.elasticsearch.common.compress;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.InputStreamStreamInput;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
@@ -48,12 +49,12 @@ public interface Compressor {
     InputStream threadLocalInputStream(InputStream in) throws IOException;
 
     /**
-     * Creates a new output stream that compresses the contents and writes to the provided output stream.
-     * Closing the returned {@link OutputStream} will close the provided output stream.
+     * Creates a new {@link StreamOutput} that compresses the contents and writes to the provided output stream.
+     * Closing the returned {@link StreamOutput} will close the delegate {@code out} stream.
      * Note: The returned stream may only be used on the thread that created it as it might use thread-local resources and must be safely
      * closed after use
      */
-    OutputStream threadLocalOutputStream(OutputStream out) throws IOException;
+    StreamOutput threadLocalStreamOutput(OutputStream out) throws IOException;
 
     /**
      * Decompress bytes into a newly allocated buffer.

--- a/server/src/main/java/org/elasticsearch/common/compress/DeflateCompressor.java
+++ b/server/src/main/java/org/elasticsearch/common/compress/DeflateCompressor.java
@@ -193,7 +193,7 @@ public class DeflateCompressor implements Compressor {
                 try {
                     super.close();
                 } finally {
-                    // We are ensured to only call this once since we wrap this stream in a BufferedOutputStream that will only close
+                    // We are ensured to only call this once since we wrap this stream in a BufferedStreamOutput that will only close
                     // its delegate once below
                     releasable.close();
                 }

--- a/server/src/main/java/org/elasticsearch/common/compress/DeflateCompressor.java
+++ b/server/src/main/java/org/elasticsearch/common/compress/DeflateCompressor.java
@@ -9,13 +9,15 @@
 
 package org.elasticsearch.common.compress;
 
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.BufferedStreamOutput;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Assertions;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Streams;
 
-import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -171,7 +173,7 @@ public class DeflateCompressor implements Compressor {
     }
 
     @Override
-    public OutputStream threadLocalOutputStream(OutputStream out) throws IOException {
+    public StreamOutput threadLocalStreamOutput(OutputStream out) throws IOException {
         out.write(HEADER);
         final ReleasableReference<Deflater> current = deflaterForStreamRef.get();
         final Releasable releasable;
@@ -197,7 +199,7 @@ public class DeflateCompressor implements Compressor {
                 }
             }
         };
-        return new BufferedOutputStream(deflaterOutputStream, BUFFER_SIZE);
+        return new BufferedStreamOutput(deflaterOutputStream, new BytesRef(new byte[BUFFER_SIZE], 0, BUFFER_SIZE));
     }
 
     private static final ThreadLocal<BytesStreamOutput> baos = ThreadLocal.withInitial(BytesStreamOutput::new);

--- a/server/src/main/java/org/elasticsearch/common/io/stream/BufferedStreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/BufferedStreamOutput.java
@@ -37,6 +37,7 @@ public class BufferedStreamOutput extends StreamOutput {
     private final int endPosition;
     private int position;
     private long flushedBytes;
+    private boolean isClosed;
 
     /**
      * Wrap the given stream, using the given {@link BytesRef} for the buffer. It is the caller's responsibility to make sure that nothing
@@ -129,8 +130,11 @@ public class BufferedStreamOutput extends StreamOutput {
 
     @Override
     public void close() throws IOException {
-        flush();
-        delegate.close();
+        if (isClosed == false) {
+            isClosed = true;
+            flush();
+            delegate.close();
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/io/stream/BytesStream.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/BytesStream.java
@@ -21,7 +21,7 @@ public abstract class BytesStream extends StreamOutput {
     public void writeWithSizePrefix(Writeable writeable) throws IOException {
         long pos = position();
         seek(pos + Integer.BYTES);
-        try (var out = new OutputStreamStreamOutput(CompressorFactory.COMPRESSOR.threadLocalOutputStream(Streams.noCloseStream(this)))) {
+        try (var out = CompressorFactory.COMPRESSOR.threadLocalStreamOutput(Streams.noCloseStream(this))) {
             out.setTransportVersion(getTransportVersion());
             writeable.writeTo(out);
         }

--- a/server/src/main/java/org/elasticsearch/common/io/stream/DelayableWriteable.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/DelayableWriteable.java
@@ -126,7 +126,7 @@ public abstract class DelayableWriteable<T extends Writeable> implements Writeab
         public Serialized<T> asSerialized(Reader<T> reader, NamedWriteableRegistry registry) {
             // TODO: this path is currently not used in production code, if it ever is this should start using pooled buffers
             BytesStreamOutput buffer = new BytesStreamOutput();
-            try (var out = new OutputStreamStreamOutput(CompressorFactory.COMPRESSOR.threadLocalOutputStream(buffer))) {
+            try (var out = CompressorFactory.COMPRESSOR.threadLocalStreamOutput(buffer)) {
                 out.setTransportVersion(TransportVersion.current());
                 reference.writeTo(out);
             } catch (IOException e) {

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -152,7 +152,7 @@ public abstract class StreamOutput extends OutputStream {
      */
     public void writeWithSizePrefix(Writeable writeable) throws IOException {
         final BytesStreamOutput tmp = new BytesStreamOutput();
-        try (var o = new OutputStreamStreamOutput(CompressorFactory.COMPRESSOR.threadLocalOutputStream(tmp))) {
+        try (var o = CompressorFactory.COMPRESSOR.threadLocalStreamOutput(tmp)) {
             o.setTransportVersion(version);
             writeable.writeTo(o);
         }

--- a/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
@@ -1273,7 +1273,7 @@ public class PersistedClusterStateService {
         private void writePages(ToXContent metadata, PageWriter pageWriter) throws IOException {
             try (
                 PageWriterOutputStream paginatedStream = new PageWriterOutputStream(documentBuffer, pageWriter);
-                OutputStream compressedStream = CompressorFactory.COMPRESSOR.threadLocalOutputStream(paginatedStream);
+                OutputStream compressedStream = CompressorFactory.COMPRESSOR.threadLocalStreamOutput(paginatedStream);
                 XContentBuilder xContentBuilder = XContentFactory.contentBuilder(XContentType.SMILE, compressedStream)
             ) {
                 xContentBuilder.startObject();

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/ChecksumBlobStoreFormat.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/ChecksumBlobStoreFormat.java
@@ -394,7 +394,7 @@ public final class ChecksumBlobStoreFormat<T> {
             };
                 XContentBuilder builder = XContentFactory.contentBuilder(
                     XContentType.SMILE,
-                    compress ? CompressorFactory.COMPRESSOR.threadLocalOutputStream(indexOutputOutputStream) : indexOutputOutputStream
+                    compress ? CompressorFactory.COMPRESSOR.threadLocalStreamOutput(indexOutputOutputStream) : indexOutputOutputStream
                 )
             ) {
                 ToXContent.Params params = extraParams.isEmpty()

--- a/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
@@ -368,9 +368,7 @@ public final class OutboundHandler {
     private static StreamOutput wrapCompressed(Compression.Scheme compressionScheme, RecyclerBytesStreamOutput bytesStream)
         throws IOException {
         if (compressionScheme == Compression.Scheme.DEFLATE) {
-            return new OutputStreamStreamOutput(
-                CompressorFactory.COMPRESSOR.threadLocalOutputStream(org.elasticsearch.core.Streams.noCloseStream(bytesStream))
-            );
+            return CompressorFactory.COMPRESSOR.threadLocalStreamOutput(Streams.noCloseStream(bytesStream));
         } else if (compressionScheme == Compression.Scheme.LZ4) {
             return new OutputStreamStreamOutput(Compression.Scheme.lz4OutputStream(Streams.noCloseStream(bytesStream)));
         } else {

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/JoinValidationServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/JoinValidationServiceTests.java
@@ -30,7 +30,6 @@ import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistryTests;
-import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
@@ -427,9 +426,7 @@ public class JoinValidationServiceTests extends ESTestCase {
     private static BytesTransportRequest serializeClusterState(ClusterState clusterState) {
         try (
             var bytesStream = new BytesStreamOutput();
-            var compressedStream = new OutputStreamStreamOutput(
-                CompressorFactory.COMPRESSOR.threadLocalOutputStream(Streams.flushOnCloseStream(bytesStream))
-            )
+            var compressedStream = CompressorFactory.COMPRESSOR.threadLocalStreamOutput(Streams.flushOnCloseStream(bytesStream))
         ) {
             compressedStream.setTransportVersion(TransportVersion.current());
             clusterState.writeTo(compressedStream);

--- a/server/src/test/java/org/elasticsearch/common/compress/DeflateCompressTests.java
+++ b/server/src/test/java/org/elasticsearch/common/compress/DeflateCompressTests.java
@@ -342,7 +342,7 @@ public class DeflateCompressTests extends ESTestCase {
         int postpadding = r.nextInt(70000);
         byte[] buffer = new byte[prepadding + bufferSize + postpadding];
         int len;
-        try (OutputStream os = c.threadLocalOutputStream(bos)) {
+        try (OutputStream os = c.threadLocalStreamOutput(bos)) {
             r.nextBytes(buffer); // fill block completely with junk
             while ((len = rawIn.read(buffer, prepadding, bufferSize)) != -1) {
                 os.write(buffer, prepadding, len);

--- a/server/src/test/java/org/elasticsearch/common/compress/DeflateCompressedXContentTests.java
+++ b/server/src/test/java/org/elasticsearch/common/compress/DeflateCompressedXContentTests.java
@@ -65,7 +65,7 @@ public class DeflateCompressedXContentTests extends ESTestCase {
     public void testDifferentCompressedRepresentation() throws Exception {
         byte[] b = "---\nf:abcdefghijabcdefghij".getBytes(StandardCharsets.UTF_8);
         BytesStreamOutput bout = new BytesStreamOutput();
-        try (OutputStream out = compressor.threadLocalOutputStream(bout)) {
+        try (OutputStream out = compressor.threadLocalStreamOutput(bout)) {
             out.write(b);
             out.flush();
             out.write(b);
@@ -73,7 +73,7 @@ public class DeflateCompressedXContentTests extends ESTestCase {
         final BytesReference b1 = bout.bytes();
 
         bout = new BytesStreamOutput();
-        try (OutputStream out = compressor.threadLocalOutputStream(bout)) {
+        try (OutputStream out = compressor.threadLocalStreamOutput(bout)) {
             out.write(b);
             out.write(b);
         }

--- a/server/src/test/java/org/elasticsearch/index/mapper/BinaryFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BinaryFieldMapperTests.java
@@ -118,7 +118,7 @@ public class BinaryFieldMapperTests extends MapperTestCase {
 
         // case 2: a value that looks compressed: this used to fail in 1.x
         BytesStreamOutput out = new BytesStreamOutput();
-        try (OutputStream compressed = CompressorFactory.COMPRESSOR.threadLocalOutputStream(out)) {
+        try (OutputStream compressed = CompressorFactory.COMPRESSOR.threadLocalStreamOutput(out)) {
             new BytesArray(binaryValue1).writeTo(compressed);
         }
         final byte[] binaryValue2 = BytesReference.toBytes(out.bytes());

--- a/server/src/test/java/org/elasticsearch/transport/DeflateTransportDecompressorTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/DeflateTransportDecompressorTests.java
@@ -16,7 +16,6 @@ import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.compress.CompressorFactory;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.recycler.Recycler;
@@ -35,7 +34,7 @@ public class DeflateTransportDecompressorTests extends ESTestCase {
     public void testSimpleCompression() throws IOException {
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             byte randomByte = randomByte();
-            try (OutputStream deflateStream = CompressorFactory.COMPRESSOR.threadLocalOutputStream(Streams.flushOnCloseStream(output))) {
+            try (OutputStream deflateStream = CompressorFactory.COMPRESSOR.threadLocalStreamOutput(Streams.flushOnCloseStream(output))) {
                 deflateStream.write(randomByte);
             }
 
@@ -54,11 +53,7 @@ public class DeflateTransportDecompressorTests extends ESTestCase {
 
     public void testMultiPageCompression() throws IOException {
         try (BytesStreamOutput output = new BytesStreamOutput()) {
-            try (
-                StreamOutput deflateStream = new OutputStreamStreamOutput(
-                    CompressorFactory.COMPRESSOR.threadLocalOutputStream(Streams.flushOnCloseStream(output))
-                )
-            ) {
+            try (StreamOutput deflateStream = CompressorFactory.COMPRESSOR.threadLocalStreamOutput(Streams.flushOnCloseStream(output))) {
                 for (int i = 0; i < 10000; ++i) {
                     deflateStream.writeInt(i);
                 }
@@ -86,11 +81,7 @@ public class DeflateTransportDecompressorTests extends ESTestCase {
 
     public void testIncrementalMultiPageCompression() throws IOException {
         try (BytesStreamOutput output = new BytesStreamOutput()) {
-            try (
-                StreamOutput deflateStream = new OutputStreamStreamOutput(
-                    CompressorFactory.COMPRESSOR.threadLocalOutputStream(Streams.flushOnCloseStream(output))
-                )
-            ) {
+            try (StreamOutput deflateStream = CompressorFactory.COMPRESSOR.threadLocalStreamOutput(Streams.flushOnCloseStream(output))) {
                 for (int i = 0; i < 10000; ++i) {
                     deflateStream.writeInt(i);
                 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTaskIndexService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTaskIndexService.java
@@ -326,8 +326,7 @@ public final class AsyncTaskIndexService<R extends AsyncResponse<R>> {
             os = Streams.noCloseStream(os);
             TransportVersion minNodeVersion = clusterService.state().getMinTransportVersion();
             TransportVersion.writeVersion(minNodeVersion, new OutputStreamStreamOutput(os));
-            os = CompressorFactory.COMPRESSOR.threadLocalOutputStream(os);
-            try (OutputStreamStreamOutput out = new OutputStreamStreamOutput(os)) {
+            try (var out = CompressorFactory.COMPRESSOR.threadLocalStreamOutput(os)) {
                 out.setTransportVersion(minNodeVersion);
                 response.writeTo(out);
             }

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExportBulk.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExportBulk.java
@@ -89,7 +89,7 @@ class HttpExportBulk extends ExportBulk {
             if (docs != null && docs.isEmpty() == false) {
                 final BytesStreamOutput scratch = new BytesStreamOutput();
                 final CountingOutputStream countingStream;
-                try (OutputStream payload = CompressorFactory.COMPRESSOR.threadLocalOutputStream(scratch)) {
+                try (OutputStream payload = CompressorFactory.COMPRESSOR.threadLocalStreamOutput(scratch)) {
                     countingStream = new CountingOutputStream(payload);
                     for (MonitoringDoc monitoringDoc : docs) {
                         writeDocument(monitoringDoc, countingStream);

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/common/io/SqlStreamOutput.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/common/io/SqlStreamOutput.java
@@ -33,7 +33,7 @@ public class SqlStreamOutput extends OutputStreamStreamOutput {
         ByteArrayOutputStream bytes = new ByteArrayOutputStream();
         StreamOutput uncompressedOut = new OutputStreamStreamOutput(Base64.getEncoder().wrap(bytes));
         TransportVersion.writeVersion(version, uncompressedOut);
-        OutputStream out = CompressorFactory.COMPRESSOR.threadLocalOutputStream(uncompressedOut);
+        OutputStream out = CompressorFactory.COMPRESSOR.threadLocalStreamOutput(uncompressedOut);
         return new SqlStreamOutput(bytes, out, version, zoneId);
     }
 


### PR DESCRIPTION
Today `Compressor#threadLocalOutputStream` returns a bare (buffered)
`OutputStream` which many callers then adapt into a `StreamOutput` using
the inefficient `OutputStreamStreamOutput`. This commit adjusts the
compressor to return a `BufferedStreamOutput`, avoiding the need for an
extra wrapper while also supporting more efficient structured write
operations such as `writeVInt` and `writeString`.