### PR TITLE
Wait for cluster to recover to yellow before checking index health (#141057)

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/DataStreamsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/DataStreamsUpgradeIT.java
@@ -171,6 +171,11 @@ public class DataStreamsUpgradeIT extends AbstractUpgradeTestCase {
                     request.addParameter("wait_for_status", "yellow");
                 }));
             } else if (CLUSTER_TYPE == ClusterType.UPGRADED) {
+                // Wait for the cluster to recover to yellow at least before checking index status
+                ensureHealth((request -> {
+                    request.addParameter("timeout", "30s");
+                    request.addParameter("wait_for_status", "yellow");
+                }));
                 ensureHealth("logs-barbaz", (request -> {
                     request.addParameter("wait_for_nodes", "3");
                     request.addParameter("wait_for_status", "green");


### PR DESCRIPTION
A hypothesis is that post-upgrade prior to this change, we checked the health of the index, but that index may not exist if it hasn't been recovered yet. This adds a check for the overall cluster to be yellow before checking the health of an individual index.

Resolves #140727
