### PR TITLE
Reduce GCP fixture token fetch failures count

### DIFF
--- a/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
+++ b/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
@@ -117,7 +117,10 @@ public class GoogleCloudStorageBlobStoreRepositoryTests extends ESMockAPIBasedRe
     @Override
     protected HttpHandler createErroneousHttpHandler(final HttpHandler delegate) {
         if (delegate instanceof FakeOAuth2HttpHandler) {
-            return new GoogleErroneousHttpHandler(delegate, randomIntBetween(2, 3));
+            // GCP Oauth2 client uses own retries: 1-second initial delay, 3-tries, 2x multiplier
+            // it can take long time to passthrough(>10s) from multiple nodes, and trip tests with timeouts
+            // https://github.com/googleapis/google-auth-library-java/blob/main/oauth2_http/java/com/google/auth/oauth2/OAuth2Utils.java#L115-L118
+            return new GoogleErroneousHttpHandler(delegate, 1);
         } else {
             return new GoogleCloudStorageStatsCollectorHttpHandler(new GoogleErroneousHttpHandler(delegate, randomIntBetween(2, 3)));
         }

--- a/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
+++ b/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
@@ -118,7 +118,7 @@ public class GoogleCloudStorageBlobStoreRepositoryTests extends ESMockAPIBasedRe
     protected HttpHandler createErroneousHttpHandler(final HttpHandler delegate) {
         if (delegate instanceof FakeOAuth2HttpHandler) {
             // GCP Oauth2 client uses own retries: 1-second initial delay, 3-tries, 2x multiplier
-            // it can take long time to passthrough(>10s) from multiple nodes, and trip tests with timeouts
+            // it can take long time to pass through(>10s) from multiple nodes, and trip tests with timeouts
             // https://github.com/googleapis/google-auth-library-java/blob/main/oauth2_http/java/com/google/auth/oauth2/OAuth2Utils.java#L115-L118
             return new GoogleErroneousHttpHandler(delegate, 1);
         } else {

--- a/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
+++ b/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreRepositoryTests.java
@@ -114,12 +114,12 @@ public class GoogleCloudStorageBlobStoreRepositoryTests extends ESMockAPIBasedRe
         );
     }
 
+    // GCP Oauth2 client uses own retries: 1-second initial delay, 3-tries, 2x multiplier
+    // it can take long time to pass through(>10s) from multiple nodes, and trip tests with timeouts
+    // https://github.com/googleapis/google-auth-library-java/blob/main/oauth2_http/java/com/google/auth/oauth2/OAuth2Utils.java#L115-L118
     @Override
     protected HttpHandler createErroneousHttpHandler(final HttpHandler delegate) {
         if (delegate instanceof FakeOAuth2HttpHandler) {
-            // GCP Oauth2 client uses own retries: 1-second initial delay, 3-tries, 2x multiplier
-            // it can take long time to pass through(>10s) from multiple nodes, and trip tests with timeouts
-            // https://github.com/googleapis/google-auth-library-java/blob/main/oauth2_http/java/com/google/auth/oauth2/OAuth2Utils.java#L115-L118
             return new GoogleErroneousHttpHandler(delegate, 1);
         } else {
             return new GoogleCloudStorageStatsCollectorHttpHandler(new GoogleErroneousHttpHandler(delegate, randomIntBetween(2, 3)));

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESMockAPIBasedRepositoryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESMockAPIBasedRepositoryIntegTestCase.java
@@ -291,7 +291,7 @@ public abstract class ESMockAPIBasedRepositoryIntegTestCase extends ESBlobStoreR
             this.requests = new ConcurrentHashMap<>();
             this.delegate = delegate;
             this.maxErrorsPerRequest = maxErrorsPerRequest;
-            assert maxErrorsPerRequest > 1;
+            assert maxErrorsPerRequest > 0;
         }
 
         @Override


### PR DESCRIPTION
Fix https://github.com/elastic/elasticsearch/issues/140711

It appears that GCP Oauth2 client (we don't use one directly, it's wrapped in layers of GCS client) uses different retry settings than GCS. Also these settings are hardcoded: 1 second initial delay, 3 retries, 2x multiplier. Currently fixture will always throw 2-3 errors before pass, that adds 2.5-4 seconds wait time per node, and sometimes it's no perfectly parallel.
That means a single operation such as create repository with verification=true can run longer than 10 seconds and trip testing threshold.

This PR reduces number of retries to 1. Maybe we should make `createRepository(name)` by default without verification, there are plenty of tests exercising this path.