### PR TITLE
Small optimization in SyntheticIdPostingsEnum

### DIFF
--- a/docs/changelog/140956.yaml
+++ b/docs/changelog/140956.yaml
@@ -1,0 +1,5 @@
+pr: 140956
+summary: Small optimization in `SyntheticIdPostingsEnum`
+area: TSDB
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdFieldsProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdFieldsProducer.java
@@ -346,6 +346,7 @@ public class TSDBSyntheticIdFieldsProducer extends FieldsProducer {
         private int docID = -1;
 
         private SyntheticIdPostingsEnum(int docID, int termTsIdOrd, long termTimestamp) {
+            assert docID < maxDocs : docID + " >= " + maxDocs;
             this.docValues = new TSDBSyntheticIdDocValuesHolder(fieldInfos, docValuesProducer);
             this.termTsIdOrd = termTsIdOrd;
             this.termTimestamp = termTimestamp;
@@ -362,7 +363,11 @@ public class TSDBSyntheticIdFieldsProducer extends FieldsProducer {
             if (docID == DocIdSetIterator.NO_MORE_DOCS) {
                 return docID;
             }
-            int nextDocID = (docID == -1) ? startDocId : docID + 1;
+            if (docID == -1) {
+                docID = startDocId;
+                return docID;
+            }
+            int nextDocID = docID + 1;
             if (nextDocID < maxDocs) {
                 int tsIdOrd = docValues.docTsIdOrdinal(nextDocID);
                 if (tsIdOrd == termTsIdOrd) {
@@ -370,7 +375,7 @@ public class TSDBSyntheticIdFieldsProducer extends FieldsProducer {
                     if (timestamp == termTimestamp) {
                         assert Objects.equals(
                             docValues.docRoutingHash(nextDocID),
-                            docValues.docRoutingHash((docID == -1) ? startDocId : docID)
+                            docValues.docRoutingHash(docID)
                         );
                         docID = nextDocID;
                         return docID;

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdFieldsProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/TSDBSyntheticIdFieldsProducer.java
@@ -373,10 +373,7 @@ public class TSDBSyntheticIdFieldsProducer extends FieldsProducer {
                 if (tsIdOrd == termTsIdOrd) {
                     long timestamp = docValues.docTimestamp(nextDocID);
                     if (timestamp == termTimestamp) {
-                        assert Objects.equals(
-                            docValues.docRoutingHash(nextDocID),
-                            docValues.docRoutingHash(docID)
-                        );
+                        assert Objects.equals(docValues.docRoutingHash(nextDocID), docValues.docRoutingHash(docID));
                         docID = nextDocID;
                         return docID;
                     }


### PR DESCRIPTION
When accessing the first docID in the SyntheticIdPostingsEnum, we can avoid reading the _tsid and @timestamp doc values as they are already known.

Relates ES-13603