### PR TITLE
Fix muted test handling in serverless

### DIFF
--- a/x-pack/plugin/esql/build.gradle
+++ b/x-pack/plugin/esql/build.gradle
@@ -615,8 +615,7 @@ tasks.named('stringTemplates').configure {
   }
 }
 
-
-test {
+tasks.named("test").configure {
   if (System.getProperty("golden.noactual") != null || project.hasProperty("golden.noactual")) {
     systemProperty "golden.noactual", "true"
   }


### PR DESCRIPTION
this early instantation of the test task actually makes mutedtest buildservice fail on serverless builds