### PR TITLE
[9.2] Fix shutdown prepare service to use the "correct" task manager (#140698)

### DIFF
--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexNodeShutdownIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/ReindexNodeShutdownIT.java
@@ -108,8 +108,8 @@ public class ReindexNodeShutdownIT extends ESIntegTestCase {
 
             @Override
             public void onFailure(Exception e) {
-                logger.debug("Encounterd " + e.toString());
-                fail(e, "Encounterd " + e.toString());
+                logger.debug("Encountered " + e.toString());
+                fail(e, "Encountered " + e.toString());
             }
         };
         internalCluster().client(coordNodeName).execute(ReindexAction.INSTANCE, reindexRequest, reindexListener);

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -1269,7 +1269,7 @@ class NodeConstruction {
             onlinePrewarmingService
         );
 
-        final var shutdownPrepareService = new ShutdownPrepareService(settings, httpServerTransport, taskManager, terminationHandler);
+        final var shutdownPrepareService = new ShutdownPrepareService(settings, httpServerTransport, transportService, terminationHandler);
 
         modules.add(loadPersistentTasksService(settingsModule, clusterService, threadPool, clusterModule.getIndexNameExpressionResolver()));
 

--- a/server/src/main/java/org/elasticsearch/node/ShutdownPrepareService.java
+++ b/server/src/main/java/org/elasticsearch/node/ShutdownPrepareService.java
@@ -22,6 +22,7 @@ import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.index.reindex.ReindexAction;
 import org.elasticsearch.node.internal.TerminationHandler;
 import org.elasticsearch.tasks.TaskManager;
+import org.elasticsearch.transport.TransportService;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -67,15 +68,15 @@ public class ShutdownPrepareService {
     public ShutdownPrepareService(
         Settings settings,
         HttpServerTransport httpServerTransport,
-        TaskManager taskManager,
+        TransportService transportService,
         TerminationHandler terminationHandler
     ) {
         this.maxTimeout = MAXIMUM_SHUTDOWN_TIMEOUT_SETTING.get(settings);
 
         final var reindexTimeout = MAXIMUM_REINDEXING_TIMEOUT_SETTING.get(settings);
         addShutdownHook("http-server-transport-stop", httpServerTransport::close);
-        addShutdownHook("async-search-stop", () -> awaitSearchTasksComplete(maxTimeout, taskManager));
-        addShutdownHook("reindex-stop", () -> awaitReindexTasksComplete(reindexTimeout, taskManager));
+        addShutdownHook("async-search-stop", () -> awaitSearchTasksComplete(maxTimeout, transportService.getTaskManager()));
+        addShutdownHook("reindex-stop", () -> awaitReindexTasksComplete(reindexTimeout, transportService.getTaskManager()));
         if (terminationHandler != null) {
             addShutdownHook("termination-handler-stop", terminationHandler::handleTermination);
         }


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Fix shutdown prepare service to use the "correct" task manager (#140698)