### PR TITLE
PromQL: Fix last_over_time test failure

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-last-over-time.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-last-over-time.csv-spec
@@ -54,7 +54,7 @@ clients:double | cluster:keyword | time_bucket:datetime
 implicit_last_over_time_of_integer_promql
 required_capability: promql_pre_tech_preview_v12
 
-PROMQL index=k8s step=1m clients=(avg by (cluster) (network.eth0.currently_connected_clients[1m]))
+PROMQL index=k8s step=1m clients=(avg by (cluster) (last_over_time(network.eth0.currently_connected_clients[1m])))
 | SORT step, cluster | LIMIT 10;
 
 clients:double | step:datetime            | cluster:keyword
@@ -126,7 +126,7 @@ bytes:double | cluster:keyword | time_bucket:datetime
 implicit_last_over_time_of_long_promql
 required_capability: promql_pre_tech_preview_v12
 
-PROMQL index=k8s step=1m bytes=(avg by (cluster) (network.bytes_in[1m]))
+PROMQL index=k8s step=1m bytes=(avg by (cluster) (last_over_time(network.bytes_in[1m])))
 | SORT step, cluster | LIMIT 10;
 
 bytes:double | step:datetime            | cluster:keyword
@@ -196,7 +196,7 @@ tx:long | cluster:keyword | time_bucket:datetime
 implicit_last_over_time_with_filtering_promql
 required_capability: promql_pre_tech_preview_v12
 
-PROMQL index=k8s step=10m tx=(sum by (cluster) (network.bytes_in{pod="one"}[10m]))
+PROMQL index=k8s step=10m tx=(sum by (cluster) (last_over_time(network.bytes_in{pod="one"}[10m])))
 | SORT step, cluster | LIMIT 10;
 
 tx:double | step:datetime            | cluster:keyword
@@ -230,7 +230,7 @@ tx:long | cluster:keyword | time_bucket:datetime
 implicit_last_over_time_with_inline_filtering_promql
 required_capability: promql_pre_tech_preview_v12
 
-PROMQL index=k8s step=10m tx=(sum by (cluster) (network.bytes_in{pod="one"}[10m]))
+PROMQL index=k8s step=10m tx=(sum by (cluster) (last_over_time(network.bytes_in{pod="one"}[10m])))
 | SORT step, cluster | LIMIT 10;
 
 tx:double | step:datetime            | cluster:keyword
@@ -244,8 +244,6 @@ tx:double | step:datetime            | cluster:keyword
 206.0     | 2024-05-10T00:20:00.000Z | qa
 238.0     | 2024-05-10T00:20:00.000Z | staging
 ;
-
-
 
 last_over_time_older_than_10d
 required_capability: ts_command_v0


### PR DESCRIPTION
While PromQL traditionally applies last_over_time implicitly to range vectors, it seems this behavior is not yet supported in the ESQL PromQL implementation.