### PR TITLE
[9.3] Tidy up PatternTextCompositeValues

### DIFF
--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextDocValues.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextDocValues.java
@@ -27,7 +27,7 @@ public final class PatternTextDocValues extends BinaryDocValues {
         this.argsInfoDocValues = argsInfoDocValues;
     }
 
-    static PatternTextDocValues from(
+    static BinaryDocValues from(
         LeafReader leafReader,
         String templateFieldName,
         String argsFieldName,

--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextFieldType.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextFieldType.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.logsdb.patterntext;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queries.intervals.Intervals;
@@ -119,7 +120,7 @@ public class PatternTextFieldType extends TextFamilyFieldType {
     @Override
     public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
         return new ValueFetcher() {
-            PatternTextCompositeValues docValues;
+            BinaryDocValues docValues;
 
             @Override
             public void setNextReader(LeafReaderContext context) {

--- a/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextIndexFieldData.java
+++ b/x-pack/plugin/logsdb/src/main/java/org/elasticsearch/xpack/logsdb/patterntext/PatternTextIndexFieldData.java
@@ -72,7 +72,7 @@ public class PatternTextIndexFieldData implements IndexFieldData<LeafFieldData> 
     @Override
     public LeafFieldData loadDirect(LeafReaderContext context) throws IOException {
         LeafReader leafReader = context.reader();
-        PatternTextCompositeValues values = PatternTextCompositeValues.from(leafReader, fieldType);
+        var values = PatternTextCompositeValues.from(leafReader, fieldType);
         return new LeafFieldData() {
 
             final ToScriptFieldFactory<SortedBinaryDocValues> factory = KeywordDocValuesField::new;


### PR DESCRIPTION
Backporting #140806 to 9.3 branch.

* Just return PatternTextDocValues if there is no stored subfield.
* Either attempt load stored sub field as binary doc values or stored fields
* Change PatternTextCompositeValues#from(...) to return BinaryDocValues. PatternTextCompositeValues doesn't add anything api wise and usages should just rely on BinaryDocValues api.