### PR TITLE
[9.3] Corrects a seemingly simple bug where we pass numCands instead of k (#140839)

### DIFF
--- a/docs/changelog/140839.yaml
+++ b/docs/changelog/140839.yaml
@@ -1,0 +1,5 @@
+pr: 140839
+summary: Corrects a seemingly simple bug where we pass `numCands` instead of k
+area: Vector Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/vectors/KnnSearchBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/KnnSearchBuilder.java
@@ -474,9 +474,9 @@ public class KnnSearchBuilder implements Writeable, ToXContentFragment, Rewritea
         if (queryVectorBuilder != null) {
             throw new IllegalArgumentException("missing rewrite");
         }
-        return new KnnVectorQueryBuilder(field, queryVector, numCands, numCands, visitPercentage, rescoreVectorBuilder, similarity).boost(
-            boost
-        ).queryName(queryName).addFilterQueries(filterQueries);
+        return new KnnVectorQueryBuilder(field, queryVector, k, numCands, visitPercentage, rescoreVectorBuilder, similarity).boost(boost)
+            .queryName(queryName)
+            .addFilterQueries(filterQueries);
     }
 
     public Float getSimilarity() {

--- a/server/src/test/java/org/elasticsearch/search/vectors/KnnSearchBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/KnnSearchBuilderTests.java
@@ -251,15 +251,9 @@ public class KnnSearchBuilderTests extends AbstractXContentSerializingTestCase<K
             builder.addFilterQuery(filter);
         }
 
-        QueryBuilder expected = new KnnVectorQueryBuilder(
-            field,
-            vector,
-            numCands,
-            numCands,
-            visitPercentage,
-            rescoreVectorBuilder,
-            similarity
-        ).addFilterQueries(filterQueries).boost(boost);
+        QueryBuilder expected = new KnnVectorQueryBuilder(field, vector, k, numCands, visitPercentage, rescoreVectorBuilder, similarity)
+            .addFilterQueries(filterQueries)
+            .boost(boost);
         assertEquals(expected, builder.toQueryBuilder());
     }
 


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Corrects a seemingly simple bug where we pass numCands instead of k (#140839)