### PR TITLE
Docs: Remove mysterious '<images>' from ecommerce data install steps

### DIFF
--- a/docs/reference/scripting-languages/painless/painless-context-examples.md
+++ b/docs/reference/scripting-languages/painless/painless-context-examples.md
@@ -18,10 +18,7 @@ Each document in this dataset represents a complete eCommerce order. Every order
 
 1. Go to **Integrations** and search for **Sample Data**.   
 2. On the **Sample data** page, expand the **Other sample data sets**.
-<image1>
-3. Click **Add data** to install **Sample eCommerce orders**.
-<image2>
-<image3>
+3. Click **Add data** to install **Sample eCommerce orders**.   
 4. **Verify Installation:** Navigate to **Analytics \> Discover** and select the `kibana_sample_data_ecommerce` data view. You should see eCommerce order documents with complete customer, product, and transaction information.
 
 


### PR DESCRIPTION
Removes a few `<image>` tags that for some bizarre reason I accidentally included in the [Painless ecommerce data install steps](https://www.elastic.co/docs/reference/scripting-languages/painless/painless-context-examples#painless-sample-data-install).

---
fixed:

<img width="551" height="213" alt="Screenshot 2026-01-23 at 2 48 09 PM" src="https://github.com/user-attachments/assets/b040f110-3929-4bf7-ad66-d5ebb7cf6014" />
