### PR TITLE
Added a note on behavior when cluster.routing.allocation.enable is set to none.

### DIFF
--- a/docs/reference/elasticsearch/configuration-reference/cluster-level-shard-allocation-routing-settings.md
+++ b/docs/reference/elasticsearch/configuration-reference/cluster-level-shard-allocation-routing-settings.md
@@ -39,6 +39,9 @@ $$$cluster-routing-allocation-enable$$$
 
 This setting only affects future allocations, and does not re-allocate or un-allocate currently allocated shards. It also does not affect the recovery of local primary shards when restarting a node. A restarted node that has a copy of an unassigned primary shard will recover that primary immediately, assuming that its allocation id matches one of the active allocation ids in the cluster state.
 
+::::{note}
+When cluster.routing.allocation.enable setting is set to none, this does not block ingestion but will prevent new indices from creating(including the indices getting created using ILM Rollover) as it prevents all primaries and their replicas from allocating to nodes within the cluster.
+::::
 
 $$$cluster-routing-allocation-same-shard-host$$$
 


### PR DESCRIPTION
Added a note on the behavior when the cluster.routing.allocation.enable setting is set to none.

As part of @stefnestor 2026 Support KB alignment project updated the docs with the latest information from our articles.


Source that were used as basis for changes.
- https://support.elastic.dev/knowledge/view/VZsIyjcS

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
