### PR TITLE
[9.3] Remove ILM-stopped-check before the cluster update in `migrateToDataTiersRouting` (#140885) (#140892)

### DIFF
--- a/docs/changelog/140892.yaml
+++ b/docs/changelog/140892.yaml
@@ -1,0 +1,6 @@
+pr: 140892
+summary: Remove ILM-stopped-check before the cluster update in `migrateToDataTiersRouting`
+area: ILM
+type: bug
+issues:
+ - 140885

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportMigrateToDataTiersAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportMigrateToDataTiersAction.java
@@ -19,7 +19,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
-import org.elasticsearch.cluster.metadata.ProjectMetadata;
 import org.elasticsearch.cluster.project.ProjectResolver;
 import org.elasticsearch.cluster.routing.RerouteService;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -38,11 +37,8 @@ import org.elasticsearch.xpack.cluster.action.MigrateToDataTiersAction;
 import org.elasticsearch.xpack.cluster.action.MigrateToDataTiersRequest;
 import org.elasticsearch.xpack.cluster.action.MigrateToDataTiersResponse;
 import org.elasticsearch.xpack.cluster.metadata.MetadataMigrateToDataTiersRoutingService.MigratedEntities;
-import org.elasticsearch.xpack.core.ilm.IndexLifecycleMetadata;
 
 import static org.elasticsearch.xpack.cluster.metadata.MetadataMigrateToDataTiersRoutingService.migrateToDataTiersRouting;
-import static org.elasticsearch.xpack.core.ilm.LifecycleOperationMetadata.currentILMMode;
-import static org.elasticsearch.xpack.core.ilm.OperationMode.STOPPED;
 
 public class TransportMigrateToDataTiersAction extends TransportMasterNodeAction<MigrateToDataTiersRequest, MigrateToDataTiersResponse> {
 
@@ -115,17 +111,9 @@ public class TransportMigrateToDataTiersAction extends TransportMasterNodeAction
             return;
         }
 
-        ProjectMetadata projectMetadata = projectResolver.getProjectMetadata(state);
-        IndexLifecycleMetadata currentMetadata = projectMetadata.custom(IndexLifecycleMetadata.TYPE);
-        if (currentMetadata != null && currentILMMode(projectMetadata) != STOPPED) {
-            listener.onFailure(
-                new IllegalStateException(
-                    "stop ILM before migrating to data tiers, current state is [" + currentILMMode(projectMetadata) + "]"
-                )
-            );
-            return;
-        }
-
+        // We do not check if ILM has stopped before submitting the cluster state update
+        // like we do in other requests, because it is possible that this cluster state is
+        // not up to date and this API is not heavily used.
         final SetOnce<MigratedEntities> migratedEntities = new SetOnce<>();
         submitUnbatchedTask("migrate-to-data-tiers []", new ClusterStateUpdateTask(Priority.HIGH) {
             @Override


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Remove ILM-stopped-check before the cluster update in `migrateToDataTiersRouting` (#140885) (#140892)