### PR TITLE
Clears inherited env before setting new vars

### DIFF
--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerProcessBuilder.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerProcessBuilder.java
@@ -207,6 +207,7 @@ public class ServerProcessBuilder {
     ) throws InterruptedException, IOException {
 
         var builder = new ProcessBuilder(Stream.concat(Stream.of(command), Stream.concat(jvmOptions.stream(), jvmArgs.stream())).toList());
+        builder.environment().clear();
         builder.environment().putAll(environment);
         setWorkingDir(builder, workingDir);
         builder.redirectOutput(ProcessBuilder.Redirect.INHERIT);


### PR DESCRIPTION
Ensures that the process runs with only the explicitly specified environment variables by clearing any inherited values first. Prevents unexpected environment leakage into the server process.

The current codebase fails the cleared environment test:

`./gradlew ":distribution:tools:server-cli:test" --tests "org .elasticsearch.server.cli.ServerProcessTests.testEnvCleared"`

This is consistent with existing patterns. We already clear the child environment in `Spawner` and `ProcessUtils` (`pb.environment().clear()` / `processBuilder.environment().clear()`), so this change follows the same approach for process isolation.
