### PR TITLE
[9.2] Fix tests and logging for Docker-based tests and unmute the tests (#141098)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -227,24 +227,12 @@ tests:
 - class: org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT
   method: test {p0=mtermvectors/10_basic/Tests catching other exceptions per item}
   issue: https://github.com/elastic/elasticsearch/issues/122414
-- class: org.elasticsearch.packaging.test.DockerTests
-  method: test090SecurityCliPackaging
-  issue: https://github.com/elastic/elasticsearch/issues/131107
 - class: org.elasticsearch.xpack.esql.expression.function.fulltext.ScoreTests
   method: testSerializationOfSimple {TestCase=<boolean>}
   issue: https://github.com/elastic/elasticsearch/issues/131334
 - class: org.elasticsearch.xpack.esql.analysis.VerifierTests
   method: testMatchInsideEval
   issue: https://github.com/elastic/elasticsearch/issues/131336
-- class: org.elasticsearch.packaging.test.DockerTests
-  method: test071BindMountCustomPathWithDifferentUID
-  issue: https://github.com/elastic/elasticsearch/issues/120917
-- class: org.elasticsearch.packaging.test.DockerTests
-  method: test171AdditionalCliOptionsAreForwarded
-  issue: https://github.com/elastic/elasticsearch/issues/120925
-- class: org.elasticsearch.packaging.test.DockerTests
-  method: test050BasicApiTests
-  issue: https://github.com/elastic/elasticsearch/issues/120911
 - class: org.elasticsearch.xpack.restart.FullClusterRestartIT
   method: testWatcherWithApiKey {cluster=UPGRADED}
   issue: https://github.com/elastic/elasticsearch/issues/131964
@@ -473,12 +461,6 @@ tests:
 - class: org.elasticsearch.readiness.ReadinessClusterIT
   method: testReadinessDuringRestartsNormalOrder
   issue: https://github.com/elastic/elasticsearch/issues/136955
-- class: org.elasticsearch.packaging.test.DockerTests
-  method: test140CgroupOsStatsAreAvailable
-  issue: https://github.com/elastic/elasticsearch/issues/131372
-- class: org.elasticsearch.packaging.test.DockerTests
-  method: test070BindMountCustomPathConfAndJvmOptions
-  issue: https://github.com/elastic/elasticsearch/issues/131366
 - class: org.elasticsearch.index.reindex.ReindexNodeShutdownIT
   method: testReindexWithShutdown
   issue: https://github.com/elastic/elasticsearch/issues/139806

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -57,6 +57,7 @@ import static org.elasticsearch.packaging.util.docker.Docker.chownWithPrivilegeE
 import static org.elasticsearch.packaging.util.docker.Docker.copyFromContainer;
 import static org.elasticsearch.packaging.util.docker.Docker.existsInContainer;
 import static org.elasticsearch.packaging.util.docker.Docker.findInContainer;
+import static org.elasticsearch.packaging.util.docker.Docker.getContainerId;
 import static org.elasticsearch.packaging.util.docker.Docker.getContainerLogs;
 import static org.elasticsearch.packaging.util.docker.Docker.getImageHealthcheck;
 import static org.elasticsearch.packaging.util.docker.Docker.getImageLabels;
@@ -123,13 +124,20 @@ public class DockerTests extends PackagingTestCase {
 
     @After
     public void teardownTest() {
-        removeContainer();
+        // Container cleanup is handled in PackagingTestCase.teardown() so that the TestWatcher
+        // can dump container logs before we remove the container on failures.
         rm(tempDir);
+    }
+
+    @Override
+    protected boolean shouldRemoveDockerContainerAfterTest() {
+        return true;
     }
 
     @Override
     protected void dumpDebug() {
         final Result containerLogs = getContainerLogs();
+        logger.warn("Container id for debug logs: " + getContainerId());
         logger.warn("Elasticsearch log stdout:\n" + containerLogs.stdout());
         logger.warn("Elasticsearch log stderr:\n" + containerLogs.stderr());
     }

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
@@ -232,6 +232,22 @@ public abstract class PackagingTestCase extends Assert {
             }
         }
 
+        // Only remove docker containers after each test when a test class explicitly opts in.
+        // This runs after the TestWatcher (which calls dumpDebug on failure), so the container is still
+        // available for diagnostics.
+        if (distribution().isDocker() && shouldRemoveDockerContainerAfterTest()) {
+            removeContainer();
+        }
+    }
+
+    /**
+     * Controls whether a Docker-based test should remove its container during {@link #teardown()}.
+     * <p>
+     * Default is {@code false} because some docker test classes intentionally reuse a container across
+     * multiple test methods (e.g., {@code KeystoreManagementTests}).
+     */
+    protected boolean shouldRemoveDockerContainerAfterTest() {
+        return false;
     }
 
     /** The {@link Distribution} that should be tested in this case */

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
@@ -742,6 +742,10 @@ public class Docker {
     }
 
     public static Shell.Result getContainerLogs(String containerId) {
+        if (containerId == null || containerId.isBlank()) {
+            // Avoid running `docker logs null` which is confusing and hides the real failure.
+            return new Shell.Result(1, "", "No container id available to fetch docker logs");
+        }
         return sh.run("docker logs " + containerId);
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Fix tests and logging for Docker-based tests and unmute the tests (#141098)](https://github.com/elastic/elasticsearch/pull/141098)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)