### PR TITLE
[9.3]  T digest field type docs #140478 

### DIFF
--- a/docs/changelog/140478.yaml
+++ b/docs/changelog/140478.yaml
@@ -1,0 +1,5 @@
+pr: 140478
+summary: T digest field type docs
+area: Mapping
+type: enhancement
+issues: []

--- a/docs/reference/elasticsearch/mapping-reference/field-data-types.md
+++ b/docs/reference/elasticsearch/mapping-reference/field-data-types.md
@@ -77,6 +77,9 @@ Dates
 [`histogram`](/reference/elasticsearch/mapping-reference/histogram.md)
 :   Pre-aggregated numerical values in the form of a histogram.
 
+[`tdigest`](/reference/elasticsearch/mapping-reference/t-digest.md) {applies_to}`stack: preview 9.3+` {applies_to}`serverless: preview`
+:   Pre-aggregated numerical values in the form of a T-Digest.
+
 
 ### Text search types [text-search-types]
 

--- a/docs/reference/elasticsearch/mapping-reference/t-digest.md
+++ b/docs/reference/elasticsearch/mapping-reference/t-digest.md
@@ -1,0 +1,123 @@
+---
+applies_to:
+  stack: preview 9.3
+  serverless: preview
+navigation_title: "T-digest"
+---
+
+# T-digest field type [tdigest]
+
+A field to store pre-aggregated numerical data constructed using the [T-Digest](/reference/aggregations/search-aggregations-metrics-percentile-aggregation.md) algorithm.
+
+## Structure of a `tdigest` field
+
+A `tdigest` field requires two arrays:
+
+* A `centroids` array of
+  [`double`](/reference/elasticsearch/mapping-reference/number.md), containing
+  the computed centroids.  These must be provided in ascending order.
+* A `counts` array of
+  [`long`](/reference/elasticsearch/mapping-reference/number.md), containing the
+  computed counts for each of the centroids.  This must be the same length as
+  the `centroids` array
+
+The field also accepts three optional summary fields:
+
+* `sum`, a [`double`](/reference/elasticsearch/mapping-reference/number.md),
+  representing the sum of the values being summarized by the t-digest
+* `min`, a [`double`](/reference/elasticsearch/mapping-reference/number.md),
+  representing the minimum of the values being summarized by the t-digest
+* `max`, a [`double`](/reference/elasticsearch/mapping-reference/number.md),
+  representing the maximum of the values being summarized by the t-digest
+
+Specifying the summary values enables them to be calculated with
+higher accuracy from the raw data. If not specified, Elasticsearch
+computes them based on the given `centroids` and `counts`, with some loss of
+accuracy.
+
+## Limitations
+
+* A `tdigest` field can only store a single sketch per document. Multi-values or nested arrays are not supported.
+* `tdigest` fields do not support sorting and are not searchable.
+
+
+## Configuring T-Digest Fields
+
+T-Digest fields accept two field-specific configuration parameters:
+
+* `compression`, a
+  [`double`](/reference/elasticsearch/mapping-reference/number.md) between `0` and
+  `10000` (excluding `0`), which corresponds to the parameter of the same name in
+  the [T-Digest](/reference/aggregations/search-aggregations-metrics-percentile-aggregation.md) algorithm.
+  In general, the higher this number, the more space on disk the field will use
+  but the more accurate the sketch approximations will be.  Default is `100`
+* `digest_type`, which selects the merge strategy to use with the sketch.  Valid
+  values are `default` and `high_accuracy`.  The default is `default`.  The
+  `default` is optimized for storage and performance, while still producing a
+  good approximation.  The `high_accuracy` variant uses more memory, disk, and
+  CPU for a better approximation.
+
+## Use cases [tdigest-use-cases]
+
+`tdigest` fields are primarily intended for use with aggregations. To make them
+efficient for aggregations, the data are stored as compact [doc
+values](/reference/elasticsearch/mapping-reference/doc-values.md) and not
+indexed.
+
+`tdigest` fields are supported in the following [ES|QL](/reference/query-languages/esql.md) aggregation functions:
+
+* [Avg](/reference/query-languages/esql/functions-operators/aggregation-functions.md#esql-avg)
+* [Max](/reference/query-languages/esql/functions-operators/aggregation-functions.md#esql-max)
+  and
+  [Min](/reference/query-languages/esql/functions-operators/aggregation-functions.md#esql-min)
+* [Percentile](/reference/query-languages/esql/functions-operators/aggregation-functions.md#esql-percentile)
+* [Present](/reference/query-languages/esql/functions-operators/aggregation-functions.md#esql-present) and
+  [Absent](/reference/query-languages/esql/functions-operators/aggregation-functions.md#esql-absent)
+
+
+## Synthetic `_source` [tdigest-synthetic-source]
+
+`tdigest` fields support [synthetic `_source`](/reference/elasticsearch/mapping-reference/mapping-source-field.md#synthetic-source) in their default configuration.
+
+::::{note}
+To save space, zero-count buckets are not stored in `tdigest` doc values. If you index a `tdigest` field with zero-count buckets and synthetic `_source` is enabled, those buckets won't appear when you retrieve the field.
+::::
+
+## Examples
+
+### Create an index with a `tdigest` field
+
+```console
+PUT my-index-000001
+{
+  "mappings": {
+    "properties": {
+      "latency": {
+        "type": "tdigest"
+      }
+    }
+  }
+}
+```
+
+### Index a simple document
+
+```console
+PUT my-index-000001/_doc/1
+{
+  "latency": {
+    "centroids": [0.1, 0.2, 0.3, 0.4, 0.5],
+    "counts": [3, 7, 23, 12, 6]
+  }
+}
+```
+
+### Query via ES|QL
+
+```console
+POST /_query?format=txt
+{
+	"query": "FROM test | STATS Percentile(99, latency)"
+}
+
+

--- a/docs/reference/elasticsearch/toc.yml
+++ b/docs/reference/elasticsearch/toc.yml
@@ -158,6 +158,8 @@ toc:
           - file: mapping-reference/geo-point.md
           - file: mapping-reference/geo-shape.md
           - file: mapping-reference/histogram.md
+          - file: mapping-reference/exponential-histogram.md
+          - file: mapping-reference/t-digest.md
           - file: mapping-reference/ip.md
           - file: mapping-reference/parent-join.md
           - file: mapping-reference/keyword.md

--- a/docs/reference/query-languages/esql/limitations.md
+++ b/docs/reference/query-languages/esql/limitations.md
@@ -32,7 +32,7 @@ By default, an {{esql}} query returns up to 1,000 rows. You can increase the num
     * You can use `to_datetime` to cast to millisecond dates to use unsupported functions
 
 * `double` (`float`, `half_float`, `scaled_float` are represented as `double`)
-* `dense_vector` {applies_to}`stack: preview 9.2` {applies_to}`serverless: preview`
+* `dense_vector` {applies_to}`stack: preview 9.2+` {applies_to}`serverless: preview`
 * `ip`
 * `keyword` [family](/reference/elasticsearch/mapping-reference/keyword.md) including `keyword`, `constant_keyword`, and `wildcard`
 * `int` (`short` and `byte` are represented as `int`)
@@ -47,28 +47,24 @@ By default, an {{esql}} query returns up to 1,000 rows. You can increase the num
     * `geo_shape`
     * `point`
     * `shape`
-* TSDB metrics {applies_to}`stack: preview 9.2` {applies_to}`serverless: preview`
+* TSDB metrics {applies_to}`stack: preview 9.2+` {applies_to}`serverless: preview`
    * `counter`
    * `gauge`
    * `aggregate_metric_double`
+   * `exponential_histogram` {applies_to}`stack: preview 9.3+` {applies_to}`serverless: preview`
+   * `tdigest` {applies_to}`stack: preview 9.3+` {applies_to}`serverless: preview`
 
 
 ### Unsupported types [_unsupported_types]
 
-{{esql}} does not yet support the following field types:
+{{esql}} does not support certain field types. If the limitation only applies to specific product versions, it is indicated in the following list:
 
-::::{tab-set}
-:::{tab-item} 9.0-9.1
-* `dense_vector`
-* TSDB metrics
+* {applies_to}`stack: ga 9.0-9.1` `dense_vector`
+* {applies_to}`stack: ga 9.0-9.1` TSDB metrics
    * `counter`
    * `gauge`
    * `aggregate_metric_double`
-:::
-:::{tab-item} 9.2+
-This limitation no longer exists and TSDB metrics and `dense_vector` are now supported (preview).
-:::
-::::
+
 * Date/time
 
     * `date_range`
@@ -177,56 +173,11 @@ FROM books
 | WHERE MATCH(author, "Faulkner")
 ```
 
-Note that, because of [the way {{esql}} treats `text` values](#esql-limitations-text-fields),
-any queries on `text` fields that do not explicitly use the full-text functions,
+Note that any queries on `text` fields that do not explicitly use the full-text functions,
 [`MATCH`](/reference/query-languages/esql/functions-operators/search-functions.md#esql-match),
 [`QSTR`](/reference/query-languages/esql/functions-operators/search-functions.md#esql-qstr) or
 [`KQL`](/reference/query-languages/esql/functions-operators/search-functions.md#esql-kql),
 will behave as if the fields are actually `keyword` fields: they are case-sensitive and need to match the full string.
-
-
-## `text` fields behave like `keyword` fields [esql-limitations-text-fields]
-
-While {{esql}} supports [`text`](/reference/elasticsearch/mapping-reference/text.md) fields, {{esql}} does not treat these fields like the Search API does. {{esql}} queries do not query or aggregate the [analyzed string](docs-content://manage-data/data-store/text-analysis.md). Instead, an {{esql}} query will try to get a `text` field’s subfield of the [keyword family type](/reference/elasticsearch/mapping-reference/keyword.md) and query/aggregate that. If it’s not possible to retrieve a `keyword` subfield, {{esql}} will get the string from a document’s `_source`. If the `_source` cannot be retrieved, for example when using synthetic source, `null` is returned.
-
-Once a `text` field is retrieved, if the query touches it in any way, for example passing it into a function, the type will be converted to `keyword`. In fact, functions that operate on both `text` and `keyword` fields will perform as if the `text` field was a `keyword` field all along.
-
-For example, the following query will return a column `greatest` of type `keyword` no matter whether any or all of `field1`, `field2`, and `field3` are of type `text`:
-
-```esql
-| FROM index
-| EVAL greatest = GREATEST(field1, field2, field3)
-```
-
-Note that {{esql}}'s retrieval of `keyword` subfields may have unexpected consequences.
-Other than when explicitly using the full-text functions,
-[`MATCH`](/reference/query-languages/esql/functions-operators/search-functions.md#esql-match) and
-[`QSTR`](/reference/query-languages/esql/functions-operators/search-functions.md#esql-qstr),
-any {{esql}} query on a `text` field is case-sensitive.
-
-For example, after indexing a field of type `text` with the value `Elasticsearch query language`, the following `WHERE` clause does not match because the `LIKE` operator is case-sensitive:
-
-```esql
-| WHERE field LIKE "elasticsearch query language"
-```
-
-The following `WHERE` clause does not match either, because the `LIKE` operator tries to match the whole string:
-
-```esql
-| WHERE field LIKE "Elasticsearch"
-```
-
-As a workaround, use wildcards and regular expressions. For example:
-
-```esql
-| WHERE field RLIKE "[Ee]lasticsearch.*"
-```
-
-Furthermore, a subfield may have been mapped with a [normalizer](/reference/elasticsearch/mapping-reference/normalizer.md), which can transform the original string. Or it may have been mapped with [`ignore_above`](/reference/elasticsearch/mapping-reference/ignore-above.md), which can truncate the string. None of these mapping operations are applied to an {{esql}} query, which may lead to false positives or negatives.
-
-To avoid these issues, a best practice is to be explicit about the field that you query,
-and query `keyword` sub-fields instead of `text` fields.
-Or consider using one of the [full-text search](/reference/query-languages/esql/functions-operators/search-functions.md) functions.
 
 
 ## Using {{esql}} to query multiple indices [esql-multi-index-limitations]
@@ -238,12 +189,12 @@ As discussed in more detail in [Using {{esql}} to query multiple indices](/refer
 
 ## Time series data streams [esql-tsdb]
 
-::::{tab-set}
-:::{tab-item} 9.0-9.1
-{{esql}} does not support querying time series data streams (TSDS).
+::::{applies-switch}
+:::{applies-item} stack: preview 9.2+
+Time series data streams (TSDS) are supported in technical preview.
 :::
-:::{tab-item} 9.2+
-This limitation no longer exists and time series data streams (TSDS) are now supported (preview).
+:::{applies-item} stack: ga 9.0-9.1
+{{esql}} does not support querying time series data streams (TSDS).
 :::
 ::::
 
@@ -310,15 +261,11 @@ Also, [`INLINE STATS`](/reference/query-languages/esql/commands/inlinestats-by.m
 
 ## Kibana limitations [esql-limitations-kibana]
 
-* The user interface to filter data is not enabled when Discover is in {{esql}} mode. To filter data, write a query that uses the [`WHERE`](/reference/query-languages/esql/commands/where.md) command instead.
+* The filter bar interface is not enabled when Discover is in {{esql}} mode. To filter data, use [variable controls](docs-content://explore-analyze/discover/try-esql.md#add-variable-control), filter buttons within the table and field list, or write a query that uses the [`WHERE`](/reference/query-languages/esql/commands/where.md) command instead.
 * Discover shows no more than 10,000 rows. This limit only applies to the number of rows that are retrieved by the query and displayed in Discover. Queries and aggregations run on the full data set.
 * Discover shows no more than 50 columns. If a query returns more than 50 columns, Discover only shows the first 50.
 * CSV export from Discover shows no more than 10,000 rows. This limit only applies to the number of rows that are retrieved by the query and displayed in Discover. Queries and aggregations run on the full data set.
 * Querying many indices at once without any filters can cause an error in kibana which looks like `[esql] > Unexpected error from Elasticsearch: The content length (536885793) is bigger than the maximum allowed string (536870888)`. The response from {{esql}} is too long. Use [`DROP`](/reference/query-languages/esql/commands/drop.md) or [`KEEP`](/reference/query-languages/esql/commands/keep.md) to limit the number of fields returned.
-
-## Cross-cluster search limitations [esql-ccs-limitations]
-
-{{esql}} does not support [Cross-Cluster Search (CCS)](docs-content://explore-analyze/cross-cluster-search.md) on [`semantic_text` fields](/reference/elasticsearch/mapping-reference/semantic-text.md).
 
 ## Known issues [esql-known-issues]
 

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/TDigestFieldMapper.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/TDigestFieldMapper.java
@@ -51,7 +51,7 @@ import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.field.DocValuesScriptFieldFactory;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.MultiValueMode;
-import org.elasticsearch.search.aggregations.metrics.TDigestState;
+import org.elasticsearch.search.aggregations.metrics.TDigestExecutionHint;
 import org.elasticsearch.search.sort.BucketedSort;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.tdigest.parsing.TDigestParser;
@@ -89,7 +89,7 @@ public class TDigestFieldMapper extends FieldMapper {
 
         private final Parameter<Map<String, String>> meta = Parameter.metaParam();
         private final Parameter<Explicit<Boolean>> ignoreMalformed;
-        private final Parameter<TDigestState.Type> digestType;
+        private final Parameter<TDigestExecutionHint> digestType;
         private final Parameter<Double> compression;
 
         public Builder(String name, boolean ignoreMalformedByDefault) {
@@ -104,8 +104,8 @@ public class TDigestFieldMapper extends FieldMapper {
                 "digest_type",
                 false,
                 m -> toType(m).digestType,
-                TDigestState.Type.HYBRID,
-                TDigestState.Type.class
+                TDigestExecutionHint.DEFAULT,
+                TDigestExecutionHint.class
             );
             this.compression = new Parameter<>(
                 "compression",
@@ -147,7 +147,7 @@ public class TDigestFieldMapper extends FieldMapper {
 
     private final Explicit<Boolean> ignoreMalformed;
     private final boolean ignoreMalformedByDefault;
-    private final TDigestState.Type digestType;
+    private final TDigestExecutionHint digestType;
     private final double compression;
 
     public TDigestFieldMapper(String simpleName, MappedFieldType mappedFieldType, BuilderParams builderParams, Builder builder) {
@@ -163,7 +163,7 @@ public class TDigestFieldMapper extends FieldMapper {
         return ignoreMalformed.value();
     }
 
-    public TDigestState.Type digestType() {
+    public TDigestExecutionHint digestType() {
         return digestType;
     }
 

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/mapper/TDigestFieldBlockLoaderTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/mapper/TDigestFieldBlockLoaderTests.java
@@ -14,7 +14,7 @@ import org.elasticsearch.datageneration.datasource.DataSourceRequest;
 import org.elasticsearch.datageneration.datasource.DataSourceResponse;
 import org.elasticsearch.index.mapper.BlockLoaderTestCase;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.search.aggregations.metrics.TDigestState;
+import org.elasticsearch.search.aggregations.metrics.TDigestExecutionHint;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.analytics.AnalyticsPlugin;
 
@@ -55,7 +55,7 @@ public class TDigestFieldBlockLoaderTests extends BlockLoaderTestCase {
                 if (ESTestCase.randomBoolean()) {
                     map.put("ignore_malformed", ESTestCase.randomBoolean());
                     map.put("compression", randomDoubleBetween(1.0, 1000.0, true));
-                    map.put("digest_type", randomFrom(TDigestState.Type.values()));
+                    map.put("digest_type", randomFrom(TDigestExecutionHint.values()));
                 }
                 return map;
             });

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/mapper/TDigestFieldMapperTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/mapper/TDigestFieldMapperTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.index.mapper.MapperTestCase;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.SourceToParse;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.search.aggregations.metrics.TDigestExecutionHint;
 import org.elasticsearch.search.aggregations.metrics.TDigestState;
 import org.elasticsearch.tdigest.Centroid;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -59,7 +60,7 @@ public class TDigestFieldMapperTests extends MapperTestCase {
     @Override
     protected void registerParameters(ParameterChecker checker) throws IOException {
         checker.registerUpdateCheck(b -> b.field("ignore_malformed", true), m -> assertTrue(m.ignoreMalformed()));
-        checker.registerConflictCheck("digest_type", b -> b.field("digest_type", TDigestState.Type.AVL_TREE));
+        checker.registerConflictCheck("digest_type", b -> b.field("digest_type", TDigestExecutionHint.HIGH_ACCURACY));
         checker.registerConflictCheck("compression", b -> b.field("compression", 117));
     }
 


### PR DESCRIPTION
This adds documentation for the new t-digest field type.

backport of https://github.com/elastic/elasticsearch/pull/140478
