### PR TITLE
Improve memory allocation when parsing WKT from Json

### DIFF
--- a/docs/changelog/141039.yaml
+++ b/docs/changelog/141039.yaml
@@ -1,0 +1,5 @@
+pr: 141039
+summary: Improve memory allocation when parsing WKT from Json
+area: Geo
+type: enhancement
+issues: []

--- a/libs/geo/src/main/java/org/elasticsearch/geometry/utils/WellKnownText.java
+++ b/libs/geo/src/main/java/org/elasticsearch/geometry/utils/WellKnownText.java
@@ -22,11 +22,15 @@ import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.Polygon;
 import org.elasticsearch.geometry.Rectangle;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.io.StreamTokenizer;
 import java.io.StringReader;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -411,8 +415,20 @@ public class WellKnownText {
         sb.append(RPAREN);
     }
 
+    public static Geometry fromWKT(GeometryValidator validator, boolean coerce, byte[] utfBytes, int offset, int length) throws IOException,
+        ParseException {
+        return fromWKT(
+            validator,
+            coerce,
+            new InputStreamReader(new ByteArrayInputStream(utfBytes, offset, length), StandardCharsets.UTF_8)
+        );
+    }
+
     public static Geometry fromWKT(GeometryValidator validator, boolean coerce, String wkt) throws IOException, ParseException {
-        StringReader reader = new StringReader(wkt);
+        return fromWKT(validator, coerce, new StringReader(wkt));
+    }
+
+    private static Geometry fromWKT(GeometryValidator validator, boolean coerce, Reader reader) throws IOException, ParseException {
         try {
             // setup the tokenizer; configured to read words w/o numbers
             StreamTokenizer tokenizer = new StreamTokenizer(reader);

--- a/libs/geo/src/test/java/org/elasticsearch/geometry/CircleTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geometry/CircleTests.java
@@ -12,7 +12,6 @@ package org.elasticsearch.geometry;
 import org.elasticsearch.geometry.utils.GeographyValidator;
 import org.elasticsearch.geometry.utils.GeometryValidator;
 import org.elasticsearch.geometry.utils.StandardValidator;
-import org.elasticsearch.geometry.utils.WellKnownText;
 
 import java.io.IOException;
 import java.text.ParseException;
@@ -34,14 +33,9 @@ public class CircleTests extends BaseGeometryTestCase<Circle> {
 
     public void testBasicSerialization() throws IOException, ParseException {
         GeometryValidator validator = GeographyValidator.instance(true);
-        assertEquals("CIRCLE (20.0 10.0 15.0)", WellKnownText.toWKT(new Circle(20, 10, 15)));
-        assertEquals(new Circle(20, 10, 15), WellKnownText.fromWKT(validator, true, "circle (20.0 10.0 15.0)"));
-
-        assertEquals("CIRCLE (20.0 10.0 15.0 25.0)", WellKnownText.toWKT(new Circle(20, 10, 25, 15)));
-        assertEquals(new Circle(20, 10, 25, 15), WellKnownText.fromWKT(validator, true, "circle (20.0 10.0 15.0 25.0)"));
-
-        assertEquals("CIRCLE EMPTY", WellKnownText.toWKT(Circle.EMPTY));
-        assertEquals(Circle.EMPTY, WellKnownText.fromWKT(validator, true, "CIRCLE EMPTY)"));
+        assertSerialization(validator, true, "CIRCLE (20.0 10.0 15.0)", new Circle(20, 10, 15));
+        assertSerialization(validator, true, "CIRCLE (20.0 10.0 15.0 25.0)", new Circle(20, 10, 25, 15));
+        assertSerialization(validator, true, "CIRCLE EMPTY", Circle.EMPTY);
     }
 
     public void testInitValidation() {

--- a/libs/geo/src/test/java/org/elasticsearch/geometry/GeometryCollectionTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geometry/GeometryCollectionTests.java
@@ -31,18 +31,12 @@ public class GeometryCollectionTests extends BaseGeometryTestCase<GeometryCollec
 
     public void testBasicSerialization() throws IOException, ParseException {
         GeometryValidator validator = GeographyValidator.instance(true);
-        assertEquals(
+        assertSerialization(
+            validator,
+            true,
             "GEOMETRYCOLLECTION (POINT (20.0 10.0),POINT EMPTY)",
-            WellKnownText.toWKT(new GeometryCollection<Geometry>(Arrays.asList(new Point(20, 10), Point.EMPTY)))
+            new GeometryCollection<Geometry>(Arrays.asList(new Point(20, 10), Point.EMPTY))
         );
-
-        assertEquals(
-            new GeometryCollection<Geometry>(Arrays.asList(new Point(20, 10), Point.EMPTY)),
-            WellKnownText.fromWKT(validator, true, "GEOMETRYCOLLECTION (POINT (20.0 10.0),POINT EMPTY)")
-        );
-
-        assertEquals("GEOMETRYCOLLECTION EMPTY", WellKnownText.toWKT(GeometryCollection.EMPTY));
-        assertEquals(GeometryCollection.EMPTY, WellKnownText.fromWKT(validator, true, "GEOMETRYCOLLECTION EMPTY)"));
     }
 
     @SuppressWarnings("ConstantConditions")

--- a/libs/geo/src/test/java/org/elasticsearch/geometry/LineTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geometry/LineTests.java
@@ -27,23 +27,14 @@ public class LineTests extends BaseGeometryTestCase<Line> {
 
     public void testBasicSerialization() throws IOException, ParseException {
         GeometryValidator validator = GeographyValidator.instance(true);
-        assertEquals("LINESTRING (3.0 1.0, 4.0 2.0)", WellKnownText.toWKT(new Line(new double[] { 3, 4 }, new double[] { 1, 2 })));
-        assertEquals(
-            new Line(new double[] { 3, 4 }, new double[] { 1, 2 }),
-            WellKnownText.fromWKT(validator, true, "LINESTRING (3 1, 4 2)")
-        );
-
-        assertEquals(
+        assertSerialization(validator, true, "LINESTRING (3.0 1.0, 4.0 2.0)", new Line(new double[] { 3, 4 }, new double[] { 1, 2 }));
+        assertSerialization(
+            validator,
+            true,
             "LINESTRING (3.0 1.0 5.0, 4.0 2.0 6.0)",
-            WellKnownText.toWKT(new Line(new double[] { 3, 4 }, new double[] { 1, 2 }, new double[] { 5, 6 }))
+            new Line(new double[] { 3, 4 }, new double[] { 1, 2 }, new double[] { 5, 6 })
         );
-        assertEquals(
-            new Line(new double[] { 3, 4 }, new double[] { 1, 2 }, new double[] { 6, 5 }),
-            WellKnownText.fromWKT(validator, true, "LINESTRING (3 1 6, 4 2 5)")
-        );
-
-        assertEquals("LINESTRING EMPTY", WellKnownText.toWKT(Line.EMPTY));
-        assertEquals(Line.EMPTY, WellKnownText.fromWKT(validator, true, "LINESTRING EMPTY)"));
+        assertSerialization(validator, true, "LINESTRING EMPTY", Line.EMPTY);
     }
 
     public void testInitValidation() {

--- a/libs/geo/src/test/java/org/elasticsearch/geometry/MultiLineTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geometry/MultiLineTests.java
@@ -35,17 +35,13 @@ public class MultiLineTests extends BaseGeometryTestCase<MultiLine> {
 
     public void testBasicSerialization() throws IOException, ParseException {
         GeometryValidator validator = GeographyValidator.instance(true);
-        assertEquals(
+        assertSerialization(
+            validator,
+            true,
             "MULTILINESTRING ((3.0 1.0, 4.0 2.0))",
-            WellKnownText.toWKT(new MultiLine(Collections.singletonList(new Line(new double[] { 3, 4 }, new double[] { 1, 2 }))))
+            new MultiLine(Collections.singletonList(new Line(new double[] { 3, 4 }, new double[] { 1, 2 })))
         );
-        assertEquals(
-            new MultiLine(Collections.singletonList(new Line(new double[] { 3, 4 }, new double[] { 1, 2 }))),
-            WellKnownText.fromWKT(validator, true, "MULTILINESTRING ((3 1, 4 2))")
-        );
-
-        assertEquals("MULTILINESTRING EMPTY", WellKnownText.toWKT(MultiLine.EMPTY));
-        assertEquals(MultiLine.EMPTY, WellKnownText.fromWKT(validator, true, "MULTILINESTRING EMPTY)"));
+        assertSerialization(validator, true, "MULTILINESTRING EMPTY", MultiLine.EMPTY);
     }
 
     public void testValidation() {

--- a/libs/geo/src/test/java/org/elasticsearch/geometry/MultiPointTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geometry/MultiPointTests.java
@@ -36,29 +36,20 @@ public class MultiPointTests extends BaseGeometryTestCase<MultiPoint> {
 
     public void testBasicSerialization() throws IOException, ParseException {
         GeometryValidator validator = GeographyValidator.instance(true);
-        assertEquals("MULTIPOINT (2.0 1.0)", WellKnownText.toWKT(new MultiPoint(Collections.singletonList(new Point(2, 1)))));
-        assertEquals(
-            new MultiPoint(Collections.singletonList(new Point(2, 1))),
-            WellKnownText.fromWKT(validator, true, "MULTIPOINT (2 1)")
+        assertSerialization(validator, true, "MULTIPOINT (2.0 1.0)", new MultiPoint(Collections.singletonList(new Point(2, 1))));
+        assertSerialization(
+            validator,
+            true,
+            "MULTIPOINT (2.0 1.0, 3.0 4.0)",
+            new MultiPoint(Arrays.asList(new Point(2, 1), new Point(3, 4)))
         );
-
-        assertEquals("MULTIPOINT (2.0 1.0, 3.0 4.0)", WellKnownText.toWKT(new MultiPoint(Arrays.asList(new Point(2, 1), new Point(3, 4)))));
-        assertEquals(
-            new MultiPoint(Arrays.asList(new Point(2, 1), new Point(3, 4))),
-            WellKnownText.fromWKT(validator, true, "MULTIPOINT (2 1, 3 4)")
-        );
-
-        assertEquals(
+        assertSerialization(
+            validator,
+            true,
             "MULTIPOINT (2.0 1.0 10.0, 3.0 4.0 20.0)",
-            WellKnownText.toWKT(new MultiPoint(Arrays.asList(new Point(2, 1, 10), new Point(3, 4, 20))))
+            new MultiPoint(Arrays.asList(new Point(2, 1, 10), new Point(3, 4, 20)))
         );
-        assertEquals(
-            new MultiPoint(Arrays.asList(new Point(2, 1, 10), new Point(3, 4, 20))),
-            WellKnownText.fromWKT(validator, true, "MULTIPOINT (2 1 10, 3 4 20)")
-        );
-
-        assertEquals("MULTIPOINT EMPTY", WellKnownText.toWKT(MultiPoint.EMPTY));
-        assertEquals(MultiPoint.EMPTY, WellKnownText.fromWKT(validator, true, "MULTIPOINT EMPTY)"));
+        assertSerialization(validator, true, "MULTIPOINT EMPTY", MultiPoint.EMPTY);
     }
 
     public void testValidation() {

--- a/libs/geo/src/test/java/org/elasticsearch/geometry/MultiPolygonTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geometry/MultiPolygonTests.java
@@ -35,23 +35,15 @@ public class MultiPolygonTests extends BaseGeometryTestCase<MultiPolygon> {
 
     public void testBasicSerialization() throws IOException, ParseException {
         GeometryValidator validator = GeographyValidator.instance(true);
-        assertEquals(
+        assertSerialization(
+            validator,
+            true,
             "MULTIPOLYGON (((3.0 1.0, 4.0 2.0, 5.0 3.0, 3.0 1.0)))",
-            WellKnownText.toWKT(
-                new MultiPolygon(
-                    Collections.singletonList(new Polygon(new LinearRing(new double[] { 3, 4, 5, 3 }, new double[] { 1, 2, 3, 1 })))
-                )
-            )
-        );
-        assertEquals(
             new MultiPolygon(
                 Collections.singletonList(new Polygon(new LinearRing(new double[] { 3, 4, 5, 3 }, new double[] { 1, 2, 3, 1 })))
-            ),
-            WellKnownText.fromWKT(validator, true, "MULTIPOLYGON (((3.0 1.0, 4.0 2.0, 5.0 3.0, 3.0 1.0)))")
+            )
         );
-
-        assertEquals("MULTIPOLYGON EMPTY", WellKnownText.toWKT(MultiPolygon.EMPTY));
-        assertEquals(MultiPolygon.EMPTY, WellKnownText.fromWKT(validator, true, "MULTIPOLYGON EMPTY)"));
+        assertSerialization(validator, true, "MULTIPOLYGON EMPTY", MultiPolygon.EMPTY);
     }
 
     public void testValidation() {

--- a/libs/geo/src/test/java/org/elasticsearch/geometry/PointTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geometry/PointTests.java
@@ -28,14 +28,9 @@ public class PointTests extends BaseGeometryTestCase<Point> {
 
     public void testBasicSerialization() throws IOException, ParseException {
         GeometryValidator validator = GeographyValidator.instance(true);
-        assertEquals("POINT (20.0 10.0)", WellKnownText.toWKT(new Point(20, 10)));
-        assertEquals(new Point(20, 10), WellKnownText.fromWKT(validator, true, "point (20.0 10.0)"));
-
-        assertEquals("POINT (20.0 10.0 100.0)", WellKnownText.toWKT(new Point(20, 10, 100)));
-        assertEquals(new Point(20, 10, 100), WellKnownText.fromWKT(validator, true, "POINT (20.0 10.0 100.0)"));
-
-        assertEquals("POINT EMPTY", WellKnownText.toWKT(Point.EMPTY));
-        assertEquals(Point.EMPTY, WellKnownText.fromWKT(validator, true, "POINT EMPTY)"));
+        assertSerialization(validator, true, "POINT (20.0 10.0)", new Point(20, 10));
+        assertSerialization(validator, true, "POINT (20.0 10.0 100.0)", new Point(20, 10, 100));
+        assertSerialization(validator, true, "POINT EMPTY", Point.EMPTY);
     }
 
     public void testInitValidation() {

--- a/libs/geo/src/test/java/org/elasticsearch/geometry/PolygonTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geometry/PolygonTests.java
@@ -28,26 +28,19 @@ public class PolygonTests extends BaseGeometryTestCase<Polygon> {
 
     public void testBasicSerialization() throws IOException, ParseException {
         GeometryValidator validator = GeographyValidator.instance(true);
-        assertEquals(
+        assertSerialization(
+            validator,
+            true,
             "POLYGON ((3.0 1.0, 4.0 2.0, 5.0 3.0, 3.0 1.0))",
-            WellKnownText.toWKT(new Polygon(new LinearRing(new double[] { 3, 4, 5, 3 }, new double[] { 1, 2, 3, 1 })))
+            new Polygon(new LinearRing(new double[] { 3, 4, 5, 3 }, new double[] { 1, 2, 3, 1 }))
         );
-        assertEquals(
-            new Polygon(new LinearRing(new double[] { 3, 4, 5, 3 }, new double[] { 1, 2, 3, 1 })),
-            WellKnownText.fromWKT(validator, true, "POLYGON ((3 1, 4 2, 5 3, 3 1))")
-        );
-
-        assertEquals(
+        assertSerialization(
+            validator,
+            true,
             "POLYGON ((3.0 1.0 5.0, 4.0 2.0 4.0, 5.0 3.0 3.0, 3.0 1.0 5.0))",
-            WellKnownText.toWKT(
-                new Polygon(new LinearRing(new double[] { 3, 4, 5, 3 }, new double[] { 1, 2, 3, 1 }, new double[] { 5, 4, 3, 5 }))
-            )
+            new Polygon(new LinearRing(new double[] { 3, 4, 5, 3 }, new double[] { 1, 2, 3, 1 }, new double[] { 5, 4, 3, 5 }))
         );
-        assertEquals(
-            new Polygon(new LinearRing(new double[] { 3, 4, 5, 3 }, new double[] { 1, 2, 3, 1 }, new double[] { 5, 4, 3, 5 })),
-            WellKnownText.fromWKT(validator, true, "POLYGON ((3 1 5, 4 2 4, 5 3 3, 3 1 5))")
-        );
-
+        assertSerialization(validator, true, "POLYGON EMPTY", Polygon.EMPTY);
         // Auto closing in coerce mode
         assertEquals(
             new Polygon(new LinearRing(new double[] { 3, 4, 5, 3 }, new double[] { 1, 2, 3, 1 })),
@@ -64,9 +57,6 @@ public class PolygonTests extends BaseGeometryTestCase<Polygon> {
             ),
             WellKnownText.fromWKT(validator, true, "POLYGON ((3 1, 4 2, 5 3, 3 1), (0.5 1.5, 2.5 1.5, 2.0 1.0))")
         );
-
-        assertEquals("POLYGON EMPTY", WellKnownText.toWKT(Polygon.EMPTY));
-        assertEquals(Polygon.EMPTY, WellKnownText.fromWKT(validator, true, "POLYGON EMPTY)"));
     }
 
     public void testInitValidation() {

--- a/libs/geo/src/test/java/org/elasticsearch/geometry/RectangleTests.java
+++ b/libs/geo/src/test/java/org/elasticsearch/geometry/RectangleTests.java
@@ -13,7 +13,6 @@ import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.geometry.utils.GeographyValidator;
 import org.elasticsearch.geometry.utils.GeometryValidator;
 import org.elasticsearch.geometry.utils.StandardValidator;
-import org.elasticsearch.geometry.utils.WellKnownText;
 
 import java.io.IOException;
 import java.text.ParseException;
@@ -27,11 +26,8 @@ public class RectangleTests extends BaseGeometryTestCase<Rectangle> {
 
     public void testBasicSerialization() throws IOException, ParseException {
         GeometryValidator validator = GeographyValidator.instance(true);
-        assertEquals("BBOX (10.0, 20.0, 40.0, 30.0)", WellKnownText.toWKT(new Rectangle(10, 20, 40, 30)));
-        assertEquals(new Rectangle(10, 20, 40, 30), WellKnownText.fromWKT(validator, true, "BBOX (10.0, 20.0, 40.0, 30.0)"));
-
-        assertEquals("BBOX EMPTY", WellKnownText.toWKT(Rectangle.EMPTY));
-        assertEquals(Rectangle.EMPTY, WellKnownText.fromWKT(validator, true, "BBOX EMPTY)"));
+        assertSerialization(validator, true, "BBOX (10.0, 20.0, 40.0, 30.0)", new Rectangle(10, 20, 40, 30));
+        assertSerialization(validator, true, "BBOX EMPTY", Rectangle.EMPTY);
     }
 
     public void testInitValidation() {

--- a/server/src/main/java/org/elasticsearch/common/geo/GeometryParserFormat.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeometryParserFormat.java
@@ -16,6 +16,8 @@ import org.elasticsearch.geometry.utils.WellKnownText;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentString;
+import org.elasticsearch.xcontent.support.MapXContentParser;
 
 import java.io.IOException;
 import java.text.ParseException;
@@ -41,7 +43,12 @@ public enum GeometryParserFormat {
             if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
                 return null;
             }
-            return WellKnownText.fromWKT(validator, coerce, parser.text());
+            if (parser instanceof MapXContentParser) {
+                // we have already serialized the string so using optimize text will allocate a new byte array
+                return WellKnownText.fromWKT(validator, coerce, parser.text());
+            }
+            XContentString.UTF8Bytes utfBytes = parser.optimizedText().bytes();
+            return WellKnownText.fromWKT(validator, coerce, utfBytes.bytes(), utfBytes.offset(), utfBytes.length());
         }
 
     },


### PR DESCRIPTION
XContent offers an API called  XContentString.UTF8Bytes that provide access  to the text bytes of the json documents without having to read them as a string. That can be used for parsing WKT and avoid the allocation on a potential big string.

This PR adds the possibility of parsing WKT directly for UTF8 bytes and modifies the geometry parser for WKT to take advantage of this API.