### PR TITLE
[9.3] Retry batch-delete items in GCS (#138951)

### DIFF
--- a/docs/changelog/138951.yaml
+++ b/docs/changelog/138951.yaml
@@ -1,0 +1,6 @@
+pr: 138951
+summary: Retry bulk-delete items in GCS
+area: Snapshot/Restore
+type: enhancement
+issues:
+ - 138364

--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GcsRepositoryStatsCollector.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GcsRepositoryStatsCollector.java
@@ -190,6 +190,18 @@ public class GcsRepositoryStatsCollector {
         }
     }
 
+    /**
+     * Tracks stats, but does not add them to collector. For example DELETE operations are not tracked. It might change in the future.
+     */
+    public void skipCollectRunnable(OperationPurpose purpose, StorageOperation operation, Runnable runnable) {
+        initAndGetThreadLocal(purpose, operation);
+        try {
+            runnable.run();
+        } finally {
+            clearThreadLocal();
+        }
+    }
+
     public <T> T collectIOSupplier(OperationPurpose purpose, StorageOperation operation, IOSupplier<T> blobFn) throws IOException {
         var t = timer.absoluteTimeInMillis();
         var stats = initAndGetThreadLocal(purpose, operation);

--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStore.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStore.java
@@ -10,14 +10,13 @@
 package org.elasticsearch.repositories.gcs;
 
 import com.google.cloud.BaseServiceException;
-import com.google.cloud.BatchResult;
 import com.google.cloud.WriteChannel;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.BlobListOption;
-import com.google.cloud.storage.StorageBatch;
+import com.google.cloud.storage.StorageBatchResult;
 import com.google.cloud.storage.StorageException;
 
 import org.apache.logging.log4j.LogManager;
@@ -58,18 +57,16 @@ import java.nio.channels.WritableByteChannel;
 import java.nio.file.FileAlreadyExistsException;
 import java.util.ArrayList;
 import java.util.Base64;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.net.HttpURLConnection.HTTP_GONE;
-import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_PRECON_FAILED;
 import static org.elasticsearch.core.Strings.format;
+import static org.elasticsearch.rest.RestStatus.TOO_MANY_REQUESTS;
 
 class GoogleCloudStorageBlobStore implements BlobStore {
 
@@ -85,7 +82,9 @@ class GoogleCloudStorageBlobStore implements BlobStore {
     // called "resumable upload")
     // https://cloud.google.com/storage/docs/json_api/v1/how-tos/resumable-upload
     public static final int LARGE_BLOB_THRESHOLD_BYTE_SIZE;
-    public static final int MAX_DELETES_PER_BATCH = 1000;
+
+    // MAX deletes per batch is 100 https://docs.cloud.google.com/storage/docs/batch#overview
+    public static final int MAX_DELETES_PER_BATCH = 100;
 
     static {
         final String key = "es.repository_gcs.large_blob_threshold_byte_size";
@@ -551,72 +550,6 @@ class GoogleCloudStorageBlobStore implements BlobStore {
         return deleteResult;
     }
 
-    /**
-     * Deletes multiple blobs from the specific bucket using a batch request
-     *
-     * @param purpose the operation purpose
-     * @param blobNames names of the blobs to delete
-     */
-    void deleteBlobs(OperationPurpose purpose, Iterator<String> blobNames) throws IOException {
-        if (blobNames.hasNext() == false) {
-            return;
-        }
-        final Iterator<BlobId> blobIdsToDelete = new Iterator<>() {
-            @Override
-            public boolean hasNext() {
-                return blobNames.hasNext();
-            }
-
-            @Override
-            public BlobId next() {
-                return BlobId.of(bucketName, blobNames.next());
-            }
-        };
-        final List<BlobId> failedBlobs = Collections.synchronizedList(new ArrayList<>());
-        try {
-            final AtomicReference<StorageException> ioe = new AtomicReference<>();
-            StorageBatch batch = client().batch();
-            int pendingDeletesInBatch = 0;
-            while (blobIdsToDelete.hasNext()) {
-                BlobId blob = blobIdsToDelete.next();
-                batch.delete(blob).notify(new BatchResult.Callback<>() {
-                    @Override
-                    public void success(Boolean result) {}
-
-                    @Override
-                    public void error(StorageException exception) {
-                        if (exception.getCode() != HTTP_NOT_FOUND) {
-                            // track up to 10 failed blob deletions for the exception message below
-                            if (failedBlobs.size() < 10) {
-                                failedBlobs.add(blob);
-                            }
-                            if (ioe.compareAndSet(null, exception) == false) {
-                                ioe.get().addSuppressed(exception);
-                            }
-                        }
-                    }
-                });
-                pendingDeletesInBatch++;
-                if (pendingDeletesInBatch % MAX_DELETES_PER_BATCH == 0) {
-                    batch.submit();
-                    batch = client().batch();
-                    pendingDeletesInBatch = 0;
-                }
-            }
-            if (pendingDeletesInBatch > 0) {
-                batch.submit();
-            }
-
-            final StorageException exception = ioe.get();
-            if (exception != null) {
-                throw exception;
-            }
-        } catch (final Exception e) {
-            throw new IOException("Exception when deleting blobs " + failedBlobs, e);
-        }
-        assert failedBlobs.isEmpty();
-    }
-
     private static String buildKey(String keyPath, String s) {
         assert s != null;
         return keyPath + s;
@@ -749,7 +682,7 @@ class GoogleCloudStorageBlobStore implements BlobStore {
                 if (statusCode == RestStatus.PRECONDITION_FAILED.getStatus()) {
                     return OptionalBytesReference.MISSING;
                 }
-                if (statusCode == RestStatus.TOO_MANY_REQUESTS.getStatus()) {
+                if (statusCode == TOO_MANY_REQUESTS.getStatus()) {
                     finalException = ExceptionsHelper.useOrSuppress(finalException, serviceException);
                     if (retries.hasNext()) {
                         try {
@@ -762,6 +695,105 @@ class GoogleCloudStorageBlobStore implements BlobStore {
                     } else {
                         throw finalException;
                     }
+                }
+            }
+        }
+    }
+
+    // GCS retry codes https://docs.cloud.google.com/storage/docs/retry-strategy#java
+    private static boolean isRetryErrCode(int code) {
+        final var status = RestStatus.fromCode(code);
+        if (status == null) {
+            return false;
+        }
+        return switch (status) {
+            case REQUEST_TIMEOUT, TOO_MANY_REQUESTS, INTERNAL_SERVER_ERROR, BAD_GATEWAY, SERVICE_UNAVAILABLE, GATEWAY_TIMEOUT -> true;
+            default -> false;
+        };
+    }
+
+    /**
+     * Deletes multiple blobs from the specific bucket using a batch request
+     *
+     * @param blobNames names of the blobs to delete
+     */
+    void deleteBlobs(OperationPurpose purpose, Iterator<String> blobNames) throws IOException {
+        if (blobNames.hasNext() == false) {
+            return;
+        }
+
+        record DeleteResult(BlobId blobId, StorageBatchResult<Boolean> result) {}
+        record DeleteFailure(BlobId blobId, int errCode) {}
+
+        // The following algorithm maximizes the size of every batch by merging retryable items
+        // from the previous batch and new items. When batch results have failed items, we first retry
+        // only a single item using the SDK client's retry strategy (exponential-backoff). Retrying
+        // a single item should provide enough time to back-off from throttling or temporary GCS
+        // failures. Once a single item successfully retries, we proceed with the next batch, combining
+        // the remaining failures and new items.
+        //
+        // Which is roughly looks like this:
+        // - create batch of 100 new items
+        // - submit batch
+        // - receive 100 results, with 10 retryable failures
+        // - retry 1 failure using non-batched delete using SDK retry strategy
+        // - (loop) create batch from 9 remaining failures and 91 new items
+
+        final var batchResults = new ArrayList<DeleteResult>(MAX_DELETES_PER_BATCH);
+        final var batchFailures = new ArrayList<DeleteFailure>(MAX_DELETES_PER_BATCH);
+        while (blobNames.hasNext() || batchFailures.isEmpty() == false) {
+
+            // create a new batch from failed and new items, failed first
+            final var batch = client().batch();
+            for (var failure : batchFailures) {
+                batchResults.add(new DeleteResult(failure.blobId, batch.delete(failure.blobId)));
+            }
+            batchFailures.clear();
+            while (blobNames.hasNext() && batchResults.size() < MAX_DELETES_PER_BATCH) {
+                final var blobId = BlobId.of(bucketName, blobNames.next());
+                batchResults.add(new DeleteResult(blobId, batch.delete(blobId)));
+            }
+
+            // The whole batch request uses GCS client's retry logic, but individual item failures are not retried.
+            // Collect all retryable failures or terminate on non-retryable error.
+            try {
+                batch.submit();
+            } catch (Exception e) {
+                throw new IOException("Failed to execute batch", e);
+            }
+            StorageException nonRetryableException = null;
+            for (var deleteResult : batchResults) {
+                try {
+                    deleteResult.result.get();
+                } catch (StorageException e) {
+                    final var errCode = e.getCode();
+                    batchFailures.add(new DeleteFailure(deleteResult.blobId, e.getCode()));
+                    if (nonRetryableException == null && isRetryErrCode(errCode) == false) {
+                        nonRetryableException = e;
+                    }
+                }
+            }
+            if (nonRetryableException != null) {
+                throw new IOException(
+                    "One or more batch items failed, non-retryable exception; all batch failures: " + batchFailures,
+                    nonRetryableException
+                );
+            }
+            batchResults.clear();
+
+            // Delete single item using GCS client's retry logic.
+            // It should provide enough back-off before trying next batch.
+            if (batchFailures.isEmpty() == false) {
+                final var retryBlobId = batchFailures.getLast().blobId;
+                try {
+                    client().delete(purpose, retryBlobId);
+                    // remaining items go into the next batch
+                    batchFailures.removeLast();
+                } catch (StorageException e) {
+                    throw new IOException(
+                        "Failed to retry single batch item, blobId=" + retryBlobId + "; all batch failures: " + batchFailures,
+                        e
+                    );
                 }
             }
         }

--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/MeteredStorage.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/MeteredStorage.java
@@ -33,6 +33,7 @@ import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.stream.Stream;
 
+import static org.elasticsearch.repositories.gcs.StorageOperation.DELETE;
 import static org.elasticsearch.repositories.gcs.StorageOperation.GET;
 import static org.elasticsearch.repositories.gcs.StorageOperation.INSERT;
 import static org.elasticsearch.repositories.gcs.StorageOperation.LIST;
@@ -80,6 +81,10 @@ public class MeteredStorage {
 
     public Blob meteredGet(OperationPurpose purpose, BlobId blobId) throws IOException {
         return statsCollector.collectIOSupplier(purpose, GET, () -> storage.get(blobId));
+    }
+
+    public void delete(OperationPurpose purpose, BlobId blobId) {
+        statsCollector.skipCollectRunnable(purpose, DELETE, () -> storage.delete(blobId));
     }
 
     public void meteredCreate(

--- a/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/StorageOperation.java
+++ b/modules/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/StorageOperation.java
@@ -12,7 +12,8 @@ package org.elasticsearch.repositories.gcs;
 public enum StorageOperation {
     INSERT("InsertObject"),
     GET("GetObject"),
-    LIST("ListObjects");
+    LIST("ListObjects"),
+    DELETE("DeleteObject");
 
     final String key;
 

--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreContainerTests.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobStoreContainerTests.java
@@ -54,11 +54,7 @@ public class GoogleCloudStorageBlobStoreContainerTests extends ESTestCase {
         } else {
             StorageBatchResult<Boolean> resultA = mock(StorageBatchResult.class);
             doReturn(resultA).when(batch).delete(eq(BlobId.of("bucket", "blobA")));
-            doAnswer(invocation -> {
-                StorageException storageException = new StorageException(new IOException("Batched delete throws a storage exception"));
-                ((BatchResult.Callback) invocation.getArguments()[0]).error(storageException);
-                return null;
-            }).when(resultA).notify(any(StorageBatchResult.Callback.class));
+            doThrow(new StorageException(new IOException("Batch item delete throws exception"))).when(resultA).get();
 
             StorageBatchResult<Boolean> resultB = mock(StorageBatchResult.class);
             doReturn(resultB).when(batch).delete(eq(BlobId.of("bucket", "blobB")));

--- a/test/fixtures/gcs-fixture/src/main/java/fixture/gcs/MockGcsBlobStore.java
+++ b/test/fixtures/gcs-fixture/src/main/java/fixture/gcs/MockGcsBlobStore.java
@@ -215,8 +215,8 @@ public class MockGcsBlobStore {
 
     record UpdateResponse(int statusCode, HttpHeaderParser.Range rangeHeader, long storedContentLength) {}
 
-    void deleteBlob(String path) {
-        blobs.remove(path);
+    boolean deleteBlob(String path) {
+        return blobs.remove(path) != null;
     }
 
     private String stripPrefixIfPresent(@Nullable String prefix, String toStrip) {

--- a/test/fixtures/gcs-fixture/src/test/java/fixture/gcs/GoogleCloudStorageHttpHandlerTests.java
+++ b/test/fixtures/gcs-fixture/src/test/java/fixture/gcs/GoogleCloudStorageHttpHandlerTests.java
@@ -47,6 +47,15 @@ import java.util.stream.Stream;
 import java.util.zip.GZIPOutputStream;
 
 import static java.util.Objects.requireNonNull;
+import static org.elasticsearch.rest.RestStatus.BAD_GATEWAY;
+import static org.elasticsearch.rest.RestStatus.GATEWAY_TIMEOUT;
+import static org.elasticsearch.rest.RestStatus.INTERNAL_SERVER_ERROR;
+import static org.elasticsearch.rest.RestStatus.NOT_FOUND;
+import static org.elasticsearch.rest.RestStatus.NO_CONTENT;
+import static org.elasticsearch.rest.RestStatus.OK;
+import static org.elasticsearch.rest.RestStatus.REQUEST_TIMEOUT;
+import static org.elasticsearch.rest.RestStatus.SERVICE_UNAVAILABLE;
+import static org.elasticsearch.rest.RestStatus.TOO_MANY_REQUESTS;
 
 public class GoogleCloudStorageHttpHandlerTests extends ESTestCase {
 
@@ -56,7 +65,7 @@ public class GoogleCloudStorageHttpHandlerTests extends ESTestCase {
 
     public void testRejectsBadUri() {
         assertEquals(
-            RestStatus.NOT_FOUND.getStatus(),
+            NOT_FOUND.getStatus(),
             handleRequest(new GoogleCloudStorageHttpHandler("bucket"), randomFrom("GET", "PUT", "POST", "DELETE", "HEAD"), "/not-in-bucket")
                 .status()
         );
@@ -76,7 +85,7 @@ public class GoogleCloudStorageHttpHandlerTests extends ESTestCase {
         final var handler = new GoogleCloudStorageHttpHandler(bucket);
         final var blobName = "path/" + randomAlphaOfLength(10);
 
-        assertEquals(RestStatus.NOT_FOUND, getBlobContents(handler, bucket, blobName, null, null).restStatus());
+        assertEquals(NOT_FOUND, getBlobContents(handler, bucket, blobName, null, null).restStatus());
 
         assertEquals(
             new TestHttpResponse(RestStatus.OK, "{\"kind\":\"storage#objects\",\"items\":[],\"prefixes\":[]}"),
@@ -103,24 +112,22 @@ public class GoogleCloudStorageHttpHandlerTests extends ESTestCase {
             {"kind":"storage#objects","items":[],"prefixes":[]}"""), listBlobs(handler, bucket, "some/other/path", null));
 
         var boundary = newMultipartBoundary();
-        assertEquals(
-            new TestHttpResponse(RestStatus.OK, """
-                --$boundary
-                content-type: application/http
-                content-id: response-1
-
-                HTTP/1.1 204 No Content
-
-
-                --$boundary--""".replace("\n", "\r\n").replace("$boundary", boundary)),
-            handleRequest(
+        // there is 10% chance for error response, run many iterations to catch errors
+        for (int i = 0; i < 100; i++) {
+            final var deleteResponse = handleRequest(
                 handler,
                 "POST",
                 "/batch/storage/v1",
                 createBatchDeleteRequest(bucket, boundary, blobName),
                 Headers.of("Content-Type", "multipart/mixed; boundary=" + boundary)
-            )
-        );
+            );
+            final var expectedDeleteVariants = batchDeleteItemVariants(boundary);
+            assertTrue(
+                "delete response does not match any variant\n--response--\n" + deleteResponse + "\n--variants--\n" + expectedDeleteVariants,
+                expectedDeleteVariants.contains(deleteResponse)
+            );
+        }
+
         assertEquals(
             RestStatus.OK,
             handleRequest(
@@ -244,7 +251,7 @@ public class GoogleCloudStorageHttpHandlerTests extends ESTestCase {
         assertEquals(new TestHttpResponse(RESUME_INCOMPLETE, rangeHeader(0, 99)), uploadPart2Response);
 
         // incomplete upload should not be visible yet
-        assertEquals(RestStatus.NOT_FOUND, getBlobContents(handler, bucket, blobName, null, null).restStatus());
+        assertEquals(NOT_FOUND, getBlobContents(handler, bucket, blobName, null, null).restStatus());
 
         final var part3 = randomAlphaOfLength(30);
         final var uploadPart3Response = handleRequest(handler, "PUT", sessionURI, part3, contentRangeHeader(100, 129, 130));
@@ -561,6 +568,21 @@ public class GoogleCloudStorageHttpHandlerTests extends ESTestCase {
         assertEquals(Set.of("e/g/"), new HashSet<>(jsonMapView.get("prefixes")));
     }
 
+    public void testMethodBucketObjectPattern() {
+        final var inputs = new String[] {
+            "DELETE http://host/storage/v1/b/bucket/o/test/tests-vQzflxz2Swa_bhmlM6gtyA/data-DxS0qi-A.dat?generation=1 HTTP/1.1",
+            "DELETE http://host:49177/storage/v1/b/bucket/o/test/tests-vQzflxz2Swa_bhmlM6gtyA/data-DxS0qi-A.dat?generation=1",
+            "DELETE http://127.0.0.1:49177/storage/v1/b/bucket/o/test/tests-vQzflxz2Swa_bhmlM6gtyA/data-DxS0qi-A.dat HTTP/1.1",
+            "DELETE http://127.0.0.1:49177/storage/v1/b/bucket/o/test/tests-vQzflxz2Swa_bhmlM6gtyA/data-DxS0qi-A.dat", };
+        for (var in : inputs) {
+            final var m = GoogleCloudStorageHttpHandler.METHOD_BUCKET_OBJECT_PATTERN.matcher(in);
+            assertTrue(in, m.find());
+            assertEquals("DELETE", m.group("method"));
+            assertEquals("bucket", m.group("bucket"));
+            assertEquals("test/tests-vQzflxz2Swa_bhmlM6gtyA/data-DxS0qi-A.dat", m.group("object"));
+        }
+    }
+
     private static TestHttpResponse executeUpload(
         GoogleCloudStorageHttpHandler handler,
         String bucket,
@@ -852,6 +874,34 @@ public class GoogleCloudStorageHttpHandlerTests extends ESTestCase {
         });
         builder.append("--").append(boundary).append("--");
         return builder.toString();
+    }
+
+    public static final List<RestStatus> DELETE_STATUSES = List.of(
+        NO_CONTENT,
+        NOT_FOUND,
+        REQUEST_TIMEOUT,
+        TOO_MANY_REQUESTS,
+        INTERNAL_SERVER_ERROR,
+        BAD_GATEWAY,
+        SERVICE_UNAVAILABLE,
+        GATEWAY_TIMEOUT
+    );
+
+    private static final String BATCH_RESPONSE_ITEM_TEMPLATE = """
+        --$boundary
+        content-type: application/http
+        content-id: response-1
+
+        $content
+        --$boundary--""";
+
+    // batch item deletion is randomized, here we produce all possible outcomes for template above
+    private static List<TestHttpResponse> batchDeleteItemVariants(String boundary) {
+        return DELETE_STATUSES.stream()
+            .map(GoogleCloudStorageHttpHandler::deleteItemStatusToHttpContent)
+            .map(content -> BATCH_RESPONSE_ITEM_TEMPLATE.replace("\n", "\r\n").replace("$boundary", boundary).replace("$content", content))
+            .map(content -> new TestHttpResponse(OK, content))
+            .toList();
     }
 
     private static class TestHttpExchange extends HttpExchange {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Retry batch-delete items in GCS (#138951)](https://github.com/elastic/elasticsearch/pull/138951)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)