### PR TITLE
[9.0] add reindex kibana index (#141124)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -107,7 +107,7 @@ class KibanaOwnedReservedRoleDescriptors {
             new RoleDescriptor.IndicesPrivileges[] {
                 // System indices defined in KibanaPlugin
                 RoleDescriptor.IndicesPrivileges.builder()
-                    .indices(".kibana*", ".reporting-*")
+                    .indices(".kibana*", ".reporting-*", ".reindexed-v8-kibana*")
                     .privileges("all")
                     .allowRestrictedIndices(true)
                     .build(),


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [add reindex kibana index (#141124)](https://github.com/elastic/elasticsearch/pull/141124)

<!--- Backport version: 9.6.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)