### PR TITLE
[9.3] Fix test failure in TDigestFieldBlockLoaderTests (#139851)

### DIFF
--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/mapper/TDigestFieldBlockLoaderTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/mapper/TDigestFieldBlockLoaderTests.java
@@ -101,18 +101,12 @@ public class TDigestFieldBlockLoaderTests extends BlockLoaderTestCase {
             }
         }
 
-        long finalTotalCount = totalCount;
-        return Map.of(
-            "min",
-            valueAsMap.get("min"),
-            "max",
-            valueAsMap.get("max"),
-            "sum",
-            valueAsMap.get("sum"),
-            "value_count",
-            finalTotalCount,
-            "encoded_digest",
-            streamOutput.bytes().toBytesRef()
-        );
+        Map<String, Object> toReturn = new HashMap<>();
+        toReturn.put("encoded_digest", streamOutput.bytes().toBytesRef());
+        toReturn.put("min", valueAsMap.get("min"));
+        toReturn.put("max", valueAsMap.get("max"));
+        toReturn.put("sum", valueAsMap.get("sum"));
+        toReturn.put("value_count", totalCount);
+        return toReturn;
     }
 }


### PR DESCRIPTION
Closes #140798.

# Backport

This will backport the following commits from `main` to `9.3`:
 - [Fix test failure in TDigestFieldBlockLoaderTests (#139851)](https://github.com/elastic/elasticsearch/pull/139851)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)