### PR TITLE
Drop CPS `project_routing` param from search's rest API specs

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/async_search.submit.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/async_search.submit.json
@@ -136,10 +136,6 @@
         "type": "string",
         "description": "Specify the node or shard the operation should be performed on (default: random)"
       },
-      "project_routing": {
-        "type": "string",
-        "description": "A Lucene query using project metadata tags to limit which projects to search, such as _alias:_origin or _alias:*pr*. Only supported in serverless."
-      },
       "rest_total_hits_as_int": {
         "type": "boolean",
         "description": "Indicates whether hits.total should be rendered as an integer or an object in the rest search response",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search.json
@@ -130,10 +130,6 @@
         "type": "string",
         "description": "Specify the node or shard the operation should be performed on (default: random)"
       },
-      "project_routing": {
-        "type": "string",
-        "description": "A Lucene query using project metadata tags to limit which projects to search, such as _alias:_origin or _alias:*pr*. Only supported in serverless."
-      },
       "q": {
         "type": "string",
         "description": "Query in the Lucene query string syntax"


### PR DESCRIPTION
Except for multisearch requests, `project_routing` cannot appear as a query param. This PR drops it from the remnants: `_search` and `_async_search`.