### PR TITLE
[Test] Adjust init order in SnapshotResiliencyTestHelper

### DIFF
--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTestHelper.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTestHelper.java
@@ -662,7 +662,36 @@ public class SnapshotResiliencyTestHelper {
                     .mapperMetrics(MapperMetrics.NOOP)
                     .mergeMetrics(MergeMetrics.NOOP)
                     .build();
-                final RecoverySettings recoverySettings = new RecoverySettings(settings, clusterSettings);
+
+                this.searchService = new SearchService(
+                    clusterService,
+                    indicesService,
+                    threadPool,
+                    scriptService,
+                    bigArrays,
+                    new FetchPhase(Collections.emptyList()),
+                    new NoneCircuitBreakerService(),
+                    EmptySystemIndices.INSTANCE.getExecutorSelector(),
+                    Tracer.NOOP,
+                    OnlinePrewarmingService.NOOP
+                );
+
+                final SnapshotFilesProvider snapshotFilesProvider = new SnapshotFilesProvider(repositoriesService);
+                peerRecoveryTargetService = new PeerRecoveryTargetService(
+                    client,
+                    threadPool,
+                    transportService,
+                    recoverySettings,
+                    clusterService,
+                    snapshotFilesProvider
+                );
+
+                final ActionFilters actionFilters = new ActionFilters(emptySet());
+                Map<ActionType<?>, TransportAction<?, ?>> actions = new HashMap<>();
+
+                // Inject initialization from subclass which may be needed by initializations after this point.
+                doInit(actions, actionFilters);
+
                 snapshotShardsService = new SnapshotShardsService(
                     settings,
                     clusterService,
@@ -672,8 +701,6 @@ public class SnapshotResiliencyTestHelper {
                 );
                 shardStateAction = new ShardStateAction(clusterService, transportService, allocationService, rerouteService, threadPool);
                 nodeConnectionsService = new NodeConnectionsService(clusterService.getSettings(), threadPool, transportService);
-                final ActionFilters actionFilters = new ActionFilters(emptySet());
-                Map<ActionType<?>, TransportAction<?, ?>> actions = new HashMap<>();
                 actions.put(
                     TransportUpdateSnapshotStatusAction.TYPE,
                     new TransportUpdateSnapshotStatusAction(transportService, clusterService, threadPool, snapshotsService, actionFilters)
@@ -725,28 +752,7 @@ public class SnapshotResiliencyTestHelper {
                     client,
                     SearchExecutionStatsCollector.makeWrapper(responseCollectorService)
                 );
-                this.searchService = new SearchService(
-                    clusterService,
-                    indicesService,
-                    threadPool,
-                    scriptService,
-                    bigArrays,
-                    new FetchPhase(Collections.emptyList()),
-                    new NoneCircuitBreakerService(),
-                    EmptySystemIndices.INSTANCE.getExecutorSelector(),
-                    Tracer.NOOP,
-                    OnlinePrewarmingService.NOOP
-                );
 
-                final SnapshotFilesProvider snapshotFilesProvider = new SnapshotFilesProvider(repositoriesService);
-                peerRecoveryTargetService = new PeerRecoveryTargetService(
-                    client,
-                    threadPool,
-                    transportService,
-                    recoverySettings,
-                    clusterService,
-                    snapshotFilesProvider
-                );
                 indicesClusterStateService = new IndicesClusterStateService(
                     settings,
                     indicesService,
@@ -1084,8 +1090,6 @@ public class SnapshotResiliencyTestHelper {
                         projectResolver
                     )
                 );
-
-                doInit(actions, actionFilters);
 
                 client.initialize(
                     actions,


### PR DESCRIPTION
The initialization order is adjusted so that subclass initialization is called in the right place to provide future injection for SnapshotShardsService
