### PR TITLE
[8.19] Test fix: use previous step info to assert missing SLM snapshot (#141197)

### DIFF
--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/TimeSeriesLifecycleActionsIT.java
@@ -73,6 +73,7 @@ import static org.elasticsearch.xpack.TimeSeriesRestDriver.updatePolicy;
 import static org.elasticsearch.xpack.core.ilm.ShrinkIndexNameSupplier.SHRUNKEN_INDEX_PREFIX;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -252,6 +253,7 @@ public class TimeSeriesLifecycleActionsIT extends IlmESRestTestCase {
         });
     }
 
+    @SuppressWarnings("unchecked")
     public void testWaitForSnapshot() throws Exception {
         createIndexWithSettings(
             client(),
@@ -272,7 +274,19 @@ public class TimeSeriesLifecycleActionsIT extends IlmESRestTestCase {
         assertBusy(() -> {
             Map<String, Object> indexILMState = explainIndex(client(), index);
             assertThat(indexILMState.get("action"), is("wait_for_snapshot"));
-            assertThat(indexILMState.get("failed_step"), is("wait-for-snapshot"));
+            if (indexILMState.containsKey("failed_step")) {
+                assertThat(indexILMState.get("failed_step"), is("wait-for-snapshot"));
+            } else {
+                // The failed step gets reset every time ILM retries, so we introduce an alternative check
+                // We check that ILM is re-trying the wait-for-snapshot step
+                assertThat(indexILMState.get("step"), is("wait-for-snapshot"));
+                assertThat(indexILMState.get(FAILED_STEP_RETRY_COUNT_FIELD), notNullValue());
+                assertThat((int) indexILMState.get(FAILED_STEP_RETRY_COUNT_FIELD), greaterThan(0));
+                // And that the previous step failed because the SLM policy was missing
+                assertThat(indexILMState.get("previous_step_info"), notNullValue());
+                Map<String, Object> previousStepInfo = (Map<String, Object>) indexILMState.get("previous_step_info");
+                assertThat(previousStepInfo.get("reason"), equalTo("configured policy '" + slmPolicy + "' not found"));
+            }
         }, slmPolicy);
         createSlmPolicy(slmPolicy, snapshotRepo); // put the slm policy back
         assertBusy(() -> {


### PR DESCRIPTION
Test `TimeSeriesLifecycleActionsIT testWaitForSnapshot` is deleting the SLM policy and tries to verify that ILM will fail the `wait-for-snapshot` step.

When ILM fails the `wait-for-snapshot` step it goes into an error step and sets `failed_step` to be `wait-for-snapshot`. This is what this tests was using in the assertion.

However, ILM retries the step periodically and when it retries it move from the step error to `wait-for-snapshot` and unsets the `failed_step`. If these periodic retries align with the `assertBusy`, it's possible to keep failing the assert even what we want to test has happened.

To mitigate that we add an alternative way of checking. If the `failed_step` is not present then we check the following:

- The current step is `wait-for-snapshot`
- This step has been retried at least one time
- The previous step failed because of a missing SLM policy.