### PR TITLE
Fixed a bug in logsdb rolling upgrade sereverless tests involving par…

### DIFF
--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/AbstractStringTypeLogsdbRollingUpgradeTestCase.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/AbstractStringTypeLogsdbRollingUpgradeTestCase.java
@@ -9,18 +9,22 @@ package org.elasticsearch.xpack.logsdb;
 
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.test.rest.ObjectPath;
 import org.junit.Before;
 
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -32,82 +36,126 @@ public abstract class AbstractStringTypeLogsdbRollingUpgradeTestCase extends Abs
         { "@timestamp": "$now", "message": "$message", "length": $length, "factor": $factor }
         """;
 
-    private final String dataStreamName;
-    private final String template;
-    private final List<String> messages = new ArrayList<>();
     private final int numNodes;
 
-    private String templateId;
+    private final Map<String, List<String>> messagesPerDataStream = new HashMap<>();  // tracks messages per data stream
+    private final Map<String, String> templateIds = new HashMap<>();  // track template IDs per data stream
 
-    public AbstractStringTypeLogsdbRollingUpgradeTestCase(String dataStreamName, String template) {
-        this.dataStreamName = dataStreamName;
-        this.template = template;
+    protected record TemplateConfig(String dataStreamName, String template) {}
+
+    public AbstractStringTypeLogsdbRollingUpgradeTestCase() {
         this.numNodes = Integer.parseInt(System.getProperty("tests.num_nodes", "3"));
     }
 
     @Before
-    public void createIndex() throws Exception {
+    public void setup() throws Exception {
         checkRequiredFeatures();
+        verifyClusterIsRunningOldVersion();
+        createIndices();
+    }
+
+    private void createIndices() throws IOException {
         LogsdbIndexingRollingUpgradeIT.maybeEnableLogsdbByDefault();
 
-        // data stream name should already be reflective of whats being tested, so template id can be random
-        templateId = UUID.randomUUID().toString();
-        LogsdbIndexingRollingUpgradeIT.createTemplate(dataStreamName, templateId, template);
+        for (TemplateConfig config : getTemplates()) {
+            // data stream name should already be reflective of whats being tested, so template id can be random
+            String templateId = UUID.randomUUID().toString();
+            templateIds.put(config.dataStreamName(), templateId);
+            messagesPerDataStream.put(config.dataStreamName(), new ArrayList<>());
+            LogsdbIndexingRollingUpgradeIT.createTemplate(config.dataStreamName(), templateId, config.template());
+        }
     }
+
+    private void verifyClusterIsRunningOldVersion() throws IOException {
+        String expectedOldVersion = System.getProperty("tests.old_cluster_version");
+        assertThat("tests.old_cluster_version system property must be set", expectedOldVersion, notNullValue());
+
+        // Strip -SNAPSHOT suffix for comparison since builds from refspecs may not include it
+        String normalizedExpectedVersion = expectedOldVersion.replace("-SNAPSHOT", "");
+
+        Set<String> nodeVersions = readVersionsFromNodesInfo(adminClient());
+
+        assertThat(
+            "All nodes should be running the old version [" + expectedOldVersion + "] but found: " + nodeVersions,
+            nodeVersions,
+            everyItem(equalTo(normalizedExpectedVersion))
+        );
+    }
+
+    protected abstract List<TemplateConfig> getTemplates();
 
     /**
      * Override this method to add feature checks that must pass before the test runs.
      * Use {@code assumeTrue} to skip the test if required features are not available.
      */
-    protected void checkRequiredFeatures() throws Exception {
+    protected void checkRequiredFeatures() {
         // Default: no additional feature requirements
     }
 
-    protected List<String> getMessages() {
-        return messages;
+    /**
+     * Returns the messages indexed for a specific data stream.
+     */
+    protected List<String> getMessages(String dataStreamName) {
+        return messagesPerDataStream.get(dataStreamName);
     }
 
     public void testIndexing() throws Exception {
-        // before upgrading
-        indexDocumentsAndVerifyResults();
+        List<TemplateConfig> templates = getTemplates();
 
-        // verify that logsdb and synthetic source are enabled before proceeding
-        // note, we must index at least one document to create the data stream (data streams are created lazily on first index)
-        String firstBackingIndex = getDataStreamBackingIndexNames(dataStreamName).getFirst();
-        var settings = (Map<?, ?>) getIndexSettings(firstBackingIndex, true).get(firstBackingIndex);
-        assertThat(((Map<?, ?>) settings.get("settings")).get("index.mode"), equalTo("logsdb"));
-        assertThat(((Map<?, ?>) settings.get("defaults")).get("index.mapping.source.mode"), equalTo("SYNTHETIC"));
+        // before upgrading
+        for (TemplateConfig config : templates) {
+            indexDocumentsAndVerifyResults(config);
+        }
+
+        // verification must happen after we've indexed at least one document as streams are initialized lazily
+        verifyIndexMode(IndexMode.LOGSDB, templates.get(0).dataStreamName);
 
         // during upgrade
         for (int i = 0; i < numNodes; i++) {
             upgradeNode(i);
-            indexDocumentsAndVerifyResults();
+            for (TemplateConfig config : templates) {
+                indexDocumentsAndVerifyResults(config);
+            }
         }
 
         // after everything is upgraded
-        indexDocumentsAndVerifyResults();
+        for (TemplateConfig config : templates) {
+            indexDocumentsAndVerifyResults(config);
+        }
     }
 
-    private void indexDocumentsAndVerifyResults() throws Exception {
-        // given - implicitly start from the previous state
+    private void indexDocumentsAndVerifyResults(TemplateConfig config) throws Exception {
+        String dataStreamName = config.dataStreamName();
 
         // when - index some documents
-        indexDocuments(1, 5);
+        indexDocuments(dataStreamName, 1, 5);
 
-        // then
-
-        // verify that the data stream is healthy and still as expected
-        assertDataStream();
+        // then - verify that the data stream is healthy and still as expected
+        assertDataStream(dataStreamName);
 
         // performs some searches and queries, expect everything to pass
-        search();
-        query();
+        search(dataStreamName);
+        query(config);
+    }
+
+    protected void verifyIndexMode(IndexMode indexMode, String dataStreamName) throws IOException {
+        String writeBackingIndex = getDataStreamBackingIndexNames(dataStreamName).getLast();
+        var settings = (Map<?, ?>) getIndexSettings(writeBackingIndex, true).get(writeBackingIndex);
+
+        // when index mode is not specified (like when standard mode is used), then settings.index.mode will return null
+        if (indexMode == IndexMode.STANDARD) {
+            assertThat(((Map<?, ?>) settings.get("defaults")).get("index.mode"), equalTo(indexMode.getName()));
+            assertThat(((Map<?, ?>) settings.get("settings")).get("index.mapping.source.mode"), equalTo("synthetic"));
+        } else {
+            assertThat(((Map<?, ?>) settings.get("settings")).get("index.mode"), equalTo(indexMode.getName()));
+            assertThat(((Map<?, ?>) settings.get("defaults")).get("index.mapping.source.mode"), equalTo("SYNTHETIC"));
+        }
     }
 
     /**
      * Verifies that we're still using the expected data stream and thats its healthy.
      */
-    protected void assertDataStream() throws IOException {
+    protected void assertDataStream(String dataStreamName) throws IOException {
         var getDataStreamsRequest = new Request("GET", "/_data_stream/" + dataStreamName);
         var getDataStreamResponse = client().performRequest(getDataStreamsRequest);
 
@@ -116,7 +164,7 @@ public abstract class AbstractStringTypeLogsdbRollingUpgradeTestCase extends Abs
 
         assertThat(ObjectPath.evaluate(dataStreams, "data_streams.0.name"), equalTo(dataStreamName));
         assertThat(ObjectPath.evaluate(dataStreams, "data_streams.0.indices"), hasSize(1));
-        assertThat(ObjectPath.evaluate(dataStreams, "data_streams.0.template"), equalTo(templateId));
+        assertThat(ObjectPath.evaluate(dataStreams, "data_streams.0.template"), equalTo(templateIds.get(dataStreamName)));
 
         ensureGreen(dataStreamName);
     }
@@ -144,11 +192,13 @@ public abstract class AbstractStringTypeLogsdbRollingUpgradeTestCase extends Abs
     /**
      * Create an arbitrary document containing random values and index it.
      */
-    protected void indexDocuments(int numRequests, int numDocs) throws Exception {
+    protected void indexDocuments(String dataStreamName, int numRequests, int numDocs) throws Exception {
+        List<String> messages = messagesPerDataStream.get(dataStreamName);
+
         for (int i = 0; i < numRequests; i++) {
             // create the request
             Request request = new Request("POST", "/" + dataStreamName + "/_bulk");
-            request.setJsonEntity(createRequestBody(numDocs, Instant.now()));
+            request.setJsonEntity(createRequestBody(messages, numDocs, Instant.now()));
             request.addParameter("refresh", "true");
 
             // send the request and receive response
@@ -161,7 +211,7 @@ public abstract class AbstractStringTypeLogsdbRollingUpgradeTestCase extends Abs
         }
     }
 
-    private String createRequestBody(int numDocs, Instant startTime) {
+    private String createRequestBody(List<String> messages, int numDocs, Instant startTime) {
         StringBuilder requestBody = new StringBuilder();
 
         for (int i = 0; i < numDocs; i++) {
@@ -188,7 +238,9 @@ public abstract class AbstractStringTypeLogsdbRollingUpgradeTestCase extends Abs
     }
 
     @SuppressWarnings("unchecked")
-    private void search() throws IOException {
+    private void search(String dataStreamName) throws IOException {
+        List<String> messages = messagesPerDataStream.get(dataStreamName);
+
         Request searchRequest = new Request("GET", "/" + dataStreamName + "/_search");
         searchRequest.setJsonEntity("""
             {
@@ -219,7 +271,10 @@ public abstract class AbstractStringTypeLogsdbRollingUpgradeTestCase extends Abs
         assertThat(values, containsInAnyOrder(messages.toArray()));
     }
 
