### PR TITLE
Refactor posting iterators to provide more information

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/NeighborQueue.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/cluster/NeighborQueue.java
@@ -128,7 +128,7 @@ public class NeighborQueue {
         return NumericUtils.sortableIntToFloat((int) (order.apply(heapValue) >> 32));
     }
 
-    private int decodeNodeId(long heapValue) {
+    public int decodeNodeId(long heapValue) {
         return (int) ~(order.apply(heapValue));
     }
 
@@ -147,13 +147,13 @@ public class NeighborQueue {
      * removes the current top element, returns its node id and adds the new element
      * to the queue.
      * */
-    public int popAndAddRaw(long raw) {
+    public long popRawAndAddRaw(long raw) {
         long top = heap.top();
         if (raw < top) {
             return decodeNodeId(raw);
         }
         heap.updateTop(raw);
-        return decodeNodeId(top);
+        return top;
     }
 
     public void clear() {

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/CentroidIterator.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/CentroidIterator.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.vectors.diskbbq;
+
+import java.io.IOException;
+
+/**
+ * An iterator over centroids that provides posting list metadata.
+ */
+public interface CentroidIterator {
+    boolean hasNext();
+
+    PostingMetadata nextPosting() throws IOException;
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/IVFVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/IVFVectorsReader.java
@@ -325,11 +325,10 @@ public abstract class IVFVectorsReader extends KnnVectorsReader {
         // filtering? E.g. keep exploring until we hit an expected number of parent documents vs. child vectors?
         while (centroidPrefetchingIterator.hasNext()
             && (maxVectorVisited > expectedDocs || knnCollector.minCompetitiveSimilarity() == Float.NEGATIVE_INFINITY)) {
-            // todo do we actually need to know the score???
-            CentroidOffsetAndLength offsetAndLength = centroidPrefetchingIterator.nextPostingListOffsetAndLength();
+            PostingMetadata postingMetadata = centroidPrefetchingIterator.nextPosting();
             // todo do we need direct access to the raw centroid???, this is used for quantizing, maybe hydrating and quantizing
             // is enough?
-            expectedDocs += scorer.resetPostingsScorer(offsetAndLength.offset());
+            expectedDocs += scorer.resetPostingsScorer(postingMetadata);
             actualDocs += scorer.visit(knnCollector);
             if (knnCollector.getSearchStrategy() != null) {
                 knnCollector.getSearchStrategy().nextVectorsBlock();
@@ -341,8 +340,8 @@ public abstract class IVFVectorsReader extends KnnVectorsReader {
             int filteredVectors = (int) Math.ceil(numVectors * percentFiltered);
             float expectedScored = Math.min(2 * filteredVectors * unfilteredRatioVisited, expectedDocs / 2f);
             while (centroidPrefetchingIterator.hasNext() && (actualDocs < expectedScored || actualDocs < knnCollector.k())) {
-                CentroidOffsetAndLength offsetAndLength = centroidPrefetchingIterator.nextPostingListOffsetAndLength();
-                scorer.resetPostingsScorer(offsetAndLength.offset());
+                PostingMetadata postingMetadata = centroidPrefetchingIterator.nextPosting();
+                scorer.resetPostingsScorer(postingMetadata);
                 actualDocs += scorer.visit(knnCollector);
                 if (knnCollector.getSearchStrategy() != null) {
                     knnCollector.getSearchStrategy().nextVectorsBlock();
@@ -468,17 +467,9 @@ public abstract class IVFVectorsReader extends KnnVectorsReader {
     public abstract PostingVisitor getPostingVisitor(FieldInfo fieldInfo, IndexInput postingsLists, float[] target, Bits needsScoring)
         throws IOException;
 
-    public record CentroidOffsetAndLength(long offset, long length) {}
-
-    public interface CentroidIterator {
-        boolean hasNext();
-
-        CentroidOffsetAndLength nextPostingListOffsetAndLength() throws IOException;
-    }
-
     public interface PostingVisitor {
         /** returns the number of documents in the posting list */
-        int resetPostingsScorer(long offset) throws IOException;
+        int resetPostingsScorer(PostingMetadata metadata) throws IOException;
 
         /** returns the number of scored documents */
         int visit(KnnCollector collector) throws IOException;

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/PostingMetadata.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/PostingMetadata.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.index.codec.vectors.diskbbq;
+
+/**
+ * Metadata about a posting list for a centroid.
+ *
+ * @param offset          The offset of the posting list in the index.
+ * @param length          The length of the posting list in bytes.
+ * @param centroidOrdinal The ordinal of the centroid.
+ * @param centroidScore   The score of the centroid.
+ */
+public record PostingMetadata(long offset, long length, int centroidOrdinal, float centroidScore) {
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/PostingMetadata.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/PostingMetadata.java
@@ -17,5 +17,4 @@ package org.elasticsearch.index.codec.vectors.diskbbq;
  * @param centroidOrdinal The ordinal of the centroid.
  * @param centroidScore   The score of the centroid.
  */
-public record PostingMetadata(long offset, long length, int centroidOrdinal, float centroidScore) {
-}
+public record PostingMetadata(long offset, long length, int centroidOrdinal, float centroidScore) {}

--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQVectorsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/diskbbq/next/ESNextDiskBBQVectorsReader.java
@@ -29,8 +29,10 @@ import org.apache.lucene.util.packed.DirectWriter;
 import org.elasticsearch.index.codec.vectors.GenericFlatVectorReaders;
 import org.elasticsearch.index.codec.vectors.OptimizedScalarQuantizer;
 import org.elasticsearch.index.codec.vectors.cluster.NeighborQueue;
+import org.elasticsearch.index.codec.vectors.diskbbq.CentroidIterator;
 import org.elasticsearch.index.codec.vectors.diskbbq.DocIdsWriter;
 import org.elasticsearch.index.codec.vectors.diskbbq.IVFVectorsReader;
+import org.elasticsearch.index.codec.vectors.diskbbq.PostingMetadata;
 import org.elasticsearch.index.codec.vectors.diskbbq.PrefetchingCentroidIterator;
 import org.elasticsearch.simdvec.ES92Int7VectorsScorer;
 import org.elasticsearch.simdvec.ESNextOSQVectorsScorer;
@@ -275,12 +277,14 @@ public class ESNextDiskBBQVectorsReader extends IVFVectorsReader {
             }
 
             @Override
-            public CentroidOffsetAndLength nextPostingListOffsetAndLength() throws IOException {
-                int centroidOrdinal = neighborQueue.pop();
-                centroids.seek(offset + (long) Long.BYTES * 2 * centroidOrdinal);
+            public PostingMetadata nextPosting() throws IOException {
+                long centroidOrdinalAndScore = neighborQueue.popRaw();
+                int centroidOrd = neighborQueue.decodeNodeId(centroidOrdinalAndScore);
+                float score = neighborQueue.decodeScore(centroidOrdinalAndScore);
+                centroids.seek(offset + (long) Long.BYTES * 2 * centroidOrd);
                 long postingListOffset = centroids.readLong();
                 long postingListLength = centroids.readLong();
-                return new CentroidOffsetAndLength(postingListOffset, postingListLength);
+                return new PostingMetadata(postingListOffset, postingListLength, centroidOrd, score);
             }
         };
     }
@@ -314,7 +318,7 @@ public class ESNextDiskBBQVectorsReader extends IVFVectorsReader {
                 }
 
                 @Override
-                public CentroidOffsetAndLength nextPostingListOffsetAndLength() {
+                public PostingMetadata nextPosting() {
                     return null;
                 }
             };
@@ -384,18 +388,20 @@ public class ESNextDiskBBQVectorsReader extends IVFVectorsReader {
             }
 
             @Override
-            public CentroidOffsetAndLength nextPostingListOffsetAndLength() throws IOException {
-                int centroidOrdinal = nextCentroid();
+            public PostingMetadata nextPosting() throws IOException {
+                long centroidOrdinalAndScore = nextCentroid();
+                int centroidOrdinal = neighborQueue.decodeNodeId(centroidOrdinalAndScore);
+                float score = neighborQueue.decodeScore(centroidOrdinalAndScore);
                 centroids.seek(childrenFileOffsets + (long) Long.BYTES * 2 * centroidOrdinal);
                 long postingListOffset = centroids.readLong();
                 long postingListLength = centroids.readLong();
-                return new CentroidOffsetAndLength(postingListOffset, postingListLength);
+                return new PostingMetadata(postingListOffset, postingListLength, centroidOrdinal, score);
             }
 
-            private int nextCentroid() throws IOException {
+            private long nextCentroid() throws IOException {
                 if (currentParentQueue.size() > 0) {
                     // return next centroid and maybe add a children from the current parent queue
-                    return neighborQueue.popAndAddRaw(currentParentQueue.popRaw());
+                    return neighborQueue.popRawAndAddRaw(currentParentQueue.popRaw());
                 } else if (parentsQueue.size() > 0) {
                     // current parent queue is empty, populate it again with the next parent
                     int pop = parentsQueue.pop();
@@ -416,7 +422,7 @@ public class ESNextDiskBBQVectorsReader extends IVFVectorsReader {
                     );
                     return nextCentroid();
                 } else {
-                    return neighborQueue.pop();
+                    return neighborQueue.popRaw();
                 }
             }
         };
@@ -606,9 +612,9 @@ public class ESNextDiskBBQVectorsReader extends IVFVectorsReader {
         }
 
         @Override
-        public int resetPostingsScorer(long offset) throws IOException {
+        public int resetPostingsScorer(PostingMetadata metadata) throws IOException {
             quantized = false;
-            indexInput.seek(offset);
+            indexInput.seek(metadata.offset());
             indexInput.readFloats(centroid, 0, centroid.length);
             centroidDp = Float.intBitsToFloat(indexInput.readInt());
             vectors = indexInput.readVInt();


### PR DESCRIPTION
I am breaking out various PRs that are refactors to allow the asymmetric centroid quantization work to progress.

This is a fairly simple one. We already have information for the posting metadata which includes the centroid ordinal & score of that centroid. This refactor exposes this information and breaks away from internal classes in IVFReader.