### PR TITLE
Test fix: use previous step info to assert missing SLM snapshot

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -240,9 +240,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.heap_attack.HeapAttackLookupJoinIT
   method: testLookupExplosionBigString
   issue: https://github.com/elastic/elasticsearch/issues/138510
-- class: org.elasticsearch.xpack.ilm.TimeSeriesLifecycleActionsIT
-  method: testWaitForSnapshot
-  issue: https://github.com/elastic/elasticsearch/issues/138669
 - class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
   method: testDatafeedTimingStats_DatafeedRecreated
   issue: https://github.com/elastic/elasticsearch/issues/138348

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -243,9 +243,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
   method: testDatafeedTimingStats_DatafeedRecreated
   issue: https://github.com/elastic/elasticsearch/issues/138348
-- class: org.elasticsearch.xpack.ilm.actions.DownsampleActionIT
-  method: testILMWaitsForTimeSeriesEndTimeToLapse
-  issue: https://github.com/elastic/elasticsearch/issues/138843
 - class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
   method: testStopLookback_closeJobFalse
   issue: https://github.com/elastic/elasticsearch/issues/139024


### PR DESCRIPTION
Test `TimeSeriesLifecycleActionsIT testWaitForSnapshot` is deleting the SLM policy and tries to verify that ILM will fail the `wait-for-snapshot` step. 

When ILM fails the `wait-for-snapshot` step it goes into an `error` step and sets `failed_step` to be `wait-for-snapshot`. This is what this tests was using in the assertion.

However, ILM retries the step periodically and when it retries it move from the step `error` to `wait-for-snapshot` and unsets the `failed_step`. If these periodic retries align with the `assertBusy`, it's possible to keep failing the assert even what we want to test has happened.

To mitigate that we add an alternative way of checking. If the `failed_step` is not present then we check the following:

1. The current step is `wait-for-snapshot`
2. This step has been retried at least one time
3. The previous step failed because of a missing SLM policy.

Closes #138669
