### PR TITLE
Skip empty flush queue in rate

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AbstractRateGroupingFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AbstractRateGroupingFunction.java
@@ -134,8 +134,13 @@ class AbstractRateGroupingFunction {
             for (int i = startIndex; i < endIndex; i++) {
                 int start = sliceOffsets.get(i * 2L);
                 int end = sliceOffsets.get(i * 2L + 1);
-                queue.valueCount += (end - start);
-                queue.add(new Slice(buffer.timestamps, start, end));
+                if (start < end) {
+                    queue.valueCount += (end - start);
+                    queue.add(new Slice(buffer.timestamps, start, end));
+                }
+            }
+            if (queue.valueCount == 0) {
+                return null;
             }
             return queue;
         }


### PR DESCRIPTION
We should check and skip flush queues that have no samples.

Closes #141107