### PR TITLE
[Native] Improve numerical stability of `score`/`bulkScore` using FMA

### DIFF
--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/ES91Int4VectorsScorer.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/ES91Int4VectorsScorer.java
@@ -174,7 +174,7 @@ public class ES91Int4VectorsScorer {
         // For euclidean, we need to invert the score and apply the additional correction, which is
         // assumed to be the squared l2norm of the centroid centered vectors.
         if (similarityFunction == EUCLIDEAN) {
-            score = queryAdditionalCorrection + additionalCorrection - 2 * score;
+            score = Math.fma(score, -2.0f, queryAdditionalCorrection + additionalCorrection);
             return Math.max(1 / (1f + score), 0);
         } else {
             // For cosine and max inner product, we need to apply the additional correction, which is

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/ES91OSQVectorsScorer.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/ES91OSQVectorsScorer.java
@@ -121,7 +121,7 @@ public class ES91OSQVectorsScorer {
         // For euclidean, we need to invert the score and apply the additional correction, which is
         // assumed to be the squared l2norm of the centroid centered vectors.
         if (similarityFunction == EUCLIDEAN) {
-            score = queryAdditionalCorrection + additionalCorrection - 2 * score;
+            score = Math.fma(score, -2.0f, queryAdditionalCorrection + additionalCorrection);
             return Math.max(1 / (1f + score), 0);
         } else {
             // For cosine and max inner product, we need to apply the additional correction, which is

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/ES92Int7VectorsScorer.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/ES92Int7VectorsScorer.java
@@ -174,7 +174,7 @@ public class ES92Int7VectorsScorer {
         // For euclidean, we need to invert the score and apply the additional correction, which is
         // assumed to be the squared l2norm of the centroid centered vectors.
         if (similarityFunction == EUCLIDEAN) {
-            score = queryAdditionalCorrection + additionalCorrection - 2 * score;
+            score = Math.fma(score, -2.0f, queryAdditionalCorrection + additionalCorrection);
             return Math.max(1 / (1f + score), 0);
         } else {
             // For cosine and max inner product, we need to apply the additional correction, which is

--- a/libs/simdvec/src/main/java/org/elasticsearch/simdvec/ESNextOSQVectorsScorer.java
+++ b/libs/simdvec/src/main/java/org/elasticsearch/simdvec/ESNextOSQVectorsScorer.java
@@ -202,7 +202,7 @@ public class ESNextOSQVectorsScorer {
         // For euclidean, we need to invert the score and apply the additional correction, which is
         // assumed to be the squared l2norm of the centroid centered vectors.
         if (similarityFunction == EUCLIDEAN) {
-            score = queryAdditionalCorrection + additionalCorrection - 2 * score;
+            score = Math.fma(score, -2.0f, queryAdditionalCorrection + additionalCorrection);
             return Math.max(1 / (1f + score), 0);
         } else {
             // For cosine and max inner product, we need to apply the additional correction, which is

--- a/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/MemorySegmentES92PanamaInt7VectorsScorer.java
+++ b/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/MemorySegmentES92PanamaInt7VectorsScorer.java
@@ -304,7 +304,7 @@ abstract class MemorySegmentES92PanamaInt7VectorsScorer extends ES92Int7VectorsS
             // For euclidean, we need to invert the score and apply the additional correction, which is
             // assumed to be the squared l2norm of the centroid centered vectors.
             if (similarityFunction == EUCLIDEAN) {
-                res = res.mul(-2).add(additionalCorrections).add(queryAdditionalCorrection).add(1f);
+                res = res.fma(FloatVector.broadcast(FLOAT_SPECIES, -2), additionalCorrections).add(queryAdditionalCorrection + 1.0f);
                 res = FloatVector.broadcast(FLOAT_SPECIES, 1).div(res).max(0);
                 res.intoArray(scores, i);
             } else {
@@ -369,7 +369,7 @@ abstract class MemorySegmentES92PanamaInt7VectorsScorer extends ES92Int7VectorsS
             var res = res1.add(res2).add(res3).add(res4);
 
             if (similarityFunction == EUCLIDEAN) {
-                res = res.mul(-2).add(additionalCorrections).add(queryAdditionalCorrection).add(1f);
+                res = res.fma(FloatVector.broadcast(FLOAT_SPECIES, -2), additionalCorrections).add(queryAdditionalCorrection + 1.0f);
                 res = FloatVector.broadcast(FLOAT_SPECIES, 1).div(res).max(0);
                 res.intoArray(scores, i, floatVectorMask);
             } else {

--- a/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/MSBitToInt4ESNextOSQVectorsScorer.java
+++ b/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/MSBitToInt4ESNextOSQVectorsScorer.java
@@ -485,7 +485,7 @@ final class MSBitToInt4ESNextOSQVectorsScorer extends MemorySegmentESNextOSQVect
             // For euclidean, we need to invert the score and apply the additional correction, which is
             // assumed to be the squared l2norm of the centroid centered vectors.
             if (similarityFunction == EUCLIDEAN) {
-                res = res.mul(-2).add(additionalCorrections).add(queryAdditionalCorrection).add(1f);
+                res = res.fma(FloatVector.broadcast(FLOAT_SPECIES_128, -2), additionalCorrections).add(queryAdditionalCorrection + 1.0f);
                 res = FloatVector.broadcast(FLOAT_SPECIES_128, 1).div(res).max(0);
                 maxScore = Math.max(maxScore, res.reduceLanes(VectorOperators.MAX));
                 res.intoArray(scores, i);
@@ -558,7 +558,7 @@ final class MSBitToInt4ESNextOSQVectorsScorer extends MemorySegmentESNextOSQVect
             // For euclidean, we need to invert the score and apply the additional correction, which is
             // assumed to be the squared l2norm of the centroid centered vectors.
             if (similarityFunction == EUCLIDEAN) {
-                res = res.mul(-2).add(additionalCorrections).add(queryAdditionalCorrection).add(1f);
+                res = res.fma(FloatVector.broadcast(FLOAT_SPECIES_256, -2), additionalCorrections).add(queryAdditionalCorrection + 1.0f);
                 res = FloatVector.broadcast(FLOAT_SPECIES_256, 1).div(res).max(0);
                 maxScore = Math.max(maxScore, res.reduceLanes(VectorOperators.MAX));
                 res.intoArray(scores, i);

--- a/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/MSDibitToInt4ESNextOSQVectorsScorer.java
+++ b/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/MSDibitToInt4ESNextOSQVectorsScorer.java
@@ -314,7 +314,7 @@ final class MSDibitToInt4ESNextOSQVectorsScorer extends MemorySegmentESNextOSQVe
             // For euclidean, we need to invert the score and apply the additional correction, which is
             // assumed to be the squared l2norm of the centroid centered vectors.
             if (similarityFunction == EUCLIDEAN) {
-                res = res.mul(-2).add(additionalCorrections).add(queryAdditionalCorrection).add(1f);
+                res = res.fma(FloatVector.broadcast(FLOAT_SPECIES_128, -2), additionalCorrections).add(queryAdditionalCorrection + 1.0f);
                 res = FloatVector.broadcast(FLOAT_SPECIES_128, 1).div(res).max(0);
                 maxScore = Math.max(maxScore, res.reduceLanes(VectorOperators.MAX));
                 res.intoArray(scores, i);
@@ -389,7 +389,7 @@ final class MSDibitToInt4ESNextOSQVectorsScorer extends MemorySegmentESNextOSQVe
             // For euclidean, we need to invert the score and apply the additional correction, which is
             // assumed to be the squared l2norm of the centroid centered vectors.
             if (similarityFunction == EUCLIDEAN) {
-                res = res.mul(-2).add(additionalCorrections).add(queryAdditionalCorrection).add(1f);
+                res = res.fma(FloatVector.broadcast(FLOAT_SPECIES_256, -2), additionalCorrections).add(queryAdditionalCorrection + 1.0f);
                 res = FloatVector.broadcast(FLOAT_SPECIES_256, 1).div(res).max(0);
                 maxScore = Math.max(maxScore, res.reduceLanes(VectorOperators.MAX));
                 res.intoArray(scores, i);

--- a/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/MSInt4SymmetricESNextOSQVectorsScorer.java
+++ b/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/MSInt4SymmetricESNextOSQVectorsScorer.java
@@ -316,7 +316,7 @@ final class MSInt4SymmetricESNextOSQVectorsScorer extends MemorySegmentESNextOSQ
             // For euclidean, we need to invert the score and apply the additional correction, which is
             // assumed to be the squared l2norm of the centroid centered vectors.
             if (similarityFunction == EUCLIDEAN) {
-                res = res.mul(-2).add(additionalCorrections).add(queryAdditionalCorrection).add(1f);
+                res = res.fma(FloatVector.broadcast(FLOAT_SPECIES_128, -2), additionalCorrections).add(queryAdditionalCorrection + 1.0f);
                 res = FloatVector.broadcast(FLOAT_SPECIES_128, 1).div(res).max(0);
                 maxScore = Math.max(maxScore, res.reduceLanes(VectorOperators.MAX));
                 res.intoArray(scores, i);
@@ -391,7 +391,7 @@ final class MSInt4SymmetricESNextOSQVectorsScorer extends MemorySegmentESNextOSQ
             // For euclidean, we need to invert the score and apply the additional correction, which is
             // assumed to be the squared l2norm of the centroid centered vectors.
             if (similarityFunction == EUCLIDEAN) {
-                res = res.mul(-2).add(additionalCorrections).add(queryAdditionalCorrection).add(1f);
+                res = res.fma(FloatVector.broadcast(FLOAT_SPECIES_256, -2), additionalCorrections).add(queryAdditionalCorrection + 1.0f);
                 res = FloatVector.broadcast(FLOAT_SPECIES_256, 1).div(res).max(0);
                 maxScore = Math.max(maxScore, res.reduceLanes(VectorOperators.MAX));
                 res.intoArray(scores, i);

--- a/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/MemorySegmentES91Int4VectorsScorer.java
+++ b/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/MemorySegmentES91Int4VectorsScorer.java
@@ -378,7 +378,7 @@ public final class MemorySegmentES91Int4VectorsScorer extends ES91Int4VectorsSco
             // For euclidean, we need to invert the score and apply the additional correction, which is
             // assumed to be the squared l2norm of the centroid centered vectors.
             if (similarityFunction == EUCLIDEAN) {
-                res = res.mul(-2).add(additionalCorrections).add(queryAdditionalCorrection).add(1f);
+                res = res.fma(FloatVector.broadcast(FLOAT_SPECIES, -2), additionalCorrections).add(queryAdditionalCorrection + 1.0f);
                 res = FloatVector.broadcast(FLOAT_SPECIES, 1).div(res).max(0);
                 res.intoArray(scores, i);
             } else {

--- a/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/MemorySegmentES91OSQVectorsScorer.java
+++ b/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/MemorySegmentES91OSQVectorsScorer.java
@@ -450,7 +450,7 @@ public final class MemorySegmentES91OSQVectorsScorer extends ES91OSQVectorsScore
             // For euclidean, we need to invert the score and apply the additional correction, which is
             // assumed to be the squared l2norm of the centroid centered vectors.
             if (similarityFunction == EUCLIDEAN) {
-                res = res.mul(-2).add(additionalCorrections).add(queryAdditionalCorrection).add(1f);
+                res = res.fma(FloatVector.broadcast(FLOAT_SPECIES_128, -2), additionalCorrections).add(queryAdditionalCorrection + 1.0f);
                 res = FloatVector.broadcast(FLOAT_SPECIES_128, 1).div(res).max(0);
                 maxScore = Math.max(maxScore, res.reduceLanes(VectorOperators.MAX));
                 res.intoArray(scores, i);
@@ -525,7 +525,7 @@ public final class MemorySegmentES91OSQVectorsScorer extends ES91OSQVectorsScore
             // For euclidean, we need to invert the score and apply the additional correction, which is
             // assumed to be the squared l2norm of the centroid centered vectors.
             if (similarityFunction == EUCLIDEAN) {
-                res = res.mul(-2).add(additionalCorrections).add(queryAdditionalCorrection).add(1f);
+                res = res.fma(FloatVector.broadcast(FLOAT_SPECIES_256, -2), additionalCorrections).add(queryAdditionalCorrection + 1.0f);
                 res = FloatVector.broadcast(FLOAT_SPECIES_256, 1).div(res).max(0);
                 maxScore = Math.max(maxScore, res.reduceLanes(VectorOperators.MAX));
                 res.intoArray(scores, i);

--- a/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/OnHeapES91OSQVectorsScorer.java
+++ b/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/OnHeapES91OSQVectorsScorer.java
@@ -441,7 +441,8 @@ public final class OnHeapES91OSQVectorsScorer extends ES91OSQVectorsScorer {
             // For euclidean, we need to invert the score and apply the additional correction, which is
             // assumed to be the squared l2norm of the centroid centered vectors.
             if (similarityFunction == EUCLIDEAN) {
-                res = res.mul(-2).add(additionalCorrectionsVect).add(queryAdditionalCorrection).add(1f);
+                res = res.fma(FloatVector.broadcast(FLOAT_SPECIES_128, -2), additionalCorrectionsVect)
+                    .add(queryAdditionalCorrection + 1.0f);
                 res = FloatVector.broadcast(FLOAT_SPECIES_128, 1).div(res).max(0);
                 maxScore = Math.max(maxScore, res.reduceLanes(VectorOperators.MAX));
                 res.intoArray(scores, i);
@@ -505,7 +506,8 @@ public final class OnHeapES91OSQVectorsScorer extends ES91OSQVectorsScorer {
             // For euclidean, we need to invert the score and apply the additional correction, which is
             // assumed to be the squared l2norm of the centroid centered vectors.
             if (similarityFunction == EUCLIDEAN) {
-                res = res.mul(-2).add(additionalCorrectionsVect).add(queryAdditionalCorrection).add(1f);
+                res = res.fma(FloatVector.broadcast(FLOAT_SPECIES_256, -2), additionalCorrectionsVect)
+                    .add(queryAdditionalCorrection + 1.0f);
                 res = FloatVector.broadcast(FLOAT_SPECIES_256, 1).div(res).max(0);
                 maxScore = Math.max(maxScore, res.reduceLanes(VectorOperators.MAX));
                 res.intoArray(scores, i);


### PR DESCRIPTION
While investigating https://github.com/elastic/elasticsearch/issues/141106, we realized that the scalar and panama implementations of scoring have a tiny difference. This should not matter in the real cases, but the sequence of operations is susceptible of rounding errors, which can be significant for some inputs.

This PR uniforms the scalar and panama implementations, using form both a FMA instruction rather than the current mul + add (or add + mul). This should give a tiny performance benefit, but most importantly should be more accurate (less prone to numeric errors).
