### PR TITLE
[9.3] Ignore JNA Cleaner thread in TestContainersThreadFilter (#140614)

### DIFF
--- a/test/fixtures/testcontainer-utils/src/main/java/org/elasticsearch/test/fixtures/testcontainers/TestContainersThreadFilter.java
+++ b/test/fixtures/testcontainer-utils/src/main/java/org/elasticsearch/test/fixtures/testcontainers/TestContainersThreadFilter.java
@@ -14,12 +14,17 @@ import com.carrotsearch.randomizedtesting.ThreadFilter;
 /**
  * test container spawns extra threads, which causes our thread leak
  * detection to fail. Filter these threads out since we can't clean them up.
+ *
+ * This also filters the "JNA Cleaner" thread since TestContainers uses JNA
+ * internally for Docker communication, and the JNA cleaner is a static
+ * JVM-level thread that cleans up native memory references.
  */
 public class TestContainersThreadFilter implements ThreadFilter {
     @Override
     public boolean reject(Thread t) {
         return t.getName().startsWith("testcontainers-")
             || t.getName().startsWith("ducttape")
-            || t.getName().startsWith("ForkJoinPool.commonPool-worker-");
+            || t.getName().startsWith("ForkJoinPool.commonPool-worker-")
+            || t.getName().equals("JNA Cleaner");
     }
 }


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Ignore JNA Cleaner thread in TestContainersThreadFilter (#140614)