### PR TITLE
Fix S3BlobContainerRetriesTests

### DIFF
--- a/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobContainerRetriesTests.java
+++ b/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobContainerRetriesTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.OperationPurpose;
 import org.elasticsearch.common.blobstore.OptionalBytesReference;
+import org.elasticsearch.common.blobstore.RetryingInputStream;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.Streams;
@@ -1593,7 +1594,7 @@ public class S3BlobContainerRetriesTests extends AbstractBlobContainerRetriesTes
     /**
      * Asserts that an InputStream is fully consumed, or aborted, when it is closed
      */
-    private static class AssertingInputStream extends FilterInputStream {
+    private static class AssertingInputStream extends FilterInputStream implements RetryingInputStreamUnwrappable {
 
         private final String blobName;
         private final boolean range;
@@ -1647,6 +1648,11 @@ public class S3BlobContainerRetriesTests extends AbstractBlobContainerRetriesTes
                 assertThat(in, instanceOf(ByteArrayInputStream.class));
                 assertThat(((ByteArrayInputStream) in).available(), equalTo(0));
             }
+        }
+
+        @Override
+        public RetryingInputStream<?> unwrap() {
+            return in instanceof RetryingInputStream<?> retryingInputStream ? retryingInputStream : null;
         }
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/AbstractBlobContainerRetriesTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/AbstractBlobContainerRetriesTestCase.java
@@ -297,6 +297,11 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
             ) {
                 if (stream instanceof RetryingInputStream<?> ris) {
                     meaningfulProgressSize.set(ris.meaningfulProgressSize());
+                } else if (stream instanceof RetryingInputStreamUnwrappable rius) {
+                    final var wrapped = rius.unwrap();
+                    if (wrapped != null) {
+                        meaningfulProgressSize.set(wrapped.meaningfulProgressSize());
+                    }
                 }
                 Streams.readFully(stream);
             }
@@ -314,7 +319,7 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
         int meaningfulProgressRetries = Math.toIntExact(
             retryContentSizes.stream().filter(contentSize -> contentSize >= meaningfulProgressSize.get()).count()
         );
-        assertEquals(exception.getSuppressed().length, maxRetries + meaningfulProgressRetries);
+        assertEquals(maxRetries + meaningfulProgressRetries, exception.getSuppressed().length);
     }
 
     protected org.hamcrest.Matcher<Integer> getMaxRetriesMatcher(int maxRetries) {
@@ -613,5 +618,14 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
      */
     protected final TestBlobContainerBuilder blobContainerBuilder() {
         return new TestBlobContainerBuilder();
+    }
+
+    /**
+     * If we wrap the {@link RetryingInputStream} in tests we can expose it using this interface
+     * so that {@link #testReadBlobWithReadTimeouts()} can determine the meaninful progress size
+     */
+    protected interface RetryingInputStreamUnwrappable {
+        @Nullable
+        RetryingInputStream<?> unwrap();
     }
 }


### PR DESCRIPTION
This allows the fix from #139999 to work for `S3BlobContainerRetriesTests`. This one has been failing intermittently.

Reliably reproduce failure before the change with 
```
./gradlew ":modules:repository-s3:test" --tests "org.elasticsearch.repositories.s3.S3BlobContainerRetriesTests.testReadBlobWithReadTimeouts" -Dtests.seed=82D8B342D5D86B9
```