### PR TITLE
ESQL: Mute 250_high_cardinality_keyword

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -342,6 +342,9 @@ tests:
 - class: org.elasticsearch.repositories.blobstore.testkit.analyze.RepositoryAnalysisSuccessIT
   method: testRepositoryAnalysis
   issue: https://github.com/elastic/elasticsearch/issues/140638
+- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlClientYamlIT
+  method: test {p0=esql/250_high_cardinality_keyword/*
+  issue: https://github.com/elastic/elasticsearch/issues/140639
 
 # Examples:
 #


### PR DESCRIPTION
Relates https://github.com/elastic/elasticsearch/issues/140639

These are failing the release tests.