### PR TITLE
[9.3] ESQL: Enable nullify and fail unmapped resolution in tech-preview (#140528)

### DIFF
--- a/docs/changelog/140528.yaml
+++ b/docs/changelog/140528.yaml
@@ -1,0 +1,5 @@
+pr: 140528
+summary: Enable nullify and fail unmapped resolution in tech-preview
+area: ES|QL
+type: feature
+issues: []

--- a/docs/reference/query-languages/esql/kibana/definition/settings/unmapped_fields.json
+++ b/docs/reference/query-languages/esql/kibana/definition/settings/unmapped_fields.json
@@ -4,6 +4,6 @@
   "type" : "keyword",
   "serverlessOnly" : false,
   "preview" : true,
-  "snapshotOnly" : true,
-  "description" : "Defines how unmapped fields are treated. Possible values are: \"FAIL\" (default) - fails the query if unmapped fields are present; \"NULLIFY\" - treats unmapped fields as null values; \"LOAD\" - attempts to load the fields from the source."
+  "snapshotOnly" : false,
+  "description" : "Defines how unmapped fields are treated. Possible values are: \"FAIL\" (default) - fails the query if unmapped fields are present; \"NULLIFY\" - treats unmapped fields as null values. "
 }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-nullify.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-nullify.csv-spec
@@ -207,7 +207,7 @@ ROW x = 1
 | STATS s = SUM(foo)
 ;
 
-s:long
+s:double
 null
 ;
 
@@ -223,7 +223,7 @@ foo:null
 null
 ;
 
-statsAggs
+statsAggsGrouped
 required_capability: optional_fields_nullify_tech_preview
 required_capability: fix_agg_on_null_by_replacing_with_eval
 
@@ -232,7 +232,7 @@ ROW x = 1
 | STATS s = SUM(foo) BY bar
 ;
 
-s:long | bar:null
+s:double | bar:null
 null   | null
 ;
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-nullify.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-nullify.csv-spec
@@ -1,5 +1,5 @@
 simpleKeep
-required_capability: optional_fields
+required_capability: optional_fields_nullify_tech_preview
 
 SET unmapped_fields="nullify"\;
 FROM employees
@@ -14,7 +14,7 @@ null
 ;
 
 keepStar
-required_capability: optional_fields
+required_capability: optional_fields_nullify_tech_preview
 
 SET unmapped_fields="nullify"\;
 FROM employees
@@ -29,7 +29,7 @@ avg_worked_seconds:long|birth_date:date|emp_no:integer|first_name:keyword|gender
 
 
 keepStarSimpleKeep
-required_capability: optional_fields
+required_capability: optional_fields_nullify_tech_preview
 
 SET unmapped_fields="nullify"\;
 FROM employees
@@ -45,7 +45,7 @@ null
 ;
 
 keepStarEval
-required_capability: optional_fields
+required_capability: optional_fields_nullify_tech_preview
 
 SET unmapped_fields="nullify"\;
 FROM employees
@@ -61,7 +61,7 @@ avg_worked_seconds:long|birth_date:date|emp_no:integer|first_name:keyword|gender
 
 
 dropPatternSimpleKeep
-required_capability: optional_fields
+required_capability: optional_fields_nullify_tech_preview
 
 SET unmapped_fields="nullify"\;
 FROM employees
@@ -77,7 +77,7 @@ null
 ;
 
 dropPatternEval
-required_capability: optional_fields
+required_capability: optional_fields_nullify_tech_preview
 
 SET unmapped_fields="nullify"\;
 FROM employees
@@ -93,7 +93,7 @@ null                      | null
 ;
 
 keepWithPattern
-required_capability: optional_fields
+required_capability: optional_fields_nullify_tech_preview
 
 SET unmapped_fields="nullify"\;
 FROM employees
@@ -107,7 +107,7 @@ emp_no:integer|foo:null
 ;
 
 rowKeep
-required_capability: optional_fields
+required_capability: optional_fields_nullify_tech_preview
 
 SET unmapped_fields="nullify"\;
 ROW x = 1
@@ -120,7 +120,7 @@ x:integer      |does_not_exist_field1:null|y:integer      |does_not_exist_field2
 ;
 
 rowDrop
-required_capability: optional_fields
+required_capability: optional_fields_nullify_tech_preview
 
 SET unmapped_fields="nullify"\;
 ROW x = 1
