### PR TITLE
[9.3] ES|QL - fix dense vector enrich bug (#139774)

### DIFF
--- a/docs/changelog/139774.yaml
+++ b/docs/changelog/139774.yaml
@@ -1,0 +1,6 @@
+pr: 139774
+summary: ES|QL - fix ENRICH command when using dense_vector columns
+area: ES|QL
+type: bug
+issues:
+ - 137699

--- a/x-pack/plugin/esql/compute/build.gradle
+++ b/x-pack/plugin/esql/compute/build.gradle
@@ -960,6 +960,11 @@ tasks.named('stringTemplates').configure {
     it.inputFile = enrichResultBuilderInput
     it.outputFile = "org/elasticsearch/xpack/compute/operator/lookup/EnrichResultBuilderForBoolean.java"
   }
+  template {
+    it.properties = floatProperties
+    it.inputFile = enrichResultBuilderInput
+    it.outputFile = "org/elasticsearch/xpack/compute/operator/lookup/EnrichResultBuilderForFloat.java"
+  }
 
   // TODO: add {value}_over_time for other types: boolean, bytes_refs
   def generateTimestampAggregatorClasses = { inputFilename, prefix = "" ->

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/xpack/compute/operator/lookup/EnrichResultBuilderForFloat.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/xpack/compute/operator/lookup/EnrichResultBuilderForFloat.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.operator.lookup;
+
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.util.ObjectArray;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.FloatBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.core.Releasables;
+
+import java.util.Arrays;
+
+/**
+ * {@link EnrichResultBuilder} for Floats.
+ * This class is generated. Edit `X-EnrichResultBuilder.java.st` instead.
+ */
+final class EnrichResultBuilderForFloat extends EnrichResultBuilder {
+    private ObjectArray<float[]> cells;
+
+    EnrichResultBuilderForFloat(BlockFactory blockFactory, int channel) {
+        super(blockFactory, channel);
+        this.cells = blockFactory.bigArrays().newObjectArray(1);
+    }
+
+    @Override
+    void addInputPage(IntVector positions, Page page) {
+        FloatBlock block = page.getBlock(channel);
+        for (int i = 0; i < positions.getPositionCount(); i++) {
+            int valueCount = block.getValueCount(i);
+            if (valueCount == 0) {
+                continue;
+            }
+            int cellPosition = positions.getInt(i);
+            cells = blockFactory.bigArrays().grow(cells, cellPosition + 1);
+            final var oldCell = cells.get(cellPosition);
+            final var newCell = extendCell(oldCell, valueCount);
+            cells.set(cellPosition, newCell);
+            int dstIndex = oldCell != null ? oldCell.length : 0;
+            adjustBreaker(RamUsageEstimator.sizeOf(newCell) - (oldCell != null ? RamUsageEstimator.sizeOf(oldCell) : 0));
+            int firstValueIndex = block.getFirstValueIndex(i);
+            for (int v = 0; v < valueCount; v++) {
+                newCell[dstIndex + v] = block.getFloat(firstValueIndex + v);
+            }
+        }
+    }
+
+    private float[] extendCell(float[] oldCell, int newValueCount) {
+        if (oldCell == null) {
+            return new float[newValueCount];
+        } else {
+            return Arrays.copyOf(oldCell, oldCell.length + newValueCount);
+        }
+    }
+
+    private float[] combineCell(float[] first, float[] second) {
+        if (first == null) {
+            return second;
+        }
+        if (second == null) {
+            return first;
+        }
+        var result = new float[first.length + second.length];
+        System.arraycopy(first, 0, result, 0, first.length);
+        System.arraycopy(second, 0, result, first.length, second.length);
+        return result;
+    }
+
+    private void appendGroupToBlockBuilder(FloatBlock.Builder builder, float[] group) {
+        if (group == null) {
+            builder.appendNull();
+        } else if (group.length == 1) {
+            builder.appendFloat(group[0]);
+        } else {
+            builder.beginPositionEntry();
+            // TODO: sort and dedup and set MvOrdering
+            for (var v : group) {
+                builder.appendFloat(v);
+            }
+            builder.endPositionEntry();
+        }
+    }
+
+    private float[] getCellOrNull(int position) {
+        return position < cells.size() ? cells.get(position) : null;
+    }
+
+    private Block buildWithSelected(IntBlock selected) {
+        try (FloatBlock.Builder builder = blockFactory.newFloatBlockBuilder(selected.getPositionCount())) {
+            for (int i = 0; i < selected.getPositionCount(); i++) {
+                int selectedCount = selected.getValueCount(i);
+                switch (selectedCount) {
+                    case 0 -> builder.appendNull();
+                    case 1 -> {
+                        int groupId = selected.getInt(selected.getFirstValueIndex(i));
+                        appendGroupToBlockBuilder(builder, getCellOrNull(groupId));
+                    }
+                    default -> {
+                        int firstValueIndex = selected.getFirstValueIndex(i);
+                        var cell = getCellOrNull(selected.getInt(firstValueIndex));
+                        for (int p = 1; p < selectedCount; p++) {
+                            int groupId = selected.getInt(firstValueIndex + p);
+                            cell = combineCell(cell, getCellOrNull(groupId));
+                        }
+                        appendGroupToBlockBuilder(builder, cell);
+                    }
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    private Block buildWithSelected(IntVector selected) {
+        try (FloatBlock.Builder builder = blockFactory.newFloatBlockBuilder(selected.getPositionCount())) {
+            for (int i = 0; i < selected.getPositionCount(); i++) {
+                appendGroupToBlockBuilder(builder, getCellOrNull(selected.getInt(i)));
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
+    Block build(IntBlock selected) {
+        var vector = selected.asVector();
+        if (vector != null) {
+            return buildWithSelected(vector);
+        } else {
+            return buildWithSelected(selected);
+        }
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(cells, super::close);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/EnrichResultBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/lookup/EnrichResultBuilder.java
@@ -55,6 +55,7 @@ abstract class EnrichResultBuilder implements Releasable {
             case INT -> new EnrichResultBuilderForInt(blockFactory, channel);
             case LONG -> new EnrichResultBuilderForLong(blockFactory, channel);
             case DOUBLE -> new EnrichResultBuilderForDouble(blockFactory, channel);
+            case FLOAT -> new EnrichResultBuilderForFloat(blockFactory, channel);
             case BOOLEAN -> new EnrichResultBuilderForBoolean(blockFactory, channel);
             case BYTES_REF -> new EnrichResultBuilderForBytesRef(blockFactory, channel);
             default -> throw new IllegalArgumentException("no enrich result builder for [" + elementType + "]");

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AllSupportedFieldsTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/AllSupportedFieldsTestCase.java
@@ -999,9 +999,7 @@ public class AllSupportedFieldsTestCase extends ESRestTestCase {
             // https://github.com/elastic/elasticsearch/issues/127350
             case AGGREGATE_METRIC_DOUBLE, SCALED_FLOAT,
                 // https://github.com/elastic/elasticsearch/issues/139255
-                EXPONENTIAL_HISTOGRAM, TDIGEST,
-                // https://github.com/elastic/elasticsearch/issues/137699
-                DENSE_VECTOR -> false;
+                EXPONENTIAL_HISTOGRAM, TDIGEST -> false;
             default -> true;
         };
     }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/dense_vector.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/dense_vector.csv-spec
@@ -105,3 +105,40 @@ row hex_str = "0102030405060708090a0b0c0d0e0f"
 vector:dense_vector
  [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0]
 ;
+
+denseVectorWithEnrich
+required_capability: enrich_load
+required_capability: enrich_dense_vector_bugfix
+
+from colors 
+| enrich colors_policy
+| sort color_name
+| limit 10
+| keep color_name, cmyk_vector
+;
+
+color_name:text | cmyk_vector:dense_vector
+aqua marine     | [50.0, 0.0, 17.0, 0.0]
+azure           | [6.0, 0.0, 0.0, 0.0]
+beige           | [0.0, 0.0, 10.0, 4.0]
+bisque          | [0.0, 11.0, 23.0, 0.0]
+black           | [0.0, 0.0, 0.0, 100.0]
+blue            | [100.0, 100.0, 0.0, 0.0]
+brown           | [0.0, 75.0, 75.0, 35.0]
+burly wood      | [0.0, 17.0, 39.0, 13.0]
+chartreuse      | [50.0, 0.0, 100.0, 0.0]
+chocolate       | [0.0, 50.0, 86.0, 18.0]
+;
+
+denseVectorRowWithEnrich
+required_capability: enrich_load
+required_capability: enrich_dense_vector_bugfix
+
+row id=0
+| enrich colors_policy
+| keep color_name, cmyk_vector
+;
+
+color_name:text | cmyk_vector:dense_vector
+maroon          | [0.0, 100.0, 100.0, 50.0]
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/enrich-policy-colors_cmyk.json
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/enrich-policy-colors_cmyk.json
@@ -2,6 +2,6 @@
   "match": {
     "indices": "colors_cmyk",
     "match_field": "id",
-    "enrich_fields": ["color_name"]
+    "enrich_fields": ["color_name", "cmyk_vector"]
   }
 }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/vector-cosine-similarity.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/vector-cosine-similarity.csv-spec
@@ -178,27 +178,28 @@ silver      | 0.9258201122283936 | [0.0, 0.0, 0.0, 25.0]
 cosineSimilarityWithEnrich
 required_capability: vector_similarity_functions_pushdown
 required_capability: enrich_load
+required_capability: enrich_dense_vector_bugfix
 
 from colors
 | where color != "black" 
 | eval s = v_cosine(rgb_vector, [1, 2, 3])
 | enrich colors_policy
-| keep color_name, s
+| keep color_name, cmyk_vector, s  
 | sort s desc, color_name asc
 | limit 10
 ;
 
-color_name:text | s:double
-turquoise       | 0.9721468091011047
-aqua marine     | 0.9580987691879272
-cyan            | 0.9449111819267273
-teal            | 0.9449111819267273
-lavender        | 0.9381157159805298
-azure           | 0.9347044825553894
-mint cream      | 0.9287823438644409
-gainsboro       | 0.9258201122283936
-gray            | 0.9258201122283936
-silver          | 0.9258201122283936
+color_name:text | cmyk_vector:dense_vector | s:double     
+turquoise       | [71.0, 0.0, 7.0, 12.0]   | 0.9721468091011047
+aqua marine     | [50.0, 0.0, 17.0, 0.0]   | 0.9580987691879272
+cyan            | [100.0, 0.0, 0.0, 0.0]   | 0.9449111819267273
+teal            | [100.0, 0.0, 0.0, 50.0]  | 0.9449111819267273
+lavender        | [8.0, 8.0, 0.0, 2.0]     | 0.9381157159805298
+azure           | [6.0, 0.0, 0.0, 0.0]     | 0.9347044825553894
+mint cream      | [4.0, 0.0, 2.0, 0.0]     | 0.9287823438644409
+gainsboro       | [0.0, 0.0, 0.0, 14.0]    | 0.9258201122283936
+gray            | [0.0, 0.0, 0.0, 50.0]    | 0.9258201122283936
+silver          | [0.0, 0.0, 0.0, 25.0]    | 0.9258201122283936    
 ;
 
 similarityWithFork

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/vector-dot-product.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/vector-dot-product.csv-spec
@@ -196,26 +196,27 @@ indigo     | 438.0
 dotProductWithEnrich
 required_capability: vector_similarity_functions_pushdown
 required_capability: enrich_load
+required_capability: enrich_dense_vector_bugfix
 
 from colors
 | eval s = v_dot_product(rgb_vector, [1, 2, 3])
 | enrich colors_policy
-| keep color_name, s
+| keep color_name, cmyk_vector, s
 | sort s desc, color_name asc
 | limit 10
 ;
 
-color_name:text | s:double
-white           | 1530.0
-azure           | 1515.0
-mint cream      | 1505.0
-snow            | 1505.0
-ivory           | 1485.0
-honeydew        | 1470.0
-sea shell       | 1459.0
-lavender        | 1440.0
-old lace        | 1433.0
-linen           | 1420.0
+color_name:text | cmyk_vector:dense_vector | s:double
+white           | [0.0, 0.0, 0.0, 0.0]     | 1530.0
+azure           | [6.0, 0.0, 0.0, 0.0]     | 1515.0
+mint cream      | [4.0, 0.0, 2.0, 0.0]     | 1505.0
+snow            | [0.0, 2.0, 2.0, 0.0]     | 1505.0
+ivory           | [0.0, 0.0, 6.0, 0.0]     | 1485.0
+honeydew        | [6.0, 0.0, 6.0, 0.0]     | 1470.0
+sea shell       | [0.0, 4.0, 7.0, 0.0]     | 1459.0
+lavender        | [8.0, 8.0, 0.0, 2.0]     | 1440.0
+old lace        | [0.0, 3.0, 9.0, 1.0]     | 1433.0
+linen           | [0.0, 4.0, 8.0, 2.0]     | 1420.0
 ;
 
 similarityWithFork

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/vector-hamming.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/vector-hamming.csv-spec
@@ -196,26 +196,27 @@ lime       | 11.0
 hammingWithEnrich
 required_capability: vector_similarity_functions_pushdown
 required_capability: enrich_load
+required_capability: enrich_dense_vector_bugfix
 
 from colors
 | eval s = v_hamming(rgb_byte_vector, [1, 2, 3])
 | enrich colors_policy
-| keep color_name, s
+| keep color_name, cmyk_vector, s  
 | sort s desc, color_name asc
 | limit 10
 ;
 
-color_name:text | s:double
-aqua marine     | 18.0
-coral           | 18.0
-corn silk       | 17.0
-ivory           | 17.0
-sea shell       | 17.0
-white           | 17.0
-beige           | 16.0
-chartreuse      | 16.0
-crimson         | 16.0
-gainsboro       | 16.0
+color_name:text | cmyk_vector:dense_vector | s:double     
+aqua marine     | [50.0, 0.0, 17.0, 0.0]   | 18.0
+coral           | [0.0, 50.0, 69.0, 0.0]   | 18.0
+corn silk       | [0.0, 3.0, 14.0, 0.0]    | 17.0
+ivory           | [0.0, 0.0, 6.0, 0.0]     | 17.0
+sea shell       | [0.0, 4.0, 7.0, 0.0]     | 17.0
+white           | [0.0, 0.0, 0.0, 0.0]     | 17.0
+beige           | [0.0, 0.0, 10.0, 4.0]    | 16.0
+chartreuse      | [50.0, 0.0, 100.0, 0.0]  | 16.0
+crimson         | [0.0, 91.0, 73.0, 14.0]  | 16.0
+gainsboro       | [0.0, 0.0, 0.0, 14.0]    | 16.0     
 ;
 
 similarityWithFork

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/vector-l1-norm.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/vector-l1-norm.csv-spec
@@ -196,26 +196,27 @@ crimson    | 170.0
 l1NormWithEnrich
 required_capability: vector_similarity_functions_pushdown
 required_capability: enrich_load
+required_capability: enrich_dense_vector_bugfix
 
 from colors
 | eval s = v_l1_norm(rgb_vector, [1, 2, 3])
 | enrich colors_policy
-| keep color_name, s
+| keep color_name, cmyk_vector, s  
 | sort s desc, color_name asc
 | limit 10
 ;
 
-color_name:text | s:double
-white           | 759.0
-snow            | 749.0
-azure           | 744.0
-ivory           | 744.0
-mint cream      | 744.0
-sea shell       | 732.0
-honeydew        | 729.0
-old lace        | 722.0
-corn silk       | 717.0
-linen           | 714.0
+color_name:text | cmyk_vector:dense_vector | s:double
+white           | [0.0, 0.0, 0.0, 0.0]     | 759.0
+snow            | [0.0, 2.0, 2.0, 0.0]     | 749.0
+azure           | [6.0, 0.0, 0.0, 0.0]     | 744.0
+ivory           | [0.0, 0.0, 6.0, 0.0]     | 744.0
+mint cream      | [4.0, 0.0, 2.0, 0.0]     | 744.0
+sea shell       | [0.0, 4.0, 7.0, 0.0]     | 732.0
+honeydew        | [6.0, 0.0, 6.0, 0.0]     | 729.0
+old lace        | [0.0, 3.0, 9.0, 1.0]     | 722.0
+corn silk       | [0.0, 3.0, 14.0, 0.0]    | 717.0
+linen           | [0.0, 4.0, 8.0, 2.0]     | 714.0
 ;
 
 similarityWithFork

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/vector-l2-norm.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/vector-l2-norm.csv-spec
@@ -196,26 +196,27 @@ teal       | 109.22454071044922
 l2NormWithEnrich
 required_capability: vector_similarity_functions_pushdown
 required_capability: enrich_load
+required_capability: enrich_dense_vector_bugfix
 
 from colors
 | eval s = v_l2_norm(rgb_vector, [1, 2, 3])
 | enrich colors_policy
-| keep color_name, s
+| keep color_name, cmyk_vector, s  
 | sort s desc, color_name asc
 | limit 10
 ;
 
-color_name:text | s:double
-white           | 438.2111511230469
-snow            | 432.468505859375
-ivory           | 429.7604064941406
-azure           | 429.6905822753906
-mint cream      | 429.59747314453125
-sea shell       | 422.8356628417969
-honeydew        | 421.0688781738281
-old lace        | 417.2313537597656
-corn silk       | 414.87469482421875
-linen           | 412.5215148925781
+color_name:text | cmyk_vector:dense_vector | s:double
+white           | [0.0, 0.0, 0.0, 0.0]     | 438.2111511230469
+snow            | [0.0, 2.0, 2.0, 0.0]     | 432.468505859375
+ivory           | [0.0, 0.0, 6.0, 0.0]     | 429.7604064941406
+azure           | [6.0, 0.0, 0.0, 0.0]     | 429.6905822753906
+mint cream      | [4.0, 0.0, 2.0, 0.0]     | 429.59747314453125
+sea shell       | [0.0, 4.0, 7.0, 0.0]     | 422.8356628417969
+honeydew        | [6.0, 0.0, 6.0, 0.0]     | 421.0688781738281
+old lace        | [0.0, 3.0, 9.0, 1.0]     | 417.2313537597656
+corn silk       | [0.0, 3.0, 14.0, 0.0]    | 414.87469482421875
+linen           | [0.0, 4.0, 8.0, 2.0]     | 412.5215148925781
 ;
 
 similarityWithFork

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1811,6 +1811,11 @@ public class EsqlCapabilities {
          */
         METADATA_TIER_FIELD,
 
+        /**
+         * Enrich works with dense_vector fields
+         */
+        ENRICH_DENSE_VECTOR_BUGFIX,
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;


### PR DESCRIPTION
Backports the following commits to 9.3:
 - ES|QL - fix dense vector enrich bug (#139774)