### PR TITLE
[8.19] Fix updatecli configuration for updating Iron Bank docker images (#140562)

### DIFF
--- a/.github/updatecli/values.d/ironbank.yml
+++ b/.github/updatecli/values.d/ironbank.yml
@@ -1,6 +1,6 @@
 config:
   - path: distribution/docker/src/docker/iron_bank
-    dockerfile: ../dockerfiles/ironbank/Dockerfile
+    dockerfile: ../Dockerfile
 
 pull_request:
   labels:

--- a/.github/updatecli/values.d/ironbank.yml
+++ b/.github/updatecli/values.d/ironbank.yml
@@ -1,0 +1,11 @@
+config:
+  - path: distribution/docker/src/docker/iron_bank
+    dockerfile: ../dockerfiles/ironbank/Dockerfile
+
+pull_request:
+  labels:
+    - ":Delivery/Tooling"
+    - ":Delivery/Packaging"
+    - "auto-merge-without-approval"
+    - "dependencies"
+

--- a/.github/updatecli/values.d/scm.yml
+++ b/.github/updatecli/values.d/scm.yml
@@ -1,0 +1,16 @@
+scm:
+  enabled: true
+  owner: elastic
+  repository: elasticsearch
+  branch: "main" # this value is overwritten by the GH workflow to match current branch
+  commitusingapi: true
+  # begin updatecli-compose policy values
+  user: elasticmachine
+  email: 42973632+elasticmachine@users.noreply.github.com
+  # end updatecli-compose policy values
+
+pull_request:
+  labels:
+    - ":Delivery/Tooling"
+    - "auto-merge-without-approval"
+    - "dependencies"

--- a/.github/updatecli/values.d/updatecli-compose.yml
+++ b/.github/updatecli/values.d/updatecli-compose.yml
@@ -1,0 +1,3 @@
+spec:
+  files:
+    - "updatecli-compose.yaml"

--- a/updatecli-compose.yaml
+++ b/updatecli-compose.yaml
@@ -1,0 +1,13 @@
+# Config file for `updatecli compose ...`.
+# https://www.updatecli.io/docs/core/compose/
+policies:
+  - name: Handle ironbank bumps
+    policy: ghcr.io/elastic/oblt-updatecli-policies/ironbank/templates:0.5.3@sha256:1d5b2f8ca1c141ebe0368d39ec1cdf8bc32662795a21416907eb02b8bf40d890
+    values:
+      - .github/updatecli/values.d/scm.yml
+      - .github/updatecli/values.d/ironbank.yml
+  - name: Update Updatecli policies
+    policy: ghcr.io/updatecli/policies/autodiscovery/updatecli:0.8.0@sha256:99e9e61b501575c2c176c39f2275998d198b590a3f6b1fe829f7315f8d457e7f
+    values:
+      - .github/updatecli/values.d/scm.yml
+      - .github/updatecli/values.d/updatecli-compose.yml


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix updatecli configuration for updating Iron Bank docker images (#140562)](https://github.com/elastic/elasticsearch/pull/140562)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)