### PR TITLE
[8.19] Remove 7.17.30 from Version.java

### DIFF
--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -130,7 +130,6 @@ public class Version implements VersionId<Version>, ToXContentFragment {
     public static final Version V_7_17_27 = new Version(7_17_27_99);
     public static final Version V_7_17_28 = new Version(7_17_28_99);
     public static final Version V_7_17_29 = new Version(7_17_29_99);
-    public static final Version V_7_17_30 = new Version(7_17_30_99);
 
     public static final Version V_8_0_0 = new Version(8_00_00_99);
     public static final Version V_8_0_1 = new Version(8_00_01_99);


### PR DESCRIPTION
This fixes bwc testing against latest released 7.17 version
