### PR TITLE
[Test] Set explicit heap size in `DebPreservationTests` to prevent oom-killed failures

### DIFF
--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DebPreservationTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DebPreservationTests.java
@@ -100,6 +100,10 @@ public class DebPreservationTests extends PackagingTestCase {
         installation = installPackage(sh, distribution());
         assertInstalled(distribution());
 
+        // The @Before hook that normally pins heap runs before installation is assigned in this test,
+        // so explicitly set it here to avoid CI oom-killed from auto heap sizing.
+        setHeap("1g");
+
         // Ensure ES is started
         Packages.runElasticsearchStartCommand(sh);
         ServerUtils.waitForElasticsearch(installation);


### PR DESCRIPTION
The @Before hook for heap sizing runs before installation is assigned, 
leading to potential issues with automatic heap sizing.
This change sets the heap size to 1g 
explicitly to avoid oom-killed errors during tests.

This has started to fail sporadically on `8.19` branch recently.
I think the heap size should be set for these tests in general, but I do not know why it has started to fail now and only on `8.19`. 