### PR TITLE
[9.3] ES|QL: Fix Present and Absent aggregate functions (#140671)

### DIFF
--- a/docs/changelog/140671.yaml
+++ b/docs/changelog/140671.yaml
@@ -1,0 +1,5 @@
+pr: 140671
+summary: Fix Present/Absent agg functions
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/PresentAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/PresentAggregatorFunction.java
@@ -78,6 +78,8 @@ public class PresentAggregatorFunction implements AggregatorFunction {
 
     @Override
     public void addRawInput(Page page, BooleanVector mask) {
+        // is a previous page has non-null values we can return immediately
+        if (state) return;
         if (mask.isConstant() && mask.getBoolean(0) == false) return;
 
         Block block = page.getBlock(blockIndex());


### PR DESCRIPTION
Backports the following commits to 9.3:
 - ES|QL: Fix Present and Absent aggregate functions (#140671)