### PR TITLE
Implement queryDSL min/max agg for exponential histograms

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/exponentialhistogram/fielddata/ExponentialHistogramValuesReader.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/exponentialhistogram/fielddata/ExponentialHistogramValuesReader.java
@@ -46,5 +46,15 @@ public interface ExponentialHistogramValuesReader {
      */
     double sumValue() throws IOException;
 
+    /**
+     * A shortcut for invoking {@link ExponentialHistogram#min()} on the return value of {@link #histogramValue()}.
+     * This method is more performant because it avoids loading the unnecessary parts of the histogram.
+     * Must be called only after a successful call to {@link #advanceExact(int)}.
+     * If the histogram is empty, this will return {@code Double.POSITIVE_INFINITY}.
+     *
+     * @return the minimum of the values in the histogram for the current document
+     */
+    double minValue() throws IOException;
+
     // TODO: add accessors for min/max/sum which don't load the entire histogram
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/exponentialhistogram/fielddata/ExponentialHistogramValuesReader.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/exponentialhistogram/fielddata/ExponentialHistogramValuesReader.java
@@ -56,5 +56,15 @@ public interface ExponentialHistogramValuesReader {
      */
     double minValue() throws IOException;
 
+    /**
+     * A shortcut for invoking {@link ExponentialHistogram#max()} on the return value of {@link #histogramValue()}.
+     * This method is more performant because it avoids loading the unnecessary parts of the histogram.
+     * Must be called only after a successful call to {@link #advanceExact(int)}.
+     * If the histogram is empty, this will return {@code Double.NEGATIVE_INFINITY}.
+     *
+     * @return the maximum of the values in the histogram for the current document
+     */
+    double maxValue() throws IOException;
+
     // TODO: add accessors for min/max/sum which don't load the entire histogram
 }

--- a/x-pack/plugin/mapper-exponential-histogram/src/main/java/org/elasticsearch/xpack/exponentialhistogram/ExponentialHistogramFieldMapper.java
+++ b/x-pack/plugin/mapper-exponential-histogram/src/main/java/org/elasticsearch/xpack/exponentialhistogram/ExponentialHistogramFieldMapper.java
@@ -841,6 +841,18 @@ public class ExponentialHistogramFieldMapper extends FieldMapper {
             }
             return NumericUtils.sortableLongToDouble(valueSums.longValue());
         }
+
+        @Override
+        public double minValue() throws IOException {
+            if (currentDocId == -1) {
+                throw new IllegalStateException("No histogram present for current document");
+            }
+            if (valueMinima == null || valueMinima.advanceExact(currentDocId) == false) {
+                // empty histogram
+                return Double.POSITIVE_INFINITY;
+            }
+            return NumericUtils.sortableLongToDouble(valueMinima.longValue());
+        }
     }
 
     private class ExponentialHistogramSyntheticFieldLoader implements CompositeSyntheticFieldLoader.DocValuesLayer {

--- a/x-pack/plugin/mapper-exponential-histogram/src/main/java/org/elasticsearch/xpack/exponentialhistogram/ExponentialHistogramFieldMapper.java
+++ b/x-pack/plugin/mapper-exponential-histogram/src/main/java/org/elasticsearch/xpack/exponentialhistogram/ExponentialHistogramFieldMapper.java
@@ -853,6 +853,18 @@ public class ExponentialHistogramFieldMapper extends FieldMapper {
             }
             return NumericUtils.sortableLongToDouble(valueMinima.longValue());
         }
