### PR TITLE
[8.19] Migrate third party module tests using legacy test clusters framework (#140991)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/RestrictedBuildApiService.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/RestrictedBuildApiService.java
@@ -53,9 +53,6 @@ public abstract class RestrictedBuildApiService implements BuildService<Restrict
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:qa:multi-cluster-search-security:legacy-with-basic-license");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:qa:multi-cluster-search-security:legacy-with-full-license");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:qa:multi-cluster-search-security:legacy-with-restricted-trust");
-        map.put(LegacyRestTestBasePlugin.class, ":x-pack:qa:third-party:jira");
-        map.put(LegacyRestTestBasePlugin.class, ":x-pack:qa:third-party:pagerduty");
-        map.put(LegacyRestTestBasePlugin.class, ":x-pack:qa:third-party:slack");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:ent-search:qa:rest");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:eql:qa:ccs-rolling-upgrade");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:eql:qa:correctness");

--- a/x-pack/qa/third-party/build.gradle
+++ b/x-pack/qa/third-party/build.gradle
@@ -1,0 +1,8 @@
+apply plugin: 'elasticsearch.java'
+
+dependencies {
+  api project(':test:framework')
+  api project(':test:yaml-rest-runner')
+  api project(':test:test-clusters')
+  api project(xpackModule('core'))
+}

--- a/x-pack/qa/third-party/jira/build.gradle
+++ b/x-pack/qa/third-party/jira/build.gradle
@@ -3,18 +3,18 @@ import groovy.json.JsonSlurper
 import javax.net.ssl.HttpsURLConnection
 import java.nio.charset.StandardCharsets
 
-import org.elasticsearch.gradle.internal.info.BuildParams
-
-apply plugin: 'elasticsearch.legacy-yaml-rest-test'
+apply plugin: 'elasticsearch.internal-yaml-rest-test'
 
 dependencies {
-  yamlRestTestImplementation project(':x-pack:plugin:core')
-  yamlRestTestImplementation project(path: xpackModule('watcher'))
+  yamlRestTestImplementation project(':x-pack:qa:third-party')
+
+  clusterModules project(xpackModule('watcher'))
+  clusterModules project(xpackModule('ilm'))
 }
 
 restResources {
   restApi {
-    include 'watcher'
+    include '_common', 'cluster', 'indices', 'search', 'watcher'
   }
 }
 
