### PR TITLE
Flip cloud-ess-fips default from FIPS 140-2 to FIPS 140-3

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -26,7 +26,7 @@ boolean useLocalArtifacts = buildId != null && buildId.isBlank() == false && use
 
 // FIPS version for Docker builds: '140-2' (default) or '140-3'
 // Use -Ddocker.fips.version=140-3 to build with FIPS 140-3 / BC 2.x libraries
-ext.isFips140_3 = providers.systemProperty('docker.fips.version').getOrElse('140-2') == '140-3'
+ext.isFips140_3 = providers.systemProperty('docker.fips.version').getOrElse('140-3') == '140-3'
 
 repositories {
   // Define a repository that allows Gradle to fetch a resource from GitHub. This

--- a/docs/changelog/140788.yaml
+++ b/docs/changelog/140788.yaml
@@ -1,0 +1,5 @@
+pr: 140788
+summary: Flip cloud-ess-fips default from FIPS 140-2 to FIPS 140-3
+area: Packaging
+type: enhancement
+issues: []


### PR DESCRIPTION
This changes updates the default value for the `docker.fips.version` Gradle build variable from `140-2` to `140-3`.

Default `cloud-ess-fips` Docker builds will now include Bouncy Castle 2.0.x libraries with FIPS 140-3 certification.

This builds on a prior PR that added broad FIPS 140-3 awareness: https://github.com/elastic/elasticsearch/pull/139319