### PR TITLE
[9.0] Document subobject auto flattening limitation. (#141144)

### DIFF
--- a/docs/reference/elasticsearch/mapping-reference/nested.md
+++ b/docs/reference/elasticsearch/mapping-reference/nested.md
@@ -18,6 +18,10 @@ When ingesting key-value pairs with a large, arbitrary set of keys, you might co
 Nested fields have incomplete support in Kibana. While they are visible and searchable in Discover, they cannot be used to build visualizations in Lens.
 ::::
 
+::::{warning}
+If a parent object field mapping has `subobject` set to `false` or the root object `subobject` set to `false`, then nested field mappings are also auto flattened and only leaf field mappings are retained. This means that the nested field mapping's functionality is disabled.
+::::
+
 
 ## How arrays of objects are flattened [nested-arrays-flattening-objects]
 

--- a/docs/reference/elasticsearch/mapping-reference/subobjects.md
+++ b/docs/reference/elasticsearch/mapping-reference/subobjects.md
@@ -105,6 +105,10 @@ The `subobjects` setting for existing fields and the top-level mapping definitio
 
 ## Auto-flattening object mappings [subobjects-auto-flattening]
 
+::::{warning}
+Object fields of type `nested` don't work when wrapped by an object field that is configured with `subobjects: false`.
+::::
+
 It is generally recommended to define the properties of an object that is configured with `subobjects: false` with dotted field names (as shown in the first example). However, it is also possible to define these properties as sub-objects in the mappings. In that case, the mapping will be automatically flattened before it is stored. This makes it easier to re-use existing mappings without having to re-write them.
 
 Note that auto-flattening will not work when certain [mapping parameters](/reference/elasticsearch/mapping-reference/mapping-parameters.md) are set on object mappings that are defined under an object configured with `subobjects: false`:


### PR DESCRIPTION
Backports the following commits to 9.0:
 - Document subobject auto flattening limitation. (#141144)