### PR TITLE
Use RECENT write-load in write-load constraint decider by default

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/WriteLoadConstraintSettings.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/WriteLoadConstraintSettings.java
@@ -84,7 +84,7 @@ public class WriteLoadConstraintSettings {
     public static final Setting<WriteLoadDeciderShardWriteLoadType> WRITE_LOAD_DECIDER_SHARD_WRITE_LOAD_TYPE_SETTING = Setting.enumSetting(
         WriteLoadDeciderShardWriteLoadType.class,
         SETTING_PREFIX + "shard_write_load_type",
-        WriteLoadDeciderShardWriteLoadType.PEAK,
+        WriteLoadDeciderShardWriteLoadType.RECENT,
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );


### PR DESCRIPTION
After switching to recent write load we see much better correlation with the node-level write load and much freer movement of shards when resolving hot-spots.

It's been configured to `RECENT` for the last couple of weeks in prod without incident.

Relates: ES-13429

Before (Using `PEAK` shard write load)
<img width="924" height="434" alt="Screenshot 2026-01-28 at 2 59 09 pm" src="https://github.com/user-attachments/assets/3cc8ef34-eccd-4fb4-ab76-ca17a8384087" />

After (Using `RECENT` shard write load)
<img width="924" height="434" alt="Screenshot 2026-01-28 at 3 01 17 pm" src="https://github.com/user-attachments/assets/fd16fe0a-1843-4423-b17b-f984c7963f9e" />

