### PR TITLE
rest-api-spec: add options to cat.circuit_breaker

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.circuit_breaker.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.circuit_breaker.json
@@ -65,7 +65,18 @@
       },
       "h": {
         "type": "list",
-        "description": "Comma-separated list of column names to display"
+        "description": "Comma-separated list of column names to display",
+        "options": [
+          "breaker",
+          "estimated",
+          "estimated_bytes",
+          "limit",
+          "limit_bytes",
+          "node_id",
+          "node_name",
+          "overhead",
+          "tripped"
+        ]
       },
       "help": {
         "type": "boolean",


### PR DESCRIPTION
This endpoint was added in https://github.com/elastic/elasticsearch/pull/136890