### PR TITLE
Estimate Synonyms Map Memory Usage - POC DO NOT MERGE

### DIFF
--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymTokenFilterFactory.java
@@ -47,7 +47,7 @@ public class SynonymTokenFilterFactory extends AbstractTokenFilterFactory {
                 for (String line : rulesList) {
                     sb.append(line).append(System.lineSeparator());
                 }
-                return new ReaderWithOrigin(new StringReader(sb.toString()), "'" + factory.name() + "' analyzer settings");
+                return new ReaderWithOrigin(new StringReader(sb.toString()), "'" + factory.name() + "' analyzer settings", INLINE);
             }
         },
         INDEX("synonyms_set") {
@@ -68,12 +68,14 @@ public class SynonymTokenFilterFactory extends AbstractTokenFilterFactory {
                     reader = new ReaderWithOrigin(
                         new StringReader(""),
                         "fake empty [" + synonymsSet + "] synonyms_set in .synonyms index",
+                        INDEX,
                         synonymsSet
                     );
                 } else {
                     reader = new ReaderWithOrigin(
                         Analysis.getReaderFromIndex(synonymsSet, factory.synonymsManagementAPIService, factory.lenient),
                         "[" + synonymsSet + "] synonyms_set in .synonyms index",
+                        INDEX,
                         synonymsSet
                     );
                 }
@@ -88,7 +90,8 @@ public class SynonymTokenFilterFactory extends AbstractTokenFilterFactory {
                 return new ReaderWithOrigin(
                     // Pass the inline setting name because "_path" is appended by getReaderFromFile
                     Analysis.getReaderFromFile(factory.environment, synonymsPath, SynonymsSource.INLINE.getSettingName()),
-                    synonymsPath
+                    synonymsPath,
+                    LOCAL_FILE
                 );
             }
         };
@@ -242,9 +245,9 @@ public class SynonymTokenFilterFactory extends AbstractTokenFilterFactory {
         }
     }
 
