### PR TITLE
Fix `testAckListenerReceivesNacksIfPublicationTimesOut`

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -312,9 +312,6 @@ tests:
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test072RunEsAsDifferentUserAndGroup
   issue: https://github.com/elastic/elasticsearch/issues/140127
-- class: org.elasticsearch.cluster.coordination.AtomicRegisterCoordinatorTests
-  method: testAckListenerReceivesNacksIfPublicationTimesOut
-  issue: https://github.com/elastic/elasticsearch/issues/140509
 
 # Examples:
 #

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -666,14 +666,29 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
 
             follower0.heal();
             follower1.heal();
-            cluster.stabilise();
-            assertTrue("expected eventual nack from " + follower0, ackCollector.hasAckedUnsuccessfully(follower0));
-            assertTrue("expected eventual nack from " + follower1, ackCollector.hasAckedUnsuccessfully(follower1));
+
             if (expectLeaderAcksSuccessfullyInStateless) {
                 // A stateless leader directly updates the cluster state in the remote blob store: it does not require communication with
-                // the other cluster nodes to procceed with an update commit to the cluster state.
+                // the other cluster nodes to proceed with an update commit to the cluster state, so in fact the publication doesn't really
+                // time out in this case. However, this means the nodes may remain lagging until the next cluster state update - there's no
+                // master failover to resync them in this case. The nacks happen when the blackholed requests are processed.
+
+                while (leader.deliverBlackholedRequests()) {
+                    // processing the requests takes a few steps - 10 is more than enough
+                    cluster.runFor(DEFAULT_DELAY_VARIABILITY * 10, "processing blackholed cluster state update requests");
+                }
+
+                assertTrue("expected eventual nack from " + follower0, ackCollector.hasAckedUnsuccessfully(follower0));
+                assertTrue("expected eventual nack from " + follower1, ackCollector.hasAckedUnsuccessfully(follower1));
                 assertTrue("expected ack from leader, " + leader, ackCollector.hasAckedSuccessfully(leader));
+
+                leader.submitValue(randomLong());
+                cluster.stabilise();
             } else {
+                // The timeout causes the publication to fail, the leader stands down and runs another election, and everything settles:
+                cluster.stabilise();
+                assertTrue("expected eventual nack from " + follower0, ackCollector.hasAckedUnsuccessfully(follower0));
+                assertTrue("expected eventual nack from " + follower1, ackCollector.hasAckedUnsuccessfully(follower1));
                 assertTrue("expected eventual nack from leader, " + leader, ackCollector.hasAckedUnsuccessfully(leader));
             }
         }


### PR DESCRIPTION
This test is kinda bogus with an atomic register because it doesn't
actually time out as claimed. Nonetheless, we do want to know that the
nacks are genuinely delivered eventually under these conditions. This
commit adjusts the test to handle the relaxed lag detector introduced
in #140434.

Closes #140509