### PR TITLE
[9.2] Fix yamlCompatibility for unmaintained previous major (#141390)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
@@ -154,6 +154,25 @@ public class BwcVersions implements Serializable {
         return unreleased.keySet().stream().sorted().toList();
     }
 
+    public Optional<UnreleasedVersionInfo> getUnmaintainedPreviousMajor() {
+
+        return getUnreleased().stream()
+            .filter(v -> v.getMajor() == currentVersion.getMajor() - 1)
+            .min(Comparator.reverseOrder())
+            .isPresent()
+                ? Optional.empty()
+                : getReleased().stream()
+                    .filter(v -> v.getMajor() == currentVersion.getMajor() - 1)
+                    .min(Comparator.reverseOrder())
+                    .map(
+                        version -> new UnreleasedVersionInfo(
+                            version,
+                            String.format("%d.%d", version.getMajor(), version.getMinor()),
+                            ":distribution:bwc:major1"
+                        )
+                    );
+    }
+
     public void compareToAuthoritative(List<Version> authoritativeReleasedVersions) {
         Set<Version> notReallyReleased = new HashSet<>(getReleased());
         notReallyReleased.removeAll(authoritativeReleasedVersions);
@@ -178,7 +197,7 @@ public class BwcVersions implements Serializable {
         }
     }
 
-    private List<Version> getReleased() {
+    public List<Version> getReleased() {
         return versions.stream()
             .filter(v -> v.getMajor() >= currentVersion.getMajor() - 1)
             .filter(v -> unreleased.containsKey(v) == false)

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
@@ -33,6 +33,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -104,6 +105,25 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
                 fileSystemOperations
             );
         }
+
+        // We need source access to unmaintained previous major for our yamlRestTest compatibility tests but we do not
+        // want bwc coverage for this atm.
+        Optional<BwcVersions.UnreleasedVersionInfo> unmaintainedPreviousMajor = buildParams.getBwcVersions().getUnmaintainedPreviousMajor();
+        if (unmaintainedPreviousMajor.isPresent()) {
+            configureBwcProject(
+                project.project(unmaintainedPreviousMajor.get().gradleProjectPath()),
+                buildParams,
+                unmaintainedPreviousMajor.get(),
+                providerFactory,
+                objectFactory,
+                toolChainService,
+                isCi,
+                fileSystemOperations
+            );
+        }
+        // In a scenario where we do not have unreleased previous major we still wanna resolve some resources directly from branch
+        // (e.g. needed by YamlRestTestCompatibilityTestPlugin)
+
     }
 
     private static void configureBwcProject(

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/compat/compat/AbstractYamlRestCompatTestPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/compat/compat/AbstractYamlRestCompatTestPlugin.java
@@ -9,7 +9,6 @@
 
 package org.elasticsearch.gradle.internal.test.rest.compat.compat;
 
-import org.elasticsearch.gradle.Version;
 import org.elasticsearch.gradle.internal.ElasticsearchJavaBasePlugin;
 import org.elasticsearch.gradle.internal.info.GlobalBuildInfoPlugin;
 import org.elasticsearch.gradle.internal.test.rest.CopyRestApiTask;
@@ -96,13 +95,13 @@ public abstract class AbstractYamlRestCompatTestPlugin implements Plugin<Project
 
         // determine the previous rest compatibility version and BWC project path
         int currentMajor = buildParams.getBwcVersions().getCurrentVersion().getMajor();
-        Version lastMinor = buildParams.getBwcVersions()
+        String lastMinorProjectPath = buildParams.getBwcVersions()
             .getUnreleased()
             .stream()
             .filter(v -> v.getMajor() == currentMajor - 1)
             .min(Comparator.reverseOrder())
-            .get();
-        String lastMinorProjectPath = buildParams.getBwcVersions().unreleasedInfo(lastMinor).gradleProjectPath();
+            .map(v -> buildParams.getBwcVersions().unreleasedInfo(v).gradleProjectPath())
+            .orElseGet(() -> buildParams.getBwcVersions().getUnmaintainedPreviousMajor().get().gradleProjectPath());
 
         // copy compatible rest specs
         Configuration bwcMinorConfig = project.getConfigurations().create(BWC_MINOR_CONFIG_NAME);


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Fix yamlCompatibility for unmaintained previous major (#141390)