### PR TITLE
Refactor: Use single constant for default exponential histogram bucket limit

### DIFF
--- a/libs/exponential-histogram/src/main/java/org/elasticsearch/exponentialhistogram/ExponentialHistogramMerger.java
+++ b/libs/exponential-histogram/src/main/java/org/elasticsearch/exponentialhistogram/ExponentialHistogramMerger.java
@@ -56,7 +56,9 @@ public class ExponentialHistogramMerger implements Accountable, Releasable {
     private boolean closed = false;
 
     /**
-     * Creates a new instance with the OpenTelemetry SDK default bucket limit of {@link ExponentialHistogramMerger#DEFAULT_MAX_HISTOGRAM_BUCKETS}
+     * Creates a new instance with the OpenTelemetry SDK default bucket limit of
+     * {@link ExponentialHistogramMerger#DEFAULT_MAX_HISTOGRAM_BUCKETS}.
+     *
      * @param circuitBreaker the circuit breaker to use to limit memory allocations
      */
     public static ExponentialHistogramMerger create(ExponentialHistogramCircuitBreaker circuitBreaker) {

--- a/libs/exponential-histogram/src/main/java/org/elasticsearch/exponentialhistogram/ExponentialHistogramMerger.java
+++ b/libs/exponential-histogram/src/main/java/org/elasticsearch/exponentialhistogram/ExponentialHistogramMerger.java
@@ -37,7 +37,8 @@ import static org.elasticsearch.exponentialhistogram.ExponentialScaleUtils.getMa
  */
 public class ExponentialHistogramMerger implements Accountable, Releasable {
     // OpenTelemetry SDK default, we might make this configurable later
-    private static final int MAX_HISTOGRAM_BUCKETS = 320;
+    public static final int DEFAULT_MAX_HISTOGRAM_BUCKETS = 320;
+
     private static final long BASE_SIZE = RamUsageEstimator.shallowSizeOfInstance(ExponentialHistogramMerger.class) + DownscaleStats.SIZE;
 
     // Our algorithm is not in-place, therefore we use two histograms and ping-pong between them
@@ -55,11 +56,11 @@ public class ExponentialHistogramMerger implements Accountable, Releasable {
     private boolean closed = false;
 
     /**
-     * Creates a new instance with the OpenTelemetry SDK default bucket limit of {@link ExponentialHistogramMerger#MAX_HISTOGRAM_BUCKETS}
+     * Creates a new instance with the OpenTelemetry SDK default bucket limit of {@link ExponentialHistogramMerger#DEFAULT_MAX_HISTOGRAM_BUCKETS}
      * @param circuitBreaker the circuit breaker to use to limit memory allocations
      */
     public static ExponentialHistogramMerger create(ExponentialHistogramCircuitBreaker circuitBreaker) {
-        return create(MAX_HISTOGRAM_BUCKETS, circuitBreaker);
+        return create(DEFAULT_MAX_HISTOGRAM_BUCKETS, circuitBreaker);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExponentialHistogramState.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExponentialHistogramState.java
@@ -34,14 +34,12 @@ import java.util.List;
 
 import static org.elasticsearch.exponentialhistogram.ExponentialHistogram.MAX_SCALE;
 import static org.elasticsearch.exponentialhistogram.ExponentialHistogram.MIN_SCALE;
+import static org.elasticsearch.exponentialhistogram.ExponentialHistogramMerger.DEFAULT_MAX_HISTOGRAM_BUCKETS;
 
 /**
  * Decorates {@link ExponentialHistogram} with custom serialization and implements commonly used functionality for aggregations.
  */
 public class ExponentialHistogramState implements Releasable, Accountable {
-
-    // OpenTelemetry SDK default, we might make this configurable later
-    static final int MAX_HISTOGRAM_BUCKETS = 320;
 
     private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(ExponentialHistogramState.class);
 
@@ -106,13 +104,13 @@ public class ExponentialHistogramState implements Releasable, Accountable {
         if (mergedHistograms == null) {
             if (deserializedHistogram == null) {
                 mergedHistograms = ExponentialHistogramMerger.create(
-                    MAX_HISTOGRAM_BUCKETS,
+                    DEFAULT_MAX_HISTOGRAM_BUCKETS,
                     new ElasticCircuitBreakerWrapper(circuitBreaker)
                 );
             } else {
                 // do not upscale the deserialized histogram
                 mergedHistograms = ExponentialHistogramMerger.createWithMaxScale(
-                    MAX_HISTOGRAM_BUCKETS,
+                    DEFAULT_MAX_HISTOGRAM_BUCKETS,
                     deserializedHistogram.scale(),
                     new ElasticCircuitBreakerWrapper(circuitBreaker)
                 );

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ExponentialHistogramStateTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ExponentialHistogramStateTests.java
@@ -33,6 +33,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.IntStream;
 
+import static org.elasticsearch.exponentialhistogram.ExponentialHistogramMerger.DEFAULT_MAX_HISTOGRAM_BUCKETS;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
@@ -53,7 +54,7 @@ public class ExponentialHistogramStateTests extends ESTestCase {
     }
 
     public void testRandomHistogramSerializationAndDeserialization() throws IOException {
-        ReleasableExponentialHistogram histogram = randomHistogram(randomIntBetween(4, ExponentialHistogramState.MAX_HISTOGRAM_BUCKETS));
+        ReleasableExponentialHistogram histogram = randomHistogram(randomIntBetween(4, DEFAULT_MAX_HISTOGRAM_BUCKETS));
 
         ExponentialHistogramState state = ExponentialHistogramState.create(breaker(), histogram);
         assertThat(state.histogram(), equalTo(histogram));
@@ -95,7 +96,7 @@ public class ExponentialHistogramStateTests extends ESTestCase {
 
     public void testAdd() throws IOException {
         List<ReleasableExponentialHistogram> inputHistos = IntStream.range(0, randomIntBetween(1, 20))
-            .mapToObj(i -> randomHistogram(randomIntBetween(4, ExponentialHistogramState.MAX_HISTOGRAM_BUCKETS)))
+            .mapToObj(i -> randomHistogram(randomIntBetween(4, DEFAULT_MAX_HISTOGRAM_BUCKETS)))
             .toList();
 
         ExponentialHistogramState state = ExponentialHistogramState.create(breaker());
@@ -113,7 +114,7 @@ public class ExponentialHistogramStateTests extends ESTestCase {
         }
 
         ExponentialHistogram expectedResult = ExponentialHistogram.merge(
-            ExponentialHistogramState.MAX_HISTOGRAM_BUCKETS,
+            DEFAULT_MAX_HISTOGRAM_BUCKETS,
             ExponentialHistogramCircuitBreaker.noop(),
             inputHistos.iterator()
         );


### PR DESCRIPTION
During the downsampling implementation @gmarouli moved the default, OpenTelemetry based bucket limit for exponential histograms rightfully into the exponential histogram library.

This PR removed the duplication of this constant in the ES|QL merge implementation and ensures we really use only this constant everywhere. 
