### PR TITLE
[9.1] [Test] Set explicit heap size in DebPreservationTests to prevent oom-killed failures (#141440)

### DIFF
--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DebPreservationTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DebPreservationTests.java
@@ -100,6 +100,10 @@ public class DebPreservationTests extends PackagingTestCase {
         installation = installPackage(sh, distribution());
         assertInstalled(distribution());
 
+        // The @Before hook that normally pins heap runs before installation is assigned in this test,
+        // so explicitly set it here to avoid CI oom-killed from auto heap sizing.
+        setHeap("1g");
+
         // Ensure ES is started
         Packages.runElasticsearchStartCommand(sh);
         ServerUtils.waitForElasticsearch(installation);


### PR DESCRIPTION
Backports the following commits to 9.1:
 - [Test] Set explicit heap size in DebPreservationTests to prevent oom-killed failures (#141440)