### PR TITLE
Optimize bloom filter merging by processing longs instead of bytes

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/bloomfilter/ES94BloomFilterDocValuesFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/bloomfilter/ES94BloomFilterDocValuesFormat.java
@@ -38,12 +38,14 @@ import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.store.RandomAccessInput;
+import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.lucene.store.IndexOutputOutputStream;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ByteArray;
+import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.index.codec.FilterDocValuesProducer;
 
@@ -335,6 +337,9 @@ public class ES94BloomFilterDocValuesFormat extends DocValuesFormat {
                 return;
             }
 
+            final var pageSizeInBytes = PageCacheRecycler.PAGE_SIZE_IN_BYTES;
+            final var newBloomFilterPageScratch = new BytesRef(pageSizeInBytes);
+            final var existingPageScratch = new BytesRef(pageSizeInBytes);
             for (int readerIdx = 0; readerIdx < mergeState.docValuesProducers.length; readerIdx++) {
                 final FieldInfo fieldInfo = mergeState.fieldInfos[readerIdx].fieldInfo(bloomFilterFieldName);
                 if (fieldInfo == null) {
@@ -360,11 +365,31 @@ public class ES94BloomFilterDocValuesFormat extends DocValuesFormat {
                         + bloomFilterFieldReader.getBloomFilterBitSetSizeInBits();
 
                 RandomAccessInput bloomFilterData = bloomFilterFieldReader.bloomFilterIn;
-                for (int i = 0; i < bitSetSizeInBytes; i++) {
-                    var existingBloomFilterByte = bloomFilterData.readByte(i);
-                    var resultingBloomFilterByte = buffer.get(i);
-                    // TODO: Consider merging more than a byte at a time to speed up the process
-                    buffer.set(i, (byte) (existingBloomFilterByte | resultingBloomFilterByte));
+                int offset = 0;
+                while (offset < bitSetSizeInBytes) {
+                    var pageLen = Math.min(pageSizeInBytes, bitSetSizeInBytes - offset);
+                    // Read one BigArrays page at a time to amortize the cost of going through
+                    // the big arrays machinery. In most systems, this means that we'll read
+                    // 4 OS page cache pages at a time, but since we're reading it sequentially
+                    // and when we create the BloomFilterFieldReader we call madvise to prefetch
+                    // the entire bloom filter, it should be fine.
+                    buffer.get(offset, pageLen, newBloomFilterPageScratch);
+                    bloomFilterData.readBytes(offset, existingPageScratch.bytes, 0, pageLen);
+
+                    int i = 0;
+                    for (; i + Long.BYTES <= pageLen; i += Long.BYTES) {
+                        long existing = (long) BitUtil.VH_LE_LONG.get(existingPageScratch.bytes, i);
+                        long current = (long) BitUtil.VH_LE_LONG.get(newBloomFilterPageScratch.bytes, i);
+                        BitUtil.VH_LE_LONG.set(newBloomFilterPageScratch.bytes, i, existing | current);
+                    }
+
+                    // OR the remaining bytes that do not fit in a Long
+                    for (; i < pageLen; i++) {
+                        newBloomFilterPageScratch.bytes[i] |= existingPageScratch.bytes[i];
+                    }
+
+                    buffer.set(offset, newBloomFilterPageScratch.bytes, 0, pageLen);
+                    offset += pageLen;
                 }
             }
         }


### PR DESCRIPTION
During segment merges, bloom filters are combined using bitwise OR. 
Previously this was done byte-by-byte, which was inefficient for large bloom filters.

This change reads data in 16KB pages and processes 8 bytes at a time using 
VarHandle long operations, reducing the number of iterations by 8x for most of the data.
