### PR TITLE
PromQL: fix binary operations between scalar functions and vectors

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/promql/PromqlLogicalPlanBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/promql/PromqlLogicalPlanBuilder.java
@@ -443,6 +443,7 @@ public class PromqlLogicalPlanBuilder extends PromqlExpressionBuilder {
                 case Literal literal -> new LiteralSelector(source, literal);
                 case Node n -> throw new IllegalStateException("Unexpected value: " + n);
             };
+            assert providedParam instanceof PromqlPlan;
             PromqlDataType actualType = PromqlPlan.getType(providedParam);
             PromqlDataType expectedType = expectedParam.type();
             if (actualType != expectedType) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlPlan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlPlan.java
@@ -8,12 +8,26 @@
 package org.elasticsearch.xpack.esql.plan.logical.promql;
 
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.xpack.esql.core.expression.Attribute;
+import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
+
+import java.util.List;
 
 /**
  * Marker interface for PromQL-specific logical plan nodes.
  */
 public interface PromqlPlan {
+
+    /**
+     * Returns any grouping attributes, for example those added via {@code by(...)},
+     * or {@link FieldAttribute#timeSeriesAttribute(Source)} (group by all).
+     * <p>
+     * Note: The value and step column are added by {@link PromqlCommand#output()}
+     * and should not be added by implementations of this interface.
+     */
+    List<Attribute> output();
 
     /**
      * The PromQL return type of this plan node.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlPlan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlPlan.java
@@ -67,11 +67,11 @@ public interface PromqlPlan {
         return getType(plan) == PromqlDataType.SCALAR;
     }
 
+    @Nullable
     static PromqlDataType getType(@Nullable LogicalPlan plan) {
-        return switch (plan) {
-            case PromqlPlan promqlPlan -> promqlPlan.returnType();
-            case null -> null;
-            default -> throw new IllegalArgumentException("Logical plan " + plan.getClass().getSimpleName() + " is not a PromqlPlan");
-        };
+        if (plan instanceof PromqlPlan promqlPlan) {
+            return promqlPlan.returnType();
+        }
+        return null;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/operator/VectorBinaryOperator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/operator/VectorBinaryOperator.java
@@ -17,7 +17,6 @@ import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.promql.PromqlDataType;
 import org.elasticsearch.xpack.esql.plan.logical.promql.PromqlPlan;
 import org.elasticsearch.xpack.esql.plan.logical.promql.selector.LabelMatcher;
-import org.elasticsearch.xpack.esql.plan.logical.promql.selector.LiteralSelector;
 import org.elasticsearch.xpack.esql.session.Configuration;
 
 import java.io.IOException;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/operator/VectorBinaryOperator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/operator/VectorBinaryOperator.java
@@ -84,10 +84,15 @@ public abstract sealed class VectorBinaryOperator extends BinaryPlan implements 
     }
 
     private List<Attribute> computeOutputAttributes() {
-        if (left() instanceof LiteralSelector) {
+        // Between an instant vector and a scalar,
+        // the operator is applied to the value of every data sample in the vector.
+        // Therefore, we're returning any grouping attributes (like those created for by (...) and _timeseries) from the vector.
+        // If both the left and right are a scalar, this works, too
+        // as both outputs will be empty (scalars don't have any grouping attributes).
+        if (PromqlPlan.returnsScalar(left())) {
             return right().output();
         }
-        if (right() instanceof LiteralSelector) {
+        if (PromqlPlan.returnsScalar(right())) {
             return left().output();
         }
         Set<String> outputLabels;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlLogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/promql/PromqlLogicalPlanOptimizerTests.java
@@ -40,6 +40,7 @@ import org.elasticsearch.xpack.esql.expression.predicate.nulls.IsNotNull;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Add;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Div;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Mul;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Sub;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.NotEquals;
 import org.elasticsearch.xpack.esql.index.EsIndex;
@@ -72,6 +73,7 @@ import static org.elasticsearch.xpack.esql.EsqlTestUtils.emptyInferenceResolutio
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.loadMapping;
 import static org.elasticsearch.xpack.esql.analysis.VerifierTests.error;
 import static org.elasticsearch.xpack.esql.plan.QuerySettings.UNMAPPED_FIELDS;
+import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
@@ -660,6 +662,23 @@ public class PromqlLogicalPlanOptimizerTests extends AbstractLogicalPlanOptimize
         TimeSeriesAggregate tsAgg = plan.collect(TimeSeriesAggregate.class).getFirst();
         LastOverTime last = as(Alias.unwrap(tsAgg.aggregates().getFirst()), LastOverTime.class);
         assertThat(as(last.field(), FieldAttribute.class).sourceText(), equalTo("network.bytes_in"));
+    }
+
+    public void testBinaryArithmeticInstantSelectorAndScalarFunction() {
+        var plan = planPromql("PROMQL index=k8s step=1m bits=(pi() - network.bytes_in)");
+        assertThat(plan.output().stream().map(Attribute::name).toList(), equalTo(List.of("bits", "step", "_timeseries")));
+
+        Sub sub = as(plan.collect(Eval.class).get(1).fields().getLast().child(), Sub.class);
+        assertThat((double) as(sub.left(), Literal.class).fold(null), closeTo(Math.PI, 1e-9));
+        assertThat(as(as(sub.right(), ToDouble.class).field(), ReferenceAttribute.class).sourceText(), equalTo("network.bytes_in"));
+
+        TimeSeriesAggregate tsAgg = plan.collect(TimeSeriesAggregate.class).getFirst();
+        LastOverTime last = as(Alias.unwrap(tsAgg.aggregates().getFirst()), LastOverTime.class);
+        assertThat(as(last.field(), FieldAttribute.class).sourceText(), equalTo("network.bytes_in"));
+    }
+
+    public void testBinaryArithmeticScalarFunctions() {
+        assertConstantResult("pi() - pi()", equalTo(0.0));
     }
 
     public void testBinaryAcrossSeriesAndLiteral() {


### PR DESCRIPTION
fixes #141172