+
+        @Override
+        public double maxValue() throws IOException {
+            if (currentDocId == -1) {
+                throw new IllegalStateException("No histogram present for current document");
+            }
+            if (valueMaxima == null || valueMaxima.advanceExact(currentDocId) == false) {
+                // empty histogram
+                return Double.NEGATIVE_INFINITY;
+            }
+            return NumericUtils.sortableLongToDouble(valueMaxima.longValue());
+        }
     }
 
     private class ExponentialHistogramSyntheticFieldLoader implements CompositeSyntheticFieldLoader.DocValuesLayer {

--- a/x-pack/plugin/mapper-exponential-histogram/src/main/java/org/elasticsearch/xpack/exponentialhistogram/ExponentialHistogramMapperPlugin.java
+++ b/x-pack/plugin/mapper-exponential-histogram/src/main/java/org/elasticsearch/xpack/exponentialhistogram/ExponentialHistogramMapperPlugin.java
@@ -34,7 +34,8 @@ public class ExponentialHistogramMapperPlugin extends Plugin implements MapperPl
             ExponentialHistogramAggregatorsRegistrar::registerSumAggregator,
             ExponentialHistogramAggregatorsRegistrar::registerAvgAggregator,
             ExponentialHistogramAggregatorsRegistrar::registerHistogramAggregator,
-            ExponentialHistogramAggregatorsRegistrar::registerMinAggregator
+            ExponentialHistogramAggregatorsRegistrar::registerMinAggregator,
+            ExponentialHistogramAggregatorsRegistrar::registerMaxAggregator
         );
     }
 }

--- a/x-pack/plugin/mapper-exponential-histogram/src/main/java/org/elasticsearch/xpack/exponentialhistogram/ExponentialHistogramMapperPlugin.java
+++ b/x-pack/plugin/mapper-exponential-histogram/src/main/java/org/elasticsearch/xpack/exponentialhistogram/ExponentialHistogramMapperPlugin.java
@@ -33,7 +33,8 @@ public class ExponentialHistogramMapperPlugin extends Plugin implements MapperPl
             ExponentialHistogramAggregatorsRegistrar::registerValueCountAggregator,
             ExponentialHistogramAggregatorsRegistrar::registerSumAggregator,
             ExponentialHistogramAggregatorsRegistrar::registerAvgAggregator,
-            ExponentialHistogramAggregatorsRegistrar::registerHistogramAggregator
+            ExponentialHistogramAggregatorsRegistrar::registerHistogramAggregator,
+            ExponentialHistogramAggregatorsRegistrar::registerMinAggregator
         );
     }
 }

--- a/x-pack/plugin/mapper-exponential-histogram/src/main/java/org/elasticsearch/xpack/exponentialhistogram/aggregations/ExponentialHistogramAggregatorsRegistrar.java
+++ b/x-pack/plugin/mapper-exponential-histogram/src/main/java/org/elasticsearch/xpack/exponentialhistogram/aggregations/ExponentialHistogramAggregatorsRegistrar.java
@@ -8,12 +8,14 @@ package org.elasticsearch.xpack.exponentialhistogram.aggregations;
 
 import org.elasticsearch.search.aggregations.bucket.histogram.HistogramAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.AvgAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.MaxAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.MinAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.SumAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.ValueCountAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
 import org.elasticsearch.xpack.exponentialhistogram.aggregations.bucket.histogram.ExponentialHistogramBackedHistogramAggregator;
 import org.elasticsearch.xpack.exponentialhistogram.aggregations.metrics.ExponentialHistogramAvgAggregator;
+import org.elasticsearch.xpack.exponentialhistogram.aggregations.metrics.ExponentialHistogramMaxAggregator;
 import org.elasticsearch.xpack.exponentialhistogram.aggregations.metrics.ExponentialHistogramMinAggregator;
 import org.elasticsearch.xpack.exponentialhistogram.aggregations.metrics.ExponentialHistogramSumAggregator;
 import org.elasticsearch.xpack.exponentialhistogram.aggregations.metrics.ExponentialHistogramValueCountAggregator;
@@ -65,6 +67,15 @@ public class ExponentialHistogramAggregatorsRegistrar {
             MinAggregationBuilder.REGISTRY_KEY,
             ExponentialHistogramValuesSourceType.EXPONENTIAL_HISTOGRAM,
             ExponentialHistogramMinAggregator::new,
+            true
+        );
+    }
+
+    public static void registerMaxAggregator(ValuesSourceRegistry.Builder builder) {
+        builder.register(
+            MaxAggregationBuilder.REGISTRY_KEY,
+            ExponentialHistogramValuesSourceType.EXPONENTIAL_HISTOGRAM,
+            ExponentialHistogramMaxAggregator::new,
             true
         );
     }

