### PR TITLE
PromQL: Clamp function

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql.csv-spec
@@ -219,3 +219,59 @@ PROMQL index=k8s step=1h result=(tanh(vector(0.0)));
 result:double | step:datetime
 0.0           | 2024-05-10T00:00:00.000Z
 ;
+
+clamp_scalar
+required_capability: promql_pre_tech_preview_v14
+PROMQL index=k8s step=1h result=(clamp(vector(5.0), 0, 10));
+
+result:double | step:datetime
+5.0           | 2024-05-10T00:00:00.000Z
+;
+
+clamp_scalar_below_min
+required_capability: promql_pre_tech_preview_v14
+PROMQL index=k8s step=1h result=(clamp(vector(-5.0), 0, 10));
+
+result:double | step:datetime
+0.0           | 2024-05-10T00:00:00.000Z
+;
+
+clamp_scalar_above_max
+required_capability: promql_pre_tech_preview_v14
+PROMQL index=k8s step=1h result=(clamp(vector(15.0), 0, 10));
+
+result:double | step:datetime
+10.0          | 2024-05-10T00:00:00.000Z
+;
+
+clamp_min_scalar
+required_capability: promql_pre_tech_preview_v14
+PROMQL index=k8s step=1h result=(clamp_min(vector(-5.0), 0));
+
+result:double | step:datetime
+0.0           | 2024-05-10T00:00:00.000Z
+;
+
+clamp_min_scalar_above
+required_capability: promql_pre_tech_preview_v14
+PROMQL index=k8s step=1h result=(clamp_min(vector(5.0), 0));
+
+result:double | step:datetime
+5.0           | 2024-05-10T00:00:00.000Z
+;
+
+clamp_max_scalar
+required_capability: promql_pre_tech_preview_v14
+PROMQL index=k8s step=1h result=(clamp_max(vector(15.0), 10));
+
+result:double | step:datetime
+10.0          | 2024-05-10T00:00:00.000Z
+;
+
+clamp_max_scalar_below
+required_capability: promql_pre_tech_preview_v14
+PROMQL index=k8s step=1h result=(clamp_max(vector(5.0), 10));
+
+result:double | step:datetime
+5.0           | 2024-05-10T00:00:00.000Z
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql.csv-spec
@@ -221,7 +221,7 @@ result:double | step:datetime
 ;
 
 clamp_scalar
-required_capability: promql_pre_tech_preview_v14
+required_capability: promql_clamp
 PROMQL index=k8s step=1h result=(clamp(vector(5.0), 0, 10));
 
 result:double | step:datetime
@@ -229,7 +229,7 @@ result:double | step:datetime
 ;
 
 clamp_scalar_below_min
-required_capability: promql_pre_tech_preview_v14
+required_capability: promql_clamp
 PROMQL index=k8s step=1h result=(clamp(vector(-5.0), 0, 10));
 
 result:double | step:datetime
@@ -237,7 +237,7 @@ result:double | step:datetime
 ;
 
 clamp_scalar_above_max
-required_capability: promql_pre_tech_preview_v14
+required_capability: promql_clamp
 PROMQL index=k8s step=1h result=(clamp(vector(15.0), 0, 10));
 
 result:double | step:datetime
@@ -245,7 +245,7 @@ result:double | step:datetime
 ;
 
 clamp_min_scalar
-required_capability: promql_pre_tech_preview_v14
+required_capability: promql_clamp
 PROMQL index=k8s step=1h result=(clamp_min(vector(-5.0), 0));
 
 result:double | step:datetime
@@ -253,7 +253,7 @@ result:double | step:datetime
 ;
 
 clamp_min_scalar_above
-required_capability: promql_pre_tech_preview_v14
+required_capability: promql_clamp
 PROMQL index=k8s step=1h result=(clamp_min(vector(5.0), 0));
 
 result:double | step:datetime
@@ -261,7 +261,7 @@ result:double | step:datetime
 ;
 
 clamp_max_scalar