-    record ReaderWithOrigin(Reader reader, String origin, String resource) {
-        ReaderWithOrigin(Reader reader, String origin) {
-            this(reader, origin, null);
+    record ReaderWithOrigin(Reader reader, String origin, SynonymsSource synonymsSource, String resource) {
+        ReaderWithOrigin(Reader reader, String origin, SynonymsSource synonymsSource) {
+            this(reader, origin, synonymsSource, null);
         }
     }
 }

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymTokenFilterFactory.java
@@ -272,7 +272,7 @@ public class SynonymTokenFilterFactory extends AbstractTokenFilterFactory {
         final Function<String[], Long> estimateSize = a -> {
             long estimatedSize = 0;
             for (String s : a) {
-                estimatedSize += s.trim().getBytes(StandardCharsets.UTF_8).length;;
+                estimatedSize += s.trim().getBytes(StandardCharsets.UTF_8).length;
             }
 
             return estimatedSize;

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymTokenFilterFactory.java
@@ -27,8 +27,11 @@ import org.elasticsearch.index.analysis.TokenFilterFactory;
 import org.elasticsearch.index.analysis.TokenizerFactory;
 import org.elasticsearch.synonyms.SynonymsManagementAPIService;
 
+import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.function.Function;
 
@@ -236,6 +239,11 @@ public class SynonymTokenFilterFactory extends AbstractTokenFilterFactory {
                 parser = new ESWordnetSynonymParser(true, expand, lenient, analyzer);
                 ((ESWordnetSynonymParser) parser).parse(rules.reader);
             } else {
+                if (rules.synonymsSource == SynonymsSource.INDEX) {
+                    long estimatedSize = estimateSynonymsMapSize(rules);
+                    // TODO: Add estimated size to circuit breaker
+                }
+
                 parser = new ESSolrSynonymParser(true, expand, lenient, analyzer);
                 ((ESSolrSynonymParser) parser).parse(rules.reader);
             }
@@ -243,6 +251,56 @@ public class SynonymTokenFilterFactory extends AbstractTokenFilterFactory {
         } catch (Exception e) {
             throw new IllegalArgumentException("failed to build synonyms from [" + rules.origin + "]", e);
         }
+    }
+
+    /**
+     * <p>
+     * Estimates the synonyms map size by summing up the size of all the terms in the provided rules. The size of each term is determined
+     * by UTF8 encoding it and taking its length.
+     * </p>
+     * <p>
+     * Note that this method does not deduplicate terms. Doing so would require storing a reference to each unique term, which may require
+     * a significant amount of memory. Since the point of this method is to estimate the synonyms map size to avoid OOMs while building it,
+     * low memory usage is prioritized in the implementation.
+     * </p>
+     *
+     * @param rules
+     * @return
+     * @throws IOException
+     */
+    static long estimateSynonymsMapSize(ReaderWithOrigin rules) throws IOException {
+        final Function<String[], Long> estimateSize = a -> {
+            long estimatedSize = 0;
+            for (String s : a) {
+                estimatedSize += s.getBytes(StandardCharsets.UTF_8).length;
+            }
+
+            return estimatedSize;
+        };
+
+        long totalEstimatedSize = 0;
+        try (BufferedReader bufferedReader = new BufferedReader(rules.reader)) {
+            String line = bufferedReader.readLine();
+            while (line != null) {
+                if (line.isEmpty() || line.startsWith("#")) {
+                    continue; // Ignore empty lines and comments
+                }
+
+                String[] inputAndOutput = line.split("=>", 2);
+                totalEstimatedSize += estimateSize.apply(inputAndOutput[0].split(","));
+                if (inputAndOutput.length == 2) {
+                    // Explicit synonym
+                    totalEstimatedSize += estimateSize.apply(inputAndOutput[1].split(","));
+                }
+
+                line = bufferedReader.readLine();
+            }
+
+        } finally {
+            rules.reader.reset();
+        }
+
+        return totalEstimatedSize;
     }
 
     record ReaderWithOrigin(Reader reader, String origin, SynonymsSource synonymsSource, String resource) {

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymTokenFilterFactory.java
@@ -272,30 +272,30 @@ public class SynonymTokenFilterFactory extends AbstractTokenFilterFactory {
         final Function<String[], Long> estimateSize = a -> {
             long estimatedSize = 0;
             for (String s : a) {
-                estimatedSize += s.getBytes(StandardCharsets.UTF_8).length;
+                estimatedSize += s.trim().getBytes(StandardCharsets.UTF_8).length;;
             }
 
             return estimatedSize;
         };
 
         long totalEstimatedSize = 0;
-        try (BufferedReader bufferedReader = new BufferedReader(rules.reader)) {
+        try {
+            // Don't close the buffered reader because that also closes the underlying rules reader
+            BufferedReader bufferedReader = new BufferedReader(rules.reader);
             String line = bufferedReader.readLine();
             while (line != null) {
-                if (line.isEmpty() || line.startsWith("#")) {
-                    continue; // Ignore empty lines and comments
-                }
-
-                String[] inputAndOutput = line.split("=>", 2);
-                totalEstimatedSize += estimateSize.apply(inputAndOutput[0].split(","));
-                if (inputAndOutput.length == 2) {
-                    // Explicit synonym
-                    totalEstimatedSize += estimateSize.apply(inputAndOutput[1].split(","));
+                // Ignore empty lines and comments
+                if (line.isEmpty() == false && line.startsWith("#") == false) {
+                    String[] inputAndOutput = line.split("=>", 2);
+                    totalEstimatedSize += estimateSize.apply(inputAndOutput[0].split(","));
+                    if (inputAndOutput.length == 2) {
+                        // Explicit synonym
+                        totalEstimatedSize += estimateSize.apply(inputAndOutput[1].split(","));
+                    }
                 }
 
                 line = bufferedReader.readLine();
             }
-
         } finally {
             rules.reader.reset();
         }

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/SynonymsAnalysisTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/SynonymsAnalysisTests.java
@@ -563,7 +563,11 @@ public class SynonymsAnalysisTests extends ESTestCase {
             foo, bar, baz
             # foo, bar, baz
             """;
-        SynonymTokenFilterFactory.ReaderWithOrigin readerWithOrigin = new SynonymTokenFilterFactory.ReaderWithOrigin(new StringReader(synonyms), "test", SynonymTokenFilterFactory.SynonymsSource.LOCAL_FILE);
+        SynonymTokenFilterFactory.ReaderWithOrigin readerWithOrigin = new SynonymTokenFilterFactory.ReaderWithOrigin(
+            new StringReader(synonyms),
+            "test",
+            SynonymTokenFilterFactory.SynonymsSource.LOCAL_FILE
+        );
         assertEquals(18, SynonymTokenFilterFactory.estimateSynonymsMapSize(readerWithOrigin));
     }
 

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/SynonymsAnalysisTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/SynonymsAnalysisTests.java
@@ -32,6 +32,7 @@ import org.hamcrest.MatcherAssert;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.StringReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -554,6 +555,16 @@ public class SynonymsAnalysisTests extends ESTestCase {
 
             assertEquals(factory, "Token filter [" + factory + "] cannot be used to parse synonyms", e.getMessage());
         }
+    }
+
+    public void testEstimateSynonymsMapSize() throws Exception {
+        String synonyms = """
+            foo => bar, baz
+            foo, bar, baz
+            # foo, bar, baz
+            """;
+        SynonymTokenFilterFactory.ReaderWithOrigin readerWithOrigin = new SynonymTokenFilterFactory.ReaderWithOrigin(new StringReader(synonyms), "test", SynonymTokenFilterFactory.SynonymsSource.LOCAL_FILE);
+        assertEquals(18, SynonymTokenFilterFactory.estimateSynonymsMapSize(readerWithOrigin));
     }
 
     private void match(String analyzerName, String source, String target) throws IOException {


### PR DESCRIPTION
This is a small POC focused on how to estimate the synonyms map memory usage before it is built. This is done in a way that uses very little memory, as the primary use case for this check is to detect when a large synonym set would cause an OOM once built into a synonyms map.

The current approach only considers raw term storage requirements, and not the size of the FST in `SynonymMap`. Temporary scratch variables used while building the `SynonymMap` are also not considered, they are assumed to be negligible. The goal is to compute an upper bounds for the `SynonymMap` memory usage, which will then be used by a circuit breaker to prevent OOMs.

Sharing this early to get feedback on the high level approach. I plan on iterating on this to get a more accurate estimate of the upper bounds for `SynonymMap` memory usage.