### PR TITLE
Fix WriteLoadConstraintDeciderIT.testHighNodeWriteLoadPreventsNewShardAllocation

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -333,9 +333,6 @@ tests:
 - class: org.elasticsearch.xpack.security.authc.TokenServiceTests
   method: testAttachAndGetToken
   issue: https://github.com/elastic/elasticsearch/issues/141470
-- class: org.elasticsearch.cluster.routing.allocation.decider.WriteLoadConstraintDeciderIT
-  method: testHighNodeWriteLoadPreventsNewShardAllocation
-  issue: https://github.com/elastic/elasticsearch/issues/141493
 
 # Examples:
 #

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/WriteLoadConstraintDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/WriteLoadConstraintDeciderIT.java
@@ -688,36 +688,17 @@ public class WriteLoadConstraintDeciderIT extends ESIntegTestCase {
         int secondDataNodeExpectedNumShards,
         int thirdDataNodeExpectedNumShards
     ) {
-        logger.info("--> Checking shard assignment for index: " + index.getName());
 
         int firstDataNodeRealNumberOfShards = routingNodes.node(firstDataNodeId).numberOfOwningShardsForIndex(index);
         if (firstDataNodeRealNumberOfShards != firstDataNodeExpectedNumShards) {
-            logger.info(
-                "--> First data node has "
-                    + firstDataNodeRealNumberOfShards
-                    + " shards assigned, expected "
-                    + firstDataNodeExpectedNumShards
-            );
             return false;
         }
         int secondDataNodeRealNumberOfShards = routingNodes.node(secondDataNodeId).numberOfOwningShardsForIndex(index);
         if (secondDataNodeRealNumberOfShards != secondDataNodeExpectedNumShards) {
-            logger.info(
-                "--> Second data node has "
-                    + secondDataNodeRealNumberOfShards
-                    + " shards assigned, expected "
-                    + secondDataNodeExpectedNumShards
-            );
             return false;
         }
         int thirdDataNodeRealNumberOfShards = routingNodes.node(thirdDataNodeId).numberOfOwningShardsForIndex(index);
         if (thirdDataNodeRealNumberOfShards != thirdDataNodeExpectedNumShards) {
-            logger.info(
-                "--> Third data node has "
-                    + thirdDataNodeRealNumberOfShards
-                    + " shards assigned, expected "
-                    + thirdDataNodeExpectedNumShards
-            );
             return false;
         }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/WriteLoadConstraintDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/WriteLoadConstraintDeciderIT.java
@@ -688,17 +688,36 @@ public class WriteLoadConstraintDeciderIT extends ESIntegTestCase {
         int secondDataNodeExpectedNumShards,
         int thirdDataNodeExpectedNumShards
     ) {
+        logger.info("--> Checking shard assignment for index: " + index.getName());
 
         int firstDataNodeRealNumberOfShards = routingNodes.node(firstDataNodeId).numberOfOwningShardsForIndex(index);
         if (firstDataNodeRealNumberOfShards != firstDataNodeExpectedNumShards) {
+            logger.info(
+                "--> First data node has "
+                    + firstDataNodeRealNumberOfShards
+                    + " shards assigned, expected "
+                    + firstDataNodeExpectedNumShards
+            );
             return false;
         }
         int secondDataNodeRealNumberOfShards = routingNodes.node(secondDataNodeId).numberOfOwningShardsForIndex(index);
         if (secondDataNodeRealNumberOfShards != secondDataNodeExpectedNumShards) {
+            logger.info(
+                "--> Second data node has "
+                    + secondDataNodeRealNumberOfShards
+                    + " shards assigned, expected "
+                    + secondDataNodeExpectedNumShards
+            );
             return false;
         }
         int thirdDataNodeRealNumberOfShards = routingNodes.node(thirdDataNodeId).numberOfOwningShardsForIndex(index);
         if (thirdDataNodeRealNumberOfShards != thirdDataNodeExpectedNumShards) {
+            logger.info(
+                "--> Third data node has "
+                    + thirdDataNodeRealNumberOfShards
+                    + " shards assigned, expected "
+                    + thirdDataNodeExpectedNumShards
+            );
             return false;
         }
 
@@ -779,31 +798,36 @@ public class WriteLoadConstraintDeciderIT extends ESIntegTestCase {
         // Randomly distribute shards' peak write-loads so that we can check later that shard movements are prioritized correctly
         final double writeLoadThreshold = maximumShardWriteLoad
             * BalancedShardsAllocator.Balancer.PrioritiseByShardWriteLoadComparator.THRESHOLD_RATIO;
-        final List<Double> shardPeakWriteLoads = new ArrayList<>();
+        final List<Double> shardRecentWriteLoads = new ArrayList<>();
         // Need at least one with the maximum write-load
-        shardPeakWriteLoads.add((double) maximumShardWriteLoad);
+        shardRecentWriteLoads.add((double) maximumShardWriteLoad);
         final int remainingShards = indexMetadata.getNumberOfShards() - 1;
         // Some over-threshold, some under
         for (int i = 0; i < remainingShards; ++i) {
             if (randomBoolean()) {
-                shardPeakWriteLoads.add(randomDoubleBetween(writeLoadThreshold, maximumShardWriteLoad, true));
+                shardRecentWriteLoads.add(randomDoubleBetween(writeLoadThreshold, maximumShardWriteLoad, true));
             } else {
-                shardPeakWriteLoads.add(randomDoubleBetween(0.0, writeLoadThreshold, true));
+                shardRecentWriteLoads.add(randomDoubleBetween(0.0, writeLoadThreshold, true));
             }
         }
-        assertThat(shardPeakWriteLoads, hasSize(indexMetadata.getNumberOfShards()));
-        Collections.shuffle(shardPeakWriteLoads, random());
+        assertThat(shardRecentWriteLoads, hasSize(indexMetadata.getNumberOfShards()));
+        Collections.shuffle(shardRecentWriteLoads, random());
         final List<ShardStats> shardStats = new ArrayList<>(indexMetadata.getNumberOfShards());
         for (int i = 0; i < indexMetadata.getNumberOfShards(); i++) {
-            shardStats.add(createShardStats(indexMetadata, i, shardPeakWriteLoads.get(i), assignedShardNodeId));
+            shardStats.add(createShardStats(indexMetadata, i, shardRecentWriteLoads.get(i), assignedShardNodeId));
         }
         return shardStats;
     }
 
     /**
-     * Helper to create a dummy {@link ShardStats} for the given index shard with the supplied {@code peakWriteLoad} value.
+     * Helper to create a dummy {@link ShardStats} for the given index shard with the supplied {@code recentWriteLoad} value.
      */
-    private static ShardStats createShardStats(IndexMetadata indexMeta, int shardIndex, double peakWriteLoad, String assignedShardNodeId) {
+    private static ShardStats createShardStats(
+        IndexMetadata indexMeta,
+        int shardIndex,
+        double recentWriteLoad,
+        String assignedShardNodeId
+    ) {
         ShardId shardId = new ShardId(indexMeta.getIndex(), shardIndex);
         Path path = createTempDir().resolve("indices").resolve(indexMeta.getIndexUUID()).resolve(String.valueOf(shardIndex));
         ShardRouting shardRouting = ShardRouting.newUnassigned(
@@ -819,7 +843,7 @@ public class WriteLoadConstraintDeciderIT extends ESIntegTestCase {
         stats.docs = new DocsStats(100, 0, randomByteSizeValue().getBytes());
         stats.store = new StoreStats();
         stats.indexing = new IndexingStats(
-            new IndexingStats.Stats(1, 1, 1, 1, 1, 1, 1, 1, 1, false, 1, 234, 234, 1000, 0.123, peakWriteLoad)
+            new IndexingStats.Stats(1, 1, 1, 1, 1, 1, 1, 1, 1, false, 1, 234, 234, 1000, recentWriteLoad, 0.123)
         );
         return new ShardStats(shardRouting, new ShardPath(false, path, path, shardId), stats, null, null, null, false, 0);
     }


### PR DESCRIPTION
This test failure was a result of us switching from peak to recent write load, and not updating the tests to match

Fixes: #141493