### PR TITLE
[9.2] Handle routing shards deprecate in agg spec tests (#141224)

### DIFF
--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/matrix_stats_multi_value_field.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/matrix_stats_multi_value_field.yml
@@ -2,6 +2,7 @@
 setup:
   - requires:
       cluster_features: ["gte_v8.7.0"]
+      test_runner_features: [ "allowed_warnings" ]
       reason: serialization bug fixed in 8.7.0
 
   - do:
@@ -21,6 +22,8 @@ setup:
                 "type": "double"
               "vals":
                 "type": "float"
+      allowed_warnings:
+        - "[index.number_of_routing_shards] setting was deprecated in Elasticsearch and will be removed in a future release. See the deprecation documentation for the next major version."
 
   - do:
       indices.create:

--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/matrix_stats_single_value_field.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/matrix_stats_single_value_field.yml
@@ -1,5 +1,7 @@
 ---
 setup:
+  - requires:
+      test_runner_features: [ "allowed_warnings" ]
 
   - do:
       indices.create:
@@ -16,6 +18,8 @@ setup:
                 "type": "double"
               "val3":
                 "type": "double"
+      allowed_warnings:
+        - "[index.number_of_routing_shards] setting was deprecated in Elasticsearch and will be removed in a future release. See the deprecation documentation for the next major version."
 
   - do:
       indices.create:

--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/percentiles_hdr_metric.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/percentiles_hdr_metric.yml
@@ -1,4 +1,7 @@
 setup:
+  - requires:
+      test_runner_features: [ "allowed_warnings" ]
+
   - do:
       indices.create:
           index: test_1
@@ -14,6 +17,8 @@ setup:
                    type : double
                 string_field:
                    type: keyword
+      allowed_warnings:
+        - "[index.number_of_routing_shards] setting was deprecated in Elasticsearch and will be removed in a future release. See the deprecation documentation for the next major version."
 
   - do:
        bulk:


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Handle routing shards deprecate in agg spec tests (#141224)