### PR TITLE
Fix RankVectorsFieldMapperTests#testSyntheticSource

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -303,9 +303,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.single_node.PushQueriesIT
   method: testEqualityAndOther {SEMANTIC_TEXT_WITH_KEYWORD}
   issue: https://github.com/elastic/elasticsearch/issues/141170
-- class: org.elasticsearch.xpack.rank.vectors.mapper.RankVectorsFieldMapperTests
-  method: testSyntheticSource
-  issue: https://github.com/elastic/elasticsearch/issues/141187
 - class: org.elasticsearch.reindex.management.ReindexManagementMultiProjectIT
   method: testListingReindexOnlyWorksForCorrectProject
   issue: https://github.com/elastic/elasticsearch/issues/141122


### PR DESCRIPTION
This test is failing because of the way we compute the magnitude is not stable and can results in slightly different values depending if the code is being is being interpreted or the code is compiled by the JIT. 

To avoid this flakiness we are overriding the method LuceneTestCase#assertDocValuesEquals and adding specific logic for the magnitude so we can check the actual values with a delta.

fixes https://github.com/elastic/elasticsearch/issues/141187