-    protected void query() throws Exception {
+    protected void query(TemplateConfig config) throws Exception {
+        String dataStreamName = config.dataStreamName();
+        List<String> messages = messagesPerDataStream.get(dataStreamName);
+
         var queryRequest = new Request("POST", "/_query");
         queryRequest.addParameter("pretty", "true");
         queryRequest.setJsonEntity("""

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/AbstractStringTypeLogsdbRollingUpgradeTestCase.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/AbstractStringTypeLogsdbRollingUpgradeTestCase.java
@@ -68,8 +68,20 @@ public abstract class AbstractStringTypeLogsdbRollingUpgradeTestCase extends Abs
 
     private void verifyClusterIsRunningOldVersion() throws IOException {
         String expectedOldVersion = System.getProperty("tests.old_cluster_version");
-        assertThat("tests.old_cluster_version system property must be set", expectedOldVersion, notNullValue());
+        if (expectedOldVersion != null) {
+            verifyOldVersion(expectedOldVersion);
+        } else {
+            String expectedServerlessOldVersion = System.getProperty("tests.serverless.bwc_stack_version");
+            verifyOldVersion(expectedServerlessOldVersion);
+            assertThat(
+                "tests.old_cluster_version or tests.serverless.bwc_stack_version system property must be set",
+                expectedServerlessOldVersion,
+                notNullValue()
+            );
+        }
+    }
 
+    private void verifyOldVersion(String expectedOldVersion) throws IOException {
         // Strip -SNAPSHOT suffix for comparison since builds from refspecs may not include it
         String normalizedExpectedVersion = expectedOldVersion.replace("-SNAPSHOT", "");
 

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/KeywordRollingUpgradeIT.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/KeywordRollingUpgradeIT.java
@@ -7,12 +7,10 @@
 
 package org.elasticsearch.xpack.logsdb;
 
-import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.mapper.Mapper;
 
-import java.util.Arrays;
+import java.util.Map;
 
 public class KeywordRollingUpgradeIT extends AbstractStringWithIgnoreAboveRollingUpgradeTestCase {
 
@@ -59,16 +57,19 @@ public class KeywordRollingUpgradeIT extends AbstractStringWithIgnoreAboveRollin
             }
         }""";
 
-    public KeywordRollingUpgradeIT(String template, String testScenario, Mapper.IgnoreAbove ignoreAbove) {
-        super(DATA_STREAM_NAME_PREFIX + "." + testScenario, template, ignoreAbove);
-    }
-
-    @ParametersFactory
-    public static Iterable<Object[]> data() {
-        return Arrays.asList(
-            new Object[][] {
-                { TEMPLATE, "basic", new Mapper.IgnoreAbove(null, IndexMode.LOGSDB) },
-                { TEMPLATE_WITH_IGNORE_ABOVE, "with-ignore-above", new Mapper.IgnoreAbove(50, IndexMode.LOGSDB) } }
+    @Override
+    protected Map<String, TemplateConfigWithIgnoreAbove> getTemplatesWithIgnoreAbove() {
+        var basicTemplate = new TemplateConfigWithIgnoreAbove(
+            DATA_STREAM_NAME_PREFIX + ".basic",
+            TEMPLATE,
+            new Mapper.IgnoreAbove(null, IndexMode.LOGSDB)
         );
+        var templateWithIgnoreAbove = new TemplateConfigWithIgnoreAbove(
+            DATA_STREAM_NAME_PREFIX + ".with-ignore-above",
+            TEMPLATE_WITH_IGNORE_ABOVE,
+            new Mapper.IgnoreAbove(50, IndexMode.LOGSDB)
+        );
+
+        return Map.of(basicTemplate.dataStreamName(), basicTemplate, templateWithIgnoreAbove.dataStreamName(), templateWithIgnoreAbove);
     }
 }

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/MatchOnlyTextRollingUpgradeIT.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/MatchOnlyTextRollingUpgradeIT.java
@@ -7,11 +7,9 @@
 
 package org.elasticsearch.xpack.logsdb;
 
-import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-
 import org.elasticsearch.index.mapper.MapperFeatures;
 
-import java.util.Arrays;
+import java.util.List;
 
 public class MatchOnlyTextRollingUpgradeIT extends AbstractStringTypeLogsdbRollingUpgradeTestCase {
 
@@ -88,27 +86,24 @@ public class MatchOnlyTextRollingUpgradeIT extends AbstractStringTypeLogsdbRolli
             }
         }""";
 
-    public MatchOnlyTextRollingUpgradeIT(String template, String testScenario) {
-        super(DATA_STREAM_NAME_PREFIX + "." + testScenario, template);
-    }
-
-    @ParametersFactory
-    public static Iterable<Object[]> data() {
-        return Arrays.asList(
-            new Object[][] {
-                { TEMPLATE, "basic" },
-                { TEMPLATE_WITH_MULTI_FIELD, "with-keyword-multi-field" },
-                { TEMPLATE_WITH_MULTI_FIELD_AND_IGNORE_ABOVE, "with-keyword-multi-field-and-ignore-above" } }
+    @Override
+    protected List<TemplateConfig> getTemplates() {
+        return List.of(
+            new TemplateConfig(DATA_STREAM_NAME_PREFIX + ".basic", TEMPLATE),
+            new TemplateConfig(DATA_STREAM_NAME_PREFIX + ".with-keyword-multi-field", TEMPLATE_WITH_MULTI_FIELD),
+            new TemplateConfig(
+                DATA_STREAM_NAME_PREFIX + ".with-keyword-multi-field-and-ignore-above",
+                TEMPLATE_WITH_MULTI_FIELD_AND_IGNORE_ABOVE
+            )
         );
     }
 
     @Override
-    public void testIndexing() throws Exception {
+    protected void checkRequiredFeatures() {
         assumeTrue(
             "Match only text block loader bug is present and fix is not present in this cluster",
             oldClusterHasFeature(MapperFeatures.MATCH_ONLY_TEXT_BLOCK_LOADER_FIX)
         );
-        super.testIndexing();
     }
 
 }

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/PatternTextRollingUpgradeIT.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/PatternTextRollingUpgradeIT.java
@@ -7,9 +7,7 @@
 
 package org.elasticsearch.xpack.logsdb;
 
-import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-
-import java.util.Arrays;
+import java.util.List;
 
 public class PatternTextRollingUpgradeIT extends AbstractStringTypeLogsdbRollingUpgradeTestCase {
 
@@ -87,17 +85,15 @@ public class PatternTextRollingUpgradeIT extends AbstractStringTypeLogsdbRolling
             }
         }""";
 
-    public PatternTextRollingUpgradeIT(String template, String testScenario) {
-        super(DATA_STREAM_NAME_PREFIX + "." + testScenario, template);
-    }
-
-    @ParametersFactory
-    public static Iterable<Object[]> data() {
-        return Arrays.asList(
-            new Object[][] {
-                { TEMPLATE, "basic" },
-                { TEMPLATE_WITH_MULTI_FIELD, "with-keyword-multi-field" },
-                { TEMPLATE_WITH_MULTI_FIELD_AND_IGNORE_ABOVE, "with-keyword-multi-field-and-ignore-above" } }
+    @Override
+    protected List<TemplateConfig> getTemplates() {
+        return List.of(
+            new TemplateConfig(DATA_STREAM_NAME_PREFIX + ".basic", TEMPLATE),
+            new TemplateConfig(DATA_STREAM_NAME_PREFIX + ".with-keyword-multi-field", TEMPLATE_WITH_MULTI_FIELD),
+            new TemplateConfig(
+                DATA_STREAM_NAME_PREFIX + ".with-keyword-multi-field-and-ignore-above",
+                TEMPLATE_WITH_MULTI_FIELD_AND_IGNORE_ABOVE
+            )
         );
     }
 

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/TextRollingUpgradeIT.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/TextRollingUpgradeIT.java
@@ -7,9 +7,7 @@
 
 package org.elasticsearch.xpack.logsdb;
 
-import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-
-import java.util.Arrays;
+import java.util.List;
 
 public class TextRollingUpgradeIT extends AbstractStringTypeLogsdbRollingUpgradeTestCase {
 
@@ -86,17 +84,15 @@ public class TextRollingUpgradeIT extends AbstractStringTypeLogsdbRollingUpgrade
             }
         }""";
 
-    public TextRollingUpgradeIT(String template, String testScenario) {
-        super(DATA_STREAM_NAME_PREFIX + "." + testScenario, template);
-    }
-
-    @ParametersFactory
-    public static Iterable<Object[]> data() {
-        return Arrays.asList(
-            new Object[][] {
-                { TEMPLATE, "basic" },
-                { TEMPLATE_WITH_MULTI_FIELD, "with-keyword-multi-field" },
-                { TEMPLATE_WITH_MULTI_FIELD_AND_IGNORE_ABOVE, "with-keyword-multi-field-and-ignore-above" } }
+    @Override
+    protected List<TemplateConfig> getTemplates() {
+        return List.of(
+            new TemplateConfig(DATA_STREAM_NAME_PREFIX + ".basic", TEMPLATE),
+            new TemplateConfig(DATA_STREAM_NAME_PREFIX + ".with-keyword-multi-field", TEMPLATE_WITH_MULTI_FIELD),
+            new TemplateConfig(
+                DATA_STREAM_NAME_PREFIX + ".with-keyword-multi-field-and-ignore-above",
+                TEMPLATE_WITH_MULTI_FIELD_AND_IGNORE_ABOVE
+            )
         );
     }
 

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/WildcardRollingUpgradeIT.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/WildcardRollingUpgradeIT.java
@@ -7,12 +7,10 @@
 
 package org.elasticsearch.xpack.logsdb;
 
-import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
-
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.mapper.Mapper;
 
-import java.util.Arrays;
+import java.util.Map;
 
 public class WildcardRollingUpgradeIT extends AbstractStringWithIgnoreAboveRollingUpgradeTestCase {
 
@@ -59,16 +57,19 @@ public class WildcardRollingUpgradeIT extends AbstractStringWithIgnoreAboveRolli
             }
         }""";
 
-    public WildcardRollingUpgradeIT(String template, String testScenario, Mapper.IgnoreAbove ignoreAbove) {
-        super(DATA_STREAM_NAME_PREFIX + "." + testScenario, template, ignoreAbove);
-    }
-
-    @ParametersFactory
-    public static Iterable<Object[]> data() {
-        return Arrays.asList(
-            new Object[][] {
-                { TEMPLATE, "basic", new Mapper.IgnoreAbove(null, IndexMode.LOGSDB) },
-                { TEMPLATE_WITH_IGNORE_ABOVE, "with-ignore-above", new Mapper.IgnoreAbove(50, IndexMode.LOGSDB) } }
+    @Override
+    protected Map<String, TemplateConfigWithIgnoreAbove> getTemplatesWithIgnoreAbove() {
+        var basicTemplate = new TemplateConfigWithIgnoreAbove(
+            DATA_STREAM_NAME_PREFIX + ".basic",
+            TEMPLATE,
+            new Mapper.IgnoreAbove(null, IndexMode.LOGSDB)
         );
+        var templateWithIgnoreAbove = new TemplateConfigWithIgnoreAbove(
+            DATA_STREAM_NAME_PREFIX + ".with-ignore-above",
+            TEMPLATE_WITH_IGNORE_ABOVE,
+            new Mapper.IgnoreAbove(50, IndexMode.LOGSDB)
+        );
+
+        return Map.of(basicTemplate.dataStreamName(), basicTemplate, templateWithIgnoreAbove.dataStreamName(), templateWithIgnoreAbove);
     }
 }


### PR DESCRIPTION
Parametrized tests reuse the `cluster` defined in the parent class. This means that every test case beyond the first doesn't actually perform a rolling upgrade, but rather starts from an upgraded state. 

This PR addresses that. It removes `@ParameterFactory` and replaces it with `getTemplates()`. The parent class calls `getTemplates()` to perform indexing and verifications for each template at every stage of the test. In other words, templates are all tested against an old cluster, then a mixed cluster, and finally an upgraded cluster.

Furthermore, to prevent issues like this from happening again, I've added a cluster version check into the `@Before` call.