-required_capability: promql_pre_tech_preview_v14
+required_capability: promql_clamp
 PROMQL index=k8s step=1h result=(clamp_max(vector(15.0), 10));
 
 result:double | step:datetime
@@ -269,7 +269,7 @@ result:double | step:datetime
 ;
 
 clamp_max_scalar_below
-required_capability: promql_pre_tech_preview_v14
+required_capability: promql_clamp
 PROMQL index=k8s step=1h result=(clamp_max(vector(5.0), 10));
 
 result:double | step:datetime

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1813,6 +1813,11 @@ public class EsqlCapabilities {
         PROMQL_MULTIPLE_FILTERS_FOR_SAME_LABEL(PROMQL_PRE_TECH_PREVIEW_V14.isEnabled()),
 
         /**
+         * PromQL clamp, clamp_min, and clamp_max functions support.
+         */
+        PROMQL_CLAMP(Build.current().isSnapshot()),
+
+        /**
          * KNN function adds support for k and visit_percentage options
          */
         KNN_FUNCTION_OPTIONS_K_VISIT_PERCENTAGE,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/promql/function/PromqlFunctionRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/promql/function/PromqlFunctionRegistry.java
@@ -40,10 +40,6 @@ import org.elasticsearch.xpack.esql.expression.function.aggregate.TimeSeriesAggr
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Variance;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.VarianceOverTime;
 import org.elasticsearch.xpack.esql.expression.function.scalar.Clamp;
-import org.elasticsearch.xpack.esql.expression.function.scalar.UnaryScalarFunction;
-import org.elasticsearch.xpack.esql.expression.function.scalar.conditional.ClampMax;
-import org.elasticsearch.xpack.esql.expression.function.scalar.conditional.ClampMin;
-import org.elasticsearch.xpack.esql.expression.function.scalar.Clamp;
 import org.elasticsearch.xpack.esql.expression.function.scalar.conditional.ClampMax;
 import org.elasticsearch.xpack.esql.expression.function.scalar.conditional.ClampMin;
 import org.elasticsearch.xpack.esql.expression.function.scalar.math.Abs;
@@ -237,7 +233,6 @@ public class PromqlFunctionRegistry {
     protected interface AcrossSeriesBinary<T extends AggregateFunction> {
         T build(Source source, Expression field, Expression filter, Expression window, Expression param);
     }
-
 
     @FunctionalInterface
     protected interface ValueTransformationFunction<T extends ScalarFunction> {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/promql/function/PromqlFunctionRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/promql/function/PromqlFunctionRegistry.java
@@ -39,6 +39,13 @@ import org.elasticsearch.xpack.esql.expression.function.aggregate.SumOverTime;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.TimeSeriesAggregateFunction;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Variance;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.VarianceOverTime;
+import org.elasticsearch.xpack.esql.expression.function.scalar.Clamp;
+import org.elasticsearch.xpack.esql.expression.function.scalar.UnaryScalarFunction;
+import org.elasticsearch.xpack.esql.expression.function.scalar.conditional.ClampMax;
+import org.elasticsearch.xpack.esql.expression.function.scalar.conditional.ClampMin;
+import org.elasticsearch.xpack.esql.expression.function.scalar.Clamp;
+import org.elasticsearch.xpack.esql.expression.function.scalar.conditional.ClampMax;
+import org.elasticsearch.xpack.esql.expression.function.scalar.conditional.ClampMin;
 import org.elasticsearch.xpack.esql.expression.function.scalar.math.Abs;
 import org.elasticsearch.xpack.esql.expression.function.scalar.math.Acos;
 import org.elasticsearch.xpack.esql.expression.function.scalar.math.Asin;
@@ -110,7 +117,7 @@ public class PromqlFunctionRegistry {
             if (toNearest == null) {
                 return new Round(source, value, null);
             } else {
-                // round to nearest multiple of toNearest: round(value / toNearest) * toNearest
+                // round to the nearest multiple of toNearest: round(value / toNearest) * toNearest
                 return new Mul(source, new Round(source, new Div(source, value, toNearest), null), toNearest);
             }
         }),
@@ -124,6 +131,9 @@ public class PromqlFunctionRegistry {
         valueTransformationFunction("sin", Sin::new),
         valueTransformationFunction("tan", Tan::new),
         valueTransformationFunction("tanh", Tanh::new),
+        valueTransformationFunctionBinary("clamp_min", ClampMin::new),
+        valueTransformationFunctionBinary("clamp_max", ClampMax::new),
+        valueTransformationFunctionTernary("clamp", Clamp::new),
 
         vector(),
 
@@ -228,6 +238,7 @@ public class PromqlFunctionRegistry {
         T build(Source source, Expression field, Expression filter, Expression window, Expression param);
     }
 
+
     @FunctionalInterface
     protected interface ValueTransformationFunction<T extends ScalarFunction> {
         T build(Source source, Expression value);
@@ -236,6 +247,11 @@ public class PromqlFunctionRegistry {
     @FunctionalInterface
     protected interface ValueTransformationFunctionBinary<T extends ScalarFunction> {
         T build(Source source, Expression value, Expression arg1);
+    }
+
+    @FunctionalInterface
+    protected interface ValueTransformationFunctionTernary<T extends Expression> {
+        T build(Source source, Expression value, Expression arg1, Expression arg2);
     }
 
     @FunctionalInterface
@@ -309,6 +325,24 @@ public class PromqlFunctionRegistry {
         );
     }
 
+    private static FunctionDefinition valueTransformationFunctionBinary(String name, ValueTransformationFunctionBinary<?> builder) {
+        return new FunctionDefinition(
+            name,
+            FunctionType.VALUE_TRANSFORMATION,
+            Arity.TWO,
+            (source, target, timestamp, window, extraParams) -> builder.build(source, target, extraParams.get(0))
+        );
+    }
+
+    private static FunctionDefinition valueTransformationFunctionTernary(String name, ValueTransformationFunctionTernary<?> builder) {
+        return new FunctionDefinition(
+            name,
+            FunctionType.VALUE_TRANSFORMATION,
+            Arity.fixed(3),
+            (source, target, timestamp, window, extraParams) -> builder.build(source, target, extraParams.get(0), extraParams.get(1))
+        );
+    }
+
     private static FunctionDefinition valueTransformationFunctionOptionalArg(String name, ValueTransformationFunctionBinary<?> builder) {
         return new FunctionDefinition(
             name,
@@ -358,9 +392,6 @@ public class PromqlFunctionRegistry {
 
         // Instant vector functions
         "absent",
-        "clamp",
-        "clamp_max",
-        "clamp_min",
         "ln",
         "log2",
         "scalar",

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/promql/PromqlLogicalPlanBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/promql/PromqlLogicalPlanBuilder.java
@@ -480,7 +480,7 @@ public class PromqlLogicalPlanBuilder extends PromqlExpressionBuilder {
             plan = new AcrossSeriesAggregate(source, child, name, List.of(), grouping, groupings);
         } else {
             List<Expression> extraParams = params.stream()
-                .skip(1) // skip first param (child)
+                .skip(1) // skip the first param (child)
                 .map(Expression.class::cast)
                 .toList();
             plan = switch (metadata.functionType()) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -304,6 +304,10 @@ public class CsvTests extends ESTestCase {
             );
             assumeFalse("can't load metrics in csv tests", testCase.requiredCapabilities.contains(PromqlFeatures.capabilityName()));
             assumeFalse(
+                "can't load metrics in csv tests",
+                testCase.requiredCapabilities.contains(EsqlCapabilities.Cap.PROMQL_CLAMP.capabilityName())
+            );
+            assumeFalse(
                 "can't use QSTR function in csv tests",
                 testCase.requiredCapabilities.contains(EsqlCapabilities.Cap.QSTR_FUNCTION.capabilityName())
             );


### PR DESCRIPTION
In this diff we add support for clamp-like functions in PromQL. 

Note: The PromQL clamp function semantics differs from ESQL. In case of `min` > `max` it [return empty vector](PromQL: math transforming functions) whereas ESQL returns `max`. This implementation follows ESQL.  