### PR TITLE
Set lucene upper Java feature version for unit tests

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
@@ -144,6 +144,8 @@ public abstract class ElasticsearchTestBasePlugin implements Plugin<Project> {
                     return List.of();
                 }
             });
+            test.getJvmArgumentProviders()
+                .add(() -> List.of("-Dorg.apache.lucene.vectorization.upperJavaFeatureVersion=" + test.getJavaVersion().getMajorVersion()));
 
             String argline = System.getProperty("tests.jvm.argline");
             if (argline != null) {


### PR DESCRIPTION
As a follow up to #141190, this ensures that the `upperJavaFeatureVersion` system property is set when running unit tests. This ensures that the optimized vector api implementations are used on later JDK versions.