### PR TITLE
[9.3] Skip empty flush queue in rate (#141125)

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AbstractRateGroupingFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AbstractRateGroupingFunction.java
@@ -132,8 +132,13 @@ class AbstractRateGroupingFunction {
             for (int i = startIndex; i < endIndex; i++) {
                 int start = sliceOffsets.get(i * 2L);
                 int end = sliceOffsets.get(i * 2L + 1);
-                queue.valueCount += (end - start);
-                queue.add(new Slice(buffer.timestamps, start, end));
+                if (start < end) {
+                    queue.valueCount += (end - start);
+                    queue.add(new Slice(buffer.timestamps, start, end));
+                }
+            }
+            if (queue.valueCount == 0) {
+                return null;
             }
             return queue;
         }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Skip empty flush queue in rate (#141125)](https://github.com/elastic/elasticsearch/pull/141125)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)