@@ -39,20 +39,7 @@ tasks.register("cleanJira", DefaultTask) {
 if (!jiraUrl && !jiraUser && !jiraPassword && !jiraProject) {
   tasks.named("yamlRestTest").configure { enabled = false }
 } else {
-  testClusters.matching { it.name == "yamlRestTest" }.configureEach {
-    testDistribution = 'DEFAULT'
-    setting 'xpack.security.enabled', 'false'
-    setting 'xpack.ml.enabled', 'false'
-    setting 'xpack.license.self_generated.type', 'trial'
-    setting 'logger.org.elasticsearch.xpack.watcher', 'DEBUG'
-    setting 'xpack.notification.jira.account.test.issue_defaults.issuetype.name', 'Bug'
-    setting 'xpack.notification.jira.account.test.issue_defaults.labels.0', 'integration-tests'
-    setting 'xpack.notification.jira.account.test.issue_defaults.project.key', jiraProject
-    keystore 'xpack.notification.jira.account.test.secure_url', jiraUrl
-    keystore 'xpack.notification.jira.account.test.secure_user', jiraUser
-    keystore 'xpack.notification.jira.account.test.secure_password', jiraPassword
-  }
-  tasks.named("yamlRestTest")configure { finalizedBy "cleanJira" }
+  tasks.named("yamlRestTest").configure { finalizedBy "cleanJira" }
 }
 
 if (buildParams.inFipsJvm){

--- a/x-pack/qa/third-party/jira/src/yamlRestTest/java/org/elasticsearch/smoketest/WatcherJiraYamlTestSuiteIT.java
+++ b/x-pack/qa/third-party/jira/src/yamlRestTest/java/org/elasticsearch/smoketest/WatcherJiraYamlTestSuiteIT.java
@@ -9,22 +9,29 @@ package org.elasticsearch.smoketest;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
-import org.elasticsearch.test.rest.yaml.ClientYamlTestResponse;
-import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
-import org.elasticsearch.xpack.core.watcher.support.WatcherIndexTemplateRegistryField;
-import org.junit.After;
-import org.junit.Before;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
-import static org.hamcrest.Matchers.is;
+import org.junit.ClassRule;
 
 /** Runs rest tests against external cluster */
-public class WatcherJiraYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
+public class WatcherJiraYamlTestSuiteIT extends AbstractWatcherThirdPartyYamlTestSuiteIT {
+
+    @ClassRule
+    public static ElasticsearchCluster cluster = baseClusterBuilder().setting(
+        "xpack.notification.jira.account.test.issue_defaults.issuetype.name",
+        "Bug"
+    )
+        .setting("xpack.notification.jira.account.test.issue_defaults.labels.0", "integration-tests")
+        .setting("xpack.notification.jira.account.test.issue_defaults.project.key", System.getenv("jira_project"))
+        .keystore("xpack.notification.jira.account.test.secure_url", System.getenv("jira_url"))
+        .keystore("xpack.notification.jira.account.test.secure_user", System.getenv("jira_user"))
+        .keystore("xpack.notification.jira.account.test.secure_password", System.getenv("jira_password"))
+        .build();
+
+    @Override
+    protected ElasticsearchCluster getCluster() {
+        return cluster;
+    }
 
     public WatcherJiraYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {
         super(testCandidate);
@@ -32,46 +39,6 @@ public class WatcherJiraYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
 
     @ParametersFactory
     public static Iterable<Object[]> parameters() throws Exception {
-        return ESClientYamlSuiteTestCase.createParameters();
-    }
-
-    @Before
-    public void startWatcher() throws Exception {
-        final List<String> watcherTemplates = List.of(WatcherIndexTemplateRegistryField.TEMPLATE_NAMES_NO_ILM);
-        assertBusy(() -> {
-            try {
-                getAdminExecutionContext().callApi("watcher.start", Map.of(), List.of(), Map.of());
-
-                for (String template : watcherTemplates) {
-                    ClientYamlTestResponse templateExistsResponse = getAdminExecutionContext().callApi(
-                        "indices.exists_template",
-                        Map.of("name", template),
-                        List.of(),
-                        Map.of()
-                    );
-                    assertThat(templateExistsResponse.getStatusCode(), is(200));
-                }
-
-                ClientYamlTestResponse response = getAdminExecutionContext().callApi("watcher.stats", Map.of(), List.of(), Map.of());
-                String state = response.evaluate("stats.0.watcher_state");
-                assertThat(state, is("started"));
-            } catch (IOException e) {
-                throw new AssertionError(e);
-            }
-        });
-    }
-
-    @After
-    public void stopWatcher() throws Exception {
-        assertBusy(() -> {
-            try {
-                getAdminExecutionContext().callApi("watcher.stop", Map.of(), List.of(), Map.of());
-                ClientYamlTestResponse response = getAdminExecutionContext().callApi("watcher.stats", Map.of(), List.of(), Map.of());
-                String state = response.evaluate("stats.0.watcher_state");
-                assertThat(state, is("stopped"));
-            } catch (IOException e) {
-                throw new AssertionError(e);
-            }
-        }, 60, TimeUnit.SECONDS);
+        return createParameters();
     }
 }

--- a/x-pack/qa/third-party/pagerduty/build.gradle
+++ b/x-pack/qa/third-party/pagerduty/build.gradle
@@ -1,31 +1,24 @@
 import org.elasticsearch.gradle.internal.info.BuildParams
 
-apply plugin: 'elasticsearch.legacy-yaml-rest-test'
+apply plugin: 'elasticsearch.internal-yaml-rest-test'
 
 dependencies {
-  yamlRestTestImplementation project(':x-pack:plugin:core')
-  yamlRestTestImplementation project(path: xpackModule('watcher'))
+  yamlRestTestImplementation project(':x-pack:qa:third-party')
+
+  clusterModules project(xpackModule('watcher'))
+  clusterModules project(xpackModule('ilm'))
+}
+
+restResources {
+  restApi {
+    include '_common', 'watcher', 'indices', 'cluster', 'search'
+  }
 }
 
 String pagerDutyServiceKey = System.getenv('pagerduty_service_api_key')
 
-restResources {
-  restApi {
-    include 'watcher'
-  }
-}
-
 if (!pagerDutyServiceKey) {
   tasks.named("yamlRestTest").configure { enabled = false }
-} else {
-  testClusters.matching { it.name == "yamlRestTest" }.configureEach {
-    testDistribution = 'DEFAULT'
-    setting 'xpack.security.enabled', 'false'
-    setting 'xpack.ml.enabled', 'false'
-    setting 'xpack.license.self_generated.type', 'trial'
-    setting 'logger.org.elasticsearch.xpack.watcher', 'DEBUG'
-    keystore 'xpack.notification.pagerduty.account.test_account.secure_service_api_key', pagerDutyServiceKey
-  }
 }
 
 if (buildParams.inFipsJvm){

--- a/x-pack/qa/third-party/slack/build.gradle
+++ b/x-pack/qa/third-party/slack/build.gradle
@@ -1,15 +1,17 @@
 import org.elasticsearch.gradle.internal.info.BuildParams
 
-apply plugin: 'elasticsearch.legacy-yaml-rest-test'
+apply plugin: 'elasticsearch.internal-yaml-rest-test'
 
 dependencies {
-  yamlRestTestImplementation project(':x-pack:plugin:core')
-  yamlRestTestImplementation project(path: xpackModule('watcher'))
+  yamlRestTestImplementation project(':x-pack:qa:third-party')
+
+  clusterModules project(xpackModule('watcher'))
+  clusterModules project(xpackModule('ilm'))
 }
 
 restResources {
   restApi {
-    include 'watcher'
+    include '_common', 'cluster', 'indices', 'search', 'watcher'
   }
 }
 
@@ -17,15 +19,6 @@ String slackUrl = System.getenv('slack_url')
 
 if (!slackUrl) {
   tasks.named("yamlRestTest").configure { enabled = false }
-} else {
-  testClusters.matching { it.name == "yamlRestTest" }.configureEach {
-    testDistribution = 'DEFAULT'
-    setting 'xpack.security.enabled', 'false'
-    setting 'xpack.ml.enabled', 'false'
-    setting 'xpack.license.self_generated.type', 'trial'
-    setting 'logger.org.elasticsearch.xpack.watcher', 'DEBUG'
-    keystore 'xpack.notification.slack.account.test_account.secure_url', slackUrl
-  }
 }
 
 if (buildParams.inFipsJvm){

--- a/x-pack/qa/third-party/slack/src/yamlRestTest/java/org/elasticsearch/smoketest/WatcherSlackYamlTestSuiteIT.java
+++ b/x-pack/qa/third-party/slack/src/yamlRestTest/java/org/elasticsearch/smoketest/WatcherSlackYamlTestSuiteIT.java
@@ -9,22 +9,22 @@ package org.elasticsearch.smoketest;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
-import org.elasticsearch.test.rest.yaml.ClientYamlTestResponse;
-import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
-import org.elasticsearch.xpack.core.watcher.support.WatcherIndexTemplateRegistryField;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.ClassRule;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
+public class WatcherSlackYamlTestSuiteIT extends AbstractWatcherThirdPartyYamlTestSuiteIT {
 
-import static org.hamcrest.Matchers.is;
+    @ClassRule
+    public static ElasticsearchCluster cluster = baseClusterBuilder().keystore(
+        "xpack.notification.slack.account.test_account.secure_url",
+        System.getenv("slack_url")
+    ).build();
 
-/** Runs rest tests against external cluster */
-public class WatcherSlackYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
+    @Override
+    protected ElasticsearchCluster getCluster() {
+        return cluster;
+    }
 
     public WatcherSlackYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {
         super(testCandidate);
@@ -32,46 +32,6 @@ public class WatcherSlackYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
 
     @ParametersFactory
     public static Iterable<Object[]> parameters() throws Exception {
-        return ESClientYamlSuiteTestCase.createParameters();
-    }
-
-    @Before
-    public void startWatcher() throws Exception {
-        final List<String> watcherTemplates = List.of(WatcherIndexTemplateRegistryField.TEMPLATE_NAMES_NO_ILM);
-        assertBusy(() -> {
-            try {
-                getAdminExecutionContext().callApi("watcher.start", Map.of(), List.of(), Map.of());
-
-                for (String template : watcherTemplates) {
-                    ClientYamlTestResponse templateExistsResponse = getAdminExecutionContext().callApi(
-                        "indices.exists_template",
-                        Map.of("name", template),
-                        List.of(),
-                        Map.of()
-                    );
-                    assertThat(templateExistsResponse.getStatusCode(), is(200));
-                }
-
-                ClientYamlTestResponse response = getAdminExecutionContext().callApi("watcher.stats", Map.of(), List.of(), Map.of());
-                String state = response.evaluate("stats.0.watcher_state");
-                assertThat(state, is("started"));
-            } catch (IOException e) {
-                throw new AssertionError(e);
-            }
-        });
-    }
-
-    @After
-    public void stopWatcher() throws Exception {
-        assertBusy(() -> {
-            try {
-                getAdminExecutionContext().callApi("watcher.stop", Map.of(), List.of(), Map.of());
-                ClientYamlTestResponse response = getAdminExecutionContext().callApi("watcher.stats", Map.of(), List.of(), Map.of());
-                String state = response.evaluate("stats.0.watcher_state");
-                assertThat(state, is("stopped"));
-            } catch (IOException e) {
-                throw new AssertionError(e);
-            }
-        }, 60, TimeUnit.SECONDS);
+        return createParameters();
     }
 }

--- a/x-pack/qa/third-party/src/main/java/org/elasticsearch/smoketest/AbstractWatcherThirdPartyYamlTestSuiteIT.java
+++ b/x-pack/qa/third-party/src/main/java/org/elasticsearch/smoketest/AbstractWatcherThirdPartyYamlTestSuiteIT.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.smoketest;
+
+import com.carrotsearch.randomizedtesting.annotations.Name;
+
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.LocalClusterSpecBuilder;
+import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
+import org.elasticsearch.test.rest.yaml.ClientYamlTestResponse;
+import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
+import org.elasticsearch.xpack.core.watcher.support.WatcherIndexTemplateRegistryField;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.is;
+
+public abstract class AbstractWatcherThirdPartyYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
+
+    private static final Map<String, String> NO_ERROR_TRACE = Map.of("error_trace", "false");
+
+    protected static LocalClusterSpecBuilder<ElasticsearchCluster> baseClusterBuilder() {
+        return ElasticsearchCluster.local()
+            .module("x-pack-watcher")
+            .module("x-pack-ilm")
+            .setting("xpack.security.enabled", "false")
+            .setting("xpack.license.self_generated.type", "trial")
+            .setting("logger.org.elasticsearch.xpack.watcher", "DEBUG");
+    }
+
+    protected AbstractWatcherThirdPartyYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {
+        super(testCandidate);
+    }
+
+    protected abstract ElasticsearchCluster getCluster();
+
+    @Override
+    protected String getTestRestCluster() {
+        return getCluster().getHttpAddresses();
+    }
+
+    @Before
+    public void startWatcher() throws Exception {
+        final List<String> watcherTemplates = List.of(WatcherIndexTemplateRegistryField.TEMPLATE_NAMES);
+        assertBusy(() -> {
+            try {
+                getAdminExecutionContext().callApi("watcher.start", NO_ERROR_TRACE, List.of(), Map.of());
+
+                for (String template : watcherTemplates) {
+                    ClientYamlTestResponse templateExistsResponse = getAdminExecutionContext().callApi(
+                        "indices.exists_index_template",
+                        Map.of("name", template, "error_trace", "false"),
+                        List.of(),
+                        Map.of()
+                    );
+                    assertThat(templateExistsResponse.getStatusCode(), is(200));
+                }
+
+                ClientYamlTestResponse response = getAdminExecutionContext().callApi("watcher.stats", NO_ERROR_TRACE, List.of(), Map.of());
+                String state = response.evaluate("stats.0.watcher_state");
+                assertThat(state, is("started"));
+            } catch (IOException e) {
+                throw new AssertionError(e);
+            }
+        });
+    }
+
+    @After
+    public void stopWatcher() throws Exception {
+        assertBusy(() -> {
+            try {
+                getAdminExecutionContext().callApi("watcher.stop", NO_ERROR_TRACE, List.of(), Map.of());
+                ClientYamlTestResponse response = getAdminExecutionContext().callApi("watcher.stats", NO_ERROR_TRACE, List.of(), Map.of());
+                String state = response.evaluate("stats.0.watcher_state");
+                assertThat(state, is("stopped"));
+            } catch (IOException e) {
+                throw new AssertionError(e);
+            }
+        }, 60, TimeUnit.SECONDS);
+    }
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Migrate third party module tests using legacy test clusters framework (#140991)](https://github.com/elastic/elasticsearch/pull/140991)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)