### PR TITLE
Use IndexOrDocValuesQuery in NumberFieldType#termQuery implementations

### DIFF
--- a/docs/changelog/140734.yaml
+++ b/docs/changelog/140734.yaml
@@ -1,0 +1,5 @@
+pr: 140734
+summary: Use `IndexOrDocValuesQuery` in `NumberFieldType#termQuery` implementations
+area: Search
+type: enhancement
+issues: []

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
@@ -308,7 +308,7 @@ public class ScaledFloatFieldMapper extends FieldMapper {
         public Query termQuery(Object value, SearchExecutionContext context) {
             failIfNotIndexedNorDocValuesFallback(context);
             long scaledValue = Math.round(scale(value));
-            return NumberFieldMapper.NumberType.LONG.termQuery(name(), scaledValue, indexType().hasPoints());
+            return NumberFieldMapper.NumberType.LONG.termQuery(name(), scaledValue, indexType());
         }
 
         @Override

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldTypeTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldTypeTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.index.mapper.extras;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.DoublePoint;
+import org.apache.lucene.document.LongField;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.DirectoryReader;
@@ -48,7 +49,7 @@ public class ScaledFloatFieldTypeTests extends FieldTypeTestCase {
         );
         double value = (randomDouble() * 2 - 1) * 10000;
         long scaledValue = Math.round(value * ft.getScalingFactor());
-        assertEquals(LongPoint.newExactQuery("scaled_float", scaledValue), ft.termQuery(value, MOCK_CONTEXT));
+        assertEquals(LongField.newExactQuery("scaled_float", scaledValue), ft.termQuery(value, MOCK_CONTEXT));
 
         MappedFieldType ft2 = new ScaledFloatFieldMapper.ScaledFloatFieldType("scaled_float", 0.1 + randomDouble() * 100, false);
         ElasticsearchException e2 = expectThrows(ElasticsearchException.class, () -> ft2.termQuery("42", MOCK_CONTEXT_DISALLOW_EXPENSIVE));

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
@@ -12,9 +12,13 @@ package org.elasticsearch.index.mapper;
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 
 import org.apache.lucene.document.Document;
+import org.apache.lucene.document.DoubleField;
 import org.apache.lucene.document.DoublePoint;
+import org.apache.lucene.document.FloatField;
 import org.apache.lucene.document.FloatPoint;
+import org.apache.lucene.document.IntField;
 import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.document.LongField;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.DirectoryReader;
@@ -109,22 +113,46 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
     }
 
     public void testByteTermQueryWithDecimalPart() {
-        MappedFieldType ft = new NumberFieldMapper.NumberFieldType("field", NumberType.BYTE, randomBoolean());
+        MappedFieldType ft = new NumberFieldMapper.NumberFieldType("field", NumberType.BYTE, true, true);
+        assertTrue(ft.termQuery(42.1, MOCK_CONTEXT) instanceof MatchNoDocsQuery);
+
+        ft = new NumberFieldMapper.NumberFieldType("field", NumberType.BYTE, true, false);
+        assertTrue(ft.termQuery(42.1, MOCK_CONTEXT) instanceof MatchNoDocsQuery);
+
+        ft = new NumberFieldMapper.NumberFieldType("field", NumberType.BYTE, false, true);
         assertTrue(ft.termQuery(42.1, MOCK_CONTEXT) instanceof MatchNoDocsQuery);
     }
 
     public void testShortTermQueryWithDecimalPart() {
-        MappedFieldType ft = new NumberFieldMapper.NumberFieldType("field", NumberType.SHORT, randomBoolean());
+        MappedFieldType ft = new NumberFieldMapper.NumberFieldType("field", NumberType.SHORT, true, true);
+        assertTrue(ft.termQuery(42.1, MOCK_CONTEXT) instanceof MatchNoDocsQuery);
+
+        ft = new NumberFieldMapper.NumberFieldType("field", NumberType.SHORT, false, true);
+        assertTrue(ft.termQuery(42.1, MOCK_CONTEXT) instanceof MatchNoDocsQuery);
+
+        ft = new NumberFieldMapper.NumberFieldType("field", NumberType.SHORT, true, false);
         assertTrue(ft.termQuery(42.1, MOCK_CONTEXT) instanceof MatchNoDocsQuery);
     }
 
     public void testIntegerTermQueryWithDecimalPart() {
-        MappedFieldType ft = new NumberFieldMapper.NumberFieldType("field", NumberType.INTEGER, randomBoolean());
+        MappedFieldType ft = new NumberFieldMapper.NumberFieldType("field", NumberType.INTEGER, true, true);
+        assertTrue(ft.termQuery(42.1, MOCK_CONTEXT) instanceof MatchNoDocsQuery);
+
+        ft = new NumberFieldMapper.NumberFieldType("field", NumberType.INTEGER, true, false);
+        assertTrue(ft.termQuery(42.1, MOCK_CONTEXT) instanceof MatchNoDocsQuery);
+
+        ft = new NumberFieldMapper.NumberFieldType("field", NumberType.INTEGER, false, true);
         assertTrue(ft.termQuery(42.1, MOCK_CONTEXT) instanceof MatchNoDocsQuery);
     }
 
     public void testLongTermQueryWithDecimalPart() {
-        MappedFieldType ft = new NumberFieldMapper.NumberFieldType("field", NumberFieldMapper.NumberType.LONG, randomBoolean());
+        MappedFieldType ft = new NumberFieldMapper.NumberFieldType("field", NumberFieldMapper.NumberType.LONG, true, true);
+        assertTrue(ft.termQuery(42.1, MOCK_CONTEXT) instanceof MatchNoDocsQuery);
+
+        ft = new NumberFieldMapper.NumberFieldType("field", NumberFieldMapper.NumberType.LONG, true, false);
+        assertTrue(ft.termQuery(42.1, MOCK_CONTEXT) instanceof MatchNoDocsQuery);
+
+        ft = new NumberFieldMapper.NumberFieldType("field", NumberFieldMapper.NumberType.LONG, false, true);
         assertTrue(ft.termQuery(42.1, MOCK_CONTEXT) instanceof MatchNoDocsQuery);
     }
 
