### PR TITLE
Fix ES:QL Driver logging for 4xx errors and cancellations

### DIFF
--- a/docs/changelog/140905.yaml
+++ b/docs/changelog/140905.yaml
@@ -1,0 +1,6 @@
+area: ES|QL
+issues:
+ - 138008
+pr: 140905
+summary: Fix ES:QL Driver logging for 4xx errors and cancellations
+type: bug

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Driver.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Driver.java
@@ -20,8 +20,10 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.TaskCancelledException;
 
 import java.util.ArrayList;
@@ -196,7 +198,16 @@ public class Driver implements Releasable, Describable {
                 LOGGER.debug("Cancelling running driver [{}]", shortDescription, e);
                 throw e;
             } catch (RuntimeException e) {
-                LOGGER.warn(Strings.format("Error running driver [%s]", shortDescription), e);
+                RestStatus status = ExceptionsHelper.status(e);
+                // HTTP 4xx status codes (400-499) indicate client/user errors: malformed requests, authentication
+                // failures, cancellations, etc. These are expected user actions, not system failures, so log at
+                // DEBUG level to reduce noise. HTTP 5xx status codes (500+) indicate server errors: internal
+                // failures, timeouts, etc. These are system failures that need attention, so log at WARN level.
+                if (status.getStatus() >= 400 && status.getStatus() < 500) {
+                    LOGGER.debug(Strings.format("User error running driver [%s]", shortDescription), e);
+                } else {
+                    LOGGER.warn(Strings.format("Error running driver [%s]", shortDescription), e);
+                }
                 throw e;
             } finally {
                 assert driverContext.assertEndRunLoop();

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Driver.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Driver.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.compute.operator;
 
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ContextPreservingActionListener;
 import org.elasticsearch.action.support.SubscribableListener;
@@ -20,7 +21,6 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.rest.RestStatus;


### PR DESCRIPTION
# Fix ES:QL Driver logging for 4xx errors and cancellations
Reduces log noise by logging 4xx client errors (including cancellations) at DEBUG instead of WARN/ERROR.
## Problem:
Over 80% of ES:QL errors in serverless are from user cancellations, which are expected user actions, not system failures. These were logged at WARN/ERROR, creating noise.
## Solution:
TaskCancelledException is already handled separately at DEBUG level
RuntimeException with 4xx status codes (400-499) are now logged at DEBUG level
5xx server errors continue to be logged at WARN level
## Impact:
Reduces log noise from expected client actions while preserving visibility into actual system failures.

Closes  #138008