### PR TITLE
[9.3] Sort the values of a legacy histogram during downsampling (#140771)

### DIFF
--- a/docs/changelog/140771.yaml
+++ b/docs/changelog/140771.yaml
@@ -1,0 +1,6 @@
+pr: 140771
+summary: Sort the values of a legacy histogram during downsampling
+area: Downsampling
+type: bug
+issues:
+ - 139382

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/TDigestHistogramFieldProducer.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/TDigestHistogramFieldProducer.java
@@ -80,12 +80,17 @@ abstract class TDigestHistogramFieldProducer extends AbstractDownsampleFieldProd
         public void write(XContentBuilder builder) throws IOException {
             if (isEmpty() == false) {
                 Iterator<Centroid> centroids = tDigestState.uniqueCentroids();
-                final List<Double> values = new ArrayList<>();
-                final List<Long> counts = new ArrayList<>();
+                List<Centroid> sortedCentroids = new ArrayList<>(tDigestState.centroidCount());
                 while (centroids.hasNext()) {
-                    Centroid centroid = centroids.next();
-                    values.add(centroid.mean());
-                    counts.add(centroid.count());
+                    sortedCentroids.add(centroids.next());
+                }
+                sortedCentroids.sort(Centroid::compareTo);
+                double[] values = new double[sortedCentroids.size()];
+                long[] counts = new long[sortedCentroids.size()];
+                for (int i = 0; i < sortedCentroids.size(); i++) {
+                    Centroid centroid = sortedCentroids.get(i);
+                    values[i] = centroid.mean();
+                    counts[i] = centroid.count();
                 }
                 builder.startObject(name()).field("counts", counts).field("values", values).endObject();
                 tDigestState.close();


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Sort the values of a legacy histogram during downsampling (#140771)