### PR TITLE
Fixed text fields binary doc values breaking intake

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -215,6 +215,7 @@ public class IndexVersions {
     public static final IndexVersion STORE_FALLBACK_TEXT_FIELDS_IN_BINARY_DOC_VALUES = def(9_062_0_00, Version.LUCENE_10_3_2);
     public static final IndexVersion STORE_FALLBACK_MOT_FIELDS_IN_BINARY_DOC_VALUES = def(9_063_0_00, Version.LUCENE_10_3_2);
     public static final IndexVersion MOD_ROUTING_FUNCTION = def(9_064_0_00, Version.LUCENE_10_3_2);
+    public static final IndexVersion TEXT_FIELDS_BINARY_DOC_VALUES_TSDB_DOC_VALUES_FORMAT_CHECK = def(9_065_0_00, Version.LUCENE_10_3_2);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -360,8 +360,13 @@ public final class TextFieldMapper extends FieldMapper {
         }
 
         private static boolean usesBinaryDocValues(final IndexSettings indexSettings) {
-            return indexSettings.getIndexVersionCreated().onOrAfter(IndexVersions.STORE_FALLBACK_TEXT_FIELDS_IN_BINARY_DOC_VALUES)
-                && indexSettings.useTimeSeriesDocValuesFormat();
+            IndexVersion indexVersion = indexSettings.getIndexVersionCreated();
+            if (indexVersion.onOrAfter(IndexVersions.TEXT_FIELDS_BINARY_DOC_VALUES_TSDB_DOC_VALUES_FORMAT_CHECK)) {
+                return indexSettings.useTimeSeriesDocValuesFormat();
+            }
+            // for BWC - indices created before TEXT_FIELDS_BINARY_DOC_VALUES_TSDB_DOC_VALUES_FORMAT_CHECK, stored fallback fields only in
+            // binary doc values
+            return indexVersion.onOrAfter(IndexVersions.STORE_FALLBACK_TEXT_FIELDS_IN_BINARY_DOC_VALUES);
         }
 
         public Builder index(boolean index) {


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/140471 we changed how fallback text fields are stored. At the time we got luck (unlucky?) and the CI passed. However, the intake is now breaking.

The reason for the failure is that prior to https://github.com/elastic/elasticsearch/pull/140471 , we stored fallback text fields exclusively in binary doc values. But with https://github.com/elastic/elasticsearch/pull/140471 , we're now switching between binary doc values and stored fields depending on whether the time series doc values format is enabled.

This PR addresses that.