### PR TITLE
Reapply "Use common retry logic for Azure (#139422)"

### DIFF
--- a/docs/changelog/139422.yaml
+++ b/docs/changelog/139422.yaml
@@ -1,0 +1,5 @@
+pr: 139422
+summary: Use common retry logic for Azure
+area: Snapshot/Restore
+type: enhancement
+issues: []

--- a/modules/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureBlobStoreRepositoryTests.java
+++ b/modules/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureBlobStoreRepositoryTests.java
@@ -70,6 +70,7 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.repositories.RepositoriesMetrics.METRIC_REQUESTS_TOTAL;
 import static org.elasticsearch.repositories.blobstore.BlobStoreTestUtil.randomPurpose;
+import static org.elasticsearch.repositories.blobstore.BlobStoreTestUtil.randomRetryingPurpose;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.allOf;
@@ -402,7 +403,7 @@ public class AzureBlobStoreRepositoryTests extends ESMockAPIBasedRepositoryInteg
             container.writeBlob(randomPurpose(), blobName, new ByteArrayInputStream(data), data.length, true);
 
             var originalDataInputStream = new ByteArrayInputStream(data);
-            try (var azureInputStream = container.readBlob(randomPurpose(), blobName)) {
+            try (var azureInputStream = container.readBlob(randomRetryingPurpose(), blobName)) {
                 for (int i = 0; i < data.length; i++) {
                     assertThat(originalDataInputStream.read(), is(equalTo(azureInputStream.read())));
                 }

--- a/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobContainer.java
+++ b/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobContainer.java
@@ -9,11 +9,8 @@
 
 package org.elasticsearch.repositories.azure;
 
-import com.azure.core.exception.HttpResponseException;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.blobstore.BlobContainer;
@@ -26,8 +23,6 @@ import org.elasticsearch.common.blobstore.support.BlobMetadata;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.Nullable;
-import org.elasticsearch.repositories.blobstore.RequestedRangeNotSatisfiedException;
-import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -67,20 +62,7 @@ public class AzureBlobContainer extends AbstractBlobContainer {
             // stream to it.
             throw new NoSuchFileException("Blob [" + blobKey + "] not found");
         }
-        try {
-            return blobStore.getInputStream(purpose, blobKey, position, length);
-        } catch (Exception e) {
-            if (ExceptionsHelper.unwrap(e, HttpResponseException.class) instanceof HttpResponseException httpResponseException) {
-                final var httpStatusCode = httpResponseException.getResponse().getStatusCode();
-                if (httpStatusCode == RestStatus.NOT_FOUND.getStatus()) {
-                    throw new NoSuchFileException("Blob [" + blobKey + "] not found");
-                }
-                if (httpStatusCode == RestStatus.REQUESTED_RANGE_NOT_SATISFIED.getStatus()) {
-                    throw new RequestedRangeNotSatisfiedException(blobKey, position, length == null ? -1 : length, e);
-                }
-            }
-            throw new IOException("Unable to get input stream for blob [" + blobKey + "]", e);
-        }
+        return new AzureRetryingInputStream(blobStore, purpose, blobKey, position, length);
     }
 
     @Override

--- a/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobStore.java
+++ b/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobStore.java
@@ -17,7 +17,6 @@ import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 import com.azure.core.http.HttpMethod;
-import com.azure.core.http.rest.ResponseBase;
 import com.azure.core.util.BinaryData;
 import com.azure.core.util.FluxUtil;
 import com.azure.core.util.logging.ClientLogger;
@@ -345,7 +344,21 @@ public class AzureBlobStore implements BlobStore {
         return false;
     }
 
-    public InputStream getInputStream(OperationPurpose purpose, String blob, long position, final @Nullable Long length) {
+    int getMaxReadRetries() {
+        return service.getMaxReadRetries(projectId, clientName);
+    }
+
+    /**
+     * Get an {@link InputStream} for reading the specified blob. The returned input stream will not retry on a read failure,
+     * to get an input stream that implements retries use {@link AzureBlobContainer#readBlob(OperationPurpose, String, long, long)}
+     */
+    AzureInputStream getInputStream(
+        OperationPurpose purpose,
+        String blob,
+        long position,
+        final @Nullable Long length,
+        @Nullable String eTag
+    ) {
         logger.trace(() -> format("reading container [%s], blob [%s]", container, blob));
         final AzureBlobServiceClient azureBlobServiceClient = getAzureBlobServiceClientClient(purpose);
         final BlobServiceClient syncClient = azureBlobServiceClient.getSyncClient();
@@ -360,19 +373,14 @@ public class AzureBlobStore implements BlobStore {
             totalSize = position + length;
         }
         BlobAsyncClient blobAsyncClient = asyncClient.getBlobContainerAsyncClient(container).getBlobAsyncClient(blob);
-        int maxReadRetries = service.getMaxReadRetries(projectId, clientName);
-        try {
-            return new AzureInputStream(
-                blobAsyncClient,
-                position,
-                length == null ? totalSize : length,
-                totalSize,
-                maxReadRetries,
-                azureBlobServiceClient.getAllocator()
-            );
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        return new AzureInputStream(
+            blobAsyncClient,
+            position,
+            length == null ? totalSize : length,
+            totalSize,
+            azureBlobServiceClient.getAllocator(),
+            eTag
+        );
     }
 
     public Map<String, BlobMetadata> listBlobsByPrefix(OperationPurpose purpose, String keyPath, String prefix) throws IOException {
@@ -1076,27 +1084,35 @@ public class AzureBlobStore implements BlobStore {
         return requestMetricsRecorder;
     }
 
-    private static class AzureInputStream extends InputStream {
+    static class AzureInputStream extends InputStream {
         private final CancellableRateLimitedFluxIterator<ByteBuf> cancellableRateLimitedFluxIterator;
         private ByteBuf byteBuf;
         private boolean closed;
         private final ByteBufAllocator allocator;
+        private final String eTag;
 
         private AzureInputStream(
             final BlobAsyncClient client,
             long rangeOffset,
             long rangeLength,
             long contentLength,
-            int maxRetries,
-            ByteBufAllocator allocator
-        ) throws IOException {
+            ByteBufAllocator allocator,
+            @Nullable String ifMatchETag
+        ) {
             rangeLength = Math.min(rangeLength, contentLength - rangeOffset);
             final BlobRange range = new BlobRange(rangeOffset, rangeLength);
-            DownloadRetryOptions downloadRetryOptions = new DownloadRetryOptions().setMaxRetryRequests(maxRetries);
-            Flux<ByteBuf> byteBufFlux = client.downloadWithResponse(range, downloadRetryOptions, null, false)
+            final DownloadRetryOptions downloadRetryOptions = new DownloadRetryOptions().setMaxRetryRequests(0);
+            final BlobRequestConditions requestConditions = new BlobRequestConditions().setIfMatch(ifMatchETag);
+            final AtomicReference<String> eTagRef = new AtomicReference<>();
+            Flux<ByteBuf> byteBufFlux = client.downloadWithResponse(range, downloadRetryOptions, requestConditions, false)
                 .flux()
-                .concatMap(ResponseBase::getValue) // it's important to use concatMap, since flatMap doesn't provide ordering
-                                                   // guarantees and that's not fun to debug :(
+                .concatMap(response -> {
+                    if (eTagRef.compareAndSet(null, response.getDeserializedHeaders().getETag()) == false) {
+                        assert eTagRef.get().equals(response.getDeserializedHeaders().getETag()) : "Got multiple, differing ETags?!";
+                    }
+                    return response.getValue();
+                }) // it's important to use concatMap, since flatMap doesn't provide ordering
+                   // guarantees and that's not fun to debug :(
                 .filter(Objects::nonNull)
                 .map(this::copyBuffer); // Sadly we have to copy the buffers since the memory is released after the flux execution
                                         // ends and we need that the byte buffer outlives that lifecycle. Since the SDK provides an
@@ -1112,6 +1128,10 @@ public class AzureBlobStore implements BlobStore {
             // blob doesn't exist
             byteBufFlux.subscribe(cancellableRateLimitedFluxIterator);
             getNextByteBuf();
+            assert eTagRef.get() != null : "eTag should have been set";
+            assert ifMatchETag == null || eTagRef.get().equals(ifMatchETag)
+                : "eTag mismatch; requested=" + ifMatchETag + " received=" + eTagRef.get();
+            this.eTag = eTagRef.get();
         }
 
         private ByteBuf copyBuffer(ByteBuffer buffer) {
@@ -1173,27 +1193,27 @@ public class AzureBlobStore implements BlobStore {
             }
         }
 
+        public String getETag() {
+            return eTag;
+        }
+
         private void releaseByteBuf(ByteBuf buf) {
             ReferenceCountUtil.safeRelease(buf);
             this.byteBuf = null;
         }
 
         @Nullable
-        private ByteBuf getNextByteBuf() throws IOException {
-            try {
-                if (byteBuf == null && cancellableRateLimitedFluxIterator.hasNext() == false) {
-                    return null;
-                }
-
-                if (byteBuf != null) {
-                    return byteBuf;
-                }
-
-                byteBuf = cancellableRateLimitedFluxIterator.next();
-                return byteBuf;
-            } catch (Exception e) {
-                throw new IOException("Unable to read blob", e.getCause());
+        private ByteBuf getNextByteBuf() {
+            if (byteBuf == null && cancellableRateLimitedFluxIterator.hasNext() == false) {
+                return null;
             }
+
+            if (byteBuf != null) {
+                return byteBuf;
+            }
+
+            byteBuf = cancellableRateLimitedFluxIterator.next();
+            return byteBuf;
         }
     }
 

--- a/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepositoryPlugin.java
+++ b/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepositoryPlugin.java
@@ -118,7 +118,8 @@ public class AzureRepositoryPlugin extends Plugin implements RepositoryPlugin, R
             AzureStorageSettings.PROXY_HOST_SETTING,
             AzureStorageSettings.PROXY_PORT_SETTING,
             AzureStorageSettings.ENDPOINT_SETTING,
-            AzureStorageSettings.SECONDARY_ENDPOINT_SETTING
+            AzureStorageSettings.SECONDARY_ENDPOINT_SETTING,
+            AzureStorageSettings.READ_TIMEOUT_SETTING
         );
     }
 

--- a/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRetryingInputStream.java
+++ b/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRetryingInputStream.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.repositories.azure;
+
+import com.azure.core.exception.HttpResponseException;
+import com.azure.core.http.policy.RetryStrategy;
+
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.common.blobstore.OperationPurpose;
+import org.elasticsearch.common.blobstore.RetryingInputStream;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.repositories.blobstore.RequestedRangeNotSatisfiedException;
+import org.elasticsearch.rest.RestStatus;
+
+import java.io.IOException;
+import java.nio.file.NoSuchFileException;
+
+public class AzureRetryingInputStream extends RetryingInputStream<String> {
+
+    protected AzureRetryingInputStream(AzureBlobStore azureBlobStore, OperationPurpose purpose, String blob, long position, Long length)
+        throws IOException {
+        super(
+            new AzureBlobStoreServices(azureBlobStore, purpose, blob),
+            purpose,
+            position,
+            length == null ? Long.MAX_VALUE - 1 : position + length
+        );
+    }
+
+    private record AzureBlobStoreServices(AzureBlobStore blobStore, OperationPurpose purpose, String blob)
+        implements
+            RetryingInputStream.BlobStoreServices<String> {
+
+        @Override
+        public SingleAttemptInputStream<String> getInputStream(@Nullable String version, long start, long end) throws IOException {
+            try {
+                final Long length = end < Long.MAX_VALUE - 1 ? end - start : null;
+                final AzureBlobStore.AzureInputStream inputStream = blobStore.getInputStream(purpose, blob, start, length, version);
+                return new SingleAttemptInputStream<>(inputStream, start, inputStream.getETag());
+            } catch (RuntimeException e) {
+                if (ExceptionsHelper.unwrap(e, HttpResponseException.class) instanceof HttpResponseException httpResponseException) {
+                    final var httpStatusCode = httpResponseException.getResponse().getStatusCode();
+                    if (httpStatusCode == RestStatus.NOT_FOUND.getStatus()) {
+                        throw new NoSuchFileException("blob object [" + blob + "] not found");
+                    }
+                    if (httpStatusCode == RestStatus.REQUESTED_RANGE_NOT_SATISFIED.getStatus()) {
+                        throw new RequestedRangeNotSatisfiedException(blob, start, end == Long.MAX_VALUE - 1 ? -1 : end - start, e);
+                    }
+                }
+                throw e;
+            }
+        }
+
+        @Override
+        public void onRetryStarted(StreamAction action) {
+            // No metrics for Azure
+        }
+
+        @Override
+        public void onRetrySucceeded(StreamAction action, long numberOfRetries) {
+            // No metrics for Azure
+        }
+
+        @Override
+        public long getMeaningfulProgressSize() {
+            return Math.max(1L, blobStore.getReadChunkSize() / 100L);
+        }
+
+        @Override
+        public int getMaxRetries() {
+            return blobStore.getMaxReadRetries();
+        }
+
+        @Override
+        public String getBlobDescription() {
+            return blob;
+        }
+
+        /**
+         * The range of errors that are retried in Azure is quite liberal by default. This
+         * is overridden in {@link com.azure.core.http.policy.ExponentialBackoff}, but in
+         * our configuration it ends up using the default.
+         *
+         * @see RetryStrategy#shouldRetryException(Throwable)
+         */
+        @Override
+        public boolean isRetryableException(StreamAction action, Exception e) {
+            return true;
+        }
+    }
+}

--- a/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureStorageSettings.java
+++ b/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureStorageSettings.java
@@ -99,6 +99,13 @@ final class AzureStorageSettings {
         () -> ACCOUNT_SETTING
     );
 
+    public static final AffixSetting<TimeValue> READ_TIMEOUT_SETTING = Setting.affixKeySetting(
+        AZURE_CLIENT_PREFIX_KEY,
+        "read_timeout",
+        key -> Setting.timeSetting(key, TimeValue.MINUS_ONE, Property.NodeScope),
+        () -> ACCOUNT_SETTING
+    );
+
     /** The type of the proxy to connect to azure through. Can be direct (no proxy, default), http or socks */
     public static final AffixSetting<Proxy.Type> PROXY_TYPE_SETTING = Setting.affixKeySetting(
         AZURE_CLIENT_PREFIX_KEY,
@@ -130,6 +137,7 @@ final class AzureStorageSettings {
     private final String connectString;
     private final String endpointSuffix;
     private final TimeValue timeout;
+    private final TimeValue readTimeout;
     private final int maxRetries;
     private final Proxy proxy;
     private final boolean hasCredentials;
@@ -141,6 +149,7 @@ final class AzureStorageSettings {
         String sasToken,
         String endpointSuffix,
         TimeValue timeout,
+        TimeValue readTimeout,
         int maxRetries,
         Proxy.Type proxyType,
         String proxyHost,
@@ -153,6 +162,7 @@ final class AzureStorageSettings {
         this.hasCredentials = Strings.hasText(key) || Strings.hasText(sasToken);
         this.endpointSuffix = endpointSuffix;
         this.timeout = timeout;
+        this.readTimeout = readTimeout;
         this.maxRetries = maxRetries;
         this.credentialsUsageFeatures = Strings.hasText(key) ? Set.of("uses_key_credentials")
             : Strings.hasText(sasToken) ? Set.of("uses_sas_token")
@@ -185,6 +195,10 @@ final class AzureStorageSettings {
 
     public TimeValue getTimeout() {
         return timeout;
+    }
+
+    public TimeValue getReadTimeout() {
+        return readTimeout;
     }
 
     public int getMaxRetries() {
@@ -257,6 +271,7 @@ final class AzureStorageSettings {
         final StringBuilder sb = new StringBuilder("AzureStorageSettings{");
         sb.append("account='").append(account).append('\'');
         sb.append(", timeout=").append(timeout);
+        sb.append(", readTimeout=").append(readTimeout);
         sb.append(", endpointSuffix='").append(endpointSuffix).append('\'');
         sb.append(", maxRetries=").append(maxRetries);
         sb.append(", proxy=").append(proxy);
@@ -299,6 +314,7 @@ final class AzureStorageSettings {
                 sasToken.toString(),
                 getValue(settings, clientName, ENDPOINT_SUFFIX_SETTING),
                 getValue(settings, clientName, TIMEOUT_SETTING),
+                getValue(settings, clientName, READ_TIMEOUT_SETTING),
                 getValue(settings, clientName, MAX_RETRIES_SETTING),
                 getValue(settings, clientName, PROXY_TYPE_SETTING),
                 getValue(settings, clientName, PROXY_HOST_SETTING),
@@ -390,12 +406,23 @@ final class AzureStorageSettings {
             && Objects.equals(connectString, that.connectString)
             && Objects.equals(endpointSuffix, that.endpointSuffix)
             && Objects.equals(timeout, that.timeout)
+            && Objects.equals(readTimeout, that.readTimeout)
             && Objects.equals(proxy, that.proxy)
             && Objects.equals(credentialsUsageFeatures, that.credentialsUsageFeatures);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(account, connectString, endpointSuffix, timeout, maxRetries, proxy, hasCredentials, credentialsUsageFeatures);
+        return Objects.hash(
+            account,
+            connectString,
+            endpointSuffix,
+            timeout,
+            readTimeout,
+            maxRetries,
+            proxy,
+            hasCredentials,
+            credentialsUsageFeatures
+        );
     }
 }

--- a/modules/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AbstractAzureServerTestCase.java
+++ b/modules/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AbstractAzureServerTestCase.java
@@ -28,13 +28,14 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.core.Tuple;
 import org.elasticsearch.mocksocket.MockHttpServer;
 import org.elasticsearch.repositories.RepositoriesMetrics;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.fixture.HttpHeaderParser;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.After;
@@ -44,8 +45,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.time.Duration;
 import java.util.Base64;
-import java.util.Locale;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
@@ -104,21 +106,13 @@ public abstract class AbstractAzureServerTestCase extends ESTestCase {
     }
 
     protected BlobContainer createBlobContainer(final int maxRetries) {
-        return createBlobContainer(maxRetries, null, LocationMode.PRIMARY_ONLY);
-    }
-
-    protected BlobContainer createBlobContainer(final int maxRetries, String secondaryHost, final LocationMode locationMode) {
-        final String clientName = randomAlphaOfLength(5).toLowerCase(Locale.ROOT);
-        final MockSecureSettings secureSettings = new MockSecureSettings();
-        secureSettings.setString(ACCOUNT_SETTING.getConcreteSettingForNamespace(clientName).getKey(), ACCOUNT);
-        final String key = Base64.getEncoder().encodeToString(randomAlphaOfLength(14).getBytes(UTF_8));
-        secureSettings.setString(KEY_SETTING.getConcreteSettingForNamespace(clientName).getKey(), key);
-
-        return createBlobContainer(maxRetries, secondaryHost, locationMode, clientName, secureSettings);
+        return builder().withMaxRetries(maxRetries).build();
     }
 
     protected BlobContainer createBlobContainer(
         final int maxRetries,
+        final TimeValue tryTimeout,
+        @Nullable final TimeValue readTimeout,
         String secondaryHost,
         final LocationMode locationMode,
         String clientName,
@@ -132,7 +126,10 @@ public abstract class AbstractAzureServerTestCase extends ESTestCase {
         }
         clientSettings.put(ENDPOINT_SUFFIX_SETTING.getConcreteSettingForNamespace(clientName).getKey(), endpoint);
         clientSettings.put(MAX_RETRIES_SETTING.getConcreteSettingForNamespace(clientName).getKey(), maxRetries);
-        clientSettings.put(TIMEOUT_SETTING.getConcreteSettingForNamespace(clientName).getKey(), TimeValue.timeValueMillis(500));
+        clientSettings.put(TIMEOUT_SETTING.getConcreteSettingForNamespace(clientName).getKey(), tryTimeout);
+        if (readTimeout != null) {
+            clientSettings.put(AzureStorageSettings.READ_TIMEOUT_SETTING.getConcreteSettingForNamespace(clientName).getKey(), readTimeout);
+        }
 
         clientSettings.setSecureSettings(secureSettings);
         clientSettings.put(DiscoveryNode.STATELESS_ENABLED_SETTING_NAME, serverlessMode);
@@ -145,13 +142,14 @@ public abstract class AbstractAzureServerTestCase extends ESTestCase {
         ) {
             @Override
             RequestRetryOptions getRetryOptions(LocationMode locationMode, AzureStorageSettings azureStorageSettings) {
+                RequestRetryOptions retryOptions = super.getRetryOptions(locationMode, azureStorageSettings);
                 return new RequestRetryOptions(
                     RetryPolicyType.EXPONENTIAL,
-                    maxRetries + 1,
-                    60,
-                    50L,
-                    100L,
-                    // The SDK doesn't work well with ip endponts. Secondary host endpoints that contain
+                    retryOptions.getMaxTries(),
+                    retryOptions.getTryTimeoutDuration(),
+                    Duration.ofMillis(50),
+                    Duration.ofMillis(100L),
+                    // The SDK doesn't work well with ip endpoints. Secondary host endpoints that contain
                     // a path causes the sdk to rewrite the endpoint with an invalid path, that's the reason why we provide just the host +
                     // port.
                     secondaryHost != null ? secondaryHost.replaceFirst("/" + ACCOUNT, "") : null
@@ -190,28 +188,28 @@ public abstract class AbstractAzureServerTestCase extends ESTestCase {
         return randomByteArrayOfLength(randomIntBetween(1, 1 << 20)); // rarely up to 1mb
     }
 
-    private static final Pattern RANGE_PATTERN = Pattern.compile("^bytes=([0-9]+)-([0-9]+)$");
+    private static final Pattern RANGE_PATTERN = Pattern.compile("^bytes=([0-9]+)-(-1|[0-9]+)$");
 
-    protected static Tuple<Long, Long> getRanges(HttpExchange exchange) {
+    public static HttpHeaderParser.Range getRanges(HttpExchange exchange) {
         final String rangeHeader = exchange.getRequestHeaders().getFirst("X-ms-range");
         if (rangeHeader == null) {
-            return Tuple.tuple(0L, MAX_RANGE_VAL);
+            return new HttpHeaderParser.Range(0L, MAX_RANGE_VAL);
         }
 
         final Matcher matcher = RANGE_PATTERN.matcher(rangeHeader);
         assertTrue(rangeHeader + " matches expected pattern", matcher.matches());
         final long rangeStart = Long.parseLong(matcher.group(1));
-        final long rangeEnd = Long.parseLong(matcher.group(2));
+        final long rangeEnd = "-1".equals(matcher.group(2)) ? MAX_RANGE_VAL : Long.parseLong(matcher.group(2));
         assertThat(rangeStart, lessThanOrEqualTo(rangeEnd));
-        return Tuple.tuple(rangeStart, rangeEnd);
+        return new HttpHeaderParser.Range(rangeStart, rangeEnd);
     }
 
     protected static int getRangeStart(HttpExchange exchange) {
-        return Math.toIntExact(getRanges(exchange).v1());
+        return Math.toIntExact(getRanges(exchange).start());
     }
 
     protected static Optional<Integer> getRangeEnd(HttpExchange exchange) {
-        final long rangeEnd = getRanges(exchange).v2();
+        final long rangeEnd = getRanges(exchange).end();
         if (rangeEnd == MAX_RANGE_VAL) {
             return Optional.empty();
         }
@@ -223,7 +221,7 @@ public abstract class AbstractAzureServerTestCase extends ESTestCase {
         return "http://" + InetAddresses.toUriString(address.getAddress()) + ":" + address.getPort() + "/" + accountName;
     }
 
-    protected void readFromInputStream(InputStream inputStream, long bytesToRead) {
+    public static void readFromInputStream(InputStream inputStream, long bytesToRead) {
         try {
             long totalBytesRead = 0;
             while (inputStream.read() != -1 && totalBytesRead < bytesToRead) {
@@ -232,6 +230,70 @@ public abstract class AbstractAzureServerTestCase extends ESTestCase {
             assertThat(totalBytesRead, equalTo(bytesToRead));
         } catch (IOException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    protected BlobContainerBuilder builder() {
+        return new BlobContainerBuilder();
+    }
+
+    protected class BlobContainerBuilder {
+        private int maxRetries = 5;
+        private TimeValue tryTimeout = TimeValue.timeValueSeconds(60);
+        @Nullable
+        private TimeValue readTimeout;
+        @Nullable
+        private String secondaryHost;
+        private LocationMode locationMode = LocationMode.PRIMARY_ONLY;
+        private String clientName = randomIdentifier();
+        @Nullable
+        private SecureSettings secureSettings;
+
+        public BlobContainerBuilder withClientName(String clientName) {
+            this.clientName = Objects.requireNonNull(clientName);
+            return this;
+        }
+
+        public BlobContainerBuilder withMaxRetries(int maxRetries) {
+            this.maxRetries = maxRetries;
+            return this;
+        }
+
+        public BlobContainerBuilder withTryTimeout(TimeValue tryTimeout) {
+            this.tryTimeout = Objects.requireNonNull(tryTimeout);
+            return this;
+        }
+
+        public BlobContainerBuilder withReadTimeout(TimeValue readTimeout) {
+            this.readTimeout = readTimeout;
+            return this;
+        }
+
+        public BlobContainerBuilder withSecondaryHost(String secondaryHost) {
+            this.secondaryHost = secondaryHost;
+            return this;
+        }
+
+        public BlobContainerBuilder withLocationMode(LocationMode locationMode) {
+            this.locationMode = Objects.requireNonNull(locationMode);
+            return this;
+        }
+
+        public BlobContainerBuilder withSecureSettings(SecureSettings secureSettings) {
+            this.secureSettings = secureSettings;
+            return this;
+        }
+
+        public BlobContainer build() {
+            if (secureSettings == null) {
+                final MockSecureSettings secureSettings = new MockSecureSettings();
+                secureSettings.setString(ACCOUNT_SETTING.getConcreteSettingForNamespace(clientName).getKey(), ACCOUNT);
+                final String key = Base64.getEncoder().encodeToString(randomAlphaOfLength(14).getBytes(UTF_8));
+                secureSettings.setString(KEY_SETTING.getConcreteSettingForNamespace(clientName).getKey(), key);
+                this.secureSettings = secureSettings;
+            }
+
+            return createBlobContainer(maxRetries, tryTimeout, readTimeout, secondaryHost, locationMode, clientName, secureSettings);
         }
     }
 }

--- a/modules/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureBlobContainerRetriesTests.java
+++ b/modules/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureBlobContainerRetriesTests.java
@@ -6,46 +6,91 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
+
 package org.elasticsearch.repositories.azure;
 
 import fixture.azure.AzureHttpHandler;
 
+import com.azure.storage.common.policy.RequestRetryOptions;
+import com.azure.storage.common.policy.RetryPolicyType;
+import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
 
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.metadata.RepositoryMetadata;
+import org.elasticsearch.cluster.project.TestProjectResolvers;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.blobstore.BlobContainer;
+import org.elasticsearch.common.blobstore.BlobPath;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.hash.MessageDigests;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.lucene.store.ByteArrayIndexInput;
 import org.elasticsearch.common.lucene.store.InputStreamIndexInput;
+import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.common.settings.MockSecureSettings;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.CountDown;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.mocksocket.MockHttpServer;
+import org.elasticsearch.repositories.RepositoriesMetrics;
+import org.elasticsearch.repositories.blobstore.AbstractBlobContainerRetriesTestCase;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.RestUtils;
+import org.elasticsearch.test.ClusterServiceUtils;
+import org.elasticsearch.test.fixture.HttpHeaderParser;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.After;
+import org.junit.Before;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.nio.file.NoSuchFileException;
+import java.time.Duration;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.elasticsearch.repositories.azure.AbstractAzureServerTestCase.getRanges;
+import static org.elasticsearch.repositories.azure.AbstractAzureServerTestCase.readFromInputStream;
+import static org.elasticsearch.repositories.azure.AzureRepository.Repository.CONTAINER_SETTING;
+import static org.elasticsearch.repositories.azure.AzureRepository.Repository.LOCATION_MODE_SETTING;
+import static org.elasticsearch.repositories.azure.AzureRepository.Repository.MAX_SINGLE_PART_UPLOAD_SIZE_SETTING;
+import static org.elasticsearch.repositories.azure.AzureStorageSettings.ACCOUNT_SETTING;
+import static org.elasticsearch.repositories.azure.AzureStorageSettings.ENDPOINT_SUFFIX_SETTING;
+import static org.elasticsearch.repositories.azure.AzureStorageSettings.KEY_SETTING;
+import static org.elasticsearch.repositories.azure.AzureStorageSettings.MAX_RETRIES_SETTING;
+import static org.elasticsearch.repositories.azure.AzureStorageSettings.READ_TIMEOUT_SETTING;
+import static org.elasticsearch.repositories.azure.AzureStorageSettings.TIMEOUT_SETTING;
 import static org.elasticsearch.repositories.blobstore.BlobStoreTestUtil.randomPurpose;
+import static org.elasticsearch.repositories.blobstore.BlobStoreTestUtil.randomRetryingPurpose;
 import static org.elasticsearch.repositories.blobstore.ESBlobStoreRepositoryIntegTestCase.randomBytes;
-import static org.elasticsearch.test.hamcrest.OptionalMatchers.isPresentWith;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -57,7 +102,38 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
  * This class tests how a {@link AzureBlobContainer} and its underlying SDK client are retrying requests when reading or writing blobs.
  */
 @SuppressForbidden(reason = "use a http server")
-public class AzureBlobContainerRetriesTests extends AbstractAzureServerTestCase {
+public class AzureBlobContainerRetriesTests extends AbstractBlobContainerRetriesTestCase {
+
+    private static final String ACCOUNT = "account";
+    private static final String CONTAINER = "container";
+
+    private AzureClientProvider clientProvider;
+    private ClusterService clusterService;
+    private ThreadPool threadPool;
+    private HttpServer secondaryHttpServer;
+
+    @Before
+    public void setUp() throws Exception {
+        threadPool = new TestThreadPool(
+            getTestClass().getName(),
+            AzureRepositoryPlugin.executorBuilder(Settings.EMPTY),
+            AzureRepositoryPlugin.nettyEventLoopExecutorBuilder(Settings.EMPTY)
+        );
+        secondaryHttpServer = MockHttpServer.createHttp(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        secondaryHttpServer.start();
+        clientProvider = AzureClientProvider.create(threadPool, Settings.EMPTY);
+        clientProvider.start();
+        clusterService = ClusterServiceUtils.createClusterService(threadPool);
+        super.setUp();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        clientProvider.close();
+        super.tearDown();
+        secondaryHttpServer.stop(0);
+        ThreadPool.terminate(threadPool, 10L, TimeUnit.SECONDS);
+    }
 
     public void testReadNonexistentBlobThrowsNoSuchFileException() {
         final BlobContainer blobContainer = createBlobContainer(between(1, 5));
@@ -78,7 +154,8 @@ public class AzureBlobContainerRetriesTests extends AbstractAzureServerTestCase 
         final CountDown countDownHead = new CountDown(maxRetries);
         final CountDown countDownGet = new CountDown(maxRetries);
         final byte[] bytes = randomBlobContent();
-        httpServer.createContext("/account/container/read_blob_max_retries", exchange -> {
+        final BlobContainer blobContainer = createBlobContainer(maxRetries);
+        httpServer.createContext(downloadStorageEndpoint(blobContainer, "read_blob_max_retries"), exchange -> {
             try {
                 Streams.readFully(exchange.getRequestBody());
                 if ("HEAD".equals(exchange.getRequestMethod())) {
@@ -113,19 +190,79 @@ public class AzureBlobContainerRetriesTests extends AbstractAzureServerTestCase 
             }
         });
 
-        final BlobContainer blobContainer = createBlobContainer(maxRetries);
-        try (InputStream inputStream = blobContainer.readBlob(randomPurpose(), "read_blob_max_retries")) {
+        try (InputStream inputStream = blobContainer.readBlob(randomRetryingPurpose(), "read_blob_max_retries")) {
             assertArrayEquals(bytes, BytesReference.toBytes(Streams.readFully(inputStream)));
             assertThat(countDownHead.isCountedDown(), is(true));
             assertThat(countDownGet.isCountedDown(), is(true));
         }
     }
 
+    public void testReadBlobWithFailuresMidDownload() throws IOException {
+        final int responsesToSend = randomIntBetween(3, 5);
+        final AtomicInteger responseCounter = new AtomicInteger(responsesToSend);
+        final byte[] blobContents = randomBlobContent();
+        final String eTag = UUIDs.base64UUID();
+        final BlobContainer blobContainer = createBlobContainer(responsesToSend * 2);
+        httpServer.createContext(downloadStorageEndpoint(blobContainer, "read_blob_fail_mid_stream"), exchange -> {
+            try {
+                Streams.readFully(exchange.getRequestBody());
+                if ("HEAD".equals(exchange.getRequestMethod())) {
+                    exchange.getResponseHeaders().add("Content-Type", "application/octet-stream");
+                    exchange.getResponseHeaders().add("x-ms-blob-content-length", String.valueOf(blobContents.length));
+                    exchange.getResponseHeaders().add("Content-Length", String.valueOf(blobContents.length));
+                    exchange.getResponseHeaders().add("x-ms-blob-type", "blockblob");
+                    exchange.sendResponseHeaders(RestStatus.OK.getStatus(), -1);
+                } else if ("GET".equals(exchange.getRequestMethod())) {
+                    if (responseCounter.decrementAndGet() > 0) {
+                        switch (randomIntBetween(1, 3)) {
+                            case 1 -> {
+                                final Integer rCode = randomFrom(
+                                    RestStatus.INTERNAL_SERVER_ERROR.getStatus(),
+                                    RestStatus.SERVICE_UNAVAILABLE.getStatus(),
+                                    RestStatus.TOO_MANY_REQUESTS.getStatus()
+                                );
+                                logger.info("---> sending error: {}", rCode);
+                                exchange.sendResponseHeaders(rCode, -1);
+                            }
+                            case 2 -> logger.info("---> sending no response");
+                            case 3 -> sendResponse(eTag, blobContents, exchange, true);
+                        }
+                    } else {
+                        sendResponse(eTag, blobContents, exchange, false);
+                    }
+                }
+            } finally {
+                exchange.close();
+            }
+        });
+
+        try (InputStream inputStream = blobContainer.readBlob(randomRetryingPurpose(), "read_blob_fail_mid_stream")) {
+            assertArrayEquals(blobContents, BytesReference.toBytes(Streams.readFully(inputStream)));
+        }
+    }
+
+    private void sendResponse(String eTag, byte[] blobContents, HttpExchange exchange, boolean partial) throws IOException {
+        final var ranges = getRanges(exchange);
+        final int start = Math.toIntExact(ranges.start());
+        final int end = partial ? randomIntBetween(start, Math.toIntExact(ranges.end())) : Math.toIntExact(ranges.end());
+        final var contents = Arrays.copyOfRange(blobContents, start, end + 1);
+
+        logger.info("---> responding to: {} -> {} (sending chunk of size {})", ranges.start(), ranges.end(), contents.length);
+        exchange.getResponseHeaders().add("Content-Type", "application/octet-stream");
+        exchange.getResponseHeaders().add("x-ms-blob-content-length", String.valueOf(blobContents.length));
+        exchange.getResponseHeaders().add("Content-Length", String.valueOf(blobContents.length));
+        exchange.getResponseHeaders().add("x-ms-blob-type", "blockblob");
+        exchange.getResponseHeaders().add("ETag", eTag);
+        exchange.sendResponseHeaders(RestStatus.OK.getStatus(), blobContents.length - ranges.start());
+        exchange.getResponseBody().write(contents, 0, contents.length);
+    }
+
     public void testReadRangeBlobWithRetries() throws Exception {
         final int maxRetries = randomIntBetween(1, 5);
         final CountDown countDownGet = new CountDown(maxRetries);
         final byte[] bytes = randomBlobContent();
-        httpServer.createContext("/account/container/read_range_blob_max_retries", exchange -> {
+        final BlobContainer blobContainer = createBlobContainer(maxRetries);
+        httpServer.createContext(downloadStorageEndpoint(blobContainer, "read_range_blob_max_retries"), exchange -> {
             try {
                 Streams.readFully(exchange.getRequestBody());
                 if ("HEAD".equals(exchange.getRequestMethod())) {
@@ -134,13 +271,17 @@ public class AzureBlobContainerRetriesTests extends AbstractAzureServerTestCase 
                     if (countDownGet.countDown()) {
                         final int rangeStart = getRangeStart(exchange);
                         assertThat(rangeStart, lessThan(bytes.length));
-                        final Optional<Integer> rangeEnd = getRangeEnd(exchange);
-                        assertThat(rangeEnd, isPresentWith(greaterThanOrEqualTo(rangeStart)));
-                        final int length = (rangeEnd.get() - rangeStart) + 1;
+                        final OptionalInt rangeEnd = getRangeEnd(exchange);
+                        assertTrue(rangeEnd.isPresent());
+                        assertThat(rangeEnd.getAsInt(), greaterThanOrEqualTo(rangeStart));
+                        final int length = (rangeEnd.getAsInt() - rangeStart) + 1;
                         assertThat(length, lessThanOrEqualTo(bytes.length - rangeStart));
                         exchange.getResponseHeaders().add("Content-Type", "application/octet-stream");
                         exchange.getResponseHeaders()
-                            .add("Content-Range", "bytes " + rangeStart + "-" + (rangeStart + rangeEnd.get() + 1) + "/" + bytes.length);
+                            .add(
+                                "Content-Range",
+                                "bytes " + rangeStart + "-" + (rangeStart + rangeEnd.getAsInt() + 1) + "/" + bytes.length
+                            );
                         exchange.getResponseHeaders().add("x-ms-blob-content-length", String.valueOf(length));
                         exchange.getResponseHeaders().add("Content-Length", String.valueOf(length));
                         exchange.getResponseHeaders().add("x-ms-blob-type", "blockblob");
@@ -158,7 +299,6 @@ public class AzureBlobContainerRetriesTests extends AbstractAzureServerTestCase 
             }
         });
 
-        final BlobContainer blobContainer = createBlobContainer(maxRetries);
         final int position = randomIntBetween(0, bytes.length - 1);
         final int length = randomIntBetween(1, bytes.length - position);
         try (InputStream inputStream = blobContainer.readBlob(randomPurpose(), "read_range_blob_max_retries", position, length)) {
@@ -172,8 +312,9 @@ public class AzureBlobContainerRetriesTests extends AbstractAzureServerTestCase 
         final int maxRetries = randomIntBetween(1, 5);
         final CountDown countDown = new CountDown(maxRetries);
 
+        final BlobContainer blobContainer = createBlobContainer(maxRetries);
         final byte[] bytes = randomBlobContent();
-        httpServer.createContext("/account/container/write_blob_max_retries", exchange -> {
+        httpServer.createContext(downloadStorageEndpoint(blobContainer, "write_blob_max_retries"), exchange -> {
             if ("PUT".equals(exchange.getRequestMethod())) {
                 if (countDown.countDown()) {
                     final BytesReference body = Streams.readFully(exchange.getRequestBody());
@@ -202,7 +343,6 @@ public class AzureBlobContainerRetriesTests extends AbstractAzureServerTestCase 
             }
         });
 
-        final BlobContainer blobContainer = createBlobContainer(maxRetries);
         try (InputStream stream = new InputStreamIndexInput(new ByteArrayIndexInput("desc", bytes), bytes.length)) {
             blobContainer.writeBlob(randomPurpose(), "write_blob_max_retries", stream, bytes.length, false);
         }
@@ -222,8 +362,9 @@ public class AzureBlobContainerRetriesTests extends AbstractAzureServerTestCase 
         final AtomicInteger countDownUploads = new AtomicInteger(nbErrors * nbBlocks);
         final CountDown countDownComplete = new CountDown(nbErrors);
 
+        final BlobContainer blobContainer = createBlobContainer(maxRetries);
         final Map<String, BytesReference> blocks = new ConcurrentHashMap<>();
-        httpServer.createContext("/account/container/write_large_blob", exchange -> {
+        httpServer.createContext(downloadStorageEndpoint(blobContainer, "write_large_blob"), exchange -> {
 
             if ("PUT".equals(exchange.getRequestMethod())) {
                 final Map<String, String> params = new HashMap<>();
@@ -271,8 +412,6 @@ public class AzureBlobContainerRetriesTests extends AbstractAzureServerTestCase 
             exchange.close();
         });
 
-        final BlobContainer blobContainer = createBlobContainer(maxRetries);
-
         try (InputStream stream = new InputStreamIndexInput(new ByteArrayIndexInput("desc", data), data.length)) {
             blobContainer.writeBlob(randomPurpose(), "write_large_blob", stream, data.length, false);
         }
@@ -294,7 +433,8 @@ public class AzureBlobContainerRetriesTests extends AbstractAzureServerTestCase 
         final CountDown countDownComplete = new CountDown(nbErrors);
 
         final Map<String, BytesReference> blocks = new ConcurrentHashMap<>();
-        httpServer.createContext("/account/container/write_large_blob_streaming", exchange -> {
+        final BlobContainer blobContainer = createBlobContainer(maxRetries);
+        httpServer.createContext(downloadStorageEndpoint(blobContainer, "write_large_blob_streaming"), exchange -> {
 
             if ("PUT".equals(exchange.getRequestMethod())) {
                 final Map<String, String> params = new HashMap<>();
@@ -341,7 +481,6 @@ public class AzureBlobContainerRetriesTests extends AbstractAzureServerTestCase 
             exchange.close();
         });
 
-        final BlobContainer blobContainer = createBlobContainer(maxRetries);
         blobContainer.writeMetadataBlob(randomPurpose(), "write_large_blob_streaming", false, randomBoolean(), out -> {
             int outstanding = data.length;
             while (outstanding > 0) {
@@ -361,7 +500,8 @@ public class AzureBlobContainerRetriesTests extends AbstractAzureServerTestCase 
     public void testRetryUntilFail() throws Exception {
         final int maxRetries = randomIntBetween(2, 5);
         final AtomicInteger requestsReceived = new AtomicInteger(0);
-        httpServer.createContext("/account/container/write_blob_max_retries", exchange -> {
+        final BlobContainer blobContainer = createBlobContainer(maxRetries);
+        httpServer.createContext(downloadStorageEndpoint(blobContainer, "write_blob_max_retries"), exchange -> {
             try {
                 requestsReceived.incrementAndGet();
                 if (Streams.readFully(exchange.getRequestBody()).length() > 0) {
@@ -375,7 +515,6 @@ public class AzureBlobContainerRetriesTests extends AbstractAzureServerTestCase 
             }
         });
 
-        final BlobContainer blobContainer = createBlobContainer(maxRetries);
         try (InputStream stream = new InputStream() {
             @Override
             public int read() throws IOException {
@@ -394,7 +533,7 @@ public class AzureBlobContainerRetriesTests extends AbstractAzureServerTestCase 
                 IOException.class,
                 () -> blobContainer.writeBlob(randomPurpose(), "write_blob_max_retries", stream, randomIntBetween(1, 128), randomBoolean())
             );
-            assertThat(ioe.getMessage(), is("Unable to write blob write_blob_max_retries"));
+            assertThat(ioe.getMessage(), is("Unable to write blob " + blobContainer.path().buildAsString() + "write_blob_max_retries"));
             // The mock http server uses 1 thread to process the requests, it's possible that the
             // call to writeBlob throws before all the requests have been processed in the http server,
             // as the http server thread might get de-scheduled and the sdk keeps sending requests
@@ -457,7 +596,7 @@ public class AzureBlobContainerRetriesTests extends AbstractAzureServerTestCase 
             httpServer.createContext(blobPath, failingHandler);
             secondaryHttpServer.createContext(blobPath, workingHandler);
             // The SDK doesn't work well with secondary host endpoints that contain
-            // a path, that's the reason why we sould provide just the host + port;
+            // a path, that's the reason why we should provide just the host + port;
             secondaryHost = getEndpointForServer(secondaryHttpServer, "account");
         } else if (locationMode == LocationMode.SECONDARY_THEN_PRIMARY) {
             secondaryHttpServer.createContext(blobPath, failingHandler);
@@ -466,12 +605,191 @@ public class AzureBlobContainerRetriesTests extends AbstractAzureServerTestCase 
         }
 
         final BlobContainer blobContainer = createBlobContainer(maxRetries, secondaryHost, locationMode);
-        try (InputStream inputStream = blobContainer.readBlob(randomPurpose(), "read_blob_from_secondary")) {
+        try (InputStream inputStream = blobContainer.readBlob(randomRetryingPurpose(), "read_blob_from_secondary")) {
             assertArrayEquals(bytes, BytesReference.toBytes(Streams.readFully(inputStream)));
 
             // It does round robin, first tries on the primary, then on the secondary
             assertThat(failedHeadCalls.get(), equalTo(1));
             assertThat(failedGetCalls.get(), equalTo(1));
         }
+    }
+
+    private BlobContainer createBlobContainer(int maxRetries, String secondaryHost, LocationMode locationMode) {
+        return createBlobContainer(maxRetries, null, null, null, null, null, BlobPath.EMPTY, secondaryHost, locationMode);
+    }
+
+    private BlobContainer createBlobContainer(int maxRetries) {
+        return createBlobContainer(maxRetries, null, null, null, null, null, null);
+    }
+
+    @Override
+    protected String downloadStorageEndpoint(BlobContainer container, String blob) {
+        return "/account/container/" + container.path().buildAsString() + blob;
+    }
+
+    @Override
+    protected String bytesContentType() {
+        return "application/octet-stream";
+    }
+
+    @Override
+    protected Class<? extends Exception> unresponsiveExceptionType() {
+        // Actually a reactor.core.Exceptions.ReactiveException which is not visible, but extends RuntimeException
+        return RuntimeException.class;
+    }
+
+    @Override
+    protected BlobContainer createBlobContainer(
+        @Nullable Integer maxRetries,
+        @Nullable TimeValue readTimeout,
+        @Nullable Boolean disableChunkedEncoding,
+        @Nullable Integer maxConnections,
+        @Nullable ByteSizeValue bufferSize,
+        @Nullable Integer maxBulkDeletes,
+        @Nullable BlobPath blobContainerPath
+    ) {
+        return createBlobContainer(
+            maxRetries,
+            readTimeout,
+            disableChunkedEncoding,
+            maxConnections,
+            bufferSize,
+            maxBulkDeletes,
+            blobContainerPath,
+            null,
+            LocationMode.PRIMARY_ONLY
+        );
+    }
+
+    private BlobContainer createBlobContainer(
+        @Nullable Integer maxRetries,
+        @Nullable TimeValue readTimeout,
+        @Nullable Boolean disableChunkedEncoding,
+        @Nullable Integer maxConnections,
+        @Nullable ByteSizeValue bufferSize,
+        @Nullable Integer maxBulkDeletes,
+        @Nullable BlobPath blobContainerPath,
+        @Nullable String secondaryHost,
+        LocationMode locationMode
+    ) {
+        warnIfUnsupportedSettingSet("disableChunkedEncoding", disableChunkedEncoding);
+        warnIfUnsupportedSettingSet("maxConnections", maxConnections);
+        warnIfUnsupportedSettingSet("bufferSize", bufferSize);
+        warnIfUnsupportedSettingSet("maxBulkDeletes", maxBulkDeletes);
+
+        final Settings.Builder clientSettings = Settings.builder();
+        final String clientName = randomAlphaOfLength(5).toLowerCase(Locale.ROOT);
+
+        String endpoint = "ignored;DefaultEndpointsProtocol=http;BlobEndpoint=" + getEndpointForServer(httpServer, ACCOUNT);
+        if (secondaryHost != null) {
+            endpoint += ";BlobSecondaryEndpoint=" + getEndpointForServer(secondaryHttpServer, ACCOUNT);
+        }
+        clientSettings.put(ENDPOINT_SUFFIX_SETTING.getConcreteSettingForNamespace(clientName).getKey(), endpoint);
+        if (maxRetries != null) {
+            clientSettings.put(MAX_RETRIES_SETTING.getConcreteSettingForNamespace(clientName).getKey(), maxRetries);
+        }
+        clientSettings.put(TIMEOUT_SETTING.getConcreteSettingForNamespace(clientName).getKey(), TimeValue.timeValueSeconds(1));
+        if (readTimeout != null) {
+            clientSettings.put(READ_TIMEOUT_SETTING.getConcreteSettingForNamespace(clientName).getKey(), readTimeout);
+        }
+
+        final MockSecureSettings secureSettings = new MockSecureSettings();
+        secureSettings.setString(ACCOUNT_SETTING.getConcreteSettingForNamespace(clientName).getKey(), ACCOUNT);
+        final String key = Base64.getEncoder().encodeToString(randomAlphaOfLength(14).getBytes(UTF_8));
+        secureSettings.setString(KEY_SETTING.getConcreteSettingForNamespace(clientName).getKey(), key);
+        clientSettings.setSecureSettings(secureSettings);
+
+        final AzureStorageService service = new AzureStorageService(
+            clientSettings.build(),
+            clientProvider,
+            clusterService,
+            TestProjectResolvers.DEFAULT_PROJECT_ONLY
+        ) {
+            @Override
+            RequestRetryOptions getRetryOptions(LocationMode locationMode, AzureStorageSettings azureStorageSettings) {
+                RequestRetryOptions retryOptions = super.getRetryOptions(locationMode, azureStorageSettings);
+                return new RequestRetryOptions(
+                    RetryPolicyType.EXPONENTIAL,
+                    retryOptions.getMaxTries(),
+                    retryOptions.getTryTimeoutDuration(),
+                    Duration.ofMillis(50),
+                    Duration.ofMillis(100),
+                    // The SDK doesn't work well with ip endpoints. Secondary host endpoints that contain
+                    // a path causes the sdk to rewrite the endpoint with an invalid path, that's the reason why we provide just the host +
+                    // port.
+                    secondaryHost != null ? secondaryHost.replaceFirst("/" + ACCOUNT, "") : null
+                );
+            }
+
+            @Override
+            long getUploadBlockSize() {
+                return ByteSizeUnit.MB.toBytes(1);
+            }
+        };
+
+        final RepositoryMetadata repositoryMetadata = new RepositoryMetadata(
+            "repository",
+            AzureRepository.TYPE,
+            Settings.builder()
+                .put(CONTAINER_SETTING.getKey(), CONTAINER)
+                .put(ACCOUNT_SETTING.getKey(), clientName)
+                .put(LOCATION_MODE_SETTING.getKey(), locationMode)
+                .put(MAX_SINGLE_PART_UPLOAD_SIZE_SETTING.getKey(), ByteSizeValue.of(1, ByteSizeUnit.MB))
+                .build()
+        );
+
+        return new AzureBlobContainer(
+            Objects.requireNonNullElse(blobContainerPath, randomBoolean() ? BlobPath.EMPTY : BlobPath.EMPTY.add(randomIdentifier())),
+            new AzureBlobStore(ProjectId.DEFAULT, repositoryMetadata, service, BigArrays.NON_RECYCLING_INSTANCE, RepositoriesMetrics.NOOP)
+        );
+    }
+
+    private void warnIfUnsupportedSettingSet(String settingName, Object value) {
+        if (value != null) {
+            logger.warn("Setting [{}] is not supported for Azure repository. Ignoring value [{}]", settingName, value);
+        }
+    }
+
+    private String getEndpointForServer(HttpServer server, String accountName) {
+        InetSocketAddress address = server.getAddress();
+        return "http://" + InetAddresses.toUriString(address.getAddress()) + ":" + address.getPort() + "/" + accountName;
+    }
+
+    @Override
+    protected void addSuccessfulDownloadHeaders(HttpExchange exchange, byte[] blobContents) {
+        exchange.getResponseHeaders().add("x-ms-blob-content-length", String.valueOf(blobContents.length));
+        exchange.getResponseHeaders().add("Content-Length", String.valueOf(blobContents.length));
+        exchange.getResponseHeaders().add("x-ms-blob-type", "blockblob");
+        exchange.getResponseHeaders().add("ETag", eTagForContents(blobContents));
+    }
+
+    @Override
+    protected HttpHeaderParser.Range getRange(HttpExchange exchange) {
+        return getRanges(exchange);
+    }
+
+    @Override
+    protected HttpHandler interceptGetBlobRequest(HttpHandler handler, byte[] blobContents) {
+        return exchange -> {
+            if (exchange.getRequestMethod().equals("HEAD")) {
+                try (exchange) {
+                    handleHeadRequest(exchange, blobContents);
+                }
+            } else {
+                handler.handle(exchange);
+            }
+        };
+    }
+
+    protected void handleHeadRequest(HttpExchange exchange, byte[] blobContents) throws IOException {
+        if (exchange.getRequestHeaders().containsKey("X-ms-range")) {
+            ExceptionsHelper.maybeDieOnAnotherThread(new AssertionError("Shouldn't send a HEAD request for a range"));
+        }
+        addSuccessfulDownloadHeaders(exchange, blobContents);
+        exchange.sendResponseHeaders(RestStatus.OK.getStatus(), -1);
+    }
+
+    private static String eTagForContents(byte[] blobContents) {
+        return Base64.getEncoder().encodeToString(MessageDigests.digest(new BytesArray(blobContents), MessageDigests.md5()));
     }
 }

--- a/modules/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureBlobContainerRetriesTests.java
+++ b/modules/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureBlobContainerRetriesTests.java
@@ -756,9 +756,8 @@ public class AzureBlobContainerRetriesTests extends AbstractBlobContainerRetries
     }
 
     @Override
-    protected void addSuccessfulDownloadHeaders(HttpExchange exchange, byte[] blobContents) {
-        exchange.getResponseHeaders().add("x-ms-blob-content-length", String.valueOf(blobContents.length));
-        exchange.getResponseHeaders().add("Content-Length", String.valueOf(blobContents.length));
+    protected void addSuccessfulDownloadHeaders(HttpExchange exchange, byte[] blobContents, int contentLength) {
+        exchange.getResponseHeaders().add("Content-Length", String.valueOf(contentLength));
         exchange.getResponseHeaders().add("x-ms-blob-type", "blockblob");
         exchange.getResponseHeaders().add("ETag", eTagForContents(blobContents));
     }
@@ -785,7 +784,7 @@ public class AzureBlobContainerRetriesTests extends AbstractBlobContainerRetries
         if (exchange.getRequestHeaders().containsKey("X-ms-range")) {
             ExceptionsHelper.maybeDieOnAnotherThread(new AssertionError("Shouldn't send a HEAD request for a range"));
         }
-        addSuccessfulDownloadHeaders(exchange, blobContents);
+        addSuccessfulDownloadHeaders(exchange, blobContents, blobContents.length);
         exchange.sendResponseHeaders(RestStatus.OK.getStatus(), -1);
     }
 

--- a/modules/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureBlobContainerTests.java
+++ b/modules/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureBlobContainerTests.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+package org.elasticsearch.repositories.azure;
+
+import com.sun.net.httpserver.HttpExchange;
+
+import org.elasticsearch.common.blobstore.BlobContainer;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.hash.MessageDigests;
+import org.elasticsearch.common.io.Streams;
+import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.rest.RestStatus;
+
+import java.io.InputStream;
+import java.util.Base64;
+
+import static org.elasticsearch.repositories.blobstore.BlobStoreTestUtil.randomFiniteRetryingPurpose;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.lessThan;
+
+@SuppressForbidden(reason = "use a http server")
+public class AzureBlobContainerTests extends AbstractAzureServerTestCase {
+
+    public void testCanConfigureReadTimeout() {
+        final byte[] bytes = randomBlobContent();
+        httpServer.createContext("/account/container/read_blob_read_timeout", exchange -> {
+            logger.info("Received request: {} {}", exchange.getRequestMethod(), exchange.getRequestURI());
+            Streams.readFully(exchange.getRequestBody());
+            if ("HEAD".equals(exchange.getRequestMethod())) {
+                sendBlobHeaders(exchange, bytes);
+                exchange.sendResponseHeaders(RestStatus.OK.getStatus(), -1);
+                exchange.close();
+            } else if ("GET".equals(exchange.getRequestMethod())) {
+                sendBlobHeaders(exchange, bytes);
+                exchange.sendResponseHeaders(RestStatus.OK.getStatus(), bytes.length);
+                // Send the response headers back then stop (this is required to trigger the read timeout)
+                exchange.getResponseBody().flush();
+            }
+        });
+
+        /*
+         * The read timeout should be reflected in the timeout message
+         */
+        {
+            final var tryTimeout = TimeValue.timeValueSeconds(60);
+            final var readTimeoutMillis = randomLongBetween(100, 1000);
+            final BlobContainer blobContainer = builder().withMaxRetries(0)
+                .withTryTimeout(tryTimeout)
+                .withReadTimeout(TimeValue.timeValueMillis(readTimeoutMillis))
+                .build();
+            final long startTimeMillis = System.currentTimeMillis();
+            final RuntimeException readBlobException = assertThrows(RuntimeException.class, () -> {
+                try (InputStream inputStream = blobContainer.readBlob(randomFiniteRetryingPurpose(), "read_blob_read_timeout")) {
+                    assertArrayEquals(bytes, BytesReference.toBytes(Streams.readFully(inputStream)));
+                }
+            });
+            assertThat(
+                readBlobException.getMessage(),
+                containsString("Channel read timed out after " + readTimeoutMillis + " milliseconds")
+            );
+            final long elapsedTimeMillis = System.currentTimeMillis() - startTimeMillis;
+            assertThat(elapsedTimeMillis, lessThan(tryTimeout.millis()));
+        }
+    }
+
+    protected void sendBlobHeaders(HttpExchange exchange, byte[] blobContents) {
+        exchange.getResponseHeaders().add("x-ms-blob-content-length", String.valueOf(blobContents.length));
+        exchange.getResponseHeaders().add("Content-Length", String.valueOf(blobContents.length));
+        exchange.getResponseHeaders().add("x-ms-blob-type", "blockblob");
+        exchange.getResponseHeaders().add("ETag", eTagForContents(blobContents));
+    }
+
+    private static String eTagForContents(byte[] blobContents) {
+        return Base64.getEncoder().encodeToString(MessageDigests.digest(new BytesArray(blobContents), MessageDigests.md5()));
+    }
+}

--- a/modules/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureSasTokenTests.java
+++ b/modules/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureSasTokenTests.java
@@ -24,7 +24,7 @@ import java.util.Locale;
 
 import static org.elasticsearch.repositories.azure.AzureStorageSettings.ACCOUNT_SETTING;
 import static org.elasticsearch.repositories.azure.AzureStorageSettings.SAS_TOKEN_SETTING;
-import static org.elasticsearch.repositories.blobstore.BlobStoreTestUtil.randomPurpose;
+import static org.elasticsearch.repositories.blobstore.BlobStoreTestUtil.randomRetryingPurpose;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
@@ -77,8 +77,11 @@ public class AzureSasTokenTests extends AbstractAzureServerTestCase {
             }
         });
 
-        final BlobContainer blobContainer = createBlobContainer(maxRetries, null, LocationMode.PRIMARY_ONLY, clientName, secureSettings);
-        try (InputStream inputStream = blobContainer.readBlob(randomPurpose(), "sas_test")) {
+        final BlobContainer blobContainer = builder().withMaxRetries(maxRetries)
+            .withClientName(clientName)
+            .withSecureSettings(secureSettings)
+            .build();
+        try (InputStream inputStream = blobContainer.readBlob(randomRetryingPurpose(), "sas_test")) {
             assertArrayEquals(bytes, BytesReference.toBytes(Streams.readFully(inputStream)));
         }
     }

--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerRetriesTests.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerRetriesTests.java
@@ -263,7 +263,7 @@ public class GoogleCloudStorageBlobContainerRetriesTests extends AbstractBlobCon
     }
 
     @Override
-    protected void addSuccessfulDownloadHeaders(HttpExchange exchange, byte[] blobContents) {
+    protected void addSuccessfulDownloadHeaders(HttpExchange exchange, byte[] blobContents, int contentLength) {
         exchange.getResponseHeaders().add("x-goog-generation", String.valueOf(randomNonNegativeInt()));
     }
 
@@ -297,10 +297,10 @@ public class GoogleCloudStorageBlobContainerRetriesTests extends AbstractBlobCon
         httpServer.createContext(downloadStorageEndpoint(blobContainer, "large_blob_retries"), exchange -> {
             Streams.readFully(exchange.getRequestBody());
             exchange.getResponseHeaders().add("Content-Type", "application/octet-stream");
-            addSuccessfulDownloadHeaders(exchange, bytes);
             final HttpHeaderParser.Range range = getRange(exchange);
             final int offset = Math.toIntExact(range.start());
             final byte[] chunk = Arrays.copyOfRange(bytes, offset, Math.toIntExact(Math.min(range.end() + 1, bytes.length)));
+            addSuccessfulDownloadHeaders(exchange, bytes, chunk.length);
             exchange.sendResponseHeaders(RestStatus.OK.getStatus(), chunk.length);
             if (randomBoolean() && countDown.decrementAndGet() >= 0) {
                 exchange.getResponseBody().write(chunk, 0, chunk.length - 1);

--- a/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobContainerRetriesTests.java
+++ b/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobContainerRetriesTests.java
@@ -52,7 +52,6 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.repositories.RepositoriesMetrics;
 import org.elasticsearch.repositories.blobstore.AbstractBlobContainerRetriesTestCase;
-import org.elasticsearch.repositories.blobstore.BlobStoreTestUtil;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.telemetry.InstrumentType;
 import org.elasticsearch.telemetry.Measurement;
@@ -97,8 +96,10 @@ import java.util.regex.Pattern;
 import static org.elasticsearch.cluster.node.DiscoveryNode.STATELESS_ENABLED_SETTING_NAME;
 import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
 import static org.elasticsearch.common.io.Streams.readFully;
+import static org.elasticsearch.repositories.blobstore.BlobStoreTestUtil.randomFiniteRetryingPurpose;
 import static org.elasticsearch.repositories.blobstore.BlobStoreTestUtil.randomNonDataPurpose;
 import static org.elasticsearch.repositories.blobstore.BlobStoreTestUtil.randomPurpose;
+import static org.elasticsearch.repositories.blobstore.BlobStoreTestUtil.randomRetryingPurpose;
 import static org.elasticsearch.repositories.s3.S3ClientSettings.DISABLE_CHUNKED_ENCODING;
 import static org.elasticsearch.repositories.s3.S3ClientSettings.ENDPOINT_SETTING;
 import static org.elasticsearch.repositories.s3.S3ClientSettings.MAX_CONNECTIONS_SETTING;
@@ -1504,16 +1505,6 @@ public class S3BlobContainerRetriesTests extends AbstractBlobContainerRetriesTes
     protected Matcher<Integer> getMaxRetriesMatcher(int maxRetries) {
         // some attempts make meaningful progress and do not count towards the max retry limit
         return allOf(greaterThanOrEqualTo(maxRetries), lessThanOrEqualTo(S3RetryingInputStream.MAX_SUPPRESSED_EXCEPTIONS));
-    }
-
-    @Override
-    protected OperationPurpose randomRetryingPurpose() {
-        return BlobStoreTestUtil.randomRetryingPurpose();
-    }
-
-    @Override
-    protected OperationPurpose randomFiniteRetryingPurpose() {
-        return BlobStoreTestUtil.randomFiniteRetryingPurpose();
     }
 
     private void assertMetricsForOpeningStream() {

--- a/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobContainerRetriesTests.java
+++ b/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobContainerRetriesTests.java
@@ -60,7 +60,6 @@ import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockLog;
 import org.elasticsearch.watcher.ResourceWatcherService;
-import org.hamcrest.Matcher;
 import org.junit.After;
 import org.junit.Before;
 import org.mockito.Mockito;
@@ -106,19 +105,16 @@ import static org.elasticsearch.repositories.s3.S3ClientSettings.MAX_CONNECTIONS
 import static org.elasticsearch.repositories.s3.S3ClientSettings.MAX_RETRIES_SETTING;
 import static org.elasticsearch.repositories.s3.S3ClientSettings.READ_TIMEOUT_SETTING;
 import static org.elasticsearch.repositories.s3.S3ClientSettingsTests.DEFAULT_REGION_UNAVAILABLE;
-import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.matchesRegex;
 
 /**
@@ -1499,12 +1495,6 @@ public class S3BlobContainerRetriesTests extends AbstractBlobContainerRetriesTes
                 )
             );
         }
-    }
-
-    @Override
-    protected Matcher<Integer> getMaxRetriesMatcher(int maxRetries) {
-        // some attempts make meaningful progress and do not count towards the max retry limit
-        return allOf(greaterThanOrEqualTo(maxRetries), lessThanOrEqualTo(S3RetryingInputStream.MAX_SUPPRESSED_EXCEPTIONS));
     }
 
     private void assertMetricsForOpeningStream() {

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -285,9 +285,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.GenerativeForkIT
   method: test {csv-spec:string.Url_encode_component tests with table reads}
   issue: https://github.com/elastic/elasticsearch/issues/140809
-- class: org.elasticsearch.repositories.azure.AzureBlobContainerRetriesTests
-  method: testReadBlobWithPrematureConnectionClose
-  issue: https://github.com/elastic/elasticsearch/issues/140954
 - class: org.elasticsearch.xpack.esql.heap_attack.HeapAttackSubqueryIT
   method: testGiantTextFieldInSubqueryIntermediateResultsWithSort
   issue: https://github.com/elastic/elasticsearch/issues/141034

--- a/server/src/test/java/org/elasticsearch/common/blobstore/RetryingInputStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/common/blobstore/RetryingInputStreamTests.java
@@ -14,7 +14,6 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Streams;
-import org.elasticsearch.repositories.blobstore.BlobStoreTestUtil;
 import org.elasticsearch.repositories.blobstore.RequestedRangeNotSatisfiedException;
 import org.elasticsearch.test.ESTestCase;
 
@@ -30,6 +29,8 @@ import java.util.stream.Stream;
 import static org.elasticsearch.common.blobstore.RetryingInputStream.StreamAction.OPEN;
 import static org.elasticsearch.common.blobstore.RetryingInputStream.StreamAction.READ;
 import static org.elasticsearch.common.bytes.BytesReferenceTestUtils.equalBytes;
+import static org.elasticsearch.repositories.blobstore.BlobStoreTestUtil.randomFiniteRetryingPurpose;
+import static org.elasticsearch.repositories.blobstore.BlobStoreTestUtil.randomRetryingPurpose;
 import static org.hamcrest.Matchers.empty;
 
 public class RetryingInputStreamTests extends ESTestCase {
@@ -383,16 +384,5 @@ public class RetryingInputStreamTests extends ESTestCase {
     private static InputStream inputStreamAtIndex(BytesReference bytesReference, int startIndex) throws IOException {
         final int remainingBytes = bytesReference.length() - startIndex;
         return bytesReference.slice(startIndex, remainingBytes).streamInput();
-    }
-
-    public static OperationPurpose randomRetryingPurpose() {
-        return randomValueOtherThan(OperationPurpose.REPOSITORY_ANALYSIS, BlobStoreTestUtil::randomPurpose);
-    }
-
-    public static OperationPurpose randomFiniteRetryingPurpose() {
-        return randomValueOtherThanMany(
-            purpose -> purpose == OperationPurpose.REPOSITORY_ANALYSIS || purpose == OperationPurpose.INDICES,
-            BlobStoreTestUtil::randomPurpose
-        );
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/AbstractBlobContainerRetriesTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/AbstractBlobContainerRetriesTestCase.java
@@ -54,7 +54,6 @@ import static org.elasticsearch.test.NeverMatcher.never;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.either;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.lessThan;
@@ -92,8 +91,9 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
      *
      * @param exchange the exchange
      * @param blobContents the entire blob contents (even if only a range was requested)
+     * @param contentLength the length of the response we're sending
      */
-    protected void addSuccessfulDownloadHeaders(HttpExchange exchange, byte[] blobContents) {}
+    protected void addSuccessfulDownloadHeaders(HttpExchange exchange, byte[] blobContents, int contentLength) {}
 
     protected abstract String downloadStorageEndpoint(BlobContainer container, String blob);
 
@@ -140,10 +140,11 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
             if (countDown.countDown()) {
                 final int rangeStart = getRangeStart(exchange);
                 assertThat(rangeStart, lessThan(bytes.length));
-                addSuccessfulDownloadHeaders(exchange, bytes);
+                int responseLength = bytes.length - rangeStart;
+                addSuccessfulDownloadHeaders(exchange, bytes, responseLength);
                 exchange.getResponseHeaders().add("Content-Type", bytesContentType());
-                exchange.sendResponseHeaders(HttpStatus.SC_OK, bytes.length - rangeStart);
-                exchange.getResponseBody().write(bytes, rangeStart, bytes.length - rangeStart);
+                exchange.sendResponseHeaders(HttpStatus.SC_OK, responseLength);
+                exchange.getResponseBody().write(bytes, rangeStart, responseLength);
                 exchange.close();
                 return;
             }
@@ -208,7 +209,7 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
                     final int effectiveRangeEnd = Math.min(bytes.length - 1, rangeEnd);
                     final int length = (effectiveRangeEnd - rangeStart) + 1;
                     exchange.getResponseHeaders().add("Content-Type", bytesContentType());
-                    addSuccessfulDownloadHeaders(exchange, bytes);
+                    addSuccessfulDownloadHeaders(exchange, bytes, length);
                     exchange.sendResponseHeaders(HttpStatus.SC_OK, length);
                     exchange.getResponseBody().write(bytes, rangeStart, length);
                     exchange.close();
@@ -310,14 +311,7 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
                     ? blobContainer.readBlob(randomFiniteRetryingPurpose(), "read_blob_incomplete")
                     : blobContainer.readBlob(randomFiniteRetryingPurpose(), "read_blob_incomplete", position, length)
             ) {
-                if (stream instanceof RetryingInputStream<?> ris) {
-                    meaningfulProgressSize.set(ris.meaningfulProgressSize());
-                } else if (stream instanceof RetryingInputStreamUnwrappable rius) {
-                    final var wrapped = rius.unwrap();
-                    if (wrapped != null) {
-                        meaningfulProgressSize.set(wrapped.meaningfulProgressSize());
-                    }
-                }
+                meaningfulProgressSize.set(extractMeaningfulProgressSize(stream));
                 Streams.readFully(stream);
             }
         });
@@ -335,10 +329,6 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
             retryContentSizes.stream().filter(contentSize -> contentSize >= meaningfulProgressSize.get()).count()
         );
         assertEquals(maxRetries + meaningfulProgressRetries, exception.getSuppressed().length);
-    }
-
-    protected org.hamcrest.Matcher<Integer> getMaxRetriesMatcher(int maxRetries) {
-        return equalTo(maxRetries);
     }
 
     public void testReadBlobWithNoHttpResponse() {
@@ -370,20 +360,27 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
 
         // HTTP server sends a partial response
         final byte[] bytes = randomBlobContent(1);
+
+        // A list to track response sizes, some streams (i.e. RetryingInputStream) allow more retries when meaningful amount of bytes
+        // is transferred in a single try. See below.
+        final List<Long> retryContentSizes = Collections.synchronizedList(new ArrayList<>());
+
         httpServer.createContext(downloadStorageEndpoint(blobContainer, "read_blob_incomplete"), interceptGetBlobRequest(exchange -> {
-            sendIncompleteContent(exchange, bytes);
+            retryContentSizes.add((long) sendIncompleteContent(exchange, bytes));
             if (alwaysFlushBody) {
                 exchange.getResponseBody().flush();
             }
             exchange.close();
         }, bytes));
 
+        final AtomicLong meaningfulProgressSize = new AtomicLong(Long.MAX_VALUE);
         final Exception exception = expectThrows(Exception.class, () -> {
             try (
                 InputStream stream = randomBoolean()
                     ? blobContainer.readBlob(randomFiniteRetryingPurpose(), "read_blob_incomplete", 0, 1)
                     : blobContainer.readBlob(randomFiniteRetryingPurpose(), "read_blob_incomplete")
             ) {
+                meaningfulProgressSize.set(extractMeaningfulProgressSize(stream));
                 Streams.readFully(stream);
             }
         });
@@ -400,7 +397,22 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
                 alwaysFlushBody ? never() : containsString("the target server failed to respond")
             )
         );
-        assertThat(exception.getSuppressed().length, getMaxRetriesMatcher(Math.min(10, maxRetries)));
+        int meaningfulProgressRetries = Math.toIntExact(
+            retryContentSizes.stream().filter(contentSize -> contentSize >= meaningfulProgressSize.get()).count()
+        );
+        assertEquals(Math.min(10, maxRetries + meaningfulProgressRetries), exception.getSuppressed().length);
+    }
+
+    private long extractMeaningfulProgressSize(InputStream stream) {
+        if (stream instanceof RetryingInputStream<?> ris) {
+            return ris.meaningfulProgressSize();
+        } else if (stream instanceof RetryingInputStreamUnwrappable rius) {
+            final var wrapped = rius.unwrap();
+            if (wrapped != null) {
+                return wrapped.meaningfulProgressSize();
+            }
+        }
+        throw new IllegalArgumentException("unexpected stream type: " + stream.getClass());
     }
 
     protected static byte[] randomBlobContent() {
@@ -448,7 +460,7 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
             length = bytes.length - rangeStart;
         }
         exchange.getResponseHeaders().add("Content-Type", bytesContentType());
-        addSuccessfulDownloadHeaders(exchange, bytes);
+        addSuccessfulDownloadHeaders(exchange, bytes, length);
         exchange.sendResponseHeaders(HttpStatus.SC_OK, length);
         int minSend = Math.min(0, length - 1);
         final int bytesToSend = randomIntBetween(minSend, length - 1);

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/AbstractBlobContainerRetriesTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/AbstractBlobContainerRetriesTestCase.java
@@ -10,13 +10,13 @@
 package org.elasticsearch.repositories.blobstore;
 
 import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 
 import org.apache.http.ConnectionClosedException;
 import org.apache.http.HttpStatus;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.BlobPath;
-import org.elasticsearch.common.blobstore.OperationPurpose;
 import org.elasticsearch.common.blobstore.RetryingInputStream;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.Streams;
@@ -43,10 +43,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.OptionalInt;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static org.elasticsearch.repositories.blobstore.BlobStoreTestUtil.randomFiniteRetryingPurpose;
 import static org.elasticsearch.repositories.blobstore.BlobStoreTestUtil.randomPurpose;
+import static org.elasticsearch.repositories.blobstore.BlobStoreTestUtil.randomRetryingPurpose;
 import static org.elasticsearch.test.NeverMatcher.never;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
@@ -60,7 +63,7 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 @SuppressForbidden(reason = "use a http server")
 public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
 
-    private static final long MAX_RANGE_VAL = Long.MAX_VALUE - 1;
+    protected static final long MAX_RANGE_VAL = Long.MAX_VALUE - 1;
 
     protected HttpServer httpServer;
 
@@ -86,8 +89,11 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
 
     /**
      * Override to add any headers you expect on a successful download
+     *
+     * @param exchange the exchange
+     * @param blobContents the entire blob contents (even if only a range was requested)
      */
-    protected void addSuccessfulDownloadHeaders(HttpExchange exchange) {}
+    protected void addSuccessfulDownloadHeaders(HttpExchange exchange, byte[] blobContents) {}
 
     protected abstract String downloadStorageEndpoint(BlobContainer container, String blob);
 
@@ -129,12 +135,12 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
         final byte[] bytes = randomBlobContent();
         final TimeValue readTimeout = TimeValue.timeValueSeconds(between(1, 3));
         final BlobContainer blobContainer = blobContainerBuilder().maxRetries(maxRetries).readTimeout(readTimeout).build();
-        httpServer.createContext(downloadStorageEndpoint(blobContainer, "read_blob_max_retries"), exchange -> {
+        httpServer.createContext(downloadStorageEndpoint(blobContainer, "read_blob_max_retries"), interceptGetBlobRequest(exchange -> {
             Streams.readFully(exchange.getRequestBody());
             if (countDown.countDown()) {
                 final int rangeStart = getRangeStart(exchange);
                 assertThat(rangeStart, lessThan(bytes.length));
-                addSuccessfulDownloadHeaders(exchange);
+                addSuccessfulDownloadHeaders(exchange, bytes);
                 exchange.getResponseHeaders().add("Content-Type", bytesContentType());
                 exchange.sendResponseHeaders(HttpStatus.SC_OK, bytes.length - rangeStart);
                 exchange.getResponseBody().write(bytes, rangeStart, bytes.length - rangeStart);
@@ -157,7 +163,7 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
             if (randomBoolean()) {
                 exchange.close();
             }
-        });
+        }, bytes));
 
         try (InputStream inputStream = blobContainer.readBlob(randomRetryingPurpose(), "read_blob_max_retries")) {
             final int readLimit;
@@ -188,41 +194,44 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
         final TimeValue readTimeout = TimeValue.timeValueSeconds(between(5, 10));
         final BlobContainer blobContainer = blobContainerBuilder().maxRetries(maxRetries).readTimeout(readTimeout).build();
         final byte[] bytes = randomBlobContent();
-        httpServer.createContext(downloadStorageEndpoint(blobContainer, "read_range_blob_max_retries"), exchange -> {
-            Streams.readFully(exchange.getRequestBody());
-            if (countDown.countDown()) {
-                final int rangeStart = getRangeStart(exchange);
-                assertThat(rangeStart, lessThan(bytes.length));
-                assertTrue(getRangeEnd(exchange).isPresent());
-                final int rangeEnd = getRangeEnd(exchange).getAsInt();
-                assertThat(rangeEnd, greaterThanOrEqualTo(rangeStart));
-                // adapt range end to be compliant to https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35
-                final int effectiveRangeEnd = Math.min(bytes.length - 1, rangeEnd);
-                final int length = (effectiveRangeEnd - rangeStart) + 1;
-                exchange.getResponseHeaders().add("Content-Type", bytesContentType());
-                addSuccessfulDownloadHeaders(exchange);
-                exchange.sendResponseHeaders(HttpStatus.SC_OK, length);
-                exchange.getResponseBody().write(bytes, rangeStart, length);
-                exchange.close();
-                return;
-            }
-            if (randomBoolean()) {
-                exchange.sendResponseHeaders(
-                    randomFrom(
-                        HttpStatus.SC_INTERNAL_SERVER_ERROR,
-                        HttpStatus.SC_BAD_GATEWAY,
-                        HttpStatus.SC_SERVICE_UNAVAILABLE,
-                        HttpStatus.SC_GATEWAY_TIMEOUT
-                    ),
-                    -1
-                );
-            } else if (randomBoolean()) {
-                sendIncompleteContent(exchange, bytes);
-            }
-            if (randomBoolean()) {
-                exchange.close();
-            }
-        });
+        httpServer.createContext(
+            downloadStorageEndpoint(blobContainer, "read_range_blob_max_retries"),
+            interceptGetBlobRequest(exchange -> {
+                Streams.readFully(exchange.getRequestBody());
+                if (countDown.countDown()) {
+                    final int rangeStart = getRangeStart(exchange);
+                    assertThat(rangeStart, lessThan(bytes.length));
+                    assertTrue(getRangeEnd(exchange).isPresent());
+                    final int rangeEnd = getRangeEnd(exchange).getAsInt();
+                    assertThat(rangeEnd, greaterThanOrEqualTo(rangeStart));
+                    // adapt range end to be compliant to https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35
+                    final int effectiveRangeEnd = Math.min(bytes.length - 1, rangeEnd);
+                    final int length = (effectiveRangeEnd - rangeStart) + 1;
+                    exchange.getResponseHeaders().add("Content-Type", bytesContentType());
+                    addSuccessfulDownloadHeaders(exchange, bytes);
+                    exchange.sendResponseHeaders(HttpStatus.SC_OK, length);
+                    exchange.getResponseBody().write(bytes, rangeStart, length);
+                    exchange.close();
+                    return;
+                }
+                if (randomBoolean()) {
+                    exchange.sendResponseHeaders(
+                        randomFrom(
+                            HttpStatus.SC_INTERNAL_SERVER_ERROR,
+                            HttpStatus.SC_BAD_GATEWAY,
+                            HttpStatus.SC_SERVICE_UNAVAILABLE,
+                            HttpStatus.SC_GATEWAY_TIMEOUT
+                        ),
+                        -1
+                    );
+                } else if (randomBoolean()) {
+                    sendIncompleteContent(exchange, bytes);
+                }
+                if (randomBoolean()) {
+                    exchange.close();
+                }
+            }, bytes)
+        );
 
         final int position = randomIntBetween(0, bytes.length - 1);
         final int length = randomIntBetween(0, randomBoolean() ? bytes.length : Integer.MAX_VALUE);
@@ -266,24 +275,30 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
             .build();
 
         // HTTP server does not send a response
-        httpServer.createContext(downloadStorageEndpoint(blobContainer, "read_blob_unresponsive"), exchange -> {});
+        final byte[] bytes = randomBlobContent();
+        httpServer.createContext(
+            downloadStorageEndpoint(blobContainer, "read_blob_unresponsive"),
+            interceptGetBlobRequest(exchange -> {}, bytes)
+        );
 
         Exception exception = expectThrows(
             unresponsiveExceptionType(),
             () -> Streams.readFully(blobContainer.readBlob(randomFiniteRetryingPurpose(), "read_blob_unresponsive"))
         );
-        assertThat(exception.getMessage().toLowerCase(Locale.ROOT), containsString("read timed out"));
-        assertThat(exception.getCause(), instanceOf(SocketTimeoutException.class));
+        assertThat(
+            exception.getMessage().toLowerCase(Locale.ROOT),
+            anyOf(containsString("read timed out"), containsString("java.util.concurrent.timeoutexception"))
+        );
+        assertThat(exception.getCause(), anyOf(instanceOf(SocketTimeoutException.class), instanceOf(TimeoutException.class)));
 
         // A list to track response sizes, some streams (i.e. RetryingInputStream) allow more retries when meaningful amount of bytes
         // is transferred in a single try. See below.
         final List<Long> retryContentSizes = Collections.synchronizedList(new ArrayList<>());
 
         // HTTP server sends a partial response
-        final byte[] bytes = randomBlobContent();
         httpServer.createContext(
             downloadStorageEndpoint(blobContainer, "read_blob_incomplete"),
-            exchange -> retryContentSizes.add((long) sendIncompleteContent(exchange, bytes))
+            interceptGetBlobRequest(exchange -> retryContentSizes.add((long) sendIncompleteContent(exchange, bytes)), bytes)
         );
 
         final int position = randomIntBetween(0, bytes.length - 1);
@@ -326,14 +341,6 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
         return equalTo(maxRetries);
     }
 
-    protected OperationPurpose randomRetryingPurpose() {
-        return randomPurpose();
-    }
-
-    protected OperationPurpose randomFiniteRetryingPurpose() {
-        return randomPurpose();
-    }
-
     public void testReadBlobWithNoHttpResponse() {
         final TimeValue readTimeout = TimeValue.timeValueMillis(between(100, 200));
         final BlobContainer blobContainer = blobContainerBuilder().maxRetries(randomInt(5)).readTimeout(readTimeout).build();
@@ -351,24 +358,25 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
         assertThat(
             exception.getMessage().toLowerCase(Locale.ROOT),
             either(containsString("the target server failed to respond")).or(containsString("unexpected end of file from server"))
+                .or(containsString("connection prematurely closed before response"))
         );
     }
 
     public void testReadBlobWithPrematureConnectionClose() {
-        final int maxRetries = randomInt(20);
+        final int maxRetries = randomInt(10);
         final BlobContainer blobContainer = blobContainerBuilder().maxRetries(maxRetries).build();
 
         final boolean alwaysFlushBody = randomBoolean();
 
         // HTTP server sends a partial response
         final byte[] bytes = randomBlobContent(1);
-        httpServer.createContext(downloadStorageEndpoint(blobContainer, "read_blob_incomplete"), exchange -> {
+        httpServer.createContext(downloadStorageEndpoint(blobContainer, "read_blob_incomplete"), interceptGetBlobRequest(exchange -> {
             sendIncompleteContent(exchange, bytes);
             if (alwaysFlushBody) {
                 exchange.getResponseBody().flush();
             }
             exchange.close();
-        });
+        }, bytes));
 
         final Exception exception = expectThrows(Exception.class, () -> {
             try (
@@ -387,6 +395,7 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
                 containsString("premature end of content-length delimited message body"),
                 containsString("connection closed prematurely"),
                 containsString("premature eof"),
+                containsString("connection prematurely closed during response"),
                 // if we didn't call exchange.getResponseBody().flush() then we might not even have sent the response headers:
                 alwaysFlushBody ? never() : containsString("the target server failed to respond")
             )
@@ -402,7 +411,7 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
         return randomByteArrayOfLength(randomIntBetween(minSize, frequently() ? 512 : 1 << 20)); // rarely up to 1mb
     }
 
-    protected static HttpHeaderParser.Range getRange(HttpExchange exchange) {
+    protected HttpHeaderParser.Range getRange(HttpExchange exchange) {
         final String rangeHeader = exchange.getRequestHeaders().getFirst("Range");
         if (rangeHeader == null) {
             return new HttpHeaderParser.Range(0L, MAX_RANGE_VAL);
@@ -414,11 +423,11 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
         return range;
     }
 
-    protected static int getRangeStart(HttpExchange exchange) {
+    protected int getRangeStart(HttpExchange exchange) {
         return Math.toIntExact(getRange(exchange).start());
     }
 
-    protected static OptionalInt getRangeEnd(HttpExchange exchange) {
+    protected OptionalInt getRangeEnd(HttpExchange exchange) {
         final long rangeEnd = getRange(exchange).end();
         if (rangeEnd == MAX_RANGE_VAL) {
             return OptionalInt.empty();
@@ -439,7 +448,7 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
             length = bytes.length - rangeStart;
         }
         exchange.getResponseHeaders().add("Content-Type", bytesContentType());
-        addSuccessfulDownloadHeaders(exchange);
+        addSuccessfulDownloadHeaders(exchange, bytes);
         exchange.sendResponseHeaders(HttpStatus.SC_OK, length);
         int minSend = Math.min(0, length - 1);
         final int bytesToSend = randomIntBetween(minSend, length - 1);
@@ -627,5 +636,16 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
     protected interface RetryingInputStreamUnwrappable {
         @Nullable
         RetryingInputStream<?> unwrap();
+    }
+
+    /**
+     * All calls to the blob endpoint should pass through here. This allows e.g. Azure to handle the pre-flight HEAD request
+     *
+     * @param handler The actual handler
+     * @param blobContents The blob contents being simulated
+     * @return The original handler with any necessary wrapping
+     */
+    protected HttpHandler interceptGetBlobRequest(HttpHandler handler, byte[] blobContents) {
+        return handler;
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/AbstractBlobContainerRetriesTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/AbstractBlobContainerRetriesTestCase.java
@@ -412,7 +412,8 @@ public abstract class AbstractBlobContainerRetriesTestCase extends ESTestCase {
                 return wrapped.meaningfulProgressSize();
             }
         }
-        throw new IllegalArgumentException("unexpected stream type: " + stream.getClass());
+        // The passed stream is not a RetryingInputStream, so there is no concept of "meaningful progress"
+        return Long.MAX_VALUE;
     }
 
     protected static byte[] randomBlobContent() {


### PR DESCRIPTION
#139422 was reverted because we discovered a race condition which was made more likely to occur by this change. We have [fixed the race condition now](https://github.com/elastic/elasticsearch/pull/141323). This PR re-applies the Azure common retry logic change.

Also un-mute the test that detected the race condition

Fixes #140954

Marked as `>non-issue` because the original PR was marked as an enhancement and we don't want to list it twice.