### PR TITLE
[8.19] Fix tests and logging for Docker-based tests and unmute the tests (#141098)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -330,27 +330,9 @@ tests:
 - class: org.elasticsearch.xpack.esql.plugin.DataNodeRequestSenderIT
   method: testSearchWhileRelocating
   issue: https://github.com/elastic/elasticsearch/issues/128500
-- class: org.elasticsearch.packaging.test.DockerTests
-  method: test050BasicApiTests
-  issue: https://github.com/elastic/elasticsearch/issues/120911
-- class: org.elasticsearch.packaging.test.DockerTests
-  method: test070BindMountCustomPathConfAndJvmOptions
-  issue: https://github.com/elastic/elasticsearch/issues/131366
 - class: org.elasticsearch.qa.verify_version_constants.VerifyVersionConstantsIT
   method: testLuceneVersionConstant
   issue: https://github.com/elastic/elasticsearch/issues/139816
-- class: org.elasticsearch.packaging.test.DockerTests
-  method: test071BindMountCustomPathWithDifferentUID
-  issue: https://github.com/elastic/elasticsearch/issues/120917
-- class: org.elasticsearch.packaging.test.DockerTests
-  method: test130JavaHasCorrectOwnership
-  issue: https://github.com/elastic/elasticsearch/issues/131369
-- class: org.elasticsearch.packaging.test.DockerTests
-  method: test171AdditionalCliOptionsAreForwarded
-  issue: https://github.com/elastic/elasticsearch/issues/120925
-- class: org.elasticsearch.packaging.test.DockerTests
-  method: test140CgroupOsStatsAreAvailable
-  issue: https://github.com/elastic/elasticsearch/issues/131372
 - class: org.elasticsearch.search.basic.SearchWithRandomDisconnectsIT
   method: testSearchWithRandomDisconnects
   issue: https://github.com/elastic/elasticsearch/issues/138128

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -57,6 +57,7 @@ import static org.elasticsearch.packaging.util.docker.Docker.chownWithPrivilegeE
 import static org.elasticsearch.packaging.util.docker.Docker.copyFromContainer;
 import static org.elasticsearch.packaging.util.docker.Docker.existsInContainer;
 import static org.elasticsearch.packaging.util.docker.Docker.findInContainer;
+import static org.elasticsearch.packaging.util.docker.Docker.getContainerId;
 import static org.elasticsearch.packaging.util.docker.Docker.getContainerLogs;
 import static org.elasticsearch.packaging.util.docker.Docker.getImageHealthcheck;
 import static org.elasticsearch.packaging.util.docker.Docker.getImageLabels;
@@ -124,13 +125,20 @@ public class DockerTests extends PackagingTestCase {
 
     @After
     public void teardownTest() {
-        removeContainer();
+        // Container cleanup is handled in PackagingTestCase.teardown() so that the TestWatcher
+        // can dump container logs before we remove the container on failures.
         rm(tempDir);
+    }
+
+    @Override
+    protected boolean shouldRemoveDockerContainerAfterTest() {
+        return true;
     }
 
     @Override
     protected void dumpDebug() {
         final Result containerLogs = getContainerLogs();
+        logger.warn("Container id for debug logs: " + getContainerId());
         logger.warn("Elasticsearch log stdout:\n" + containerLogs.stdout());
         logger.warn("Elasticsearch log stderr:\n" + containerLogs.stderr());
     }

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/PackagingTestCase.java
@@ -232,6 +232,22 @@ public abstract class PackagingTestCase extends Assert {
             }
         }
 
+        // Only remove docker containers after each test when a test class explicitly opts in.
+        // This runs after the TestWatcher (which calls dumpDebug on failure), so the container is still
+        // available for diagnostics.
+        if (distribution().isDocker() && shouldRemoveDockerContainerAfterTest()) {
+            removeContainer();
+        }
+    }
+
+    /**
+     * Controls whether a Docker-based test should remove its container during {@link #teardown()}.
+     * <p>
+     * Default is {@code false} because some docker test classes intentionally reuse a container across
+     * multiple test methods (e.g., {@code KeystoreManagementTests}).
+     */
+    protected boolean shouldRemoveDockerContainerAfterTest() {
+        return false;
     }
 
     /** The {@link Distribution} that should be tested in this case */

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/ServerUtils.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/ServerUtils.java
@@ -154,12 +154,12 @@ public class ServerUtils {
             return executor.execute(request).returnResponse();
         } catch (Exception e) {
             logger.warn(
-                "Failed to execute request [{}] with username/password [{}/{}] and caCert [{}]",
+                "Failed to execute request [{}] with username/password [{}/{}] and caCert [{}], exception: {}",
                 request.toString(),
                 username,
                 password,
                 caCert,
-                e
+                e.getMessage()
             );
             throw e;
         }
