### PR TITLE
bump watch history template version to account for serverless fix

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/support/WatcherIndexTemplateRegistryField.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/support/WatcherIndexTemplateRegistryField.java
@@ -23,8 +23,9 @@ public final class WatcherIndexTemplateRegistryField {
     // version 15: remove watches and triggered watches, these are now system indices
     // version 16: change watch history ILM policy
     // version 17: exclude input chain from indexing
+    // version 18: exclude input chain from indexing (serverless)
     // Note: if you change this, also inform the kibana team around the watcher-ui
-    public static final int INDEX_TEMPLATE_VERSION = 17;
+    public static final int INDEX_TEMPLATE_VERSION = 18;
     public static final String HISTORY_TEMPLATE_NAME = ".watch-history-" + INDEX_TEMPLATE_VERSION;
     public static final String HISTORY_TEMPLATE_NAME_NO_ILM = ".watch-history-no-ilm-" + INDEX_TEMPLATE_VERSION;
     public static final String[] TEMPLATE_NAMES = new String[] { HISTORY_TEMPLATE_NAME };


### PR DESCRIPTION
Bump watch history template version to account for serverless fix.

Relates to ES-13889, https://github.com/elastic/elasticsearch/pull/117701/