### PR TITLE
Fix race condition in CancellableRateLimitedFluxIterator

### DIFF
--- a/docs/changelog/141323.yaml
+++ b/docs/changelog/141323.yaml
@@ -1,0 +1,5 @@
+pr: 141323
+summary: Fix race condition in `CancellableRateLimitedFluxIterator`
+area: Snapshot/Restore
+type: bug
+issues: []

--- a/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/CancellableRateLimitedFluxIterator.java
+++ b/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/CancellableRateLimitedFluxIterator.java
@@ -52,9 +52,16 @@ class CancellableRateLimitedFluxIterator<T> implements Subscriber<T>, Iterator<T
     private final Consumer<T> cleaner;
     private final AtomicReference<Subscription> subscription = new AtomicReference<>();
     private static final Logger logger = LogManager.getLogger(CancellableRateLimitedFluxIterator.class);
-    private volatile Throwable error;
-    private volatile boolean done;
+    private volatile DoneState doneState = DoneState.STILL_READING;
     private int emittedElements;
+
+    /**
+     * This is used to set 'done' and 'error' atomically
+     */
+    private record DoneState(boolean done, Throwable error) {
+        static final DoneState STILL_READING = new DoneState(false, null);
+        static final DoneState FINISHED = new DoneState(true, null);
+    }
 
     /**
      * Creates a new CancellableRateLimitedFluxIterator that would request to it's upstream publisher
@@ -78,11 +85,11 @@ class CancellableRateLimitedFluxIterator<T> implements Subscriber<T>, Iterator<T
         // and it's possible that the consumer thread is blocked
         // waiting until the producer emits an element.
         for (;;) {
-            boolean isDone = done;
+            final DoneState lastDoneState = this.doneState;
             boolean isQueueEmpty = queue.isEmpty();
 
-            if (isDone) {
-                Throwable e = error;
+            if (lastDoneState.done()) {
+                Throwable e = lastDoneState.error();
                 if (e != null) {
                     throw new RuntimeException(e);
                 } else if (isQueueEmpty) {
@@ -97,7 +104,7 @@ class CancellableRateLimitedFluxIterator<T> implements Subscriber<T>, Iterator<T
             // Provide visibility guarantees for the modified queue
             lock.lock();
             try {
-                while (done == false && queue.isEmpty()) {
+                while (doneState.done() == false && queue.isEmpty()) {
                     condition.await();
                 }
             } catch (InterruptedException e) {
@@ -119,10 +126,14 @@ class CancellableRateLimitedFluxIterator<T> implements Subscriber<T>, Iterator<T
         T nextElement = queue.poll();
 
         if (nextElement == null) {
-            cancelSubscription();
-            signalConsumer();
+            if (doneState.done() && doneState.error() != null) {
+                throw new RuntimeException(doneState.error());
+            } else {
+                cancelSubscription();
+                signalConsumer();
 
-            throw new IllegalStateException("Queue is empty: Expected one element to be available from the Reactive Streams source.");
+                throw new IllegalStateException("Queue is empty: Expected one element to be available from the Reactive Streams source.");
+            }
         }
 
         int totalEmittedElements = emittedElements + 1;
@@ -150,7 +161,7 @@ class CancellableRateLimitedFluxIterator<T> implements Subscriber<T>, Iterator<T
         // It's possible that we receive more elements after cancelling the subscription
         // since it might have outstanding requests before the cancellation. In that case
         // we just clean the resources.
-        if (done) {
+        if (doneState.done()) {
             cleanElement(element);
             return;
         }
@@ -166,7 +177,7 @@ class CancellableRateLimitedFluxIterator<T> implements Subscriber<T>, Iterator<T
     }
 
     public void cancel() {
-        done = true;
+        doneState = DoneState.FINISHED;
         cancelSubscription();
         clearQueue();
         // cancel should be called from the consumer
@@ -178,15 +189,14 @@ class CancellableRateLimitedFluxIterator<T> implements Subscriber<T>, Iterator<T
 
     @Override
     public void onError(Throwable t) {
-        done = true;
+        doneState = new DoneState(true, t);
         clearQueue();
-        error = t;
         signalConsumer();
     }
 
     @Override
     public void onComplete() {
-        done = true;
+        doneState = DoneState.FINISHED;
         signalConsumer();
     }
 

--- a/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/CancellableRateLimitedFluxIterator.java
+++ b/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/CancellableRateLimitedFluxIterator.java
@@ -61,6 +61,10 @@ class CancellableRateLimitedFluxIterator<T> implements Subscriber<T>, Iterator<T
     private record DoneState(boolean done, Throwable error) {
         static final DoneState STILL_READING = new DoneState(false, null);
         static final DoneState FINISHED = new DoneState(true, null);
+
+        public DoneState {
+            assert done || error == null : "Must be done to specify an error";
+        }
     }
 
     /**


### PR DESCRIPTION
When an error occurs with the download, the reactive framework calls `org.elasticsearch.repositories.azure.CancellableRateLimitedFluxIterator#onError` which sets `done=true`, then clears the queue, then sets `error=t`.

It's possible that `hasNext` sees the `done=true` but doesn't see the `error=t` which will mean `hasNext` can return `false`, which we take to mean we've reached the end of the sequence of chunks, when in fact the iteration terminated due to an error. `hasNext` should throw the error in this case so the consumer knows they've read an incomplete sequence.

This iterator terminates with an error rather infrequently because currently we rely on retries in the Azure client (i.e. we'd only see it terminate with an error once the configured retries are exhausted). With [the shift](https://github.com/elastic/elasticsearch/pull/139422) to using the common retry infrastructure, this code path will be executed for every individual failure, so it becomes more likely that we will hit this race condition.

This change modifies the update to `done` and `error` to make it atomic. This will remove the above edge case.