### PR TITLE
[9.3] Fix transport serialization for AllocationDecision (#140500)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationDecision.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationDecision.java
@@ -86,8 +86,7 @@ public enum AllocationDecision implements Writeable {
             if (id == NOT_PREFERRED.id) {
                 // NOT_PREFERRED was originally hidden / unimplemented converted to YES. So for older versions continue to use YES.
                 out.write(YES.id);
-            }
-            if (id > THROTTLED.id) {
+            } else if (id > THROTTLED.id) {
                 // NOT_PREFERRED was placed after THROTTLE in the enum list, so any subsequent values were pushed +1. Shift the enum value
                 // back for older versions.
                 out.write(id - 1);

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationDecisionTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationDecisionTests.java
@@ -36,16 +36,19 @@ public class AllocationDecisionTests extends ESTestCase {
 
     // Testing for ADD_NOT_PREFERRED_ALLOCATION_DECISION TransportVersion.
     public void testSerializationBackwardsCompatibility() throws IOException {
+        final var sentinel = randomIdentifier();
         {
             // NOT_PREFERRED should be converted to YES on writeTo.
             AllocationDecision allocationDecision = AllocationDecision.NOT_PREFERRED;
             BytesStreamOutput output = new BytesStreamOutput();
             output.setTransportVersion(TransportVersion.minimumCompatible());
             allocationDecision.writeTo(output);
+            output.writeString(sentinel);
             assertEquals(AllocationDecision.YES, AllocationDecision.readFrom(output.bytes().streamInput()));
             StreamInput input = output.bytes().streamInput();
             input.setTransportVersion(TransportVersion.minimumCompatible());
             assertEquals(AllocationDecision.readFrom(input), AllocationDecision.YES);
+            assertEquals(sentinel, input.readString());
         }
         {
             // YES and THROTTLE are unaffected by writeTo or readFrom. The enum ID values did not change.
@@ -53,10 +56,12 @@ public class AllocationDecisionTests extends ESTestCase {
             BytesStreamOutput output = new BytesStreamOutput();
             output.setTransportVersion(TransportVersion.minimumCompatible());
             allocationDecision.writeTo(output);
+            output.writeString(sentinel);
             assertEquals(allocationDecision.id, AllocationDecision.readFrom(output.bytes().streamInput()).id);
             StreamInput input = output.bytes().streamInput();
             input.setTransportVersion(TransportVersion.minimumCompatible());
             assertEquals(allocationDecision, AllocationDecision.readFrom(input));
+            assertEquals(sentinel, input.readString());
         }
         {
             // The following enum values will get shifted -1 for backwards compatibility because NOT_PREFERRED was added and placed before
@@ -68,11 +73,13 @@ public class AllocationDecisionTests extends ESTestCase {
             BytesStreamOutput output = new BytesStreamOutput();
             output.setTransportVersion(TransportVersion.minimumCompatible());
             allocationDecision.writeTo(output);
+            output.writeString(sentinel);
             // Without the minimumCompatible version set on the input stream, we'll see the old enum ID, which is -1 compared to the new.
             assertEquals(allocationDecision.id, AllocationDecision.readFrom(output.bytes().streamInput()).id + 1);
             StreamInput input = output.bytes().streamInput();
             input.setTransportVersion(TransportVersion.minimumCompatible());
             assertEquals(allocationDecision, AllocationDecision.readFrom(input));
+            assertEquals(sentinel, input.readString());
         }
     }
 


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Fix transport serialization for AllocationDecision (#140500)