### PR TITLE
Strengthen MPU-based CAS in S3 repo

### DIFF
--- a/docs/changelog/141411.yaml
+++ b/docs/changelog/141411.yaml
@@ -1,0 +1,5 @@
+area: Snapshot/Restore
+issues: []
+pr: 141411
+summary: Strengthen MPU-based CAS in S3 repo
+type: enhancement

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobContainer.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobContainer.java
@@ -62,6 +62,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
@@ -930,7 +931,8 @@ class S3BlobContainer extends AbstractBlobContainer {
 
                 // Step 3: Ensure all other uploads in currentUploads are complete (either successfully, aborted by us or by another upload)
 
-                .<Void>newForked(l -> ensureOtherUploadsComplete(uploadId, uploadIndex, currentUploads, l))
+                .<Void>newForked(l -> abortOtherUploads(uploadId, uploadIndex, currentUploads, l))
+                .<Void>andThen(l -> ensureOtherUploadsComplete(uploadId, currentUploads, l))
 
                 // Step 4: Read the current register value. Note that getRegister only has read-after-write semantics but that's ok here as:
                 // - all earlier uploads are now complete,
@@ -1082,7 +1084,7 @@ class S3BlobContainer extends AbstractBlobContainer {
             return found ? uploadIndex : -1;
         }
 
-        private void ensureOtherUploadsComplete(
+        private void abortOtherUploads(
             String uploadId,
             int uploadIndex,
             List<MultipartUpload> currentUploads,
@@ -1114,6 +1116,67 @@ class S3BlobContainer extends AbstractBlobContainer {
             } else {
                 cancelOtherUploads(uploadId, currentUploads, listener);
             }
+        }
+
+        private void ensureOtherUploadsComplete(String uploadId, List<MultipartUpload> currentUploads, ActionListener<Void> listener) {
+            final var otherUploadIds = Sets.<String>newHashSetWithExpectedSize(currentUploads.size());
+            for (var currentUpload : currentUploads) {
+                final var otherUploadId = currentUpload.uploadId();
+                if (uploadId.equals(otherUploadId) == false) {
+                    otherUploadIds.add(otherUploadId);
+                }
+            }
+
+            if (otherUploadIds.isEmpty()) {
+                logger.trace("no uploads to await, proceeding with [{}]", uploadId);
+                listener.onResponse(null);
+                return;
+            }
+
+            final var executor = threadPool.executor(ThreadPool.Names.SNAPSHOT);
+            final var timeoutListener = new SubscribableListener<Void>();
+            timeoutListener.addListener(listener);
+            timeoutListener.addTimeout(blobStore.getCompareAndExchangeTimeToLive(), threadPool, executor);
+
+            class OtherUploadsWaiter extends ActionRunnable<Void> {
+                OtherUploadsWaiter() {
+                    super(timeoutListener);
+                }
+
+                @Override
+                protected void doRun() {
+                    if (timeoutListener.isDone()) {
+                        logger.trace("uploads {} still incomplete at timeout, failing [{}]", otherUploadIds, uploadId);
+                        return;
+                    }
+
+                    final var newUploads = listMultipartUploads();
+                    final var newUploadIds = Sets.<String>newHashSetWithExpectedSize(newUploads.size());
+                    for (var newUpload : newUploads) {
+                        newUploadIds.add(newUpload.uploadId());
+                    }
+                    if (newUploadIds.contains(uploadId) == false) {
+                        logger.trace("upload [{}] not found in {}", uploadId, newUploadIds);
+                        throw AwsServiceException.builder().statusCode(RestStatus.NOT_FOUND.getStatus()).build();
+                    }
+
+                    newUploadIds.retainAll(otherUploadIds);
+                    if (newUploadIds.isEmpty()) {
+                        logger.trace("uploads {} all complete, proceeding with [{}]", otherUploadIds, uploadId);
+                        timeoutListener.onResponse(null);
+                    } else {
+                        logger.trace(
+                            "uploads {} from {} still in progress, retrying before completing [{}]",
+                            newUploadIds,
+                            otherUploadIds,
+                            uploadId
+                        );
+                        threadPool.schedule(OtherUploadsWaiter.this, blobStore.getCompareAndExchangeAntiContentionDelay(), executor);
+                    }
+                }
+            }
+
+            new OtherUploadsWaiter().run();
         }
 
         private void cancelOtherUploads(String uploadId, List<MultipartUpload> currentUploads, ActionListener<Void> listener) {

--- a/x-pack/plugin/snapshot-repo-test-kit/qa/s3/src/javaRestTest/java/org/elasticsearch/repositories/blobstore/testkit/analyze/AbstractS3RepositoryAnalysisRestTestCase.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/qa/s3/src/javaRestTest/java/org/elasticsearch/repositories/blobstore/testkit/analyze/AbstractS3RepositoryAnalysisRestTestCase.java
@@ -126,8 +126,8 @@ public abstract class AbstractS3RepositoryAnalysisRestTestCase extends AbstractR
 
         if (consistencyModel().hasConditionalWrites()) {
             if (randomBoolean()) {
-                // false is the default, but sometimes set it explicitly here:
-                settings.put("unsafely_incompatible_with_s3_conditional_writes", false);
+                // even if we have conditional writes (and thus weak MPU abort consistency) the MPU-based impl should still work
+                settings.put("unsafely_incompatible_with_s3_conditional_writes", randomBoolean());
             }
         } else {
             // if the storage doesn't support conditional writes we have to use the MPU-based impl


### PR DESCRIPTION
The `AbortMultipartUpload` API may return early, before the abort
completes, but in this case the `ListMultipartUploads` API will still
indicate the upload is in progress. Thus we can safely ensure that all
the aborted uploads have completed with a follow-up check against the
`ListMultipartUploads` API. This commit adds the missing check.