### PR TITLE
[9.1] Handle routing shards deprecation in api tests (#141139)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/create/40_routing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/create/40_routing.yml
@@ -1,5 +1,7 @@
 ---
 "Routing":
+ - requires:
+    test_runner_features: [ "allowed_warnings" ]
 
  - do:
      indices.create:
@@ -9,6 +11,8 @@
            index:
              number_of_shards: 5
              number_of_routing_shards: 5
+     allowed_warnings:
+       - "[index.number_of_routing_shards] setting was deprecated in Elasticsearch and will be removed in a future release. See the deprecation documentation for the next major version."
 
  - do:
       create:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/delete/50_refresh.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/delete/50_refresh.yml
@@ -1,7 +1,7 @@
 ---
 "Refresh":
-
-
+ - requires:
+    test_runner_features: [ "allowed_warnings" ]
 
  - do:
       indices.create:
@@ -14,6 +14,8 @@
                   number_of_replicas: 0
                   # make sure that we don't have shard relocations; otherwise search can be executed by a relocated shard
                   routing.rebalance.enable: none
+      allowed_warnings:
+        - "[index.number_of_routing_shards] setting was deprecated in Elasticsearch and will be removed in a future release. See the deprecation documentation for the next major version."
  - do:
       cluster.health:
           wait_for_status: green

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/exists/40_routing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/exists/40_routing.yml
@@ -1,6 +1,7 @@
 ---
 "Routing":
-
+ - requires:
+    test_runner_features: [ "allowed_warnings" ]
 
  - do:
      indices.create:
@@ -10,6 +11,8 @@
            index:
              number_of_shards: 5
              number_of_routing_shards: 5
+     allowed_warnings:
+       - "[index.number_of_routing_shards] setting was deprecated in Elasticsearch and will be removed in a future release. See the deprecation documentation for the next major version."
 
  - do:
       index:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/40_routing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/40_routing.yml
@@ -1,7 +1,7 @@
 ---
 "Routing":
-
-
+ - requires:
+    test_runner_features: [ "allowed_warnings" ]
 
  - do:
      indices.create:
@@ -11,6 +11,8 @@
            index:
              number_of_shards: 5
              number_of_routing_shards: 5
+     allowed_warnings:
+       - "[index.number_of_routing_shards] setting was deprecated in Elasticsearch and will be removed in a future release. See the deprecation documentation for the next major version."
 
  - do:
       index:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get_source/40_routing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get_source/40_routing.yml
@@ -1,8 +1,7 @@
 ---
 "Routing":
-
-
-
+ - requires:
+    test_runner_features: [ "allowed_warnings" ]
 
  - do:
      indices.create:
@@ -12,6 +11,8 @@
            index:
              number_of_shards: 5
              number_of_routing_shards: 5
+     allowed_warnings:
+       - "[index.number_of_routing_shards] setting was deprecated in Elasticsearch and will be removed in a future release. See the deprecation documentation for the next major version."
 
  - do:
       index:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/index/40_routing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/index/40_routing.yml
@@ -1,6 +1,7 @@
 ---
 "Routing":
-
+ - requires:
+    test_runner_features: [ "allowed_warnings" ]
 
  - do:
      indices.create:
@@ -10,6 +11,8 @@
            index:
              number_of_shards: 5
              number_of_routing_shards: 5
+     allowed_warnings:
+       - "[index.number_of_routing_shards] setting was deprecated in Elasticsearch and will be removed in a future release. See the deprecation documentation for the next major version."
 
  - do:
       index:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.split/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.split/10_basic.yml
@@ -1,5 +1,8 @@
 ---
 setup:
+  - requires:
+      test_runner_features: [ "allowed_warnings" ]
+
   - do:
       indices.create:
         index: source
@@ -9,6 +12,8 @@ setup:
             index.number_of_shards: 2
             index.number_of_replicas: 0
             index.number_of_routing_shards: 4
+      allowed_warnings:
+        - "[index.number_of_routing_shards] setting was deprecated in Elasticsearch and will be removed in a future release. See the deprecation documentation for the next major version."
   - do:
       index:
         index: source
@@ -189,6 +194,9 @@ setup:
 
 ---
 "Create illegal split indices":
+  - requires:
+      test_runner_features: [ "allowed_warnings" ]
+
   # try to do an illegal split with number_of_routing_shards set
   - do:
       catch: /illegal_argument_exception/
@@ -202,6 +210,8 @@ setup:
             index.number_of_replicas: 0
             index.number_of_shards: 4
             index.number_of_routing_shards: 8
+      allowed_warnings:
+        - "[index.number_of_routing_shards] setting was deprecated in Elasticsearch and will be removed in a future release. See the deprecation documentation for the next major version."
 
   # try to do an illegal split with illegal number_of_shards
   - do:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.split/20_source_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.split/20_source_mapping.yml
@@ -1,5 +1,7 @@
 ---
 "Split index ignores target template mapping":
+  - requires:
+      test_runner_features: [ "allowed_warnings" ]
 
   # create index
   - do:
@@ -15,6 +17,8 @@
             properties:
               count:
                 type: text
+      allowed_warnings:
+        - "[index.number_of_routing_shards] setting was deprecated in Elasticsearch and will be removed in a future release. See the deprecation documentation for the next major version."
 
   # index document
   - do:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.split/30_copy_settings.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.split/30_copy_settings.yml
@@ -3,6 +3,9 @@
   - skip:
       features: [arbitrary_key]
 
+  - requires:
+      test_runner_features: [ "allowed_warnings" ]
+
   - do:
       nodes.info:
         node_id: data:true
@@ -21,6 +24,8 @@
             index.number_of_shards: 1
             index.number_of_routing_shards: 4
             index.merge.scheduler.max_merge_count: 4
+      allowed_warnings:
+        - "[index.number_of_routing_shards] setting was deprecated in Elasticsearch and will be removed in a future release. See the deprecation documentation for the next major version."
 
   # make it read-only
   - do:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.split/40_routing_partition_size.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.split/40_routing_partition_size.yml
@@ -1,4 +1,7 @@
 more than 1:
+  - requires:
+      test_runner_features: [ "allowed_warnings" ]
+
   - do:
       indices.create:
         index: source
@@ -12,6 +15,8 @@ more than 1:
           mappings:
             _routing:
               required: true
+      allowed_warnings:
+        - "[index.number_of_routing_shards] setting was deprecated in Elasticsearch and will be removed in a future release. See the deprecation documentation for the next major version."
 
   - do:
       index:
@@ -100,6 +105,9 @@ more than 1:
 
 ---
 exactly 1:
+  - requires:
+      test_runner_features: [ "warnings", "allowed_warnings" ]
+
   - do:
       indices.create:
         index: source
@@ -113,6 +121,8 @@ exactly 1:
           mappings:
             _routing:
               required: true
+      allowed_warnings:
+        - "[index.number_of_routing_shards] setting was deprecated in Elasticsearch and will be removed in a future release. See the deprecation documentation for the next major version."
 
   - do:
       index:
@@ -201,6 +211,9 @@ exactly 1:
 
 ---
 nested:
+  - requires:
+      test_runner_features: [ "warnings", "allowed_warnings" ]
+
   - do:
       indices.create:
         index: source
@@ -217,6 +230,8 @@ nested:
             properties:
               n:
                 type: nested
+      allowed_warnings:
+        - "[index.number_of_routing_shards] setting was deprecated in Elasticsearch and will be removed in a future release. See the deprecation documentation for the next major version."
 
   - do:
       index:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.split/50_routing_required.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.split/50_routing_required.yml
@@ -1,4 +1,7 @@
 routing required:
+  - requires:
+      test_runner_features: [ "allowed_warnings" ]
+
   - do:
       indices.create:
         index: source
@@ -11,6 +14,8 @@ routing required:
           mappings:
             _routing:
               required: true
+      allowed_warnings:
+        - "[index.number_of_routing_shards] setting was deprecated in Elasticsearch and will be removed in a future release. See the deprecation documentation for the next major version."
 
   - do:
       index:
@@ -101,6 +106,7 @@ routing required:
 nested:
   - requires:
       cluster_features: ["gte_v8.5.0"]
+      test_runner_features: [ "allowed_warnings" ]
       reason: "fixed in 8.5.0"
 
   - do:
@@ -118,6 +124,8 @@ nested:
             properties:
               n:
                 type: nested
+      allowed_warnings:
+        - "[index.number_of_routing_shards] setting was deprecated in Elasticsearch and will be removed in a future release. See the deprecation documentation for the next major version."
 
   - do:
       index:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.split/60_nested.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.split/60_nested.yml
@@ -1,5 +1,8 @@
 ---
 nested:
+  - requires:
+      test_runner_features: [ "allowed_warnings" ]
+
   - do:
       indices.create:
         index: source
@@ -13,6 +16,8 @@ nested:
             properties:
               n:
                 type: nested
+      allowed_warnings:
+        - "[index.number_of_routing_shards] setting was deprecated in Elasticsearch and will be removed in a future release. See the deprecation documentation for the next major version."
 
   - do:
       index:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mget/40_routing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mget/40_routing.yml
@@ -1,5 +1,8 @@
 ---
 routing:
+  - requires:
+      test_runner_features: [ "allowed_warnings" ]
+
   - do:
       indices.create:
         index:    test_1
@@ -8,6 +11,8 @@ routing:
             index:
               number_of_shards: 5
               number_of_routing_shards: 5
+      allowed_warnings:
+        - "[index.number_of_routing_shards] setting was deprecated in Elasticsearch and will be removed in a future release. See the deprecation documentation for the next major version."
 
   - do:
       index:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/scroll/12_slices.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/scroll/12_slices.yml
@@ -1,5 +1,8 @@
 ---
 setup:
+  - requires:
+      test_runner_features: [ "allowed_warnings" ]
+
   - do:
       indices.create:
         index: test_sliced_scroll
@@ -7,6 +10,8 @@ setup:
           settings:
             number_of_shards: 5
             number_of_routing_shards: 5
+      allowed_warnings:
+        - "[index.number_of_routing_shards] setting was deprecated in Elasticsearch and will be removed in a future release. See the deprecation documentation for the next major version."
 
   - do:
       index:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/update/40_routing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/update/40_routing.yml
@@ -1,7 +1,7 @@
 ---
 "Routing":
-
-
+ - requires:
+    test_runner_features: [ "allowed_warnings" ]
 
  - do:
      indices.create:
@@ -11,6 +11,8 @@
            index:
              number_of_shards: 5
              number_of_routing_shards: 5
+     allowed_warnings:
+       - "[index.number_of_routing_shards] setting was deprecated in Elasticsearch and will be removed in a future release. See the deprecation documentation for the next major version."
 
  - do:
       update:


### PR DESCRIPTION
Backports the following commits to 9.1:
 - Handle routing shards deprecation in api tests (#141139)