### PR TITLE
[9.3] Use sub keyword block loader with ignore_above for text fields (#140622)

### DIFF
--- a/docs/changelog/140622.yaml
+++ b/docs/changelog/140622.yaml
@@ -1,0 +1,5 @@
+pr: 140622
+summary: Use sub keyword block loader with `ignore_above` for text fields
+area: ES|QL
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/mapper/BlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BlockLoader.java
@@ -248,6 +248,12 @@ public interface BlockLoader {
          * @return stored fields for the current document
          */
         Map<String, List<Object>> storedFields() throws IOException;
+
+        /**
+         * Whether stored fields have already been loaded for the current document.
+         * If the stored fields are not loaded yet, the block loader might avoid loading them when not needed.
+         */
+        boolean loaded();
     }
 
     /**
@@ -510,6 +516,107 @@ public interface BlockLoader {
         @Override
         public final String toString() {
             return "Delegating[to=" + delegatingTo() + ", impl=" + delegate + "]";
+        }
+    }
+
+    /**
+     * A {@link BlockLoader} that conditionally selects one of two underlying loaders based on the underlying data.
+     * It prefers the {@code preferLoader} when possible, falling back to the {@code fallbackLoader} otherwise.
+     * <p>
+     * For example, a text field with a synthetic source can be loaded from its child keyword field when possible,
+     * which is faster than loading from stored fields:
+     * <pre>
+     * {
+     *     "parent_text_field": {
+     *         "type": "text",
+     *         "fields": {
+     *             "child_keyword_field": {
+     *                 "type": "keyword",
+     *                 "ignore_above": 256
+     *             }
+     *         }
+     *     }
+     * }
+     * </pre>
+     * If no values in a segment exceed the 256-character limit, then we can safely use the block loader from the
+     * keyword field for the entire segment. Alternatively, on a per-document basis, if doc-1 has the value "a"
+     * (under the limit) and doc-2 has the value "bcd..." (exceeds the limit), we can load doc-1 from the doc_values
+     * of keyword field and doc-2 from the slower stored fields.
+     */
+    abstract class ConditionalBlockLoader implements BlockLoader {
+        private final BlockLoader preferLoader;
+        private final BlockLoader fallbackLoader;
+
+        protected ConditionalBlockLoader(BlockLoader preferLoader, BlockLoader fallbackLoader) {
+            this.preferLoader = preferLoader;
+            this.fallbackLoader = fallbackLoader;
+        }
+
+        @Override
+        public Builder builder(BlockFactory factory, int expectedCount) {
+            return fallbackLoader.builder(factory, expectedCount);
+        }
+
+        /**
+         * Determines whether the preferred loader can be used for all documents in the given leaf context.
+         */
+        protected abstract boolean canUsePreferLoaderForLeaf(LeafReaderContext context) throws IOException;
+
+        /**
+         * Whether we can use the prefer loader for the given doc ID. If {@code true}, then the preferred loader is used
+         * to avoid loading stored fields or source.
+         */
+        protected abstract boolean canUsePreferLoaderForDoc(int docId) throws IOException;
+
+        @Override
+        public ColumnAtATimeReader columnAtATimeReader(LeafReaderContext context) throws IOException {
+            if (canUsePreferLoaderForLeaf(context)) {
+                return preferLoader.columnAtATimeReader(context);
+            } else {
+                return fallbackLoader.columnAtATimeReader(context);
+            }
+        }
+
+        @Override
+        public RowStrideReader rowStrideReader(LeafReaderContext context) throws IOException {
+            if (preferLoader.rowStrideStoredFieldSpec().noRequirements() == false) {
+                return fallbackLoader.rowStrideReader(context);
+            }
+            RowStrideReader preferReader = preferLoader.rowStrideReader(context);
+            if (canUsePreferLoaderForLeaf(context)) {
+                return preferReader;
+            }
+            RowStrideReader fallbackReader = fallbackLoader.rowStrideReader(context);
+            return new RowStrideReader() {
+                @Override
+                public void read(int docId, StoredFields storedFields, Builder builder) throws IOException {
+                    if (storedFields.loaded() == false && canUsePreferLoaderForDoc(docId)) {
+                        preferReader.read(docId, storedFields, builder);
+                    } else {
+                        fallbackReader.read(docId, storedFields, builder);
+                    }
+                }
+
+                @Override
+                public boolean canReuse(int startingDocID) {
+                    return fallbackReader.canReuse(startingDocID) && preferReader.canReuse(startingDocID);
+                }
+            };
+        }
+
+        @Override
+        public StoredFieldsSpec rowStrideStoredFieldSpec() {
+            return fallbackLoader.rowStrideStoredFieldSpec();
+        }
+
+        @Override
+        public boolean supportsOrdinals() {
+            return false;
+        }
+
+        @Override
+        public SortedSetDocValues ordinals(LeafReaderContext context) throws IOException {
+            return null;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/BlockLoaderStoredFieldsFromLeafLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BlockLoaderStoredFieldsFromLeafLoader.java
@@ -69,4 +69,9 @@ public class BlockLoaderStoredFieldsFromLeafLoader implements BlockLoader.Stored
         advanceIfNeeded();
         return loader.storedFields();
     }
+
+    @Override
+    public boolean loaded() {
+        return loaderDocId == docId;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFamilyFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFamilyFieldType.java
@@ -9,10 +9,17 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SegmentReader;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.queries.intervals.IntervalsSource;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.index.query.SearchExecutionContext;
 
+import java.io.IOException;
 import java.util.Map;
 
 /**
@@ -120,4 +127,72 @@ public abstract class TextFamilyFieldType extends StringFieldType {
         );
     }
 
+    /**
+     * A {@link BlockLoader.ConditionalBlockLoader} that checks whether the prefer field exists in the _ignore field.
+     * If the prefer field's term does not exist in the _ignore field, the prefer loader is used for all documents.
+     * If the term exists in the _ignore field, the loader checks each document: if the term appears in the _ignore field for a document,
+     * the fallback loader is used for that document; otherwise use the prefer loader.
+     */
+    public static final class ConditionalBlockLoaderWithIgnoreField extends BlockLoader.ConditionalBlockLoader {
+        private LeafReaderContext lastContext;
+        private DocIdSetIterator postings;
+        private final String preferField;
+
+        public ConditionalBlockLoaderWithIgnoreField(String preferField, BlockLoader preferLoader, BlockLoader fallbackLoader) {
+            super(preferLoader, fallbackLoader);
+            this.preferField = preferField;
+        }
+
+        private DocIdSetIterator loadPostings(LeafReaderContext context) throws IOException {
+            if (context.reader().getFieldInfos().fieldInfo(preferField) == null) {
+                // the prefer_field missing or hidden; use fallback loader for all docs
+                return DocIdSetIterator.all(context.reader().maxDoc());
+            }
+            Terms terms = context.reader().terms(IgnoredFieldMapper.NAME);
+            // the _ignore field might be hidden by FLS, unwrap the leaf reader
+            if (terms == null) {
+                SegmentReader segmentReader = Lucene.tryUnwrapSegmentReader(context.reader());
+                if (segmentReader == null) {
+                    // can't unwrap the leaf reader so use the fallback for all docs
+                    return DocIdSetIterator.all(context.reader().maxDoc());
+                }
+                terms = segmentReader.terms(IgnoredFieldMapper.NAME);
+            }
+            if (terms == null) {
+                // the _ignore field does not exist, use the prefer loader for all docs
+                return null;
+            }
+            TermsEnum iterator = terms.iterator();
+            if (iterator.seekExact(new BytesRef(preferField))) {
+                return iterator.postings(null, 0);
+            }
+            // the prefer field does not exist in the _ignore field, use the prefer loader for all docs
+            return null;
+        }
+
+        @Override
+        protected boolean canUsePreferLoaderForLeaf(LeafReaderContext context) throws IOException {
+            if (lastContext != context) {
+                lastContext = context;
+                postings = loadPostings(context);
+                if (postings != null) {
+                    postings.nextDoc();
+                }
+            }
+            return postings == null || postings.docID() == DocIdSetIterator.NO_MORE_DOCS;
+        }
+
+        @Override
+        protected boolean canUsePreferLoaderForDoc(int docId) throws IOException {
+            if (postings == null) {
+                return true;
+            }
+            int current = postings.docID();
+            if (current < docId) {
+                return postings.advance(docId) > docId;
+            } else {
+                return current > docId;
+            }
+        }
+    }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -1114,7 +1114,7 @@ public final class TextFieldMapper extends FieldMapper {
 
         @Override
         public BlockLoader blockLoader(BlockLoaderContext blContext) {
-            // 1. check if we can load from a synthetic source delegate
+            // Check if we can load from a synthetic source delegate
             if (canUseSyntheticSourceDelegateForLoading()) {
                 return new BlockLoader.Delegating(syntheticSourceDelegate.get().blockLoader(blContext)) {
                     @Override
@@ -1123,9 +1123,22 @@ public final class TextFieldMapper extends FieldMapper {
                     }
                 };
             }
+            BlockLoader fallbackLoader = nonDelegateBlockLoader(blContext);
+            if (syntheticSourceDelegate.isPresent() && syntheticSourceDelegate.get().ignoreAbove().valuesPotentiallyIgnored()) {
+                var preferLoader = new BlockLoader.Delegating(syntheticSourceDelegate.get().blockLoader(blContext)) {
+                    @Override
+                    public String delegatingTo() {
+                        return syntheticSourceDelegate.get().name();
+                    }
+                };
+                return new ConditionalBlockLoaderWithIgnoreField(syntheticSourceDelegate.get().name(), preferLoader, fallbackLoader);
+            }
+            return fallbackLoader;
+        }
 
-            // 2. check if we can load from a parent field
+        private BlockLoader nonDelegateBlockLoader(BlockLoaderContext blContext) {
             /*
+             * Check if we can load from a parent field
              * If this is a sub-text field try and return the parent's loader. Text
              * fields will always be slow to load and if the parent is exact then we
              * should use that instead.
@@ -1146,24 +1159,24 @@ public final class TextFieldMapper extends FieldMapper {
                 }
             }
 
-            // 3. bwc - check if we need to load from ignored source (aka fallback synthetic source)
+            // Bwc - check if we need to load from ignored source (aka fallback synthetic source)
             if (wasIndexCreatedWhenTextFieldsWereStoredInIgnoredSource()) {
                 if (isSyntheticSourceEnabled() && syntheticSourceDelegate.isEmpty() && parentField == null && isStored() == false) {
                     return fallbackSyntheticSourceBlockLoader(blContext);
                 }
             }
 
-            // 4. check if we can load from a stored field
+            // Check if we can load from a stored field
             if (isStored()) {
                 return new BlockStoredFieldsReader.BytesFromStringsBlockLoader(name());
             }
 
-            // 5. check if we can load from a fallback stored field
+            // Check if we can load from a fallback stored field
             if (isSyntheticSourceEnabled() && syntheticSourceDelegate.isEmpty() && parentField == null) {
                 return new BlockStoredFieldsReader.BytesFromStringsBlockLoader(syntheticSourceFallbackFieldName());
             }
 
-            // 6. load directly from _source (synthetic or not)
+            // Load directly from _source (synthetic or not)
             SourceValueFetcher fetcher = SourceValueFetcher.toString(blContext.sourcePaths(name()), blContext.indexSettings());
             return new BlockSourceReader.BytesRefsBlockLoader(fetcher, blockReaderDisiLookup(blContext));
         }

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -20,8 +20,12 @@ import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.IndexableFieldType;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.index.PostingsEnum;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.TermsEnum;
@@ -41,6 +45,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.SynonymQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.CannedTokenStream;
 import org.apache.lucene.tests.analysis.MockSynonymAnalyzer;
 import org.apache.lucene.tests.analysis.Token;
@@ -65,6 +70,7 @@ import org.elasticsearch.index.fielddata.FieldDataContext;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.LeafFieldData;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
+import org.elasticsearch.index.fieldvisitor.StoredFieldLoader;
 import org.elasticsearch.index.mapper.TextFieldMapper.TextFieldType;
 import org.elasticsearch.index.query.MatchPhrasePrefixQueryBuilder;
 import org.elasticsearch.index.query.MatchPhraseQueryBuilder;
@@ -72,6 +78,7 @@ import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.search.MatchQueryParser;
 import org.elasticsearch.index.search.QueryStringQueryParser;
 import org.elasticsearch.script.field.TextDocValuesField;
+import org.elasticsearch.search.fetch.StoredFieldsSpec;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.lookup.SourceProvider;
 import org.elasticsearch.xcontent.ToXContent;
@@ -82,13 +89,18 @@ import org.junit.AssumptionViolatedException;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
@@ -1852,6 +1864,151 @@ public class TextFieldMapperTests extends MapperTestCase {
 
         // then
         assertThat(fieldType.omitNorms(), is(false));
+    }
+
+    public void testConditionalBlockLoader() throws IOException {
+        int numDocs = between(5, 100);
+        List<Object> textValues = new ArrayList<>();
+        for (int i = 0; i < numDocs; i++) {
+            int numValues = between(1, 2);
+            if (numValues == 1) {
+                textValues.add(randomAlphaOfLength(between(1, 512)));
+            } else {
+                Set<String> subs = new HashSet<>();
+                for (int v = 0; v < numValues; v++) {
+                    subs.add(randomAlphaOfLength(between(1, 512)));
+                }
+                textValues.add(subs);
+            }
+        }
+        for (int ignoreAbove : List.of(5, 20, 128, 256, 512, 1000, Integer.MAX_VALUE)) {
+            final int ignoreAboveFinal = ignoreAbove;
+            var mapping = mapping(b -> {
+                b.startObject("name");
+                b.field("type", "text");
+                b.startObject("fields");
+                b.startObject("keyword");
+                b.field("type", "keyword");
+                b.field("ignore_above", ignoreAboveFinal);
+                b.endObject();
+                b.endObject();
+                b.endObject();
+            });
+            try (MapperService mapperService = createSytheticSourceMapperService(mapping); Directory directory = newDirectory()) {
+                IndexWriterConfig conf = new IndexWriterConfig();
+                conf.setMergePolicy(NoMergePolicy.INSTANCE);
+                IndexWriter iw = new IndexWriter(directory, conf);
+                DocumentMapper mapper = mapperService.documentMapper();
+                for (Object v : textValues) {
+                    var source = source(b -> { b.field("name", v); });
+                    ParsedDocument doc = mapper.parse(source);
+                    iw.addDocument(doc.rootDoc());
+                }
+                iw.close();
+                try (DirectoryReader reader = DirectoryReader.open(directory)) {
+                    LeafReaderContext ctx = reader.leaves().get(0);
+                    SearchLookup searchLookup = new SearchLookup(mapperService.mappingLookup().fieldTypesLookup()::get, null, null);
+                    BlockLoader blockLoader = mapperService.fieldType("name").blockLoader(new MappedFieldType.BlockLoaderContext() {
+                        @Override
+                        public String indexName() {
+                            return mapperService.getIndexSettings().getIndex().getName();
+                        }
+
+                        @Override
+                        public IndexSettings indexSettings() {
+                            return mapperService.getIndexSettings();
+                        }
+
+                        @Override
+                        public MappedFieldType.FieldExtractPreference fieldExtractPreference() {
+                            return MappedFieldType.FieldExtractPreference.NONE;
+                        }
+
+                        @Override
+                        public SearchLookup lookup() {
+                            return searchLookup;
+                        }
+
+                        @Override
+                        public Set<String> sourcePaths(String name) {
+                            return mapperService.mappingLookup().sourcePaths(name);
+                        }
+
+                        @Override
+                        public String parentField(String field) {
+                            return mapperService.mappingLookup().parentField(field);
+                        }
+
+                        @Override
+                        public FieldNamesFieldMapper.FieldNamesFieldType fieldNames() {
+                            return (FieldNamesFieldMapper.FieldNamesFieldType) mapperService.fieldType(FieldNamesFieldMapper.NAME);
+                        }
+                    });
+                    Predicate<Object> exceedIgnoreAbove = v -> {
+                        if (v instanceof Collection<?> ls) {
+                            return ls.stream().anyMatch(s -> s.toString().length() > ignoreAbove);
+                        } else {
+                            return v.toString().length() > ignoreAbove;
+                        }
+                    };
+                    final TestBlock testBlock;
+                    if (textValues.stream().anyMatch(exceedIgnoreAbove)) {
+                        assertNull(blockLoader.columnAtATimeReader(ctx));
+                        assertFalse(blockLoader.rowStrideStoredFieldSpec().noRequirements());
+                        var rowReader = blockLoader.rowStrideReader(ctx);
+                        StoredFieldsSpec storedFieldsSpec = blockLoader.rowStrideStoredFieldSpec();
+                        SourceLoader.Leaf leafSourceLoader = null;
+                        if (storedFieldsSpec.requiresSource()) {
+                            var sourceLoader = mapperService.mappingLookup().newSourceLoader(null, SourceFieldMetrics.NOOP);
+                            leafSourceLoader = sourceLoader.leaf(ctx.reader(), null);
+                            storedFieldsSpec = storedFieldsSpec.merge(
+                                new StoredFieldsSpec(true, storedFieldsSpec.requiresMetadata(), sourceLoader.requiredStoredFields())
+                            );
+                        }
+                        var storedFields = new BlockLoaderStoredFieldsFromLeafLoader(
+                            StoredFieldLoader.fromSpec(storedFieldsSpec).getLoader(ctx, null),
+                            leafSourceLoader
+                        );
+                        try (var builder = blockLoader.builder(TestBlock.factory(), numDocs)) {
+                            for (int doc = 0; doc < textValues.size(); doc++) {
+                                Object values = textValues.get(doc);
+                                storedFields.advanceTo(doc);
+                                rowReader.read(doc, storedFields, builder);
+                                final boolean fallback = exceedIgnoreAbove.test(values);
+                                assertThat(
+                                    "doc=" + doc + " values=" + values + " ignore_above=" + ignoreAbove,
+                                    storedFields.loaded(),
+                                    equalTo(fallback)
+                                );
+                            }
+                            testBlock = (TestBlock) builder.build();
+                        }
+                    } else {
+                        var columnReader = blockLoader.columnAtATimeReader(ctx);
+                        assertNotNull(columnReader);
+                        testBlock = (TestBlock) columnReader.read(
+                            TestBlock.factory(),
+                            TestBlock.docs(IntStream.range(0, numDocs).toArray()),
+                            0,
+                            randomBoolean()
+                        );
+                    }
+                    for (int i = 0; i < textValues.size(); i++) {
+                        Object expected = textValues.get(i);
+                        if (expected instanceof Collection<?> ls) {
+                            expected = ls.stream().map(v -> new BytesRef(v.toString())).sorted().toList();
+                        } else {
+                            expected = new BytesRef(expected.toString());
+                        }
+                        if (testBlock.get(i) instanceof Collection<?> c) {
+                            assertThat(c.stream().sorted().toList(), equalTo(expected));
+                        } else {
+                            assertThat(testBlock.get(i), equalTo(expected));
+                        }
+                    }
+                }
+            }
+        }
     }
 
     @Override

--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/StoredFieldsSequentialIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/StoredFieldsSequentialIT.java
@@ -74,7 +74,7 @@ public class StoredFieldsSequentialIT extends ESRestTestCase {
     public void testAggTwentyPercent() throws IOException {
         testQuery(null, """
             FROM test
-            | WHERE STARTS_WITH(test.keyword, "test1") OR STARTS_WITH(test.keyword, "test2")
+            | WHERE STARTS_WITH(testkw, "test1") OR STARTS_WITH(testkw, "test2")
             | STATS SUM(LENGTH(test))
             """, 200, true);
     }
@@ -98,7 +98,7 @@ public class StoredFieldsSequentialIT extends ESRestTestCase {
      */
     private void testAggTenPercent(Double percent, boolean sequential) throws IOException {
         String filter = IntStream.range(0, 10)
-            .mapToObj(i -> String.format(Locale.ROOT, "STARTS_WITH(test.keyword, \"test%s%s\")", i, i))
+            .mapToObj(i -> String.format(Locale.ROOT, "STARTS_WITH(testkw, \"test%s%s\")", i, i))
             .collect(Collectors.joining(" OR "));
         testQuery(percent, String.format(Locale.ROOT, """
             FROM test
@@ -179,7 +179,9 @@ public class StoredFieldsSequentialIT extends ESRestTestCase {
               },
               "mappings": {
                 "properties": {
-                  "i": {"type": "long"}
+                  "i": {"type": "long"},
+                  "test": {"type": "text"},
+                  "testkw": {"type": "keyword"}
                 }
               }
             }""");
@@ -195,8 +197,8 @@ public class StoredFieldsSequentialIT extends ESRestTestCase {
         for (int i = 0; i < 1000; i++) {
             b.append(String.format(Locale.ROOT, """
                 {"create":{"_index":"test"}}
-                {"test":"test%03d", "i": %d}
-                """, i, i));
+                {"test":"test%03d", "testkw": "test%03d", "i": %d}
+                """, i, i, i));
         }
         bulk.setJsonEntity(b.toString());
         Response bulkResponse = client().performRequest(bulk);

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/lookup-join.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/lookup-join.csv-spec
@@ -318,6 +318,7 @@ emp_no:integer | language_code:integer
 
 nonUniqueRightKeyFromRow
 required_capability: join_lookup_v12
+required_capability: conditional_block_loader_for_text_fields
 
 ROW language_code = 2
 | LOOKUP JOIN languages_lookup_non_unique_key ON language_code
@@ -326,7 +327,7 @@ ROW language_code = 2
 
 ignoreOrder:true
 language_code:integer | country:text       | language_name:keyword
-2                     | [Germany, Austria] | German
+2                     | [Austria, Germany] | German
 2                     | Switzerland        | German
 2                     | null               | German
 ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1832,6 +1832,11 @@ public class EsqlCapabilities {
          */
         ENRICH_DENSE_VECTOR_BUGFIX,
 
+        /**
+         * Adds a conditional block loader for text fields that prefers using the sub-keyword field whenever possible.
+         */
+        CONDITIONAL_BLOCK_LOADER_FOR_TEXT_FIELDS,
+
         // Last capability should still have a comma for fewer merge conflicts when adding new ones :)
         // This comment prevents the semicolon from being on the previous capability when Spotless formats the file.
         ;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Use sub keyword block loader with ignore_above for text fields (#140622)](https://github.com/elastic/elasticsearch/pull/140622)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)