### PR TITLE
[8.19] This reduces the default sampling rate for traces in ES and disables reporting of internal spans, so only root spans aka transactions get reported. (#140840)

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
@@ -239,7 +239,8 @@ public abstract class RunTask extends DefaultTestClustersTask {
                         mockServer.start();
                         node.setting("telemetry.metrics.enabled", "true");
                         node.setting("telemetry.tracing.enabled", "true");
-                        node.setting("telemetry.agent.transaction_sample_rate", "0.10");
+                        node.setting("telemetry.agent.transaction_sample_rate", "1.0");
+                        node.setting("telemetry.agent.transaction_max_spans", "100");
                         node.setting("telemetry.agent.metrics_interval", "10s");
                         node.setting("telemetry.agent.server_url", "http://127.0.0.1:" + mockServer.getPort());
                     } catch (IOException e) {

--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/APMJvmOptions.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/APMJvmOptions.java
@@ -41,20 +41,17 @@ class APMJvmOptions {
     /**
      * Contains agent configuration that must always be applied, and cannot be overridden.
      */
-    // tag::noformat
-    private static final Map<String, String> STATIC_CONFIG = Map.of(
-        // Identifies the version of Elasticsearch in the captured trace data.
-        "service_version", Build.current().version(),
-
+    private static final Map<String, String> STATIC_CONFIG = Map.ofEntries(
+        Map.entry("service_version", Build.current().version()),
         // ES does not use auto-instrumentation.
-        "instrument", "false",
-        "enable_experimental_instrumentations", "true"
-        );
+        Map.entry("instrument", "false"),
+        Map.entry("enable_experimental_instrumentations", "true")
+    );
 
     /**
      * Contains default configuration that will be used unless overridden by explicit configuration.
      */
-    private static final Map<String, String> CONFIG_DEFAULTS = Map.of(
+    private static final Map<String, String> CONFIG_DEFAULTS = Map.ofEntries(
         // This is used to keep all the errors and transactions of a service
         // together and is the primary filter in the Elastic APM user interface.
         //
@@ -65,28 +62,29 @@ class APMJvmOptions {
         // the reported hostname (automatically discovered or manually
         // configured through hostname). However, if this node's `node.name` is
         // set, then that value is used for the `service_node_name`.
-        "service_name", "elasticsearch",
+        Map.entry("service_name", "elasticsearch"),
 
         // An arbitrary string that identifies this deployment environment. For
         // example, "dev", "staging" or "prod". Can be anything you like, but must
         // have the same value across different systems in the same deployment
         // environment.
-        "environment", "dev",
+        Map.entry("environment", "dev"),
 
         // Logging configuration. Unless you need detailed logs about what the APM
-        // is doing, leave this value alone.
-        "log_level", "warn",
-        "log_format_file", "JSON",
-        "application_packages", "org.elasticsearch,org.apache.lucene",
-        "metrics_interval", "120s",
-        "breakdown_metrics", "false",
-        "central_config", "false",
-        "transaction_sample_rate", "0.2",
+        // is doing, leave this at warn or error.
+        Map.entry("log_level", "error"),
+        Map.entry("log_format_file", "JSON"),
+        Map.entry("application_packages", "org.elasticsearch,org.apache.lucene"),
+        Map.entry("metrics_interval", "120s"),
+        Map.entry("breakdown_metrics", "false"),
+        Map.entry("central_config", "false"),
+        Map.entry("transaction_sample_rate", "0.001"),
+        // Only report root spans (transactions), discard internal spans
+        Map.entry("transaction_max_spans", "0"),
         // Don't collect stacktraces for spans, typically these are of little use as
         // always pointing to APMTracer.stopTrace invoked from TaskManager
-        "stack_trace_limit", "0"
-        );
-    // end::noformat
+        Map.entry("stack_trace_limit", "0")
+    );
 
     /**
      * Lists all APM configuration keys that are not dynamic and must be configured via the config file.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [This reduces the default sampling rate for traces in ES and disables reporting of internal spans, so only root spans aka transactions get reported. (#140840)](https://github.com/elastic/elasticsearch/pull/140840)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)