### PR TITLE
Fix `SnapshotResiliencyTests#testSnapshotWithNodeDisconnects`

### DIFF
--- a/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
+++ b/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
@@ -395,6 +395,8 @@ public abstract class PeerFinder {
                 if (transportService.nodeConnected(discoveryNode)) {
                     if (peersRequestInFlight == false) {
                         requestPeers();
+                    } else {
+                        logger.trace("{} probe already in flight, skipping", this);
                     }
                 } else {
                     logger.trace("{} no longer connected", this);

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTestHelper.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTestHelper.java
@@ -351,14 +351,10 @@ public class SnapshotResiliencyTestHelper {
             disconnectedNodes.forEach(nodeName -> {
                 if (nodes.containsKey(nodeName)) {
                     final DiscoveryNode node = nodes.get(nodeName).node;
-                    nodes.values()
-                        .forEach(
-                            n -> n.transportService.openConnection(
-                                node,
-                                null,
-                                ActionTestUtils.assertNoFailureListener(c -> logger.debug("--> Connected [{}] to [{}]", n.node, node))
-                            )
-                        );
+                    nodes.values().forEach(n -> n.transportService.openConnection(node, null, ActionTestUtils.assertNoFailureListener(c -> {
+                        logger.debug("--> Connected [{}] to [{}]", n.node, node);
+                        n.mockTransport.deliverBlackholedRequests();
+                    })));
                 }
             });
         }

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransport.java
@@ -21,6 +21,8 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.CloseableConnection;
@@ -48,6 +50,8 @@ import static org.apache.lucene.tests.util.LuceneTestCase.rarely;
  * A basic transport implementation that allows to intercept requests that have been sent
  */
 public class MockTransport extends StubbableTransport {
+
+    private static final Logger logger = LogManager.getLogger(MockTransport.class);
 
     private TransportMessageListener listener;
     private final ConcurrentMap<Long, Tuple<DiscoveryNode, String>> requests = new ConcurrentHashMap<>();
@@ -91,7 +95,9 @@ public class MockTransport extends StubbableTransport {
     @SuppressWarnings("unchecked")
     public <Response extends TransportResponse> void handleResponse(final long requestId, final Response response) {
         final TransportResponseHandler<Response> transportResponseHandler = getTransportResponseHandler(requestId);
-        if (transportResponseHandler != null) {
+        if (transportResponseHandler == null) {
+            logger.trace("response handler for request [{}] not found", requestId);
+        } else {
             final Response deliveredResponse;
             try (BytesStreamOutput output = new BytesStreamOutput()) {
                 response.writeTo(output);


### PR DESCRIPTION
This test was (very rarely) failing to stabilise after the disruptions
are removed because of a lost `PeerFinder` response. This commit
addresses the issue by making sure to deliver (i.e. fail) all blocked
requests when removing the disruptions. It also adds a couple of bits of
`TRACE` logging that helped track down the problem.