### PR TITLE
Rename FlattenedDocValuesSyntheticFieldLoader

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedDocValuesSyntheticFieldLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedDocValuesSyntheticFieldLoader.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.TreeSet;
 import java.util.stream.Stream;
 
-class FlattenedSortedSetDocValuesSyntheticFieldLoader implements SourceLoader.SyntheticFieldLoader {
+class FlattenedDocValuesSyntheticFieldLoader implements SourceLoader.SyntheticFieldLoader {
     private final String fieldFullPath;
     private final String keyedFieldFullPath;
     private final String keyedIgnoredValuesFieldFullPath;
@@ -37,15 +37,16 @@ class FlattenedSortedSetDocValuesSyntheticFieldLoader implements SourceLoader.Sy
     private List<Object> ignoredValues = List.of();
 
     /**
-     * Build a loader for flattened fields from doc values.
+     * Build a loader for flattened fields from either binary or sorted set doc values.
      *
      * @param fieldFullPath                        full path to the original field
      * @param keyedFieldFullPath                   full path to the keyed field to load doc values from
      * @param keyedIgnoredValuesFieldFullPath      full path to the keyed field that stores values that are not present in doc values
      *                                             due to ignore_above
      * @param leafName                             the name of the leaf field to use in the rendered {@code _source}
+     * @param usesBinaryDocValues                  whether the values are stored using binary or sorted set doc values
      */
-    FlattenedSortedSetDocValuesSyntheticFieldLoader(
+    FlattenedDocValuesSyntheticFieldLoader(
         String fieldFullPath,
         String keyedFieldFullPath,
         @Nullable String keyedIgnoredValuesFieldFullPath,

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -1054,7 +1054,7 @@ public final class FlattenedFieldMapper extends FieldMapper {
     protected SyntheticSourceSupport syntheticSourceSupport() {
         if (fieldType().hasDocValues()) {
             return new SyntheticSourceSupport.Native(
-                () -> new FlattenedSortedSetDocValuesSyntheticFieldLoader(
+                () -> new FlattenedDocValuesSyntheticFieldLoader(
                     fullPath(),
                     fullPath() + KEYED_FIELD_SUFFIX,
                     fieldType().ignoreAbove.valuesPotentiallyIgnored() ? fullPath() + KEYED_IGNORED_VALUES_FIELD_SUFFIX : null,


### PR DESCRIPTION
As of #140246, flattened fields might use either binary or sorted set doc values, and the associated synthetic field loader can handle either format. This patch updates the name and javadoc of that field loader to document this behavior.
