### PR TITLE
[TEST] Skip injecting boundary tuple only on lower boundary for rate tests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -354,9 +354,6 @@ tests:
 - class: org.elasticsearch.repositories.blobstore.testkit.analyze.RepositoryAnalysisFailureIT
   method: testFailsOnCopyAfterWrite
   issue: https://github.com/elastic/elasticsearch/issues/140819
-- class: org.elasticsearch.xpack.esql.action.RandomizedTimeSeriesIT
-  method: testRateGroupByNothing
-  issue: https://github.com/elastic/elasticsearch/issues/139639
 
 # Examples:
 #

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/RandomizedTimeSeriesIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/RandomizedTimeSeriesIT.java
@@ -50,6 +50,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
@@ -418,9 +419,9 @@ public class RandomizedTimeSeriesIT extends AbstractEsqlIntegTestCase {
     ) {
         String timeseriesId = timeseries.getFirst().v1();
         var referenceTuple = isLowerBoundary ? timeseries.getFirst().v2() : timeseries.getLast().v2();
-        if (referenceTuple.v1().toEpochMilli() % (secondsInWindow * 1000L) == 0) {
+        if (isLowerBoundary && referenceTuple.v1().toEpochMilli() % (secondsInWindow * 1000L) == 0) {
             // The reference tuple is already on the boundary.
-            return false;
+            return true;
         }
         Tuple<Instant, Double> otherTuple = null;
         long otherTimestamp = 0;

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/RandomizedTimeSeriesIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/RandomizedTimeSeriesIT.java
@@ -50,7 +50,6 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;


### PR DESCRIPTION
Follow up on #140649, we still need to inject a tuple on the upper boundary if applicable.

Fixes #139639
Fixes #140853

