### PR TITLE
[8.19] Fix stderr leak in Docker ES process detection (#140701)

### DIFF
--- a/docs/changelog/140701.yaml
+++ b/docs/changelog/140701.yaml
@@ -1,0 +1,5 @@
+pr: 140701
+summary: Fix stderr leak in Docker ES process detection
+area: Packaging
+type: bug
+issues: []

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
@@ -81,7 +81,7 @@ public class Docker {
      */
     private static final String ELASTICSEARCH_FULL_CLASSNAME = "org.elasticsearch.bootstrap.Elasticsearch";
     private static final String FIND_ELASTICSEARCH_PROCESS = "for pid in $(ps -eo pid,comm | grep java | awk '\\''{print $1}'\\''); "
-        + "do cmdline=$(tr \"\\0\" \" \" < /proc/$pid/cmdline 2>/dev/null); [[ $cmdline == *"
+        + "do cmdline=$(cat /proc/$pid/cmdline 2>/dev/null | tr \"\\0\" \" \"); [[ $cmdline == *"
         + ELASTICSEARCH_FULL_CLASSNAME
         + "* ]] && echo \"$pid: $cmdline\"; done";
 


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Fix stderr leak in Docker ES process detection (#140701)