@@ -243,7 +243,7 @@ public class ServerUtils {
         Path caCert
     ) throws Exception {
         Objects.requireNonNull(status);
-        boolean shouldRetryOnAuthNFailure = false;
+
         // we loop here rather than letting httpclient handle retries so we can measure the entire waiting time
         final long startTime = System.currentTimeMillis();
         long lastRequest = 0;
@@ -265,10 +265,11 @@ public class ServerUtils {
                         password,
                         caCert
                     );
+
                     if (response.getStatusLine().getStatusCode() >= 300) {
                         // We create the security index on startup (in order to create an enrollment token and/or set the elastic password)
                         // In Docker, even when the ELASTIC_PASSWORD is set, when the security index exists and we get an authN attempt as
-                        // `elastic` , the reserved realm checks the security index first. It can happen that we check the security index
+                        // `elastic`, the reserved realm checks the security index first. It can happen that we check the security index
                         // too early after the security index creation in DockerTests causing an UnavailableShardsException. We retry
                         // authentication errors for a couple of seconds just to verify this is not the case.
                         if (timeElapsed < dockerWaitForSecurityIndex && response.getStatusLine().getStatusCode() == 401) {
@@ -276,7 +277,6 @@ public class ServerUtils {
                                 "Authentication against docker failed (possibly due to UnavailableShardsException for the security index)"
                                     + ", retrying..."
                             );
-                            shouldRetryOnAuthNFailure = true;
                         } else {
                             final String statusLine = response.getStatusLine().toString();
                             final String body = EntityUtils.toString(response.getEntity());
@@ -284,8 +284,9 @@ public class ServerUtils {
                                 "Connecting to elasticsearch cluster health API failed:\n" + statusLine + "\n" + body
                             );
                         }
+                    } else {
+                        started = true;
                     }
-                    started = true;
 
                 } catch (Exception e) {
                     if (thrownException == null) {
@@ -309,26 +310,24 @@ public class ServerUtils {
             throw new RuntimeException("Elasticsearch did not start", thrownException);
         }
 
-        if (shouldRetryOnAuthNFailure == false) {
-            final String url;
-            if (index == null) {
-                url = (caCert != null ? "https" : "http")
-                    + "://localhost:9200/_cluster/health?wait_for_status="
-                    + status
-                    + "&timeout=60s"
-                    + "&pretty";
-            } else {
-                url = (caCert != null ? "https" : "http")
-                    + "://localhost:9200/_cluster/health/"
-                    + index
-                    + "?wait_for_status="
-                    + status
-                    + "&timeout=60s&pretty";
-            }
-
-            final String body = makeRequest(Request.Get(url), username, password, caCert);
-            assertThat("cluster health response must contain desired status", body, containsString(status));
+        final String url;
+        if (index == null) {
+            url = (caCert != null ? "https" : "http")
+                + "://localhost:9200/_cluster/health?wait_for_status="
+                + status
+                + "&timeout=60s"
+                + "&pretty";
+        } else {
+            url = (caCert != null ? "https" : "http")
+                + "://localhost:9200/_cluster/health/"
+                + index
+                + "?wait_for_status="
+                + status
+                + "&timeout=60s&pretty";
         }
+
+        final String body = makeRequest(Request.Get(url), username, password, caCert);
+        assertThat("cluster health response must contain desired status", body, containsString(status));
     }
 
     public static void runElasticsearchTests() throws Exception {

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/docker/Docker.java
@@ -742,6 +742,10 @@ public class Docker {
     }
 
     public static Shell.Result getContainerLogs(String containerId) {
+        if (containerId == null || containerId.isBlank()) {
+            // Avoid running `docker logs null` which is confusing and hides the real failure.
+            return new Shell.Result(1, "", "No container id available to fetch docker logs");
+        }
         return sh.run("docker logs " + containerId);
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix tests and logging for Docker-based tests and unmute the tests (#141098)](https://github.com/elastic/elasticsearch/pull/141098)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)