### PR TITLE
Enable undesired allocation tracking by default

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/UndesiredAllocationsTracker.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/UndesiredAllocationsTracker.java
@@ -18,7 +18,6 @@ import org.elasticsearch.common.FrequencyCappedAction;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.time.TimeProvider;
-import org.elasticsearch.common.util.FeatureFlag;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.shard.ShardId;
@@ -44,7 +43,6 @@ public class UndesiredAllocationsTracker {
     private static final Logger logger = LogManager.getLogger(UndesiredAllocationsTracker.class);
 
     private static final TimeValue FIVE_MINUTES = timeValueMinutes(5);
-    private static final FeatureFlag UNDESIRED_ALLOCATION_TRACKER_ENABLED = new FeatureFlag("undesired_allocation_tracker");
 
     /**
      * Warning logs will be periodically written if we see a shard that's been in an undesired allocation for this long
@@ -73,7 +71,7 @@ public class UndesiredAllocationsTracker {
      */
     public static final Setting<Integer> MAX_UNDESIRED_ALLOCATIONS_TO_TRACK = Setting.intSetting(
         "cluster.routing.allocation.desired_balance.undesired_duration_logging.max_to_track",
-        UNDESIRED_ALLOCATION_TRACKER_ENABLED.isEnabled() ? 10 : 0,
+        10,
         0,
         100,
         Setting.Property.Dynamic,


### PR DESCRIPTION
This has been turned on by overrides for a couple of months now and doesn't appear to cause any issues. This is just to turn it on by default so the overrides can be removed.

Relates: ES-11928

