### PR TITLE
[9.3] ESQL: Added more null aggs tests on RATE

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-rate.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-rate.csv-spec
@@ -416,3 +416,143 @@ null_literal:double | null_propagated:double | rate:double
 null                | null                   | 13.1737
 null                | null                   | 10.6491
 ;
+
+rateOnNullsWithOnlyNullResults
+required_capability: ts_command_v0
+required_capability: metrics_group_by_all
+required_capability: metrics_group_by_all_with_ts_dimensions
+required_capability: fix_agg_on_null_by_replacing_with_eval
+
+TS k8s
+| EVAL null_col = null
+| STATS
+    null_literal = rate(null),
+    null_propagated = rate(null_col)
+| KEEP null_literal, null_propagated
+| LIMIT 2;
+
+null_literal:double | null_propagated:double
+null                | null
+null                | null
+;
+
+rateOnNullsWithTimeseriesColumn
+required_capability: ts_command_v0
+required_capability: metrics_group_by_all
+required_capability: metrics_group_by_all_with_ts_dimensions
+required_capability: fix_agg_on_null_by_replacing_with_eval
+
+TS k8s
+| STATS null_literal = rate(null)
+;
+ignoreOrder:true
+
+null_literal:double | _timeseries:keyword
+null                | "{""cluster"":""staging"",""pod"":""one"",""region"":""us""}"
+null                | "{""cluster"":""staging"",""pod"":""three"",""region"":""us""}"
+null                | "{""cluster"":""prod"",""pod"":""two"",""region"":[""eu"",""us""]}"
+null                | "{""cluster"":""prod"",""pod"":""three"",""region"":[""eu"",""us""]}"
+null                | "{""cluster"":""staging"",""pod"":""two"",""region"":""us""}"
+null                | "{""cluster"":""prod"",""pod"":""one"",""region"":[""eu"",""us""]}"
+null                | "{""cluster"":""qa"",""pod"":""three""}"
+null                | "{""cluster"":""qa"",""pod"":""one""}"
+null                | "{""cluster"":""qa"",""pod"":""two""}"
+;
+
+rateOnNullsSecondStats
+required_capability: ts_command_v0
+required_capability: metrics_group_by_all
+required_capability: metrics_group_by_all_with_ts_dimensions
+required_capability: fix_agg_on_null_by_replacing_with_eval
+
+TS k8s
+| STATS null_literal = rate(null)
+| STATS row_count = COUNT(1)
+;
+
+row_count:long
+9
+;
+
+rateOnNullsGrouping
+required_capability: ts_command_v0
+required_capability: metrics_group_by_all
+required_capability: metrics_group_by_all_with_ts_dimensions
+required_capability: fix_agg_on_null_by_replacing_with_eval
+
+TS k8s
+| EVAL null_col = null
+| STATS
+    rate = rate(network.total_bytes_in),
+    null_literal = rate(null),
+    null_propagated = rate(null_col)
+  BY bucket = tbucket(1 hour)
+| EVAL rate=ROUND(rate, 4)
+| KEEP null_literal, null_propagated, bucket, rate
+| SORT rate DESC
+| LIMIT 2;
+ignoreOrder:true
+
+null_literal:double | null_propagated:double | bucket:datetime          | rate:double
+null                | null                   | 2024-05-10T00:00:00.000Z | 4.3799
+null                | null                   | 2024-05-10T00:00:00.000Z | 3.9598
+;
+
+rateOnNullsWithOnlyNullResultsGrouping
+required_capability: ts_command_v0
+required_capability: metrics_group_by_all
+required_capability: metrics_group_by_all_with_ts_dimensions
+required_capability: fix_agg_on_null_by_replacing_with_eval
+
+TS k8s
+| EVAL null_col = null
+| STATS
+    null_literal = rate(null),
+    null_propagated = rate(null_col)
+  BY bucket = tbucket(1 hour)
+| KEEP null_literal, null_propagated, bucket
+| LIMIT 2;
+
+null_literal:double | null_propagated:double | bucket:datetime
+null                | null                   | 2024-05-10T00:00:00.000Z
+null                | null                   | 2024-05-10T00:00:00.000Z
+;
+
+rateOnNullsWithTimeseriesColumnGrouping
+required_capability: ts_command_v0
+required_capability: metrics_group_by_all
+required_capability: metrics_group_by_all_with_ts_dimensions
+required_capability: fix_agg_on_null_by_replacing_with_eval
+
+TS k8s
+| STATS null_literal = rate(null) BY bucket = tbucket(1 hour)
+;
+ignoreOrder:true
+
+null_literal:double | _timeseries:keyword                                                   | bucket:datetime
+null                | "{""cluster"":""staging"",""pod"":""one"",""region"":""us""}"         | 2024-05-10T00:00:00.000Z
+null                | "{""cluster"":""staging"",""pod"":""three"",""region"":""us""}"       | 2024-05-10T00:00:00.000Z
+null                | "{""cluster"":""prod"",""pod"":""two"",""region"":[""eu"",""us""]}"   | 2024-05-10T00:00:00.000Z
+null                | "{""cluster"":""prod"",""pod"":""three"",""region"":[""eu"",""us""]}" | 2024-05-10T00:00:00.000Z
+null                | "{""cluster"":""staging"",""pod"":""two"",""region"":""us""}"         | 2024-05-10T00:00:00.000Z
+null                | "{""cluster"":""prod"",""pod"":""one"",""region"":[""eu"",""us""]}"   | 2024-05-10T00:00:00.000Z
+null                | "{""cluster"":""qa"",""pod"":""three""}"                              | 2024-05-10T00:00:00.000Z
+null                | "{""cluster"":""qa"",""pod"":""one""}"                                | 2024-05-10T00:00:00.000Z
+null                | "{""cluster"":""qa"",""pod"":""two""}"                                | 2024-05-10T00:00:00.000Z
+;
+
+rateOnNullsSecondStatsGrouping
+required_capability: ts_command_v0
+required_capability: metrics_group_by_all
+required_capability: metrics_group_by_all_with_ts_dimensions
+required_capability: fix_agg_on_null_by_replacing_with_eval
+
+TS k8s
+| STATS null_literal = rate(null)
+  BY bucket = tbucket(1 hour)
+| STATS row_count = COUNT(1)
+;
+
+row_count:long
+9
+;


### PR DESCRIPTION
9.3 backport of https://github.com/elastic/elasticsearch/pull/140585