### PR TITLE
Randomize use_synthetic_source in TSDBSyntheticIdsIT

### DIFF
--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/TSDBSyntheticIdsIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/TSDBSyntheticIdsIT.java
@@ -1028,8 +1028,8 @@ public class TSDBSyntheticIdsIT extends ESIntegTestCase {
 
     private static void putDataStreamTemplate(String indexPattern, int shards) throws IOException {
         final var settings = indexSettings(shards, 0).put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES.getName())
-            .put(IndexSettings.BLOOM_FILTER_ID_FIELD_ENABLED_SETTING.getKey(), false)
             .put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), -1)
+            .put(IndexSettings.RECOVERY_USE_SYNTHETIC_SOURCE_SETTING.getKey(), randomBoolean())
             .put(IndexSettings.USE_SYNTHETIC_ID.getKey(), true);
 
         final var mappings = """


### PR DESCRIPTION
We can randomize the usage of `index.recovery.use_synthetic_source` to exercise both `LuceneChangesSnapshot` and `LuceneSyntheticSourceChangesSnapshot`.

It also removed BLOOM_FILTER_ID_FIELD_ENABLED_SETTING which is unnecessary.

Relates ES-13603