### PR TITLE
[9.3] Use a single array for buffering rate data points (#140855)

### DIFF
--- a/docs/changelog/140855.yaml
+++ b/docs/changelog/140855.yaml
@@ -1,0 +1,5 @@
+pr: 140855
+summary: Use a single array for buffering rate data points
+area: ES|QL
+type: enhancement
+issues: []

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateDoubleGroupingAggregatorFunction.java
@@ -9,12 +9,14 @@ package org.elasticsearch.compute.aggregation;
 // begin generated imports
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.PriorityQueue;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.DoubleArray;
 import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.common.util.LongObjectPagedHashMap;
 import org.elasticsearch.common.util.ObjectArray;
+import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.DoubleBlock;
@@ -31,12 +33,10 @@ import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 // end generated imports
 
-public final class RateDoubleGroupingAggregatorFunction implements GroupingAggregatorFunction {
+public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGroupingFunction implements GroupingAggregatorFunction {
 
     public static final class FunctionSupplier implements AggregatorFunctionSupplier {
         // Overriding constructor to support isRateOverTime flag
@@ -81,7 +81,7 @@ public final class RateDoubleGroupingAggregatorFunction implements GroupingAggre
         new IntermediateStateDesc("resets", ElementType.DOUBLE)
     );
 
-    private ObjectArray<Buffer> buffers;
+    private final DoubleRawBuffer rawBuffer;
     private final List<Integer> channels;
     private final DriverContext driverContext;
     private final BigArrays bigArrays;
@@ -89,9 +89,7 @@ public final class RateDoubleGroupingAggregatorFunction implements GroupingAggre
     private final boolean isRateOverTime;
     private final double dateFactor;
 
-    // tracking min/max group ids to allow flushing the raw buffer when the slice index changed
-    private int minRawInputGroupId = Integer.MAX_VALUE;
-    private int maxRawInputGroupId = Integer.MIN_VALUE;
+    // track lastSliceIndex to allow flushing the raw buffer when the slice index changed
     private int lastSliceIndex = -1;
 
     public RateDoubleGroupingAggregatorFunction(
@@ -104,14 +102,16 @@ public final class RateDoubleGroupingAggregatorFunction implements GroupingAggre
         this.driverContext = driverContext;
         this.bigArrays = driverContext.bigArrays();
         this.isRateOverTime = isRateOverTime;
-        ObjectArray<Buffer> buffers = driverContext.bigArrays().newObjectArray(256);
         this.dateFactor = isDateNanos ? 1_000_000_000.0 : 1000.0;
+        boolean success = false;
         try {
+            this.rawBuffer = new DoubleRawBuffer(bigArrays);
             this.reducedStates = driverContext.bigArrays().newObjectArray(256);
-            this.buffers = buffers;
-            buffers = null;
+            success = true;
         } finally {
-            Releasables.close(buffers);
+            if (success == false) {
+                close();
+            }
         }
     }
 
@@ -192,7 +192,6 @@ public final class RateDoubleGroupingAggregatorFunction implements GroupingAggre
     // Note that this path can be executed randomly in tests, not in production
     private void addRawInput(int positionOffset, IntBlock groups, DoubleBlock valueBlock, LongVector timestampVector) {
         int lastGroup = -1;
-        Buffer buffer = null;
         int positionCount = groups.getPositionCount();
         for (int p = 0; p < positionCount; p++) {
             if (groups.isNull(p)) {
@@ -210,11 +209,11 @@ public final class RateDoubleGroupingAggregatorFunction implements GroupingAggre
                 final int groupId = groups.getInt(g);
                 final var value = valueBlock.getDouble(valueBlock.getFirstValueIndex(valuePosition));
                 if (lastGroup != groupId) {
-                    buffer = getBuffer(groupId, 1, timestamp);
-                    buffer.appendWithoutResize(timestamp, value);
+                    rawBuffer.prepareForAppend(groupId, 1, timestamp);
+                    rawBuffer.appendWithoutResize(timestamp, value);
                     lastGroup = groupId;
                 } else {
-                    buffer.maybeResizeAndAppend(bigArrays, timestamp, value);
+                    rawBuffer.maybeResizeAndAppend(timestamp, value);
                 }
             }
         }
@@ -261,13 +260,13 @@ public final class RateDoubleGroupingAggregatorFunction implements GroupingAggre
     }
 
     private void addSubRange(int group, int from, int to, DoubleVector valueVector, LongVector timestampVector) {
-        var buffer = getBuffer(group, to - from, timestampVector.getLong(from));
-        buffer.appendRange(from, to, valueVector, timestampVector);
+        rawBuffer.prepareForAppend(group, to - from, timestampVector.getLong(from));
+        rawBuffer.appendRange(from, to, valueVector, timestampVector);
     }
 
     private void addSubRange(int group, int from, int to, DoubleBlock valueBlock, LongVector timestampVector) {
-        var buffer = getBuffer(group, to - from, timestampVector.getLong(from));
-        buffer.appendRange(from, to, valueBlock, timestampVector);
+        rawBuffer.prepareForAppend(group, to - from, timestampVector.getLong(from));
+        rawBuffer.appendRange(from, to, valueBlock, timestampVector);
     }
 
     @Override
@@ -356,6 +355,7 @@ public final class RateDoubleGroupingAggregatorFunction implements GroupingAggre
         BlockFactory blockFactory = driverContext.blockFactory();
         int positionCount = selected.getPositionCount();
         try (
+            var flushQueues = rawBuffer.prepareForFlush();
             var timestamps = blockFactory.newLongBlockBuilder(positionCount * 2);
             var values = blockFactory.newDoubleBlockBuilder(positionCount * 2);
             var sampleCounts = blockFactory.newLongVectorFixedBuilder(positionCount);
@@ -363,7 +363,7 @@ public final class RateDoubleGroupingAggregatorFunction implements GroupingAggre
         ) {
             for (int p = 0; p < positionCount; p++) {
                 int group = selected.getInt(p);
-                var state = flushAndCombineState(group);
+                var state = flushAndCombineState(flushQueues, group);
                 // Do not combine intervals across shards because intervals from different indices may overlap.
                 if (state != null && state.samples > 0) {
                     timestamps.beginPositionEntry();
@@ -394,92 +394,71 @@ public final class RateDoubleGroupingAggregatorFunction implements GroupingAggre
 
     @Override
     public void close() {
-        for (long i = 0; i < buffers.size(); i++) {
-            Buffer buffer = buffers.get(i);
-            if (buffer != null) {
-                buffer.close();
-            }
-        }
-        Releasables.close(reducedStates, buffers);
-    }
-
-    private Buffer getBuffer(int groupId, int newElements, long firstTimestamp) {
-        buffers = bigArrays.grow(buffers, groupId + 1);
-        Buffer buffer = buffers.get(groupId);
-        if (buffer == null) {
-            buffer = new Buffer(bigArrays, newElements);
-            buffers.set(groupId, buffer);
-            minRawInputGroupId = Math.min(minRawInputGroupId, groupId);
-            maxRawInputGroupId = Math.max(maxRawInputGroupId, groupId);
-        } else {
-            buffer.ensureCapacity(bigArrays, newElements, firstTimestamp);
-        }
-        return buffer;
+        Releasables.close(reducedStates, rawBuffer);
     }
 
     void flushRawBuffers() {
-        if (minRawInputGroupId > maxRawInputGroupId) {
+        if (rawBuffer.minGroupId > rawBuffer.maxGroupId) {
             return;
         }
-        reducedStates = bigArrays.grow(reducedStates, maxRawInputGroupId + 1);
-        for (int groupId = minRawInputGroupId; groupId <= maxRawInputGroupId; groupId++) {
-            Buffer buffer = buffers.getAndSet(groupId, null);
-            if (buffer != null) {
-                try (buffer) {
+        reducedStates = bigArrays.grow(reducedStates, rawBuffer.maxGroupId + 1);
+        try (var flushQueues = rawBuffer.prepareForFlush()) {
+            for (int groupId = rawBuffer.minGroupId; groupId <= rawBuffer.maxGroupId; groupId++) {
+                var flushQueue = flushQueues.getFlushQueue(groupId);
+                if (flushQueue != null) {
                     ReducedState state = reducedStates.get(groupId);
                     if (state == null) {
                         state = new ReducedState();
                         reducedStates.set(groupId, state);
                     }
-                    buffer.flush(state);
+                    flushGroup(state, rawBuffer, flushQueue);
                 }
             }
         }
-        minRawInputGroupId = Integer.MAX_VALUE;
-        maxRawInputGroupId = Integer.MIN_VALUE;
+        rawBuffer.minGroupId = Integer.MAX_VALUE;
+        rawBuffer.maxGroupId = Integer.MIN_VALUE;
     }
 
-    /**
-     * Buffers data points in two arrays: one for timestamps and one for values, partitioned into multiple slices.
-     * Each slice is sorted in descending order of timestamp. A new slice is created when a data point has a
-     * timestamp greater than the last point of the current slice. Since each page is sorted by descending timestamp,
-     * we only need to compare the first point of the new page with the last point of the current slice to decide
-     * if a new slice is needed. During merging, a priority queue is used to iterate through the slices, selecting
-     * the slice with the greatest timestamp.
-     */
-    static final class Buffer implements Releasable {
-        private LongArray timestamps;
+    static final class DoubleRawBuffer extends RawBuffer {
         private DoubleArray values;
-        private int pendingCount;
-        int[] sliceOffsets;
-        private static final int[] EMPTY_SLICES = new int[0];
 
-        Buffer(BigArrays bigArrays, int initialSize) {
-            this.timestamps = bigArrays.newLongArray(Math.max(initialSize, 32), false);
-            this.values = bigArrays.newDoubleArray(Math.max(initialSize, 32), false);
-            this.sliceOffsets = EMPTY_SLICES;
+        DoubleRawBuffer(BigArrays bigArrays) {
+            super(bigArrays);
+            boolean success = false;
+            try {
+                this.values = bigArrays.newDoubleArray(PageCacheRecycler.DOUBLE_PAGE_SIZE, false);
+                success = true;
+            } finally {
+                if (success == false) {
+                    close();
+                }
+            }
+        }
+
+        void prepareForAppend(int groupId, int count, long firstTimestamp) {
+            prepareSlicesOnly(groupId, firstTimestamp);
+            int newSize = valueCount + count;
+            timestamps = bigArrays.grow(timestamps, newSize);
+            values = bigArrays.grow(values, newSize);
         }
 
         void appendWithoutResize(long timestamp, double value) {
-            timestamps.set(pendingCount, timestamp);
-            values.set(pendingCount, value);
-            pendingCount++;
+            timestamps.set(valueCount, timestamp);
+            values.set(valueCount, value);
+            valueCount++;
         }
 
-        void maybeResizeAndAppend(BigArrays bigArrays, long timestamp, double value) {
-            timestamps = bigArrays.grow(timestamps, pendingCount + 1);
-            values = bigArrays.grow(values, pendingCount + 1);
-
-            timestamps.set(pendingCount, timestamp);
-            values.set(pendingCount, value);
-            pendingCount++;
+        void maybeResizeAndAppend(long timestamp, double value) {
+            timestamps = bigArrays.grow(timestamps, valueCount + 1);
+            values = bigArrays.grow(values, valueCount + 1);
+            appendWithoutResize(timestamp, value);
         }
 
         void appendRange(int fromPosition, int toPosition, DoubleVector valueVector, LongVector timestampVector) {
             for (int p = fromPosition; p < toPosition; p++) {
-                values.set(pendingCount, valueVector.getDouble(p));
-                timestamps.set(pendingCount, timestampVector.getLong(p));
-                pendingCount++;
+                values.set(valueCount, valueVector.getDouble(p));
+                timestamps.set(valueCount, timestampVector.getLong(p));
+                valueCount++;
             }
         }
 
@@ -489,117 +468,88 @@ public final class RateDoubleGroupingAggregatorFunction implements GroupingAggre
                     continue;
                 }
                 assert valueBlock.getValueCount(p) == 1 : "expected single-valued block " + valueBlock;
-                values.set(pendingCount, valueBlock.getDouble(p));
-                timestamps.set(pendingCount, timestampVector.getLong(p));
-                pendingCount++;
+                values.set(valueCount, valueBlock.getDouble(p));
+                timestamps.set(valueCount, timestampVector.getLong(p));
+                valueCount++;
             }
-        }
-
-        void ensureCapacity(BigArrays bigArrays, int count, long firstTimestamp) {
-            int newSize = pendingCount + count;
-            timestamps = bigArrays.grow(timestamps, newSize);
-            values = bigArrays.grow(values, newSize);
-            if (pendingCount > 0 && firstTimestamp > timestamps.get(pendingCount - 1)) {
-                if (sliceOffsets.length == 0 || sliceOffsets[sliceOffsets.length - 1] != pendingCount) {
-                    sliceOffsets = ArrayUtil.growExact(sliceOffsets, sliceOffsets.length + 1);
-                    sliceOffsets[sliceOffsets.length - 1] = pendingCount;
-                }
-            }
-        }
-
-        void flush(ReducedState state) {
-            if (pendingCount == 0) {
-                return;
-            }
-            if (pendingCount == 1) {
-                state.samples++;
-                long t = timestamps.get(0);
-                double v = values.get(0);
-                state.appendInterval(new Interval(t, v, t, v));
-                return;
-            }
-            PriorityQueue<Slice> pq = mergeQueue();
-            // first
-            final long lastTimestamp;
-            final double lastValue;
-            {
-                Slice top = pq.top();
-                lastTimestamp = top.timestamp;
-                int position = top.next();
-                lastValue = values.get(position);
-                if (top.exhausted()) {
-                    pq.pop();
-                } else {
-                    pq.updateTop();
-                }
-            }
-            var prevValue = lastValue;
-            int position = -1;
-            while (pq.size() > 0) {
-                Slice top = pq.top();
-                position = top.next();
-                if (top.exhausted()) {
-                    pq.pop();
-                } else {
-                    pq.updateTop();
-                }
-                var val = values.get(position);
-                if (val > prevValue) {
-                    state.resets += val;
-                }
-                prevValue = val;
-            }
-            state.samples += pendingCount;
-            state.appendInterval(new Interval(lastTimestamp, lastValue, timestamps.get(position), prevValue));
-        }
-
-        private PriorityQueue<Slice> mergeQueue() {
-            PriorityQueue<Slice> pq = new PriorityQueue<>(this.sliceOffsets.length + 1) {
-                @Override
-                protected boolean lessThan(Slice a, Slice b) {
-                    return a.timestamp > b.timestamp; // want the latest timestamp first
-                }
-            };
-            int startOffset = 0;
-            for (int sliceOffset : sliceOffsets) {
-                pq.add(new Slice(this, startOffset, sliceOffset));
-                startOffset = sliceOffset;
-            }
-            pq.add(new Slice(this, startOffset, pendingCount));
-            return pq;
         }
 
         @Override
         public void close() {
-            timestamps.close();
-            values.close();
+            Releasables.close(values, super::close);
         }
     }
 
-    static final class Slice {
-        int start;
-        long timestamp;
-        final int end;
-        final Buffer buffer;
-
-        Slice(Buffer buffer, int start, int end) {
-            this.buffer = buffer;
-            this.start = start;
-            this.end = end;
-            this.timestamp = buffer.timestamps.get(start);
+    static void flushGroup(ReducedState state, DoubleRawBuffer buffer, FlushQueue flushQueue) {
+        var timestamps = buffer.timestamps;
+        var values = buffer.values;
+        if (flushQueue.valueCount == 1) {
+            state.samples++;
+            long t = timestamps.get(flushQueue.top().start);
+            var v = values.get(flushQueue.top().start);
+            state.appendInterval(new Interval(t, v, t, v));
+            return;
         }
-
-        boolean exhausted() {
-            return start >= end;
-        }
-
-        int next() {
-            int index = start++;
-            if (start < end) {
-                timestamp = buffer.timestamps.get(start);
+        // first
+        final long lastTimestamp;
+        final double lastValue;
+        Slice top;
+        {
+            top = flushQueue.top();
+            int position = top.next();
+            lastTimestamp = timestamps.get(position);
+            lastValue = values.get(position);
+            if (top.exhausted()) {
+                flushQueue.pop();
+                top = flushQueue.top();
+            } else {
+                top = flushQueue.updateTop();
             }
-            return index;
         }
+        var prevValue = lastValue;
+        long secondNextTimestamp = flushQueue.secondNextTimestamp();
+        while (flushQueue.size() > 1) {
+            // If the last timestamp is greater than the maximum timestamp of the next two candidate slices,
+            // there is no overlap with subsequent slices, so batch merging can be performed without comparing
+            // timestamps from the buffer.
+            if (top.lastTimestamp() > secondNextTimestamp) {
+                for (int p = top.start; p < top.end; p++) {
+                    var val = values.get(p);
+                    if (val > prevValue) {
+                        state.resets += val;
+                    }
+                    prevValue = val;
+                }
+                flushQueue.pop();
+                top = flushQueue.top();
+                secondNextTimestamp = flushQueue.secondNextTimestamp();
+                continue;
+            }
+            var val = values.get(top.next());
+            if (val > prevValue) {
+                state.resets += val;
+            }
+            prevValue = val;
+            if (top.exhausted()) {
+                flushQueue.pop();
+                top = flushQueue.top();
+                secondNextTimestamp = flushQueue.secondNextTimestamp();
+            } else if (top.nextTimestamp < secondNextTimestamp) {
+                top = flushQueue.updateTop();
+                secondNextTimestamp = flushQueue.secondNextTimestamp();
+            }
+        }
+        // last slice
+        top = flushQueue.top();
+        for (int p = top.start; p < top.end; p++) {
+            var val = values.get(p);
+            if (val > prevValue) {
+                state.resets += val;
+            }
+            prevValue = val;
+        }
+        state.samples += flushQueue.valueCount;
+        state.appendInterval(new Interval(lastTimestamp, lastValue, timestamps.get(top.end - 1), prevValue));
     }
 
     @Override
@@ -607,12 +557,13 @@ public final class RateDoubleGroupingAggregatorFunction implements GroupingAggre
         BlockFactory blockFactory = driverContext.blockFactory();
         int positionCount = selected.getPositionCount();
         try (
+            var flushQueues = rawBuffer.prepareForFlush();
             var rates = blockFactory.newDoubleBlockBuilder(positionCount);
-            var flushedStates = new LongObjectPagedHashMap<ReducedState>(positionCount, driverContext.bigArrays())
+            var flushedStates = new LongObjectPagedHashMap<ReducedState>(positionCount, bigArrays)
         ) {
             for (int p = 0; p < positionCount; p++) {
                 int group = selected.getInt(p);
-                var state = flushAndCombineState(group);
+                var state = flushAndCombineState(flushQueues, group);
                 if (state != null) {
                     flushedStates.put(group, state);
                     // combine intervals for the final evaluation
@@ -650,16 +601,14 @@ public final class RateDoubleGroupingAggregatorFunction implements GroupingAggre
         }
     }
 
-    ReducedState flushAndCombineState(int groupId) {
+    ReducedState flushAndCombineState(FlushQueues flushQueues, int groupId) {
         ReducedState state = groupId < reducedStates.size() ? reducedStates.getAndSet(groupId, null) : null;
-        Buffer buffer = groupId < buffers.size() ? buffers.getAndSet(groupId, null) : null;
-        if (buffer != null) {
-            try (buffer) {
-                if (state == null) {
-                    state = new ReducedState();
-                }
-                buffer.flush(state);
+        var flushQueue = flushQueues.getFlushQueue(groupId);
+        if (flushQueue != null) {
+            if (state == null) {
+                state = new ReducedState();
             }
+            flushGroup(state, rawBuffer, flushQueue);
         }
         return state;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
@@ -9,12 +9,14 @@ package org.elasticsearch.compute.aggregation;
 // begin generated imports
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.PriorityQueue;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.DoubleArray;
 import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.common.util.LongObjectPagedHashMap;
 import org.elasticsearch.common.util.ObjectArray;
+import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.DoubleBlock;
@@ -31,12 +33,10 @@ import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 // end generated imports
 
-public final class RateIntGroupingAggregatorFunction implements GroupingAggregatorFunction {
+public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupingFunction implements GroupingAggregatorFunction {
 
     public static final class FunctionSupplier implements AggregatorFunctionSupplier {
         // Overriding constructor to support isRateOverTime flag
@@ -81,7 +81,7 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
         new IntermediateStateDesc("resets", ElementType.DOUBLE)
     );
 
-    private ObjectArray<Buffer> buffers;
+    private final IntRawBuffer rawBuffer;
     private final List<Integer> channels;
     private final DriverContext driverContext;
     private final BigArrays bigArrays;
@@ -89,9 +89,7 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
     private final boolean isRateOverTime;
     private final double dateFactor;
 
-    // tracking min/max group ids to allow flushing the raw buffer when the slice index changed
-    private int minRawInputGroupId = Integer.MAX_VALUE;
-    private int maxRawInputGroupId = Integer.MIN_VALUE;
+    // track lastSliceIndex to allow flushing the raw buffer when the slice index changed
     private int lastSliceIndex = -1;
 
     public RateIntGroupingAggregatorFunction(
@@ -104,14 +102,16 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
         this.driverContext = driverContext;
         this.bigArrays = driverContext.bigArrays();
         this.isRateOverTime = isRateOverTime;
-        ObjectArray<Buffer> buffers = driverContext.bigArrays().newObjectArray(256);
         this.dateFactor = isDateNanos ? 1_000_000_000.0 : 1000.0;
+        boolean success = false;
         try {
+            this.rawBuffer = new IntRawBuffer(bigArrays);
             this.reducedStates = driverContext.bigArrays().newObjectArray(256);
-            this.buffers = buffers;
-            buffers = null;
+            success = true;
         } finally {
-            Releasables.close(buffers);
+            if (success == false) {
+                close();
+            }
         }
     }
 
@@ -192,7 +192,6 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
     // Note that this path can be executed randomly in tests, not in production
     private void addRawInput(int positionOffset, IntBlock groups, IntBlock valueBlock, LongVector timestampVector) {
         int lastGroup = -1;
-        Buffer buffer = null;
         int positionCount = groups.getPositionCount();
         for (int p = 0; p < positionCount; p++) {
             if (groups.isNull(p)) {
@@ -210,11 +209,11 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
                 final int groupId = groups.getInt(g);
                 final var value = valueBlock.getInt(valueBlock.getFirstValueIndex(valuePosition));
                 if (lastGroup != groupId) {
-                    buffer = getBuffer(groupId, 1, timestamp);
-                    buffer.appendWithoutResize(timestamp, value);
+                    rawBuffer.prepareForAppend(groupId, 1, timestamp);
+                    rawBuffer.appendWithoutResize(timestamp, value);
                     lastGroup = groupId;
                 } else {
-                    buffer.maybeResizeAndAppend(bigArrays, timestamp, value);
+                    rawBuffer.maybeResizeAndAppend(timestamp, value);
                 }
             }
         }
@@ -261,13 +260,13 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
     }
 
     private void addSubRange(int group, int from, int to, IntVector valueVector, LongVector timestampVector) {
-        var buffer = getBuffer(group, to - from, timestampVector.getLong(from));
-        buffer.appendRange(from, to, valueVector, timestampVector);
+        rawBuffer.prepareForAppend(group, to - from, timestampVector.getLong(from));
+        rawBuffer.appendRange(from, to, valueVector, timestampVector);
     }
 
     private void addSubRange(int group, int from, int to, IntBlock valueBlock, LongVector timestampVector) {
-        var buffer = getBuffer(group, to - from, timestampVector.getLong(from));
-        buffer.appendRange(from, to, valueBlock, timestampVector);
+        rawBuffer.prepareForAppend(group, to - from, timestampVector.getLong(from));
+        rawBuffer.appendRange(from, to, valueBlock, timestampVector);
     }
 
     @Override
@@ -356,6 +355,7 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
         BlockFactory blockFactory = driverContext.blockFactory();
         int positionCount = selected.getPositionCount();
         try (
+            var flushQueues = rawBuffer.prepareForFlush();
             var timestamps = blockFactory.newLongBlockBuilder(positionCount * 2);
             var values = blockFactory.newIntBlockBuilder(positionCount * 2);
             var sampleCounts = blockFactory.newLongVectorFixedBuilder(positionCount);
@@ -363,7 +363,7 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
         ) {
             for (int p = 0; p < positionCount; p++) {
                 int group = selected.getInt(p);
-                var state = flushAndCombineState(group);
+                var state = flushAndCombineState(flushQueues, group);
                 // Do not combine intervals across shards because intervals from different indices may overlap.
                 if (state != null && state.samples > 0) {
                     timestamps.beginPositionEntry();
@@ -394,92 +394,71 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
 
     @Override
     public void close() {
-        for (long i = 0; i < buffers.size(); i++) {
-            Buffer buffer = buffers.get(i);
-            if (buffer != null) {
-                buffer.close();
-            }
-        }
-        Releasables.close(reducedStates, buffers);
-    }
-
-    private Buffer getBuffer(int groupId, int newElements, long firstTimestamp) {
-        buffers = bigArrays.grow(buffers, groupId + 1);
-        Buffer buffer = buffers.get(groupId);
-        if (buffer == null) {
-            buffer = new Buffer(bigArrays, newElements);
-            buffers.set(groupId, buffer);
-            minRawInputGroupId = Math.min(minRawInputGroupId, groupId);
-            maxRawInputGroupId = Math.max(maxRawInputGroupId, groupId);
-        } else {
-            buffer.ensureCapacity(bigArrays, newElements, firstTimestamp);
-        }
-        return buffer;
+        Releasables.close(reducedStates, rawBuffer);
     }
 
     void flushRawBuffers() {
-        if (minRawInputGroupId > maxRawInputGroupId) {
+        if (rawBuffer.minGroupId > rawBuffer.maxGroupId) {
             return;
         }
-        reducedStates = bigArrays.grow(reducedStates, maxRawInputGroupId + 1);
-        for (int groupId = minRawInputGroupId; groupId <= maxRawInputGroupId; groupId++) {
-            Buffer buffer = buffers.getAndSet(groupId, null);
-            if (buffer != null) {
-                try (buffer) {
+        reducedStates = bigArrays.grow(reducedStates, rawBuffer.maxGroupId + 1);
+        try (var flushQueues = rawBuffer.prepareForFlush()) {
+            for (int groupId = rawBuffer.minGroupId; groupId <= rawBuffer.maxGroupId; groupId++) {
+                var flushQueue = flushQueues.getFlushQueue(groupId);
+                if (flushQueue != null) {
                     ReducedState state = reducedStates.get(groupId);
                     if (state == null) {
                         state = new ReducedState();
                         reducedStates.set(groupId, state);
                     }
-                    buffer.flush(state);
+                    flushGroup(state, rawBuffer, flushQueue);
                 }
             }
         }
-        minRawInputGroupId = Integer.MAX_VALUE;
-        maxRawInputGroupId = Integer.MIN_VALUE;
+        rawBuffer.minGroupId = Integer.MAX_VALUE;
+        rawBuffer.maxGroupId = Integer.MIN_VALUE;
     }
 
-    /**
-     * Buffers data points in two arrays: one for timestamps and one for values, partitioned into multiple slices.
-     * Each slice is sorted in descending order of timestamp. A new slice is created when a data point has a
-     * timestamp greater than the last point of the current slice. Since each page is sorted by descending timestamp,
-     * we only need to compare the first point of the new page with the last point of the current slice to decide
-     * if a new slice is needed. During merging, a priority queue is used to iterate through the slices, selecting
-     * the slice with the greatest timestamp.
-     */
-    static final class Buffer implements Releasable {
-        private LongArray timestamps;
+    static final class IntRawBuffer extends RawBuffer {
         private IntArray values;
-        private int pendingCount;
-        int[] sliceOffsets;
-        private static final int[] EMPTY_SLICES = new int[0];
 
-        Buffer(BigArrays bigArrays, int initialSize) {
-            this.timestamps = bigArrays.newLongArray(Math.max(initialSize, 32), false);
-            this.values = bigArrays.newIntArray(Math.max(initialSize, 32), false);
-            this.sliceOffsets = EMPTY_SLICES;
+        IntRawBuffer(BigArrays bigArrays) {
+            super(bigArrays);
+            boolean success = false;
+            try {
+                this.values = bigArrays.newIntArray(PageCacheRecycler.DOUBLE_PAGE_SIZE, false);
+                success = true;
+            } finally {
+                if (success == false) {
+                    close();
+                }
+            }
+        }
+
+        void prepareForAppend(int groupId, int count, long firstTimestamp) {
+            prepareSlicesOnly(groupId, firstTimestamp);
+            int newSize = valueCount + count;
+            timestamps = bigArrays.grow(timestamps, newSize);
+            values = bigArrays.grow(values, newSize);
         }
 
         void appendWithoutResize(long timestamp, int value) {
-            timestamps.set(pendingCount, timestamp);
-            values.set(pendingCount, value);
-            pendingCount++;
+            timestamps.set(valueCount, timestamp);
+            values.set(valueCount, value);
+            valueCount++;
         }
 
-        void maybeResizeAndAppend(BigArrays bigArrays, long timestamp, int value) {
-            timestamps = bigArrays.grow(timestamps, pendingCount + 1);
-            values = bigArrays.grow(values, pendingCount + 1);
-
-            timestamps.set(pendingCount, timestamp);
-            values.set(pendingCount, value);
-            pendingCount++;
+        void maybeResizeAndAppend(long timestamp, int value) {
+            timestamps = bigArrays.grow(timestamps, valueCount + 1);
+            values = bigArrays.grow(values, valueCount + 1);
+            appendWithoutResize(timestamp, value);
         }
 
         void appendRange(int fromPosition, int toPosition, IntVector valueVector, LongVector timestampVector) {
             for (int p = fromPosition; p < toPosition; p++) {
-                values.set(pendingCount, valueVector.getInt(p));
-                timestamps.set(pendingCount, timestampVector.getLong(p));
-                pendingCount++;
+                values.set(valueCount, valueVector.getInt(p));
+                timestamps.set(valueCount, timestampVector.getLong(p));
+                valueCount++;
             }
         }
 
@@ -489,117 +468,88 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
                     continue;
                 }
                 assert valueBlock.getValueCount(p) == 1 : "expected single-valued block " + valueBlock;
-                values.set(pendingCount, valueBlock.getInt(p));
-                timestamps.set(pendingCount, timestampVector.getLong(p));
-                pendingCount++;
+                values.set(valueCount, valueBlock.getInt(p));
+                timestamps.set(valueCount, timestampVector.getLong(p));
+                valueCount++;
             }
-        }
-
-        void ensureCapacity(BigArrays bigArrays, int count, long firstTimestamp) {
-            int newSize = pendingCount + count;
-            timestamps = bigArrays.grow(timestamps, newSize);
-            values = bigArrays.grow(values, newSize);
-            if (pendingCount > 0 && firstTimestamp > timestamps.get(pendingCount - 1)) {
-                if (sliceOffsets.length == 0 || sliceOffsets[sliceOffsets.length - 1] != pendingCount) {
-                    sliceOffsets = ArrayUtil.growExact(sliceOffsets, sliceOffsets.length + 1);
-                    sliceOffsets[sliceOffsets.length - 1] = pendingCount;
-                }
-            }
-        }
-
-        void flush(ReducedState state) {
-            if (pendingCount == 0) {
-                return;
-            }
-            if (pendingCount == 1) {
-                state.samples++;
-                long t = timestamps.get(0);
-                int v = values.get(0);
-                state.appendInterval(new Interval(t, v, t, v));
-                return;
-            }
-            PriorityQueue<Slice> pq = mergeQueue();
-            // first
-            final long lastTimestamp;
-            final int lastValue;
-            {
-                Slice top = pq.top();
-                lastTimestamp = top.timestamp;
-                int position = top.next();
-                lastValue = values.get(position);
-                if (top.exhausted()) {
-                    pq.pop();
-                } else {
-                    pq.updateTop();
-                }
-            }
-            var prevValue = lastValue;
-            int position = -1;
-            while (pq.size() > 0) {
-                Slice top = pq.top();
-                position = top.next();
-                if (top.exhausted()) {
-                    pq.pop();
-                } else {
-                    pq.updateTop();
-                }
-                var val = values.get(position);
-                if (val > prevValue) {
-                    state.resets += val;
-                }
-                prevValue = val;
-            }
-            state.samples += pendingCount;
-            state.appendInterval(new Interval(lastTimestamp, lastValue, timestamps.get(position), prevValue));
-        }
-
-        private PriorityQueue<Slice> mergeQueue() {
-            PriorityQueue<Slice> pq = new PriorityQueue<>(this.sliceOffsets.length + 1) {
-                @Override
-                protected boolean lessThan(Slice a, Slice b) {
-                    return a.timestamp > b.timestamp; // want the latest timestamp first
-                }
-            };
-            int startOffset = 0;
-            for (int sliceOffset : sliceOffsets) {
-                pq.add(new Slice(this, startOffset, sliceOffset));
-                startOffset = sliceOffset;
-            }
-            pq.add(new Slice(this, startOffset, pendingCount));
-            return pq;
         }
 
         @Override
         public void close() {
-            timestamps.close();
-            values.close();
+            Releasables.close(values, super::close);
         }
     }
 
-    static final class Slice {
-        int start;
-        long timestamp;
-        final int end;
-        final Buffer buffer;
-
-        Slice(Buffer buffer, int start, int end) {
-            this.buffer = buffer;
-            this.start = start;
-            this.end = end;
-            this.timestamp = buffer.timestamps.get(start);
+    static void flushGroup(ReducedState state, IntRawBuffer buffer, FlushQueue flushQueue) {
+        var timestamps = buffer.timestamps;
+        var values = buffer.values;
+        if (flushQueue.valueCount == 1) {
+            state.samples++;
+            long t = timestamps.get(flushQueue.top().start);
+            var v = values.get(flushQueue.top().start);
+            state.appendInterval(new Interval(t, v, t, v));
+            return;
         }
-
-        boolean exhausted() {
-            return start >= end;
-        }
-
-        int next() {
-            int index = start++;
-            if (start < end) {
-                timestamp = buffer.timestamps.get(start);
+        // first
+        final long lastTimestamp;
+        final int lastValue;
+        Slice top;
+        {
+            top = flushQueue.top();
+            int position = top.next();
+            lastTimestamp = timestamps.get(position);
+            lastValue = values.get(position);
+            if (top.exhausted()) {
+                flushQueue.pop();
+                top = flushQueue.top();
+            } else {
+                top = flushQueue.updateTop();
             }
-            return index;
         }
+        var prevValue = lastValue;
+        long secondNextTimestamp = flushQueue.secondNextTimestamp();
+        while (flushQueue.size() > 1) {
+            // If the last timestamp is greater than the maximum timestamp of the next two candidate slices,
+            // there is no overlap with subsequent slices, so batch merging can be performed without comparing
+            // timestamps from the buffer.
+            if (top.lastTimestamp() > secondNextTimestamp) {
+                for (int p = top.start; p < top.end; p++) {
+                    var val = values.get(p);
+                    if (val > prevValue) {
+                        state.resets += val;
+                    }
+                    prevValue = val;
+                }
+                flushQueue.pop();
+                top = flushQueue.top();
+                secondNextTimestamp = flushQueue.secondNextTimestamp();
+                continue;
+            }
+            var val = values.get(top.next());
+            if (val > prevValue) {
+                state.resets += val;
+            }
+            prevValue = val;
+            if (top.exhausted()) {
+                flushQueue.pop();
+                top = flushQueue.top();
+                secondNextTimestamp = flushQueue.secondNextTimestamp();
+            } else if (top.nextTimestamp < secondNextTimestamp) {
+                top = flushQueue.updateTop();
+                secondNextTimestamp = flushQueue.secondNextTimestamp();
+            }
+        }
+        // last slice
+        top = flushQueue.top();
+        for (int p = top.start; p < top.end; p++) {
+            var val = values.get(p);
+            if (val > prevValue) {
+                state.resets += val;
+            }
+            prevValue = val;
+        }
+        state.samples += flushQueue.valueCount;
+        state.appendInterval(new Interval(lastTimestamp, lastValue, timestamps.get(top.end - 1), prevValue));
     }
 
     @Override
@@ -607,12 +557,13 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
         BlockFactory blockFactory = driverContext.blockFactory();
         int positionCount = selected.getPositionCount();
         try (
+            var flushQueues = rawBuffer.prepareForFlush();
             var rates = blockFactory.newDoubleBlockBuilder(positionCount);
-            var flushedStates = new LongObjectPagedHashMap<ReducedState>(positionCount, driverContext.bigArrays())
+            var flushedStates = new LongObjectPagedHashMap<ReducedState>(positionCount, bigArrays)
         ) {
             for (int p = 0; p < positionCount; p++) {
                 int group = selected.getInt(p);
-                var state = flushAndCombineState(group);
+                var state = flushAndCombineState(flushQueues, group);
                 if (state != null) {
                     flushedStates.put(group, state);
                     // combine intervals for the final evaluation
@@ -650,16 +601,14 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
         }
     }
 
-    ReducedState flushAndCombineState(int groupId) {
+    ReducedState flushAndCombineState(FlushQueues flushQueues, int groupId) {
         ReducedState state = groupId < reducedStates.size() ? reducedStates.getAndSet(groupId, null) : null;
-        Buffer buffer = groupId < buffers.size() ? buffers.getAndSet(groupId, null) : null;
-        if (buffer != null) {
-            try (buffer) {
-                if (state == null) {
-                    state = new ReducedState();
-                }
-                buffer.flush(state);
+        var flushQueue = flushQueues.getFlushQueue(groupId);
+        if (flushQueue != null) {
+            if (state == null) {
+                state = new ReducedState();
             }
+            flushGroup(state, rawBuffer, flushQueue);
         }
         return state;
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateLongGroupingAggregatorFunction.java
@@ -9,12 +9,14 @@ package org.elasticsearch.compute.aggregation;
 // begin generated imports
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.PriorityQueue;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.DoubleArray;
 import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.common.util.LongObjectPagedHashMap;
 import org.elasticsearch.common.util.ObjectArray;
+import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.DoubleBlock;
@@ -31,12 +33,10 @@ import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 // end generated imports
 
-public final class RateLongGroupingAggregatorFunction implements GroupingAggregatorFunction {
+public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupingFunction implements GroupingAggregatorFunction {
 
     public static final class FunctionSupplier implements AggregatorFunctionSupplier {
         // Overriding constructor to support isRateOverTime flag
@@ -81,7 +81,7 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
         new IntermediateStateDesc("resets", ElementType.DOUBLE)
     );
 
-    private ObjectArray<Buffer> buffers;
+    private final LongRawBuffer rawBuffer;
     private final List<Integer> channels;
     private final DriverContext driverContext;
     private final BigArrays bigArrays;
@@ -89,9 +89,7 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
     private final boolean isRateOverTime;
     private final double dateFactor;
 
-    // tracking min/max group ids to allow flushing the raw buffer when the slice index changed
-    private int minRawInputGroupId = Integer.MAX_VALUE;
-    private int maxRawInputGroupId = Integer.MIN_VALUE;
+    // track lastSliceIndex to allow flushing the raw buffer when the slice index changed
     private int lastSliceIndex = -1;
 
     public RateLongGroupingAggregatorFunction(
@@ -104,14 +102,16 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
         this.driverContext = driverContext;
         this.bigArrays = driverContext.bigArrays();
         this.isRateOverTime = isRateOverTime;
-        ObjectArray<Buffer> buffers = driverContext.bigArrays().newObjectArray(256);
         this.dateFactor = isDateNanos ? 1_000_000_000.0 : 1000.0;
+        boolean success = false;
         try {
+            this.rawBuffer = new LongRawBuffer(bigArrays);
             this.reducedStates = driverContext.bigArrays().newObjectArray(256);
-            this.buffers = buffers;
-            buffers = null;
+            success = true;
         } finally {
-            Releasables.close(buffers);
+            if (success == false) {
+                close();
+            }
         }
     }
 
@@ -192,7 +192,6 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
     // Note that this path can be executed randomly in tests, not in production
     private void addRawInput(int positionOffset, IntBlock groups, LongBlock valueBlock, LongVector timestampVector) {
         int lastGroup = -1;
-        Buffer buffer = null;
         int positionCount = groups.getPositionCount();
         for (int p = 0; p < positionCount; p++) {
             if (groups.isNull(p)) {
@@ -210,11 +209,11 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
                 final int groupId = groups.getInt(g);
                 final var value = valueBlock.getLong(valueBlock.getFirstValueIndex(valuePosition));
                 if (lastGroup != groupId) {
-                    buffer = getBuffer(groupId, 1, timestamp);
-                    buffer.appendWithoutResize(timestamp, value);
+                    rawBuffer.prepareForAppend(groupId, 1, timestamp);
+                    rawBuffer.appendWithoutResize(timestamp, value);
                     lastGroup = groupId;
                 } else {
-                    buffer.maybeResizeAndAppend(bigArrays, timestamp, value);
+                    rawBuffer.maybeResizeAndAppend(timestamp, value);
                 }
             }
         }
@@ -261,13 +260,13 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
     }
 
     private void addSubRange(int group, int from, int to, LongVector valueVector, LongVector timestampVector) {
-        var buffer = getBuffer(group, to - from, timestampVector.getLong(from));
-        buffer.appendRange(from, to, valueVector, timestampVector);
+        rawBuffer.prepareForAppend(group, to - from, timestampVector.getLong(from));
+        rawBuffer.appendRange(from, to, valueVector, timestampVector);
     }
 
     private void addSubRange(int group, int from, int to, LongBlock valueBlock, LongVector timestampVector) {
-        var buffer = getBuffer(group, to - from, timestampVector.getLong(from));
-        buffer.appendRange(from, to, valueBlock, timestampVector);
+        rawBuffer.prepareForAppend(group, to - from, timestampVector.getLong(from));
+        rawBuffer.appendRange(from, to, valueBlock, timestampVector);
     }
 
     @Override
@@ -356,6 +355,7 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
         BlockFactory blockFactory = driverContext.blockFactory();
         int positionCount = selected.getPositionCount();
         try (
+            var flushQueues = rawBuffer.prepareForFlush();
             var timestamps = blockFactory.newLongBlockBuilder(positionCount * 2);
             var values = blockFactory.newLongBlockBuilder(positionCount * 2);
             var sampleCounts = blockFactory.newLongVectorFixedBuilder(positionCount);
@@ -363,7 +363,7 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
         ) {
             for (int p = 0; p < positionCount; p++) {
                 int group = selected.getInt(p);
-                var state = flushAndCombineState(group);
+                var state = flushAndCombineState(flushQueues, group);
                 // Do not combine intervals across shards because intervals from different indices may overlap.
                 if (state != null && state.samples > 0) {
                     timestamps.beginPositionEntry();
@@ -394,92 +394,71 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
 
     @Override
     public void close() {
-        for (long i = 0; i < buffers.size(); i++) {
-            Buffer buffer = buffers.get(i);
-            if (buffer != null) {
-                buffer.close();
-            }
-        }
-        Releasables.close(reducedStates, buffers);
-    }
-
-    private Buffer getBuffer(int groupId, int newElements, long firstTimestamp) {
-        buffers = bigArrays.grow(buffers, groupId + 1);
-        Buffer buffer = buffers.get(groupId);
-        if (buffer == null) {
-            buffer = new Buffer(bigArrays, newElements);
-            buffers.set(groupId, buffer);
-            minRawInputGroupId = Math.min(minRawInputGroupId, groupId);
-            maxRawInputGroupId = Math.max(maxRawInputGroupId, groupId);
-        } else {
-            buffer.ensureCapacity(bigArrays, newElements, firstTimestamp);
-        }
-        return buffer;
+        Releasables.close(reducedStates, rawBuffer);
     }
 
     void flushRawBuffers() {
-        if (minRawInputGroupId > maxRawInputGroupId) {
+        if (rawBuffer.minGroupId > rawBuffer.maxGroupId) {
             return;
         }
-        reducedStates = bigArrays.grow(reducedStates, maxRawInputGroupId + 1);
-        for (int groupId = minRawInputGroupId; groupId <= maxRawInputGroupId; groupId++) {
-            Buffer buffer = buffers.getAndSet(groupId, null);
-            if (buffer != null) {
-                try (buffer) {
+        reducedStates = bigArrays.grow(reducedStates, rawBuffer.maxGroupId + 1);
+        try (var flushQueues = rawBuffer.prepareForFlush()) {
+            for (int groupId = rawBuffer.minGroupId; groupId <= rawBuffer.maxGroupId; groupId++) {
+                var flushQueue = flushQueues.getFlushQueue(groupId);
+                if (flushQueue != null) {
                     ReducedState state = reducedStates.get(groupId);
                     if (state == null) {
                         state = new ReducedState();
                         reducedStates.set(groupId, state);
                     }
-                    buffer.flush(state);
+                    flushGroup(state, rawBuffer, flushQueue);
                 }
             }
         }
-        minRawInputGroupId = Integer.MAX_VALUE;
-        maxRawInputGroupId = Integer.MIN_VALUE;
+        rawBuffer.minGroupId = Integer.MAX_VALUE;
+        rawBuffer.maxGroupId = Integer.MIN_VALUE;
     }
 
-    /**
-     * Buffers data points in two arrays: one for timestamps and one for values, partitioned into multiple slices.
-     * Each slice is sorted in descending order of timestamp. A new slice is created when a data point has a
-     * timestamp greater than the last point of the current slice. Since each page is sorted by descending timestamp,
-     * we only need to compare the first point of the new page with the last point of the current slice to decide
-     * if a new slice is needed. During merging, a priority queue is used to iterate through the slices, selecting
-     * the slice with the greatest timestamp.
-     */
-    static final class Buffer implements Releasable {
-        private LongArray timestamps;
+    static final class LongRawBuffer extends RawBuffer {
         private LongArray values;
-        private int pendingCount;
-        int[] sliceOffsets;
-        private static final int[] EMPTY_SLICES = new int[0];
 
-        Buffer(BigArrays bigArrays, int initialSize) {
-            this.timestamps = bigArrays.newLongArray(Math.max(initialSize, 32), false);
-            this.values = bigArrays.newLongArray(Math.max(initialSize, 32), false);
-            this.sliceOffsets = EMPTY_SLICES;
+        LongRawBuffer(BigArrays bigArrays) {
+            super(bigArrays);
+            boolean success = false;
+            try {
+                this.values = bigArrays.newLongArray(PageCacheRecycler.DOUBLE_PAGE_SIZE, false);
+                success = true;
+            } finally {
+                if (success == false) {
+                    close();
+                }
+            }
+        }
+
+        void prepareForAppend(int groupId, int count, long firstTimestamp) {
+            prepareSlicesOnly(groupId, firstTimestamp);
+            int newSize = valueCount + count;
+            timestamps = bigArrays.grow(timestamps, newSize);
+            values = bigArrays.grow(values, newSize);
         }
 
         void appendWithoutResize(long timestamp, long value) {
-            timestamps.set(pendingCount, timestamp);
-            values.set(pendingCount, value);
-            pendingCount++;
+            timestamps.set(valueCount, timestamp);
+            values.set(valueCount, value);
+            valueCount++;
         }
 
-        void maybeResizeAndAppend(BigArrays bigArrays, long timestamp, long value) {
-            timestamps = bigArrays.grow(timestamps, pendingCount + 1);
-            values = bigArrays.grow(values, pendingCount + 1);
-
-            timestamps.set(pendingCount, timestamp);
-            values.set(pendingCount, value);
-            pendingCount++;
+        void maybeResizeAndAppend(long timestamp, long value) {
+            timestamps = bigArrays.grow(timestamps, valueCount + 1);
+            values = bigArrays.grow(values, valueCount + 1);
+            appendWithoutResize(timestamp, value);
         }
 
         void appendRange(int fromPosition, int toPosition, LongVector valueVector, LongVector timestampVector) {
             for (int p = fromPosition; p < toPosition; p++) {
-                values.set(pendingCount, valueVector.getLong(p));
-                timestamps.set(pendingCount, timestampVector.getLong(p));
-                pendingCount++;
+                values.set(valueCount, valueVector.getLong(p));
+                timestamps.set(valueCount, timestampVector.getLong(p));
+                valueCount++;
             }
         }
 
@@ -489,117 +468,88 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
                     continue;
                 }
                 assert valueBlock.getValueCount(p) == 1 : "expected single-valued block " + valueBlock;
-                values.set(pendingCount, valueBlock.getLong(p));
-                timestamps.set(pendingCount, timestampVector.getLong(p));
-                pendingCount++;
+                values.set(valueCount, valueBlock.getLong(p));
+                timestamps.set(valueCount, timestampVector.getLong(p));
+                valueCount++;
             }
-        }
-
-        void ensureCapacity(BigArrays bigArrays, int count, long firstTimestamp) {
-            int newSize = pendingCount + count;
-            timestamps = bigArrays.grow(timestamps, newSize);
-            values = bigArrays.grow(values, newSize);
-            if (pendingCount > 0 && firstTimestamp > timestamps.get(pendingCount - 1)) {
-                if (sliceOffsets.length == 0 || sliceOffsets[sliceOffsets.length - 1] != pendingCount) {
-                    sliceOffsets = ArrayUtil.growExact(sliceOffsets, sliceOffsets.length + 1);
-                    sliceOffsets[sliceOffsets.length - 1] = pendingCount;
-                }
-            }
-        }
-
-        void flush(ReducedState state) {
-            if (pendingCount == 0) {
-                return;
-            }
-            if (pendingCount == 1) {
-                state.samples++;
-                long t = timestamps.get(0);
-                long v = values.get(0);
-                state.appendInterval(new Interval(t, v, t, v));
-                return;
-            }
-            PriorityQueue<Slice> pq = mergeQueue();
-            // first
-            final long lastTimestamp;
-            final long lastValue;
-            {
-                Slice top = pq.top();
-                lastTimestamp = top.timestamp;
-                int position = top.next();
-                lastValue = values.get(position);
-                if (top.exhausted()) {
-                    pq.pop();
-                } else {
-                    pq.updateTop();
-                }
-            }
-            var prevValue = lastValue;
-            int position = -1;
-            while (pq.size() > 0) {
-                Slice top = pq.top();
-                position = top.next();
-                if (top.exhausted()) {
-                    pq.pop();
-                } else {
-                    pq.updateTop();
-                }
-                var val = values.get(position);
-                if (val > prevValue) {
-                    state.resets += val;
-                }
-                prevValue = val;
-            }
-            state.samples += pendingCount;
-            state.appendInterval(new Interval(lastTimestamp, lastValue, timestamps.get(position), prevValue));
-        }
-
-        private PriorityQueue<Slice> mergeQueue() {
-            PriorityQueue<Slice> pq = new PriorityQueue<>(this.sliceOffsets.length + 1) {
-                @Override
-                protected boolean lessThan(Slice a, Slice b) {
-                    return a.timestamp > b.timestamp; // want the latest timestamp first
-                }
-            };
-            int startOffset = 0;
-            for (int sliceOffset : sliceOffsets) {
-                pq.add(new Slice(this, startOffset, sliceOffset));
-                startOffset = sliceOffset;
-            }
-            pq.add(new Slice(this, startOffset, pendingCount));
-            return pq;
         }
 
         @Override
         public void close() {
-            timestamps.close();
-            values.close();
+            Releasables.close(values, super::close);
         }
     }
 
-    static final class Slice {
-        int start;
-        long timestamp;
-        final int end;
-        final Buffer buffer;
-
-        Slice(Buffer buffer, int start, int end) {
-            this.buffer = buffer;
-            this.start = start;
-            this.end = end;
-            this.timestamp = buffer.timestamps.get(start);
+    static void flushGroup(ReducedState state, LongRawBuffer buffer, FlushQueue flushQueue) {
+        var timestamps = buffer.timestamps;
+        var values = buffer.values;
+        if (flushQueue.valueCount == 1) {
+            state.samples++;
+            long t = timestamps.get(flushQueue.top().start);
+            var v = values.get(flushQueue.top().start);
+            state.appendInterval(new Interval(t, v, t, v));
+            return;
         }
-
-        boolean exhausted() {
-            return start >= end;
-        }
-
-        int next() {
-            int index = start++;
-            if (start < end) {
-                timestamp = buffer.timestamps.get(start);
+        // first
+        final long lastTimestamp;
+        final long lastValue;
+        Slice top;
+        {
+            top = flushQueue.top();
+            int position = top.next();
+            lastTimestamp = timestamps.get(position);
+            lastValue = values.get(position);
+            if (top.exhausted()) {
+                flushQueue.pop();
+                top = flushQueue.top();
+            } else {
+                top = flushQueue.updateTop();
             }
-            return index;
         }
+        var prevValue = lastValue;
+        long secondNextTimestamp = flushQueue.secondNextTimestamp();
+        while (flushQueue.size() > 1) {
+            // If the last timestamp is greater than the maximum timestamp of the next two candidate slices,
+            // there is no overlap with subsequent slices, so batch merging can be performed without comparing
+            // timestamps from the buffer.
+            if (top.lastTimestamp() > secondNextTimestamp) {
+                for (int p = top.start; p < top.end; p++) {
+                    var val = values.get(p);
+                    if (val > prevValue) {
+                        state.resets += val;
+                    }
+                    prevValue = val;
+                }
+                flushQueue.pop();
+                top = flushQueue.top();
+                secondNextTimestamp = flushQueue.secondNextTimestamp();
+                continue;
+            }
+            var val = values.get(top.next());
+            if (val > prevValue) {
+                state.resets += val;
+            }
+            prevValue = val;
+            if (top.exhausted()) {
+                flushQueue.pop();
+                top = flushQueue.top();
+                secondNextTimestamp = flushQueue.secondNextTimestamp();
+            } else if (top.nextTimestamp < secondNextTimestamp) {
+                top = flushQueue.updateTop();
+                secondNextTimestamp = flushQueue.secondNextTimestamp();
+            }
+        }
+        // last slice
+        top = flushQueue.top();
+        for (int p = top.start; p < top.end; p++) {
+            var val = values.get(p);
+            if (val > prevValue) {
+                state.resets += val;
+            }
+            prevValue = val;
+        }
+        state.samples += flushQueue.valueCount;
+        state.appendInterval(new Interval(lastTimestamp, lastValue, timestamps.get(top.end - 1), prevValue));
     }
 
     @Override
@@ -607,12 +557,13 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
         BlockFactory blockFactory = driverContext.blockFactory();
         int positionCount = selected.getPositionCount();
         try (
+            var flushQueues = rawBuffer.prepareForFlush();
             var rates = blockFactory.newDoubleBlockBuilder(positionCount);
-            var flushedStates = new LongObjectPagedHashMap<ReducedState>(positionCount, driverContext.bigArrays())
+            var flushedStates = new LongObjectPagedHashMap<ReducedState>(positionCount, bigArrays)
         ) {
             for (int p = 0; p < positionCount; p++) {
                 int group = selected.getInt(p);
-                var state = flushAndCombineState(group);
+                var state = flushAndCombineState(flushQueues, group);
                 if (state != null) {
                     flushedStates.put(group, state);
                     // combine intervals for the final evaluation
@@ -650,16 +601,14 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
         }
     }
 
-    ReducedState flushAndCombineState(int groupId) {
+    ReducedState flushAndCombineState(FlushQueues flushQueues, int groupId) {
         ReducedState state = groupId < reducedStates.size() ? reducedStates.getAndSet(groupId, null) : null;
-        Buffer buffer = groupId < buffers.size() ? buffers.getAndSet(groupId, null) : null;
-        if (buffer != null) {
-            try (buffer) {
-                if (state == null) {
-                    state = new ReducedState();
-                }
-                buffer.flush(state);
+        var flushQueue = flushQueues.getFlushQueue(groupId);
+        if (flushQueue != null) {
+            if (state == null) {
+                state = new ReducedState();
             }
+            flushGroup(state, rawBuffer, flushQueue);
         }
         return state;
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AbstractRateGroupingFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AbstractRateGroupingFunction.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+import org.apache.lucene.util.PriorityQueue;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.IntArray;
+import org.elasticsearch.common.util.LongArray;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
+
+class AbstractRateGroupingFunction {
+    /**
+     * Buffers data points in two arrays: one for timestamps and one for values, partitioned into multiple slices.
+     * Each slice is sorted in descending order of timestamp. A new slice is created when a data point has a
+     * timestamp greater than the last point of the current slice or it belongs to a different group (=timeseries).
+     * Since each page is sorted by descending timestamp,
+     * we only need to compare the first point of the new page with the last point of the current slice to decide
+     * if a new slice is needed. During merging, a priority queue is used to iterate through the slices, selecting
+     * the slice with the greatest timestamp.
+     */
+    abstract static class RawBuffer implements Releasable {
+        final BigArrays bigArrays;
+        LongArray timestamps;
+        int valueCount;
+
+        IntArray sliceStarts;
+        IntArray sliceGroupIds;
+        int sliceCount;
+        int lastGroupId = -1;
+        int minGroupId = Integer.MAX_VALUE;
+        int maxGroupId = Integer.MIN_VALUE;
+
+        RawBuffer(BigArrays bigArrays) {
+            this.bigArrays = bigArrays;
+            boolean success = false;
+            try {
+                this.timestamps = bigArrays.newLongArray(PageCacheRecycler.LONG_PAGE_SIZE, false);
+                this.sliceStarts = bigArrays.newIntArray(512, false);
+                this.sliceGroupIds = bigArrays.newIntArray(512, false);
+                success = true;
+            } finally {
+                if (success == false) {
+                    close();
+                }
+            }
+        }
+
+        final void prepareSlicesOnly(int groupId, long firstTimestamp) {
+            if (lastGroupId == groupId && valueCount > 0 && timestamps.get(valueCount - 1) > firstTimestamp) {
+                return;
+            }
+            // start a new slice
+            sliceStarts = bigArrays.grow(sliceStarts, sliceCount + 1L);
+            sliceGroupIds = bigArrays.grow(sliceGroupIds, sliceCount + 1L);
+            if (groupId < minGroupId) {
+                minGroupId = groupId;
+            }
+            if (groupId > maxGroupId) {
+                maxGroupId = groupId;
+            }
+            sliceStarts.set(sliceCount, valueCount);
+            sliceGroupIds.set(sliceCount, groupId);
+            lastGroupId = groupId;
+            sliceCount++;
+        }
+
+        final FlushQueues prepareForFlush() {
+            if (minGroupId > maxGroupId) {
+                return new FlushQueues(this, minGroupId, maxGroupId, null, null);
+            }
+            final int numGroups = maxGroupId - minGroupId + 1;
+            // count the number of slices in each group
+            int[] runningOffsets = new int[numGroups];
+            for (int i = 0; i < sliceCount; i++) {
+                int groupIndex = sliceGroupIds.get(i) - minGroupId;
+                runningOffsets[groupIndex]++;
+            }
+            int runningOffset = 0;
+            for (int i = 0; i < numGroups; i++) {
+                int count = runningOffsets[i];
+                runningOffsets[i] = runningOffset;
+                runningOffset += count;
+            }
+            IntArray sliceOffsets = bigArrays.newIntArray(sliceCount * 2L, false);
+            for (int i = 0; i < sliceCount; i++) {
+                int groupIndex = sliceGroupIds.get(i) - minGroupId;
+                int startOffset = sliceStarts.get(i);
+                final int endOffset;
+                if ((i + 1) < sliceCount) {
+                    endOffset = sliceStarts.get(i + 1);
+                } else {
+                    endOffset = valueCount;
+                }
+                int dstIndex = runningOffsets[groupIndex]++;
+                sliceOffsets.set(dstIndex * 2L, startOffset);
+                sliceOffsets.set(dstIndex * 2L + 1, endOffset);
+            }
+            valueCount = 0;
+            sliceCount = 0;
+            lastGroupId = -1;
+            return new FlushQueues(this, minGroupId, maxGroupId, runningOffsets, sliceOffsets);
+        }
+
+        @Override
+        public void close() {
+            Releasables.close(timestamps, sliceStarts, sliceGroupIds);
+        }
+    }
+
+    record FlushQueues(RawBuffer buffer, int minGroupId, int maxGroupId, int[] runningOffsets, IntArray sliceOffsets)
+        implements
+            Releasable {
+        FlushQueue getFlushQueue(int groupId) {
+            if (groupId < minGroupId || groupId > maxGroupId) {
+                return null;
+            }
+            int groupIndex = groupId - minGroupId;
+            int endIndex = runningOffsets[groupIndex];
+            int startIndex = groupIndex == 0 ? 0 : runningOffsets[groupIndex - 1];
+            int numSlices = endIndex - startIndex;
+            if (numSlices == 0) {
+                return null;
+            }
+            FlushQueue queue = new FlushQueue(numSlices);
+            for (int i = startIndex; i < endIndex; i++) {
+                int start = sliceOffsets.get(i * 2L);
+                int end = sliceOffsets.get(i * 2L + 1);
+                queue.valueCount += (end - start);
+                queue.add(new Slice(buffer.timestamps, start, end));
+            }
+            return queue;
+        }
+
+        @Override
+        public void close() {
+            Releasables.close(sliceOffsets);
+        }
+    }
+
+    static final class Slice {
+        int start;
+        int end;
+        long nextTimestamp;
+        private long lastTimestamp = Long.MAX_VALUE;
+        final LongArray timestamps;
+
+        Slice(LongArray timestamps, int start, int end) {
+            this.timestamps = timestamps;
+            this.start = start;
+            this.end = end;
+            this.nextTimestamp = timestamps.get(start);
+        }
+
+        boolean exhausted() {
+            return start >= end;
+        }
+
+        int next() {
+            int currentIndex = start;
+            start++;
+            if (start < end) {
+                nextTimestamp = timestamps.get(start); // next timestamp
+            }
+            return currentIndex;
+        }
+
+        long lastTimestamp() {
+            if (lastTimestamp == Long.MAX_VALUE) {
+                lastTimestamp = timestamps.get(end - 1);
+            }
+            return lastTimestamp;
+        }
+    }
+
+    static final class FlushQueue extends PriorityQueue<Slice> {
+        int valueCount;
+
+        FlushQueue(int maxSize) {
+            super(maxSize);
+        }
+
+        /**
+         * Returns the timestamp of the slice that would be next in line after the best slice.
+         */
+        long secondNextTimestamp() {
+            final Object[] heap = getHeapArray();
+            final int size = size();
+            if (size == 2) {
+                return ((Slice) heap[2]).nextTimestamp;
+            } else if (size >= 3) {
+                return Math.max(((Slice) heap[2]).nextTimestamp, ((Slice) heap[3]).nextTimestamp);
+            } else {
+                return Long.MIN_VALUE;
+            }
+        }
+
+        @Override
+        protected boolean lessThan(Slice a, Slice b) {
+            return a.nextTimestamp > b.nextTimestamp; // want the latest timestamp first
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-RateGroupingAggregatorFunction.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-RateGroupingAggregatorFunction.java.st
@@ -9,12 +9,14 @@ package org.elasticsearch.compute.aggregation;
 // begin generated imports
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.PriorityQueue;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.DoubleArray;
 import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.common.util.LongObjectPagedHashMap;
 import org.elasticsearch.common.util.ObjectArray;
+import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.DoubleBlock;
@@ -31,12 +33,10 @@ import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 // end generated imports
 
-public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggregatorFunction {
+public final class Rate$Type$GroupingAggregatorFunction extends AbstractRateGroupingFunction implements GroupingAggregatorFunction {
 
     public static final class FunctionSupplier implements AggregatorFunctionSupplier {
         // Overriding constructor to support isRateOverTime flag
@@ -81,7 +81,7 @@ public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggre
         new IntermediateStateDesc("resets", ElementType.DOUBLE)
     );
 
-    private ObjectArray<Buffer> buffers;
+    private final $Type$RawBuffer rawBuffer;
     private final List<Integer> channels;
     private final DriverContext driverContext;
     private final BigArrays bigArrays;
@@ -89,9 +89,7 @@ public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggre
     private final boolean isRateOverTime;
     private final double dateFactor;
 
-    // tracking min/max group ids to allow flushing the raw buffer when the slice index changed
-    private int minRawInputGroupId = Integer.MAX_VALUE;
-    private int maxRawInputGroupId = Integer.MIN_VALUE;
+    // track lastSliceIndex to allow flushing the raw buffer when the slice index changed
     private int lastSliceIndex = -1;
 
     public Rate$Type$GroupingAggregatorFunction(
@@ -104,14 +102,16 @@ public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggre
         this.driverContext = driverContext;
         this.bigArrays = driverContext.bigArrays();
         this.isRateOverTime = isRateOverTime;
-        ObjectArray<Buffer> buffers = driverContext.bigArrays().newObjectArray(256);
         this.dateFactor = isDateNanos ? 1_000_000_000.0 : 1000.0;
+        boolean success = false;
         try {
+            this.rawBuffer = new $Type$RawBuffer(bigArrays);
             this.reducedStates = driverContext.bigArrays().newObjectArray(256);
-            this.buffers = buffers;
-            buffers = null;
+            success = true;
         } finally {
-            Releasables.close(buffers);
+            if (success == false) {
+                close();
+            }
         }
     }
 
@@ -192,7 +192,6 @@ public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggre
     // Note that this path can be executed randomly in tests, not in production
     private void addRawInput(int positionOffset, IntBlock groups, $Type$Block valueBlock, LongVector timestampVector) {
         int lastGroup = -1;
-        Buffer buffer = null;
         int positionCount = groups.getPositionCount();
         for (int p = 0; p < positionCount; p++) {
             if (groups.isNull(p)) {
@@ -210,11 +209,11 @@ public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggre
                 final int groupId = groups.getInt(g);
                 final var value = valueBlock.get$Type$(valueBlock.getFirstValueIndex(valuePosition));
                 if (lastGroup != groupId) {
-                    buffer = getBuffer(groupId, 1, timestamp);
-                    buffer.appendWithoutResize(timestamp, value);
+                    rawBuffer.prepareForAppend(groupId, 1, timestamp);
+                    rawBuffer.appendWithoutResize(timestamp, value);
                     lastGroup = groupId;
                 } else {
-                    buffer.maybeResizeAndAppend(bigArrays, timestamp, value);
+                    rawBuffer.maybeResizeAndAppend(timestamp, value);
                 }
             }
         }
@@ -261,13 +260,13 @@ public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggre
     }
 
     private void addSubRange(int group, int from, int to, $Type$Vector valueVector, LongVector timestampVector) {
-        var buffer = getBuffer(group, to - from, timestampVector.getLong(from));
-        buffer.appendRange(from, to, valueVector, timestampVector);
+        rawBuffer.prepareForAppend(group, to - from, timestampVector.getLong(from));
+        rawBuffer.appendRange(from, to, valueVector, timestampVector);
     }
 
     private void addSubRange(int group, int from, int to, $Type$Block valueBlock, LongVector timestampVector) {
-        var buffer = getBuffer(group, to - from, timestampVector.getLong(from));
-        buffer.appendRange(from, to, valueBlock, timestampVector);
+        rawBuffer.prepareForAppend(group, to - from, timestampVector.getLong(from));
+        rawBuffer.appendRange(from, to, valueBlock, timestampVector);
     }
 
     @Override
@@ -356,6 +355,7 @@ public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggre
         BlockFactory blockFactory = driverContext.blockFactory();
         int positionCount = selected.getPositionCount();
         try (
+            var flushQueues = rawBuffer.prepareForFlush();
             var timestamps = blockFactory.newLongBlockBuilder(positionCount * 2);
             var values = blockFactory.new$Type$BlockBuilder(positionCount * 2);
             var sampleCounts = blockFactory.newLongVectorFixedBuilder(positionCount);
@@ -363,7 +363,7 @@ public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggre
         ) {
             for (int p = 0; p < positionCount; p++) {
                 int group = selected.getInt(p);
-                var state = flushAndCombineState(group);
+                var state = flushAndCombineState(flushQueues, group);
                 // Do not combine intervals across shards because intervals from different indices may overlap.
                 if (state != null && state.samples > 0) {
                     timestamps.beginPositionEntry();
@@ -394,92 +394,71 @@ public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggre
 
     @Override
     public void close() {
-        for (long i = 0; i < buffers.size(); i++) {
-            Buffer buffer = buffers.get(i);
-            if (buffer != null) {
-                buffer.close();
-            }
-        }
-        Releasables.close(reducedStates, buffers);
-    }
-
-    private Buffer getBuffer(int groupId, int newElements, long firstTimestamp) {
-        buffers = bigArrays.grow(buffers, groupId + 1);
-        Buffer buffer = buffers.get(groupId);
-        if (buffer == null) {
-            buffer = new Buffer(bigArrays, newElements);
-            buffers.set(groupId, buffer);
-            minRawInputGroupId = Math.min(minRawInputGroupId, groupId);
-            maxRawInputGroupId = Math.max(maxRawInputGroupId, groupId);
-        } else {
-            buffer.ensureCapacity(bigArrays, newElements, firstTimestamp);
-        }
-        return buffer;
+        Releasables.close(reducedStates, rawBuffer);
     }
 
     void flushRawBuffers() {
-        if (minRawInputGroupId > maxRawInputGroupId) {
+        if (rawBuffer.minGroupId > rawBuffer.maxGroupId) {
             return;
         }
-        reducedStates = bigArrays.grow(reducedStates, maxRawInputGroupId + 1);
-        for (int groupId = minRawInputGroupId; groupId <= maxRawInputGroupId; groupId++) {
-            Buffer buffer = buffers.getAndSet(groupId, null);
-            if (buffer != null) {
-                try (buffer) {
+        reducedStates = bigArrays.grow(reducedStates, rawBuffer.maxGroupId + 1);
+        try (var flushQueues = rawBuffer.prepareForFlush()) {
+            for (int groupId = rawBuffer.minGroupId; groupId <= rawBuffer.maxGroupId; groupId++) {
+                var flushQueue = flushQueues.getFlushQueue(groupId);
+                if (flushQueue != null) {
                     ReducedState state = reducedStates.get(groupId);
                     if (state == null) {
                         state = new ReducedState();
                         reducedStates.set(groupId, state);
                     }
-                    buffer.flush(state);
+                    flushGroup(state, rawBuffer, flushQueue);
                 }
             }
         }
-        minRawInputGroupId = Integer.MAX_VALUE;
-        maxRawInputGroupId = Integer.MIN_VALUE;
+        rawBuffer.minGroupId = Integer.MAX_VALUE;
+        rawBuffer.maxGroupId = Integer.MIN_VALUE;
     }
 
-    /**
-     * Buffers data points in two arrays: one for timestamps and one for values, partitioned into multiple slices.
-     * Each slice is sorted in descending order of timestamp. A new slice is created when a data point has a
-     * timestamp greater than the last point of the current slice. Since each page is sorted by descending timestamp,
-     * we only need to compare the first point of the new page with the last point of the current slice to decide
-     * if a new slice is needed. During merging, a priority queue is used to iterate through the slices, selecting
-     * the slice with the greatest timestamp.
-     */
-    static final class Buffer implements Releasable {
-        private LongArray timestamps;
+    static final class $Type$RawBuffer extends RawBuffer {
         private $Type$Array values;
-        private int pendingCount;
-        int[] sliceOffsets;
-        private static final int[] EMPTY_SLICES = new int[0];
 
-        Buffer(BigArrays bigArrays, int initialSize) {
-            this.timestamps = bigArrays.newLongArray(Math.max(initialSize, 32), false);
-            this.values = bigArrays.new$Type$Array(Math.max(initialSize, 32), false);
-            this.sliceOffsets = EMPTY_SLICES;
+        $Type$RawBuffer(BigArrays bigArrays) {
+            super(bigArrays);
+            boolean success = false;
+            try {
+                this.values = bigArrays.new$Type$Array(PageCacheRecycler.DOUBLE_PAGE_SIZE, false);
+                success = true;
+            } finally {
+                if (success == false) {
+                    close();
+                }
+            }
+        }
+
+        void prepareForAppend(int groupId, int count, long firstTimestamp) {
+            prepareSlicesOnly(groupId, firstTimestamp);
+            int newSize = valueCount + count;
+            timestamps = bigArrays.grow(timestamps, newSize);
+            values = bigArrays.grow(values, newSize);
         }
 
         void appendWithoutResize(long timestamp, $type$ value) {
-            timestamps.set(pendingCount, timestamp);
-            values.set(pendingCount, value);
-            pendingCount++;
+            timestamps.set(valueCount, timestamp);
+            values.set(valueCount, value);
+            valueCount++;
         }
 
-        void maybeResizeAndAppend(BigArrays bigArrays, long timestamp, $type$ value) {
-            timestamps = bigArrays.grow(timestamps, pendingCount + 1);
-            values = bigArrays.grow(values, pendingCount + 1);
-
-            timestamps.set(pendingCount, timestamp);
-            values.set(pendingCount, value);
-            pendingCount++;
+        void maybeResizeAndAppend(long timestamp, $type$ value) {
+            timestamps = bigArrays.grow(timestamps, valueCount + 1);
+            values = bigArrays.grow(values, valueCount + 1);
+            appendWithoutResize(timestamp, value);
         }
 
         void appendRange(int fromPosition, int toPosition, $Type$Vector valueVector, LongVector timestampVector) {
             for (int p = fromPosition; p < toPosition; p++) {
-                values.set(pendingCount, valueVector.get$Type$(p));
-                timestamps.set(pendingCount, timestampVector.getLong(p));
-                pendingCount++;
+                values.set(valueCount, valueVector.get$Type$(p));
+                timestamps.set(valueCount, timestampVector.getLong(p));
+                valueCount++;
             }
         }
 
@@ -489,117 +468,88 @@ public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggre
                     continue;
                 }
                 assert valueBlock.getValueCount(p) == 1 : "expected single-valued block " + valueBlock;
-                values.set(pendingCount, valueBlock.get$Type$(p));
-                timestamps.set(pendingCount, timestampVector.getLong(p));
-                pendingCount++;
+                values.set(valueCount, valueBlock.get$Type$(p));
+                timestamps.set(valueCount, timestampVector.getLong(p));
+                valueCount++;
             }
-        }
-
-        void ensureCapacity(BigArrays bigArrays, int count, long firstTimestamp) {
-            int newSize = pendingCount + count;
-            timestamps = bigArrays.grow(timestamps, newSize);
-            values = bigArrays.grow(values, newSize);
-            if (pendingCount > 0 && firstTimestamp > timestamps.get(pendingCount - 1)) {
-                if (sliceOffsets.length == 0 || sliceOffsets[sliceOffsets.length - 1] != pendingCount) {
-                    sliceOffsets = ArrayUtil.growExact(sliceOffsets, sliceOffsets.length + 1);
-                    sliceOffsets[sliceOffsets.length - 1] = pendingCount;
-                }
-            }
-        }
-
-        void flush(ReducedState state) {
-            if (pendingCount == 0) {
-                return;
-            }
-            if (pendingCount == 1) {
-                state.samples++;
-                long t = timestamps.get(0);
-                $type$ v = values.get(0);
-                state.appendInterval(new Interval(t, v, t, v));
-                return;
-            }
-            PriorityQueue<Slice> pq = mergeQueue();
-            // first
-            final long lastTimestamp;
-            final $type$ lastValue;
-            {
-                Slice top = pq.top();
-                lastTimestamp = top.timestamp;
-                int position = top.next();
-                lastValue = values.get(position);
-                if (top.exhausted()) {
-                    pq.pop();
-                } else {
-                    pq.updateTop();
-                }
-            }
-            var prevValue = lastValue;
-            int position = -1;
-            while (pq.size() > 0) {
-                Slice top = pq.top();
-                position = top.next();
-                if (top.exhausted()) {
-                    pq.pop();
-                } else {
-                    pq.updateTop();
-                }
-                var val = values.get(position);
-                if (val > prevValue) {
-                    state.resets += val;
-                }
-                prevValue = val;
-            }
-            state.samples += pendingCount;
-            state.appendInterval(new Interval(lastTimestamp, lastValue, timestamps.get(position), prevValue));
-        }
-
-        private PriorityQueue<Slice> mergeQueue() {
-            PriorityQueue<Slice> pq = new PriorityQueue<>(this.sliceOffsets.length + 1) {
-                @Override
-                protected boolean lessThan(Slice a, Slice b) {
-                    return a.timestamp > b.timestamp; // want the latest timestamp first
-                }
-            };
-            int startOffset = 0;
-            for (int sliceOffset : sliceOffsets) {
-                pq.add(new Slice(this, startOffset, sliceOffset));
-                startOffset = sliceOffset;
-            }
-            pq.add(new Slice(this, startOffset, pendingCount));
-            return pq;
         }
 
         @Override
         public void close() {
-            timestamps.close();
-            values.close();
+            Releasables.close(values, super::close);
         }
     }
 
-    static final class Slice {
-        int start;
-        long timestamp;
-        final int end;
-        final Buffer buffer;
-
-        Slice(Buffer buffer, int start, int end) {
-            this.buffer = buffer;
-            this.start = start;
-            this.end = end;
-            this.timestamp = buffer.timestamps.get(start);
+    static void flushGroup(ReducedState state, $Type$RawBuffer buffer, FlushQueue flushQueue) {
+        var timestamps = buffer.timestamps;
+        var values = buffer.values;
+        if (flushQueue.valueCount == 1) {
+            state.samples++;
+            long t = timestamps.get(flushQueue.top().start);
+            var v = values.get(flushQueue.top().start);
+            state.appendInterval(new Interval(t, v, t, v));
+            return;
         }
-
-        boolean exhausted() {
-            return start >= end;
-        }
-
-        int next() {
-            int index = start++;
-            if (start < end) {
-                timestamp = buffer.timestamps.get(start);
+        // first
+        final long lastTimestamp;
+        final $type$ lastValue;
+        Slice top;
+        {
+            top = flushQueue.top();
+            int position = top.next();
+            lastTimestamp = timestamps.get(position);
+            lastValue = values.get(position);
+            if (top.exhausted()) {
+                flushQueue.pop();
+                top = flushQueue.top();
+            } else {
+                top = flushQueue.updateTop();
             }
-            return index;
         }
+        var prevValue = lastValue;
+        long secondNextTimestamp = flushQueue.secondNextTimestamp();
+        while (flushQueue.size() > 1) {
+            // If the last timestamp is greater than the maximum timestamp of the next two candidate slices,
+            // there is no overlap with subsequent slices, so batch merging can be performed without comparing
+            // timestamps from the buffer.
+            if (top.lastTimestamp() > secondNextTimestamp) {
+                for (int p = top.start; p < top.end; p++) {
+                    var val = values.get(p);
+                    if (val > prevValue) {
+                        state.resets += val;
+                    }
+                    prevValue = val;
+                }
+                flushQueue.pop();
+                top = flushQueue.top();
+                secondNextTimestamp = flushQueue.secondNextTimestamp();
+                continue;
+            }
+            var val = values.get(top.next());
+            if (val > prevValue) {
+                state.resets += val;
+            }
+            prevValue = val;
+            if (top.exhausted()) {
+                flushQueue.pop();
+                top = flushQueue.top();
+                secondNextTimestamp = flushQueue.secondNextTimestamp();
+            } else if (top.nextTimestamp < secondNextTimestamp) {
+                top = flushQueue.updateTop();
+                secondNextTimestamp = flushQueue.secondNextTimestamp();
+            }
+        }
+        // last slice
+        top = flushQueue.top();
+        for (int p = top.start; p < top.end; p++) {
+            var val = values.get(p);
+            if (val > prevValue) {
+                state.resets += val;
+            }
+            prevValue = val;
+        }
+        state.samples += flushQueue.valueCount;
+        state.appendInterval(new Interval(lastTimestamp, lastValue, timestamps.get(top.end - 1), prevValue));
     }
 
     @Override
@@ -607,12 +557,13 @@ public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggre
         BlockFactory blockFactory = driverContext.blockFactory();
         int positionCount = selected.getPositionCount();
         try (
+            var flushQueues = rawBuffer.prepareForFlush();
             var rates = blockFactory.newDoubleBlockBuilder(positionCount);
-            var flushedStates = new LongObjectPagedHashMap<ReducedState>(positionCount, driverContext.bigArrays())
+            var flushedStates = new LongObjectPagedHashMap<ReducedState>(positionCount, bigArrays)
         ) {
             for (int p = 0; p < positionCount; p++) {
                 int group = selected.getInt(p);
-                var state = flushAndCombineState(group);
+                var state = flushAndCombineState(flushQueues, group);
                 if (state != null) {
                     flushedStates.put(group, state);
                     // combine intervals for the final evaluation
@@ -650,16 +601,14 @@ public final class Rate$Type$GroupingAggregatorFunction implements GroupingAggre
         }
     }
 
-    ReducedState flushAndCombineState(int groupId) {
+    ReducedState flushAndCombineState(FlushQueues flushQueues, int groupId) {
         ReducedState state = groupId < reducedStates.size() ? reducedStates.getAndSet(groupId, null) : null;
-        Buffer buffer = groupId < buffers.size() ? buffers.getAndSet(groupId, null) : null;
-        if (buffer != null) {
-            try (buffer) {
-                if (state == null) {
-                    state = new ReducedState();
-                }
-                buffer.flush(state);
+        var flushQueue = flushQueues.getFlushQueue(groupId);
+        if (flushQueue != null) {
+            if (state == null) {
+                state = new ReducedState();
             }
+            flushGroup(state, rawBuffer, flushQueue);
         }
         return state;
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Use a single array for buffering rate data points (#140855)](https://github.com/elastic/elasticsearch/pull/140855)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)