### PR TITLE
[8.19] Reject max_number_of_allocations > 1 for low-priority model deployments (#140163)

### DIFF
--- a/docs/changelog/140163.yaml
+++ b/docs/changelog/140163.yaml
@@ -1,0 +1,6 @@
+pr: 140163
+summary: Disallow `max_number_of_allocations` > 1 for low priority model deployments
+area: Machine Learning
+type: bug
+issues:
+ - 111227

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java
@@ -392,6 +392,13 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
                 if (threadsPerAllocation > 1) {
                     validationException.addValidationError("[" + THREADS_PER_ALLOCATION + "] must be 1 when [" + PRIORITY + "] is low");
                 }
+                if (adaptiveAllocationsSettings != null
+                    && adaptiveAllocationsSettings.getMaxNumberOfAllocations() != null
+                    && adaptiveAllocationsSettings.getMaxNumberOfAllocations() > 1) {
+                    validationException.addValidationError(
+                        "[" + AdaptiveAllocationsSettings.MAX_NUMBER_OF_ALLOCATIONS + "] must be 1 when [" + PRIORITY + "] is low"
+                    );
+                }
             }
             return validationException.validationErrors().isEmpty() ? null : validationException;
         }

--- a/x-pack/plugin/ml/qa/ml-with-security/build.gradle
+++ b/x-pack/plugin/ml/qa/ml-with-security/build.gradle
@@ -30,6 +30,7 @@ tasks.named("yamlRestTest").configure {
     'ml/3rd_party_deployment/Test start deployment fails with missing model definition',
     'ml/3rd_party_deployment/Test start deployment with low priority and multiple allocations',
     'ml/3rd_party_deployment/Test start deployment with low priority and multiple threads per allocation',
+    'ml/3rd_party_deployment/Test start deployment with low priority and max allocations more than one',
     'ml/3rd_party_deployment/Test stop deployments with allow_no_match',
     'ml/3rd_party_deployment/Test cannot start 2 deployments with the same Id',
     'ml/3rd_party_deployment/Test cannot start when deployment Id matches a different model',

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
@@ -854,6 +854,16 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
                 listener.onFailure(validationException);
                 return;
             }
+            if (adaptiveAllocationsSettings != null
+                && adaptiveAllocationsSettings.getMaxNumberOfAllocations() != null
+                && adaptiveAllocationsSettings.getMaxNumberOfAllocations() > 1) {
+                ValidationException validationException = new ValidationException();
+                validationException.addValidationError(
+                    "[" + AdaptiveAllocationsSettings.MAX_NUMBER_OF_ALLOCATIONS + "] must be 1 when [" + PRIORITY + "] is low"
+                );
+                listener.onFailure(validationException);
+                return;
+            }
         }
 
         boolean hasUpdates = hasUpdates(numberOfAllocations, adaptiveAllocationsSettingsUpdates, existingAssignment);

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/3rd_party_deployment.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/3rd_party_deployment.yml
@@ -351,6 +351,18 @@ setup:
         priority: "low"
         threads_per_allocation: 4
 ---
+"Test start deployment with low priority and max allocations more than one":
+  - do:
+      catch: /\[max_number_of_allocations\] must be 1 when \[priority\] is low/
+      ml.start_trained_model_deployment:
+        model_id: test_model
+        priority: "low"
+        body:
+          adaptive_allocations:
+            enabled: true
+            min_number_of_allocations: 0
+            max_number_of_allocations: 2
+---
 "Test update deployment":
   - do:
       ml.start_trained_model_deployment:
@@ -521,6 +533,30 @@ setup:
       ml.stop_trained_model_deployment:
         model_id: test_model
   - match: { stopped: true }
+---
+"Test update deployment with low priority and max allocations more than one":
+  - do:
+      ml.start_trained_model_deployment:
+        model_id: test_model
+        priority: "low"
+        body:
+          adaptive_allocations:
+            enabled: true
+            min_number_of_allocations: 0
+            max_number_of_allocations: 1
+        wait_for: started
+  - match: { assignment.assignment_state: started }
+  - match: { assignment.task_parameters.model_id: test_model }
+  - match: { assignment.task_parameters.priority: low }
+  - match: { assignment.task_parameters.number_of_allocations: 1 }
+
+  - do:
+      catch: /\[max_number_of_allocations\] must be 1 when \[priority\] is low/
+      ml.update_trained_model_deployment:
+        model_id: test_model
+        body:
+          adaptive_allocations:
+            max_number_of_allocations: 2
 ---
 "Test put model alias on pytorch model":
   - do:


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Reject max_number_of_allocations > 1 for low-priority model deployments (#140163)