@@ -145,23 +173,74 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
         );
     }
 
+    private record TermQueryTestCase(NumberType type, Query[] expectedQueries) {}
+
     public void testTermQuery() {
-        MappedFieldType ft = new NumberFieldMapper.NumberFieldType("field", NumberFieldMapper.NumberType.LONG);
-        assertEquals(LongPoint.newExactQuery("field", 42), ft.termQuery("42", MOCK_CONTEXT));
-
-        ft = new NumberFieldMapper.NumberFieldType("field", NumberFieldMapper.NumberType.LONG, false);
-        assertEquals(SortedNumericDocValuesField.newSlowExactQuery("field", 42), ft.termQuery("42", MOCK_CONTEXT));
-
-        MappedFieldType unsearchable = unsearchable();
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> unsearchable.termQuery("42", MOCK_CONTEXT));
-        assertEquals("Cannot search on field [field] since it is not indexed nor has doc values.", e.getMessage());
-
-        MappedFieldType ft2 = new NumberFieldMapper.NumberFieldType("field", NumberFieldMapper.NumberType.LONG, false);
-        ElasticsearchException e2 = expectThrows(ElasticsearchException.class, () -> ft2.termQuery("42", MOCK_CONTEXT_DISALLOW_EXPENSIVE));
-        assertEquals(
-            "Cannot search on field [field] since it is not indexed and 'search.allow_expensive_queries' is set to false.",
-            e2.getMessage()
+        Query[] expectedIntegerQueries = new Query[] {
+            IntField.newExactQuery("field", 42),
+            IntPoint.newExactQuery("field", 42),
+            SortedNumericDocValuesField.newSlowExactQuery("field", 42) };
+        List<TermQueryTestCase> testCases = List.of(
+            new TermQueryTestCase(NumberType.BYTE, expectedIntegerQueries),
+            new TermQueryTestCase(NumberType.SHORT, expectedIntegerQueries),
+            new TermQueryTestCase(NumberType.INTEGER, expectedIntegerQueries),
+            new TermQueryTestCase(
+                NumberType.LONG,
+                new Query[] {
+                    LongField.newExactQuery("field", 42),
+                    LongPoint.newExactQuery("field", 42),
+                    SortedNumericDocValuesField.newSlowExactQuery("field", 42) }
+            ),
+            new TermQueryTestCase(
+                NumberType.FLOAT,
+                new Query[] {
+                    FloatField.newExactQuery("field", 42),
+                    FloatPoint.newExactQuery("field", 42),
+                    SortedNumericDocValuesField.newSlowExactQuery("field", NumericUtils.floatToSortableInt(42)) }
+            ),
+            new TermQueryTestCase(
+                NumberType.DOUBLE,
+                new Query[] {
+                    DoubleField.newExactQuery("field", 42),
+                    DoublePoint.newExactQuery("field", 42),
+                    SortedNumericDocValuesField.newSlowExactQuery("field", NumericUtils.doubleToSortableLong(42)) }
+            ),
+            new TermQueryTestCase(
+                NumberType.HALF_FLOAT,
+                new Query[] {
+                    new IndexOrDocValuesQuery(
+                        HalfFloatPoint.newExactQuery("field", 42),
+                        SortedNumericDocValuesField.newSlowExactQuery("field", HalfFloatPoint.halfFloatToSortableShort(42))
+                    ),
+                    HalfFloatPoint.newExactQuery("field", 42),
+                    SortedNumericDocValuesField.newSlowExactQuery("field", HalfFloatPoint.halfFloatToSortableShort(42)) }
+            )
         );
+
+        for (TermQueryTestCase testCase : testCases) {
+            MappedFieldType ft = new NumberFieldMapper.NumberFieldType("field", testCase.type());
+            assertEquals(testCase.expectedQueries[0], ft.termQuery("42", MOCK_CONTEXT));
+
+            ft = new NumberFieldMapper.NumberFieldType("field", testCase.type(), true, false);
+            assertEquals(testCase.expectedQueries[1], ft.termQuery("42", MOCK_CONTEXT));
+
+            ft = new NumberFieldMapper.NumberFieldType("field", testCase.type(), false, true);
+            assertEquals(testCase.expectedQueries[2], ft.termQuery("42", MOCK_CONTEXT));
+
+            MappedFieldType unsearchable = new NumberFieldMapper.NumberFieldType("field", testCase.type(), false, false);
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> unsearchable.termQuery("42", MOCK_CONTEXT));
+            assertEquals("Cannot search on field [field] since it is not indexed nor has doc values.", e.getMessage());
+
+            MappedFieldType ft2 = new NumberFieldMapper.NumberFieldType("field", testCase.type(), false, true);
+            ElasticsearchException e2 = expectThrows(
+                ElasticsearchException.class,
+                () -> ft2.termQuery("42", MOCK_CONTEXT_DISALLOW_EXPENSIVE)
+            );
+            assertEquals(
+                "Cannot search on field [field] since it is not indexed and 'search.allow_expensive_queries' is set to false.",
+                e2.getMessage()
+            );
+        }
     }
 
     private record OutOfRangeTermQueryTestCase(NumberType type, Object value) {}
