### PR TITLE
Fixed version check failures in tests in serverless

### DIFF
--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/AbstractStringTypeLogsdbRollingUpgradeTestCase.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/AbstractStringTypeLogsdbRollingUpgradeTestCase.java
@@ -68,29 +68,21 @@ public abstract class AbstractStringTypeLogsdbRollingUpgradeTestCase extends Abs
 
     private void verifyClusterIsRunningOldVersion() throws IOException {
         String expectedOldVersion = System.getProperty("tests.old_cluster_version");
-        if (expectedOldVersion != null) {
-            verifyOldVersion(expectedOldVersion);
-        } else {
-            String expectedServerlessOldVersion = System.getProperty("tests.serverless.bwc_stack_version");
-            verifyOldVersion(expectedServerlessOldVersion);
-            assertThat(
-                "tests.old_cluster_version or tests.serverless.bwc_stack_version system property must be set",
-                expectedServerlessOldVersion,
-                notNullValue()
-            );
-        }
-    }
 
-    private void verifyOldVersion(String expectedOldVersion) throws IOException {
+        if (expectedOldVersion == null && System.getProperty("tests.serverless.bwc_stack_version") != null) {
+            // we're running in serverless where a node's version is a commit hash rather than a release version, so skip this check
+            return;
+        }
+
         // Strip -SNAPSHOT suffix for comparison since builds from refspecs may not include it
         String normalizedExpectedVersion = expectedOldVersion.replace("-SNAPSHOT", "");
 
         Set<String> nodeVersions = readVersionsFromNodesInfo(adminClient());
 
         assertThat(
-            "All nodes should be running the old version [" + expectedOldVersion + "] but found: " + nodeVersions,
-            nodeVersions,
-            everyItem(equalTo(normalizedExpectedVersion))
+                "All nodes should be running the old version [" + expectedOldVersion + "] but found: " + nodeVersions,
+                nodeVersions,
+                everyItem(equalTo(normalizedExpectedVersion))
         );
     }
 

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/AbstractStringTypeLogsdbRollingUpgradeTestCase.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/AbstractStringTypeLogsdbRollingUpgradeTestCase.java
@@ -80,9 +80,9 @@ public abstract class AbstractStringTypeLogsdbRollingUpgradeTestCase extends Abs
         Set<String> nodeVersions = readVersionsFromNodesInfo(adminClient());
 
         assertThat(
-                "All nodes should be running the old version [" + expectedOldVersion + "] but found: " + nodeVersions,
-                nodeVersions,
-                everyItem(equalTo(normalizedExpectedVersion))
+            "All nodes should be running the old version [" + expectedOldVersion + "] but found: " + nodeVersions,
+            nodeVersions,
+            everyItem(equalTo(normalizedExpectedVersion))
         );
     }
 


### PR DESCRIPTION
Some tests are failing in serverless due to a new version check I added. The problem is that in serverless a nodes's version is replaced by a commit hash, which breaks the test.

Addresses https://github.com/elastic/elasticsearch-serverless/issues/5308

Verified by running against the serverless repo:

```
./gradlew ":qa:stateful:x-pack:plugin:logsdb:qa:rolling-upgrade:javaRestTest" --tests "org.elasticsearch.xpack.logsdb.KeywordRollingUpgradeIT.testIndexing" -Dtests.seed=C84C749B75B57064 -Dtests.locale=no-NO -Dtests.timezone=America/Monterrey -Druntime.java=25
```