### PR TITLE
[9.2] Account for overhead when calculating available system memory on startup (#139138)

### DIFF
--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/JvmArgumentParsingSystemMemoryInfo.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/JvmArgumentParsingSystemMemoryInfo.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.server.cli;
+
+import java.util.List;
+
+public abstract class JvmArgumentParsingSystemMemoryInfo implements SystemMemoryInfo {
+    private final List<String> userDefinedJvmOptions;
+
+    public JvmArgumentParsingSystemMemoryInfo(List<String> userDefinedJvmOptions) {
+        this.userDefinedJvmOptions = userDefinedJvmOptions;
+    }
+
+    protected long getBytesFromSystemProperty(String systemProperty, long defaultValue) {
+        return userDefinedJvmOptions.stream()
+            .filter(option -> option.startsWith("-D" + systemProperty + "="))
+            .map(totalMemoryOverheadBytesOption -> {
+                try {
+                    long bytes = Long.parseLong(totalMemoryOverheadBytesOption.split("=", 2)[1]);
+                    if (bytes < 0) {
+                        throw new IllegalArgumentException("Negative bytes size specified in [" + totalMemoryOverheadBytesOption + "]");
+                    }
+                    return bytes;
+                } catch (NumberFormatException e) {
+                    throw new IllegalArgumentException("Unable to parse number of bytes from [" + totalMemoryOverheadBytesOption + "]", e);
+                }
+            })
+            .reduce((previous, current) -> current) // this is effectively findLast(), so that ES_JAVA_OPTS overrides jvm.options
+            .orElse(defaultValue);
+    }
+}

--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/JvmOptionsParser.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/JvmOptionsParser.java
@@ -142,7 +142,10 @@ public final class JvmOptionsParser {
         }
 
         final List<String> substitutedJvmOptions = substitutePlaceholders(jvmOptions, Collections.unmodifiableMap(substitutions));
-        final SystemMemoryInfo memoryInfo = new OverridableSystemMemoryInfo(substitutedJvmOptions, new DefaultSystemMemoryInfo());
+        final SystemMemoryInfo memoryInfo = new OverheadSystemMemoryInfo(
+            substitutedJvmOptions,
+            new OverridableSystemMemoryInfo(substitutedJvmOptions, new DefaultSystemMemoryInfo())
+        );
         substitutedJvmOptions.addAll(machineDependentHeap.determineHeapSettings(args.nodeSettings(), memoryInfo, substitutedJvmOptions));
         final List<String> ergonomicJvmOptions = JvmErgonomics.choose(substitutedJvmOptions, args.nodeSettings());
         final List<String> systemJvmOptions = SystemJvmOptions.systemJvmOptions(args.nodeSettings(), cliSysprops);

--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/OverheadSystemMemoryInfo.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/OverheadSystemMemoryInfo.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.server.cli;
+
+import java.util.List;
+
+/**
+ * A {@link SystemMemoryInfo} implementation that reduces the reported available system memory by a set amount. This is intended to account
+ * for overhead cost of other bundled Elasticsearch processes, such as the CLI tool launcher. By default, this is
+ * {@link org.elasticsearch.server.cli.OverheadSystemMemoryInfo#SERVER_CLI_OVERHEAD } but can be overridden via the
+ * {@code es.total_memory_overhead_bytes} system property.
+ */
+public class OverheadSystemMemoryInfo extends JvmArgumentParsingSystemMemoryInfo {
+    static final long SERVER_CLI_OVERHEAD = 100 * 1024L * 1024L;
+
+    private final SystemMemoryInfo delegate;
+
+    public OverheadSystemMemoryInfo(List<String> userDefinedJvmOptions, SystemMemoryInfo delegate) {
+        super(userDefinedJvmOptions);
+        this.delegate = delegate;
+    }
+
+    @Override
+    public long availableSystemMemory() {
+        long overheadBytes = getBytesFromSystemProperty("es.total_memory_overhead_bytes", SERVER_CLI_OVERHEAD);
+        return delegate.availableSystemMemory() - overheadBytes;
+    }
+}

--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerCli.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerCli.java
@@ -118,6 +118,8 @@ class ServerCli extends EnvironmentAwareCommand {
             return;
         }
 
+        // Call the GC to try and free up as much heap as we can since we don't intend to do much if any more allocation after this
+        System.gc();
         // we are running in the foreground, so wait for the server to exit
         int exitCode = server.waitFor();
         onExit(exitCode);

--- a/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/OverheadSystemMemoryInfoTests.java
+++ b/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/OverheadSystemMemoryInfoTests.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.server.cli;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.List;
+
+import static org.elasticsearch.server.cli.OverheadSystemMemoryInfo.SERVER_CLI_OVERHEAD;
+import static org.hamcrest.Matchers.is;
+
+public class OverheadSystemMemoryInfoTests extends ESTestCase {
+
+    private static final long TRUE_SYSTEM_MEMORY = 1024 * 1024 * 1024L;
+
+    public void testNoOptions() {
+        final SystemMemoryInfo memoryInfo = new OverheadSystemMemoryInfo(List.of(), delegateSystemMemoryInfo());
+        assertThat(memoryInfo.availableSystemMemory(), is(TRUE_SYSTEM_MEMORY - SERVER_CLI_OVERHEAD));
+    }
+
+    public void testNoOverrides() {
+        final SystemMemoryInfo memoryInfo = new OverheadSystemMemoryInfo(List.of("-Da=b", "-Dx=y"), delegateSystemMemoryInfo());
+        assertThat(memoryInfo.availableSystemMemory(), is(TRUE_SYSTEM_MEMORY - SERVER_CLI_OVERHEAD));
+    }
+
+    public void testValidSingleOverride() {
+        final SystemMemoryInfo memoryInfo = new OverheadSystemMemoryInfo(
+            List.of("-Des.total_memory_overhead_bytes=50000"),
+            delegateSystemMemoryInfo()
+        );
+        assertThat(memoryInfo.availableSystemMemory(), is(TRUE_SYSTEM_MEMORY - 50000));
+    }
+
+    public void testValidOverrideInList() {
+        final SystemMemoryInfo memoryInfo = new OverheadSystemMemoryInfo(
+            List.of("-Da=b", "-Des.total_memory_overhead_bytes=50000", "-Dx=y"),
+            delegateSystemMemoryInfo()
+        );
+        assertThat(memoryInfo.availableSystemMemory(), is(TRUE_SYSTEM_MEMORY - 50000));
+    }
+
+    public void testMultipleValidOverridesInList() {
+        final SystemMemoryInfo memoryInfo = new OverheadSystemMemoryInfo(
+            List.of("-Des.total_memory_overhead_bytes=50000", "-Da=b", "-Des.total_memory_overhead_bytes=100000", "-Dx=y"),
+            delegateSystemMemoryInfo()
+        );
+        assertThat(memoryInfo.availableSystemMemory(), is(TRUE_SYSTEM_MEMORY - 100000));
+    }
+
+    public void testNegativeOverride() {
+        final SystemMemoryInfo memoryInfo = new OverheadSystemMemoryInfo(
+            List.of("-Da=b", "-Des.total_memory_overhead_bytes=-123", "-Dx=y"),
+            delegateSystemMemoryInfo()
+        );
+        try {
+            memoryInfo.availableSystemMemory();
+            fail("expected to fail");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), is("Negative bytes size specified in [-Des.total_memory_overhead_bytes=-123]"));
+        }
+    }
+
+    public void testUnparsableOverride() {
+        final SystemMemoryInfo memoryInfo = new OverheadSystemMemoryInfo(
+            List.of("-Da=b", "-Des.total_memory_overhead_bytes=invalid", "-Dx=y"),
+            delegateSystemMemoryInfo()
+        );
+        try {
+            memoryInfo.availableSystemMemory();
+            fail("expected to fail");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), is("Unable to parse number of bytes from [-Des.total_memory_overhead_bytes=invalid]"));
+        }
+    }
+
+    private static SystemMemoryInfo delegateSystemMemoryInfo() {
+        return () -> TRUE_SYSTEM_MEMORY;
+    }
+}