@@ -132,7 +132,7 @@ x:integer
 ;
 
 rowRename
-required_capability: optional_fields
+required_capability: optional_fields_nullify_tech_preview
 
 SET unmapped_fields="nullify"\;
 ROW x = 1
@@ -144,7 +144,7 @@ y:integer | bar:null
 ;
 
 fieldRename
-required_capability: optional_fields
+required_capability: optional_fields_nullify_tech_preview
 
 SET unmapped_fields="nullify"\;
 FROM employees
@@ -161,7 +161,7 @@ emp_no:integer | bar:null | bazz:null
 ;
 
 rowRenameEval
-required_capability: optional_fields
+required_capability: optional_fields_nullify_tech_preview
 
 SET unmapped_fields="nullify"\;
 ROW x = 1
@@ -174,7 +174,7 @@ whatever:integer | does_not_exist_field:null | x:integer
 ;
 
 casting
-required_capability: optional_fields
+required_capability: optional_fields_nullify_tech_preview
 
 SET unmapped_fields="nullify"\;
 ROW x = 1
@@ -186,7 +186,7 @@ x:integer |foo:null |foo::LONG:long
 ;
 
 shadowing
-required_capability: optional_fields
+required_capability: optional_fields_nullify_tech_preview
 
 SET unmapped_fields="nullify"\;
 ROW x = 1
@@ -198,9 +198,9 @@ foo:integer
 2
 ;
 
-# https://github.com/elastic/elasticsearch/pull/139797
-statsAggs-Ignore
-required_capability: optional_fields
+statsAggs
+required_capability: optional_fields_nullify_tech_preview
+required_capability: fix_agg_on_null_by_replacing_with_eval
 
 SET unmapped_fields="nullify"\;
 ROW x = 1
@@ -212,7 +212,7 @@ null
 ;
 
 statsGroups
-required_capability: optional_fields
+required_capability: optional_fields_nullify_tech_preview
 
 SET unmapped_fields="nullify"\;
 ROW x = 1
@@ -223,9 +223,9 @@ foo:null
 null
 ;
 
-# https://github.com/elastic/elasticsearch/pull/139797
-statsAggs-Ignore
-required_capability: optional_fields
+statsAggs
+required_capability: optional_fields_nullify_tech_preview
+required_capability: fix_agg_on_null_by_replacing_with_eval
 
 SET unmapped_fields="nullify"\;
 ROW x = 1
@@ -237,7 +237,7 @@ null   | null
 ;
 
 statsExpressions
-required_capability: optional_fields
+required_capability: optional_fields_nullify_tech_preview
 
 SET unmapped_fields="nullify"\;
 ROW x = 1
@@ -249,7 +249,7 @@ null   | null
 ;
 
 statsExpressionsWithAliases
-required_capability: optional_fields
+required_capability: optional_fields_nullify_tech_preview
 
 SET unmapped_fields="nullify"\;
 ROW x = 1
@@ -261,7 +261,7 @@ null   | null   | 1
 ;
 
 statsFilteredAggs
-required_capability: optional_fields
+required_capability: optional_fields_nullify_tech_preview
 
 SET unmapped_fields="nullify"\;
 ROW x = 1
@@ -273,7 +273,7 @@ s:long
 ;
 
 statsFilteredAggsAndGroups
-required_capability: optional_fields
+required_capability: optional_fields_nullify_tech_preview
 
 SET unmapped_fields="nullify"\;
 ROW x = 1
@@ -285,7 +285,7 @@ s:long | bar:null
 ;
 
 inlinestatsSum
-required_capability: optional_fields
+required_capability: optional_fields_nullify_tech_preview
 SET unmapped_fields="nullify"\;
 ROW x = 1
 | INLINE STATS s = SUM(x) + b + c BY b = bar + baz, c = x - 1
@@ -296,7 +296,7 @@ x:integer | bar:null | baz:null | s:long | b:null | c:integer
 ;
 
 filtering
-required_capability: optional_fields
+required_capability: optional_fields_nullify_tech_preview
 
 SET unmapped_fields="nullify"\;
 ROW x = 1
@@ -308,7 +308,7 @@ x:integer | foo:null
 ;
 
 filteringExpression
-required_capability: optional_fields
+required_capability: optional_fields_nullify_tech_preview
 
 SET unmapped_fields="nullify"\;
 FROM employees
@@ -321,7 +321,7 @@ emp_no:integer | emp_no_foo:null
 ;
 
 sort
