### PR TITLE
Configurable priority/max-timeout for auto-create

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/metadata/CreateIndexTimeoutIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/metadata/CreateIndexTimeoutIT.java
@@ -19,9 +19,12 @@ import org.elasticsearch.action.admin.indices.create.TransportCreateIndexAction;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.action.admin.indices.mapping.put.TransportAutoPutMappingAction;
 import org.elasticsearch.action.admin.indices.mapping.put.TransportPutMappingAction;
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseListener;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -35,11 +38,14 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.RestUtils;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.test.rest.ObjectPath;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CyclicBarrier;
+import java.util.function.Consumer;
 
+import static org.elasticsearch.action.admin.indices.create.AutoCreateAction.AUTO_CREATE_INDEX_MAX_TIMEOUT_SETTING;
 import static org.elasticsearch.cluster.metadata.MetadataCreateIndexService.CREATE_INDEX_MAX_TIMEOUT_SETTING;
 import static org.elasticsearch.cluster.metadata.MetadataMappingService.PUT_MAPPING_MAX_TIMEOUT_SETTING;
 import static org.hamcrest.Matchers.allOf;
@@ -53,6 +59,7 @@ public class CreateIndexTimeoutIT extends ESIntegTestCase {
         public List<Setting<?>> getSettings() {
             return CollectionUtils.appendToCopyNoNullElements(
                 super.getSettings(),
+                AUTO_CREATE_INDEX_MAX_TIMEOUT_SETTING,
                 CREATE_INDEX_MAX_TIMEOUT_SETTING,
                 PUT_MAPPING_MAX_TIMEOUT_SETTING
             );
@@ -68,6 +75,7 @@ public class CreateIndexTimeoutIT extends ESIntegTestCase {
     protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
         return Settings.builder()
             .put(otherSettings)
+            .put(AUTO_CREATE_INDEX_MAX_TIMEOUT_SETTING.getKey(), "1ms")
             .put(CREATE_INDEX_MAX_TIMEOUT_SETTING.getKey(), "1ms")
             .put(PUT_MAPPING_MAX_TIMEOUT_SETTING.getKey(), "1ms")
             .build();
@@ -95,6 +103,67 @@ public class CreateIndexTimeoutIT extends ESIntegTestCase {
     @Override
     protected boolean addMockHttpTransport() {
         return false; // enable HTTP
+    }
+
+    public void testAutoCreateTimeoutLimit() throws Exception {
+        final var masterClusterService = internalCluster().getCurrentMasterNodeInstance(ClusterService.class);
+        final var restClient = getRestClient();
+        final var indexName = randomIndexName();
+
+        final Consumer<Request> timeoutApplier;
+        if (randomBoolean()) {
+            timeoutApplier = r -> {};
+        } else {
+            var timeout = randomFrom(
+                MasterNodeRequest.INFINITE_MASTER_NODE_TIMEOUT,
+                TimeValue.MINUS_ONE,
+                TimeValue.THIRTY_SECONDS,
+                TimeValue.MAX_VALUE
+            ).getStringRep();
+            timeoutApplier = r -> r.addParameter("timeout", timeout);
+        }
+
+        try (var ignored = withBlockedMasterService(masterClusterService)) {
+            final var request = new Request("PUT", "/" + indexName + "/_bulk");
+            request.setJsonEntity("""
+                {"index":{}}
+                {}
+                """);
+            timeoutApplier.accept(request);
+            final var response = ObjectPath.createFromResponse(restClient.performRequest(request));
+            logger.info("--> response={}", response);
+            assertTrue(response.evaluate("errors"));
+            assertEquals(RestStatus.TOO_MANY_REQUESTS.getStatus(), (int) response.evaluate("items.0.index.status"));
+            assertThat(response.evaluate("items.0.index.error.type"), equalTo("process_cluster_event_timeout_exception"));
+            assertThat(response.evaluate("items.0.index.error.reason"), containsString("failed to process cluster event"));
+        }
+
+        updateClusterSettings(Settings.builder().put(AUTO_CREATE_INDEX_MAX_TIMEOUT_SETTING.getKey(), randomFrom("-1", "60s", "1h")));
+
+        final PlainActionFuture<Response> bulkResponseFuture = new PlainActionFuture<>();
+        try (var ignored = withBlockedMasterService(masterClusterService)) {
+            final var request = new Request("PUT", "/" + indexName + "/_bulk");
+            request.setJsonEntity("""
+                {"index":{}}
+                {}
+                """);
+            timeoutApplier.accept(request);
+            restClient.performRequestAsync(request, new ResponseListener() {
+                @Override
+                public void onSuccess(Response response) {
+                    bulkResponseFuture.onResponse(response);
+                }
+
+                @Override
+                public void onFailure(Exception exception) {
+                    bulkResponseFuture.onFailure(exception);
+                }
+            });
+            awaitPendingTask(masterClusterService, "auto create [" + indexName + "]");
+        }
+        safeGet(bulkResponseFuture);
+
+        updateClusterSettings(Settings.builder().putNull(AUTO_CREATE_INDEX_MAX_TIMEOUT_SETTING.getKey()));
     }
 
     public void testReducePriorities() throws Exception {


### PR DESCRIPTION
Similar to #139898 and #139699: users can submit auto-create tasks at an
unreasonable rate too.