### PR TITLE
Document subobject auto flattening limitation.

### DIFF
--- a/docs/reference/mapping/params/subobjects.asciidoc
+++ b/docs/reference/mapping/params/subobjects.asciidoc
@@ -114,6 +114,11 @@ The `subobjects` setting for existing fields and the top-level mapping definitio
 [[subobjects-auto-flattening]]
 ==== Auto-flattening object mappings
 
+[WARNING]
+====
+Object fields of type `nested` don't work when wrapped by an object field that is configured with `subobjects: false`.
+====
+
 It is generally recommended to define the properties of an object that is configured with `subobjects: false` with dotted field names
 (as shown in the first example).
 However, it is also possible to define these properties as sub-objects in the mappings.

--- a/docs/reference/mapping/types/nested.asciidoc
+++ b/docs/reference/mapping/types/nested.asciidoc
@@ -13,6 +13,8 @@ Nested documents and queries are typically expensive, so using the `flattened` d
 
 WARNING: Nested fields have incomplete support in Kibana. While they are visible and searchable in Discover, they cannot be used to build visualizations in Lens.
 
+WARNING: If a parent object field mapping has `subobject` set to `false` or the root object `subobject` set to `false`, then nested field mappings are also auto flattened and only leaf field mappings are retained. This means that the nested field mapping's functionality is disabled.
+
 [[nested-arrays-flattening-objects]]
 ==== How arrays of objects are flattened
 


### PR DESCRIPTION
Backporting #141144 to 8.19 branch.

Any nested object field type nested under an object field with `subobjects: false` will defacto be disabled by the auto flattening functionality that gets unabled by subobjects with `subobjects: false`.