@@ -201,12 +280,25 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
         );
 
         for (OutOfRangeTermQueryTestCase testCase : testCases) {
-            assertTrue(testCase.type.termQuery("field", testCase.value, randomBoolean()) instanceof MatchNoDocsQuery);
+            boolean indexed = randomBoolean();
+            boolean hasDocValues = indexed == false || randomBoolean();
+            assertTrue(
+                testCase.type.termQuery("field", testCase.value, IndexType.points(indexed, hasDocValues)) instanceof MatchNoDocsQuery
+            );
         }
     }
 
     public void testRangeQueryWithNegativeBounds() {
-        MappedFieldType ftInt = new NumberFieldMapper.NumberFieldType("field", NumberType.INTEGER, randomBoolean());
+        testIntegerRangeQueryWithNegativeBounds(new NumberFieldMapper.NumberFieldType("field", NumberType.INTEGER, true, true));
+        testIntegerRangeQueryWithNegativeBounds(new NumberFieldMapper.NumberFieldType("field", NumberType.INTEGER, false, true));
+        testIntegerRangeQueryWithNegativeBounds(new NumberFieldMapper.NumberFieldType("field", NumberType.INTEGER, true, false));
+
+        testLongRangeQueryWithNegativeBounds(new NumberFieldMapper.NumberFieldType("field", NumberType.LONG, true, true));
+        testLongRangeQueryWithNegativeBounds(new NumberFieldMapper.NumberFieldType("field", NumberType.LONG, false, true));
+        testLongRangeQueryWithNegativeBounds(new NumberFieldMapper.NumberFieldType("field", NumberType.LONG, true, false));
+    }
+
+    private void testIntegerRangeQueryWithNegativeBounds(MappedFieldType ftInt) {
         assertEquals(
             ftInt.rangeQuery(-3, -3, true, true, null, null, null, MOCK_CONTEXT),
             ftInt.rangeQuery(-3.5, -2.5, true, true, null, null, null, MOCK_CONTEXT)
@@ -256,8 +348,9 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
             ftInt.rangeQuery(-2, -1, true, true, null, null, null, MOCK_CONTEXT),
             ftInt.rangeQuery(-2.5, -0.5, false, false, null, null, null, MOCK_CONTEXT)
         );
+    }
 
