### PR TITLE
[8.19] Enhance updatecli configuration for branch handling (#140708)

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -8,6 +8,7 @@
         "admin",
         "write"
       ],
+      "allowed_list": ["github-actions[bot]"],
       "set_commit_status": false,
       "build_on_commit": true,
       "build_on_comment": true,

--- a/.github/updatecli/values.d/ironbank.yml
+++ b/.github/updatecli/values.d/ironbank.yml
@@ -8,4 +8,5 @@ pull_request:
     - ":Delivery/Packaging"
     - "auto-merge-without-approval"
     - "dependencies"
+    - ">non-issue"
 

--- a/.github/updatecli/values.d/updatecli-compose.yml
+++ b/.github/updatecli/values.d/updatecli-compose.yml
@@ -1,3 +1,9 @@
 spec:
   files:
     - "updatecli-compose.yaml"
+
+labels:
+  - ":Delivery/Tooling"
+  - "auto-merge-without-approval"
+  - "dependencies"
+  - ">non-issue"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Enhance updatecli configuration for branch handling (#140708)](https://github.com/elastic/elasticsearch/pull/140708)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)