### PR TITLE
[9.2] rest-api-spec: fix knn_search visibility (#141356)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/knn_search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/knn_search.json
@@ -9,7 +9,7 @@
       "version": "8.4.0",
       "description": "The kNN search API has been replaced by the `knn` option in the search API."
     },
-    "visibility": "public",
+    "visibility": "private",
     "headers": {
       "accept": [
         "application/json"


### PR DESCRIPTION
Backports the following commits to 9.2:
 - rest-api-spec: fix knn_search visibility (#141356)