### PR TITLE
Remove all usages of TransportVersionUtils.randomVersionBetween

### DIFF
--- a/server/src/test/java/org/elasticsearch/TransportVersionTests.java
+++ b/server/src/test/java/org/elasticsearch/TransportVersionTests.java
@@ -85,8 +85,8 @@ public class TransportVersionTests extends ESTestCase {
 
     public void testMin() {
         assertEquals(
-            TransportVersionUtils.getPreviousVersion(),
-            TransportVersion.min(TransportVersion.current(), TransportVersionUtils.getPreviousVersion())
+            TransportVersionUtils.getPreviousVersion(TransportVersion.current()),
+            TransportVersion.min(TransportVersion.current(), TransportVersionUtils.getPreviousVersion(TransportVersion.current()))
         );
         assertEquals(
             TransportVersion.fromId(1_01_01_99),
@@ -104,7 +104,7 @@ public class TransportVersionTests extends ESTestCase {
     public void testMax() {
         assertEquals(
             TransportVersion.current(),
-            TransportVersion.max(TransportVersion.current(), TransportVersionUtils.getPreviousVersion())
+            TransportVersion.max(TransportVersion.current(), TransportVersionUtils.getPreviousVersion(TransportVersion.current()))
         );
         assertEquals(TransportVersion.current(), TransportVersion.max(TransportVersion.fromId(1_01_01_99), TransportVersion.current()));
         TransportVersion version = TransportVersionUtils.randomVersion();

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequestTests.java
@@ -38,10 +38,7 @@ public class ClusterStateRequestTests extends ESTestCase {
                 .indices("testindex", "testindex2")
                 .indicesOptions(indicesOptions);
 
-            TransportVersion testVersion = TransportVersionUtils.randomVersionBetween(
-                TransportVersion.minimumCompatible(),
-                TransportVersion.current()
-            );
+            TransportVersion testVersion = TransportVersionUtils.randomCompatibleVersion(random());
             if (randomBoolean()) {
                 clusterStateRequest.waitForMetadataVersion(randomLongBetween(1, Long.MAX_VALUE));
             }

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeResponseTests.java
@@ -111,10 +111,7 @@ public class FieldCapabilitiesNodeResponseTests extends AbstractWireSerializingT
         );
         Randomness.shuffle(indexResponses);
         FieldCapabilitiesNodeResponse inNode = randomNodeResponse(indexResponses);
-        final TransportVersion version = TransportVersionUtils.randomVersionBetween(
-            TransportVersion.minimumCompatible(),
-            TransportVersion.current()
-        );
+        final TransportVersion version = TransportVersionUtils.randomCompatibleVersion(random());
         final FieldCapabilitiesNodeResponse outNode = copyInstance(inNode, version);
         assertThat(outNode.getFailures().keySet(), equalTo(inNode.getFailures().keySet()));
         assertThat(outNode.getUnmatchedShardIds(), equalTo(inNode.getUnmatchedShardIds()));

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponseTests.java
@@ -164,10 +164,7 @@ public class FieldCapabilitiesResponseTests extends AbstractWireSerializingTestC
         );
         Randomness.shuffle(indexResponses);
         FieldCapabilitiesResponse inResponse = randomCCSResponse(indexResponses);
-        final TransportVersion version = TransportVersionUtils.randomVersionBetween(
-            TransportVersion.minimumCompatible(),
-            TransportVersion.current()
-        );
+        final TransportVersion version = TransportVersionUtils.randomCompatibleVersion(random());
         final FieldCapabilitiesResponse outResponse = copyInstance(inResponse, version);
         assertThat(
             outResponse.getFailures().stream().flatMap(f -> Arrays.stream(f.getIndices())).toList(),

--- a/server/src/test/java/org/elasticsearch/action/index/IndexRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/index/IndexRequestTests.java
@@ -283,9 +283,9 @@ public class IndexRequestTests extends ESTestCase {
         // old version
         {
             indexRequest.setDynamicTemplateParams(createRandomDynamicTemplateParams(1, 10));
-            TransportVersion ver = TransportVersionUtils.randomVersionBetween(
-                TransportVersion.minimumCompatible(),
-                TransportVersionUtils.getPreviousVersion(IndexRequest.INGEST_REQUEST_DYNAMIC_TEMPLATE_PARAMS)
+            TransportVersion ver = TransportVersionUtils.randomVersionNotSupporting(
+                random(),
+                IndexRequest.INGEST_REQUEST_DYNAMIC_TEMPLATE_PARAMS
             );
             BytesStreamOutput out = new BytesStreamOutput();
             out.setTransportVersion(ver);
@@ -299,9 +299,9 @@ public class IndexRequestTests extends ESTestCase {
         {
             Map<String, Map<String, String>> dynamicTemplateParams = createRandomDynamicTemplateParams(0, 10);
             indexRequest.setDynamicTemplateParams(dynamicTemplateParams);
-            TransportVersion ver = TransportVersionUtils.randomVersionBetween(
-                IndexRequest.INGEST_REQUEST_DYNAMIC_TEMPLATE_PARAMS,
-                TransportVersion.current()
+            TransportVersion ver = TransportVersionUtils.randomVersionSupporting(
+                random(),
+                IndexRequest.INGEST_REQUEST_DYNAMIC_TEMPLATE_PARAMS
             );
             BytesStreamOutput out = new BytesStreamOutput();
             out.setTransportVersion(ver);

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
@@ -233,10 +233,7 @@ public class PublicationTransportHandlerTests extends ESTestCase {
                     )
                     .build();
                 allNodes.add(node);
-                nodeTransports.put(
-                    node,
-                    TransportVersionUtils.randomVersionBetween(TransportVersion.minimumCompatible(), TransportVersion.current())
-                );
+                nodeTransports.put(node, TransportVersionUtils.randomCompatibleVersion(random()));
             }
 
             final DiscoveryNodes.Builder prevNodes = DiscoveryNodes.builder();

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/NodeBalanceStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/NodeBalanceStatsTests.java
@@ -61,10 +61,7 @@ public class NodeBalanceStatsTests extends AbstractWireSerializingTestCase<Clust
     public void testSerializationWithTransportVersionNodeWeightsAddedToNodeBalanceStats() throws IOException {
         ClusterBalanceStats.NodeBalanceStats instance = createTestInstance();
         // Serialization changes based on this version
-        final var oldVersion = TransportVersionUtils.randomVersionBetween(
-            NODE_WEIGHTS_ADDED_TO_NODE_BALANCE_STATS,
-            TransportVersion.current()
-        );
+        final var oldVersion = TransportVersionUtils.randomVersionSupporting(random(), NODE_WEIGHTS_ADDED_TO_NODE_BALANCE_STATS);
         ClusterBalanceStats.NodeBalanceStats deserialized = copyInstance(instance, oldVersion);
 
         // Assert the values are as expected

--- a/server/src/test/java/org/elasticsearch/cluster/serialization/ClusterSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/serialization/ClusterSerializationTests.java
@@ -173,10 +173,7 @@ public class ClusterSerializationTests extends ESAllocationTestCase {
     }
 
     public void testSnapshotDeletionsInProgressSerialization() throws Exception {
-        TransportVersion version = TransportVersionUtils.randomVersionBetween(
-            TransportVersion.minimumCompatible(),
-            TransportVersion.current()
-        );
+        TransportVersion version = TransportVersionUtils.randomCompatibleVersion(random());
 
         boolean includeRestore = randomBoolean();
 

--- a/server/src/test/java/org/elasticsearch/cluster/version/CompatibilityVersionsTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/version/CompatibilityVersionsTests.java
@@ -32,11 +32,8 @@ public class CompatibilityVersionsTests extends ESTestCase {
     }
 
     public void testMinimumTransportVersions() {
-        TransportVersion version1 = TransportVersionUtils.getNextVersion(TransportVersion.minimumCompatible(), true);
-        TransportVersion version2 = TransportVersionUtils.randomVersionSupporting(
-            random(),
-            TransportVersionUtils.getNextVersion(version1, true)
-        );
+        TransportVersion version1 = TransportVersion.minimumCompatible();
+        TransportVersion version2 = TransportVersionUtils.randomCompatibleVersion(random());
 
         CompatibilityVersions compatibilityVersions1 = new CompatibilityVersions(version1, Map.of());
         CompatibilityVersions compatibilityVersions2 = new CompatibilityVersions(version2, Map.of());

--- a/server/src/test/java/org/elasticsearch/cluster/version/CompatibilityVersionsTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/version/CompatibilityVersionsTests.java
@@ -33,9 +33,9 @@ public class CompatibilityVersionsTests extends ESTestCase {
 
     public void testMinimumTransportVersions() {
         TransportVersion version1 = TransportVersionUtils.getNextVersion(TransportVersion.minimumCompatible(), true);
-        TransportVersion version2 = TransportVersionUtils.randomVersionBetween(
-            TransportVersionUtils.getNextVersion(version1, true),
-            TransportVersion.current()
+        TransportVersion version2 = TransportVersionUtils.randomVersionSupporting(
+            random(),
+            TransportVersionUtils.getNextVersion(version1, true)
         );
 
         CompatibilityVersions compatibilityVersions1 = new CompatibilityVersions(version1, Map.of());
@@ -79,9 +79,9 @@ public class CompatibilityVersionsTests extends ESTestCase {
      */
     public void testMinimumsAreMerged() {
         TransportVersion version1 = TransportVersionUtils.getNextVersion(TransportVersion.minimumCompatible(), true);
-        TransportVersion version2 = TransportVersionUtils.randomVersionBetween(
-            TransportVersionUtils.getNextVersion(version1, true),
-            TransportVersion.current()
+        TransportVersion version2 = TransportVersionUtils.randomVersionSupporting(
+            random(),
+            TransportVersionUtils.getNextVersion(version1, true)
         );
 
         SystemIndexDescriptor.MappingsVersion v1 = new SystemIndexDescriptor.MappingsVersion(1, 1);
@@ -108,7 +108,7 @@ public class CompatibilityVersionsTests extends ESTestCase {
 
         // should not throw
         CompatibilityVersions.ensureVersionsCompatibility(
-            new CompatibilityVersions(TransportVersionUtils.randomVersionBetween(min, TransportVersion.current()), Map.of()),
+            new CompatibilityVersions(TransportVersionUtils.randomVersionSupporting(random(), min), Map.of()),
             compatibilityVersions
         );
 

--- a/server/src/test/java/org/elasticsearch/cluster/version/CompatibilityVersionsTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/version/CompatibilityVersionsTests.java
@@ -75,11 +75,8 @@ public class CompatibilityVersionsTests extends ESTestCase {
      * complaint.
      */
     public void testMinimumsAreMerged() {
-        TransportVersion version1 = TransportVersionUtils.getNextVersion(TransportVersion.minimumCompatible(), true);
-        TransportVersion version2 = TransportVersionUtils.randomVersionSupporting(
-            random(),
-            TransportVersionUtils.getNextVersion(version1, true)
-        );
+        TransportVersion version1 = TransportVersion.minimumCompatible();
+        TransportVersion version2 = TransportVersionUtils.randomCompatibleVersion(random());
 
         SystemIndexDescriptor.MappingsVersion v1 = new SystemIndexDescriptor.MappingsVersion(1, 1);
         SystemIndexDescriptor.MappingsVersion v2 = new SystemIndexDescriptor.MappingsVersion(2, 2);
@@ -105,7 +102,7 @@ public class CompatibilityVersionsTests extends ESTestCase {
 
         // should not throw
         CompatibilityVersions.ensureVersionsCompatibility(
-            new CompatibilityVersions(TransportVersionUtils.randomVersionSupporting(random(), min), Map.of()),
+            new CompatibilityVersions(TransportVersionUtils.getNextVersion(min, true), Map.of()),
             compatibilityVersions
         );
 

--- a/server/src/test/java/org/elasticsearch/common/io/stream/DelayableWriteableTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/DelayableWriteableTests.java
@@ -202,9 +202,6 @@ public class DelayableWriteableTests extends ESTestCase {
     }
 
     private static TransportVersion randomOldVersion() {
-        return TransportVersionUtils.randomVersionBetween(
-            TransportVersion.minimumCompatible(),
-            TransportVersionUtils.getPreviousVersion(TransportVersion.current())
-        );
+        return TransportVersionUtils.randomVersionNotSupporting(random(), TransportVersion.current());
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/io/stream/VersionCheckingStreamOutputTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/VersionCheckingStreamOutputTests.java
@@ -35,10 +35,7 @@ public class VersionCheckingStreamOutputTests extends ESTestCase {
     }
 
     public void testCheckVersionCompatibility() throws IOException {
-        TransportVersion streamVersion = TransportVersionUtils.randomVersionBetween(
-            TransportVersion.minimumCompatible(),
-            TransportVersionUtils.getPreviousVersion(TransportVersion.current())
-        );
+        TransportVersion streamVersion = TransportVersionUtils.randomVersionNotSupporting(random(), TransportVersion.current());
         try (VersionCheckingStreamOutput out = new VersionCheckingStreamOutput(streamVersion)) {
             out.writeNamedWriteable(QueryBuilders.matchAllQuery());
 

--- a/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -3471,10 +3471,7 @@ public class TranslogTests extends ESTestCase {
         Engine.IndexResult eIndexResult = new Engine.IndexResult(1, randomPrimaryTerm, randomSeqNum, true, eIndex.id());
         Translog.Index index = new Translog.Index(eIndex, eIndexResult);
 
-        TransportVersion wireVersion = TransportVersionUtils.randomVersionBetween(
-            TransportVersion.minimumCompatible(),
-            TransportVersion.current()
-        );
+        TransportVersion wireVersion = TransportVersionUtils.randomCompatibleVersion(random());
         BytesStreamOutput out = new BytesStreamOutput();
         out.setTransportVersion(wireVersion);
         index.writeTo(out);

--- a/server/src/test/java/org/elasticsearch/search/internal/ShardSearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/search/internal/ShardSearchRequestTests.java
@@ -230,7 +230,7 @@ public class ShardSearchRequestTests extends AbstractSearchTestCase {
         for (int i = 0; i < iterations; i++) {
             TransportVersion version = TransportVersionUtils.randomCompatibleVersion(random());
             if (Optional.ofNullable(request.source()).map(SearchSourceBuilder::knnSearch).map(List::size).orElse(0) > 1) {
-                version = TransportVersionUtils.randomVersionBetween(TransportVersion.minimumCompatible(), TransportVersion.current());
+                version = TransportVersionUtils.randomCompatibleVersion(random());
             }
             request = copyWriteable(request, namedWriteableRegistry, ShardSearchRequest::new, version);
             channelVersion = TransportVersion.min(channelVersion, version);

--- a/server/src/test/java/org/elasticsearch/search/suggest/SuggestTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/SuggestTests.java
@@ -293,10 +293,7 @@ public class SuggestTests extends ESTestCase {
     }
 
     public void testSerialization() throws IOException {
-        TransportVersion bwcVersion = TransportVersionUtils.randomVersionBetween(
-            TransportVersion.minimumCompatible(),
-            TransportVersion.current()
-        );
+        TransportVersion bwcVersion = TransportVersionUtils.randomCompatibleVersion(random());
 
         final Suggest suggest = createTestItem();
         final Suggest bwcSuggest;

--- a/server/src/test/java/org/elasticsearch/transport/InboundDecoderTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundDecoderTests.java
@@ -367,9 +367,7 @@ public class InboundDecoderTests extends ESTestCase {
 
     public void testCheckVersionCompatibility() {
         try {
-            InboundDecoder.checkVersionCompatibility(
-                TransportVersionUtils.randomVersionBetween(TransportVersion.minimumCompatible(), TransportVersion.current())
-            );
+            InboundDecoder.checkVersionCompatibility(TransportVersionUtils.randomCompatibleVersion(random()));
         } catch (IllegalStateException e) {
             throw new AssertionError(e);
         }

--- a/test/framework/src/main/java/org/elasticsearch/test/TransportVersionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TransportVersionUtils.java
@@ -57,44 +57,20 @@ public class TransportVersionUtils {
         return RandomPicks.randomFrom(random, allReleasedVersions());
     }
 
-    /** Returns a random {@link TransportVersion} between <code>minVersion</code> and <code>maxVersion</code> (inclusive). */
-    public static TransportVersion randomVersionBetween(@Nullable TransportVersion minVersion, @Nullable TransportVersion maxVersion) {
-        return randomVersionBetween(random(), minVersion, maxVersion);
+    /**
+     * Returns a random {@link TransportVersion} which supports the given version. Effectively, this returns a version equal to, or "later"
+     * than the given version.
+     */
+    public static TransportVersion randomVersionSupporting(Random random, TransportVersion minVersion) {
+        return RandomPicks.randomFrom(random, RELEASED_VERSIONS.stream().filter(v -> v.supports(minVersion)).toList());
     }
 
-    /** Returns a random {@link TransportVersion} between <code>minVersion</code> and <code>maxVersion</code> (inclusive). */
-    public static TransportVersion randomVersionBetween(
-        Random random,
-        @Nullable TransportVersion minVersion,
-        @Nullable TransportVersion maxVersion
-    ) {
-        if (minVersion != null && maxVersion != null && maxVersion.supports(minVersion) == false) {
-            throw new IllegalArgumentException("maxVersion [" + maxVersion + "] cannot be less than minVersion [" + minVersion + "]");
-        }
-        assertNotPatch(minVersion);
-        assertNotPatch(maxVersion);
-
-        NavigableSet<TransportVersion> versions = NON_PATCH_VERSIONS;
-        if (minVersion != null) {
-            if (versions.contains(minVersion) == false) {
-                throw new IllegalArgumentException("minVersion [" + minVersion + "] does not exist.");
-            }
-            versions = versions.tailSet(minVersion, true);
-        }
-        if (maxVersion != null) {
-            if (versions.contains(maxVersion) == false) {
-                throw new IllegalArgumentException("maxVersion [" + maxVersion + "] does not exist.");
-            }
-            versions = versions.headSet(maxVersion, true);
-        }
-
-        return RandomPicks.randomFrom(random, versions);
-    }
-
-    public static TransportVersion getPreviousVersion() {
-        TransportVersion version = getPreviousVersion(TransportVersion.current());
-        assert version.supports(TransportVersion.current()) == false;
-        return version;
+    /**
+     * Returns a random {@link TransportVersion} which does not supports the given version. Effectively, this returns a version "before"
+     * the given version.
+     */
+    public static TransportVersion randomVersionNotSupporting(Random random, TransportVersion version) {
+        return RandomPicks.randomFrom(random, RELEASED_VERSIONS.stream().filter(v -> v.supports(version) == false).toList());
     }
 
     public static TransportVersion getPreviousVersion(TransportVersion version) {
@@ -159,7 +135,7 @@ public class TransportVersionUtils {
      *
      * @return whether this version is a patch version.
      */
-    public static boolean isPatchVersion(TransportVersion version) {
+    private static boolean isPatchVersion(TransportVersion version) {
         return version.id() % 100 != 0;
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/TransportVersionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TransportVersionUtils.java
@@ -12,7 +12,6 @@ package org.elasticsearch.test;
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.core.Nullable;
 
 import java.util.Collections;
 import java.util.NavigableSet;

--- a/test/framework/src/main/java/org/elasticsearch/test/TransportVersionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TransportVersionUtils.java
@@ -138,10 +138,4 @@ public class TransportVersionUtils {
     private static boolean isPatchVersion(TransportVersion version) {
         return version.id() % 100 != 0;
     }
-
-    private static void assertNotPatch(@Nullable TransportVersion version) {
-        if (version != null && isPatchVersion(version)) {
-            throw new IllegalArgumentException("Version [" + version + "] is a patch version");
-        }
-    }
 }

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -2342,10 +2342,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
 
     public void testHandshakeUpdatesVersion() {
         assumeTrue("only tcp transport has a handshake method", serviceA.getOriginalTransport() instanceof TcpTransport);
-        TransportVersion transportVersion = TransportVersionUtils.randomVersionBetween(
-            TransportVersion.minimumCompatible(),
-            TransportVersion.current()
-        );
+        TransportVersion transportVersion = TransportVersionUtils.randomCompatibleVersion(random());
         try (
             MockTransportService service = buildService(
                 "TS_C",

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ClientHelperTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ClientHelperTests.java
@@ -422,10 +422,7 @@ public class ClientHelperTests extends ESTestCase {
         }
 
         // Rewritten for older version
-        final TransportVersion previousVersion = TransportVersionUtils.randomVersionBetween(
-            TransportVersion.minimumCompatible(),
-            TransportVersionUtils.getPreviousVersion()
-        );
+        final TransportVersion previousVersion = TransportVersionUtils.randomVersionNotSupporting(random(), TransportVersion.current());
         when(clusterState.getMinTransportVersion()).thenReturn(previousVersion);
         final Map<String, String> headers2;
         if (randomBoolean()) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationSerializationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationSerializationTests.java
@@ -113,9 +113,9 @@ public class AuthenticationSerializationTests extends ESTestCase {
         );
 
         try (BytesStreamOutput out = new BytesStreamOutput()) {
-            final TransportVersion version = TransportVersionUtils.randomVersionBetween(
-                TransportVersion.minimumCompatible(),
-                TransportVersionUtils.getPreviousVersion(SECURITY_CLOUD_API_KEY_REALM_AND_TYPE)
+            final TransportVersion version = TransportVersionUtils.randomVersionNotSupporting(
+                random(),
+                SECURITY_CLOUD_API_KEY_REALM_AND_TYPE
             );
             out.setTransportVersion(version);
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTests.java
@@ -903,9 +903,9 @@ public class AuthenticationTests extends ESTestCase {
             )
             .build();
         // pick a version before that of the authentication instance to force a rewrite
-        final TransportVersion olderVersion = TransportVersionUtils.randomVersionBetween(
-            TransportVersion.minimumCompatible(),
-            TransportVersionUtils.getPreviousVersion(authentication.getEffectiveSubject().getTransportVersion())
+        final TransportVersion olderVersion = TransportVersionUtils.randomVersionNotSupporting(
+            random(),
+            authentication.getEffectiveSubject().getTransportVersion()
         );
 
         final Map<String, Object> rewrittenMetadata = Authentication.maybeRewriteMetadataForCrossClusterAccessAuthentication(
@@ -945,15 +945,11 @@ public class AuthenticationTests extends ESTestCase {
     }
 
     public void testMaybeRewriteForOlderVersionDoesNotEraseDomainForVersionsAfterDomains() {
-        final TransportVersion olderVersion = TransportVersionUtils.randomVersionBetween(
-            TransportVersion.minimumCompatible(),
-            // Don't include CURRENT, so we always have at least one newer version available below
-            TransportVersionUtils.getPreviousVersion()
-        );
-        TransportVersion transportVersion = TransportVersionUtils.randomVersionBetween(olderVersion, null);
+        final TransportVersion olderVersion = TransportVersionUtils.randomVersionNotSupporting(random(), TransportVersion.current());
+        TransportVersion transportVersion = TransportVersionUtils.randomVersionSupporting(random(), olderVersion);
         final Authentication authentication = AuthenticationTestHelper.builder()
             .realm() // randomize to test both when realm is null on the original auth and non-null, instead of setting `underDomain`
-            // Use CURRENT to force newer version in case randomVersionBetween above picks olderVersion
+            // Use CURRENT to force newer version in case randomVersionSupporting above picks olderVersion
             .transportVersion(transportVersion.equals(olderVersion) ? TransportVersion.current() : transportVersion)
             .build();
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockSerializationTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockSerializationTests.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -424,7 +423,7 @@ public class BlockSerializationTests extends SerializationTestCase {
             try (
                 CompositeBlock deserBlock = serializeDeserializeBlockWithVersion(
                     origBlock,
-                    TransportVersionUtils.randomVersionBetween(Block.ESQL_AGGREGATE_METRIC_DOUBLE_BLOCK, TransportVersion.current())
+                    TransportVersionUtils.randomVersionSupporting(random(), Block.ESQL_AGGREGATE_METRIC_DOUBLE_BLOCK)
                 )
             ) {
                 assertThat(deserBlock.getBlockCount(), equalTo(numBlocks));
@@ -486,7 +485,7 @@ public class BlockSerializationTests extends SerializationTestCase {
             try (
                 AggregateMetricDoubleBlock deserBlock = serializeDeserializeBlockWithVersion(
                     origBlock,
-                    TransportVersionUtils.randomVersionBetween(Block.ESQL_AGGREGATE_METRIC_DOUBLE_BLOCK, TransportVersion.current())
+                    TransportVersionUtils.randomVersionSupporting(random(), Block.ESQL_AGGREGATE_METRIC_DOUBLE_BLOCK)
                 )
             ) {
                 assertThat(deserBlock, equalTo(origBlock));

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/analysis/MutableAnalyzerContext.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/analysis/MutableAnalyzerContext.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.analysis;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.TransportVersionUtils;
 import org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry;
 import org.elasticsearch.xpack.esql.index.IndexResolution;
@@ -61,7 +62,7 @@ public class MutableAnalyzerContext extends AnalyzerContext {
     public RestoreTransportVersion setTemporaryTransportVersionOnOrAfter(TransportVersion minVersion) {
         TransportVersion oldVersion = this.currentVersion;
         // Set to a random version between minVersion and current
-        this.currentVersion = TransportVersionUtils.randomVersionBetween(minVersion, TransportVersion.current());
+        this.currentVersion = TransportVersionUtils.randomVersionSupporting(ESTestCase.random(), minVersion);
         return new RestoreTransportVersion(oldVersion);
     }
 

--- a/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/action/SamlInitiateSingleSignOnRequestTests.java
+++ b/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/action/SamlInitiateSingleSignOnRequestTests.java
@@ -44,7 +44,7 @@ public class SamlInitiateSingleSignOnRequestTests extends ESTestCase {
         assertThat("An invalid request is not guaranteed to serialize correctly", request.validate(), nullValue());
         final BytesStreamOutput out = new BytesStreamOutput();
         if (randomBoolean()) {
-            out.setTransportVersion(TransportVersionUtils.randomVersionBetween(IDP_CUSTOM_SAML_ATTRIBUTES, TransportVersion.current()));
+            out.setTransportVersion(TransportVersionUtils.randomVersionSupporting(random(), IDP_CUSTOM_SAML_ATTRIBUTES));
         }
         request.writeTo(out);
 

--- a/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderDocumentTests.java
+++ b/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderDocumentTests.java
@@ -180,10 +180,7 @@ public class SamlServiceProviderDocumentTests extends IdpSamlTestCase {
     }
 
     private SamlServiceProviderDocument assertSerializationRoundTrip(SamlServiceProviderDocument doc) throws IOException {
-        final TransportVersion version = TransportVersionUtils.randomVersionBetween(
-            IDP_CUSTOM_SAML_ATTRIBUTES_ALLOW_LIST,
-            TransportVersion.current()
-        );
+        final TransportVersion version = TransportVersionUtils.randomVersionSupporting(random(), IDP_CUSTOM_SAML_ATTRIBUTES_ALLOW_LIST);
         final SamlServiceProviderDocument read = copyWriteable(
             doc,
             new NamedWriteableRegistry(List.of()),

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/queries/AbstractInterceptedInferenceQueryBuilderTestCase.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/queries/AbstractInterceptedInferenceQueryBuilderTestCase.java
@@ -163,12 +163,8 @@ public abstract class AbstractInterceptedInferenceQueryBuilderTestCase<T extends
     }
 
     public void testBwCSerialization() throws Exception {
-        TransportVersion minTransportVersion = TransportVersion.max(getMinimalSupportedVersion(), TransportVersion.minimumCompatible());
         for (int i = 0; i < 100; i++) {
-            TransportVersion transportVersion = TransportVersionUtils.randomVersionBetween(
-                minTransportVersion,
-                TransportVersionUtils.getPreviousVersion(TransportVersion.current())
-            );
+            TransportVersion transportVersion = TransportVersionUtils.randomVersionNotSupporting(random(), TransportVersion.current());
             serializationTestCase(transportVersion);
         }
     }
@@ -241,10 +237,7 @@ public abstract class AbstractInterceptedInferenceQueryBuilderTestCase<T extends
             new MockInferenceRemoteClusterClient.RemoteClusterConfig(
                 remoteInferenceEndpoints,
                 remoteIndexConfigs,
-                TransportVersionUtils.randomVersionBetween(
-                    SEMANTIC_SEARCH_CCS_SUPPORT,
-                    TransportVersionUtils.getPreviousVersion(GET_INFERENCE_FIELDS_ACTION_AS_INDICES_ACTION_TV)
-                )
+                TransportVersionUtils.getPreviousVersion(GET_INFERENCE_FIELDS_ACTION_AS_INDICES_ACTION_TV)
             );
 
         QueryRewriteContext preCcsRemoteClusterContext = createQueryRewriteContext(
@@ -274,10 +267,7 @@ public abstract class AbstractInterceptedInferenceQueryBuilderTestCase<T extends
         final T nonInferenceFieldQuery = createQueryBuilder("non_inference_field");
 
         for (int i = 0; i < 100; i++) {
-            TransportVersion transportVersion = TransportVersionUtils.randomVersionBetween(
-                TransportVersion.minimumCompatible(),
-                TransportVersionUtils.getPreviousVersion(TransportVersion.current())
-            );
+            TransportVersion transportVersion = TransportVersionUtils.randomVersionNotSupporting(random(), TransportVersion.current());
 
             QueryRewriteContext queryRewriteContext = createQueryRewriteContext(
                 Map.of("local-index", Map.of(inferenceField, SPARSE_INFERENCE_ID)),
@@ -354,10 +344,7 @@ public abstract class AbstractInterceptedInferenceQueryBuilderTestCase<T extends
         assertThat(deserializedQuery, equalTo(interceptedQuery));
 
         // Test with a transport version prior to cluster alias support, which should fail
-        TransportVersion transportVersion = TransportVersionUtils.randomVersionBetween(
-            NEW_SEMANTIC_QUERY_INTERCEPTORS,
-            TransportVersionUtils.getPreviousVersion(INFERENCE_RESULTS_MAP_WITH_CLUSTER_ALIAS)
-        );
+        TransportVersion transportVersion = TransportVersionUtils.getPreviousVersion(INFERENCE_RESULTS_MAP_WITH_CLUSTER_ALIAS);
         IllegalArgumentException e = assertThrows(
             IllegalArgumentException.class,
             () -> copyNamedWriteable(interceptedQuery, writableRegistry(), QueryBuilder.class, transportVersion)

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/queries/SemanticQueryBuilderTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/queries/SemanticQueryBuilderTests.java
@@ -439,10 +439,7 @@ public class SemanticQueryBuilderTests extends AbstractQueryTestCase<SemanticQue
         };
 
         for (int i = 0; i < 100; i++) {
-            TransportVersion transportVersion = TransportVersionUtils.randomVersionBetween(
-                TransportVersion.minimumCompatible(),
-                TransportVersion.current()
-            );
+            TransportVersion transportVersion = TransportVersionUtils.randomCompatibleVersion(random());
             assertSingleInferenceResult.accept(inferenceResults1, transportVersion);
         }
 
@@ -489,10 +486,7 @@ public class SemanticQueryBuilderTests extends AbstractQueryTestCase<SemanticQue
         };
 
         for (int i = 0; i < 100; i++) {
-            TransportVersion transportVersion = TransportVersionUtils.randomVersionBetween(
-                TransportVersion.minimumCompatible(),
-                TransportVersion.current()
-            );
+            TransportVersion transportVersion = TransportVersionUtils.randomCompatibleVersion(random());
             assertMultipleInferenceResults.accept(List.of(inferenceResults1, inferenceResults2), transportVersion);
         }
     }
@@ -507,10 +501,7 @@ public class SemanticQueryBuilderTests extends AbstractQueryTestCase<SemanticQue
         SemanticQueryBuilder originalQuery = new SemanticQueryBuilder(randomAlphaOfLength(5), randomAlphaOfLength(5), null, Map.of(), true);
 
         for (int i = 0; i < 100; i++) {
-            TransportVersion transportVersion = TransportVersionUtils.randomVersionBetween(
-                originalQuery.getMinimalSupportedVersion(),
-                TransportVersionUtils.getPreviousVersion(TransportVersion.current())
-            );
+            TransportVersion transportVersion = TransportVersionUtils.randomVersionNotSupporting(random(), TransportVersion.current());
 
             if (transportVersion.supports(SEMANTIC_SEARCH_CCS_SUPPORT)) {
                 QueryBuilder deserializedQuery = copyNamedWriteable(

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityContextTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityContextTests.java
@@ -175,12 +175,15 @@ public class SecurityContextTests extends ESTestCase {
             assertEquals(original.getAuthenticatingSubject().getRealm(), authentication.getAuthenticatingSubject().getRealm());
             assertEquals(original.isRunAs(), authentication.isRunAs());
             assertEquals(original.getEffectiveSubject().getRealm(), authentication.getEffectiveSubject().getRealm());
-            assertEquals(TransportVersionUtils.getPreviousVersion(), authentication.getEffectiveSubject().getTransportVersion());
+            assertEquals(
+                TransportVersionUtils.getPreviousVersion(TransportVersion.current()),
+                authentication.getEffectiveSubject().getTransportVersion()
+            );
             assertEquals(original.getAuthenticationType(), securityContext.getAuthentication().getAuthenticationType());
             contextAtomicReference.set(originalCtx);
             // Other request headers should be preserved
             requestHeaders.forEach((k, v) -> assertThat(threadContext.getHeader(k), equalTo(v)));
-        }, TransportVersionUtils.getPreviousVersion());
+        }, TransportVersionUtils.getPreviousVersion(TransportVersion.current()));
 
         final Authentication authAfterExecution = securityContext.getAuthentication();
         assertEquals(original, authAfterExecution);


### PR DESCRIPTION
The existence of patch versions complicates the semantics of methods like `between` related to transport verisons. These methods rely on naive comparisons of `id`, which can result in selecting a version which is actually unsupported by the minimum version.

We attempted to limit this confusion by enforcing that only non-patch versions can be used with this method in #138997 but this causes other problems when using dynamic versions like `TransportVersion.current()`, since as soon as the current branch is bumped to a patch version, these usages will fail.

Instead we've eliminated the `randomVersionBetween()` method entirely, and replaced it's usages with a combination of `randomCompatibleVersion()`, `randomVersionSupporting()` and `randomVersionNotSupporting()`. These methods have much clearer semantics (uses the "supports" terminology rather than before/after) and can safely be used with patch versions.