### PR TITLE
Fixes ServerlessSnapshotShutdownIT

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/repositories/SnapshotMetricsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/repositories/SnapshotMetricsIT.java
@@ -45,6 +45,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import static org.elasticsearch.snapshots.SnapshotTestUtils.clearShutdownMetadata;
 import static org.elasticsearch.snapshots.SnapshotTestUtils.flushMasterQueue;
 import static org.elasticsearch.snapshots.SnapshotTestUtils.putShutdownForRemovalMetadata;
 import static org.elasticsearch.threadpool.ThreadPool.ESTIMATED_TIME_INTERVAL_SETTING;

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotShutdownIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotShutdownIT.java
@@ -52,6 +52,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.snapshots.SnapshotShutdownProgressTracker.SNAPSHOT_PROGRESS_DURING_SHUTDOWN_LOG_INTERVAL_SETTING;
+import static org.elasticsearch.snapshots.SnapshotTestUtils.clearShutdownMetadata;
 import static org.elasticsearch.snapshots.SnapshotTestUtils.flushMasterQueue;
 import static org.elasticsearch.snapshots.SnapshotTestUtils.putShutdownForRemovalMetadata;
 import static org.elasticsearch.snapshots.SnapshotTestUtils.putShutdownMetadata;

--- a/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -23,7 +23,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.SnapshotDeletionsInProgress;
 import org.elasticsearch.cluster.SnapshotsInProgress;
-import org.elasticsearch.cluster.metadata.NodesShutdownMetadata;
 import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.cluster.metadata.RepositoriesMetadata;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
@@ -701,25 +700,6 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
 
     protected List<String> createNSnapshots(String repoName, int count) throws Exception {
         return createNSnapshots(logger, repoName, count);
-    }
-
-    protected static void clearShutdownMetadata(ClusterService clusterService) {
-        safeAwait(listener -> clusterService.submitUnbatchedStateUpdateTask("remove restart marker", new ClusterStateUpdateTask() {
-            @Override
-            public ClusterState execute(ClusterState currentState) {
-                return currentState.copyAndUpdateMetadata(mdb -> mdb.putCustom(NodesShutdownMetadata.TYPE, NodesShutdownMetadata.EMPTY));
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                fail(e);
-            }
-
-            @Override
-            public void clusterStateProcessed(ClusterState initialState, ClusterState newState) {
-                listener.onResponse(null);
-            }
-        }));
     }
 
     protected static SubscribableListener<Void> createSnapshotInStateListener(

--- a/test/framework/src/main/java/org/elasticsearch/snapshots/SnapshotTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/snapshots/SnapshotTestUtils.java
@@ -47,6 +47,26 @@ public class SnapshotTestUtils {
             .addListener(listener);
     }
 
+    /**
+     * Updates the cluster state to mark a node for shutdown by adding or updating its shutdown metadata. Must be cleared at the end
+     * of the test by calling {@link #clearShutdownMetadata(ClusterService)}
+     * <p>
+     * This method submits an unbatched state update task to the provided {@link ClusterService}, which
+     * sets the shutdown metadata for the specified node. The metadata is built using the provided
+     * {@link SingleNodeShutdownMetadata.Builder}. Upon completion, the provided {@link ActionListener}
+     * is notified.
+     * </p>
+     * Note: At the beginning of each test, the test cluster is reset. Therefore, node names can be reused between tests if they manually
+     * start nodes. When a test adds shutdown metadata for its manually started node, <i>it must be cleared at the end of the test by
+     * calling {@link #clearShutdownMetadata(ClusterService)}</i>.
+     * Otherwise, the subsequent test can start a node with the same name which is still shutting down and cannot accept
+     * shards which leads to create index timeout.
+     *
+     * @param clusterService the {@link ClusterService} used to submit the state update task
+     * @param shutdownMetadataBuilder the builder for the node's shutdown metadata
+     * @param nodeName the name of the node to mark for shutdown
+     * @param listener the {@link ActionListener} to be notified when the operation completes or fails
+     */
     public static void putShutdownMetadata(
         ClusterService clusterService,
         SingleNodeShutdownMetadata.Builder shutdownMetadataBuilder,
@@ -99,5 +119,24 @@ public class SnapshotTestUtils {
                 listener.onResponse(null);
             }
         });
+    }
+
+    public static void clearShutdownMetadata(ClusterService clusterService) {
+        safeAwait(listener -> clusterService.submitUnbatchedStateUpdateTask("remove restart marker", new ClusterStateUpdateTask() {
+            @Override
+            public ClusterState execute(ClusterState currentState) {
+                return currentState.copyAndUpdateMetadata(mdb -> mdb.putCustom(NodesShutdownMetadata.TYPE, NodesShutdownMetadata.EMPTY));
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                fail(e);
+            }
+
+            @Override
+            public void clusterStateProcessed(ClusterState initialState, ClusterState newState) {
+                listener.onResponse(null);
+            }
+        }));
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/snapshots/SnapshotTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/snapshots/SnapshotTestUtils.java
@@ -55,12 +55,16 @@ public class SnapshotTestUtils {
      * sets the shutdown metadata for the specified node. The metadata is built using the provided
      * {@link SingleNodeShutdownMetadata.Builder}. Upon completion, the provided {@link ActionListener}
      * is notified.
-     * </p>
-     * Note: At the beginning of each test, the test cluster is reset. Therefore, node names can be reused between tests if they manually
-     * start nodes. When a test adds shutdown metadata for its manually started node, <i>it must be cleared at the end of the test by
+     * <p>
+     * NB: If using {@code ESIntegTestCase.Scope.SUITE}, at the beginning of each test, the test cluster is reset.
+     * Therefore, node names can be reused between tests if they manually start nodes.
+     * When a test adds shutdown metadata for its manually started node, <i>it must be cleared at the end of the test by
      * calling {@link #clearShutdownMetadata(ClusterService)}</i>.
      * Otherwise, the subsequent test can start a node with the same name which is still shutting down and cannot accept
      * shards which leads to create index timeout.
+     * <p>
+     * NB If using {@code ESIntegTestCase.Scope.TEST}, the test cluster exists only for the duration of the test, and so
+     * calling {@link #clearShutdownMetadata(ClusterService)} is not strictly required.
      *
      * @param clusterService the {@link ClusterService} used to submit the state update task
      * @param shutdownMetadataBuilder the builder for the node's shutdown metadata


### PR DESCRIPTION
Moves `clearShutdownMetadata` into `SnapshotTestUtils` so that it can be called from `ServerlessSnapshotShutdownIT` to clear the shutdown metadata at the end of each test

Relates: #140753
Relates: #140755
Relates: #140759
Relates: #140760
Relates: #140761
Relates: #140762
Relates: #140764
Relates: #140765