### PR TITLE
ES|QL: Fix rowsReceived for the LimitOperator

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/LimitOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/LimitOperator.java
@@ -72,6 +72,8 @@ public class LimitOperator implements Operator {
     @Override
     public void addInput(Page page) {
         assert lastInput == null : "has pending input page";
+        rowsReceived += page.getPositionCount();
+
         final int acceptedRows = limiter.tryAccumulateHits(page.getPositionCount());
         if (acceptedRows == 0) {
             page.releaseBlocks();
@@ -81,7 +83,6 @@ public class LimitOperator implements Operator {
         } else {
             lastInput = page;
         }
-        rowsReceived += acceptedRows;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/LimitOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/LimitOperatorTests.java
@@ -25,7 +25,10 @@ import java.util.stream.LongStream;
 import static org.elasticsearch.compute.test.RandomBlock.randomElementType;
 import static org.elasticsearch.test.MapMatcher.assertMap;
 import static org.elasticsearch.test.MapMatcher.matchesMap;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.sameInstance;
 
 public class LimitOperatorTests extends OperatorTestCase {
@@ -199,9 +202,11 @@ public class LimitOperatorTests extends OperatorTestCase {
     @Override
     protected final void assertStatus(Map<String, Object> map, List<Page> input, List<Page> output) {
         var emittedRows = output.stream().mapToInt(Page::getPositionCount).sum();
-        var receivedRows = input.stream().mapToInt(Page::getPositionCount).sum();
+        var inputRows = input.stream().mapToInt(Page::getPositionCount).sum();
 
-        var mapMatcher = matchesMap().entry("rows_received", receivedRows)
+        // Once LimitOperator has received enough pages to fill the limit, it no longer receives
+        // input pages which is why we cannot just check that rows_received is the total number of input pages rows.
+        var mapMatcher = matchesMap().entry("rows_received", allOf(greaterThanOrEqualTo(emittedRows), lessThanOrEqualTo(inputRows)))
             .entry("pages_processed", output.size())
             .entry("rows_emitted", emittedRows)
             .entry("limit", 100)

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/LimitOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/LimitOperatorTests.java
@@ -199,8 +199,9 @@ public class LimitOperatorTests extends OperatorTestCase {
     @Override
     protected final void assertStatus(Map<String, Object> map, List<Page> input, List<Page> output) {
         var emittedRows = output.stream().mapToInt(Page::getPositionCount).sum();
+        var receivedRows = input.stream().mapToInt(Page::getPositionCount).sum();
 
-        var mapMatcher = matchesMap().entry("rows_received", emittedRows)
+        var mapMatcher = matchesMap().entry("rows_received", receivedRows)
             .entry("pages_processed", output.size())
             .entry("rows_emitted", emittedRows)
             .entry("limit", 100)


### PR DESCRIPTION
This is a small fix. In the profile for the LimitOperator, the `rows_emitted` value is always equal to `rows_received`.
That's because we always increment the value of `rows_received` with how many rows we keep from each input page.

It seems to be the only place we do this, since for the other operators, we always increment the value with the number of rows of each input page:

https://github.com/elastic/elasticsearch/blob/24fad8fac774983bb231da34321108abef102745/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/TopNOperator.java#L438

https://github.com/elastic/elasticsearch/blob/24fad8fac774983bb231da34321108abef102745/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeSinkOperator.java#L78-L82

https://github.com/elastic/elasticsearch/blob/24fad8fac774983bb231da34321108abef102745/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/MvExpandOperator.java#L231-L237