### PR TITLE
[9.3] Fix entitlement test for MulticastSocket.send removed in JDK 26 (#141186)

### DIFF
--- a/libs/entitlement/src/test/java/org/elasticsearch/entitlement/initialization/DynamicInstrumentationTests.java
+++ b/libs/entitlement/src/test/java/org/elasticsearch/entitlement/initialization/DynamicInstrumentationTests.java
@@ -42,7 +42,9 @@ public class DynamicInstrumentationTests extends ESTestCase {
                             List.of("java/net/URLConnection"),
                             null
                         )
-                    )
+                    ),
+                    // removed in JDK 26
+                    is(new Descriptor("java/net/MulticastSocket", "send", List.of("java/net/DatagramPacket", "B"), null))
                 )
             )
         );


### PR DESCRIPTION
Backports the following commits to 9.3:
 - Fix entitlement test for MulticastSocket.send removed in JDK 26 (#141186)