### PR TITLE
ESQL: Properly mute esql/250_high_cardinality_keyword in all yaml test suites

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -342,9 +342,6 @@ tests:
 - class: org.elasticsearch.repositories.blobstore.testkit.analyze.RepositoryAnalysisSuccessIT
   method: testRepositoryAnalysis
   issue: https://github.com/elastic/elasticsearch/issues/140638
-- class: org.elasticsearch.xpack.esql.qa.multi_node.EsqlClientYamlIT
-  method: test {p0=esql/250_high_cardinality_keyword/*
-  issue: https://github.com/elastic/elasticsearch/issues/140639
 
 # Examples:
 #

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/250_high_cardinality_keyword.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/250_high_cardinality_keyword.yml
@@ -1,5 +1,8 @@
 ---
 setup:
+  - skip:
+      awaits_fix: https://github.com/elastic/elasticsearch/issues/140639
+      reason:     Fails release tests
   - requires:
       cluster_features: ["mapper.keyword.high_cardinality_length_function_fuse_to_load"]
       reason: "testing binary doc values search"


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/140641 was too specific, of course yaml tests are executed in a bunch of different environments that run under their own test classes.

This will mute the failing test for good.