--- a/x-pack/plugin/mapper-exponential-histogram/src/main/java/org/elasticsearch/xpack/exponentialhistogram/aggregations/ExponentialHistogramAggregatorsRegistrar.java
+++ b/x-pack/plugin/mapper-exponential-histogram/src/main/java/org/elasticsearch/xpack/exponentialhistogram/aggregations/ExponentialHistogramAggregatorsRegistrar.java
@@ -8,11 +8,13 @@ package org.elasticsearch.xpack.exponentialhistogram.aggregations;
 
 import org.elasticsearch.search.aggregations.bucket.histogram.HistogramAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.AvgAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.MinAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.SumAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.ValueCountAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
 import org.elasticsearch.xpack.exponentialhistogram.aggregations.bucket.histogram.ExponentialHistogramBackedHistogramAggregator;
 import org.elasticsearch.xpack.exponentialhistogram.aggregations.metrics.ExponentialHistogramAvgAggregator;
+import org.elasticsearch.xpack.exponentialhistogram.aggregations.metrics.ExponentialHistogramMinAggregator;
 import org.elasticsearch.xpack.exponentialhistogram.aggregations.metrics.ExponentialHistogramSumAggregator;
 import org.elasticsearch.xpack.exponentialhistogram.aggregations.metrics.ExponentialHistogramValueCountAggregator;
 import org.elasticsearch.xpack.exponentialhistogram.aggregations.support.ExponentialHistogramValuesSourceType;
@@ -54,6 +56,15 @@ public class ExponentialHistogramAggregatorsRegistrar {
             HistogramAggregationBuilder.REGISTRY_KEY,
             ExponentialHistogramValuesSourceType.EXPONENTIAL_HISTOGRAM,
             ExponentialHistogramBackedHistogramAggregator::new,
+            true
+        );
+    }
+
+    public static void registerMinAggregator(ValuesSourceRegistry.Builder builder) {
+        builder.register(
+            MinAggregationBuilder.REGISTRY_KEY,
+            ExponentialHistogramValuesSourceType.EXPONENTIAL_HISTOGRAM,
+            ExponentialHistogramMinAggregator::new,
             true
         );
     }

--- a/x-pack/plugin/mapper-exponential-histogram/src/main/java/org/elasticsearch/xpack/exponentialhistogram/aggregations/metrics/ExponentialHistogramMaxAggregator.java
+++ b/x-pack/plugin/mapper-exponential-histogram/src/main/java/org/elasticsearch/xpack/exponentialhistogram/aggregations/metrics/ExponentialHistogramMaxAggregator.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.exponentialhistogram.aggregations.metrics;
+
+import org.apache.lucene.search.ScoreMode;
+import org.elasticsearch.common.util.DoubleArray;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.AggregationExecutionContext;
+import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.LeafBucketCollector;
+import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
+import org.elasticsearch.search.aggregations.metrics.Max;
+import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregator;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
+import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.xpack.core.exponentialhistogram.fielddata.ExponentialHistogramValuesReader;
+import org.elasticsearch.xpack.exponentialhistogram.aggregations.support.ExponentialHistogramValuesSource;
+
+import java.io.IOException;
+import java.util.Map;
+
+public final class ExponentialHistogramMaxAggregator extends NumericMetricsAggregator.SingleValue {
+
+    private final ExponentialHistogramValuesSource.ExponentialHistogram valuesSource;
+    private final DocValueFormat format;
+
+    private DoubleArray maxs;
+
+    public ExponentialHistogramMaxAggregator(
+        String name,
+        ValuesSourceConfig config,
+        AggregationContext context,
+        Aggregator parent,
+        Map<String, Object> metadata
+    ) throws IOException {
+        super(name, context, parent, metadata);
+        assert config.hasValues();
+        this.valuesSource = (ExponentialHistogramValuesSource.ExponentialHistogram) config.getValuesSource();
+        maxs = bigArrays().newDoubleArray(1, false);
+        maxs.fill(0, maxs.size(), Double.NEGATIVE_INFINITY);
+        this.format = config.format();
+    }
+
+    @Override
+    public ScoreMode scoreMode() {
+        return valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
+    }
+
+    @Override
+    public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, final LeafBucketCollector sub) throws IOException {
+        final ExponentialHistogramValuesReader values = valuesSource.getHistogramValues(aggCtx.getLeafReaderContext());
+        return new LeafBucketCollectorBase(sub, values) {
+
+            @Override
+            public void collect(int doc, long bucket) throws IOException {
+                if (bucket >= maxs.size()) {
+                    long from = maxs.size();
+                    maxs = bigArrays().grow(maxs, bucket + 1);
+                    maxs.fill(from, maxs.size(), Double.NEGATIVE_INFINITY);
+                }
+
+                if (values.advanceExact(doc)) {
+                    double max = Math.max(maxs.get(bucket), values.maxValue());
+                    maxs.set(bucket, max);
+                }
+
+            }
+        };
+    }
+
+    @Override
+    public double metric(long owningBucketOrd) {
+        if (owningBucketOrd >= maxs.size()) {
+            return Double.NEGATIVE_INFINITY;
+        }
+        return maxs.get(owningBucketOrd);
+    }
+
+    @Override
+    public InternalAggregation buildAggregation(long bucket) {
+        if (bucket >= maxs.size()) {
+            return buildEmptyAggregation();
+        }
+        return new Max(name, maxs.get(bucket), format, metadata());
+    }
+
+    @Override
+    public InternalAggregation buildEmptyAggregation() {
+        return Max.createEmptyMax(name, format, metadata());
+    }
+
+    @Override
+    public void doClose() {
+        Releasables.close(maxs);
+    }
+
+}

