### PR TITLE
Avoid allocations in `CountingStreamOutput`

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/io/stream/CountingStreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/CountingStreamOutput.java
@@ -9,6 +9,7 @@
 
 package org.elasticsearch.common.io.stream;
 
+import org.apache.lucene.util.BitUtil;
 import org.elasticsearch.core.Nullable;
 
 import java.io.IOException;
@@ -40,12 +41,22 @@ public class CountingStreamOutput extends StreamOutput {
     }
 
     @Override
+    public void writeShort(short v) throws IOException {
+        size += Short.BYTES;
+    }
+
+    @Override
     public void writeInt(int i) {
         size += Integer.BYTES;
     }
 
     @Override
-    public void writeIntArray(int[] values) throws IOException {
+    public void writeIntLE(int i) throws IOException {
+        size += Integer.BYTES;
+    }
+
+    @Override
+    public void writeIntArray(int[] values) {
         writeVInt(values.length);
         size += (long) values.length * Integer.BYTES;
     }
@@ -56,7 +67,12 @@ public class CountingStreamOutput extends StreamOutput {
     }
 
     @Override
-    public void writeLongArray(long[] values) throws IOException {
+    public void writeLongLE(long i) {
+        size += Long.BYTES;
+    }
+
+    @Override
+    public void writeLongArray(long[] values) {
         writeVInt(values.length);
         size += (long) values.length * Long.BYTES;
     }
@@ -67,7 +83,7 @@ public class CountingStreamOutput extends StreamOutput {
     }
 
     @Override
-    public void writeFloatArray(float[] values) throws IOException {
+    public void writeFloatArray(float[] values) {
         writeVInt(values.length);
         size += (long) values.length * Float.BYTES;
     }
@@ -78,18 +94,43 @@ public class CountingStreamOutput extends StreamOutput {
     }
 
     @Override
-    public void writeDoubleArray(double[] values) throws IOException {
+    public void writeDoubleArray(double[] values) {
         writeVInt(values.length);
         size += (long) values.length * Double.BYTES;
     }
 
     @Override
-    public void writeString(String str) throws IOException {
-        StreamOutputHelper.writeString(str, this);
+    public void writeVInt(int v) {
+        // set LSB because 0 takes 1 byte
+        size += (38 - Integer.numberOfLeadingZeros(v | 1)) / 7;
     }
 
     @Override
-    public void writeOptionalString(@Nullable String str) throws IOException {
+    void writeVLongNoCheck(long v) {
+        // set LSB because 0 takes 1 byte
+        size += (70 - Long.numberOfLeadingZeros(v | 1L)) / 7;
+    }
+
+    @Override
+    public void writeZLong(long i) {
+        writeVLongNoCheck(BitUtil.zigZagEncode(i));
+    }
+
+    @Override
+    public void writeString(String str) {
+        final int charCount = str.length();
+        writeVInt(charCount);
+        size += charCount;
+        for (int i = 0; i < charCount; i++) {
+            final int c = str.charAt(i);
+            if (c > 0x007F) {
+                size += c > 0x07FF ? 2 : 1;
+            }
+        }
+    }
+
+    @Override
+    public void writeOptionalString(@Nullable String str) {
         size += 1;
         if (str != null) {
             writeString(str);
@@ -97,7 +138,7 @@ public class CountingStreamOutput extends StreamOutput {
     }
 
     @Override
-    public void writeGenericString(String value) throws IOException {
+    public void writeGenericString(String value) {
         size += 1;
         writeString(value);
     }


### PR DESCRIPTION
This shows up a bit in profiling because of its use as a way to measure
aggs size in `QueryPhaseResultConsumer#ramBytesUsedQueryResult`. No need
to actually write anything to a temporary buffer here, we can just
compute the write sizes directly.

See `StreamOutputToBytesTests#testRandomWrites` for existing adequate
test coverage.