### PR TITLE
Fix ShardBulkInferenceActionFilter adding lots of suppressed exceptions

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -345,30 +345,9 @@ tests:
 - class: org.elasticsearch.compute.aggregation.AllLastBytesRefByTimestampGroupingAggregatorFunctionTests
   method: testSimpleWithCranky
   issue: https://github.com/elastic/elasticsearch/issues/140763
-- class: org.elasticsearch.xpack.inference.action.filter.ShardBulkInferenceActionFilterIT
-  method: testItemFailures {p0=true p1=true}
-  issue: https://github.com/elastic/elasticsearch/issues/140766
-- class: org.elasticsearch.xpack.inference.action.filter.ShardBulkInferenceActionFilterIT
-  method: testBulkOperations {p0=true p1=true}
-  issue: https://github.com/elastic/elasticsearch/issues/140767
-- class: org.elasticsearch.xpack.inference.action.filter.ShardBulkInferenceActionFilterIT
-  method: testBulkOperations {p0=false p1=true}
-  issue: https://github.com/elastic/elasticsearch/issues/140768
-- class: org.elasticsearch.xpack.inference.action.filter.ShardBulkInferenceActionFilterIT
-  method: testItemFailures {p0=false p1=true}
-  issue: https://github.com/elastic/elasticsearch/issues/140769
-- class: org.elasticsearch.xpack.inference.action.filter.ShardBulkInferenceActionFilterIT
-  method: testBulkOperations {p0=true p1=false}
-  issue: https://github.com/elastic/elasticsearch/issues/140772
-- class: org.elasticsearch.xpack.inference.action.filter.ShardBulkInferenceActionFilterIT
-  method: testItemFailures {p0=true p1=false}
-  issue: https://github.com/elastic/elasticsearch/issues/140773
 - class: org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT
   method: test {p0=esql/46_downsample/Stats from downsampled and non-downsampled index simultaneously with implicit casting}
   issue: https://github.com/elastic/elasticsearch/issues/140774
-- class: org.elasticsearch.xpack.inference.action.filter.ShardBulkInferenceActionFilterIT
-  method: testItemFailures {p0=false p1=false}
-  issue: https://github.com/elastic/elasticsearch/issues/140778
 - class: org.elasticsearch.compute.aggregation.AllFirstBytesRefByTimestampGroupingAggregatorFunctionTests
   method: testSimpleWithCranky
   issue: https://github.com/elastic/elasticsearch/issues/140784

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilter.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilter.java
@@ -78,7 +78,6 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonList;
@@ -755,10 +754,13 @@ public class ShardBulkInferenceActionFilter implements MappedActionFilter {
         private void handleInferenceFailures(BulkItemRequest item, List<Exception> failures) {
             for (Exception failure : failures) {
                 // Generate a signature for the failure to deduplicate on the most important properties
-                FailureSignature failureSignature = new FailureSignature(failure);
+                FailureSignature failureSignature = new FailureSignature(item.request().id(), item.index(), failure);
 
-                Exception deduplicatedFailure = deduplicatedFailures.computeIfAbsent(failureSignature, k -> failure);
-                item.abort(item.index(), deduplicatedFailure);
+                Exception existing = deduplicatedFailures.putIfAbsent(failureSignature, failure);
+                if (existing == null) {
+                    // new failure for this request - mark as aborted
+                    item.abort(item.index(), failure);
+                }
             }
         }
 
@@ -848,31 +850,21 @@ public class ShardBulkInferenceActionFilter implements MappedActionFilter {
         }
     }
 