--- a/x-pack/plugin/mapper-exponential-histogram/src/main/java/org/elasticsearch/xpack/exponentialhistogram/aggregations/metrics/ExponentialHistogramMinAggregator.java
+++ b/x-pack/plugin/mapper-exponential-histogram/src/main/java/org/elasticsearch/xpack/exponentialhistogram/aggregations/metrics/ExponentialHistogramMinAggregator.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.exponentialhistogram.aggregations.metrics;
+
+import org.apache.lucene.search.ScoreMode;
+import org.elasticsearch.common.util.DoubleArray;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.AggregationExecutionContext;
+import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.LeafBucketCollector;
+import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
+import org.elasticsearch.search.aggregations.metrics.Min;
+import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregator;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
+import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
+import org.elasticsearch.xpack.core.exponentialhistogram.fielddata.ExponentialHistogramValuesReader;
+import org.elasticsearch.xpack.exponentialhistogram.aggregations.support.ExponentialHistogramValuesSource;
+
+import java.io.IOException;
+import java.util.Map;
+
+public final class ExponentialHistogramMinAggregator extends NumericMetricsAggregator.SingleValue {
+
+    private final ExponentialHistogramValuesSource.ExponentialHistogram valuesSource;
+    private final DocValueFormat format;
+
+    private DoubleArray mins;
+
+    public ExponentialHistogramMinAggregator(
+        String name,
+        ValuesSourceConfig config,
+        AggregationContext context,
+        Aggregator parent,
+        Map<String, Object> metadata
+    ) throws IOException {
+        super(name, context, parent, metadata);
+        assert config.hasValues();
+        this.valuesSource = (ExponentialHistogramValuesSource.ExponentialHistogram) config.getValuesSource();
+        mins = bigArrays().newDoubleArray(1, false);
+        mins.fill(0, mins.size(), Double.POSITIVE_INFINITY);
+        this.format = config.format();
+    }
+
+    @Override
+    public ScoreMode scoreMode() {
+        return valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
+    }
+
+    @Override
+    public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, final LeafBucketCollector sub) throws IOException {
+        final ExponentialHistogramValuesReader values = valuesSource.getHistogramValues(aggCtx.getLeafReaderContext());
+        return new LeafBucketCollectorBase(sub, values) {
+
+            @Override
+            public void collect(int doc, long bucket) throws IOException {
+                if (bucket >= mins.size()) {
+                    long from = mins.size();
+                    mins = bigArrays().grow(mins, bucket + 1);
+                    mins.fill(from, mins.size(), Double.POSITIVE_INFINITY);
+                }
+
+                if (values.advanceExact(doc)) {
+                    double min = Math.min(mins.get(bucket), values.minValue());
+                    mins.set(bucket, min);
+                }
+
+            }
+        };
+    }
+
+    @Override
+    public double metric(long owningBucketOrd) {
+        if (owningBucketOrd >= mins.size()) {
+            return Double.POSITIVE_INFINITY;
+        }
+        return mins.get(owningBucketOrd);
+    }
+
+    @Override
+    public InternalAggregation buildAggregation(long bucket) {
+        if (bucket >= mins.size()) {
+            return buildEmptyAggregation();
+        }
+        return new Min(name, mins.get(bucket), format, metadata());
+    }
+
+    @Override
+    public InternalAggregation buildEmptyAggregation() {
+        return Min.createEmptyMin(name, format, metadata());
+    }
+
+    @Override
+    public void doClose() {
+        Releasables.close(mins);
+    }
+
+}

