### PR TITLE
[CI] Fix for failing GenerativeForkIT test csv-spec:stats_all_first_all_last.Test retrieval of multi-values

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstBooleanByTimestampAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstBooleanByTimestampAggregator.java
@@ -134,7 +134,7 @@ public class AllFirstBooleanByTimestampAggregator {
                 // Both observations have null timestamps. No work is needed.
                 return;
             }
-            if ((current.v1Seen() == false && timestampPresent) || timestamp < current.v1()) {
+            if (timestampPresent && (current.v1Seen() == false || timestamp < current.v1())) {
                 overrideState(current, timestampPresent, timestamp, values, 0);
             }
         } else {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstBytesRefByTimestampAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstBytesRefByTimestampAggregator.java
@@ -137,7 +137,7 @@ public class AllFirstBytesRefByTimestampAggregator {
                 // Both observations have null timestamps. No work is needed.
                 return;
             }
-            if ((current.v1Seen() == false && timestampPresent) || timestamp < current.v1()) {
+            if (timestampPresent && (current.v1Seen() == false || timestamp < current.v1())) {
                 overrideState(current, timestampPresent, timestamp, values, 0);
             }
         } else {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstDoubleByTimestampAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstDoubleByTimestampAggregator.java
@@ -135,7 +135,7 @@ public class AllFirstDoubleByTimestampAggregator {
                 // Both observations have null timestamps. No work is needed.
                 return;
             }
-            if ((current.v1Seen() == false && timestampPresent) || timestamp < current.v1()) {
+            if (timestampPresent && (current.v1Seen() == false || timestamp < current.v1())) {
                 overrideState(current, timestampPresent, timestamp, values, 0);
             }
         } else {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstFloatByTimestampAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstFloatByTimestampAggregator.java
@@ -135,7 +135,7 @@ public class AllFirstFloatByTimestampAggregator {
                 // Both observations have null timestamps. No work is needed.
                 return;
             }
-            if ((current.v1Seen() == false && timestampPresent) || timestamp < current.v1()) {
+            if (timestampPresent && (current.v1Seen() == false || timestamp < current.v1())) {
                 overrideState(current, timestampPresent, timestamp, values, 0);
             }
         } else {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstIntByTimestampAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstIntByTimestampAggregator.java
@@ -129,7 +129,7 @@ public class AllFirstIntByTimestampAggregator {
                 // Both observations have null timestamps. No work is needed.
                 return;
             }
-            if ((current.v1Seen() == false && timestampPresent) || timestamp < current.v1()) {
+            if (timestampPresent && (current.v1Seen() == false || timestamp < current.v1())) {
                 overrideState(current, timestampPresent, timestamp, values, 0);
             }
         } else {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstLongByTimestampAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllFirstLongByTimestampAggregator.java
@@ -129,7 +129,7 @@ public class AllFirstLongByTimestampAggregator {
                 // Both observations have null timestamps. No work is needed.
                 return;
             }
-            if ((current.v1Seen() == false && timestampPresent) || timestamp < current.v1()) {
+            if (timestampPresent && (current.v1Seen() == false || timestamp < current.v1())) {
                 overrideState(current, timestampPresent, timestamp, values, 0);
             }
         } else {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastBooleanByTimestampAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastBooleanByTimestampAggregator.java
@@ -134,7 +134,7 @@ public class AllLastBooleanByTimestampAggregator {
                 // Both observations have null timestamps. No work is needed.
                 return;
             }
-            if ((current.v1Seen() == false && timestampPresent) || timestamp > current.v1()) {
+            if (timestampPresent && (current.v1Seen() == false || timestamp > current.v1())) {
                 overrideState(current, timestampPresent, timestamp, values, 0);
             }
         } else {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastBytesRefByTimestampAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastBytesRefByTimestampAggregator.java
@@ -137,7 +137,7 @@ public class AllLastBytesRefByTimestampAggregator {
                 // Both observations have null timestamps. No work is needed.
                 return;
             }
-            if ((current.v1Seen() == false && timestampPresent) || timestamp > current.v1()) {
+            if (timestampPresent && (current.v1Seen() == false || timestamp > current.v1())) {
                 overrideState(current, timestampPresent, timestamp, values, 0);
             }
         } else {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastDoubleByTimestampAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastDoubleByTimestampAggregator.java
@@ -135,7 +135,7 @@ public class AllLastDoubleByTimestampAggregator {
                 // Both observations have null timestamps. No work is needed.
                 return;
             }
-            if ((current.v1Seen() == false && timestampPresent) || timestamp > current.v1()) {
+            if (timestampPresent && (current.v1Seen() == false || timestamp > current.v1())) {
                 overrideState(current, timestampPresent, timestamp, values, 0);
             }
         } else {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastFloatByTimestampAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastFloatByTimestampAggregator.java
@@ -135,7 +135,7 @@ public class AllLastFloatByTimestampAggregator {
                 // Both observations have null timestamps. No work is needed.
                 return;
             }
-            if ((current.v1Seen() == false && timestampPresent) || timestamp > current.v1()) {
+            if (timestampPresent && (current.v1Seen() == false || timestamp > current.v1())) {
                 overrideState(current, timestampPresent, timestamp, values, 0);
             }
         } else {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastIntByTimestampAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastIntByTimestampAggregator.java
@@ -129,7 +129,7 @@ public class AllLastIntByTimestampAggregator {
                 // Both observations have null timestamps. No work is needed.
                 return;
             }
-            if ((current.v1Seen() == false && timestampPresent) || timestamp > current.v1()) {
+            if (timestampPresent && (current.v1Seen() == false || timestamp > current.v1())) {
                 overrideState(current, timestampPresent, timestamp, values, 0);
             }
         } else {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastLongByTimestampAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/AllLastLongByTimestampAggregator.java
@@ -129,7 +129,7 @@ public class AllLastLongByTimestampAggregator {
                 // Both observations have null timestamps. No work is needed.
                 return;
             }
-            if ((current.v1Seen() == false && timestampPresent) || timestamp > current.v1()) {
+            if (timestampPresent && (current.v1Seen() == false || timestamp > current.v1())) {
                 overrideState(current, timestampPresent, timestamp, values, 0);
             }
         } else {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-AllValueByTimestampAggregator.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-AllValueByTimestampAggregator.java.st
@@ -169,7 +169,7 @@ public class $Prefix$$Occurrence$$Type$ByTimestampAggregator {
                 // Both observations have null timestamps. No work is needed.
                 return;
             }
-            if ((current.v1Seen() == false && timestampPresent) || timestamp $if(First)$<$else$>$endif$ current.v1()) {
+            if (timestampPresent && (current.v1Seen() == false || timestamp $if(First)$<$else$>$endif$ current.v1())) {
                 overrideState(current, timestampPresent, timestamp, values, 0);
             }
         } else {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstLongByTimestampAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AllFirstLongByTimestampAggregatorFunctionTests.java
@@ -12,14 +12,18 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BlockUtils;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.SourceOperator;
 import org.elasticsearch.compute.test.TupleLongLongBlockSourceOperator;
 import org.elasticsearch.core.Tuple;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
 
 import static org.elasticsearch.compute.aggregation.AllFirstAllLastTestingUtils.processPages;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 
 public class AllFirstLongByTimestampAggregatorFunctionTests extends AggregatorFunctionTestCase {
     @Override
@@ -53,5 +57,53 @@ public class AllFirstLongByTimestampAggregatorFunctionTests extends AggregatorFu
         GroundTruthFirstLastAggregator work = new GroundTruthFirstLastAggregator(true);
         processPages(work, input);
         work.check(BlockUtils.toJavaObject(result, 0));
+    }
+
+    /**
+     * Reproduces a scenario where null timestamps incorrectly win over valid timestamps when combineIntermediate is called. We don't need
+     * multivalues anywhere to reproduce the bug.
+     *
+     * See https://github.com/elastic/elasticsearch-serverless/issues/5348
+     */
+    public void testNullTimestampDoesNotWinOverValidTimestamp() {
+        DriverContext driverContext = driverContext();
+        BlockFactory blockFactory = driverContext.blockFactory();
+
+        Page page1 = new Page(
+            // value
+            blockFactory.newLongBlockBuilder(1).beginPositionEntry().appendLong(2).build(),
+            // valid and earliest timestamp
+            blockFactory.newLongBlockBuilder(1).beginPositionEntry().appendLong(1).build()
+        );
+
+        Page page2 = new Page(
+            // value
+            blockFactory.newLongBlockBuilder(1).beginPositionEntry().appendLong(3).build(),
+            // null timestamp
+            blockFactory.newLongBlockBuilder(1).appendNull().build()
+        );
+
+        // Run each page through separate aggregators
+        List<Page> intermediatePage1 = drive(
+            simpleWithMode(AggregatorMode.INITIAL).get(driverContext),
+            List.of(page1).iterator(),
+            driverContext
+        );
+        List<Page> intermediatePage2 = drive(
+            simpleWithMode(AggregatorMode.INITIAL).get(driverContext),
+            List.of(page2).iterator(),
+            driverContext
+        );
+
+        List<Page> pages = new ArrayList<>();
+        pages.addAll(intermediatePage1);
+        pages.addAll(intermediatePage2);
+
+        // Combine intermediate results (this calls combineIntermediate to expose the bug)
+        List<Page> results = drive(simpleWithMode(AggregatorMode.FINAL).get(driverContext), pages.iterator(), driverContext);
+
+        assertThat(results, hasSize(1));
+        Block result = results.get(0).getBlock(0);
+        assertThat(BlockUtils.toJavaObject(result, 0), equalTo(2L));
     }
 }


### PR DESCRIPTION
- The test failed in serverless due to null timestamps, which are represented as -1, winning against a valid non-null timestamp that's currently held in the state. The reason was that the timestampPresent flag wasn't included in this comparison. This only affected the ungrouped case.
- The new unit test verifies this fix.