### PR TITLE
Make ECS usage dynamic mappings more restrictive.

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/ecs@mappings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/ecs@mappings.json
@@ -185,7 +185,10 @@
               "type": "scaled_float",
               "scaling_factor": 1000
             },
-            "path_match": "*.usage",
+            "path_match": [
+              "*.cpu.usage",
+              "*.memory.usage"
+            ],
             "match_mapping_type": ["double", "long", "string"]
           }
         },


### PR DESCRIPTION
The dynamic mapping for `*.usage` to `scaled_float` type was overly permissive. This is intended to capture the memory and cpu usage metrics, so it's mapping to `scaled_float`. There are other common usages of this which should not be numeric. Kubernetes labels can commonly have "usage", i.e. `kubernetes.labels.usage: prod`, this was being mapped to `scaled_float`, which is not correct.

This changes the dynamic mapping to be more restrictive, and only match on `*.cpu.usage` and `*.memory.usage`, so the metric fields will still be captured, while others will not be.

The usage fields defined in ecs are `container.cpu.usage`, `container.memory.usage`, `host.cpu.usage`.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? ✅
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?✅
- If submitting code, have you built your formula locally prior to submission with `gradle check`? ✅
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed. ✅
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)? ✅
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