--- a/x-pack/plugin/mapper-exponential-histogram/src/test/java/org/elasticsearch/xpack/exponentialhistogram/aggregations/metrics/ExponentialHistogramMaxAggregatorTests.java
+++ b/x-pack/plugin/mapper-exponential-histogram/src/test/java/org/elasticsearch/xpack/exponentialhistogram/aggregations/metrics/ExponentialHistogramMaxAggregatorTests.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.exponentialhistogram.aggregations.metrics;
+
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.exponentialhistogram.ExponentialHistogram;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.Max;
+import org.elasticsearch.search.aggregations.metrics.MaxAggregationBuilder;
+import org.elasticsearch.search.aggregations.support.AggregationInspectionHelper;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
+import org.elasticsearch.xpack.exponentialhistogram.ExponentialHistogramFieldMapper;
+import org.elasticsearch.xpack.exponentialhistogram.aggregations.ExponentialHistogramAggregatorTestCase;
+import org.elasticsearch.xpack.exponentialhistogram.aggregations.support.ExponentialHistogramValuesSourceType;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class ExponentialHistogramMaxAggregatorTests extends ExponentialHistogramAggregatorTestCase {
+
+    private static final String FIELD_NAME = "my_histogram";
+
+    public void testMatchesNumericDocValues() throws IOException {
+
+        List<ExponentialHistogram> histograms = createRandomHistograms(randomIntBetween(1, 1000));
+        boolean anyNonEmpty = histograms.stream().anyMatch(histo -> histo.valueCount() > 0);
+
+        double expectedMax = histograms.stream()
+            .mapToDouble(ExponentialHistogram::max)
+            .filter(val -> Double.isNaN(val) == false)
+            .max()
+            .orElse(Double.NEGATIVE_INFINITY);
+
+        testCase(Queries.ALL_DOCS_INSTANCE, iw -> histograms.forEach(histo -> addHistogramDoc(iw, FIELD_NAME, histo)), max -> {
+            assertThat(max.value(), equalTo(expectedMax));
+            assertThat(AggregationInspectionHelper.hasValue(max), equalTo(anyNonEmpty));
+        });
+    }
+
+    public void testNoDocs() throws IOException {
+        testCase(Queries.ALL_DOCS_INSTANCE, iw -> {
+            // Intentionally not writing any docs
+        }, max -> {
+            assertThat(max.value(), equalTo(Double.NEGATIVE_INFINITY));
+            assertThat(AggregationInspectionHelper.hasValue(max), equalTo(false));
+        });
+    }
+
+    public void testNoMatchingField() throws IOException {
+        List<ExponentialHistogram> histograms = createRandomHistograms(10);
+        testCase(Queries.ALL_DOCS_INSTANCE, iw -> histograms.forEach(histo -> addHistogramDoc(iw, "wrong_field", histo)), max -> {
+            assertThat(max.value(), equalTo(Double.NEGATIVE_INFINITY));
+            assertThat(AggregationInspectionHelper.hasValue(max), equalTo(false));
+        });
+    }
+
+    public void testQueryFiltering() throws IOException {
+        List<Map.Entry<ExponentialHistogram, Boolean>> histogramsWithFilter = createRandomHistograms(10).stream()
+            .map(histo -> Map.entry(histo, randomBoolean()))
+            .toList();
+
+        boolean anyMatch = histogramsWithFilter.stream().filter(entry -> entry.getKey().valueCount() > 0).anyMatch(Map.Entry::getValue);
+        double filteredMax = histogramsWithFilter.stream()
+            .filter(Map.Entry::getValue)
+            .filter(entry -> entry.getKey().valueCount() > 0)
+            .mapToDouble(entry -> entry.getKey().max())
+            .max()
+            .orElse(Double.NEGATIVE_INFINITY);
+
+        testCase(
+            new TermQuery(new Term("match", "yes")),
+            iw -> histogramsWithFilter.forEach(
+                entry -> addHistogramDoc(
+                    iw,
+                    FIELD_NAME,
+                    entry.getKey(),
+                    new StringField("match", entry.getValue() ? "yes" : "no", Field.Store.NO)
+                )
+            ),
+            max -> {
+                assertThat(max.value(), equalTo(filteredMax));
+                assertThat(AggregationInspectionHelper.hasValue(max), equalTo(anyMatch));
+            }
+        );
+    }
+
+    private void testCase(Query query, CheckedConsumer<RandomIndexWriter, IOException> buildIndex, Consumer<Max> verify)
+        throws IOException {
+        var fieldType = new ExponentialHistogramFieldMapper.ExponentialHistogramFieldType(FIELD_NAME, Collections.emptyMap(), null);
+        AggregationBuilder aggregationBuilder = createAggBuilderForTypeTest(fieldType, FIELD_NAME);
+        testCase(buildIndex, verify, new AggTestConfig(aggregationBuilder, fieldType).withQuery(query));
+    }
+
+    @Override
+    protected AggregationBuilder createAggBuilderForTypeTest(MappedFieldType fieldType, String fieldName) {
+        return new MaxAggregationBuilder("max_agg").field(fieldName);
+    }
+
+    @Override
+    protected List<ValuesSourceType> getSupportedValuesSourceTypes() {
+        return List.of(
+            CoreValuesSourceType.NUMERIC,
+            CoreValuesSourceType.DATE,
+            CoreValuesSourceType.BOOLEAN,
+            ExponentialHistogramValuesSourceType.EXPONENTIAL_HISTOGRAM
+        );
+    }
+}

