### PR TITLE
Document semantic text CCS support when ccs_minimize_roundtrips=false

### DIFF
--- a/docs/reference/elasticsearch/mapping-reference/semantic-text-reference.md
+++ b/docs/reference/elasticsearch/mapping-reference/semantic-text-reference.md
@@ -45,11 +45,11 @@ This parameter cannot be updated.
 `search_inference_id`
 :   (Optional, string) The {{infer}} endpoint that will be used to generate
 embeddings at query time. Use the [Create {{infer}} API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-inference-put) to create the endpoint. If not specified, the {{infer}} endpoint defined by
-`inference_id` will be used at both index and query time. 
-    
+`inference_id` will be used at both index and query time.
+
     You can update this parameter by using
-the [Update mapping API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-put-mapping).     
-    
+the [Update mapping API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-put-mapping).
+
     Learn how to [use dedicated endpoints for ingestion and search](./semantic-text-setup-configuration.md#dedicated-endpoints-for-ingestion-and-search).
 
 `index_options` {applies_to}`stack: ga 9.1`
@@ -119,13 +119,13 @@ The `semantic_text` field type specifies an {{infer}} endpoint identifier (`infe
 
 The following {{infer}} endpoint configurations are available:
 
-- [Default and preconfigured endpoints](./semantic-text-setup-configuration.md#default-and-preconfigured-endpoints): Use `semantic_text` without creating an {{infer}} endpoint manually. 
+- [Default and preconfigured endpoints](./semantic-text-setup-configuration.md#default-and-preconfigured-endpoints): Use `semantic_text` without creating an {{infer}} endpoint manually.
 
-- [ELSER on EIS](./semantic-text-setup-configuration.md#using-elser-on-eis): Use the ELSER model through the Elastic {{infer-cap}} Service. 
+- [ELSER on EIS](./semantic-text-setup-configuration.md#using-elser-on-eis): Use the ELSER model through the Elastic {{infer-cap}} Service.
 
 - [Custom endpoints](./semantic-text-setup-configuration.md#using-custom-endpoint): Create your own {{infer}} endpoint using the [Create {{infer}} API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-inference-put) to use custom models or third-party services.
 
-If you use a [custom {{infer}} endpoint](./semantic-text-setup-configuration.md#using-custom-endpoint) through your ML node and not through Elastic {{infer-cap}} Service (EIS), the recommended method is to [use dedicated endpoints for ingestion and search](./semantic-text-setup-configuration.md#dedicated-endpoints-for-ingestion-and-search). 
+If you use a [custom {{infer}} endpoint](./semantic-text-setup-configuration.md#using-custom-endpoint) through your ML node and not through Elastic {{infer-cap}} Service (EIS), the recommended method is to [use dedicated endpoints for ingestion and search](./semantic-text-setup-configuration.md#dedicated-endpoints-for-ingestion-and-search).
 
 {applies_to}`stack: ga 9.1.0` If you use EIS, you don't have to set up dedicated endpoints.
 
@@ -229,15 +229,13 @@ POST /_query
 * `semantic_text` fields can't currently be set as part
   of [dynamic templates](docs-content://manage-data/data-store/mapping/dynamic-templates.md).
 * `semantic_text` fields are not supported in indices created prior to 8.11.0.
-* `semantic_text` fields do not support [Cross-Cluster Search (CCS)](docs-content://explore-analyze/cross-cluster-search.md) when [`ccs_minimize_roundtrips`](docs-content://explore-analyze/cross-cluster-search.md#ccs-network-delays) is set to `false`.
-* `semantic_text` fields do not support [Cross-Cluster Search (CCS)](docs-content://explore-analyze/cross-cluster-search.md) in [ES|QL](/reference/query-languages/esql.md).
 * `semantic_text` fields do not support [Cross-Cluster Replication (CCR)](docs-content://deploy-manage/tools/cross-cluster-replication.md).
 * [Automatic pre-filtering](#pre-filtering-for-dense-vector-queries) in Query DSL does not apply to [Nested queries](/reference/query-languages/query-dsl/query-dsl-nested-query.md). Such queries will be applied as post-filters.
 * [Automatic pre-filtering](#pre-filtering-for-dense-vector-queries) in ES|QL does not apply to filters that use certain functions (like `WHERE TO_LOWER(my_field) == 'a'`). Such filters will be applied as post-filters.
 
 ## Document count discrepancy in `_cat/indices` [document-count-discrepancy]
 
-When an index contains a `semantic_text` field, the `docs.count` value returned by the [`_cat/indices`](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-indices) API may be higher than the number of documents you indexed. 
+When an index contains a `semantic_text` field, the `docs.count` value returned by the [`_cat/indices`](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-indices) API may be higher than the number of documents you indexed.
 This occurs because `semantic_text` stores embeddings in [nested documents](/reference/elasticsearch/mapping-reference/nested.md), one per chunk. The `_cat/indices` API counts all documents in the Lucene index, including these hidden nested documents.
 
 To count only top-level documents, excluding the nested documents that store embeddings, use one of the following APIs:

--- a/docs/reference/elasticsearch/mapping-reference/semantic-text-search-retrieval.md
+++ b/docs/reference/elasticsearch/mapping-reference/semantic-text-search-retrieval.md
@@ -62,7 +62,7 @@ By default, embeddings generated for `semantic_text` fields are stored internall
 
 The method for retrieving embeddings depends on your {{es}} version:
 
-- If you use {{es}} 9.2 and later, or {{serverless-short}}, use the [`_source.exclude_vectors`](#returning-semantic-field-embeddings-in-_source) parameter to include embeddings in `_source`. 
+- If you use {{es}} 9.2 and later, or {{serverless-short}}, use the [`_source.exclude_vectors`](#returning-semantic-field-embeddings-in-_source) parameter to include embeddings in `_source`.
 - If you use {{es}} versions earlier than 9.2, use the [`fields` parameter](#returning-semantic-field-embeddings-using-fields) with `_inference_fields` to retrieve embeddings.
 
 ### Include embeddings in `_source` [returning-semantic-field-embeddings-in-_source]
@@ -101,7 +101,7 @@ stack: ga 9.2
 serverless: ga
 ```
 
-When reindexing documents with `semantic_text` fields, you can preserve existing embeddings by including them in the source documents. This allows documents to be re-indexed without triggering {{infer}} again. 
+When reindexing documents with `semantic_text` fields, you can preserve existing embeddings by including them in the source documents. This allows documents to be re-indexed without triggering {{infer}} again.
 
 ::::{warning}
 The target index's `semantic_text` field must use the same `inference_id` as the source index to reuse existing embeddings. If the `inference_id` values do not match, the documents will fail the reindex task.
@@ -220,7 +220,7 @@ This method for returning semantic field embeddings is recommended only for {{es
 For version 9.2 and later, use the [`exclude_vectors`](#returning-semantic-field-embeddings-in-_source) parameter instead.
 :::
 
-To retrieve stored embeddings, use the `fields` parameter with `_inference_fields`. This lets you include the vector data that is not shown by default in the response. 
+To retrieve stored embeddings, use the `fields` parameter with `_inference_fields`. This lets you include the vector data that is not shown by default in the response.
 
 ```console
 POST my-index/_search
@@ -340,12 +340,19 @@ stack: ga 9.2
 serverless: unavailable
 ```
 
-`semantic_text` supports [{{ccs}} (CCS)](docs-content://explore-analyze/cross-cluster-search.md) through the [`_search` endpoint](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search) when [`ccs_minimize_roundtrips`](docs-content://explore-analyze/cross-cluster-search.md#ccs-network-delays) is set to `true`. This is the default value, so most CCS queries work automatically.
+::::{tab-set}
 
-Query `semantic_text` fields across clusters using the standard search endpoint with cluster notation:
+:::{tab-item} {{es}} 9.3+
+`semantic_text` supports [{{ccs}} (CCS)](docs-content://explore-analyze/cross-cluster-search.md) through:
+
+- The [`_search` endpoint](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search) when [`ccs_minimize_roundtrips`](docs-content://explore-analyze/cross-cluster-search.md#ccs-network-delays) is `true` or `false`.
+- [Retrievers](/reference/elasticsearch/rest-apis/retrievers.md)
+- [ES|QL](/reference/query-languages/esql.md)
+
+Query `semantic_text` fields across clusters using the standard `_search` endpoint with cluster notation:
 
 ```console
-POST local-index,remote-cluster:remote-index/_search
+POST local-index,remote-cluster:remote-index/_search <1>
 {
   "query": {
     "match": {
@@ -354,3 +361,42 @@ POST local-index,remote-cluster:remote-index/_search
   }
 }
 ```
+1. `remote-cluster:remote-index` refers to an index on the remote cluster with alias `remote-cluster`.
+
+The same notation can be used to query `semantic_text` fields across clusters with ES|QL:
+
+```console
+POST _query
+{
+    "query": """FROM local-index,remote-cluster:remote-index METADATA _score | <1>
+     WHERE MATCH(my_semantic_field, "Which country is Paris in?") |
+     SORT _score DESC |
+     KEEP my_semantic_field | LIMIT 10
+    """
+}
+```
+1. `remote-cluster:remote-index` refers to an index on the remote cluster with alias `remote-cluster`.
+:::
+
+:::{tab-item} {{es}} 9.2
+`semantic_text` supports [{{ccs}} (CCS)](docs-content://explore-analyze/cross-cluster-search.md) through the [`_search` endpoint](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search) when [`ccs_minimize_roundtrips`](docs-content://explore-analyze/cross-cluster-search.md#ccs-network-delays) is set to `true`.
+This is the default value, so most CCS queries work automatically.
+
+CCS is **not** supported in [retrievers](/reference/elasticsearch/rest-apis/retrievers.md) or [ES|QL](/reference/query-languages/esql.md).
+
+Query `semantic_text` fields across clusters using the standard `_search` endpoint with cluster notation:
+
+```console
+POST local-index,remote-cluster:remote-index/_search <1>
+{
+  "query": {
+    "match": {
+      "my_semantic_field": "Which country is Paris in?"
+    }
+  }
+}
+```
+1. `remote-cluster:remote-index` refers to an index on the remote cluster with alias `remote-cluster`.
+:::
+
+::::

--- a/docs/reference/elasticsearch/mapping-reference/semantic-text-search-retrieval.md
+++ b/docs/reference/elasticsearch/mapping-reference/semantic-text-search-retrieval.md
@@ -340,9 +340,9 @@ stack: ga 9.2
 serverless: unavailable
 ```
 
-::::{tab-set}
+::::{applies-switch}
 
-:::{tab-item} {{es}} 9.3+
+:::{applies-item} stack: ga 9.3+
 `semantic_text` supports [{{ccs}} (CCS)](docs-content://explore-analyze/cross-cluster-search.md) through:
 
 - The [`_search` endpoint](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search) when [`ccs_minimize_roundtrips`](docs-content://explore-analyze/cross-cluster-search.md#ccs-network-delays) is `true` or `false`.
@@ -378,7 +378,7 @@ POST _query
 1. `remote-cluster:remote-index` refers to an index on the remote cluster with alias `remote-cluster`.
 :::
 
-:::{tab-item} {{es}} 9.2
+:::{applies-item} stack: ga =9.2
 `semantic_text` supports [{{ccs}} (CCS)](docs-content://explore-analyze/cross-cluster-search.md) through the [`_search` endpoint](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search) when [`ccs_minimize_roundtrips`](docs-content://explore-analyze/cross-cluster-search.md#ccs-network-delays) is set to `true`.
 This is the default value, so most CCS queries work automatically.
 

--- a/docs/reference/query-languages/esql/limitations.md
+++ b/docs/reference/query-languages/esql/limitations.md
@@ -235,10 +235,6 @@ Also, [`INLINE STATS`](/reference/query-languages/esql/commands/inlinestats-by.m
 * CSV export from Discover shows no more than 10,000 rows. This limit only applies to the number of rows that are retrieved by the query and displayed in Discover. Queries and aggregations run on the full data set.
 * Querying many indices at once without any filters can cause an error in kibana which looks like `[esql] > Unexpected error from Elasticsearch: The content length (536885793) is bigger than the maximum allowed string (536870888)`. The response from {{esql}} is too long. Use [`DROP`](/reference/query-languages/esql/commands/drop.md) or [`KEEP`](/reference/query-languages/esql/commands/keep.md) to limit the number of fields returned.
 
-## Cross-cluster search limitations [esql-ccs-limitations]
-
-{{esql}} does not support [Cross-Cluster Search (CCS)](docs-content://explore-analyze/cross-cluster-search.md) on [`semantic_text` fields](/reference/elasticsearch/mapping-reference/semantic-text.md).
-
 ## Known issues [esql-known-issues]
 
 Refer to [Known issues](/release-notes/known-issues.md) for a list of known issues for {{esql}}.


### PR DESCRIPTION
Update the `semantic_text` field docs to explain CCS support when `ccs_minimize_roundtrips=false`
