### PR TITLE
[9.1] Add a callout for the 200M limit to max_primary_shard_docs (#140625)

### DIFF
--- a/docs/reference/elasticsearch/index-lifecycle-actions/ilm-rollover.md
+++ b/docs/reference/elasticsearch/index-lifecycle-actions/ilm-rollover.md
@@ -77,6 +77,10 @@ The index will roll over once any `max_*` condition is satisfied and all `min_*`
 :   (Optional, integer) Triggers rollover when the largest primary shard in the index reaches a certain number of documents. This is the maximum docs of the primary shards in the index. As with `max_docs`, replicas are ignored.
 
     ::::{tip}
+    The rollover action implicitly always rolls over a data stream or alias if one or more shards contain 200,000,000 or more documents. Normally a shard will reach 50GB long before it reaches 200M documents, but this isn’t the case for space efficient data sets. Search performance can suffer if a shard contains more than 200M documents, which is the reason for the built-in limit. Setting the `max_primary_shard_docs` to higher than 200,000,000 will have no effect. For more information about recommended limits, refer to [guidance for shard sizes](docs-content://deploy-manage/production-guidance/optimize-performance/size-shards.md)
+    ::::
+
+    ::::{tip}
     To see the current shard docs, use the [_cat shards](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-shards) API. The `docs` value shows the number of documents each shard.
     ::::
 


### PR DESCRIPTION
Backports the following commits to 9.1:
 - Add a callout for the 200M limit to max_primary_shard_docs (#140625)