### PR TITLE
[9.1] [Test] Fix test022InstallPluginsFromLocalArchive (#131353)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -337,9 +337,6 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=ml/3rd_party_deployment/Test start deployment with low priority and max allocations more than one}
   issue: https://github.com/elastic/elasticsearch/issues/140610
-- class: org.elasticsearch.packaging.test.DockerTests
-  method: test022InstallPluginsFromLocalArchive
-  issue: https://github.com/elastic/elasticsearch/issues/141460
 
 # Examples:
 #

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -213,7 +213,7 @@ public class DockerTests extends PackagingTestCase {
 
         listPluginArchive().forEach(System.out::println);
         assertThat("Expected " + plugin + " to not be installed", listPlugins(), not(hasItems(plugin)));
-        assertThat("Expected " + plugin + " available in archive", listPluginArchive(), hasSize(16));
+        assertThat("Expected " + plugin + " available in archive", listPluginArchive(), hasItems(containsString(plugin)));
 
         // Stuff the proxy settings with garbage, so any attempt to go out to the internet would fail
         sh.getEnv()


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [[Test] Fix test022InstallPluginsFromLocalArchive (#131353)](https://github.com/elastic/elasticsearch/pull/131353)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)