### PR TITLE
Empty Field Caps responses to return local resolution when asked for

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
@@ -642,7 +642,12 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
                 listener.onFailure(failures.get(0).getException());
             }
         } else {
-            listener.onResponse(FieldCapabilitiesResponse.builder().withMinTransportVersion(minTransportVersion.get()).build());
+            FieldCapabilitiesResponse.Builder builder = FieldCapabilitiesResponse.builder()
+                .withMinTransportVersion(minTransportVersion.get());
+            if (request.includeResolvedTo()) {
+                builder.withResolvedLocally(resolvedLocally);
+            }
+            listener.onResponse(builder.build());
         }
     }
 


### PR DESCRIPTION
Edge case where we did find a concrete index in a remote for an index expression but it was filtered out by index_filter.
In this case we have an empty index array and no failures. This is correct for local-only requests, but for CPS requests we need to also return local resolution (from the remotes) because we need to validate it against the flat-world model.