### PR TITLE
Migrate smoke-test-plugins to new test cluster framework

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/RestrictedBuildApiService.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/RestrictedBuildApiService.java
@@ -46,15 +46,11 @@ public abstract class RestrictedBuildApiService implements BuildService<Restrict
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:qa:runtime-fields:core-with-search");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:qa:security-example-spi-extension");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:qa:security-setup-password-tests");
-        map.put(LegacyRestTestBasePlugin.class, ":x-pack:qa:smoke-test-plugins");
-        map.put(LegacyRestTestBasePlugin.class, ":x-pack:qa:smoke-test-plugins-ssl");
-        map.put(LegacyRestTestBasePlugin.class, ":x-pack:qa:smoke-test-security-with-mustache");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:qa:xpack-prefix-rest-compat");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:ent-search:qa:rest");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:eql:qa:ccs-rolling-upgrade");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:eql:qa:correctness");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:eql:qa:mixed-node");
-        map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:identity-provider:qa:idp-rest-tests");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:ml:qa:basic-multi-node");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:ml:qa:disabled");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:ml:qa:ml-with-security");
@@ -64,7 +60,6 @@ public abstract class RestrictedBuildApiService implements BuildService<Restrict
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:searchable-snapshots:qa:hdfs");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:searchable-snapshots:qa:rest");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:searchable-snapshots:qa:url");
-        map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:security:qa:tls-basic");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:shutdown:qa:multi-node");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:shutdown:qa:rolling-upgrade");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:snapshot-based-recoveries:qa:fs");

--- a/x-pack/qa/smoke-test-plugins/build.gradle
+++ b/x-pack/qa/smoke-test-plugins/build.gradle
@@ -7,14 +7,21 @@
 
 import org.apache.tools.ant.filters.ReplaceTokens
 
-apply plugin: 'elasticsearch.legacy-yaml-rest-test'
-apply plugin: 'elasticsearch.rest-resources'
+apply plugin: 'elasticsearch.internal-yaml-rest-test'
+
+def pluginPaths = []
+def pluginNames = []
+project(':plugins').getChildProjects().each { pluginName, pluginProject ->
+  pluginPaths << pluginProject.path
+  pluginNames << pluginName
+}
 
 dependencies {
   yamlRestTestImplementation project(':x-pack:qa')
+  pluginPaths.each { pluginPath ->
+    clusterPlugins(project(pluginPath))
+  }
 }
-
-def pluginPaths = project(':plugins').getChildProjects().collect {pluginName, pluginProject -> pluginProject.path }
 
 ext.expansions = [
   'expected.plugins.count': pluginPaths.size()
@@ -25,13 +32,7 @@ tasks.named("processYamlRestTestResources").configure {
   filter("tokens" : expansions.collectEntries {k, v -> [k, v.toString()]} /* must be a map of strings */, ReplaceTokens.class)
 }
 
-testClusters.matching { it.name == "yamlRestTest" }.configureEach {
-  testDistribution = 'DEFAULT'
-  setting 'xpack.security.enabled', 'true'
-  setting 'xpack.license.self_generated.type', 'trial'
-  user username: "test_user", password: "x-pack-test-password"
-
-  pluginPaths.each {pluginPath ->
-    plugin pluginPath
-  }
+tasks.named("yamlRestTest") {
+  usesDefaultDistribution("plugins require default distro with all modules")
+  systemProperty('tests.plugin.names', pluginNames.join(','))
 }

--- a/x-pack/qa/smoke-test-plugins/src/yamlRestTest/java/org/elasticsearch/smoketest/XSmokeTestPluginsClientYamlTestSuiteIT.java
+++ b/x-pack/qa/smoke-test-plugins/src/yamlRestTest/java/org/elasticsearch/smoketest/XSmokeTestPluginsClientYamlTestSuiteIT.java
@@ -24,17 +24,11 @@ public class XSmokeTestPluginsClientYamlTestSuiteIT extends ESClientYamlSuiteTes
     private static final String PASS = "x-pack-test-password";
 
     @ClassRule
-    public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
-        .distribution(DistributionType.DEFAULT)
-        .apply(c -> {
-            for (String plugin : System.getProperty("tests.plugin.names").split(",")) {
-                c.plugin(plugin);
-            }
-        })
-        .setting("xpack.security.enabled", "true")
-        .setting("xpack.license.self_generated.type", "trial")
-        .user(USER, PASS)
-        .build();
+    public static ElasticsearchCluster cluster = ElasticsearchCluster.local().distribution(DistributionType.DEFAULT).apply(c -> {
+        for (String plugin : System.getProperty("tests.plugin.names").split(",")) {
+            c.plugin(plugin);
+        }
+    }).setting("xpack.security.enabled", "true").setting("xpack.license.self_generated.type", "trial").user(USER, PASS).build();
 
     public XSmokeTestPluginsClientYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {
         super(testCandidate);

--- a/x-pack/qa/smoke-test-plugins/src/yamlRestTest/java/org/elasticsearch/smoketest/XSmokeTestPluginsClientYamlTestSuiteIT.java
+++ b/x-pack/qa/smoke-test-plugins/src/yamlRestTest/java/org/elasticsearch/smoketest/XSmokeTestPluginsClientYamlTestSuiteIT.java
@@ -12,13 +12,29 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
+import org.junit.ClassRule;
 
 public class XSmokeTestPluginsClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
 
     private static final String USER = "test_user";
     private static final String PASS = "x-pack-test-password";
+
+    @ClassRule
+    public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .distribution(DistributionType.DEFAULT)
+        .apply(c -> {
+            for (String plugin : System.getProperty("tests.plugin.names").split(",")) {
+                c.plugin(plugin);
+            }
+        })
+        .setting("xpack.security.enabled", "true")
+        .setting("xpack.license.self_generated.type", "trial")
+        .user(USER, PASS)
+        .build();
 
     public XSmokeTestPluginsClientYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {
         super(testCandidate);
@@ -30,8 +46,12 @@ public class XSmokeTestPluginsClientYamlTestSuiteIT extends ESClientYamlSuiteTes
     }
 
     @Override
-    protected Settings restClientSettings() {
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
 
+    @Override
+    protected Settings restClientSettings() {
         String token = basicAuthHeaderValue(USER, new SecureString(PASS.toCharArray()));
         return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).build();
     }


### PR DESCRIPTION
Migrate smoke-test-plugins. Also clean up RestrictedBuildApiService entries that were previously migrated.

ES-11813