### PR TITLE
[8.19] Fix yamlCompatibility for unmaintained previous major (#141390)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcVersions.java
@@ -158,6 +158,25 @@ public class BwcVersions implements Serializable {
         return unreleased.keySet().stream().sorted().toList();
     }
 
+    public Optional<UnreleasedVersionInfo> getUnmaintainedPreviousMajor() {
+
+        return getUnreleased().stream()
+            .filter(v -> v.getMajor() == currentVersion.getMajor() - 1)
+            .min(Comparator.reverseOrder())
+            .isPresent()
+                ? Optional.empty()
+                : getReleased().stream()
+                    .filter(v -> v.getMajor() == currentVersion.getMajor() - 1)
+                    .min(Comparator.reverseOrder())
+                    .map(
+                        version -> new UnreleasedVersionInfo(
+                            version,
+                            String.format("%d.%d", version.getMajor(), version.getMinor()),
+                            ":distribution:bwc:major1"
+                        )
+                    );
+    }
+
     public void compareToAuthoritative(List<Version> authoritativeReleasedVersions) {
         Set<Version> notReallyReleased = new HashSet<>(getReleased());
         notReallyReleased.removeAll(authoritativeReleasedVersions);
@@ -182,7 +201,7 @@ public class BwcVersions implements Serializable {
         }
     }
 
-    private List<Version> getReleased() {
+    public List<Version> getReleased() {
         return versions.stream()
             .filter(v -> v.getMajor() >= currentVersion.getMajor() - 1)
             .filter(v -> unreleased.containsKey(v) == false)

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/compat/compat/AbstractYamlRestCompatTestPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/compat/compat/AbstractYamlRestCompatTestPlugin.java
@@ -98,13 +98,13 @@ public abstract class AbstractYamlRestCompatTestPlugin implements Plugin<Project
 
         // determine the previous rest compatibility version and BWC project path
         int currentMajor = buildParams.getBwcVersions().getCurrentVersion().getMajor();
-        Version lastMinor = buildParams.getBwcVersions()
+        String lastMinorProjectPath = buildParams.getBwcVersions()
             .getUnreleased()
             .stream()
             .filter(v -> v.getMajor() == currentMajor - 1)
             .min(Comparator.reverseOrder())
-            .get();
-        String lastMinorProjectPath = buildParams.getBwcVersions().unreleasedInfo(lastMinor).gradleProjectPath();
+            .map(v -> buildParams.getBwcVersions().unreleasedInfo(v).gradleProjectPath())
+            .orElseGet(() -> buildParams.getBwcVersions().getUnmaintainedPreviousMajor().get().gradleProjectPath());
 
         // copy compatible rest specs
         Configuration bwcMinorConfig = project.getConfigurations().create(BWC_MINOR_CONFIG_NAME);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix yamlCompatibility for unmaintained previous major (#141390)](https://github.com/elastic/elasticsearch/pull/141390)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)