### PR TITLE
Fixes formatting on the semantic text reference page

### DIFF
--- a/docs/reference/elasticsearch/mapping-reference/semantic-text-reference.md
+++ b/docs/reference/elasticsearch/mapping-reference/semantic-text-reference.md
@@ -30,9 +30,7 @@ You can update this parameter by using
 the [Update mapping API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-put-mapping).
 You can update the {{infer}} endpoint if no values have been indexed or if the new endpoint is compatible with the current one.
 
-::::{important}
 When updating an `inference_id` it is important to ensure the new {{infer}} endpoint produces embeddings compatible with those already indexed. This typically means using the same underlying model.
-::::
 
 :::
 

--- a/docs/reference/elasticsearch/mapping-reference/semantic-text-reference.md
+++ b/docs/reference/elasticsearch/mapping-reference/semantic-text-reference.md
@@ -22,25 +22,25 @@ endpoint will only be used at index time. Learn more about [configuring this par
 
 **Updating the `inference_id` parameter**
 
-::::{applies-switch}
+:::::{applies-switch}
 
-:::{applies-item} stack: ga 9.3+
+::::{applies-item} stack: ga 9.3+
 
 You can update this parameter by using
 the [Update mapping API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-put-mapping).
 You can update the {{infer}} endpoint if no values have been indexed or if the new endpoint is compatible with the current one.
 
-:::::{important}
+:::{important}
 When updating an `inference_id` it is important to ensure the new {{infer}} endpoint produces embeddings compatible with those already indexed. This typically means using the same underlying model.
-:::::
-
-:::
-
-:::{applies-item} stack: ga 9.0-9.2
-This parameter cannot be updated.
 :::
 
 ::::
+
+::::{applies-item} stack: ga 9.0-9.2
+This parameter cannot be updated.
+::::
+
+:::::
 
 `search_inference_id`
 :   (Optional, string) The {{infer}} endpoint that will be used to generate

--- a/docs/reference/elasticsearch/mapping-reference/semantic-text-reference.md
+++ b/docs/reference/elasticsearch/mapping-reference/semantic-text-reference.md
@@ -30,7 +30,9 @@ You can update this parameter by using
 the [Update mapping API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-put-mapping).
 You can update the {{infer}} endpoint if no values have been indexed or if the new endpoint is compatible with the current one.
 
+:::::{important}
 When updating an `inference_id` it is important to ensure the new {{infer}} endpoint produces embeddings compatible with those already indexed. This typically means using the same underlying model.
+:::::
 
 :::
 


### PR DESCRIPTION
Related issue: https://github.com/elastic/docs-content/issues/4679

On the Reference page for the semantic_text field type documentation, the [Updating the inference_id parameter](https://www.elastic.co/docs/reference/elasticsearch/mapping-reference/semantic-text-reference#semantic-text-params) tabs were formatted incorrectly.

At the moment, it looks like this on the public documentation site:

<img width="930" height="430" alt="Screenshot 2026-01-26 at 11 40 24" src="https://github.com/user-attachments/assets/0d968d5d-4261-4d67-a87c-26c790f16a03" />

On my local build, the content rendered correctly. I suspected that the Important note was causing the formatting issue, so I converted it to plain text. With this change, the GitHub preview now renders as expected:

<img width="930" height="282" alt="Screenshot 2026-01-26 at 11 41 48" src="https://github.com/user-attachments/assets/cb5c720e-d25b-4ba3-abe8-97d5d5ed0ca9" />