-required_capability: optional_fields
+required_capability: optional_fields_nullify_tech_preview
 
 SET unmapped_fields="nullify"\;
 ROW x = [1, 2]
@@ -335,7 +335,7 @@ x:integer | foo:null
 ;
 
 sortExpression
-required_capability: optional_fields
+required_capability: optional_fields_nullify_tech_preview
 
 SET unmapped_fields="nullify"\;
 ROW x = [1, 2]
@@ -349,7 +349,7 @@ x:integer | foo:null
 ;
 
 mvExpand
-required_capability: optional_fields
+required_capability: optional_fields_nullify_tech_preview
 SET unmapped_fields="nullify"\;
 ROW x = 1
 | MV_EXPAND foo
@@ -361,7 +361,7 @@ x:integer | foo:null
 
 # TODO. FROMx: this fails in parsing with just FROM even if -Ignore'd(!), in bwc tests only(!)
 subqueryNoMainIndex-Ignore
-required_capability: optional_fields
+required_capability: optional_fields_nullify_tech_preview
 required_capability: subquery_in_from_command
 
 SET unmapped_fields="nullify"\;
@@ -379,7 +379,7 @@ emp_no:integer | emp_no_foo:null | emp_no_plus:long
 ;
 
 subqueryInFromWithStatsInMainQuery-Ignore
-required_capability: optional_fields
+required_capability: optional_fields_nullify_tech_preview
 required_capability: subquery_in_from_command
 
 SET unmapped_fields="nullify"\;
@@ -402,7 +402,7 @@ client_ip:ip   |foo:null       |bar:keyword    |baz:null
 ;
 
 forkBranchesWithDifferentSchemas
-required_capability: optional_fields
+required_capability: optional_fields_nullify_tech_preview
 required_capability: fork_v9
 
 SET unmapped_fields="nullify"\;
@@ -426,7 +426,7 @@ null           |1985           |null           |abc            |fork3
 ;
 
 inlinestatsCount
-required_capability: optional_fields
+required_capability: optional_fields_nullify_tech_preview
 required_capability: inline_stats
 
 SET unmapped_fields="nullify"\;
@@ -440,7 +440,7 @@ x:integer      |does_not_exist:null|c:long         |s:double       |d:null
 ;
 
 lookupJoin
-required_capability: optional_fields
+required_capability: optional_fields_nullify_tech_preview
 required_capability: join_lookup_v12
 
 SET unmapped_fields="nullify"\;
@@ -454,7 +454,7 @@ x:integer      |does_not_exist:null |language_code:integer |language_name:keywor
 ;
 
 enrich
