### PR TITLE
Precompute next and previous group ids for rate

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateDoubleGroupingAggregatorFunction.java
@@ -564,16 +564,11 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
     public void evaluateFinal(Block[] blocks, int offset, IntVector selected, GroupingAggregatorEvaluationContext evalContext) {
         BlockFactory blockFactory = driverContext.blockFactory();
         int positionCount = selected.getPositionCount();
-        try (
-            var flushQueues = rawBuffer.prepareForFlush();
-            var rates = blockFactory.newDoubleBlockBuilder(positionCount);
-            var flushedStates = new LongObjectPagedHashMap<ReducedState>(positionCount, bigArrays)
-        ) {
+        try (var flushQueues = rawBuffer.prepareForFlush(); var rates = blockFactory.newDoubleBlockBuilder(positionCount)) {
             for (int p = 0; p < positionCount; p++) {
                 int group = selected.getInt(p);
                 var state = flushAndCombineState(flushQueues, group);
                 if (state != null) {
-                    flushedStates.put(group, state);
                     // combine intervals for the final evaluation
                     Interval[] intervals = state.intervals;
                     ArrayUtil.timSort(intervals);
@@ -586,15 +581,18 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
                     }
                 }
             }
+            if (evalContext instanceof TimeSeriesGroupingAggregatorEvaluationContext tsContext) {
+                tsContext.computeAdjacentGroupIds();
+            }
             for (int p = 0; p < positionCount; p++) {
                 int group = selected.getInt(p);
-                var state = flushedStates.get(group);
+                var state = group < reducedStates.size() ? reducedStates.get(group) : null;
 
                 final double rate;
                 if (state == null || state.samples == 0) {
                     rate = Double.NaN;
                 } else if (evalContext instanceof TimeSeriesGroupingAggregatorEvaluationContext tsContext) {
-                    rate = computeRate(flushedStates, group, tsContext, isRateOverTime, dateFactor);
+                    rate = computeRate(group, state, tsContext, isRateOverTime, dateFactor);
                 } else {
                     rate = computeRateWithoutExtrapolate(state, isRateOverTime, dateFactor);
                 }
@@ -668,7 +666,7 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
         }
     }
 
-    private static double computeRateWithoutExtrapolate(ReducedState state, boolean isRateOverTime, double dateFactor) {
+    private double computeRateWithoutExtrapolate(ReducedState state, boolean isRateOverTime, double dateFactor) {
         if (state.samples < 2) {
             return Double.NaN;
         }
@@ -687,14 +685,13 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
      * Computes the rate for a given group by interpolating boundary values with adjacent groups,
      * or extrapolating values at the time bucket boundaries.
      */
-    private static double computeRate(
-        LongObjectPagedHashMap<ReducedState> states,
+    private double computeRate(
         int group,
+        ReducedState state,
         TimeSeriesGroupingAggregatorEvaluationContext tsContext,
         boolean isRateOverTime,
         double dateFactor
     ) {
-        var state = states.get(group);
         final double tbucketStart = tsContext.rangeStartInMillis(group) / 1000.0;
         final double tbucketEnd = tsContext.rangeEndInMillis(group) / 1000.0;
         final double firstValue;
@@ -703,7 +700,7 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
         double lastTsSec = tbucketEnd;
 
         int previousGroupId = tsContext.previousGroupId(group);
-        var previousState = (previousGroupId >= 0) ? states.get(previousGroupId) : null;
+        var previousState = (0 <= previousGroupId && previousGroupId < reducedStates.size()) ? reducedStates.get(previousGroupId) : null;
         if (previousState == null || previousState.samples == 0) {
             if (state.samples == 1) {
                 firstTsSec = state.intervals[0].t1 / dateFactor;
@@ -716,7 +713,7 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
         }
 
         int nextGroupId = tsContext.nextGroupId(group);
-        var nextState = (nextGroupId >= 0) ? states.get(nextGroupId) : null;
+        var nextState = (nextGroupId >= 0 && nextGroupId < reducedStates.size()) ? reducedStates.get(nextGroupId) : null;
         if (nextState == null || nextState.samples == 0) {
             if (state.samples == 1) {
                 lastTsSec = state.intervals[0].t1 / dateFactor;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateDoubleGroupingAggregatorFunction.java
@@ -568,7 +568,7 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
             for (int p = 0; p < positionCount; p++) {
                 int group = selected.getInt(p);
                 var state = flushAndCombineState(flushQueues, group);
-                if (state != null) {
+                if (state != null && state.samples > 1 && state.intervals.length > 1) {
                     // combine intervals for the final evaluation
                     Interval[] intervals = state.intervals;
                     ArrayUtil.timSort(intervals);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateDoubleGroupingAggregatorFunction.java
@@ -567,7 +567,16 @@ public final class RateDoubleGroupingAggregatorFunction extends AbstractRateGrou
         try (var flushQueues = rawBuffer.prepareForFlush(); var rates = blockFactory.newDoubleBlockBuilder(positionCount)) {
             for (int p = 0; p < positionCount; p++) {
                 int group = selected.getInt(p);
-                var state = flushAndCombineState(flushQueues, group);
+                var state = group < reducedStates.size() ? reducedStates.get(group) : null;
+                var flushQueue = flushQueues.getFlushQueue(group);
+                if (flushQueue != null) {
+                    if (state == null) {
+                        state = new ReducedState();
+                        reducedStates = bigArrays.grow(reducedStates, group + 1);
+                        reducedStates.set(group, state);
+                    }
+                    flushGroup(state, rawBuffer, flushQueue);
+                }
                 if (state != null && state.samples > 1 && state.intervals.length > 1) {
                     // combine intervals for the final evaluation
                     Interval[] intervals = state.intervals;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
@@ -567,7 +567,16 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
         try (var flushQueues = rawBuffer.prepareForFlush(); var rates = blockFactory.newDoubleBlockBuilder(positionCount)) {
             for (int p = 0; p < positionCount; p++) {
                 int group = selected.getInt(p);
-                var state = flushAndCombineState(flushQueues, group);
+                var state = group < reducedStates.size() ? reducedStates.get(group) : null;
+                var flushQueue = flushQueues.getFlushQueue(group);
+                if (flushQueue != null) {
+                    if (state == null) {
+                        state = new ReducedState();
+                        reducedStates = bigArrays.grow(reducedStates, group + 1);
+                        reducedStates.set(group, state);
+                    }
+                    flushGroup(state, rawBuffer, flushQueue);
+                }
                 if (state != null && state.samples > 1 && state.intervals.length > 1) {
                     // combine intervals for the final evaluation
                     Interval[] intervals = state.intervals;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
@@ -564,16 +564,11 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
     public void evaluateFinal(Block[] blocks, int offset, IntVector selected, GroupingAggregatorEvaluationContext evalContext) {
         BlockFactory blockFactory = driverContext.blockFactory();
         int positionCount = selected.getPositionCount();
-        try (
-            var flushQueues = rawBuffer.prepareForFlush();
-            var rates = blockFactory.newDoubleBlockBuilder(positionCount);
-            var flushedStates = new LongObjectPagedHashMap<ReducedState>(positionCount, bigArrays)
-        ) {
+        try (var flushQueues = rawBuffer.prepareForFlush(); var rates = blockFactory.newDoubleBlockBuilder(positionCount)) {
             for (int p = 0; p < positionCount; p++) {
                 int group = selected.getInt(p);
                 var state = flushAndCombineState(flushQueues, group);
                 if (state != null) {
-                    flushedStates.put(group, state);
                     // combine intervals for the final evaluation
                     Interval[] intervals = state.intervals;
                     ArrayUtil.timSort(intervals);
@@ -586,15 +581,18 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
                     }
                 }
             }
+            if (evalContext instanceof TimeSeriesGroupingAggregatorEvaluationContext tsContext) {
+                tsContext.computeAdjacentGroupIds();
+            }
             for (int p = 0; p < positionCount; p++) {
                 int group = selected.getInt(p);
-                var state = flushedStates.get(group);
+                var state = group < reducedStates.size() ? reducedStates.get(group) : null;
 
                 final double rate;
                 if (state == null || state.samples == 0) {
                     rate = Double.NaN;
                 } else if (evalContext instanceof TimeSeriesGroupingAggregatorEvaluationContext tsContext) {
-                    rate = computeRate(flushedStates, group, tsContext, isRateOverTime, dateFactor);
+                    rate = computeRate(group, state, tsContext, isRateOverTime, dateFactor);
                 } else {
                     rate = computeRateWithoutExtrapolate(state, isRateOverTime, dateFactor);
                 }
@@ -668,7 +666,7 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
         }
     }
 
-    private static double computeRateWithoutExtrapolate(ReducedState state, boolean isRateOverTime, double dateFactor) {
+    private double computeRateWithoutExtrapolate(ReducedState state, boolean isRateOverTime, double dateFactor) {
         if (state.samples < 2) {
             return Double.NaN;
         }
@@ -687,14 +685,13 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
      * Computes the rate for a given group by interpolating boundary values with adjacent groups,
      * or extrapolating values at the time bucket boundaries.
      */
-    private static double computeRate(
-        LongObjectPagedHashMap<ReducedState> states,
+    private double computeRate(
         int group,
+        ReducedState state,
         TimeSeriesGroupingAggregatorEvaluationContext tsContext,
         boolean isRateOverTime,
         double dateFactor
     ) {
-        var state = states.get(group);
         final double tbucketStart = tsContext.rangeStartInMillis(group) / 1000.0;
         final double tbucketEnd = tsContext.rangeEndInMillis(group) / 1000.0;
         final double firstValue;
@@ -703,7 +700,7 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
         double lastTsSec = tbucketEnd;
 
         int previousGroupId = tsContext.previousGroupId(group);
-        var previousState = (previousGroupId >= 0) ? states.get(previousGroupId) : null;
+        var previousState = (0 <= previousGroupId && previousGroupId < reducedStates.size()) ? reducedStates.get(previousGroupId) : null;
         if (previousState == null || previousState.samples == 0) {
             if (state.samples == 1) {
                 firstTsSec = state.intervals[0].t1 / dateFactor;
@@ -716,7 +713,7 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
         }
 
         int nextGroupId = tsContext.nextGroupId(group);
-        var nextState = (nextGroupId >= 0) ? states.get(nextGroupId) : null;
+        var nextState = (nextGroupId >= 0 && nextGroupId < reducedStates.size()) ? reducedStates.get(nextGroupId) : null;
         if (nextState == null || nextState.samples == 0) {
             if (state.samples == 1) {
                 lastTsSec = state.intervals[0].t1 / dateFactor;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
@@ -568,7 +568,7 @@ public final class RateIntGroupingAggregatorFunction extends AbstractRateGroupin
             for (int p = 0; p < positionCount; p++) {
                 int group = selected.getInt(p);
                 var state = flushAndCombineState(flushQueues, group);
-                if (state != null) {
+                if (state != null && state.samples > 1 && state.intervals.length > 1) {
                     // combine intervals for the final evaluation
                     Interval[] intervals = state.intervals;
                     ArrayUtil.timSort(intervals);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateLongGroupingAggregatorFunction.java
@@ -568,7 +568,7 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
             for (int p = 0; p < positionCount; p++) {
                 int group = selected.getInt(p);
                 var state = flushAndCombineState(flushQueues, group);
-                if (state != null) {
+                if (state != null && state.samples > 1 && state.intervals.length > 1) {
                     // combine intervals for the final evaluation
                     Interval[] intervals = state.intervals;
                     ArrayUtil.timSort(intervals);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateLongGroupingAggregatorFunction.java
@@ -564,16 +564,11 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
     public void evaluateFinal(Block[] blocks, int offset, IntVector selected, GroupingAggregatorEvaluationContext evalContext) {
         BlockFactory blockFactory = driverContext.blockFactory();
         int positionCount = selected.getPositionCount();
-        try (
-            var flushQueues = rawBuffer.prepareForFlush();
-            var rates = blockFactory.newDoubleBlockBuilder(positionCount);
-            var flushedStates = new LongObjectPagedHashMap<ReducedState>(positionCount, bigArrays)
-        ) {
+        try (var flushQueues = rawBuffer.prepareForFlush(); var rates = blockFactory.newDoubleBlockBuilder(positionCount)) {
             for (int p = 0; p < positionCount; p++) {
                 int group = selected.getInt(p);
                 var state = flushAndCombineState(flushQueues, group);
                 if (state != null) {
-                    flushedStates.put(group, state);
                     // combine intervals for the final evaluation
                     Interval[] intervals = state.intervals;
                     ArrayUtil.timSort(intervals);
@@ -586,15 +581,18 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
                     }
                 }
             }
+            if (evalContext instanceof TimeSeriesGroupingAggregatorEvaluationContext tsContext) {
+                tsContext.computeAdjacentGroupIds();
+            }
             for (int p = 0; p < positionCount; p++) {
                 int group = selected.getInt(p);
-                var state = flushedStates.get(group);
+                var state = group < reducedStates.size() ? reducedStates.get(group) : null;
 
                 final double rate;
                 if (state == null || state.samples == 0) {
                     rate = Double.NaN;
                 } else if (evalContext instanceof TimeSeriesGroupingAggregatorEvaluationContext tsContext) {
-                    rate = computeRate(flushedStates, group, tsContext, isRateOverTime, dateFactor);
+                    rate = computeRate(group, state, tsContext, isRateOverTime, dateFactor);
                 } else {
                     rate = computeRateWithoutExtrapolate(state, isRateOverTime, dateFactor);
                 }
@@ -668,7 +666,7 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
         }
     }
 
-    private static double computeRateWithoutExtrapolate(ReducedState state, boolean isRateOverTime, double dateFactor) {
+    private double computeRateWithoutExtrapolate(ReducedState state, boolean isRateOverTime, double dateFactor) {
         if (state.samples < 2) {
             return Double.NaN;
         }
@@ -687,14 +685,13 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
      * Computes the rate for a given group by interpolating boundary values with adjacent groups,
      * or extrapolating values at the time bucket boundaries.
      */
-    private static double computeRate(
-        LongObjectPagedHashMap<ReducedState> states,
+    private double computeRate(
         int group,
+        ReducedState state,
         TimeSeriesGroupingAggregatorEvaluationContext tsContext,
         boolean isRateOverTime,
         double dateFactor
     ) {
-        var state = states.get(group);
         final double tbucketStart = tsContext.rangeStartInMillis(group) / 1000.0;
         final double tbucketEnd = tsContext.rangeEndInMillis(group) / 1000.0;
         final double firstValue;
@@ -703,7 +700,7 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
         double lastTsSec = tbucketEnd;
 
         int previousGroupId = tsContext.previousGroupId(group);
-        var previousState = (previousGroupId >= 0) ? states.get(previousGroupId) : null;
+        var previousState = (0 <= previousGroupId && previousGroupId < reducedStates.size()) ? reducedStates.get(previousGroupId) : null;
         if (previousState == null || previousState.samples == 0) {
             if (state.samples == 1) {
                 firstTsSec = state.intervals[0].t1 / dateFactor;
@@ -716,7 +713,7 @@ public final class RateLongGroupingAggregatorFunction extends AbstractRateGroupi
         }
 
         int nextGroupId = tsContext.nextGroupId(group);
-        var nextState = (nextGroupId >= 0) ? states.get(nextGroupId) : null;
+        var nextState = (nextGroupId >= 0 && nextGroupId < reducedStates.size()) ? reducedStates.get(nextGroupId) : null;
         if (nextState == null || nextState.samples == 0) {
             if (state.samples == 1) {
                 lastTsSec = state.intervals[0].t1 / dateFactor;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/GroupingAggregatorEvaluationContext.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/GroupingAggregatorEvaluationContext.java
@@ -9,12 +9,13 @@ package org.elasticsearch.compute.aggregation;
 
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.core.Releasable;
 
 /**
  * Provides a context for evaluating a grouping aggregator.
  * A time-series aggregator might need more than just the DriverContext to evaluate, such as the range interval of each group.
  */
-public class GroupingAggregatorEvaluationContext {
+public class GroupingAggregatorEvaluationContext implements Releasable {
     private final DriverContext driverContext;
 
     public GroupingAggregatorEvaluationContext(DriverContext driverContext) {
@@ -27,5 +28,10 @@ public class GroupingAggregatorEvaluationContext {
 
     public BlockFactory blockFactory() {
         return driverContext.blockFactory();
+    }
+
+    @Override
+    public void close() {
+
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/TimeSeriesGroupingAggregatorEvaluationContext.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/TimeSeriesGroupingAggregatorEvaluationContext.java
@@ -46,4 +46,9 @@ public abstract class TimeSeriesGroupingAggregatorEvaluationContext extends Grou
     public abstract int previousGroupId(int currentGroupId);
 
     public abstract int nextGroupId(int currentGroupId);
+
+    /**
+     * Computes and caches the adjacent group IDs. They weill be used in #previousGroupId and #nextGroupId.
+     */
+    public abstract void computeAdjacentGroupIds();
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/WindowGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/WindowGroupingAggregatorFunction.java
@@ -133,6 +133,11 @@ public record WindowGroupingAggregatorFunction(GroupingAggregatorFunction next, 
                     public int nextGroupId(int currentGroupId) {
                         return -1;
                     }
+
+                    @Override
+                    public void computeAdjacentGroupIds() {
+                        // not used by #nextGroupId and #previousGroupId
+                    }
                 }
             );
         }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-RateGroupingAggregatorFunction.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-RateGroupingAggregatorFunction.java.st
@@ -564,16 +564,11 @@ public final class Rate$Type$GroupingAggregatorFunction extends AbstractRateGrou
     public void evaluateFinal(Block[] blocks, int offset, IntVector selected, GroupingAggregatorEvaluationContext evalContext) {
         BlockFactory blockFactory = driverContext.blockFactory();
         int positionCount = selected.getPositionCount();
-        try (
-            var flushQueues = rawBuffer.prepareForFlush();
-            var rates = blockFactory.newDoubleBlockBuilder(positionCount);
-            var flushedStates = new LongObjectPagedHashMap<ReducedState>(positionCount, bigArrays)
-        ) {
+        try (var flushQueues = rawBuffer.prepareForFlush(); var rates = blockFactory.newDoubleBlockBuilder(positionCount)) {
             for (int p = 0; p < positionCount; p++) {
                 int group = selected.getInt(p);
                 var state = flushAndCombineState(flushQueues, group);
                 if (state != null) {
-                    flushedStates.put(group, state);
                     // combine intervals for the final evaluation
                     Interval[] intervals = state.intervals;
                     ArrayUtil.timSort(intervals);
@@ -586,15 +581,18 @@ public final class Rate$Type$GroupingAggregatorFunction extends AbstractRateGrou
                     }
                 }
             }
+            if (evalContext instanceof TimeSeriesGroupingAggregatorEvaluationContext tsContext) {
+                tsContext.computeAdjacentGroupIds();
+            }
             for (int p = 0; p < positionCount; p++) {
                 int group = selected.getInt(p);
-                var state = flushedStates.get(group);
+                var state = group < reducedStates.size() ? reducedStates.get(group) : null;
 
                 final double rate;
                 if (state == null || state.samples == 0) {
                     rate = Double.NaN;
                 } else if (evalContext instanceof TimeSeriesGroupingAggregatorEvaluationContext tsContext) {
-                    rate = computeRate(flushedStates, group, tsContext, isRateOverTime, dateFactor);
+                    rate = computeRate(group, state, tsContext, isRateOverTime, dateFactor);
                 } else {
                     rate = computeRateWithoutExtrapolate(state, isRateOverTime, dateFactor);
                 }
@@ -668,7 +666,7 @@ public final class Rate$Type$GroupingAggregatorFunction extends AbstractRateGrou
         }
     }
 
-    private static double computeRateWithoutExtrapolate(ReducedState state, boolean isRateOverTime, double dateFactor) {
+    private double computeRateWithoutExtrapolate(ReducedState state, boolean isRateOverTime, double dateFactor) {
         if (state.samples < 2) {
             return Double.NaN;
         }
@@ -687,14 +685,13 @@ public final class Rate$Type$GroupingAggregatorFunction extends AbstractRateGrou
      * Computes the rate for a given group by interpolating boundary values with adjacent groups,
      * or extrapolating values at the time bucket boundaries.
      */
-    private static double computeRate(
-        LongObjectPagedHashMap<ReducedState> states,
+    private double computeRate(
         int group,
+        ReducedState state,
         TimeSeriesGroupingAggregatorEvaluationContext tsContext,
         boolean isRateOverTime,
         double dateFactor
     ) {
-        var state = states.get(group);
         final double tbucketStart = tsContext.rangeStartInMillis(group) / 1000.0;
         final double tbucketEnd = tsContext.rangeEndInMillis(group) / 1000.0;
         final double firstValue;
@@ -703,7 +700,7 @@ public final class Rate$Type$GroupingAggregatorFunction extends AbstractRateGrou
         double lastTsSec = tbucketEnd;
 
         int previousGroupId = tsContext.previousGroupId(group);
-        var previousState = (previousGroupId >= 0) ? states.get(previousGroupId) : null;
+        var previousState = (0 <= previousGroupId && previousGroupId < reducedStates.size()) ? reducedStates.get(previousGroupId) : null;
         if (previousState == null || previousState.samples == 0) {
             if (state.samples == 1) {
                 firstTsSec = state.intervals[0].t1 / dateFactor;
@@ -716,7 +713,7 @@ public final class Rate$Type$GroupingAggregatorFunction extends AbstractRateGrou
         }
 
         int nextGroupId = tsContext.nextGroupId(group);
-        var nextState = (nextGroupId >= 0) ? states.get(nextGroupId) : null;
+        var nextState = (nextGroupId >= 0 && nextGroupId < reducedStates.size()) ? reducedStates.get(nextGroupId) : null;
         if (nextState == null || nextState.samples == 0) {
             if (state.samples == 1) {
                 lastTsSec = state.intervals[0].t1 / dateFactor;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-RateGroupingAggregatorFunction.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-RateGroupingAggregatorFunction.java.st
@@ -568,7 +568,7 @@ public final class Rate$Type$GroupingAggregatorFunction extends AbstractRateGrou
             for (int p = 0; p < positionCount; p++) {
                 int group = selected.getInt(p);
                 var state = flushAndCombineState(flushQueues, group);
-                if (state != null) {
+                if (state != null && state.samples > 1 && state.intervals.length > 1) {
                     // combine intervals for the final evaluation
                     Interval[] intervals = state.intervals;
                     ArrayUtil.timSort(intervals);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-RateGroupingAggregatorFunction.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-RateGroupingAggregatorFunction.java.st
@@ -567,7 +567,16 @@ public final class Rate$Type$GroupingAggregatorFunction extends AbstractRateGrou
         try (var flushQueues = rawBuffer.prepareForFlush(); var rates = blockFactory.newDoubleBlockBuilder(positionCount)) {
             for (int p = 0; p < positionCount; p++) {
                 int group = selected.getInt(p);
-                var state = flushAndCombineState(flushQueues, group);
+                var state = group < reducedStates.size() ? reducedStates.get(group) : null;
+                var flushQueue = flushQueues.getFlushQueue(group);
+                if (flushQueue != null) {
+                    if (state == null) {
+                        state = new ReducedState();
+                        reducedStates = bigArrays.grow(reducedStates, group + 1);
+                        reducedStates.set(group, state);
+                    }
+                    flushGroup(state, rawBuffer, flushQueue);
+                }
                 if (state != null && state.samples > 1 && state.intervals.length > 1) {
                     // combine intervals for the final evaluation
                     Interval[] intervals = state.intervals;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/HashAggregationOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/HashAggregationOperator.java
@@ -236,14 +236,15 @@ public class HashAggregationOperator implements Operator {
             blocks = new Block[keys.length + Arrays.stream(aggBlockCounts).sum()];
             System.arraycopy(keys, 0, blocks, 0, keys.length);
             int offset = keys.length;
-            var evaluationContext = evaluationContext(blockHash, keys);
-            for (int i = 0; i < aggregators.size(); i++) {
-                var aggregator = aggregators.get(i);
-                evaluateAggregator(aggregator, blocks, offset, selected, evaluationContext);
-                offset += aggBlockCounts[i];
+            try (var evaluationContext = evaluationContext(blockHash, keys)) {
+                for (int i = 0; i < aggregators.size(); i++) {
+                    var aggregator = aggregators.get(i);
+                    evaluateAggregator(aggregator, blocks, offset, selected, evaluationContext);
+                    offset += aggBlockCounts[i];
+                }
+                output = new Page(blocks);
+                success = true;
             }
-            output = new Page(blocks);
-            success = true;
         } finally {
             // selected should always be closed
             if (selected != null) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperator.java
@@ -34,7 +34,9 @@ import org.elasticsearch.index.mapper.DateFieldMapper;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -311,8 +313,34 @@ public class TimeSeriesAggregationOperator extends HashAggregationOperator {
         final BytesRefLongBlockHash hash = (BytesRefLongBlockHash) blockHash;
 
         final LongBlock timestamps = keys[0].elementType() == ElementType.LONG ? (LongBlock) keys[0] : (LongBlock) keys[1];
+
         // block hash so that we can look key
         return new TimeSeriesGroupingAggregatorEvaluationContext(driverContext) {
+            IntArray prevGroupIds;
+            IntArray nextGroupIds;
+
+            void maybeComputeGroupLinks() {
+                if (nextGroupIds != null) {
+                    return;
+                }
+                long numGroups = hash.numGroups();
+                nextGroupIds = driverContext.bigArrays().newIntArray(numGroups);
+                nextGroupIds.fill(0, numGroups, -1);
+                prevGroupIds = driverContext.bigArrays().newIntArray(numGroups);
+                prevGroupIds.fill(0, numGroups, -1);
+                Map<Long, Long> nextTimestamps = new HashMap<>(); // cached the rounded up timestamps
+                for (int groupId = 0; groupId < numGroups; groupId++) {
+                    long tsid = hash.getBytesRefKeyFromGroup(groupId);
+                    long bucketTs = hash.getLongKeyFromGroup(groupId);
+                    long nextBucketTs = nextTimestamps.computeIfAbsent(bucketTs, timeBucket::nextRoundingValue);
+                    int nextGroupId = Math.toIntExact(hash.getGroupId(tsid, nextBucketTs));
+                    if (nextGroupId >= 0) {
+                        nextGroupIds.set(groupId, nextGroupId);
+                        prevGroupIds.set(nextGroupId, groupId);
+                    }
+                }
+            }
+
             @Override
             public long rangeStartInMillis(int groupId) {
                 return timeResolution.roundDownToMillis(timestamps.getLong(groupId));
@@ -341,19 +369,19 @@ public class TimeSeriesAggregationOperator extends HashAggregationOperator {
 
             @Override
             public int previousGroupId(int currentGroupId) {
-                long tsid = hash.getBytesRefKeyFromGroup(currentGroupId);
-                long currentBucketTs = timestamps.getLong(currentGroupId);
-                long nextBucketTs = timeBucket.nextRoundingValue(currentBucketTs);
-                long previousBucketTS = currentBucketTs - (nextBucketTs - currentBucketTs);
-                return Math.toIntExact(hash.getGroupId(tsid, previousBucketTS));
+                maybeComputeGroupLinks();
+                return prevGroupIds.get(currentGroupId);
             }
 
             @Override
             public int nextGroupId(int currentGroupId) {
-                long tsid = hash.getBytesRefKeyFromGroup(currentGroupId);
-                long currentBucketTs = timestamps.getLong(currentGroupId);
-                long nextBucketTs = timeBucket.nextRoundingValue(currentBucketTs);
-                return Math.toIntExact(hash.getGroupId(tsid, nextBucketTs));
+                maybeComputeGroupLinks();
+                return nextGroupIds.get(currentGroupId);
+            }
+
+            @Override
+            public void close() {
+                Releasables.close(nextGroupIds, prevGroupIds, super::close);
             }
         };
     }


### PR DESCRIPTION
Today, during rate extrapolation, we access the previous and next groups to find adjacent data points. This process can be slow with many groups; for example, with 1.7M groups, it can take several seconds.

This change iterates through the groups once to populate the previous and next group links, avoiding redundant work.

Benchmarking with 10k_hosts_rate_5m shows execution time reduced from 54s to 43s, and the emit process from 26.8s to 15s. It remains slow, though.

We should consider computing rates concurrently among groups if the number of entries exceeds 100k.