### PR TITLE
ESQL: Mute failing release tests due to byte discrepancy

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -312,6 +312,18 @@ tests:
 - class: org.elasticsearch.packaging.test.DockerTests
   method: test072RunEsAsDifferentUserAndGroup
   issue: https://github.com/elastic/elasticsearch/issues/140127
+- class: org.elasticsearch.compute.aggregation.blockhash.BlockHashTests
+  method: testLongBytesRefHashWithMultiValuedFields
+  issue: https://github.com/elastic/elasticsearch/issues/140546
+- class: org.elasticsearch.compute.aggregation.TimeSeriesFirstDocIdDeduplicationTests
+  method: testSimpleToString
+  issue: https://github.com/elastic/elasticsearch/issues/140547
+- class: org.elasticsearch.compute.operator.RowInTableLookupOperatorTests
+  method: testSimpleToString
+  issue: https://github.com/elastic/elasticsearch/issues/140548
+- class: org.elasticsearch.compute.aggregation.WindowGroupingAggregatorFunctionTests
+  method: testSimpleToString
+  issue: https://github.com/elastic/elasticsearch/issues/140549
 
 # Examples:
 #


### PR DESCRIPTION
Mute for:
- https://github.com/elastic/elasticsearch/issues/140546
- https://github.com/elastic/elasticsearch/issues/140547
- https://github.com/elastic/elasticsearch/issues/140548
- https://github.com/elastic/elasticsearch/issues/140549