### PR TITLE
[DOCS] Correct the version for the Grok settings change

### DIFF
--- a/docs/reference/enrich-processor/grok-processor.md
+++ b/docs/reference/enrich-processor/grok-processor.md
@@ -290,7 +290,7 @@ $$$grok-watchdog-options$$$
 | Name | Default | Description |
 | --- | --- | --- |
 | `ingest.grok.watchdog.max_execution_time` | 1s | The maximum allowed execution of a grok expression evaluation. |
-| `ingest.grok.watchdog.interval` {applies_to}`stack: deprecated 9.3`| 1s | How often to check whether there are grok evaluations that take longer than the maximum allowed execution time. As of Elasticsearch 9.3, this setting is no longer necessary and is deprecated. |
+| `ingest.grok.watchdog.interval` {applies_to}`stack: deprecated 9.4`| 1s | How often to check whether there are grok evaluations that take longer than the maximum allowed execution time. As of Elasticsearch 9.4, this setting is no longer necessary and is deprecated. |
 
 
 ## Grok debugging [grok-debugging]


### PR DESCRIPTION
I fouled this up in https://github.com/elastic/elasticsearch/pull/139405 -- it should be **9.4** not **9.3**.