### PR TITLE
ESQL: WIP: simplify PruneColumns

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumns.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PruneColumns.java
@@ -27,7 +27,6 @@ import org.elasticsearch.xpack.esql.plan.logical.Sample;
 import org.elasticsearch.xpack.esql.plan.logical.UnaryPlan;
 import org.elasticsearch.xpack.esql.plan.logical.UnionAll;
 import org.elasticsearch.xpack.esql.plan.logical.join.InlineJoin;
-import org.elasticsearch.xpack.esql.plan.logical.join.StubRelation;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalSupplier;
 import org.elasticsearch.xpack.esql.planner.PlannerUtils;
@@ -39,7 +38,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.elasticsearch.xpack.esql.expression.NamedExpressions.mergeOutputExpressions;
 import static org.elasticsearch.xpack.esql.optimizer.rules.logical.PruneEmptyPlans.skipPlan;
 
 /**
@@ -149,25 +147,25 @@ public final class PruneColumns extends Rule<LogicalPlan, LogicalPlan> {
             p = pruneRightSideAndProject(ij);
             recheck.set(true);
         } else if (right != ij.right()) {
-//            if (right.anyMatch(plan -> plan instanceof Aggregate) == false) {// there is no aggregation on the right side anymore
-//                if (right instanceof StubRelation) {// right is just a StubRelation, meaning nothing is needed from the right side
-//                    p = pruneRightSideAndProject(ij);
-//                } else {
-//                    // if the right has no aggregation anymore, but it still has some other plans (evals, projects),
-//                    // we keep those and integrate them into the main plan. The InlineJoin is also replaced entirely.
-//                    p = InlineJoin.replaceStub(ij.left(), right);
-//                    p = new Project(ij.source(), p, mergeOutputExpressions(p.output(), ij.left().output()));
-//                }
-//            } else {
-//                // if the right side has been updated, replace it
-//                p = ij.replaceRight(right);
-//            }
-//            recheck.set(true);
+            // if (right.anyMatch(plan -> plan instanceof Aggregate) == false) {// there is no aggregation on the right side anymore
+            // if (right instanceof StubRelation) {// right is just a StubRelation, meaning nothing is needed from the right side
+            // p = pruneRightSideAndProject(ij);
+            // } else {
+            // // if the right has no aggregation anymore, but it still has some other plans (evals, projects),
+            // // we keep those and integrate them into the main plan. The InlineJoin is also replaced entirely.
+            // p = InlineJoin.replaceStub(ij.left(), right);
+            // p = new Project(ij.source(), p, mergeOutputExpressions(p.output(), ij.left().output()));
+            // }
+            // } else {
+            // // if the right side has been updated, replace it
+            // p = ij.replaceRight(right);
+            // }
+            // recheck.set(true);
         }
 
-//        if (recheck.get() == false) {
-//            used.addAll(p.references());
-//        }
+        // if (recheck.get() == false) {
+        // used.addAll(p.references());
+        // }
 
         return p;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/rule/RuleExecutor.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/rule/RuleExecutor.java
@@ -193,8 +193,8 @@ public abstract class RuleExecutor<TreeType extends Node<TreeType>> {
 
                     if (tf.hasChanged()) {
                         hasChanged = true;
-                        if (changeLog.isTraceEnabled()) {
-                            changeLog.trace("Rule {} applied with change\n{}", rule, NodeUtils.diffString(tf.before, tf.after));
+                        if (true) {
+                            changeLog.info("Rule {} applied with change\n{}", rule, NodeUtils.diffString(tf.before, tf.after));
                         }
                     } else {
                         if (log.isTraceEnabled()) {


### PR DESCRIPTION
Do not merge.

This is an attempt at simplifying PruneColumns by removing some special casing that _conceptually_ doesn't seem to be required, esp. when dealing with InlineStats.

Main changes:
- Pruning does work the same inside an InlineJoin branch and outside of it.
- We always prune Projects, not only inside InlineJoin. They may end up being empty projections (but we seem to have allowed this; Luigi implemented this, I think.)
- Pruning aggs works the same both in InlineJoin and outside of it.
- InlineJoin's pruning treats the join attributes as "used", preventing missing attributes from too aggressive pruning.

Most optimizer tests still pass and none exhibit the dreaded "optimized incorrectly due to missing attributes". All single node spec tests still pass.

If we go with this, we may need to make PruneColumns version-aware, because past versions probably can't deal with empty Projects.

Relates https://github.com/elastic/elasticsearch/issues/139359
Relates https://github.com/elastic/elasticsearch/issues/140757