--- a/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/OverridableSystemMemoryInfoTests.java
+++ b/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/OverridableSystemMemoryInfoTests.java
@@ -64,7 +64,7 @@ public class OverridableSystemMemoryInfoTests extends ESTestCase {
             memoryInfo.availableSystemMemory();
             fail("expected to fail");
         } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), is("Negative memory size specified in [-Des.total_memory_bytes=-123]"));
+            assertThat(e.getMessage(), is("Negative bytes size specified in [-Des.total_memory_bytes=-123]"));
         }
     }
 

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/ArchiveTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/ArchiveTests.java
@@ -507,8 +507,8 @@ public class ArchiveTests extends PackagingTestCase {
             final String nodesStatsResponse = makeRequest("https://localhost:9200/_nodes/stats");
             assertThat(nodesStatsResponse, containsString("\"adjusted_total_in_bytes\":891289600"));
             final String nodesResponse = makeRequest("https://localhost:9200/_nodes");
-            // 40% of 850MB
-            assertThat(nodesResponse, containsString("\"heap_init_in_bytes\":356515840"));
+            // 40% of (850MB - 100MB overhead) = 40% of 750MB
+            assertThat(nodesResponse, containsString("\"heap_init_in_bytes\":314572800"));
 
             stopElasticsearch();
         } finally {

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -1023,8 +1023,8 @@ public class DockerTests extends PackagingTestCase {
     public void test150MachineDependentHeap() throws Exception {
         final List<String> xArgs = machineDependentHeapTest("1536m", List.of());
 
-        // This is roughly 0.5 * 1536
-        assertThat(xArgs, hasItems("-Xms768m", "-Xmx768m"));
+        // This is roughly 0.5 * (1536 - 100) where 100 MB is the server-cli overhead
+        assertThat(xArgs, hasItems("-Xms718m", "-Xmx718m"));
     }
 
     /**
@@ -1035,12 +1035,12 @@ public class DockerTests extends PackagingTestCase {
     public void test151MachineDependentHeapWithSizeOverride() throws Exception {
         final List<String> xArgs = machineDependentHeapTest(
             "942m",
-            // 799014912 = 762m
-            List.of("-Des.total_memory_bytes=799014912")
+            // 799014912 = 762m, 52428800 = 50m
+            List.of("-Des.total_memory_bytes=799014912", "-Des.total_memory_overhead_bytes=52428800")
         );
 
-        // This is roughly 0.4 * 762, in particular it's NOT 0.4 * 942
-        assertThat(xArgs, hasItems("-Xms304m", "-Xmx304m"));
+        // This is roughly 0.4 * (762 - 50)
+        assertThat(xArgs, hasItems("-Xms284m", "-Xmx284m"));
     }
 
     private List<String> machineDependentHeapTest(final String containerMemory, final List<String> extraJvmOptions) throws Exception {

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/PackageTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/PackageTests.java
@@ -258,8 +258,8 @@ public class PackageTests extends PackagingTestCase {
                 final String nodesStatsResponse = makeRequest("https://localhost:9200/_nodes/stats");
                 assertThat(nodesStatsResponse, containsString("\"adjusted_total_in_bytes\":891289600"));
 
-                // 40% of 850MB
-                assertThat(sh.run("ps auwwx").stdout(), containsString("-Xms340m -Xmx340m"));
+                // 40% of (850MB - 100MB overhead) = 40% of 750MB
+                assertThat(sh.run("ps auwwx").stdout(), containsString("-Xms300m -Xmx300m"));
 
                 stopElasticsearch();
             });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Account for overhead when calculating available system memory on startup (#139138)](https://github.com/elastic/elasticsearch/pull/139138)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)