--- a/x-pack/plugin/mapper-exponential-histogram/src/test/java/org/elasticsearch/xpack/exponentialhistogram/aggregations/metrics/ExponentialHistogramMinAggregatorTests.java
+++ b/x-pack/plugin/mapper-exponential-histogram/src/test/java/org/elasticsearch/xpack/exponentialhistogram/aggregations/metrics/ExponentialHistogramMinAggregatorTests.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.exponentialhistogram.aggregations.metrics;
+
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.exponentialhistogram.ExponentialHistogram;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.Min;
+import org.elasticsearch.search.aggregations.metrics.MinAggregationBuilder;
+import org.elasticsearch.search.aggregations.support.AggregationInspectionHelper;
+import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.aggregations.support.ValuesSourceType;
+import org.elasticsearch.xpack.exponentialhistogram.ExponentialHistogramFieldMapper;
+import org.elasticsearch.xpack.exponentialhistogram.aggregations.ExponentialHistogramAggregatorTestCase;
+import org.elasticsearch.xpack.exponentialhistogram.aggregations.support.ExponentialHistogramValuesSourceType;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class ExponentialHistogramMinAggregatorTests extends ExponentialHistogramAggregatorTestCase {
+
+    private static final String FIELD_NAME = "my_histogram";
+
+    public void testMatchesNumericDocValues() throws IOException {
+
+        List<ExponentialHistogram> histograms = createRandomHistograms(randomIntBetween(1, 1000));
+        boolean anyNonEmpty = histograms.stream().anyMatch(histo -> histo.valueCount() > 0);
+
+        double expectedMin = histograms.stream()
+            .mapToDouble(ExponentialHistogram::min)
+            .filter(val -> Double.isNaN(val) == false)
+            .min()
+            .orElse(Double.POSITIVE_INFINITY);
+
+        testCase(Queries.ALL_DOCS_INSTANCE, iw -> histograms.forEach(histo -> addHistogramDoc(iw, FIELD_NAME, histo)), min -> {
+            assertThat(min.value(), equalTo(expectedMin));
+            assertThat(AggregationInspectionHelper.hasValue(min), equalTo(anyNonEmpty));
+        });
+    }
+
+    public void testNoDocs() throws IOException {
+        testCase(Queries.ALL_DOCS_INSTANCE, iw -> {
+            // Intentionally not writing any docs
+        }, min -> {
+            assertThat(min.value(), equalTo(Double.POSITIVE_INFINITY));
+            assertThat(AggregationInspectionHelper.hasValue(min), equalTo(false));
+        });
+    }
+
+    public void testNoMatchingField() throws IOException {
+        List<ExponentialHistogram> histograms = createRandomHistograms(10);
+        testCase(Queries.ALL_DOCS_INSTANCE, iw -> histograms.forEach(histo -> addHistogramDoc(iw, "wrong_field", histo)), min -> {
+            assertThat(min.value(), equalTo(Double.POSITIVE_INFINITY));
+            assertThat(AggregationInspectionHelper.hasValue(min), equalTo(false));
+        });
+    }
+
+    public void testQueryFiltering() throws IOException {
+        List<Map.Entry<ExponentialHistogram, Boolean>> histogramsWithFilter = createRandomHistograms(10).stream()
+            .map(histo -> Map.entry(histo, randomBoolean()))
+            .toList();
+
+        boolean anyMatch = histogramsWithFilter.stream().filter(entry -> entry.getKey().valueCount() > 0).anyMatch(Map.Entry::getValue);
+        double filteredMin = histogramsWithFilter.stream()
+            .filter(Map.Entry::getValue)
+            .filter(entry -> entry.getKey().valueCount() > 0)
+            .mapToDouble(entry -> entry.getKey().min())
+            .min()
+            .orElse(Double.POSITIVE_INFINITY);
+
+        testCase(
+            new TermQuery(new Term("match", "yes")),
+            iw -> histogramsWithFilter.forEach(
+                entry -> addHistogramDoc(
+                    iw,
+                    FIELD_NAME,
+                    entry.getKey(),
+                    new StringField("match", entry.getValue() ? "yes" : "no", Field.Store.NO)
+                )
+            ),
+            min -> {
+                assertThat(min.value(), equalTo(filteredMin));
+                assertThat(AggregationInspectionHelper.hasValue(min), equalTo(anyMatch));
+            }
+        );
+    }
+
+    private void testCase(Query query, CheckedConsumer<RandomIndexWriter, IOException> buildIndex, Consumer<Min> verify)
+        throws IOException {
+        var fieldType = new ExponentialHistogramFieldMapper.ExponentialHistogramFieldType(FIELD_NAME, Collections.emptyMap(), null);
+        AggregationBuilder aggregationBuilder = createAggBuilderForTypeTest(fieldType, FIELD_NAME);
+        testCase(buildIndex, verify, new AggTestConfig(aggregationBuilder, fieldType).withQuery(query));
+    }
+
+    @Override
+    protected AggregationBuilder createAggBuilderForTypeTest(MappedFieldType fieldType, String fieldName) {
+        return new MinAggregationBuilder("min_agg").field(fieldName);
+    }
+
+    @Override
+    protected List<ValuesSourceType> getSupportedValuesSourceTypes() {
+        return List.of(
+            CoreValuesSourceType.NUMERIC,
+            CoreValuesSourceType.DATE,
+            CoreValuesSourceType.BOOLEAN,
+            ExponentialHistogramValuesSourceType.EXPONENTIAL_HISTOGRAM
+        );
+    }
+}

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/exponential_histogram/20_aggregations.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/exponential_histogram/20_aggregations.yml
@@ -113,3 +113,18 @@ setup:
          doc_count: 4
        - key: 10920.0
          doc_count: 5
