### PR TITLE
[9.3] [CI] Quick fix of dra staging builds failing due to missing 7.17 (#140965)

### DIFF
--- a/.buildkite/scripts/dra-update-staging.sh
+++ b/.buildkite/scripts/dra-update-staging.sh
@@ -6,7 +6,7 @@ source .buildkite/scripts/branches.sh
 
 for BRANCH in "${BRANCHES[@]}"; do
   # Don't publish main branch to staging
-  if [[ "$BRANCH" == "main" ]]; then
+  if [[ "$BRANCH" == "main" || "$BRANCH" == "7.17" ]]; then
     continue
   fi
 


### PR DESCRIPTION
Backports the following commits to 9.3:
 - [CI] Quick fix of dra staging builds failing due to missing 7.17 (#140965)