### PR TITLE
Simplify setting verification

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -40,6 +40,7 @@ import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParserUtils;
+import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.gateway.MetadataStateFormat;
 import org.elasticsearch.index.Index;
@@ -2534,7 +2535,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             String indexModeString = settings.get(IndexSettings.MODE.getKey());
             final IndexMode indexMode = indexModeString != null ? IndexMode.fromString(indexModeString.toLowerCase(Locale.ROOT)) : null;
             final boolean isTsdb = indexMode == IndexMode.TIME_SERIES;
-            boolean useTimeSeriesSyntheticId = Boolean.parseBoolean(settings.get(IndexSettings.USE_SYNTHETIC_ID.getKey()));
+            boolean useTimeSeriesSyntheticId = Booleans.parseBoolean(settings.get(IndexSettings.USE_SYNTHETIC_ID.getKey()), false);
             return new IndexMetadata(
                 new Index(index, uuid),
                 version,

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -2534,16 +2534,8 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             String indexModeString = settings.get(IndexSettings.MODE.getKey());
             final IndexMode indexMode = indexModeString != null ? IndexMode.fromString(indexModeString.toLowerCase(Locale.ROOT)) : null;
             final boolean isTsdb = indexMode == IndexMode.TIME_SERIES;
-            boolean useTimeSeriesSyntheticId = false;
-            if (isTsdb
-                && IndexSettings.TSDB_SYNTHETIC_ID_FEATURE_FLAG
-                && indexCreatedVersion.onOrAfter(IndexVersions.TIME_SERIES_USE_SYNTHETIC_ID)) {
-                var setting = settings.get(IndexSettings.USE_SYNTHETIC_ID.getKey());
-                if (setting != null && setting.equalsIgnoreCase(Boolean.TRUE.toString())) {
-                    assert IndexSettings.TSDB_SYNTHETIC_ID_FEATURE_FLAG;
-                    useTimeSeriesSyntheticId = true;
-                }
-            }
+            boolean useTimeSeriesSyntheticId = settings.get(IndexSettings.USE_SYNTHETIC_ID.getKey())
+                .equalsIgnoreCase(Boolean.TRUE.toString());
             return new IndexMetadata(
                 new Index(index, uuid),
                 version,

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -2534,8 +2534,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             String indexModeString = settings.get(IndexSettings.MODE.getKey());
             final IndexMode indexMode = indexModeString != null ? IndexMode.fromString(indexModeString.toLowerCase(Locale.ROOT)) : null;
             final boolean isTsdb = indexMode == IndexMode.TIME_SERIES;
-            boolean useTimeSeriesSyntheticId = settings.get(IndexSettings.USE_SYNTHETIC_ID.getKey())
-                .equalsIgnoreCase(Boolean.TRUE.toString());
+            boolean useTimeSeriesSyntheticId = Boolean.parseBoolean(settings.get(IndexSettings.USE_SYNTHETIC_ID.getKey()));
             return new IndexMetadata(
                 new Index(index, uuid),
                 version,

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -1275,8 +1275,19 @@ public final class IndexSettings {
         useEs812PostingsFormat = scopedSettings.get(USE_ES_812_POSTINGS_FORMAT);
         intraMergeParallelismEnabled = scopedSettings.get(INTRA_MERGE_PARALLELISM_ENABLED_SETTING);
         final var useSyntheticId = IndexSettings.TSDB_SYNTHETIC_ID_FEATURE_FLAG && scopedSettings.get(USE_SYNTHETIC_ID);
+        if (useSyntheticId && version.before(IndexVersions.TIME_SERIES_USE_SYNTHETIC_ID)) {
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ROOT,
+                    "The setting [%s] is unavailable on this cluster because some nodes are running older "
+                        + "versions that do not support it. Please upgrade all nodes to the latest version "
+                        + "and try again.",
+                    USE_SYNTHETIC_ID.getKey()
+                )
+            );
+        }
+        // Make sure logic in IndexMetadata doesn't deviate from this source of truth
         if (indexMetadata.useTimeSeriesSyntheticId() != useSyntheticId) {
-            assert false;
             throw new IllegalArgumentException(
                 String.format(
                     Locale.ROOT,
@@ -1287,15 +1298,7 @@ public final class IndexSettings {
                 )
             );
         }
-        if (useSyntheticId) {
-            assert TSDB_SYNTHETIC_ID_FEATURE_FLAG;
-            assert indexMetadata.useTimeSeriesSyntheticId();
-            assert indexMetadata.getIndexMode() == IndexMode.TIME_SERIES : indexMetadata.getIndexMode();
-            assert indexMetadata.getCreationVersion().onOrAfter(IndexVersions.TIME_SERIES_USE_SYNTHETIC_ID);
-            useTimeSeriesSyntheticId = true;
-        } else {
-            useTimeSeriesSyntheticId = false;
-        }
+        useTimeSeriesSyntheticId = useSyntheticId;
         if (recoverySourceSyntheticEnabled) {
             if (DiscoveryNode.isStateless(settings)) {
                 throw new IllegalArgumentException("synthetic recovery source is only allowed in stateful");

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -1275,7 +1275,7 @@ public final class IndexSettings {
         useEs812PostingsFormat = scopedSettings.get(USE_ES_812_POSTINGS_FORMAT);
         intraMergeParallelismEnabled = scopedSettings.get(INTRA_MERGE_PARALLELISM_ENABLED_SETTING);
         final var useSyntheticId = IndexSettings.TSDB_SYNTHETIC_ID_FEATURE_FLAG && scopedSettings.get(USE_SYNTHETIC_ID);
-        if (useSyntheticId && version.before(IndexVersions.TIME_SERIES_USE_SYNTHETIC_ID)) {
+        if (useSyntheticId && version.before(IndexVersions.TIME_SERIES_USE_STORED_FIELDS_BLOOM_FILTER_FOR_ID)) {
             throw new IllegalArgumentException(
                 String.format(
                     Locale.ROOT,

--- a/server/src/main/java/org/elasticsearch/index/codec/CodecService.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/CodecService.java
@@ -16,7 +16,6 @@ import org.apache.lucene.codecs.lucene103.Lucene103Codec;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.FeatureFlag;
 import org.elasticsearch.core.Nullable;
-import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.codec.tsdb.ES93TSDBDefaultCompressionLucene103Codec;
 import org.elasticsearch.index.codec.zstd.Zstd814StoredFieldsFormat;
 import org.elasticsearch.index.mapper.MapperService;
@@ -49,11 +48,7 @@ public class CodecService implements CodecProvider {
     public CodecService(@Nullable MapperService mapperService, BigArrays bigArrays, @Nullable ThreadPool threadPool) {
         final var codecs = new HashMap<String, Codec>();
 
-        boolean useSyntheticId = mapperService != null
-            && mapperService.getIndexSettings().useTimeSeriesSyntheticId()
-            && mapperService.getIndexSettings()
-                .getIndexVersionCreated()
-                .onOrAfter(IndexVersions.TIME_SERIES_USE_STORED_FIELDS_BLOOM_FILTER_FOR_ID);
+        boolean useSyntheticId = mapperService != null && mapperService.getIndexSettings().useTimeSeriesSyntheticId();
 
         var legacyBestSpeedCodec = new LegacyPerFieldMapperCodec(Lucene103Codec.Mode.BEST_SPEED, mapperService, bigArrays, threadPool);
         if (useSyntheticId) {

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -414,8 +414,9 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
         assertTimeSeriesIndexing(IndexVersions.TIME_SERIES_DIMENSIONS_USE_SKIPPERS, false, false);
         assertTimeSeriesIndexing(IndexVersions.TIME_SERIES_ALL_FIELDS_USE_SKIPPERS, true, true);
         assertTimeSeriesIndexing(IndexVersions.TIME_SERIES_ALL_FIELDS_USE_SKIPPERS, false, true);
-        assertTimeSeriesIndexing(IndexVersions.TIME_SERIES_USE_SYNTHETIC_ID, true, false);
-        assertTimeSeriesIndexing(IndexVersions.TIME_SERIES_USE_SYNTHETIC_ID, false, false);
+        IndexVersion noSkippers = IndexVersionUtils.getPreviousVersion(IndexVersions.TIME_SERIES_DIMENSIONS_USE_SKIPPERS);
+        assertTimeSeriesIndexing(noSkippers, true, false);
+        assertTimeSeriesIndexing(noSkippers, false, false);
     }
 
     public void assertTimeSeriesIndexing(IndexVersion indexVersion, boolean isDimension, boolean hasSkippers) throws IOException {


### PR DESCRIPTION
Since no index can be created without IndexSettings it is enough to
validate the setting there. There is no way that IndexMetadata can
disagree with IndexSettings without IndexSettings throwing during
validation of the setting.

The different cases explained here:
- Setting not set: No problem
- Setting set without feature flag: IndexSettings throw because
setting is not part of allowed settings
- Setting set to false WITH feature flag: IndexMetadata report false
and IndexSettings report false. Setting is not validated
- Setting set to true WITH feature flag: IndexMetadata report true and
IndexSettings report true or throw when validating setting

Use the same required IndexVersion for index.mapping.use_synthetic_id
everywhere.

CodecService doesn't need to validate IndexVersion because this is done
by IndexSettings.

MapperTestCase used TIME_SERIES_USE_SYNTHETIC_ID to indicate "version
before time series doc value skippers". Made this more explicit.