### PR TITLE
ESQL: Naturally named fields with backticks in them should be escaped in Generative tests

### DIFF
--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
@@ -280,6 +280,9 @@ public abstract class GenerativeRestTest extends ESRestTestCase implements Query
     }
 
     private static String normalizeColumnName(String name) {
+        if (name.startsWith("`") && name.endsWith("`") && name.startsWith("```") == false) {
+            name = "``" + name + "``";
+        }
         return name.contains("-") && name.startsWith("`") == false ? Strings.format("`%s`", name) : name;
     }
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/generator/EsqlQueryGenerator.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/generator/EsqlQueryGenerator.java
@@ -547,10 +547,11 @@ public class EsqlQueryGenerator {
     }
 
     public static String unquote(String colName) {
-        if (colName.startsWith("`") && colName.endsWith("`")) {
+        if (colName.startsWith("```") && colName.endsWith("```")) {
+            return colName.substring(2, colName.length() - 2);
+        } else if (colName.startsWith("`") && colName.endsWith("`")) {
             return colName.substring(1, colName.length() - 1);
         }
         return colName;
     }
-
 }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/generator/command/pipe/EvalGenerator.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/generator/command/pipe/EvalGenerator.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.test.ESTestCase.randomBoolean;
 import static org.elasticsearch.test.ESTestCase.randomIntBetween;
+import static org.elasticsearch.xpack.esql.generator.EsqlQueryGenerator.unquote;
 
 public class EvalGenerator implements CommandGenerator {
 
@@ -81,7 +82,7 @@ public class EvalGenerator implements CommandGenerator {
         List<String> expectedColumns = (List<String>) commandDescription.context().get(NEW_COLUMNS);
         List<String> resultColNames = columns.stream().map(Column::name).toList();
         List<String> lastColumns = resultColNames.subList(resultColNames.size() - expectedColumns.size(), resultColNames.size());
-        lastColumns = lastColumns.stream().map(EvalGenerator::unquote).toList();
+        lastColumns = lastColumns.stream().map(EsqlQueryGenerator::unquote).toList();
         // expected column names are unquoted already
         if (columns.size() < expectedColumns.size() || lastColumns.equals(expectedColumns) == false) {
             return new ValidationResult(
@@ -95,12 +96,5 @@ public class EvalGenerator implements CommandGenerator {
         }
 
         return CommandGenerator.expectSameRowCount(previousCommands, previousOutput, output);
-    }
-
-    private static String unquote(String colName) {
-        if (colName.startsWith("`") && colName.endsWith("`")) {
-            return colName.substring(1, colName.length() - 1);
-        }
-        return colName;
     }
 }


### PR DESCRIPTION
Escape starting and ending backticks with triple backticks for generative tests.