### PR TITLE
Removes exceptions that aren't thrown

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStatusApisIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStatusApisIT.java
@@ -68,7 +68,7 @@ public class SnapshotStatusApisIT extends AbstractSnapshotIntegTestCase {
             .build();
     }
 
-    public void testStatusApiConsistency() throws Exception {
+    public void testStatusApiConsistency() {
         createRepository("test-repo", "fs");
 
         createIndex("test-idx-1", "test-idx-2", "test-idx-3");

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusActionTests.java
@@ -56,7 +56,7 @@ public class TransportSnapshotsStatusActionTests extends ESTestCase {
     private TransportSnapshotsStatusAction action;
 
     @Before
-    public void initializeComponents() throws Exception {
+    public void initializeComponents() {
         threadPool = new TestThreadPool(TransportSnapshotsStatusActionTests.class.getName());
         clusterService = ClusterServiceUtils.createClusterService(threadPool);
         transportService = new CapturingTransport().createTransportService(
@@ -90,18 +90,18 @@ public class TransportSnapshotsStatusActionTests extends ESTestCase {
     }
 
     @After
-    public void shutdownComponents() throws Exception {
+    public void shutdownComponents() {
         threadPool.shutdown();
         repositoriesService.close();
         transportService.close();
         clusterService.close();
     }
 
-    public void testBuildResponseDetectsTaskIsCancelledWhileProcessingCurrentSnapshotEntries() throws Exception {
+    public void testBuildResponseDetectsTaskIsCancelledWhileProcessingCurrentSnapshotEntries() {
         runBasicBuildResponseTest(true);
     }
 
-    public void testBuildResponseInvokesListenerWithResponseWhenTaskIsNotCancelled() throws Exception {
+    public void testBuildResponseInvokesListenerWithResponseWhenTaskIsNotCancelled() {
         runBasicBuildResponseTest(false);
     }
 


### PR DESCRIPTION
Removes exceptions that aren't thrown as a follow up to https://github.com/elastic/elasticsearch/pull/140737