-        MappedFieldType ftLong = new NumberFieldMapper.NumberFieldType("field", NumberType.LONG, randomBoolean());
+    private void testLongRangeQueryWithNegativeBounds(MappedFieldType ftLong) {
         assertEquals(
             ftLong.rangeQuery(-3, -3, true, true, null, null, null, MOCK_CONTEXT),
             ftLong.rangeQuery(-3.5, -2.5, true, true, null, null, null, MOCK_CONTEXT)
@@ -310,7 +403,12 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
     }
 
     public void testByteRangeQueryWithDecimalParts() {
-        MappedFieldType ft = new NumberFieldMapper.NumberFieldType("field", NumberType.BYTE, randomBoolean());
+        testByteRangeQueryWithDecimalParts(new NumberFieldMapper.NumberFieldType("field", NumberType.BYTE, true, true));
+        testByteRangeQueryWithDecimalParts(new NumberFieldMapper.NumberFieldType("field", NumberType.BYTE, false, true));
+        testByteRangeQueryWithDecimalParts(new NumberFieldMapper.NumberFieldType("field", NumberType.BYTE, true, false));
+    }
+
+    private void testByteRangeQueryWithDecimalParts(MappedFieldType ft) {
         assertEquals(
             ft.rangeQuery(2, 10, true, true, null, null, null, MOCK_CONTEXT),
             ft.rangeQuery(1.1, 10, true, true, null, null, null, MOCK_CONTEXT)
@@ -330,7 +428,12 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
     }
 
     public void testShortRangeQueryWithDecimalParts() {
-        MappedFieldType ft = new NumberFieldMapper.NumberFieldType("field", NumberType.SHORT, randomBoolean());
+        testShortRangeQueryWithDecimalParts(new NumberFieldMapper.NumberFieldType("field", NumberType.SHORT, true, true));
+        testShortRangeQueryWithDecimalParts(new NumberFieldMapper.NumberFieldType("field", NumberType.SHORT, true, false));
+        testShortRangeQueryWithDecimalParts(new NumberFieldMapper.NumberFieldType("field", NumberType.SHORT, false, true));
+    }
+
+    private void testShortRangeQueryWithDecimalParts(MappedFieldType ft) {
         assertEquals(
             ft.rangeQuery(2, 10, true, true, null, null, null, MOCK_CONTEXT),
             ft.rangeQuery(1.1, 10, true, true, null, null, null, MOCK_CONTEXT)
@@ -350,7 +453,12 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
     }
 
     public void testIntegerRangeQueryWithDecimalParts() {
-        MappedFieldType ft = new NumberFieldMapper.NumberFieldType("field", NumberType.INTEGER, randomBoolean());
+        testIntegerRangeQueryWithDecimalParts(new NumberFieldMapper.NumberFieldType("field", NumberType.INTEGER, true, true));
+        testIntegerRangeQueryWithDecimalParts(new NumberFieldMapper.NumberFieldType("field", NumberType.INTEGER, false, true));
+        testIntegerRangeQueryWithDecimalParts(new NumberFieldMapper.NumberFieldType("field", NumberType.INTEGER, true, false));
+    }
+
+    private void testIntegerRangeQueryWithDecimalParts(MappedFieldType ft) {
         assertEquals(
             ft.rangeQuery(2, 10, true, true, null, null, null, MOCK_CONTEXT),
             ft.rangeQuery(1.1, 10, true, true, null, null, null, MOCK_CONTEXT)
@@ -370,7 +478,12 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
     }
 
     public void testLongRangeQueryWithDecimalParts() {
-        MappedFieldType ft = new NumberFieldMapper.NumberFieldType("field", NumberType.LONG, randomBoolean());
+        testLongRangeQueryWithDecimalParts(new NumberFieldMapper.NumberFieldType("field", NumberType.LONG, true, true));
+        testLongRangeQueryWithDecimalParts(new NumberFieldMapper.NumberFieldType("field", NumberType.LONG, false, true));
+        testLongRangeQueryWithDecimalParts(new NumberFieldMapper.NumberFieldType("field", NumberType.LONG, true, false));
+    }
+
+    private void testLongRangeQueryWithDecimalParts(MappedFieldType ft) {
         assertEquals(
             ft.rangeQuery(2, 10, true, true, null, null, null, MOCK_CONTEXT),
             ft.rangeQuery(1.1, 10, true, true, null, null, null, MOCK_CONTEXT)
@@ -390,7 +503,12 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
     }
 
     public void testHalfFloatRangeQueryWithOverflowingBounds() {
-        MappedFieldType ft = new NumberFieldMapper.NumberFieldType("field", NumberType.HALF_FLOAT, randomBoolean());
+        testHalfFloatRangeQueryWithOverflowingBounds(new NumberFieldMapper.NumberFieldType("field", NumberType.HALF_FLOAT, true, true));
+        testHalfFloatRangeQueryWithOverflowingBounds(new NumberFieldMapper.NumberFieldType("field", NumberType.HALF_FLOAT, false, true));
+        testHalfFloatRangeQueryWithOverflowingBounds(new NumberFieldMapper.NumberFieldType("field", NumberType.HALF_FLOAT, true, false));
+    }
+
+    private void testHalfFloatRangeQueryWithOverflowingBounds(MappedFieldType ft) {
         final float min_half_float = -65504;
         final float max_half_float = 65504;
         assertEquals(
@@ -435,8 +553,12 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
     }
 
     public void testFloatRangeQueryWithOverflowingBounds() {
-        MappedFieldType ft = new NumberFieldMapper.NumberFieldType("field", NumberType.FLOAT, randomBoolean());
+        testFloatRangeQueryWithOverflowingBounds(new NumberFieldMapper.NumberFieldType("field", NumberType.FLOAT, true, true));
+        testFloatRangeQueryWithOverflowingBounds(new NumberFieldMapper.NumberFieldType("field", NumberType.FLOAT, false, true));
+        testFloatRangeQueryWithOverflowingBounds(new NumberFieldMapper.NumberFieldType("field", NumberType.FLOAT, true, false));
+    }
 
+    private void testFloatRangeQueryWithOverflowingBounds(MappedFieldType ft) {
         assertEquals(
             ft.rangeQuery(-Float.MAX_VALUE, 10.0, true, true, null, null, null, MOCK_CONTEXT),
             ft.rangeQuery(-1e+300, 10.0, true, true, null, null, null, MOCK_CONTEXT)
@@ -486,18 +608,18 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
         );
         assertEquals(expected, ft.rangeQuery("1", "3", true, true, null, null, null, MOCK_CONTEXT));
 
-        ft = new NumberFieldMapper.NumberFieldType("field", NumberFieldMapper.NumberType.LONG, false);
+        ft = new NumberFieldMapper.NumberFieldType("field", NumberFieldMapper.NumberType.LONG, false, true);
         expected = SortedNumericDocValuesField.newSlowRangeQuery("field", 1, 3);
         assertEquals(expected, ft.rangeQuery("1", "3", true, true, null, null, null, MOCK_CONTEXT));
 
-        MappedFieldType unsearchable = unsearchable();
+        MappedFieldType unsearchable = new NumberFieldMapper.NumberFieldType("field", NumberFieldMapper.NumberType.LONG, false, false);
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
             () -> unsearchable.rangeQuery("1", "3", true, true, null, null, null, MOCK_CONTEXT)
         );
         assertEquals("Cannot search on field [field] since it is not indexed nor has doc values.", e.getMessage());
 
-        MappedFieldType ft2 = new NumberFieldMapper.NumberFieldType("field", NumberFieldMapper.NumberType.LONG, false);
+        MappedFieldType ft2 = new NumberFieldMapper.NumberFieldType("field", NumberFieldMapper.NumberType.LONG, false, true);
         ElasticsearchException e2 = expectThrows(
             ElasticsearchException.class,
             () -> ft2.rangeQuery("1", "3", true, true, null, null, null, MOCK_CONTEXT_DISALLOW_EXPENSIVE)
@@ -638,9 +760,19 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
             NumberType.HALF_FLOAT.rangeQuery("field", null, +0f, true, false, false, MOCK_CONTEXT, isIndexed)
         );
 
-        assertNotEquals(NumberType.DOUBLE.termQuery("field", -0d, isIndexed), NumberType.DOUBLE.termQuery("field", +0d, isIndexed));
-        assertNotEquals(NumberType.FLOAT.termQuery("field", -0f, isIndexed), NumberType.FLOAT.termQuery("field", +0f, isIndexed));
-        assertNotEquals(NumberType.HALF_FLOAT.termQuery("field", -0f, isIndexed), NumberType.HALF_FLOAT.termQuery("field", +0f, isIndexed));
+        final boolean hasDocValues = isIndexed == false || randomBoolean(); // at least one should be true
+        assertNotEquals(
+            NumberType.DOUBLE.termQuery("field", -0d, IndexType.points(isIndexed, hasDocValues)),
+            NumberType.DOUBLE.termQuery("field", +0d, IndexType.points(isIndexed, hasDocValues))
+        );
+        assertNotEquals(
+            NumberType.FLOAT.termQuery("field", -0f, IndexType.points(isIndexed, hasDocValues)),
+            NumberType.FLOAT.termQuery("field", +0f, IndexType.points(isIndexed, hasDocValues))
+        );
+        assertNotEquals(
+            NumberType.HALF_FLOAT.termQuery("field", -0f, IndexType.points(isIndexed, hasDocValues)),
+            NumberType.HALF_FLOAT.termQuery("field", +0f, IndexType.points(isIndexed, hasDocValues))
+        );
     }
 
     // Make sure we construct the IndexOrDocValuesQuery objects with queries that match

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/ttest/TTestAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/ttest/TTestAggregatorTests.java
@@ -588,8 +588,8 @@ public class TTestAggregatorTests extends AggregatorTestCase {
 
     public void testFiltered() throws IOException {
         TTestType tTestType = randomFrom(TTestType.values());
-        MappedFieldType fieldType1 = new NumberFieldMapper.NumberFieldType("a", NumberFieldMapper.NumberType.INTEGER);
-        MappedFieldType fieldType2 = new NumberFieldMapper.NumberFieldType("b", NumberFieldMapper.NumberType.INTEGER);
+        MappedFieldType fieldType1 = new NumberFieldMapper.NumberFieldType("a", NumberFieldMapper.NumberType.INTEGER, false, true);
+        MappedFieldType fieldType2 = new NumberFieldMapper.NumberFieldType("b", NumberFieldMapper.NumberType.INTEGER, true, false);
         TTestAggregationBuilder aggregationBuilder = new TTestAggregationBuilder("t_test").a(
             new MultiValuesSourceFieldConfig.Builder().setFieldName("a").setFilter(QueryBuilders.termQuery("b", 1)).build()
         )
@@ -644,9 +644,9 @@ public class TTestAggregatorTests extends AggregatorTestCase {
 
     public void testFilteredAsSubAgg() throws IOException {
         TTestType tTestType = randomFrom(TTestType.values());
-        MappedFieldType fieldType1 = new NumberFieldMapper.NumberFieldType("h", NumberFieldMapper.NumberType.INTEGER);
-        MappedFieldType fieldType2 = new NumberFieldMapper.NumberFieldType("a", NumberFieldMapper.NumberType.INTEGER);
-        MappedFieldType fieldType3 = new NumberFieldMapper.NumberFieldType("b", NumberFieldMapper.NumberType.INTEGER);
+        MappedFieldType fieldType1 = new NumberFieldMapper.NumberFieldType("h", NumberFieldMapper.NumberType.INTEGER, false, true);
+        MappedFieldType fieldType2 = new NumberFieldMapper.NumberFieldType("a", NumberFieldMapper.NumberType.INTEGER, false, true);
+        MappedFieldType fieldType3 = new NumberFieldMapper.NumberFieldType("b", NumberFieldMapper.NumberType.INTEGER, true, false);
         TTestAggregationBuilder ttestAggregationBuilder = new TTestAggregationBuilder("t_test").a(
             new MultiValuesSourceFieldConfig.Builder().setFieldName("a").setFilter(QueryBuilders.termQuery("b", 1)).build()
         )
@@ -717,7 +717,7 @@ public class TTestAggregatorTests extends AggregatorTestCase {
         boolean fieldInA = randomBoolean();
         TTestType tTestType = randomFrom(TTestType.HOMOSCEDASTIC, TTestType.HETEROSCEDASTIC);
 
-        MappedFieldType fieldType1 = new NumberFieldMapper.NumberFieldType("field", NumberFieldMapper.NumberType.INTEGER);
+        MappedFieldType fieldType1 = new NumberFieldMapper.NumberFieldType("field", NumberFieldMapper.NumberType.INTEGER, false, true);
         MappedFieldType fieldType2 = new NumberFieldMapper.NumberFieldType("term", NumberFieldMapper.NumberType.INTEGER);
 
         boolean filterTermOne = randomBoolean();

--- a/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldTypeTests.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/test/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateMetricDoubleFieldTypeTests.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.aggregatemetric.mapper;
 
+import org.apache.lucene.document.DoubleField;
 import org.apache.lucene.document.DoublePoint;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.index.DirectoryReader;
@@ -62,7 +63,7 @@ public class AggregateMetricDoubleFieldTypeTests extends FieldTypeTestCase {
     public void testTermQuery() {
         final MappedFieldType fieldType = createDefaultFieldType("foo", Collections.emptyMap(), Metric.max);
         Query query = fieldType.termQuery(55.2, MOCK_CONTEXT);
-        assertThat(query, equalTo(DoublePoint.newRangeQuery("foo.max", 55.2, 55.2)));
+        assertThat(query, equalTo(DoubleField.newRangeQuery("foo.max", 55.2, 55.2)));
     }
 
     public void testTermsQuery() {


### PR DESCRIPTION
Use IndexOrDocValuesQuery whenever possible so for low cardinality fields we don't need to allocated a FixedBitSet if the query is together with more restrictive filters.

relates https://github.com/elastic/elasticsearch/pull/128293