### PR TITLE
[8.19] rest-api-spec: fix _internal APIs (#140896)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/_internal.delete_desired_nodes.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/_internal.delete_desired_nodes.json
@@ -29,6 +29,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Timeout for acknowledgements from all nodes"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/_internal.get_desired_nodes.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/_internal.get_desired_nodes.json
@@ -20,6 +20,13 @@
           ]
         }
       ]
+    },
+    "params": {
+      "master_timeout": {
+        "type": "time",
+        "description": "Period to wait for a connection to the master node.",
+        "default": "30s"
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/_internal.prevalidate_node_removal.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/_internal.prevalidate_node_removal.json
@@ -24,14 +24,17 @@
     "params": {
       "names": {
         "type": "list",
+        "default": [],
         "description": "A comma-separated list of node names to prevalidate"
       },
       "ids": {
         "type": "list",
+        "default": [],
         "description": "A comma-separated list of node IDs to prevalidate"
       },
       "external_ids": {
         "type": "list",
+        "default": [],
         "description": "A comma-separated list of node external IDs to prevalidate"
       },
       "master_timeout": {
@@ -41,6 +44,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       }
     }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/_internal.update_desired_nodes.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/_internal.update_desired_nodes.json
@@ -27,7 +27,7 @@
               "description": "the history id"
             },
             "version": {
-              "type": "int",
+              "type": "long",
               "description": "the version number"
             }
           }
@@ -38,6 +38,16 @@
       "dry_run": {
         "type": "boolean",
         "description": "Simulate the update"
+      },
+      "master_timeout": {
+        "type": "time",
+        "description": "Period to wait for a connection to the master node.",
+        "default": "30s"
+      },
+      "timeout": {
+        "type": "time",
+        "description": "Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.",
+        "default": "30s"
       }
     },
     "body": {

--- a/rest-api-spec/src/main/resources/schema.json
+++ b/rest-api-spec/src/main/resources/schema.json
@@ -264,7 +264,7 @@
                     "title": "Valid options when type is an enum"
                 },
                 "default": {
-                    "type": ["string", "number", "boolean"],
+                    "type": ["string", "number", "boolean", "array"],
                     "title": "Default value"
                 },
                 "deprecated": {


### PR DESCRIPTION
Backports the following commits to 8.19:
 - rest-api-spec: fix _internal APIs (#140896)