### PR TITLE
Clarify docs on lookup_index

### DIFF
--- a/docs/reference/query-languages/esql/_snippets/commands/layout/lookup-join.md
+++ b/docs/reference/query-languages/esql/_snippets/commands/layout/lookup-join.md
@@ -19,7 +19,7 @@ FROM <source_index>
 **Parameters**
 
 `<lookup_index>`
-:   The name of the lookup index. This must be a specific index name - wildcards, aliases, and remote cluster references are not supported. Indices used for lookups must be configured with the [`lookup` index mode](/reference/elasticsearch/index-settings/index-modules.md#index-mode-setting).
+:   The name of the lookup index. This must be a specific index name or alias. Wildcards and remote cluster references are not supported. Indices used for lookups must be configured with the [`lookup` index mode](/reference/elasticsearch/index-settings/index-modules.md#index-mode-setting).
 
 `<join_condition>`
 :   Can be one of the following:


### PR DESCRIPTION
Aliases could be used in `LOOKUP JOIN alias` as long as they are pointing to actual single index in lookup mode.