+
+---
+"Min aggregation":
+  - do:
+      search:
+        index: test_exponential_histogram
+        size: 0
+        body:
+          aggs:
+            min_agg:
+              min:
+                field: histo
+
+  - match: { hits.total.value: 5 }
+  - match: { aggregations.min_agg.value: -1000.0 }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/exponential_histogram/20_aggregations.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/exponential_histogram/20_aggregations.yml
@@ -128,3 +128,18 @@ setup:
 
   - match: { hits.total.value: 5 }
   - match: { aggregations.min_agg.value: -1000.0 }
+
+---
+"Max aggregation":
+  - do:
+      search:
+        index: test_exponential_histogram
+        size: 0
+        body:
+          aggs:
+            max_agg:
+              max:
+                field: histo
+
+  - match: { hits.total.value: 5 }
+  - match: { aggregations.max_agg.value: 13000.0 }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/exponential_histogram/30_aggregate_metric_aggregations_compatibility.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/exponential_histogram/30_aggregate_metric_aggregations_compatibility.yml
@@ -30,7 +30,7 @@ setup:
         body:
           '@timestamp': "2023-01-01T00:00:00Z"
           histo_or_aggregate_metric:
-            min: 1.0
+            min: 0.9
             max: 10.0
             sum: 20.0
             value_count: 3
