### PR TITLE
[9.2] Allow resolveTransportVersionConflict to run without compilation (#140851)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/AbstractGenerateTransportVersionDefinitionTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/AbstractGenerateTransportVersionDefinitionTask.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.gradle.internal.transport;
+
+import org.elasticsearch.gradle.internal.transport.TransportVersionResourcesService.IdAndDefinition;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.services.ServiceReference;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.options.Option;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public abstract class AbstractGenerateTransportVersionDefinitionTask extends DefaultTask {
+
+    @ServiceReference("transportVersionResources")
+    abstract Property<TransportVersionResourcesService> getResourceService();
+
+    @Input
+    @Optional
+    @Option(option = "increment", description = "The amount to increment the id from the current upper bounds file by")
+    public abstract Property<Integer> getIncrement();
+
+    /**
+     * The name of the upper bounds file which will be used at runtime on the current branch. Normally
+     * this equates to VersionProperties.getElasticsearchVersion().
+     */
+    @Input
+    public abstract Property<String> getCurrentUpperBoundName();
+
+    /**
+     * An additional upper bound file that will be consulted when generating a transport version.
+     * The larger of this and the current upper bound will be used to create the new primary id.
+     */
+    @InputFile
+    @Optional
+    public abstract RegularFileProperty getAlternateUpperBoundFile();
+
+    protected abstract void runGeneration(TransportVersionResourcesService resources, List<TransportVersionUpperBound> upstreamUpperBounds)
+        throws IOException;
+
+    protected abstract Set<String> getTargetUpperBoundNames(
+        TransportVersionResourcesService resources,
+        List<TransportVersionUpperBound> upstreamUpperBounds,
+        String targetDefinitionName
+    ) throws IOException;
+
+    protected abstract void writeUpperBound(TransportVersionResourcesService resources, TransportVersionUpperBound newUpperBound)
+        throws IOException;
+
+    @TaskAction
+    public void run() throws IOException {
+        TransportVersionResourcesService resources = getResourceService().get();
+        List<TransportVersionUpperBound> upstreamUpperBounds = resources.getUpperBoundsFromGitBase();
+        boolean onReleaseBranch = resources.checkIfDefinitelyOnReleaseBranch(upstreamUpperBounds, getCurrentUpperBoundName().get());
+        if (onReleaseBranch) {
+            throw new IllegalArgumentException("Transport version generation cannot run on release branches");
+        }
+
+        runGeneration(resources, upstreamUpperBounds);
+    }
+
+    protected void generateTransportVersionDefinition(
+        TransportVersionResourcesService resources,
+        String targetDefinitionName,
+        List<TransportVersionUpperBound> upstreamUpperBounds,
+        Map<Integer, List<IdAndDefinition>> idsByBase
+    ) throws IOException {
+        getLogger().lifecycle("Generating transport version name: " + targetDefinitionName);
+
+        Set<String> targetUpperBoundNames = getTargetUpperBoundNames(resources, upstreamUpperBounds, targetDefinitionName);
+
+        List<TransportVersionId> ids = updateUpperBounds(
+            resources,
+            upstreamUpperBounds,
+            targetUpperBoundNames,
+            idsByBase,
+            targetDefinitionName
+        );
+        // (Re)write the definition file.
+        resources.writeDefinition(new TransportVersionDefinition(targetDefinitionName, ids, true));
+    }
+
+    private List<TransportVersionId> updateUpperBounds(
+        TransportVersionResourcesService resources,
+        List<TransportVersionUpperBound> existingUpperBounds,
+        Set<String> targetUpperBoundNames,
+        Map<Integer, List<IdAndDefinition>> idsByBase,
+        String definitionName
+    ) throws IOException {
+        String currentUpperBoundName = getCurrentUpperBoundName().get();
+        int increment = getIncrement().get();
+        if (increment <= 0) {
+            throw new IllegalArgumentException("Invalid increment " + increment + ", must be a positive integer");
+        }
+        if (increment > 1000) {
+            throw new IllegalArgumentException("Invalid increment " + increment + ", must be no larger than 1000");
+        }
+        List<TransportVersionId> ids = new ArrayList<>();
+
+        TransportVersionDefinition existingDefinition = resources.getReferableDefinitionFromGitBase(definitionName);
+        for (TransportVersionUpperBound existingUpperBound : existingUpperBounds) {
+            String upperBoundName = existingUpperBound.name();
+
+            if (targetUpperBoundNames.contains(upperBoundName)) {
+                // Case: targeting this upper bound, find an existing id if it exists
+                TransportVersionId targetId = maybeGetExistingId(existingUpperBound, existingDefinition, definitionName);
+                if (targetId == null) {
+                    // Case: an id doesn't yet exist for this upper bound, so create one
+                    int targetIncrement = upperBoundName.equals(currentUpperBoundName) ? increment : 1;
+                    targetId = createTargetId(existingUpperBound, targetIncrement);
+                    var newUpperBound = new TransportVersionUpperBound(upperBoundName, definitionName, targetId);
+                    writeUpperBound(resources, newUpperBound);
+                }
+                ids.add(targetId);
+            } else if (resources.getChangedUpperBoundNames().contains(upperBoundName)) {
+                // Default case: we're not targeting this branch so reset it
+                resetUpperBound(resources, existingUpperBound, idsByBase, definitionName);
+            }
+        }
+
+        Collections.sort(ids);
+        return ids;
+    }
+
+    private void resetUpperBound(
+        TransportVersionResourcesService resources,
+        TransportVersionUpperBound upperBound,
+        Map<Integer, List<IdAndDefinition>> idsByBase,
+        String ignoreDefinitionName
+    ) throws IOException {
+        List<IdAndDefinition> idsForUpperBound = idsByBase.get(upperBound.definitionId().base());
+        if (idsForUpperBound == null) {
+            throw new RuntimeException("Could not find base id: " + upperBound.definitionId().base());
+        }
+        IdAndDefinition resetValue = idsForUpperBound.getLast();
+        if (resetValue.definition().name().equals(ignoreDefinitionName)) {
+            // there must be another definition in this base since the ignored definition is new
+            assert idsForUpperBound.size() >= 2;
+            resetValue = idsForUpperBound.get(idsForUpperBound.size() - 2);
+        }
+        var resetUpperBound = new TransportVersionUpperBound(upperBound.name(), resetValue.definition().name(), resetValue.id());
+        resources.writeUpperBound(resetUpperBound, false);
+    }
+
+    private TransportVersionId maybeGetExistingId(
+        TransportVersionUpperBound upperBound,
+        TransportVersionDefinition existingDefinition,
+        String name
+    ) {
+        if (existingDefinition == null) {
+            // the name doesn't yet exist, so there is no id to return
+            return null;
+        }
+        if (upperBound.definitionName().equals(name)) {
+            // the name exists and this upper bound already points at it
+            return upperBound.definitionId();
+        }
+        if (upperBound.name().equals(getCurrentUpperBoundName().get())) {
+            // this is the upper bound of the current branch, so use the primary id
+            return existingDefinition.ids().getFirst();
+        }
+        // the upper bound is for a non-current branch, so find the id with the same base
+        for (TransportVersionId id : existingDefinition.ids()) {
+            if (id.base() == upperBound.definitionId().base()) {
+                return id;
+            }
+        }
+        return null; // no existing id for this upper bound
+    }
+
+    private TransportVersionId createTargetId(TransportVersionUpperBound existingUpperBound, int increment) throws IOException {
+        int currentId = existingUpperBound.definitionId().complete();
+
+        // allow for an alternate upper bound file to be consulted. This supports Serverless basing its
+        // own transport version ids on the greater of server or serverless
+        if (getAlternateUpperBoundFile().isPresent()) {
+            Path altUpperBoundPath = getAlternateUpperBoundFile().get().getAsFile().toPath();
+            String contents = Files.readString(altUpperBoundPath, StandardCharsets.UTF_8);
+            var altUpperBound = TransportVersionUpperBound.fromString(altUpperBoundPath, contents);
+            if (altUpperBound.definitionId().complete() > currentId) {
+                currentId = altUpperBound.definitionId().complete();
+            }
+        }
+
+        return TransportVersionId.fromInt(currentId + increment);
+    }
+}

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/GenerateTransportVersionDefinitionTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/GenerateTransportVersionDefinitionTask.java
@@ -10,26 +10,17 @@
 package org.elasticsearch.gradle.internal.transport;
 
 import org.elasticsearch.gradle.internal.transport.TransportVersionResourcesService.IdAndDefinition;
-import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
-import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
-import org.gradle.api.services.ServiceReference;
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
-import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -44,7 +35,7 @@ import java.util.Set;
  * Additionally, when definition files are added or updated, the upper bounds files
  * for each relevant branch's upper bound file are also updated.
  */
-public abstract class GenerateTransportVersionDefinitionTask extends DefaultTask {
+public abstract class GenerateTransportVersionDefinitionTask extends AbstractGenerateTransportVersionDefinitionTask {
 
     /**
      * Files that contain the references to the transport version names.
@@ -52,9 +43,6 @@ public abstract class GenerateTransportVersionDefinitionTask extends DefaultTask
     @InputFiles
     @PathSensitive(PathSensitivity.RELATIVE)
     public abstract ConfigurableFileCollection getReferencesFiles();
-
-    @ServiceReference("transportVersionResources")
-    abstract Property<TransportVersionResourcesService> getResourceService();
 
     @Input
     @Optional
@@ -69,39 +57,9 @@ public abstract class GenerateTransportVersionDefinitionTask extends DefaultTask
     )
     public abstract Property<String> getBackportBranches();
 
-    @Input
-    @Optional
-    @Option(option = "increment", description = "The amount to increment the id from the current upper bounds file by")
-    public abstract Property<Integer> getIncrement();
-
-    @Input
-    @Optional
-    abstract Property<Boolean> getResolveConflict();
-
-    /**
-     * The name of the upper bounds file which will be used at runtime on the current branch. Normally
-     * this equates to VersionProperties.getElasticsearchVersion().
-     */
-    @Input
-    public abstract Property<String> getCurrentUpperBoundName();
-
-    /**
-     * An additional upper bound file that will be consulted when generating a transport version.
-     * The larger of this and the current upper bound will be used to create the new primary id.
-     */
-    @InputFile
-    @Optional
-    public abstract RegularFileProperty getAlternateUpperBoundFile();
-
-    @TaskAction
-    public void run() throws IOException {
-        TransportVersionResourcesService resources = getResourceService().get();
-        List<TransportVersionUpperBound> upstreamUpperBounds = resources.getUpperBoundsFromGitBase();
-        boolean onReleaseBranch = resources.checkIfDefinitelyOnReleaseBranch(upstreamUpperBounds, getCurrentUpperBoundName().get());
-        if (onReleaseBranch) {
-            throw new IllegalArgumentException("Transport version generation cannot run on release branches");
-        }
-
+    @Override
+    protected void runGeneration(TransportVersionResourcesService resources, List<TransportVersionUpperBound> upstreamUpperBounds)
+        throws IOException {
         Set<String> referencedNames = TransportVersionReference.collectNames(getReferencesFiles());
         Set<String> changedDefinitionNames = resources.getChangedReferableDefinitionNames();
         String targetDefinitionName = getTargetDefinitionName(resources, referencedNames, changedDefinitionNames);
@@ -114,64 +72,8 @@ public abstract class GenerateTransportVersionDefinitionTask extends DefaultTask
             getLogger().lifecycle("No transport version name detected, resetting upper bounds");
             resetAllUpperBounds(resources, idsByBase);
         } else {
-            getLogger().lifecycle("Generating transport version name: " + targetDefinitionName);
-
-            Set<String> targetUpperBoundNames = getTargetUpperBoundNames(resources, upstreamUpperBounds, targetDefinitionName);
-
-            List<TransportVersionId> ids = updateUpperBounds(
-                resources,
-                upstreamUpperBounds,
-                targetUpperBoundNames,
-                idsByBase,
-                targetDefinitionName
-            );
-            // (Re)write the definition file.
-            resources.writeDefinition(new TransportVersionDefinition(targetDefinitionName, ids, true));
+            generateTransportVersionDefinition(resources, targetDefinitionName, upstreamUpperBounds, idsByBase);
         }
-
-    }
-
-    private List<TransportVersionId> updateUpperBounds(
-        TransportVersionResourcesService resources,
-        List<TransportVersionUpperBound> existingUpperBounds,
-        Set<String> targetUpperBoundNames,
-        Map<Integer, List<IdAndDefinition>> idsByBase,
-        String definitionName
-    ) throws IOException {
-        String currentUpperBoundName = getCurrentUpperBoundName().get();
-        int increment = getIncrement().get();
-        if (increment <= 0) {
-            throw new IllegalArgumentException("Invalid increment " + increment + ", must be a positive integer");
-        }
-        if (increment > 1000) {
-            throw new IllegalArgumentException("Invalid increment " + increment + ", must be no larger than 1000");
-        }
-        List<TransportVersionId> ids = new ArrayList<>();
-        boolean stageInGit = getResolveConflict().getOrElse(false);
-
-        TransportVersionDefinition existingDefinition = resources.getReferableDefinitionFromGitBase(definitionName);
-        for (TransportVersionUpperBound existingUpperBound : existingUpperBounds) {
-            String upperBoundName = existingUpperBound.name();
-
-            if (targetUpperBoundNames.contains(upperBoundName)) {
-                // Case: targeting this upper bound, find an existing id if it exists
-                TransportVersionId targetId = maybeGetExistingId(existingUpperBound, existingDefinition, definitionName);
-                if (targetId == null) {
-                    // Case: an id doesn't yet exist for this upper bound, so create one
-                    int targetIncrement = upperBoundName.equals(currentUpperBoundName) ? increment : 1;
-                    targetId = createTargetId(existingUpperBound, targetIncrement);
-                    var newUpperBound = new TransportVersionUpperBound(upperBoundName, definitionName, targetId);
-                    resources.writeUpperBound(newUpperBound, stageInGit);
-                }
-                ids.add(targetId);
-            } else if (resources.getChangedUpperBoundNames().contains(upperBoundName)) {
-                // Default case: we're not targeting this branch so reset it
-                resetUpperBound(resources, existingUpperBound, idsByBase, definitionName);
-            }
-        }
-
-        Collections.sort(ids);
-        return ids;
     }
 
     private String getTargetDefinitionName(
@@ -207,19 +109,12 @@ public abstract class GenerateTransportVersionDefinitionTask extends DefaultTask
         }
     }
 
-    private Set<String> getTargetUpperBoundNames(
+    @Override
+    protected Set<String> getTargetUpperBoundNames(
         TransportVersionResourcesService resources,
         List<TransportVersionUpperBound> upstreamUpperBounds,
         String targetDefinitionName
     ) throws IOException {
-        if (getResolveConflict().getOrElse(false)) {
-            if (getBackportBranches().isPresent()) {
-                throw new IllegalArgumentException("Cannot use --resolve-conflict with --backport-branches");
-            }
-
-            return getUpperBoundNamesFromDefinition(resources, upstreamUpperBounds, targetDefinitionName);
-        }
-
         Set<String> targetUpperBoundNames = new HashSet<>();
         targetUpperBoundNames.add(getCurrentUpperBoundName().get());
         if (getBackportBranches().isPresent()) {
@@ -241,29 +136,6 @@ public abstract class GenerateTransportVersionDefinitionTask extends DefaultTask
         }
 
         return targetUpperBoundNames;
-    }
-
-    private Set<String> getUpperBoundNamesFromDefinition(
-        TransportVersionResourcesService resources,
-        List<TransportVersionUpperBound> upstreamUpperBounds,
-        String targetDefinitionName
-    ) throws IOException {
-        TransportVersionDefinition definition = resources.getReferableDefinition(targetDefinitionName);
-        Set<String> upperBoundNames = new HashSet<>();
-        upperBoundNames.add(getCurrentUpperBoundName().get());
-
-        // skip the primary id as that is current, which we always add
-        for (int i = 1; i < definition.ids().size(); ++i) {
-            TransportVersionId id = definition.ids().get(i);
-            // we have a small number of upper bound files, so just scan for the ones we want
-            for (TransportVersionUpperBound upperBound : upstreamUpperBounds) {
-                if (upperBound.definitionId().base() == id.base()) {
-                    upperBoundNames.add(upperBound.name());
-                }
-            }
-        }
-
-        return upperBoundNames;
     }
 
     private void resetAllUpperBounds(TransportVersionResourcesService resources, Map<Integer, List<IdAndDefinition>> idsByBase)
@@ -308,47 +180,9 @@ public abstract class GenerateTransportVersionDefinitionTask extends DefaultTask
         }
     }
 
-    private TransportVersionId maybeGetExistingId(
-        TransportVersionUpperBound upperBound,
-        TransportVersionDefinition existingDefinition,
-        String name
-    ) {
-        if (existingDefinition == null) {
-            // the name doesn't yet exist, so there is no id to return
-            return null;
-        }
-        if (upperBound.definitionName().equals(name)) {
-            // the name exists and this upper bound already points at it
-            return upperBound.definitionId();
-        }
-        if (upperBound.name().equals(getCurrentUpperBoundName().get())) {
-            // this is the upper bound of the current branch, so use the primary id
-            return existingDefinition.ids().getFirst();
-        }
-        // the upper bound is for a non-current branch, so find the id with the same base
-        for (TransportVersionId id : existingDefinition.ids()) {
-            if (id.base() == upperBound.definitionId().base()) {
-                return id;
-            }
-        }
-        return null; // no existing id for this upper bound
+    @Override
+    protected void writeUpperBound(TransportVersionResourcesService resources, TransportVersionUpperBound newUpperBound)
+        throws IOException {
+        resources.writeUpperBound(newUpperBound, false);
     }
-
-    private TransportVersionId createTargetId(TransportVersionUpperBound existingUpperBound, int increment) throws IOException {
-        int currentId = existingUpperBound.definitionId().complete();
-
-        // allow for an alternate upper bound file to be consulted. This supports Serverless basing its
-        // own transport version ids on the greater of server or serverless
-        if (getAlternateUpperBoundFile().isPresent()) {
-            Path altUpperBoundPath = getAlternateUpperBoundFile().get().getAsFile().toPath();
-            String contents = Files.readString(altUpperBoundPath, StandardCharsets.UTF_8);
-            var altUpperBound = TransportVersionUpperBound.fromString(altUpperBoundPath, contents);
-            if (altUpperBound.definitionId().complete() > currentId) {
-                currentId = altUpperBound.definitionId().complete();
-            }
-        }
-
-        return TransportVersionId.fromInt(currentId + increment);
-    }
-
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/ResolveTransportVersionConflictTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/ResolveTransportVersionConflictTask.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.gradle.internal.transport;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public abstract class ResolveTransportVersionConflictTask extends AbstractGenerateTransportVersionDefinitionTask {
+
+    @Override
+    protected void runGeneration(TransportVersionResourcesService resources, List<TransportVersionUpperBound> upstreamUpperBounds)
+        throws IOException {
+
+        Set<String> changedDefinitionNames = resources.getChangedReferableDefinitionNames();
+        if (changedDefinitionNames.isEmpty()) {
+            getLogger().lifecycle("No transport version changes detected, skipping transport version re-generation");
+            return;
+        }
+        String targetDefinitionName = changedDefinitionNames.iterator().next();
+
+        generateTransportVersionDefinition(resources, targetDefinitionName, upstreamUpperBounds, resources.getIdsByBase());
+    }
+
+    @Override
+    protected Set<String> getTargetUpperBoundNames(
+        TransportVersionResourcesService resources,
+        List<TransportVersionUpperBound> upstreamUpperBounds,
+        String targetDefinitionName
+    ) throws IOException {
+        TransportVersionDefinition definition = resources.getReferableDefinition(targetDefinitionName);
+        Set<String> upperBoundNames = new HashSet<>();
+        upperBoundNames.add(getCurrentUpperBoundName().get());
+
+        // skip the primary id as that is current, which we always add
+        for (int i = 1; i < definition.ids().size(); ++i) {
+            TransportVersionId id = definition.ids().get(i);
+            // we have a small number of upper bound files, so just scan for the ones we want
+            for (TransportVersionUpperBound upperBound : upstreamUpperBounds) {
+                if (upperBound.definitionId().base() == id.base()) {
+                    upperBoundNames.add(upperBound.name());
+                }
+            }
+        }
+
+        return upperBoundNames;
+    }
+
+    @Override
+    protected void writeUpperBound(TransportVersionResourcesService resources, TransportVersionUpperBound newUpperBound)
+        throws IOException {
+        resources.writeUpperBound(newUpperBound, true);
+    }
+}


### PR DESCRIPTION
Transport version generation relies on finding uses of `TransportVersion.fromName` to identify the definition name to generate. In the case of resolving a merge conflict, a definition has already been generated, and the merge base is used to find differences in definition files. So in the resolve conflict case, we don't actually need to find uses of `TransportVersion.fromName`, and thus don't need compilation.

This commit moves most of the logic from the generate task into a base class, which is then specialized by the normal generation task and the resolve conflict task. By avoiding compilation running resolveTransportVersionConflict should be much faster, and can run even if there are other merge conflicts which may break compilation.

relates ES-14006