### PR TITLE
Fix failing StandardToLogsDbIndexModeRollingUpgradeIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -324,9 +324,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.spatial.SpatialPushDownGeoShapeIT
   method: testQuantizedXY
   issue: https://github.com/elastic/elasticsearch/issues/141234
-- class: org.elasticsearch.xpack.logsdb.StandardToLogsDbIndexModeRollingUpgradeIT
-  method: testIndexing
-  issue: https://github.com/elastic/elasticsearch/issues/141235
 - class: org.elasticsearch.index.codec.vectors.diskbbq.next.ESNextDiskBBQVectorsFormatTests
   method: testSparseVectors
   issue: https://github.com/elastic/elasticsearch/issues/141270

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/Clusters.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/Clusters.java
@@ -14,6 +14,8 @@ import org.elasticsearch.test.cluster.util.Version;
 
 import java.util.function.Supplier;
 
+import static org.elasticsearch.test.ESTestCase.inFipsJvm;
+
 public class Clusters {
 
     public static ElasticsearchCluster oldVersionCluster(String user, String pass) {
@@ -22,6 +24,9 @@ public class Clusters {
 
     public static ElasticsearchCluster oldVersionClusterWithLogsDisabled(String user, String pass, Supplier<Boolean> useTrialLicense) {
         var cluster = clusterBuilder(user, pass);
+
+        // FIPS mode requires at least a trial license (basic license is not supported in FIPS mode)
+        boolean useTrial = inFipsJvm() || useTrialLicense.get();
 
         // LogsDB is enabled by default for data streams matching the logs-*-* pattern, and since we upgrade from standard to logsdb,
         // we need to start with logsdb disabled, then later enable it and rollover
@@ -33,7 +38,7 @@ public class Clusters {
             .module("x-pack-aggregate-metric")
             .module("x-pack-stack")
             .setting("xpack.security.autoconfiguration.enabled", "false")
-            .setting("xpack.license.self_generated.type", useTrialLicense.get() ? "trial" : "basic");
+            .setting("xpack.license.self_generated.type", useTrial ? "trial" : "basic");
 
         return cluster.build();
     }


### PR DESCRIPTION
Addresses https://github.com/elastic/elasticsearch/issues/141235.

There is a conflict between FIPS mode being enabled and the basic license being used. When both are true, the cluster will fail to start.