### PR TITLE
Make SlowCustomBinaryDocValuesTermQuery aware of index sorting.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexSortConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSortConfig.java
@@ -358,7 +358,7 @@ public final class IndexSortConfig {
     }
 
     public boolean getPrimarySortOrderDesc() {
-        return  sortSpecs[0].order == SortOrder.DESC;
+        return sortSpecs[0].order == SortOrder.DESC;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/IndexSortConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSortConfig.java
@@ -357,6 +357,10 @@ public final class IndexSortConfig {
         return sortSpecs.length > 0 && sortSpecs[0].field.equals(field);
     }
 
+    public boolean getPrimarySortOrderDesc() {
+        return  sortSpecs[0].order == SortOrder.DESC;
+    }
+
     /**
      * Builds the {@link Sort} order from the settings for this index
      * or returns null if this index has no sort.

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -640,7 +640,8 @@ public final class KeywordFieldMapper extends FieldMapper {
             if (indexType.hasTerms()) {
                 return super.termQuery(value, context);
             } else if (storedInBinaryDocValues()) {
-                return new SlowCustomBinaryDocValuesTermQuery(name(), indexedValueForSearch(value));
+                var indexSortConfig = context.getIndexSettings().getIndexSortConfig();
+                return new SlowCustomBinaryDocValuesTermQuery(name(), indexedValueForSearch(value), indexSortConfig);
             } else {
                 return SortedSetDocValuesField.newSlowExactQuery(name(), indexedValueForSearch(value));
             }

--- a/server/src/main/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesWildcardQuery.java
+++ b/server/src/main/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesWildcardQuery.java
@@ -36,7 +36,7 @@ public final class SlowCustomBinaryDocValuesWildcardQuery extends AbstractBinary
     }
 
     private SlowCustomBinaryDocValuesWildcardQuery(String fieldName, String pattern, boolean caseInsensitive, ByteRunAutomaton automaton) {
-        super(fieldName, value -> automaton.run(value.bytes, value.offset, value.length));
+        super(fieldName, (value, iterator) -> automaton.run(value.bytes, value.offset, value.length));
         this.pattern = Objects.requireNonNull(pattern);
         this.caseInsensitive = caseInsensitive;
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldTypeTests.java
@@ -43,6 +43,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.IndexSortConfig;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.analysis.AnalyzerScope;
 import org.elasticsearch.index.analysis.CharFilterFactory;
@@ -110,7 +111,11 @@ public class KeywordFieldTypeTests extends FieldTypeTestCase {
             builder,
             true
         );
-        assertEquals(new SlowCustomBinaryDocValuesTermQuery("field", new BytesRef("foo")), ft.termQuery("foo", MOCK_CONTEXT));
+        IndexSortConfig indexSortConfig = new IndexSortConfig(defaultIndexSettings());
+        assertEquals(
+            new SlowCustomBinaryDocValuesTermQuery("field", new BytesRef("foo"), indexSortConfig),
+            ft.termQuery("foo", MOCK_CONTEXT)
+        );
     }
 
     public void testTermQueryWithNormalizer() {

--- a/server/src/test/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesTermQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/queries/SlowCustomBinaryDocValuesTermQueryTests.java
@@ -16,6 +16,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.IndexSortConfig;
 import org.elasticsearch.index.mapper.MultiValuedBinaryDocValuesField;
 import org.elasticsearch.test.ESTestCase;
 
@@ -55,10 +56,13 @@ public class SlowCustomBinaryDocValuesTermQueryTests extends ESTestCase {
                 }
 
                 // search
+                IndexSortConfig indexSortConfig = new IndexSortConfig(defaultIndexSettings());
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
                     for (var entry : expectedCounts.entrySet()) {
-                        long count = searcher.count(new SlowCustomBinaryDocValuesTermQuery(fieldName, new BytesRef(entry.getKey())));
+                        long count = searcher.count(
+                            new SlowCustomBinaryDocValuesTermQuery(fieldName, new BytesRef(entry.getKey()), indexSortConfig)
+                        );
                         assertEquals(entry.getValue().longValue(), count);
                     }
                 }
@@ -68,6 +72,7 @@ public class SlowCustomBinaryDocValuesTermQueryTests extends ESTestCase {
 
     public void testNoField() throws IOException {
         String fieldName = "field";
+        IndexSortConfig indexSortConfig = new IndexSortConfig(defaultIndexSettings());
 
         // no field in index
         try (Directory dir = newDirectory()) {
@@ -75,7 +80,7 @@ public class SlowCustomBinaryDocValuesTermQueryTests extends ESTestCase {
                 writer.addDocument(new Document());
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Query query = new SlowCustomBinaryDocValuesTermQuery(fieldName, new BytesRef("a"));
+                    Query query = new SlowCustomBinaryDocValuesTermQuery(fieldName, new BytesRef("a"), indexSortConfig);
                     assertEquals(0, searcher.count(query));
                 }
             }
@@ -97,7 +102,7 @@ public class SlowCustomBinaryDocValuesTermQueryTests extends ESTestCase {
                 writer.addDocument(new Document());
                 try (IndexReader reader = writer.getReader()) {
                     IndexSearcher searcher = newSearcher(reader);
-                    Query query = new SlowCustomBinaryDocValuesTermQuery(fieldName, new BytesRef("a"));
+                    Query query = new SlowCustomBinaryDocValuesTermQuery(fieldName, new BytesRef("a"), indexSortConfig);
                     assertEquals(1, searcher.count(query));
                 }
             }


### PR DESCRIPTION
If field being queries is the primary index sort field, then segment can be skipped if found value is smaller or greater than requested value. Depending on sort order.