### PR TITLE
Reassign Data Management deprecated items

### DIFF
--- a/libs/core/src/main/java/org/elasticsearch/core/UpdateForV10.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/UpdateForV10.java
@@ -23,9 +23,7 @@ import java.lang.annotation.Target;
 public @interface UpdateForV10 {
     enum Owner {
         CORE_INFRA,
-        DATA_MANAGEMENT,
-        DISTRIBUTED_COORDINATION,
-        DISTRIBUTED_INDEXING,
+        DISTRIBUTED,
         ENTERPRISE_SEARCH,
         MACHINE_LEARNING,
         PROFILING,
@@ -33,6 +31,7 @@ public @interface UpdateForV10 {
         SEARCH_FOUNDATIONS,
         SEARCH_RELEVANCE,
         SECURITY,
+        STORAGE_ENGINE
     }
 
     /**

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportGetDataStreamsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/TransportGetDataStreamsAction.java
@@ -88,7 +88,7 @@ public class TransportGetDataStreamsAction extends TransportLocalProjectMetadata
      * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC it must be registered with the TransportService until
      * we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
     @SuppressWarnings("this-escape")
     @Inject
     public TransportGetDataStreamsAction(

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/action/TransportGetDataStreamLifecycleAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/action/TransportGetDataStreamLifecycleAction.java
@@ -51,7 +51,7 @@ public class TransportGetDataStreamLifecycleAction extends TransportLocalProject
      * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC it must be registered with the TransportService until
      * we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
     @SuppressWarnings("this-escape")
     @Inject
     public TransportGetDataStreamLifecycleAction(

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/options/action/GetDataStreamOptionsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/options/action/GetDataStreamOptionsAction.java
@@ -93,7 +93,7 @@ public class GetDataStreamOptionsAction {
          * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC we must remain able to read these requests until
          * we no longer need to support calling this action remotely.
          */
-        @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+        @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
         public Request(StreamInput in) throws IOException {
             super(in);
             this.names = in.readOptionalStringArray();
@@ -158,7 +158,7 @@ public class GetDataStreamOptionsAction {
              * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC we must remain able to write these responses until
              * we no longer need to support calling this action remotely.
              */
-            @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+            @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
             @Override
             public void writeTo(StreamOutput out) throws IOException {
                 out.writeString(dataStreamName);
@@ -191,7 +191,7 @@ public class GetDataStreamOptionsAction {
          * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC we must remain able to write these responses until
          * we no longer need to support calling this action remotely.
          */
-        @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+        @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeCollection(dataStreams);

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/options/action/TransportGetDataStreamOptionsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/options/action/TransportGetDataStreamOptionsAction.java
@@ -50,7 +50,7 @@ public class TransportGetDataStreamOptionsAction extends TransportLocalProjectMe
      * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC it must be registered with the TransportService until
      * we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
     @SuppressWarnings("this-escape")
     @Inject
     public TransportGetDataStreamOptionsAction(

--- a/modules/ingest-attachment/src/main/java/org/elasticsearch/ingest/attachment/AttachmentProcessor.java
+++ b/modules/ingest-attachment/src/main/java/org/elasticsearch/ingest/attachment/AttachmentProcessor.java
@@ -243,7 +243,7 @@ public final class AttachmentProcessor extends AbstractProcessor {
             int indexedChars = readIntProperty(TYPE, processorTag, config, "indexed_chars", NUMBER_OF_CHARS_INDEXED);
             boolean ignoreMissing = readBooleanProperty(TYPE, processorTag, config, "ignore_missing", false);
             String indexedCharsField = readOptionalStringProperty(TYPE, processorTag, config, "indexed_chars_field");
-            @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+            @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
             // Revisit whether we want to update the [remove_binary] default to be 'true' - would need to find a way to do this safely
             Boolean removeBinary = readOptionalBooleanProperty(TYPE, processorTag, config, "remove_binary");
             if (removeBinary == null) {

--- a/modules/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/UserAgentProcessor.java
+++ b/modules/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/UserAgentProcessor.java
@@ -261,7 +261,7 @@ public class UserAgentProcessor extends AbstractProcessor {
         }
     }
 
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
     // This can be removed in V10. It's not possible to create an instance with the ecs property in V9, and all instances created by V8 or
     // earlier will have been fixed when upgraded to V9.
     static boolean maybeUpgradeConfig(Map<String, Object> config) {

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3ClientSettings.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3ClientSettings.java
@@ -79,7 +79,7 @@ final class S3ClientSettings {
 
     /** The protocol to use to connect to s3, now only used if {@link #endpoint} is not a proper URI that starts with {@code http://} or
      * {@code https://}. */
-    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED_COORDINATION) // no longer used, should be removed in v10
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED) // no longer used, should be removed in v10
     static final Setting.AffixSetting<HttpScheme> PROTOCOL_SETTING = Setting.affixKeySetting(
         PREFIX,
         "protocol",
@@ -153,7 +153,7 @@ final class S3ClientSettings {
     );
 
     /** Formerly whether retries should be throttled (ie use backoff), now unused. V2 AWS SDK always uses throttling. */
-    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED_COORDINATION) // no longer used, should be removed in v10
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED) // no longer used, should be removed in v10
     static final Setting.AffixSetting<Boolean> UNUSED_USE_THROTTLE_RETRIES_SETTING = Setting.affixKeySetting(
         PREFIX,
         "use_throttle_retries",
@@ -182,7 +182,7 @@ final class S3ClientSettings {
     );
 
     /** Formerly an override for the signer to use, now unused. V2 AWS SDK only supports AWS v4 signatures. */
-    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED_COORDINATION) // no longer used, should be removed in v10
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED) // no longer used, should be removed in v10
     static final Setting.AffixSetting<String> UNUSED_SIGNER_OVERRIDE = Setting.affixKeySetting(
         PREFIX,
         "signer_override",

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/Ec2ClientSettings.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/Ec2ClientSettings.java
@@ -63,7 +63,7 @@ final class Ec2ClientSettings {
     );
 
     /** Previously, the protocol to use to connect to ec2, but now has no effect */
-    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED_COORDINATION) // no longer used, should be removed in v10
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED) // no longer used, should be removed in v10
     static final Setting<HttpScheme> PROTOCOL_SETTING = new Setting<>(
         "discovery.ec2.protocol",
         "https",

--- a/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/FullClusterRestartArchivedSettingsIT.java
+++ b/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/FullClusterRestartArchivedSettingsIT.java
@@ -66,7 +66,7 @@ public class FullClusterRestartArchivedSettingsIT extends ParameterizedFullClust
         return cluster;
     }
 
-    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED_COORDINATION) // this test is just about v8->v9 upgrades, remove it in v10
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED) // this test is just about v8->v9 upgrades, remove it in v10
     public void testBalancedShardsAllocatorThreshold() throws Exception {
         assumeTrue("test only applies for v8->v9 upgrades", getOldClusterTestVersion().getMajor() == 8);
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteResponse.java
@@ -44,7 +44,7 @@ public class ClusterRerouteResponse extends ActionResponse implements IsAcknowle
     /**
      * To be removed when REST compatibility with {@link org.elasticsearch.Version#V_8_6_0} / {@link RestApiVersion#V_8} no longer needed
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED_COORDINATION)  // to remove entirely
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)  // to remove entirely
     private final ClusterState state;
     private final RoutingExplanations explanations;
     private final boolean acknowledged;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexRequest.java
@@ -108,7 +108,7 @@ public class GetIndexRequest extends LocalClusterStateRequest implements Indices
      * NB prior to 9.1 this was a TransportMasterNodeReadAction so for BwC we must remain able to read these requests until
      * we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
     public GetIndexRequest(StreamInput in) throws IOException {
         super(in);
         indices = in.readStringArray();

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexResponse.java
@@ -72,7 +72,7 @@ public class GetIndexResponse extends ActionResponse implements ChunkedToXConten
      * The only usage of this constructor is for BwC cross-cluster transforms for clusters before v8.2. The ML team is aware that we
      * don't need to support that anymore now that we're on v9. Once they remove that BwC code, we can remove this constructor as well.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
     GetIndexResponse(StreamInput in) throws IOException {
         this.indices = in.readStringArray();
         mappings = in.readImmutableOpenMap(
@@ -165,7 +165,7 @@ public class GetIndexResponse extends ActionResponse implements ChunkedToXConten
      * NB prior to 9.1 this was a TransportMasterNodeReadAction so for BwC we must remain able to write these responses until
      * we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeStringArray(indices);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/get/TransportGetIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/get/TransportGetIndexAction.java
@@ -56,7 +56,7 @@ public class TransportGetIndexAction extends TransportLocalProjectMetadataAction
      * NB prior to 9.1 this was a TransportMasterNodeReadAction so for BwC it must be registered with the TransportService until
      * we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
     @SuppressWarnings("this-escape")
     @Inject
     public TransportGetIndexAction(

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetMappingsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetMappingsRequest.java
@@ -38,7 +38,7 @@ public class GetMappingsRequest extends LocalClusterStateRequest implements Indi
      * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC we must remain able to read these requests until
      * we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
     public GetMappingsRequest(StreamInput in) throws IOException {
         super(in);
         indices = in.readStringArray();

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetMappingsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetMappingsResponse.java
@@ -45,7 +45,7 @@ public class GetMappingsResponse extends ActionResponse implements ChunkedToXCon
      * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC we must remain able to write these responses until
      * we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         MappingMetadata.writeMappingMetadata(out, mappings);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetMappingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/TransportGetMappingsAction.java
@@ -43,7 +43,7 @@ public class TransportGetMappingsAction extends TransportLocalProjectMetadataAct
      * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC it must be registered with the TransportService until
      * we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
     @SuppressWarnings("this-escape")
     @Inject
     public TransportGetMappingsAction(

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsRequest.java
@@ -65,7 +65,7 @@ public class GetSettingsRequest extends LocalClusterStateRequest implements Indi
      * NB prior to 9.1 this was a TransportMasterNodeReadAction so for BwC we must remain able to read these requests until
      * we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
     public GetSettingsRequest(StreamInput in) throws IOException {
         super(in);
         indices = in.readStringArray();

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsResponse.java
@@ -81,7 +81,7 @@ public class GetSettingsResponse extends ActionResponse implements ChunkedToXCon
      * NB prior to 9.1 this was a TransportMasterNodeReadAction so for BwC we must remain able to write these responses until
      * we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeMap(indexToSettings, StreamOutput::writeWriteable);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/TransportGetSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/TransportGetSettingsAction.java
@@ -48,7 +48,7 @@ public class TransportGetSettingsAction extends TransportLocalProjectMetadataAct
      * NB prior to 9.1 this was a TransportMasterNodeReadAction so for BwC it must be registered with the TransportService until
      * we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
     @SuppressWarnings("this-escape")
     @Inject
     public TransportGetSettingsAction(

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetComponentTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetComponentTemplateAction.java
@@ -63,7 +63,7 @@ public class GetComponentTemplateAction extends ActionType<GetComponentTemplateA
          * NB prior to 9.0 get-component was a TransportMasterNodeReadAction so for BwC we must remain able to read these requests until
          * we no longer need to support calling this action remotely.
          */
-        @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+        @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
         public Request(StreamInput in) throws IOException {
             super(in);
             name = in.readOptionalString();
@@ -171,7 +171,7 @@ public class GetComponentTemplateAction extends ActionType<GetComponentTemplateA
          * NB prior to 9.0 get-component was a TransportMasterNodeReadAction so for BwC we must remain able to write these responses until
          * we no longer need to support calling this action remotely.
          */
-        @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+        @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeMap(componentTemplates, StreamOutput::writeWriteable);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetComposableIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetComposableIndexTemplateAction.java
@@ -67,7 +67,7 @@ public class GetComposableIndexTemplateAction extends ActionType<GetComposableIn
          * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC we must remain able to read these requests until
          * we no longer need to support calling this action remotely.
          */
-        @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+        @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
         public Request(StreamInput in) throws IOException {
             super(in);
             name = in.readOptionalString();
@@ -177,7 +177,7 @@ public class GetComposableIndexTemplateAction extends ActionType<GetComposableIn
          * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC we must remain able to write these responses until
          * we no longer need to support calling this action remotely.
          */
-        @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+        @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeMap(indexTemplates, StreamOutput::writeWriteable);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesRequest.java
@@ -39,7 +39,7 @@ public class GetIndexTemplatesRequest extends LocalClusterStateRequest {
      * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC we must remain able to read these requests until
      * we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
     public GetIndexTemplatesRequest(StreamInput in) throws IOException {
         super(in);
         names = in.readStringArray();

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesResponse.java
@@ -38,7 +38,7 @@ public class GetIndexTemplatesResponse extends ActionResponse implements ToXCont
      * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC we must remain able to write these responses until
      * we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeCollection(indexTemplates);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/TransportGetComponentTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/TransportGetComponentTemplateAction.java
@@ -43,7 +43,7 @@ public class TransportGetComponentTemplateAction extends TransportLocalProjectMe
      * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC it must be registered with the TransportService until
      * we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
     @SuppressWarnings("this-escape")
     @Inject
     public TransportGetComponentTemplateAction(

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/TransportGetComposableIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/TransportGetComposableIndexTemplateAction.java
@@ -43,7 +43,7 @@ public class TransportGetComposableIndexTemplateAction extends TransportLocalPro
      * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC it must be registered with the TransportService until
      * we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
     @SuppressWarnings("this-escape")
     @Inject
     public TransportGetComposableIndexTemplateAction(

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/TransportGetIndexTemplatesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/TransportGetIndexTemplatesAction.java
@@ -38,7 +38,7 @@ public class TransportGetIndexTemplatesAction extends TransportLocalProjectMetad
      * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC it must be registered with the TransportService until
      * we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
     @SuppressWarnings("this-escape")
     @Inject
     public TransportGetIndexTemplatesAction(

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/SimulateIndexTemplateResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/SimulateIndexTemplateResponse.java
@@ -68,7 +68,7 @@ public class SimulateIndexTemplateResponse extends ActionResponse implements ToX
      * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC we must remain able to write these responses until
      * we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeOptionalWriteable(resolvedTemplate);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
@@ -86,7 +86,7 @@ public class TransportSimulateIndexTemplateAction extends TransportLocalProjectM
      * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC it must be registered with the TransportService until
      * we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
     @SuppressWarnings("this-escape")
     @Inject
     public TransportSimulateIndexTemplateAction(

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateTemplateAction.java
@@ -66,7 +66,7 @@ public class TransportSimulateTemplateAction extends TransportLocalProjectMetada
      * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC it must be registered with the TransportService until
      * we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
     @SuppressWarnings("this-escape")
     @Inject
     public TransportSimulateTemplateAction(

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkRequestParser.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkRequestParser.java
@@ -45,7 +45,7 @@ import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_PRIMARY_T
  */
 public final class BulkRequestParser {
 
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
     // Remove deprecation logger when its usages in checkBulkActionIsProperlyClosed are removed
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(BulkRequestParser.class);
 
@@ -566,7 +566,7 @@ public final class BulkRequestParser {
 
     }
 
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT) // Remove lenient parsing in V8 BWC mode
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED) // Remove lenient parsing in V8 BWC mode
     private void checkBulkActionIsProperlyClosed(XContentParser parser, int line) throws IOException {
         XContentParser.Token token;
         try {

--- a/server/src/main/java/org/elasticsearch/action/datastreams/GetDataStreamAction.java
+++ b/server/src/main/java/org/elasticsearch/action/datastreams/GetDataStreamAction.java
@@ -117,7 +117,7 @@ public class GetDataStreamAction extends ActionType<GetDataStreamAction.Response
          * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC we must remain able to read these requests until
          * we no longer need to support calling this action remotely.
          */
-        @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+        @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
         public Request(StreamInput in) throws IOException {
             super(in);
             this.names = in.readOptionalStringArray();
@@ -325,7 +325,7 @@ public class GetDataStreamAction extends ActionType<GetDataStreamAction.Response
              * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC we must remain able to write these responses until
              * we no longer need to support calling this action remotely.
              */
-            @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+            @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
             @Override
             public void writeTo(StreamOutput out) throws IOException {
                 dataStream.writeTo(out);
@@ -546,7 +546,7 @@ public class GetDataStreamAction extends ActionType<GetDataStreamAction.Response
              * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC we must remain able to write these responses until
              * we no longer need to support calling this action remotely.
              */
-            @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+            @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
             @Override
             public void writeTo(StreamOutput out) throws IOException {
                 out.writeCollection(temporalRanges, (out1, value) -> {
@@ -643,7 +643,7 @@ public class GetDataStreamAction extends ActionType<GetDataStreamAction.Response
          * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC we must remain able to write these responses until
          * we no longer need to support calling this action remotely.
          */
-        @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+        @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeCollection(dataStreams);

--- a/server/src/main/java/org/elasticsearch/action/datastreams/lifecycle/GetDataStreamLifecycleAction.java
+++ b/server/src/main/java/org/elasticsearch/action/datastreams/lifecycle/GetDataStreamLifecycleAction.java
@@ -102,7 +102,7 @@ public class GetDataStreamLifecycleAction {
          * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC we must remain able to read these requests until
          * we no longer need to support calling this action remotely.
          */
-        @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+        @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
         public Request(StreamInput in) throws IOException {
             super(in);
             this.names = in.readOptionalStringArray();
@@ -179,7 +179,7 @@ public class GetDataStreamLifecycleAction {
              * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC we must remain able to write these responses until
              * we no longer need to support calling this action remotely.
              */
-            @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+            @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
             @Override
             public void writeTo(StreamOutput out) throws IOException {
                 out.writeString(dataStreamName);
@@ -256,7 +256,7 @@ public class GetDataStreamLifecycleAction {
          * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC we must remain able to write these responses until
          * we no longer need to support calling this action remotely.
          */
-        @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+        @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeCollection(dataStreamLifecycles);

--- a/server/src/main/java/org/elasticsearch/action/ingest/GetPipelineRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/GetPipelineRequest.java
@@ -43,7 +43,7 @@ public class GetPipelineRequest extends LocalClusterStateRequest {
      * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC we must remain able to read these requests until
      * we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
     public GetPipelineRequest(StreamInput in) throws IOException {
         super(in);
         ids = in.readStringArray();

--- a/server/src/main/java/org/elasticsearch/action/ingest/GetPipelineResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/GetPipelineResponse.java
@@ -52,7 +52,7 @@ public class GetPipelineResponse extends ActionResponse implements ToXContentObj
      * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC we must remain able to read these requests until
      * we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeCollection(pipelines);

--- a/server/src/main/java/org/elasticsearch/action/ingest/GetPipelineTransportAction.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/GetPipelineTransportAction.java
@@ -30,7 +30,7 @@ public class GetPipelineTransportAction extends TransportLocalProjectMetadataAct
      * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC it must be registered with the TransportService until
      * we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
     @SuppressWarnings("this-escape")
     @Inject
     public GetPipelineTransportAction(

--- a/server/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineRequest.java
@@ -172,7 +172,7 @@ public class SimulatePipelineRequest extends LegacyActionRequest implements ToXC
         return new Parsed(pipeline, ingestDocumentList, verbose);
     }
 
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT) // Unconditionally deprecate the _type field once V8 BWC support is removed
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED) // Unconditionally deprecate the _type field once V8 BWC support is removed
     private static List<IngestDocument> parseDocs(Map<String, Object> config, RestApiVersion restApiVersion) {
         List<Map<String, Object>> docs = ConfigurationUtils.readList(null, null, config, Fields.DOCS);
         if (docs.isEmpty()) {

--- a/server/src/main/java/org/elasticsearch/action/support/local/LocalClusterStateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/local/LocalClusterStateRequest.java
@@ -41,7 +41,7 @@ public abstract class LocalClusterStateRequest extends LegacyActionRequest {
      * This constructor exists solely for BwC purposes. It should exclusively be used by requests that used to extend
      * {@link MasterNodeReadRequest} and still need to be able to serialize incoming request.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED_COORDINATION)
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
     protected LocalClusterStateRequest(StreamInput in) throws IOException {
         this(in, true);
     }
@@ -50,7 +50,7 @@ public abstract class LocalClusterStateRequest extends LegacyActionRequest {
      * This constructor exists solely for BwC purposes. It should exclusively be used by requests that used to extend
      * {@link MasterNodeRequest} and still need to be able to serialize incoming request.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED_COORDINATION)
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
     protected LocalClusterStateRequest(StreamInput in, boolean readLocal) throws IOException {
         super(in);
         masterTimeout = in.readTimeValue();

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterModule.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterModule.java
@@ -122,7 +122,7 @@ public class ClusterModule extends AbstractModule {
 
     public static final String BALANCED_ALLOCATOR = "balanced";
     public static final String DESIRED_BALANCE_ALLOCATOR = "desired_balance"; // default
-    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED_COORDINATION)
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
     public static final Setting<String> SHARDS_ALLOCATOR_TYPE_SETTING = Setting.simpleString(
         "cluster.routing.allocation.type",
         DESIRED_BALANCE_ALLOCATOR,
@@ -514,7 +514,7 @@ public class ClusterModule extends AbstractModule {
         }
     }
 
-    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED_COORDINATION) // in v10 there is only one allocator
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED) // in v10 there is only one allocator
     private static ShardsAllocator createShardsAllocator(
         Settings settings,
         ClusterSettings clusterSettings,

--- a/server/src/main/java/org/elasticsearch/common/settings/SecureSetting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/SecureSetting.java
@@ -27,7 +27,7 @@ import java.util.Set;
 public abstract class SecureSetting<T> extends Setting<T> {
 
     /** Determines whether legacy settings with sensitive values should be allowed. */
-    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED_COORDINATION) // this should no longer be in use, even in v9, so can go away in v10
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED) // this should no longer be in use, even in v9, so can go away in v10
     private static final boolean ALLOW_INSECURE_SETTINGS = Booleans.parseBoolean(System.getProperty("es.allow_insecure_settings", "false"));
 
     private static final Set<Property> ALLOWED_PROPERTIES = EnumSet.of(

--- a/server/src/main/java/org/elasticsearch/index/engine/EngineConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/EngineConfig.java
@@ -132,7 +132,7 @@ public final class EngineConfig {
      * TODO: Remove in 9.0
      */
     @Deprecated
-    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED_INDEXING)
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
     public static final Setting<Boolean> INDEX_OPTIMIZE_AUTO_GENERATED_IDS = Setting.boolSetting(
         "index.optimize_auto_generated_id",
         true,
@@ -215,7 +215,7 @@ public final class EngineConfig {
         // Add an escape hatch in case this change proves problematic - it used
         // to be a fixed amound of RAM: 256 MB.
         // TODO: Remove this escape hatch in 8.x
-        @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED_INDEXING)
+        @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
         final String escapeHatchProperty = "es.index.memory.max_index_buffer_size";
         String maxBufferSize = System.getProperty(escapeHatchProperty);
         if (maxBufferSize != null) {

--- a/server/src/main/java/org/elasticsearch/indices/PostRecoveryMerger.java
+++ b/server/src/main/java/org/elasticsearch/indices/PostRecoveryMerger.java
@@ -47,7 +47,7 @@ class PostRecoveryMerger {
     private static final boolean TRIGGER_MERGE_AFTER_RECOVERY;
 
     static {
-        @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED_INDEXING) // remove this escape hatch
+        @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED) // remove this escape hatch
         final var propertyValue = System.getProperty("es.trigger_merge_after_recovery");
         if (propertyValue == null) {
             TRIGGER_MERGE_AFTER_RECOVERY = true;

--- a/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
@@ -1283,7 +1283,7 @@ public final class IngestDocument {
     }
 
     // Unconditionally deprecate the _type field once V7 BWC support is removed
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
     public enum Metadata {
         INDEX(IndexFieldMapper.NAME),
         TYPE("_type"),

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -833,7 +833,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         }
     }
 
-    @UpdateForV10(owner = DATA_MANAGEMENT) // Change deprecation log for special characters in name to a failure
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED) // Change deprecation log for special characters in name to a failure
     void validatePipeline(
         Map<DiscoveryNode, IngestInfo> ingestInfos,
         ProjectId projectId,

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -109,7 +109,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.core.Strings.format;
-import static org.elasticsearch.core.UpdateForV10.Owner.DATA_MANAGEMENT;
 
 /**
  * Holder class for several ingest related services.

--- a/server/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestController.java
@@ -882,7 +882,7 @@ public class RestController implements HttpServerTransport.Dispatcher {
 
     // exposed for tests; marked as UpdateForV10 because this assertion should have flushed out all double-close bugs by the time v10 is
     // released so we should be able to drop the tests that check we behave reasonably in production on this impossible path
-    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED_COORDINATION)
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
     static boolean PERMIT_DOUBLE_RESPONSE = false;
 
     private static final class ResourceHandlingHttpChannel extends DelegatingRestChannel {

--- a/server/src/main/java/org/elasticsearch/rest/RestUtils.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestUtils.java
@@ -348,7 +348,7 @@ public class RestUtils {
 
     // Remove the BWC support for the deprecated ?local parameter.
     // NOTE: ensure each usage of this method has been deprecated for long enough to remove it.
-    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED_COORDINATION)
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
     public static void consumeDeprecatedLocalParameter(RestRequest request) {
         if (request.hasParam("local") == false) {
             return;

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterRerouteAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterRerouteAction.java
@@ -60,7 +60,7 @@ public class RestClusterRerouteAction extends BaseRestHandler {
         PARSER.declareBoolean(ClusterRerouteRequest::dryRun, new ParseField("dry_run"));
     }
 
-    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED_COORDINATION) // no longer used, so can be removed
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED) // no longer used, so can be removed
     private static final String V8_DEFAULT_METRICS = Strings.arrayToCommaDelimitedString(
         EnumSet.complementOf(EnumSet.of(ClusterState.Metric.METADATA)).toArray()
     );
@@ -94,7 +94,7 @@ public class RestClusterRerouteAction extends BaseRestHandler {
         return true;
     }
 
-    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED_COORDINATION)
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
     // actually UpdateForV11 because V10 still supports the V9 API including this deprecation message
     private static final String METRIC_DEPRECATION_MESSAGE = """
         the [?metric] query parameter to the [POST /_cluster/reroute] API has no effect; its use will be forbidden in a future version""";
@@ -115,7 +115,7 @@ public class RestClusterRerouteAction extends BaseRestHandler {
             request.params().put("metric", "none");
         } else {
             assert request.getRestApiVersion().matches(RestApiVersion.equalTo(RestApiVersion.V_8));
-            @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED_COORDINATION) // forbid this parameter in the v10 API
+            @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED) // forbid this parameter in the v10 API
             // by default, return everything but metadata
             final String metric = request.param("metric");
             if (metric == null) {

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestCloseIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestCloseIndexAction.java
@@ -65,7 +65,7 @@ public class RestCloseIndexAction extends BaseRestHandler {
      * - In 9.x we throw an error that informs the user about the parameter value removal; unless we are running in rest-compatibility mode
      * with 8.x when we log a deprecation warning and handle the value as a noop.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
     private void handleIndexSettingWaitForActiveShards(final RestRequest request, final CloseIndexRequest closeIndexRequest) {
         String waitForActiveShards = request.param("wait_for_active_shards");
         if (waitForActiveShards == null) {

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetAliasesAction.java
@@ -54,7 +54,7 @@ import static org.elasticsearch.rest.RestRequest.Method.HEAD;
 @ServerlessScope(Scope.PUBLIC)
 public class RestGetAliasesAction extends BaseRestHandler {
 
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT) // remove the BWC support for the deprecated ?local parameter
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED) // remove the BWC support for the deprecated ?local parameter
     private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(RestGetAliasesAction.class);
 
     @Override
@@ -170,7 +170,7 @@ public class RestGetAliasesAction extends BaseRestHandler {
     }
 
     @Override
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT) // remove the BWC support for the deprecated ?local parameter
+    @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE) // remove the BWC support for the deprecated ?local parameter
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         // The TransportGetAliasesAction was improved do the same post processing as is happening here.
         // We can't remove this logic yet to support mixed clusters. We should be able to remove this logic here

--- a/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
@@ -49,7 +49,7 @@ public final class OutboundHandler {
 
     private final String nodeName;
 
-    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED_COORDINATION) // only used in assertions, can be dropped in future
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED) // only used in assertions, can be dropped in future
     private final TransportVersion version;
 
     private final StatsTracker statsTracker;

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -97,7 +97,7 @@ public class TransportService extends AbstractLifecycleComponent
      * Undocumented on purpose, may be removed at any time. Only use this if instructed to do so, can have other unintended consequences
      * including deadlocks.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED_COORDINATION)
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
     public static final Setting<Boolean> ENABLE_STACK_OVERFLOW_AVOIDANCE = Setting.boolSetting(
         "transport.enable_stack_protection",
         false,

--- a/server/src/test/java/org/elasticsearch/action/bulk/BulkRequestParserTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/BulkRequestParserTests.java
@@ -28,7 +28,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class BulkRequestParserTests extends ESTestCase {
 
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT) // Replace with just RestApiVersion.values() when V8 no longer exists
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED) // Replace with just RestApiVersion.values() when V8 no longer exists
     public static final List<RestApiVersion> REST_API_VERSIONS_POST_V8 = Stream.of(RestApiVersion.values())
         .filter(v -> v.matches(RestApiVersion.onOrAfter(RestApiVersion.V_9)))
         .toList();

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -2179,7 +2179,7 @@ public abstract class ESRestTestCase extends ESTestCase {
      * Note that this message is also permitted in certain YAML test cases, it can be removed there too.
      * See https://github.com/elastic/elasticsearch/issues/66419 and https://github.com/elastic/elasticsearch/pull/119594 for more details.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED_COORDINATION)
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
     private static final String WAIT_FOR_ACTIVE_SHARDS_DEFAULT_DEPRECATION_MESSAGE = "the default value for the ?wait_for_active_shards "
         + "parameter will change from '0' to 'index-setting' in version 8; specify '?wait_for_active_shards=index-setting' "
         + "to adopt the future default behaviour, or '?wait_for_active_shards=0' to preserve today's behaviour";

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/GetBasicStatusRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/GetBasicStatusRequest.java
@@ -23,7 +23,7 @@ public class GetBasicStatusRequest extends LocalClusterStateRequest {
      * Prior to 9.3 TransportGetBasicStatusAction was a TransportMasterNodeReadAction so for BwC we need to be
      * able to read this from the transport layer until we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED_COORDINATION)
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
     public GetBasicStatusRequest(StreamInput in) throws IOException {
         super(in);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/TransportGetBasicStatusAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/TransportGetBasicStatusAction.java
@@ -28,7 +28,7 @@ public class TransportGetBasicStatusAction extends TransportLocalClusterStateAct
      * Prior to 9.3 this was a TransportMasterNodeReadAction so for BwC it must be registered with the TransportService until
      * we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED_COORDINATION)
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
     @SuppressWarnings("this-escape")
     @Inject
     public TransportGetBasicStatusAction(TransportService transportService, ClusterService clusterService, ActionFilters actionFilters) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackField.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackField.java
@@ -62,7 +62,7 @@ public final class XPackField {
     /** Name constant for the voting-only-node feature. */
     public static final String VOTING_ONLY = "voting_only";
     /** Name constant for the frozen index feature. */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT) // Remove this: it is unused in v9 but needed for mixed v8/v9 clusters
+    @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE) // Remove this: it is unused in v9 but needed for mixed v8/v9 clusters
     public static final String FROZEN_INDICES = "frozen_indices";
     /** Name constant for spatial features. */
     public static final String SPATIAL = "spatial";

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/TransportXPackUsageAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/TransportXPackUsageAction.java
@@ -36,7 +36,7 @@ public class TransportXPackUsageAction extends TransportLocalClusterStateAction<
      * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC it must be registered with the TransportService until
      * we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.CORE_INFRA)
     @SuppressWarnings("this-escape")
     @Inject
     public TransportXPackUsageAction(

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageFeatureAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageFeatureAction.java
@@ -41,7 +41,7 @@ public final class XPackUsageFeatureAction {
     public static final ActionType<XPackUsageFeatureResponse> CCR = xpackUsageFeatureAction(XPackField.CCR);
     public static final ActionType<XPackUsageFeatureResponse> TRANSFORM = xpackUsageFeatureAction(XPackField.TRANSFORM);
     public static final ActionType<XPackUsageFeatureResponse> VOTING_ONLY = xpackUsageFeatureAction(XPackField.VOTING_ONLY);
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT) // Remove this: it is unused in v9 but needed for mixed v8/v9 clusters
+    @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE) // Remove this: it is unused in v9 but needed for mixed v8/v9 clusters
     public static final ActionType<XPackUsageFeatureResponse> FROZEN_INDICES = xpackUsageFeatureAction(XPackField.FROZEN_INDICES);
     public static final ActionType<XPackUsageFeatureResponse> SPATIAL = xpackUsageFeatureAction(XPackField.SPATIAL);
     public static final ActionType<XPackUsageFeatureResponse> ANALYTICS = xpackUsageFeatureAction(XPackField.ANALYTICS);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageFeatureTransportAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageFeatureTransportAction.java
@@ -25,7 +25,7 @@ public abstract class XPackUsageFeatureTransportAction extends TransportLocalClu
      * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC it must be registered with the TransportService until
      * we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.CORE_INFRA)
     @SuppressWarnings("this-escape")
     public XPackUsageFeatureTransportAction(
         String name,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/EnrichStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/EnrichStatsAction.java
@@ -48,7 +48,7 @@ public class EnrichStatsAction extends ActionType<EnrichStatsAction.Response> {
          * NB prior to 9.0 this was a TransportMasterNodeAction so for BwC we must remain able to read these requests until
          * we no longer need to support calling this action remotely.
          */
-        @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+        @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
         public Request(StreamInput in) throws IOException {
             // This request extended MasterNodeRequest instead of MasterNodeReadRequest, meaning that it didn't serialize the `local` field.
             super(in, false);
@@ -93,7 +93,7 @@ public class EnrichStatsAction extends ActionType<EnrichStatsAction.Response> {
          * NB prior to 9.0 this was a TransportMasterNodeAction so for BwC we must remain able to write these responses until
          * we no longer need to support calling this action remotely.
          */
-        @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+        @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeCollection(executingPolicies);
@@ -184,7 +184,7 @@ public class EnrichStatsAction extends ActionType<EnrichStatsAction.Response> {
              * NB prior to 9.0 this was a TransportMasterNodeAction so for BwC we must remain able to write these responses until
              * we no longer need to support calling this action remotely.
              */
-            @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+            @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
             @Override
             public void writeTo(StreamOutput out) throws IOException {
                 out.writeString(name);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/GetEnrichPolicyAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/GetEnrichPolicyAction.java
@@ -50,7 +50,7 @@ public class GetEnrichPolicyAction extends ActionType<GetEnrichPolicyAction.Resp
          * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC we must remain able to read these requests until
          * we no longer need to support calling this action remotely.
          */
-        @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+        @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
         public Request(StreamInput in) throws IOException {
             super(in);
             this.names = in.readStringCollectionAsImmutableList();
@@ -101,7 +101,7 @@ public class GetEnrichPolicyAction extends ActionType<GetEnrichPolicyAction.Resp
          * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC we must remain able to write these responses until
          * we no longer need to support calling this action remotely.
          */
-        @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+        @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeCollection(policies);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/frozen/FrozenIndicesFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/frozen/FrozenIndicesFeatureSetUsage.java
@@ -17,7 +17,7 @@ import org.elasticsearch.xpack.core.XPackField;
 import java.io.IOException;
 import java.util.Objects;
 
-@UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT) // Remove this: it is unused in v9 but needed for mixed v8/v9 clusters
+@UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED) // Remove this: it is unused in v9 but needed for mixed v8/v9 clusters
 public class FrozenIndicesFeatureSetUsage extends XPackFeatureUsage {
 
     private final int numberOfFrozenIndices;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ExplainLifecycleRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ExplainLifecycleRequest.java
@@ -46,7 +46,7 @@ public class ExplainLifecycleRequest extends LocalClusterStateRequest implements
      * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC we must remain able to read these requests until
      * we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
     public ExplainLifecycleRequest(StreamInput in) throws IOException {
         super(in);
         indices = in.readStringArray();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ExplainLifecycleResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ExplainLifecycleResponse.java
@@ -61,7 +61,7 @@ public class ExplainLifecycleResponse extends ActionResponse implements ToXConte
      * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC we must remain able to write these responses until
      * we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeCollection(indexResponses.values());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/FreezeAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/FreezeAction.java
@@ -25,7 +25,7 @@ import java.util.List;
  * state of indices.
  */
 @Deprecated
-@UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+@UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
 public class FreezeAction implements LifecycleAction {
 
     public static final String NAME = "freeze";

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicy.java
@@ -362,7 +362,7 @@ public class LifecyclePolicy implements SimpleDiffable<LifecyclePolicy>, ToXCont
         return Strings.toString(this, true, true);
     }
 
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
     public boolean maybeAddDeprecationWarningForFreezeAction(String policyName) {
         Phase coldPhase = phases.get(COLD_PHASE);
         if (coldPhase != null) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/Phase.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/Phase.java
@@ -176,7 +176,7 @@ public class Phase implements ToXContentObject, Writeable {
         return Strings.toString(this, true, true);
     }
 
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
     public boolean maybeAddDeprecationWarningForFreezeAction(String policyName) {
         if (getActions().containsKey(FreezeAction.NAME)) {
             deprecationLogger.warn(

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/action/GetLifecycleAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/action/GetLifecycleAction.java
@@ -56,7 +56,7 @@ public class GetLifecycleAction extends ActionType<GetLifecycleAction.Response> 
          * NB prior to 9.1 this was a TransportMasterNodeAction so for BwC we must remain able to write these responses until
          * we no longer need to support calling this action remotely.
          */
-        @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+        @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeCollection(policies);
@@ -117,7 +117,7 @@ public class GetLifecycleAction extends ActionType<GetLifecycleAction.Response> 
          * NB prior to 9.1 this was a TransportMasterNodeAction so for BwC we must remain able to read these requests until
          * we no longer need to support calling this action remotely.
          */
-        @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+        @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
         public Request(StreamInput in) throws IOException {
             super(in, false);
             // This used to be an AcknowledgedRequest so we need to read the ack timeout for BwC.
@@ -170,7 +170,7 @@ public class GetLifecycleAction extends ActionType<GetLifecycleAction.Response> 
          * NB prior to 9.1 this was a TransportMasterNodeAction so for BwC we must remain able to write these responses until
          * we no longer need to support calling this action remotely.
          */
-        @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+        @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             lifecyclePolicy.writeTo(out);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/action/GetStatusAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/action/GetStatusAction.java
@@ -44,7 +44,7 @@ public class GetStatusAction extends ActionType<GetStatusAction.Response> {
          * NB prior to 9.1 this was a TransportMasterNodeAction so for BwC we must remain able to read these requests until
          * we no longer need to support calling this action remotely.
          */
-        @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+        @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
         public Request(StreamInput in) throws IOException {
             super(in, false);
             // Read and ignore ack timeout.

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/put/GetWatcherSettingsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/put/GetWatcherSettingsAction.java
@@ -44,7 +44,7 @@ public class GetWatcherSettingsAction extends ActionType<GetWatcherSettingsActio
          * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC we must remain able to read these requests until
          * we no longer need to support calling this action remotely.
          */
-        @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+        @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
         public static Request readFrom(StreamInput in) throws IOException {
             return new Request(in);
         }
@@ -76,7 +76,7 @@ public class GetWatcherSettingsAction extends ActionType<GetWatcherSettingsActio
          * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC we must remain able to write these responses until
          * we no longer need to support calling this action remotely.
          */
-        @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+        @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             this.settings.writeTo(out);

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPlugin.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPlugin.java
@@ -145,7 +145,7 @@ public class EnrichPlugin extends Plugin implements SystemIndexPlugin, IngestPlu
      * This setting solely exists because the original setting was accidentally renamed in
      * https://github.com/elastic/elasticsearch/pull/111412.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
     public static final String CACHE_SIZE_SETTING_BWC_NAME = "enrich.cache.size";
     public static final Setting<FlatNumberOrByteSizeValue> CACHE_SIZE_BWC = new Setting<>(
         CACHE_SIZE_SETTING_BWC_NAME,

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportEnrichStatsAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportEnrichStatsAction.java
@@ -40,7 +40,7 @@ public class TransportEnrichStatsAction extends TransportLocalClusterStateAction
      * NB prior to 9.0 this was a TransportMasterNodeAction so for BwC it must be registered with the TransportService until
      * we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
     @SuppressWarnings("this-escape")
     @Inject
     public TransportEnrichStatsAction(

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportGetEnrichPolicyAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportGetEnrichPolicyAction.java
@@ -36,7 +36,7 @@ public class TransportGetEnrichPolicyAction extends TransportLocalProjectMetadat
      * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC it must be registered with the TransportService until
      * we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
     @SuppressWarnings("this-escape")
     @Inject
     public TransportGetEnrichPolicyAction(

--- a/x-pack/plugin/frozen-indices/src/main/java/org/elasticsearch/xpack/frozen/FrozenIndicesUsageTransportAction.java
+++ b/x-pack/plugin/frozen-indices/src/main/java/org/elasticsearch/xpack/frozen/FrozenIndicesUsageTransportAction.java
@@ -21,7 +21,7 @@ import org.elasticsearch.xpack.core.action.XPackUsageFeatureResponse;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureTransportAction;
 import org.elasticsearch.xpack.core.frozen.FrozenIndicesFeatureSetUsage;
 
-@UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT) // Remove this: it is unused in v9 but needed for mixed v8/v9 clusters
+@UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED) // Remove this: it is unused in v9 but needed for mixed v8/v9 clusters
 public class FrozenIndicesUsageTransportAction extends XPackUsageFeatureTransportAction {
 
     @Inject

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportExplainLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportExplainLifecycleAction.java
@@ -63,7 +63,7 @@ public class TransportExplainLifecycleAction extends TransportLocalProjectMetada
      * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC it must be registered with the TransportService until
      * we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
     @SuppressWarnings("this-escape")
     @Inject
     public TransportExplainLifecycleAction(

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportGetLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportGetLifecycleAction.java
@@ -47,7 +47,7 @@ public class TransportGetLifecycleAction extends TransportLocalProjectMetadataAc
      * NB prior to 9.1 this was a TransportMasterNodeAction so for BwC it must be registered with the TransportService until
      * we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
     @SuppressWarnings("this-escape")
     @Inject
     public TransportGetLifecycleAction(

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportGetStatusAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportGetStatusAction.java
@@ -32,7 +32,7 @@ public class TransportGetStatusAction extends TransportLocalProjectMetadataActio
      * NB prior to 9.1 this was a TransportMasterNodeAction so for BwC it must be registered with the TransportService until
      * we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.STORAGE_ENGINE)
     @SuppressWarnings("this-escape")
     @Inject
     public TransportGetStatusAction(

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
@@ -240,7 +240,7 @@ public class Watcher extends Plugin implements SystemIndexPlugin, ScriptPlugin, 
         NodeScope
     );
     private static final Setting<Integer> SETTING_BULK_ACTIONS = Setting.intSetting("xpack.watcher.bulk.actions", 1, 1, 10000, NodeScope);
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
     @Deprecated(forRemoval = true) // This setting is no longer used
     private static final Setting<Integer> SETTING_BULK_CONCURRENT_REQUESTS = Setting.intSetting(
         "xpack.watcher.bulk.concurrent_requests",

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportGetWatcherSettingsAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportGetWatcherSettingsAction.java
@@ -43,7 +43,7 @@ public class TransportGetWatcherSettingsAction extends TransportLocalProjectMeta
      * NB prior to 9.0 this was a TransportMasterNodeReadAction so for BwC it must be registered with the TransportService until
      * we no longer need to support calling this action remotely.
      */
-    @UpdateForV10(owner = UpdateForV10.Owner.DATA_MANAGEMENT)
+    @UpdateForV10(owner = UpdateForV10.Owner.DISTRIBUTED)
     @SuppressWarnings("this-escape")
     @Inject
     public TransportGetWatcherSettingsAction(


### PR DESCRIPTION
This commit does two things:
1. Reassigns all of the Data Management deprecations to different teams (distributed, storage engine, or core/infra).
2. Collapses the `DISTRIBUTED_INDEXING` and `DISTRIBUTED_COORDINATION` teams into just `DISTRIBUTED`.
