### PR TITLE
Fix rate buffer assertion

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -354,24 +354,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.plan.logical.CommandLicenseTests
   method: testLicenseCheck
   issue: https://github.com/elastic/elasticsearch/issues/140941
-- class: org.elasticsearch.xpack.esql.expression.function.aggregate.RateTests
-  method: testGroupingAggregate {TestCase=<small positive doubles>}
-  issue: https://github.com/elastic/elasticsearch/issues/140999
-- class: org.elasticsearch.xpack.esql.expression.function.aggregate.RateTests
-  method: testGroupingAggregate {TestCase=<positive longs>}
-  issue: https://github.com/elastic/elasticsearch/issues/141000
-- class: org.elasticsearch.xpack.esql.expression.function.aggregate.RateTests
-  method: testGroupingAggregate {TestCase=<big positive doubles>}
-  issue: https://github.com/elastic/elasticsearch/issues/141001
-- class: org.elasticsearch.xpack.esql.expression.function.aggregate.IncreaseTests
-  method: testGroupingAggregate {TestCase=<small positive doubles>}
-  issue: https://github.com/elastic/elasticsearch/issues/141002
-- class: org.elasticsearch.xpack.esql.expression.function.aggregate.IncreaseTests
-  method: testGroupingAggregate {TestCase=<positive longs>}
-  issue: https://github.com/elastic/elasticsearch/issues/141003
-- class: org.elasticsearch.xpack.esql.expression.function.aggregate.IncreaseTests
-  method: testGroupingAggregate {TestCase=<big positive doubles>}
-  issue: https://github.com/elastic/elasticsearch/issues/141004
 
 # Examples:
 #

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AbstractRateGroupingFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AbstractRateGroupingFunction.java
@@ -53,10 +53,9 @@ class AbstractRateGroupingFunction {
         }
 
         final void prepareSlicesOnly(int groupId, long firstTimestamp) {
-            if (lastGroupId == groupId) {
-                assert valueCount > 0 : "last_group_id = " + lastGroupId + ", value_count = " + valueCount;
+            if (lastGroupId == groupId && valueCount > 0) {
                 if (timestamps.get(valueCount - 1) > firstTimestamp) {
-                    return;
+                    return; // continue with the current slice
                 }
             }
             // start a new slice


### PR DESCRIPTION
There are cases where a group doesn't have data points, and if this is the first group, the assertion can fail.

Closes #140999
Closes #141000
Closes #141001
Closes #141002
Closes #141003
Closes #141004