### PR TITLE
Allow multiple synonym sets per synonym graph token filter

### DIFF
--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymTokenFilterFactory.java
@@ -62,21 +62,23 @@ public class SynonymTokenFilterFactory extends AbstractTokenFilterFactory {
                             + "]! Loading synonyms from index is supported only for search time synonyms!"
                     );
                 }
-                String synonymsSet = factory.settings.get(SynonymsSource.INDEX.getSettingName(), null);
+                String synonymSetSetting = SynonymsSource.INDEX.getSettingName();
+                List<String> synonymSets = factory.settings.getAsList(synonymSetSetting, null);
+
                 // provide empty synonyms on index creation and index metadata checks to ensure that we
                 // don't block a master thread
                 ReaderWithOrigin reader;
                 if (context != IndexCreationContext.RELOAD_ANALYZERS) {
                     reader = new ReaderWithOrigin(
                         new StringReader(""),
-                        "fake empty [" + synonymsSet + "] synonyms_set in .synonyms index",
-                        synonymsSet
+                        "fake empty [" + synonymSetSetting + "] synonyms_set(s) in .synonyms index",
+                        synonymSetSetting
                     );
                 } else {
                     reader = new ReaderWithOrigin(
-                        Analysis.getReaderFromIndex(synonymsSet, factory.synonymsManagementAPIService, factory.lenient),
-                        "[" + synonymsSet + "] synonyms_set in .synonyms index",
-                        synonymsSet
+                        Analysis.getReaderFromIndex(synonymSets, factory.synonymsManagementAPIService, factory.lenient),
+                        "[" + synonymSetSetting + "] synonyms_set(s) in .synonyms index",
+                        synonymSetSetting
                     );
                 }
 


### PR DESCRIPTION
##  Background
- The [current synonym set API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-synonyms-put-synonym) enforces a limit of `10,000` synonym rules per synonym set. 
- The Elastic-recommended workaround for the limit is to create multiple synonym sets.  
- The current implementation for [synonym graph token filter](https://www.elastic.co/docs/reference/text-analysis/analysis-synonym-graph-tokenfilter) allows configuring only one synonym set.
- The only option for combining multiple sets is to chain multiple synonym graph token filters.
- Chaining multiple synonym graph token filters is [very problematic](https://github.com/elastic/elasticsearch/issues/140170) and should not be allowed

## Customer Problem
Consider a scenario with over 10,000 synonym rules that follows the current recommendation and breaks them into smaller sets.
The recommendation will lead to cascading synonym expansions because of the chained synonym graph token filters.
Their synonym implementation is not viable and is greatly affecting their relevance. Using a synonym file is also not an option.

## Recommended Approach
### Changes
- Allow a synonym graph token filter to take a comma-separated list of synonym sets
    - Backwards compatible with a single synonum set
- Multiple synonym sets are read in parallel and combined in order
- All exception handling and logging from the previous implementation for a single set was carried over
- The changes are based on `8.19`

### Benefits
- Aligns with our original recommendation
- Avoids cascading synonym expansion
- Backwards compatible
- Minimal changes and no need for backporting other 9.0 changes
    - Ideal for cases where a major version upgrade is not an option
 