-    static class FailureSignature {
-        private final Class<? extends Throwable> failureClass;
-        private final String failureMessage;
-        private final FailureSignature failureCauseSignature;
-
-        FailureSignature(Throwable failure) {
-            failureClass = failure.getClass();
-            failureMessage = failure.getMessage();
-            failureCauseSignature = failure.getCause() != null ? new FailureSignature(failure.getCause()) : null;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            FailureSignature that = (FailureSignature) o;
-
-            return Objects.equals(failureClass, that.failureClass)
-                && Objects.equals(failureMessage, that.failureMessage)
-                && Objects.equals(failureCauseSignature, that.failureCauseSignature);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(failureClass, failureMessage, failureCauseSignature);
+    record FailureSignature(
+        String requestId,
+        String requestIndex,
+        Class<? extends Throwable> failureClass,
+        String failureMessage,
+        FailureSignature failureSignature
+    ) {
+        FailureSignature(String requestId, String index, Throwable failure) {
+            this(
+                requestId,
+                index,
+                failure.getClass(),
+                failure.getMessage(),
+                failure.getCause() != null ? new FailureSignature(requestId, index, failure.getCause()) : null
+            );
         }
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilterTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilterTests.java
@@ -1113,11 +1113,13 @@ public class ShardBulkInferenceActionFilterTests extends ESTestCase {
 
             String message = randomAlphaOfLengthBetween(5, 10);
             ShardBulkInferenceActionFilter.FailureSignature aSignature = new ShardBulkInferenceActionFilter.FailureSignature(
-                requestId,requestIndex,
+                requestId,
+                requestIndex,
                 new RuntimeException(message, aCause)
             );
             ShardBulkInferenceActionFilter.FailureSignature bSignature = new ShardBulkInferenceActionFilter.FailureSignature(
-                requestId,requestIndex,
+                requestId,
+                requestIndex,
                 new RuntimeException(message, bCause)
             );
 
@@ -1155,13 +1157,19 @@ public class ShardBulkInferenceActionFilterTests extends ESTestCase {
 
             String message = randomAlphaOfLengthBetween(5, 10);
             ShardBulkInferenceActionFilter.FailureSignature aSignature = new ShardBulkInferenceActionFilter.FailureSignature(
-                requestId,requestIndex,
+                requestId,
+                requestIndex,
                 new RuntimeException(message, aCause)
             );
             ShardBulkInferenceActionFilter.FailureSignature bSignature = rarely()
-                ? new ShardBulkInferenceActionFilter.FailureSignature(randomAlphaOfLength(5), requestIndex, new RuntimeException(message, bCause))
+                ? new ShardBulkInferenceActionFilter.FailureSignature(
+                    randomAlphaOfLength(5),
+                    requestIndex,
+                    new RuntimeException(message, bCause)
+                )
                 : new ShardBulkInferenceActionFilter.FailureSignature(
-                    requestId,requestIndex,
+                    requestId,
+                    requestIndex,
                     inequalityLevel == 0 ? randomDifference.apply(message, bCause) : new RuntimeException(message, bCause)
                 );
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilterTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilterTests.java
@@ -1099,6 +1099,8 @@ public class ShardBulkInferenceActionFilterTests extends ESTestCase {
 
     public void testEqualFailureSignatures() {
         for (int i = 0; i < 10; i++) {
+            final String requestId = randomAlphaOfLength(5);
+            final String requestIndex = randomIndexName();
             final int causeCount = randomIntBetween(0, 5);
 
             Exception aCause = null;
@@ -1111,9 +1113,11 @@ public class ShardBulkInferenceActionFilterTests extends ESTestCase {
 
             String message = randomAlphaOfLengthBetween(5, 10);
             ShardBulkInferenceActionFilter.FailureSignature aSignature = new ShardBulkInferenceActionFilter.FailureSignature(
+                requestId,requestIndex,
                 new RuntimeException(message, aCause)
             );
             ShardBulkInferenceActionFilter.FailureSignature bSignature = new ShardBulkInferenceActionFilter.FailureSignature(
+                requestId,requestIndex,
                 new RuntimeException(message, bCause)
             );
 
@@ -1136,6 +1140,8 @@ public class ShardBulkInferenceActionFilterTests extends ESTestCase {
         };
 
         for (int i = 0; i < 10; i++) {
+            final String requestId = randomAlphaOfLength(5);
+            final String requestIndex = randomIndexName();
             final int causeCount = randomIntBetween(0, 5);
             final int inequalityLevel = randomIntBetween(0, causeCount);
 
@@ -1149,11 +1155,15 @@ public class ShardBulkInferenceActionFilterTests extends ESTestCase {
 
             String message = randomAlphaOfLengthBetween(5, 10);
             ShardBulkInferenceActionFilter.FailureSignature aSignature = new ShardBulkInferenceActionFilter.FailureSignature(
+                requestId,requestIndex,
                 new RuntimeException(message, aCause)
             );
-            ShardBulkInferenceActionFilter.FailureSignature bSignature = new ShardBulkInferenceActionFilter.FailureSignature(
-                inequalityLevel == 0 ? randomDifference.apply(message, bCause) : new RuntimeException(message, bCause)
-            );
+            ShardBulkInferenceActionFilter.FailureSignature bSignature = rarely()
+                ? new ShardBulkInferenceActionFilter.FailureSignature(randomAlphaOfLength(5), requestIndex, new RuntimeException(message, bCause))
+                : new ShardBulkInferenceActionFilter.FailureSignature(
+                    requestId,requestIndex,
+                    inequalityLevel == 0 ? randomDifference.apply(message, bCause) : new RuntimeException(message, bCause)
+                );
 
             assertThat(aSignature, not(equalTo(bSignature)));
         }


### PR DESCRIPTION
Fixes #140815 

The exceptions are dedup'd, but `abort` is still called for every exception. This calls `Exception.addSuppressed` on the primary exception every time, resulting in very long causal lists that can result in OOMs.

This change ensures that `abort` is only called for new exceptions, whilst still ensuring that every request does actually get aborted when it needs to