### PR TITLE
ESQL: Fix `INLINE STATS GROUP BY null` being incorrectly pruned (#140027)

### DIFF
--- a/docs/changelog/140027.yaml
+++ b/docs/changelog/140027.yaml
@@ -1,0 +1,6 @@
+pr: 140027
+summary: "ESQL: Fix `INLINE STATS GROUP BY null` being incorrectly pruned"
+area: ES|QL
+type: bug
+issues:
+  - 139887

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/inlinestats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/inlinestats.csv-spec
@@ -5190,3 +5190,122 @@ ROW x = 0
 x:integer | a:long | b:long | c:boolean | d:boolean
 0         | 0      | 0      | false     | true
 ;
+
+
+inlineStatsGroupByNull_Basic
+required_capability: fix_inline_stats_group_by_null
+
+ROW x = 1
+| INLINE STATS c = COUNT(*) BY n = null
+| KEEP c, n
+| LIMIT 1
+;
+
+c:long	| n:null
+1     	| null         
+;
+
+
+inlineStatsGroupByNull_WithMultipleAggFunctions
+required_capability: fix_inline_stats_group_by_null
+
+ROW x = 10
+| INLINE STATS c = COUNT(*), s = SUM(x), m = MAX(x) BY n = null
+| KEEP c, s, m, n
+| LIMIT 1
+;
+
+c:long	| s:long	| m:integer	| n:null
+1     	| 10    	| 10       	| null           
+;
+
+
+inlineStatsGroupByNull_WithEval
+required_capability: fix_inline_stats_group_by_null
+
+ROW x = 1, y = 2
+| EVAL z = x + y
+| INLINE STATS c = COUNT(*) BY n = null
+| KEEP x, y, z, c, n
+;
+
+x:integer	| y:integer	| z:integer	| c:long	| n:null
+1        	| 2        	| 3        	| 1     	| null          
+;
+
+
+inlineStatsGroupByNull_WithNullLiteral
+required_capability: fix_inline_stats_group_by_null
+
+ROW x = 1
+| INLINE STATS c = COUNT(*) BY null
+| KEEP c, null
+| LIMIT 1
+;
+
+c:long	| null:null
+1     	| null         
+;
+
+
+inlineStatsGroupByNull_FromEmployees
+required_capability: fix_inline_stats_group_by_null
+
+FROM employees
+| INLINE STATS c = COUNT(*) BY n = null
+| KEEP emp_no, c, n
+| SORT emp_no
+| LIMIT 3
+;
+
+emp_no:integer	| c:long	| n:null
+10001         	| 100     	| null  
+10002         	| 100     	| null  
+10003         	| 100     	| null          
+;
+
+
+inlineStatsGroupByNull_DoubleInlineStats
+required_capability: fix_inline_stats_group_by_null
+
+ROW x = 1
+| INLINE STATS c1 = COUNT(*) BY n1 = null
+| INLINE STATS c2 = COUNT(*) BY n2 = null
+| KEEP c1, n1, c2, n2
+| LIMIT 1
+;
+
+c1:long	| n1:null	| c2:long	| n2:null
+1      	| null   	| 1      	| null  
+;
+
+
+inlineStatsGroupByNull_MultipleNullKeys
+required_capability: fix_inline_stats_group_by_null
+
+ROW x = 1
+| INLINE STATS c = COUNT(*) BY n1 = null, n2 = null
+| KEEP c, n1, n2
+| LIMIT 1
+;
+
+c:long	| n1:null	| n2:null
+1     	| null   	| null  
+;
+
+
+inlineStatsGroupByNull_MixedNullAndNonNull
+required_capability: fix_inline_stats_group_by_null
+
+FROM employees
+| INLINE STATS c = COUNT(*) BY n = null, emp_no
+| KEEP c, n, emp_no
+| SORT emp_no
+| LIMIT 3
+;
+
+c:long	| n:null	| emp_no:integer
+1     	| null  	| 10001         
+1     	| null  	| 10002         
+1     	| null  	| 10003          
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-nullify.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unmapped-nullify.csv-spec
@@ -427,16 +427,15 @@ null           |1985           |null           |abc            |fork3
 
 inlinestatsCount
 required_capability: optional_fields_nullify_tech_preview
-required_capability: inline_stats
+required_capability: fix_inline_stats_group_by_null
 
 SET unmapped_fields="nullify"\;
 ROW x = 1
 | INLINE STATS c = COUNT(*), s = SUM(does_not_exist) BY d = does_not_exist
 ;
 
-# `c` should be just 0 : https://github.com/elastic/elasticsearch/issues/139887
 x:integer      |does_not_exist:null|c:long         |s:double       |d:null
-1              |null               |null           |null           |null
+1              |null               |1              |null           |null
 ;
 
 lookupJoin

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1833,6 +1833,16 @@ public class EsqlCapabilities {
         ENRICH_DENSE_VECTOR_BUGFIX,
 
         /**
+         * Fix for INLINE STATS GROUP BY null being incorrectly pruned by PruneLeftJoinOnNullMatchingField.
+         * For INLINE STATS, the right side of the join can be Aggregate or LocalRelation (when optimized).
+         * The join key is always the grouping, and since STATS supports GROUP BY null, pruning the join when
+         * the join key (grouping) is null would incorrectly change the query results. This fix ensures
+         * PruneLeftJoinOnNullMatchingField only applies to LOOKUP JOIN (where right side is EsRelation).
+         * https://github.com/elastic/elasticsearch/issues/139887
+         */
+        FIX_INLINE_STATS_GROUP_BY_NULL(INLINE_STATS.enabled),
+
+        /**
          * Adds a conditional block loader for text fields that prefers using the sub-keyword field whenever possible.
          */
         CONDITIONAL_BLOCK_LOADER_FOR_TEXT_FIELDS,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -6354,6 +6354,269 @@ public class LogicalPlanOptimizerTests extends AbstractLogicalPlanOptimizerTests
 
     /**
      * Expects
+     * <pre>{@code
+     * Project[[c{r}#6, n{r}#8]]
+     * \_Limit[1[INTEGER],false,false]
+     *   \_InlineJoin[LEFT,[n{r}#8],[n{r}#8]]
+     *     |_Eval[[null[NULL] AS n#8]]
+     *     | \_LocalRelation[[x{r}#4],Page{blocks=[IntVectorBlock[vector=ConstantIntVector[positions=1, value=1]]]}]
+     *     \_Aggregate[[n{r}#8],[COUNT(*[KEYWORD],true[BOOLEAN],PT0S[TIME_DURATION]) AS c#6, n{r}#8]]
+     *       \_StubRelation[[x{r}#4, n{r}#8]]
+     * }</pre>
+     */
+    public void testInlineStatsGroupByNull() {
+        var query = """
+            ROW x = 1
+            | INLINE STATS c = COUNT(*) BY n = null
+            | KEEP c, n
+            | LIMIT 1
+            """;
+        if (releaseBuildForInlineStats(query)) {
+            return;
+        }
+        var plan = optimizedPlan(query);
+
+        var project = as(plan, Project.class);
+        assertThat(Expressions.names(project.projections()), is(List.of("c", "n")));
+        var limit = asLimit(project.child(), 1, false);
+        var inlineJoin = as(limit.child(), InlineJoin.class);
+        assertThat(Expressions.names(inlineJoin.config().leftFields()), is(List.of("n")));
+        // Left branch: Eval with n = null
+        var leftEval = as(inlineJoin.left(), Eval.class);
+        assertThat(Expressions.names(leftEval.fields()), is(List.of("n")));
+        var localRelation = as(leftEval.child(), LocalRelation.class);
+        // Right branch: Aggregate with COUNT(*) BY n
+        var aggregate = as(inlineJoin.right(), Aggregate.class);
+        assertThat(Expressions.names(aggregate.aggregates()), is(List.of("c", "n")));
+        assertThat(Expressions.names(aggregate.groupings()), is(List.of("n")));
+        var stub = as(aggregate.child(), StubRelation.class);
+    }
+
+    /**
+     * Expects
+     * <pre>{@code
+     * Project[[c{r}#6, s{r}#9, m{r}#12, n{r}#14]]
+     * \_Limit[1[INTEGER],false,false]
+     *   \_InlineJoin[LEFT,[n{r}#14],[n{r}#14]]
+     *     |_Eval[[null[NULL] AS n#14]]
+     *     | \_LocalRelation[[x{r}#4],Page{blocks=[IntVectorBlock[vector=ConstantIntVector[positions=1, value=10]]]}]
+     *     \_Aggregate[[n{r}#14],[COUNT(*[KEYWORD],true[BOOLEAN],PT0S[TIME_DURATION]) AS c#6, SUM(x{r}#4,true[BOOLEAN],PT0S[TIME_DURAT
+     * ION],compensated[KEYWORD]) AS s#9, MAX(x{r}#4,true[BOOLEAN],PT0S[TIME_DURATION]) AS m#12, n{r}#14]]
+     *       \_StubRelation[[x{r}#4, n{r}#14]]
+     * }</pre>
+     */
+    public void testInlineStatsGroupByNullWithMultipleAggregates() {
+        var query = """
+            ROW x = 10
+            | INLINE STATS c = COUNT(*), s = SUM(x), m = MAX(x) BY n = null
+            | KEEP c, s, m, n
+            | LIMIT 1
+            """;
+        if (releaseBuildForInlineStats(query)) {
+            return;
+        }
+        var plan = optimizedPlan(query);
+
+        var project = as(plan, Project.class);
+        assertThat(Expressions.names(project.projections()), is(List.of("c", "s", "m", "n")));
+        var limit = asLimit(project.child(), 1, false);
+        var inlineJoin = as(limit.child(), InlineJoin.class);
+        assertThat(Expressions.names(inlineJoin.config().leftFields()), is(List.of("n")));
+        // Left branch: Eval with n = null
+        var leftEval = as(inlineJoin.left(), Eval.class);
+        assertThat(Expressions.names(leftEval.fields()), is(List.of("n")));
+        var localRelation = as(leftEval.child(), LocalRelation.class);
+        // Right branch: Aggregate with COUNT(*), SUM(x), MAX(x) BY n
+        var aggregate = as(inlineJoin.right(), Aggregate.class);
+        assertThat(Expressions.names(aggregate.aggregates()), is(List.of("c", "s", "m", "n")));
+        assertThat(Expressions.names(aggregate.groupings()), is(List.of("n")));
+        var stub = as(aggregate.child(), StubRelation.class);
+    }
+
+    /**
+     * Expects
+     * <pre>{@code
+     * Project[[c1{r}#6, n1{r}#8, c2{r}#10, n2{r}#12]]
+     * \_Limit[1[INTEGER],false,false]
+     *   \_InlineJoin[LEFT,[n2{r}#12],[n2{r}#12]]
+     *     |_Eval[[null[NULL] AS n2#12]]
+     *     | \_InlineJoin[LEFT,[n1{r}#8],[n1{r}#8]]
+     *     |   |_Eval[[null[NULL] AS n1#8]]
+     *     |   | \_LocalRelation[[x{r}#4],Page{blocks=[IntVectorBlock[vector=ConstantIntVector[positions=1, value=1]]]}]
+     *     |   \_Aggregate[[n1{r}#8],[COUNT(*[KEYWORD],true[BOOLEAN],PT0S[TIME_DURATION]) AS c1#6, n1{r}#8]]
+     *     |     \_StubRelation[[x{r}#4, n1{r}#8]]
+     *     \_Aggregate[[n2{r}#12],[COUNT(*[KEYWORD],true[BOOLEAN],PT0S[TIME_DURATION]) AS c2#10, n2{r}#12]]
+     *       \_StubRelation[[x{r}#4, c1{r}#6, n1{r}#8, n2{r}#12]]
+     * }</pre>
+     */
+    public void testInlineStatsGroupByNullDouble() {
+        var query = """
+            ROW x = 1
+            | INLINE STATS c1 = COUNT(*) BY n1 = null
+            | INLINE STATS c2 = COUNT(*) BY n2 = null
+            | KEEP c1, n1, c2, n2
+            | LIMIT 1
+            """;
+        if (releaseBuildForInlineStats(query)) {
+            return;
+        }
+        var plan = optimizedPlan(query);
+
+        var project = as(plan, Project.class);
+        assertThat(Expressions.names(project.projections()), is(List.of("c1", "n1", "c2", "n2")));
+        var limit = asLimit(project.child(), 1, false);
+        var outerInlineJoin = as(limit.child(), InlineJoin.class);
+        assertThat(Expressions.names(outerInlineJoin.config().leftFields()), is(List.of("n2")));
+        // Outer left branch: Eval with n2 = null
+        var outerLeftEval = as(outerInlineJoin.left(), Eval.class);
+        assertThat(Expressions.names(outerLeftEval.fields()), is(List.of("n2")));
+        // Inner InlineJoin
+        var innerInlineJoin = as(outerLeftEval.child(), InlineJoin.class);
+        assertThat(Expressions.names(innerInlineJoin.config().leftFields()), is(List.of("n1")));
+        // Inner left branch: Eval with n1 = null
+        var innerLeftEval = as(innerInlineJoin.left(), Eval.class);
+        assertThat(Expressions.names(innerLeftEval.fields()), is(List.of("n1")));
+        var localRelation = as(innerLeftEval.child(), LocalRelation.class);
+        // Inner right branch: Aggregate with COUNT(*) BY n1
+        var innerAggregate = as(innerInlineJoin.right(), Aggregate.class);
+        assertThat(Expressions.names(innerAggregate.aggregates()), is(List.of("c1", "n1")));
+        assertThat(Expressions.names(innerAggregate.groupings()), is(List.of("n1")));
+        var innerStub = as(innerAggregate.child(), StubRelation.class);
+        // Outer right branch: Aggregate with COUNT(*) BY n2
+        var outerAggregate = as(outerInlineJoin.right(), Aggregate.class);
+        assertThat(Expressions.names(outerAggregate.aggregates()), is(List.of("c2", "n2")));
+        assertThat(Expressions.names(outerAggregate.groupings()), is(List.of("n2")));
+        var outerStub = as(outerAggregate.child(), StubRelation.class);
+    }
+
+    /**
+     * Expect
+     * <pre>{@code
+     * Project[[c{r}#4, n{r}#6]]
+     * \_Limit[3[INTEGER],false,false]
+     *   \_InlineJoin[LEFT,[n{r}#6],[n{r}#6]]
+     *     |_Eval[[null[NULL] AS n#6]]
+     *     | \_EsRelation[employees][_meta_field{f}#15, emp_no{f}#9, first_name{f}#10, g..]
+     *     \_Aggregate[[n{r}#6],[COUNT(*[KEYWORD],true[BOOLEAN],PT0S[TIME_DURATION]) AS c#4, n{r}#6]]
+     *       \_StubRelation[[_meta_field{f}#15, emp_no{f}#9, first_name{f}#10, gender{f}#11, hire_date{f}#16, job{f}#17, job.raw{f}#18, la
+     * nguages{f}#12, last_name{f}#13, long_noidx{f}#19, salary{f}#14, n{r}#6]]
+     * }</pre>
+     */
+    public void testInlineStatsGroupByNullFromEmployees() {
+        var query = """
+            FROM employees
+            | INLINE STATS c = COUNT(*) BY n = null
+            | KEEP c, n
+            | LIMIT 3
+            """;
+        if (releaseBuildForInlineStats(query)) {
+            return;
+        }
+        var plan = optimizedPlan(query);
+
+        var project = as(plan, Project.class);
+        assertThat(Expressions.names(project.projections()), is(List.of("c", "n")));
+        var limit = asLimit(project.child(), 3, false);
+        var inlineJoin = as(limit.child(), InlineJoin.class);
+        assertThat(Expressions.names(inlineJoin.config().leftFields()), is(List.of("n")));
+        // Left branch: Eval with n = null on top of EsRelation
+        var leftEval = as(inlineJoin.left(), Eval.class);
+        assertThat(Expressions.names(leftEval.fields()), is(List.of("n")));
+        var esRelation = as(leftEval.child(), EsRelation.class);
+        // Right branch: Aggregate with COUNT(*) BY n
+        var aggregate = as(inlineJoin.right(), Aggregate.class);
+        assertThat(Expressions.names(aggregate.aggregates()), is(List.of("c", "n")));
+        assertThat(Expressions.names(aggregate.groupings()), is(List.of("n")));
+        var stub = as(aggregate.child(), StubRelation.class);
+    }
+
+    /**
+     * Expects
+     * <pre>{@code
+     * Project[[c{r}#6, n1{r}#8, n2{r}#10]]
+     * \_Limit[1[INTEGER],false,false]
+     *   \_InlineJoin[LEFT,[n1{r}#8, n2{r}#10],[n1{r}#8, n2{r}#10]]
+     *     |_Eval[[null[NULL] AS n1#8, null[NULL] AS n2#10]]
+     *     | \_LocalRelation[[x{r}#4],Page{blocks=[IntVectorBlock[vector=ConstantIntVector[positions=1, value=1]]]}]
+     *     \_Aggregate[[n1{r}#8, n2{r}#10],[COUNT(*[KEYWORD],true[BOOLEAN],PT0S[TIME_DURATION]) AS c#6, n1{r}#8, n2{r}#10]]
+     *       \_StubRelation[[x{r}#4, n1{r}#8, n2{r}#10]]
+     * }</pre>
+     */
+    public void testInlineStatsGroupByNull_MultipleNullKeys() {
+        var query = """
+            ROW x = 1
+            | INLINE STATS c = COUNT(*) BY n1 = null, n2 = null
+            | KEEP c, n1, n2
+            | LIMIT 1
+            """;
+        if (releaseBuildForInlineStats(query)) {
+            return;
+        }
+        var plan = optimizedPlan(query);
+
+        var project = as(plan, Project.class);
+        assertThat(Expressions.names(project.projections()), is(List.of("c", "n1", "n2")));
+        var limit = asLimit(project.child(), 1, false);
+        var inlineJoin = as(limit.child(), InlineJoin.class);
+        assertThat(Expressions.names(inlineJoin.config().leftFields()), is(List.of("n1", "n2")));
+        // Left branch: Eval with n1 = null, n2 = null
+        var leftEval = as(inlineJoin.left(), Eval.class);
+        assertThat(Expressions.names(leftEval.fields()), is(List.of("n1", "n2")));
+        var localRelation = as(leftEval.child(), LocalRelation.class);
+        // Right branch: Aggregate with COUNT(*) BY n1, n2
+        var aggregate = as(inlineJoin.right(), Aggregate.class);
+        assertThat(Expressions.names(aggregate.aggregates()), is(List.of("c", "n1", "n2")));
+        assertThat(Expressions.names(aggregate.groupings()), is(List.of("n1", "n2")));
+        var stub = as(aggregate.child(), StubRelation.class);
+    }
+
+    /**
+     * Expects
+     * <pre>{@code
+     * Project[[c{r}#4, n{r}#6, emp_no{f}#12]]
+     * \_TopN[[Order[emp_no{f}#12,ASC,LAST]],3[INTEGER],false]
+     *   \_InlineJoin[LEFT,[n{r}#6, emp_no{f}#12],[n{r}#6, emp_no{r}#12]]
+     *     |_Eval[[null[NULL] AS n#6]]
+     *     | \_EsRelation[employees][_meta_field{f}#18, emp_no{f}#12, first_name{f}#13, ..]
+     *     \_Aggregate[[n{r}#6, emp_no{f}#12],[COUNT(*[KEYWORD],true[BOOLEAN],PT0S[TIME_DURATION]) AS c#4, n{r}#6, emp_no{f}#12]]
+     *       \_StubRelation[[_meta_field{f}#18, emp_no{f}#12, first_name{f}#13, gender{f}#14, hire_date{f}#19, job{f}#20, job.raw{f}#21, l
+     * anguages{f}#15, last_name{f}#16, long_noidx{f}#22, salary{f}#17, n{r}#6]]
+     * }</pre>
+     */
+    public void testInlineStatsGroupByNull_MixedNullAndNonNull() {
+        var query = """
+            FROM employees
+            | INLINE STATS c = COUNT(*) BY n = null, emp_no
+            | KEEP c, n, emp_no
+            | SORT emp_no
+            | LIMIT 3
+            """;
+        if (releaseBuildForInlineStats(query)) {
+            return;
+        }
+        var plan = optimizedPlan(query);
+
+        var project = as(plan, Project.class);
+        assertThat(Expressions.names(project.projections()), is(List.of("c", "n", "emp_no")));
+        var topN = as(project.child(), TopN.class);
+        assertThat(topN.order().size(), is(1));
+        var order = topN.order().get(0);
+        assertThat(Expressions.name(order.child()), is("emp_no"));
+        var inlineJoin = as(topN.child(), InlineJoin.class);
+        assertThat(Expressions.names(inlineJoin.config().leftFields()), is(List.of("n", "emp_no")));
+        // Left branch: Eval with n = null on top of EsRelation
+        var leftEval = as(inlineJoin.left(), Eval.class);
+        assertThat(Expressions.names(leftEval.fields()), is(List.of("n")));
+        var esRelation = as(leftEval.child(), EsRelation.class);
+        // Right branch: Aggregate with COUNT(*) BY n, emp_no
+        var aggregate = as(inlineJoin.right(), Aggregate.class);
+        assertThat(Expressions.names(aggregate.aggregates()), is(List.of("c", "n", "emp_no")));
+        assertThat(Expressions.names(aggregate.groupings()), is(List.of("n", "emp_no")));
+        var stub = as(aggregate.child(), StubRelation.class);
+    }
+
+    /**
+     * Expects
      *
      * <pre>{@code
      * Project[[salary{f}#19, languages{f}#17, emp_no{f}#14]]

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
@@ -115,8 +115,10 @@ import org.elasticsearch.xpack.esql.plan.logical.Limit;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
 import org.elasticsearch.xpack.esql.plan.logical.TopN;
+import org.elasticsearch.xpack.esql.plan.logical.join.InlineJoin;
 import org.elasticsearch.xpack.esql.plan.logical.join.Join;
 import org.elasticsearch.xpack.esql.plan.logical.join.JoinTypes;
+import org.elasticsearch.xpack.esql.plan.logical.join.StubRelation;
 import org.elasticsearch.xpack.esql.plan.logical.local.EmptyLocalSupplier;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
@@ -192,6 +194,7 @@ import static org.elasticsearch.xpack.esql.EsqlTestUtils.statsForMissingField;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.testAnalyzerContext;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.withDefaultLimitWarning;
 import static org.elasticsearch.xpack.esql.SerializationTestUtils.assertSerialization;
+import static org.elasticsearch.xpack.esql.action.EsqlCapabilities.Cap.INLINE_STATS;
 import static org.elasticsearch.xpack.esql.analysis.AnalyzerTestUtils.analyze;
 import static org.elasticsearch.xpack.esql.analysis.AnalyzerTestUtils.defaultLookupResolution;
 import static org.elasticsearch.xpack.esql.analysis.AnalyzerTestUtils.indexResolutions;
@@ -9098,6 +9101,78 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
         assertThat(rangeQuery.to(), equalTo(endRange));
         assertFalse(rangeQuery.includeLower());
         assertTrue(rangeQuery.includeUpper());
+    }
+
+    /**
+     * <pre>{@code
+     * ProjectExec[[c{r}#4, n{r}#6]]
+     * \_LimitExec[3[INTEGER],null]
+     *   \_ExchangeExec[[c{r}#4, n{r}#6],false]
+     *     \_FragmentExec[filter=null, estimatedRowSize=0, reducer=[], fragment=[<>
+     * Project[[c{r}#4, n{r}#6]]
+     * \_Limit[3[INTEGER],false,false]
+     *   \_InlineJoin[LEFT,[n{r}#6],[n{r}#6]]
+     *     |_Eval[[null[NULL] AS n#6]]
+     *     | \_EsRelation[test][_meta_field{f}#15, emp_no{f}#9, first_name{f}#10, g..]
+     *     \_Aggregate[[n{r}#6],[COUNT(*[KEYWORD],true[BOOLEAN],PT0S[TIME_DURATION]) AS c#4, n{r}#6]]
+     *       \_StubRelation[[_meta_field{f}#15, emp_no{f}#9, first_name{f}#10, gender{f}#11, hire_date{f}#16, job{f}#17, job.raw{f}#18, la
+     * nguages{f}#12, last_name{f}#13, long_noidx{f}#19, salary{f}#14, n{r}#6]]<>]]
+     * }</pre>
+     */
+    public void testInlineStatsGroupByNullFromEmployees() {
+        assumeTrue("INLINE STATS must be enabled", INLINE_STATS.isEnabled());
+
+        var query = """
+            FROM test
+            | INLINE STATS c = COUNT(*) BY n = null
+            | KEEP c, n
+            | LIMIT 3
+            """;
+        PhysicalPlan plan = physicalPlanNoSerializationCheck(query);
+        PhysicalPlan optimized = physicalOptimizer().optimize(plan);
+
+        // ProjectExec[[c{r}#4, n{r}#6]]
+        var project = as(optimized, ProjectExec.class);
+        assertThat(Expressions.names(project.projections()), contains("c", "n"));
+
+        // LimitExec[3[INTEGER],null]
+        var limit = as(project.child(), LimitExec.class);
+        assertThat(limit.limit().fold(FoldContext.small()), equalTo(3));
+
+        // ExchangeExec[[c{r}#4, n{r}#6],false]
+        var exchange = as(limit.child(), ExchangeExec.class);
+        assertThat(exchange.inBetweenAggs(), equalTo(false));
+        assertThat(Expressions.names(exchange.output()), contains("c", "n"));
+
+        // FragmentExec containing the logical plan
+        var fragment = as(exchange.child(), FragmentExec.class);
+        var fragmentPlan = fragment.fragment();
+
+        // Project[[c{r}#4, n{r}#6]]
+        var fragmentProject = as(fragmentPlan, Project.class);
+        assertThat(Expressions.names(fragmentProject.projections()), contains("c", "n"));
+
+        // Limit[3[INTEGER],false,false]
+        var fragmentLimit = as(fragmentProject.child(), Limit.class);
+        assertThat(fragmentLimit.limit().fold(FoldContext.small()), equalTo(3));
+
+        // InlineJoin[LEFT,[n{r}#6],[n{r}#6]]
+        var inlineJoin = as(fragmentLimit.child(), InlineJoin.class);
+        assertThat(Expressions.names(inlineJoin.config().leftFields()), contains("n"));
+        assertThat(Expressions.names(inlineJoin.config().rightFields()), contains("n"));
+
+        // Left branch: Eval[[null[NULL] AS n#6]] -> EsRelation[test]
+        var leftEval = as(inlineJoin.left(), Eval.class);
+        assertThat(Expressions.names(leftEval.fields()), contains("n"));
+        var alias = as(leftEval.fields().get(0), Alias.class);
+        assertThat(alias.child().fold(FoldContext.small()), nullValue());
+        var esRelation = as(leftEval.child(), EsRelation.class);
+
+        // Right branch: Aggregate[[n{r}#6],[COUNT(*) AS c#4, n{r}#6]] -> StubRelation
+        var aggregate = as(inlineJoin.right(), Aggregate.class);
+        assertThat(Expressions.names(aggregate.aggregates()), contains("c", "n"));
+        assertThat(Expressions.names(aggregate.groupings()), contains("n"));
+        var stubRelation = as(aggregate.child(), StubRelation.class);
     }
 
     @Override


### PR DESCRIPTION
Backports https://github.com/elastic/elasticsearch/pull/140027