### PR TITLE
[9.2] Enhance updatecli configuration for branch handling (#140708)

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -8,7 +8,7 @@
         "admin",
         "write"
       ],
-      "allowed_list": ["elastic-renovate-prod[bot]"],
+      "allowed_list": ["elastic-renovate-prod[bot]", "github-actions[bot]"],
       "set_commit_status": false,
       "build_on_commit": true,
       "build_on_comment": true,

--- a/.github/updatecli/values.d/ironbank.yml
+++ b/.github/updatecli/values.d/ironbank.yml
@@ -1,3 +1,12 @@
 config:
   - path: distribution/docker/src/docker/iron_bank
     dockerfile: ../dockerfiles/ironbank/Dockerfile
+
+pull_request:
+  labels:
+    - ":Delivery/Tooling"
+    - ":Delivery/Packaging"
+    - "auto-merge-without-approval"
+    - "dependencies"
+    - ">non-issue"
+

--- a/.github/updatecli/values.d/scm.yml
+++ b/.github/updatecli/values.d/scm.yml
@@ -2,15 +2,9 @@ scm:
   enabled: true
   owner: elastic
   repository: elasticsearch
-  branch: "{{ requiredEnv `UPDATECLI_BRANCH` }}"
+  branch: "main" # this value is overwritten by the GH workflow to match current branch
   commitusingapi: true
   # begin updatecli-compose policy values
   user: elasticmachine
   email: 42973632+elasticmachine@users.noreply.github.com
   # end updatecli-compose policy values
-  pullrequest:
-    labels:
-      - ":Delivery/Tooling"
-      - ":Delivery/Packaging"
-      - "auto-merge-without-approval"
-      - "dependencies"

--- a/.github/updatecli/values.d/updatecli-compose.yml
+++ b/.github/updatecli/values.d/updatecli-compose.yml
@@ -1,3 +1,9 @@
 spec:
   files:
     - "updatecli-compose.yaml"
+
+labels:
+  - ":Delivery/Tooling"
+  - "auto-merge-without-approval"
+  - "dependencies"
+  - ">non-issue"

--- a/.github/workflows/updatecli-compose.yml
+++ b/.github/workflows/updatecli-compose.yml
@@ -10,15 +10,38 @@ permissions:
   contents: read
 
 jobs:
-  compose:
+  setup-matrix:
     if: github.repository == 'elastic/elasticsearch'
     runs-on: ubuntu-latest
+    outputs:
+      branches: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: set-matrix
+        run: |
+          BRANCHES=$(jq -c '[.branches[].branch]' branches.json)
+          echo "matrix=$BRANCHES" >> $GITHUB_OUTPUT
+
+  compose:
+    needs: setup-matrix
+    if: github.repository == 'elastic/elasticsearch'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ${{ fromJson(needs.setup-matrix.outputs.branches) }}
     permissions:
       contents: write
       packages: read
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
+
+      - name: Update branch in SCM values
+        run: |
+          yq eval '.scm.branch = "${{ matrix.branch }}"' -i .github/updatecli/values.d/scm.yml
 
       - uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446 # v3.2.0
         with:
@@ -28,12 +51,7 @@ jobs:
 
       - uses: elastic/oblt-actions/updatecli/run@v1
         with:
-          command: --experimental compose diff
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: elastic/oblt-actions/updatecli/run@v1
-        with:
-          command: --experimental compose apply
+          # Runs in "--debug" mode to provide logs if the PR creation fails
+          command: --experimental compose apply --debug
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Enhance updatecli configuration for branch handling (#140708)](https://github.com/elastic/elasticsearch/pull/140708)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)