-required_capability: optional_fields
+required_capability: optional_fields_nullify_tech_preview
 required_capability: enrich_load
 
 SET unmapped_fields="nullify"\;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -156,9 +156,15 @@ public class EsqlCapabilities {
         METADATA_FIELDS,
 
         /**
-         * Support for optional fields (might or might not be present in the mappings).
+         * Support for optional fields (might or might not be present in the mappings) using FAIL/NULLIFY/LOAD
          */
         OPTIONAL_FIELDS(Build.current().isSnapshot()),
+
+        /**
+         * Support for Optional fields (might or might not be present in the mappings) using FAIL/NULLIFY only. This is a temporary
+         * capability until we enable the LOAD option mentioned above.
+         */
+        OPTIONAL_FIELDS_NULLIFY_TECH_PREVIEW,
 
         /**
          * Support specifically for *just* the _index METADATA field. Used by CsvTests, since that is the only metadata field currently

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/QuerySettings.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/QuerySettings.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.plan;
 
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.analysis.UnmappedResolution;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -61,18 +62,26 @@ public class QuerySettings {
         DataType.KEYWORD,
         false,
         true,
-        true,
+        false,
         "Defines how unmapped fields are treated. Possible values are: "
             + "\"FAIL\" (default) - fails the query if unmapped fields are present; "
-            + "\"NULLIFY\" - treats unmapped fields as null values; "
-            + "\"LOAD\" - attempts to load the fields from the source.",
+            + "\"NULLIFY\" - treats unmapped fields as null values. ",
+        // + "\"LOAD\" - attempts to load the fields from the source." Commented out since LOAD is currently only under snapshot.
         (value) -> {
             String resolution = Foldables.stringLiteralValueOf(value, "Unexpected value");
             try {
-                return UnmappedResolution.valueOf(resolution.toUpperCase(Locale.ROOT));
+                UnmappedResolution res = UnmappedResolution.valueOf(resolution.toUpperCase(Locale.ROOT));
+                if (res == UnmappedResolution.LOAD && EsqlCapabilities.Cap.OPTIONAL_FIELDS.isEnabled() == false) {
+                    throw new IllegalArgumentException("'LOAD' is only supported in snapshot builds");
+                }
+                return res;
             } catch (Exception exc) {
+                var values = EsqlCapabilities.Cap.OPTIONAL_FIELDS.isEnabled()
+                    ? UnmappedResolution.values()
+                    : Arrays.stream(UnmappedResolution.values()).filter(e -> e != UnmappedResolution.LOAD).toArray();
+
                 throw new IllegalArgumentException(
-                    "Invalid unmapped_fields resolution [" + value + "], must be one of " + Arrays.toString(UnmappedResolution.values())
+                    "Invalid unmapped_fields resolution [" + value + "], must be one of " + Arrays.toString(values)
                 );
             }
         },
@@ -137,6 +146,7 @@ public class QuerySettings {
         Parser<T> parser,
         T defaultValue
     ) {
+
         /**
          * Constructor with a default validator that delegates to the parser.
          */

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerUnmappedTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerUnmappedTests.java
@@ -2034,6 +2034,8 @@ public class AnalyzerUnmappedTests extends ESTestCase {
     }
 
     public void testFailAfterUnionAllOfStats() {
+        assumeTrue("Requires subquery in FROM command support", EsqlCapabilities.Cap.SUBQUERY_IN_FROM_COMMAND.isEnabled());
+
         var query = """
             FROM
                 (FROM employees
@@ -3040,7 +3042,7 @@ public class AnalyzerUnmappedTests extends ESTestCase {
     }
 
     private static String setUnmappedNullify(String query) {
-        assumeTrue("Requires OPTIONAL_FIELDS", EsqlCapabilities.Cap.OPTIONAL_FIELDS.isEnabled());
+        assumeTrue("Requires OPTIONAL_FIELDS_NULLIFY_TECH_PREVIEW", EsqlCapabilities.Cap.OPTIONAL_FIELDS_NULLIFY_TECH_PREVIEW.isEnabled());
         return "SET unmapped_fields=\"nullify\"; " + query;
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/SetParserTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/SetParserTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.parser;
 
+import org.elasticsearch.Build;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.analysis.UnmappedResolution;
@@ -22,13 +23,13 @@ import java.util.List;
 
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.randomizeCase;
 import static org.elasticsearch.xpack.esql.plan.QuerySettings.UNMAPPED_FIELDS;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
 public class SetParserTests extends AbstractStatementParserTests {
 
     public void testSet() {
-        assumeTrue("SET command available in snapshot only", EsqlCapabilities.Cap.SET_COMMAND.isEnabled());
         EsqlStatement query = unvalidatedStatement("SET foo = \"bar\"; row a = 1", new QueryParams());
         assertThat(query.plan(), is(instanceOf(Row.class)));
         assertThat(query.settings().size(), is(1));
@@ -48,7 +49,6 @@ public class SetParserTests extends AbstractStatementParserTests {
     }
 
     public void testSetWithTripleQuotes() {
-        assumeTrue("SET command available in snapshot only", EsqlCapabilities.Cap.SET_COMMAND.isEnabled());
         EsqlStatement query = unvalidatedStatement("SET foo = \"\"\"bar\"baz\"\"\"; row a = 1", new QueryParams());
         assertThat(query.plan(), is(instanceOf(Row.class)));
         assertThat(query.settings().size(), is(1));
@@ -66,7 +66,6 @@ public class SetParserTests extends AbstractStatementParserTests {
     }
 
     public void testMultipleSet() {
-        assumeTrue("SET command available in snapshot only", EsqlCapabilities.Cap.SET_COMMAND.isEnabled());
         EsqlStatement query = unvalidatedStatement(
             "SET foo = \"bar\"; SET bar = 2; SET foo = \"baz\"; SET x = 3.5; SET y = false; SET z = null; row a = 1",
             new QueryParams()
@@ -83,7 +82,6 @@ public class SetParserTests extends AbstractStatementParserTests {
     }
 
     public void testSetArrays() {
-        assumeTrue("SET command available in snapshot only", EsqlCapabilities.Cap.SET_COMMAND.isEnabled());
         EsqlStatement query = unvalidatedStatement("SET foo = [\"bar\", \"baz\"]; SET bar = [1, 2, 3]; row a = 1", new QueryParams());
         assertThat(query.plan(), is(instanceOf(Row.class)));
         assertThat(query.settings().size(), is(2));
@@ -93,7 +91,6 @@ public class SetParserTests extends AbstractStatementParserTests {
     }
 
     public void testSetWithNamedParams() {
-        assumeTrue("SET command available in snapshot only", EsqlCapabilities.Cap.SET_COMMAND.isEnabled());
         EsqlStatement query = unvalidatedStatement(
             "SET foo = \"bar\"; SET bar = ?a; SET foo = \"baz\"; SET x = ?x; row a = 1",
             new QueryParams(
@@ -113,7 +110,6 @@ public class SetParserTests extends AbstractStatementParserTests {
     }
 
     public void testSetWithPositionalParams() {
-        assumeTrue("SET command available in snapshot only", EsqlCapabilities.Cap.SET_COMMAND.isEnabled());
         EsqlStatement query = unvalidatedStatement(
             "SET foo = \"bar\"; SET bar = ?; SET foo = \"baz\"; SET x = ?; row a = ?",
             new QueryParams(
@@ -166,11 +162,32 @@ public class SetParserTests extends AbstractStatementParserTests {
         return query.settings().get(position).value().fold(FoldContext.small());
     }
 
-    public void testSetUnmappedFields() {
-        assumeTrue("SET command available in snapshot only", EsqlCapabilities.Cap.SET_COMMAND.isEnabled());
-        assumeTrue("SET command available in snapshot only", EsqlCapabilities.Cap.OPTIONAL_FIELDS.isEnabled());
+    public void testSetUnmappedFields_snapshot() {
+        assumeTrue("OPTIONAL_FIELDS option required", EsqlCapabilities.Cap.OPTIONAL_FIELDS.isEnabled());
+
         var modes = List.of("FAIL", "NULLIFY", "LOAD");
+        verifySetUnmappedFields(modes);
         assertThat(modes.size(), is(UnmappedResolution.values().length));
+    }
+
+    public void testSetUnmappedFields_nonSnapshot() {
+        assumeFalse("Requires no snapshot", Build.current().isSnapshot());
+
+        verifySetUnmappedFields(List.of("FAIL", "NULLIFY"));
+
+        String name = randomizeCase(UnmappedResolution.LOAD.name());
+        expectThrows(
+            ParsingException.class,
+            containsString(
+                "Error validating setting [unmapped_fields]: Invalid unmapped_fields resolution ["
+                    + name
+                    + "], must be one of [FAIL, NULLIFY]"
+            ),
+            () -> statement("SET unmapped_fields=\"" + name + "\"; row a = 1")
+        );
+    }
+
+    private void verifySetUnmappedFields(List<String> modes) {
         for (var mode : modes) {
             EsqlStatement statement = statement("SET unmapped_fields=\"" + randomizeCase(mode) + "\"; row a = 1");
             assertThat(statement.setting(UNMAPPED_FIELDS), is(UnmappedResolution.valueOf(mode)));
@@ -179,16 +196,21 @@ public class SetParserTests extends AbstractStatementParserTests {
     }
 
     public void testSetUnmappedFieldsWrongValue() {
-        assumeTrue("Requires the unmapped_fields setting", EsqlCapabilities.Cap.OPTIONAL_FIELDS.isEnabled());
+        assumeTrue("Requires the unmapped_fields setting", EsqlCapabilities.Cap.OPTIONAL_FIELDS_NULLIFY_TECH_PREVIEW.isEnabled());
+
         var mode = randomValueOtherThanMany(
             v -> Arrays.stream(UnmappedResolution.values()).anyMatch(x -> x.name().equalsIgnoreCase(v)),
             () -> randomAlphaOfLengthBetween(0, 10)
         );
+        var values = EsqlCapabilities.Cap.OPTIONAL_FIELDS.isEnabled()
+            ? UnmappedResolution.values()
+            : Arrays.stream(UnmappedResolution.values()).filter(e -> e != UnmappedResolution.LOAD).toArray();
         expectValidationError(
             "SET unmapped_fields=\"" + mode + "\"; row a = 1",
             "Error validating setting [unmapped_fields]: Invalid unmapped_fields resolution ["
                 + mode
-                + "], must be one of [FAIL, NULLIFY, LOAD]"
+                + "], must be one of "
+                + Arrays.toString(values)
         );
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/QuerySettingsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plan/QuerySettingsTests.java
@@ -7,7 +7,9 @@
 
 package org.elasticsearch.xpack.esql.plan;
 
+import org.elasticsearch.Build;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.esql.action.EsqlCapabilities;
 import org.elasticsearch.xpack.esql.analysis.UnmappedResolution;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
@@ -21,6 +23,7 @@ import org.junit.AfterClass;
 
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.of;
@@ -88,20 +91,39 @@ public class QuerySettingsTests extends ESTestCase {
         );
     }
 
-    public void testValidate_UnmappedFields() {
+    public void testValidate_UnmappedFields_techPreview() {
+        assumeFalse("Requires no snapshot", Build.current().isSnapshot());
+
+        validateUnmappedFields("FAIL", "NULLIFY");
+        var settingName = QuerySettings.UNMAPPED_FIELDS.name();
+        assertInvalid(
+            settingName,
+            NON_SNAPSHOT_CTX_WITH_CPS_ENABLED,
+            of("UNKNOWN"),
+            "Error validating setting [unmapped_fields]: Invalid unmapped_fields resolution [UNKNOWN], must be one of [FAIL, NULLIFY]"
+        );
+    }
+
+    public void testValidate_UnmappedFields_allValues() {
+        assumeTrue("Requires unmapped fields", EsqlCapabilities.Cap.OPTIONAL_FIELDS.isEnabled());
+        validateUnmappedFields("FAIL", "NULLIFY", "LOAD");
+    }
+
+    private void validateUnmappedFields(String... values) {
         var setting = QuerySettings.UNMAPPED_FIELDS;
 
         assertDefault(setting, equalTo(UnmappedResolution.FAIL));
 
-        assertValid(setting, of(randomizeCase("fail")), equalTo(UnmappedResolution.FAIL));
-        assertValid(setting, of(randomizeCase("nullify")), equalTo(UnmappedResolution.NULLIFY));
-        assertValid(setting, of(randomizeCase("load")), equalTo(UnmappedResolution.LOAD));
+        for (String value : values) {
+            assertValid(setting, of(randomizeCase(value)), equalTo(UnmappedResolution.valueOf(value)));
+        }
 
         assertInvalid(setting.name(), of(12), "Setting [" + setting.name() + "] must be of type KEYWORD");
         assertInvalid(
             setting.name(),
             of("UNKNOWN"),
-            "Error validating setting [unmapped_fields]: Invalid unmapped_fields resolution [UNKNOWN], must be one of [FAIL, NULLIFY, LOAD]"
+            "Error validating setting [unmapped_fields]: Invalid unmapped_fields resolution [UNKNOWN], must be one of "
+                + Arrays.toString(values)
         );
     }
 
@@ -115,23 +137,13 @@ public class QuerySettingsTests extends ESTestCase {
         );
     }
 
-    public void testValidate_UnmappedFields_nonSnapshot() {
-        var setting = QuerySettings.UNMAPPED_FIELDS;
-        assertInvalid(
-            setting.name(),
-            NON_SNAPSHOT_CTX_WITH_CPS_ENABLED,
-            of("LOAD"),
-            "Setting [" + setting.name() + "] is only available in snapshot builds"
-        );
-    }
-
-    private static <T> void assertValid(QuerySettings.QuerySettingDef<T> settingDef, Literal valueLiteral, Matcher<T> parsedValueMatcher) {
-        assertValid(settingDef, valueLiteral, parsedValueMatcher, SNAPSHOT_CTX_WITH_CPS_ENABLED);
+    private static <T> void assertValid(QuerySettings.QuerySettingDef<T> settingDef, Expression value, Matcher<T> parsedValueMatcher) {
+        assertValid(settingDef, value, parsedValueMatcher, SNAPSHOT_CTX_WITH_CPS_ENABLED);
     }
 
     private static <T> void assertValid(
         QuerySettings.QuerySettingDef<T> settingDef,
-        Literal valueLiteral,
+        Expression valueLiteral,
         Matcher<T> parsedValueMatcher,
         SettingsValidationContext ctx
     ) {


### PR DESCRIPTION
Manual backport of #140528 to 9.3.

Also backports the test fix https://github.com/elastic/elasticsearch/pull/140554.