### PR TITLE
[9.3] EQL: Fix _index on missing events in CCS (#140886)

### DIFF
--- a/docs/changelog/140886.yaml
+++ b/docs/changelog/140886.yaml
@@ -1,0 +1,5 @@
+pr: 140886
+summary: Fix `_index` on missing events in CCS
+area: EQL
+type: bug
+issues: []

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlSearchAction.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlSearchAction.java
@@ -324,7 +324,10 @@ public final class TransportEqlSearchAction extends HandledTransportAction<EqlSe
     private static void qualifyEvents(List<EqlSearchResponse.Event> events, String clusterAlias) {
         if (events != null) {
             for (EqlSearchResponse.Event e : events) {
-                e.index(buildRemoteIndexName(clusterAlias, e.index()));
+                // missing events don't have an index, we dont' have to
+                if (e.missing() == false) {
+                    e.index(buildRemoteIndexName(clusterAlias, e.index()));
+                }
             }
         }
     }


### PR DESCRIPTION
Backports the following commits to 9.3:
 - EQL: Fix _index on missing events in CCS (#140886)