### PR TITLE
[CI] Enforce resolving mrjar jdk toolchains when building vm images

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -342,6 +342,11 @@ allprojects {
     if (project.path == ':') {
       resolveJavaToolChain = true
     }
+    project.pluginManager.withPlugin('elasticsearch.mrjar') {
+      // ensure we implicitly resolve all jdks needed from the java toolchain resolution
+      println "Configuring resolveAllDependencies to depend on JavaCompile tasks for project ${project.path} because it applies the mrjar plugin"
+      dependsOn project.getTasks().withType(JavaCompile.class)
+    }
     // we run the packer script for all active branches. so we should be able to skip bwc here
     if(project.path.startsWith(":distribution:bwc:")) {
       enabled = false


### PR DESCRIPTION
As part of our ci image building we run `resolveAllDependencies` to cache most used artifacts
at image baking time.
Enforcing the compiles tasks of a mrjar plugin enforces the dynamic download of declared
java toolchains and should reduce transient resolution errors in our ci pipelines