### PR TITLE
[Native] Update Dockerfile.amd64 to use gcc/g++

### DIFF
--- a/libs/simdvec/native/Dockerfile.amd64
+++ b/libs/simdvec/native/Dockerfile.amd64
@@ -1,13 +1,7 @@
 FROM debian:latest
 
 RUN apt-get update
-RUN apt-get install -y wget
-RUN echo "deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-18 main" > /etc/apt/sources.list.d/clang.list
-RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-RUN apt-get update
-RUN apt-get install -y clang-18 openjdk-21-jdk
-RUN ln -s /usr/bin/clang-18 /usr/bin/clang
-RUN ln -s /usr/bin/clang++-18 /usr/bin/clang++
+RUN apt-get install -y gcc g++ openjdk-21-jdk
 COPY . /workspace
 WORKDIR /workspace
 RUN ./gradlew --quiet --console=plain clean buildSharedLibrary


### PR DESCRIPTION
The latest debian distribution we use in our native build Docker images includes GCC 14.
I benchmarked binaries generated with GCC and clang (both the current version we use (18) and the latest one (21)), and in our cases the binaries produced with GCC are faster (up to 10% faster, in microbenchmarks). 
clang is historically better at auto-vectorization, but since we are not using that (we write our own vector code by hand), it makes sense to switch to GCC (so we use the same compiler as int the aarch64/ARM Dockerfile)