### PR TITLE
[9.3] Downsampling, change TDigest merging method to `MergingDigest` (#140935)

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/TDigestStates.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/TDigestStates.java
@@ -61,7 +61,7 @@ public final class TDigestStates {
                 return;
             }
             if (merger == null) {
-                merger = TDigestState.create(breaker, COMPRESSION, EXECUTION_HINT);
+                merger = TDigestState.createOfType(breaker, TDigestState.Type.MERGING, COMPRESSION);
             }
             histogram.addTo(merger);
             sum = nanAwareAgg(histogram.getSum(), sum, Double::sum);
@@ -142,7 +142,7 @@ public final class TDigestStates {
             double sum;
             long count;
             if (state == null) {
-                state = TDigestState.create(breaker, COMPRESSION, EXECUTION_HINT);
+                state = TDigestState.createOfType(breaker, TDigestState.Type.MERGING, COMPRESSION);
                 states.set(groupId, state);
                 min = Double.NaN;
                 max = Double.NaN;


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Downsampling, change TDigest merging method to `MergingDigest` (#140935)