@@ -107,3 +107,33 @@ setup:
               avg:
                 field: histo_or_aggregate_metric
   - match: { aggregations.avg_metric.value: 12.0 }
+
+---
+"Min aggregation over aggregate_metric_double and exponential_histogram":
+  - do:
+      search:
+        index: test-data-stream
+        size: 0
+        body:
+          aggs:
+            min_agg:
+              min:
+                field: histo_or_aggregate_metric
+
+  - match: { hits.total.value: 2 }
+  - match: { aggregations.min_agg.value: 0.9 }
+
+---
+"Max aggregation over aggregate_metric_double and exponential_histogram":
+  - do:
+      search:
+        index: test-data-stream
+        size: 0
+        body:
+          aggs:
+            max_agg:
+              max:
+                field: histo_or_aggregate_metric
+
+  - match: { hits.total.value: 2 }
+  - match: { aggregations.max_agg.value: 10.0 }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/exponential_histogram/40_tdigest_histogram_aggregations_compatibility.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/exponential_histogram/40_tdigest_histogram_aggregations_compatibility.yml
@@ -28,7 +28,7 @@ setup:
         body:
           '@timestamp': "2023-01-01T00:00:00Z"
           tdigest_or_exp_histo:
-            values: [1.0, 2.0, 4.0]
+            values: [0.9, 2.0, 4.0]
             counts: [2, 2, 1]
 
   # Update the index template to change the field type to exponential_histogram
@@ -89,7 +89,7 @@ setup:
             sum_metric:
               sum:
                 field: tdigest_or_exp_histo
-  - match: { aggregations.sum_metric.value: 110.0 }
+  - match: { aggregations.sum_metric.value: 109.8 }
 
 ---
 "Average aggregation over aggregate_metric_double and exponential_histogram":
@@ -102,4 +102,34 @@ setup:
             avg_metric:
               avg:
                 field: tdigest_or_exp_histo
-  - match: { aggregations.avg_metric.value: 11.0 }
+  - match: { aggregations.avg_metric.value: 10.98 }
+
+---
+"Min aggregation over aggregate_metric_double and exponential_histogram":
+  - do:
+      search:
+        index: test-data-stream
+        size: 0
+        body:
+          aggs:
+            min_agg:
+              min:
+                field: tdigest_or_exp_histo
+
+  - match: { hits.total.value: 2 }
+  - match: { aggregations.min_agg.value: 0.9 }
+
+---
+"Max aggregation over aggregate_metric_double and exponential_histogram":
+  - do:
+      search:
+        index: test-data-stream
+        size: 0
+        body:
+          aggs:
+            max_agg:
+              max:
+                field: tdigest_or_exp_histo
+
+  - match: { hits.total.value: 2 }
+  - match: { aggregations.max_agg.value: 10.0 }


### PR DESCRIPTION
Part of #135625.
I'll add documentation once we've finished the implementation for all aggs.
Like for the other aggs, this PR also ensures support for querying mixed data sets consisting of exponential histograms and either `histogram`s or `aggregate_metric_double`s.
