### PR TITLE
[9.2] rest-api-spec: fix more default values (#141097)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/async_search.submit.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/async_search.submit.json
@@ -68,6 +68,7 @@
       },
       "analyze_wildcard": {
         "type": "boolean",
+        "default": false,
         "description": "Specify whether wildcard and prefix queries should be analyzed (default: false)"
       },
       "ccs_minimize_roundtrips": {
@@ -102,7 +103,8 @@
       },
       "from": {
         "type": "int",
-        "description": "Starting offset (default: 0)"
+        "default": 0,
+        "description": "Starting offset"
       },
       "ignore_unavailable": {
         "type": "boolean",
@@ -163,7 +165,8 @@
       },
       "size": {
         "type": "int",
-        "description": "Number of hits to return (default: 10)"
+        "default": 10,
+        "description": "Number of hits to return"
       },
       "sort": {
         "type": "list",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_settings.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cluster.put_settings.json
@@ -27,7 +27,8 @@
     "params": {
       "flat_settings": {
         "type": "boolean",
-        "description": "Return settings in flat format (default: false)"
+        "default": false,
+        "description": "Return settings in flat format"
       },
       "master_timeout": {
         "type": "time",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/dangling_indices.delete_dangling_index.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/dangling_indices.delete_dangling_index.json
@@ -35,6 +35,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/dangling_indices.import_dangling_index.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/dangling_indices.import_dangling_index.json
@@ -35,6 +35,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_data_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_data_lifecycle.json
@@ -42,6 +42,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit timestamp for the document"
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_data_stream_options.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_data_stream_options.json
@@ -42,6 +42,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit timestamp for the document"
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.explain_data_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.explain_data_lifecycle.json
@@ -30,6 +30,7 @@
     "params": {
       "include_defaults": {
         "type": "boolean",
+        "default": false,
         "description": "indicates if the API should return the default values the system uses for the index's lifecycle"
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.forcemerge.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.forcemerge.json
@@ -36,6 +36,7 @@
     "params": {
       "flush": {
         "type": "boolean",
+        "default": true,
         "description": "Specify whether the index should be flushed after performing the operation (default: true)"
       },
       "ignore_unavailable": {
@@ -64,6 +65,7 @@
       },
       "only_expunge_deletes": {
         "type": "boolean",
+        "default": false,
         "description": "Specify whether the operation should only expunge deleted documents"
       },
       "wait_for_completion": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/license.post_start_basic.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/license.post_start_basic.json
@@ -24,6 +24,7 @@
     "params": {
       "acknowledge": {
         "type": "boolean",
+        "default": false,
         "description": "whether the user has acknowledged acknowledge messages (default: false)"
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/license.post_start_trial.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/license.post_start_trial.json
@@ -24,10 +24,12 @@
     "params": {
       "type": {
         "type": "string",
+        "default": "trial",
         "description": "The type of trial license to generate (default: \"trial\")"
       },
       "acknowledge": {
         "type": "boolean",
+        "default": false,
         "description": "whether the user has acknowledged acknowledge messages (default: false)"
       },
       "master_timeout": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.hot_threads.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/nodes.hot_threads.json
@@ -68,6 +68,7 @@
       },
       "sort": {
         "type": "enum",
+        "default": "total",
         "options": [
           "cpu",
           "wait",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/profiling.status.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/profiling.status.json
@@ -29,6 +29,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Explicit operation timeout"
       },
       "wait_for_resources_created": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.rollup_search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.rollup_search.json
@@ -38,6 +38,7 @@
     "params": {
       "typed_keys": {
         "type": "boolean",
+        "default": false,
         "description": "Specify whether aggregation and suggester names should be prefixed by their respective types in the response"
       },
       "rest_total_hits_as_int": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.get_transform_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.get_transform_stats.json
@@ -40,6 +40,7 @@
       },
       "timeout": {
         "type": "time",
+        "default": "30s",
         "description": "Controls the time to wait for the stats"
       },
       "allow_no_match": {


### PR DESCRIPTION
Backports the following commits to 9.2:
 - rest-api-spec: fix more default values (#141097)