### PR TITLE
Expose xpack.inference.query_timeout in serverless

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
@@ -227,7 +227,8 @@ public class InferencePlugin extends Plugin
         TimeValue.timeValueSeconds(10),
         TimeValue.timeValueMillis(1),
         Setting.Property.NodeScope,
-        Setting.Property.Dynamic
+        Setting.Property.Dynamic,
+        Setting.Property.ServerlessPublic
     );
 
     public static final LicensedFeature.Momentary INFERENCE_API_FEATURE = LicensedFeature.momentary(


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/131551, we added the `xpack.inference.query_timeout` cluster setting to make the query-time inference timeout configurable. This PR exposes this cluster setting in serverless.