### PR TITLE
PromQL: Nested aggregations

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql-nested.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql-nested.csv-spec
@@ -1,7 +1,9 @@
 // Tests for nested PromQL function patterns.
+// E.g., max(avg by (cluster) (sum by (cluster, pod) (network.cost)))
 
 nested_within_series_sum_avg_over_time
 required_capability: promql_command_v0
+required_capability: promql_nested_aggregates
 PROMQL index=k8s step=1h result=(sum(avg_over_time(network.cost[1h])));
 
 result:double       | step:datetime
@@ -10,6 +12,7 @@ result:double       | step:datetime
 
 nested_within_series_avg_avg_over_time
 required_capability: promql_command_v0
+required_capability: promql_nested_aggregates
 PROMQL index=k8s step=1h result=(avg(avg_over_time(network.cost[1h])));
 
 result:double       | step:datetime
@@ -18,6 +21,7 @@ result:double       | step:datetime
 
 nested_within_series_max_sum_over_time
 required_capability: promql_command_v0
+required_capability: promql_nested_aggregates
 PROMQL index=k8s step=1h result=(max(sum_over_time(network.cost[1h])));
 
 result:double | step:datetime
@@ -26,6 +30,7 @@ result:double | step:datetime
 
 nested_within_series_min_count_over_time
 required_capability: promql_command_v0
+required_capability: promql_nested_aggregates
 PROMQL index=k8s step=1h result=(min(count_over_time(network.cost[1h])));
 
 result:double | step:datetime
@@ -34,6 +39,7 @@ result:double | step:datetime
 
 nested_within_series_sum_by_cluster_avg_over_time
 required_capability: promql_command_v0
+required_capability: promql_nested_aggregates
 PROMQL index=k8s step=1h result=(sum by (cluster) (avg_over_time(network.cost[1h])))
 | SORT cluster;
 
@@ -46,6 +52,7 @@ result:double          | step:datetime            | cluster:keyword
 
 nested_same_grouping_sum_avg_by_cluster
 required_capability: promql_command_v0
+required_capability: promql_nested_aggregates
 PROMQL index=k8s step=1h result=(sum by (cluster) (avg by (cluster) (network.cost)))
 | SORT cluster;
 
@@ -57,6 +64,7 @@ result:double          | step:datetime            | cluster:keyword
 
 nested_same_grouping_max_min_by_pod
 required_capability: promql_command_v0
+required_capability: promql_nested_aggregates
 PROMQL index=k8s step=1h result=(max by (pod) (min by (pod) (network.cost)))
 | SORT pod;
 
@@ -68,6 +76,7 @@ result:double | step:datetime            | pod:keyword
 
 nested_different_grouping_avg_sum_by_cluster
 required_capability: promql_command_v0
+required_capability: promql_nested_aggregates
 PROMQL index=k8s step=1h result=(avg(sum by (cluster) (avg_over_time(network.cost[1h]))));
 
 result:double          | step:datetime
@@ -76,6 +85,7 @@ result:double          | step:datetime
 
 nested_different_grouping_max_avg_by_cluster
 required_capability: promql_command_v0
+required_capability: promql_nested_aggregates
 PROMQL index=k8s step=1h result=(max(avg by (cluster) (network.cost)));
 
 result:double          | step:datetime
@@ -84,6 +94,7 @@ result:double          | step:datetime
 
 nested_different_grouping_min_sum_by_pod
 required_capability: promql_command_v0
+required_capability: promql_nested_aggregates
 PROMQL index=k8s step=1h result=(min(sum by (pod) (network.cost)));
 
 result:double | step:datetime
@@ -92,6 +103,7 @@ result:double | step:datetime
 
 nested_different_grouping_avg_by_cluster_sum_by_cluster_pod
 required_capability: promql_command_v0
+required_capability: promql_nested_aggregates
 PROMQL index=k8s step=1h result=(avg by (cluster) (sum by (cluster, pod) (network.cost)))
 | SORT cluster;
 
@@ -103,6 +115,7 @@ result:double          | step:datetime            | cluster:keyword
 
 nested_three_levels_max_avg_sum
 required_capability: promql_command_v0
+required_capability: promql_nested_aggregates
 PROMQL index=k8s step=1h result=(max(avg by (cluster) (sum by (cluster, pod) (network.cost))));
 
 result:double | step:datetime
@@ -111,6 +124,7 @@ result:double | step:datetime
 
 nested_three_levels_sum_max_min
 required_capability: promql_command_v0
+required_capability: promql_nested_aggregates
 PROMQL index=k8s step=1h result=(sum(max by (cluster) (min by (pod) (network.cost))));
 
 result:double | step:datetime

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql-nested.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql-nested.csv-spec
@@ -1,0 +1,118 @@
+// Tests for nested PromQL function patterns.
+
+nested_within_series_sum_avg_over_time
+required_capability: promql_command_v0
+PROMQL index=k8s step=1h result=(sum(avg_over_time(network.cost[1h])));
+
+result:double       | step:datetime
+56.32254035241995   | 2024-05-10T00:00:00.000Z
+;
+
+nested_within_series_avg_avg_over_time
+required_capability: promql_command_v0
+PROMQL index=k8s step=1h result=(avg(avg_over_time(network.cost[1h])));
+
+result:double       | step:datetime
+6.2580600391577725  | 2024-05-10T00:00:00.000Z
+;
+
+nested_within_series_max_sum_over_time
+required_capability: promql_command_v0
+PROMQL index=k8s step=1h result=(max(sum_over_time(network.cost[1h])));
+
+result:double | step:datetime
+210.625       | 2024-05-10T00:00:00.000Z
+;
+
+nested_within_series_min_count_over_time
+required_capability: promql_command_v0
+PROMQL index=k8s step=1h result=(min(count_over_time(network.cost[1h])));
+
+result:double | step:datetime
+13.0          | 2024-05-10T00:00:00.000Z
+;
+
+nested_within_series_sum_by_cluster_avg_over_time
+required_capability: promql_command_v0
+PROMQL index=k8s step=1h result=(sum by (cluster) (avg_over_time(network.cost[1h])))
+| SORT cluster;
+
+result:double          | step:datetime            | cluster:keyword
+18.032269021739133     | 2024-05-10T00:00:00.000Z | prod
+20.76903735632184      | 2024-05-10T00:00:00.000Z | qa
+17.521233974358974     | 2024-05-10T00:00:00.000Z | staging
+;
+
+
+nested_same_grouping_sum_avg_by_cluster
+required_capability: promql_command_v0
+PROMQL index=k8s step=1h result=(sum by (cluster) (avg by (cluster) (network.cost)))
+| SORT cluster;
+
+result:double          | step:datetime            | cluster:keyword
+6.208333333333333      | 2024-05-10T00:00:00.000Z | prod
+8.833333333333334      | 2024-05-10T00:00:00.000Z | qa
+5.291666666666667      | 2024-05-10T00:00:00.000Z | staging
+;
+
+nested_same_grouping_max_min_by_pod
+required_capability: promql_command_v0
+PROMQL index=k8s step=1h result=(max by (pod) (min by (pod) (network.cost)))
+| SORT pod;
+
+result:double | step:datetime            | pod:keyword
+4.625         | 2024-05-10T00:00:00.000Z | one
+0.0           | 2024-05-10T00:00:00.000Z | three
+1.75          | 2024-05-10T00:00:00.000Z | two
+;
+
+nested_different_grouping_avg_sum_by_cluster
+required_capability: promql_command_v0
+PROMQL index=k8s step=1h result=(avg(sum by (cluster) (avg_over_time(network.cost[1h]))));
+
+result:double          | step:datetime
+18.774180117473318     | 2024-05-10T00:00:00.000Z
+;
+
+nested_different_grouping_max_avg_by_cluster
+required_capability: promql_command_v0
+PROMQL index=k8s step=1h result=(max(avg by (cluster) (network.cost)));
+
+result:double          | step:datetime
+8.833333333333334      | 2024-05-10T00:00:00.000Z
+;
+
+nested_different_grouping_min_sum_by_pod
+required_capability: promql_command_v0
+PROMQL index=k8s step=1h result=(min(sum by (pod) (network.cost)));
+
+result:double | step:datetime
+18.75         | 2024-05-10T00:00:00.000Z
+;
+
+nested_different_grouping_avg_by_cluster_sum_by_cluster_pod
+required_capability: promql_command_v0
+PROMQL index=k8s step=1h result=(avg by (cluster) (sum by (cluster, pod) (network.cost)))
+| SORT cluster;
+
+result:double          | step:datetime            | cluster:keyword
+6.208333333333333      | 2024-05-10T00:00:00.000Z | prod
+8.833333333333334      | 2024-05-10T00:00:00.000Z | qa
+5.291666666666667      | 2024-05-10T00:00:00.000Z | staging
+;
+
+nested_three_levels_max_avg_sum
+required_capability: promql_command_v0
+PROMQL index=k8s step=1h result=(max(avg by (cluster) (sum by (cluster, pod) (network.cost))));
+
+result:double | step:datetime
+8.833333333333334 | 2024-05-10T00:00:00.000Z
+;
+
+nested_three_levels_sum_max_min
+required_capability: promql_command_v0
+PROMQL index=k8s step=1h result=(sum(max by (cluster) (min by (pod) (network.cost))));
+
+result:double | step:datetime
+4.625         | 2024-05-10T00:00:00.000Z
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql-nested.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-timeseries-promql-nested.csv-spec
@@ -74,6 +74,36 @@ result:double | step:datetime            | pod:keyword
 1.75          | 2024-05-10T00:00:00.000Z | two
 ;
 
+nested_count_sum_by_cluster
+required_capability: promql_command_v0
+required_capability: promql_nested_aggregates
+PROMQL index=k8s step=1h result=(count(sum by (cluster) (network.cost)));
+
+result:double | step:datetime
+3.0           | 2024-05-10T00:00:00.000Z
+;
+
+nested_count_by_cluster_sum_by_cluster_pod
+required_capability: promql_command_v0
+required_capability: promql_nested_aggregates
+PROMQL index=k8s step=1h result=(count by (cluster) (sum by (cluster, pod) (network.cost)))
+| SORT cluster;
+
+result:double | step:datetime            | cluster:keyword
+3.0           | 2024-05-10T00:00:00.000Z | prod
+3.0           | 2024-05-10T00:00:00.000Z | qa
+3.0           | 2024-05-10T00:00:00.000Z | staging
+;
+
+nested_quantile_avg_by_cluster
+required_capability: promql_command_v0
+required_capability: promql_nested_aggregates
+PROMQL index=k8s step=1h result=(quantile(0.5, avg by (cluster) (network.cost)));
+
+result:double          | step:datetime
+5.300833333333333      | 2024-05-10T00:00:00.000Z
+;
+
 nested_different_grouping_avg_sum_by_cluster
 required_capability: promql_command_v0
 required_capability: promql_nested_aggregates
@@ -122,6 +152,15 @@ result:double | step:datetime
 8.833333333333334 | 2024-05-10T00:00:00.000Z
 ;
 
+nested_four_levels_max_avg_sum_avg_over_time
+required_capability: promql_command_v0
+required_capability: promql_nested_aggregates
+PROMQL index=k8s step=1h result=(max(avg by (cluster) (sum by (cluster, pod) (avg_over_time(network.cost[1h])))));
+
+result:double    | step:datetime
+6.92301245210728 | 2024-05-10T00:00:00.000Z
+;
+
 nested_three_levels_sum_max_min
 required_capability: promql_command_v0
 required_capability: promql_nested_aggregates
@@ -129,4 +168,23 @@ PROMQL index=k8s step=1h result=(sum(max by (cluster) (min by (pod) (network.cos
 
 result:double | step:datetime
 4.625         | 2024-05-10T00:00:00.000Z
+;
+
+nested_aggregate_inside_binary_operator
+required_capability: promql_command_v0
+required_capability: promql_nested_aggregates
+PROMQL index=k8s step=1h start="2024-05-10T00:00:00.000Z" end="2024-05-10T01:00:00.000Z"
+  result=(time() - avg(sum by (cluster) (avg_over_time(network.cost[1h]))));
+
+result:double        | step:datetime
+1.7152991812258198E9 | 2024-05-10T00:00:00.000Z
+;
+
+nested_aggregate_with_transformation_between
+required_capability: promql_command_v0
+required_capability: promql_nested_aggregates
+PROMQL index=k8s step=1h result=(avg(ceil(sum by (cluster) (network.cost))));
+
+result:double      | step:datetime
+20.666666666666668 | 2024-05-10T00:00:00.000Z
 ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -1906,6 +1906,12 @@ public class EsqlCapabilities {
         PROMQL_UNMAPPED_FIELDS_FILTER_NULLS,
 
         /**
+         * Support for nested across-series aggregates in PromQL.
+         * E.g., avg(sum by (cluster) (rate(foo[5m])))
+         */
+        PROMQL_NESTED_AGGREGATES(PROMQL_COMMAND_V0.isEnabled()),
+
+        /**
          * KNN function adds support for k and visit_percentage options
          */
         KNN_FUNCTION_OPTIONS_K_VISIT_PERCENTAGE,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
@@ -77,7 +77,7 @@ import org.elasticsearch.xpack.esql.optimizer.rules.logical.SubstituteSurrogateP
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.TranslateTimeSeriesAggregate;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.WarnLostSortOrder;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.local.PruneLeftJoinOnNullMatchingField;
-import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.TranslatePromqlToTimeSeriesAggregate;
+import org.elasticsearch.xpack.esql.optimizer.rules.logical.promql.TranslatePromqlToEsqlPlan;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.rule.ParameterizedRuleExecutor;
 import org.elasticsearch.xpack.esql.rule.RuleExecutor;
@@ -149,8 +149,8 @@ public class LogicalPlanOptimizer extends ParameterizedRuleExecutor<LogicalPlan,
             // Needs to occur before ReplaceAggregateAggExpressionWithEval, which will update the functions, losing the filter.
             new SubstituteFilteredExpression(),
             new RemoveStatsOverride(),
-            // translate PromQL plans to time-series aggregates before TranslateTimeSeriesAggregate
-            new TranslatePromqlToTimeSeriesAggregate(),
+            // translate PromQL plan to ESQL. It should run before TranslateTimeSeriesAggregate.
+            new TranslatePromqlToEsqlPlan(),
             // translate metric aggregates early before they are converted to nested expressions
             new TranslateTimeSeriesAggregate(),
             new PruneUnusedIndexMode(),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslatePromqlToEsqlPlan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslatePromqlToEsqlPlan.java
@@ -89,15 +89,13 @@ import java.util.List;
  *           └── EsRelation(*, mode=TIME_SERIES)
  * </pre>
  */
-public final class TranslatePromqlToTimeSeriesAggregate extends OptimizerRules.ParameterizedOptimizerRule<
-    PromqlCommand,
-    LogicalOptimizerContext> {
+public final class TranslatePromqlToEsqlPlan extends OptimizerRules.ParameterizedOptimizerRule<PromqlCommand, LogicalOptimizerContext> {
 
     // TODO make configurable via lookback_delta parameter and (cluster?) setting
     public static final Duration DEFAULT_LOOKBACK = Duration.ofMinutes(5);
     public static final String STEP_COLUMN_NAME = "step";
 
-    public TranslatePromqlToTimeSeriesAggregate() {
+    public TranslatePromqlToEsqlPlan() {
         super(OptimizerRules.TransformDirection.UP);
     }
 
@@ -132,8 +130,10 @@ public final class TranslatePromqlToTimeSeriesAggregate extends OptimizerRules.P
         } else {
             // Nested aggregations: wrap innermost to TimeSeriesAggregate then each outer in Aggregate node
             AcrossSeriesAggregate innermost = aggregateChain.getLast();
+            // TimeSeriesAggregate[expression]
             Expression innerValue = mapNode(promqlCommand, innermost.child(), labelFilterConditions, context, stepAttr);
             plan = addLabelFilters(promqlCommand, labelFilterConditions, plan);
+            // Function call
             Expression aggExpr = mapAggregateExpression(innermost, innerValue, stepAttr, promqlCommand);
             aggregatePlan = createEsqlTimeSeriesAggregate(promqlCommand, plan, stepBucketAlias, innermost.groupings(), aggExpr);
 
@@ -208,7 +208,7 @@ public final class TranslatePromqlToTimeSeriesAggregate extends OptimizerRules.P
      * PromQL: sum by (cluster) (rate(http_requests[5m]))
      *
      * Translated to:
-     *   TimeSeriesAggregate(groupBy=[step, cluster, _tsid], aggs=[sum(rate(value)), step, cluster])
+     *   TimeSeriesAggregate(groupBy=[step, cluster], aggs=[sum(rate(value)), step, cluster])
      *     └── child plan
      * </pre>
      */

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslatePromqlToEsqlPlan.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslatePromqlToEsqlPlan.java
@@ -41,7 +41,6 @@ import org.elasticsearch.xpack.esql.expression.promql.function.PromqlFunctionReg
 import org.elasticsearch.xpack.esql.optimizer.LogicalOptimizerContext;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.OptimizerRules;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.TranslateTimeSeriesAggregate;
-import org.elasticsearch.xpack.esql.optimizer.rules.logical.local.IgnoreNullMetrics;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
@@ -69,24 +68,32 @@ import java.util.Comparator;
 import java.util.List;
 
 /**
- * Translates PromQL logical plans into ESQL TimeSeriesAggregate nodes.
+ * Translates PromQL logical plan into ESQL plan.
  *
- * This rule runs before {@link TranslateTimeSeriesAggregate} to convert PromQL-specific
- * plans (WithinSeriesAggregate, AcrossSeriesAggregate) into standard ESQL TimeSeriesAggregate
- * nodes that can then be further optimized by the existing time-series translation pipeline.
+ * This rule runs before {@link TranslateTimeSeriesAggregate} to convert PromQL-specific plan
+ * into standard ESQL nodes (TimeSeriesAggregate, Aggregate, Eval, etc.) that can then be further optimized.
  *
  * Translation examples:
  * <pre>
  * PromQL: rate(http_requests[5m])
+ * Result: TimeSeriesAggregate[rate(value), groupBy=[step]]
  *
- * PromQL Plan:
- *   WithinSeriesAggregate(name="rate")
- *     └── RangeSelector(http_requests, range=5m)
+ * PromQL: sum by (cluster) (rate(http_requests[5m]))
+ * Result: TimeSeriesAggregate[sum(rate(value)), groupBy=[step, cluster]]
  *
- * Translated to:
- *   TimeSeriesAggregate(groupBy=[_tsid], aggs=[rate(value, @timestamp)])
- *     └── Filter(__name__ == "http_requests")
- *           └── EsRelation(*, mode=TIME_SERIES)
+ * PromQL: avg(sum by (cluster) (rate(http_requests[5m])))
+ * Result: Aggregate[avg(sum_result), groupBy=[step]]
+ *           \_ TimeSeriesAggregate[sum(rate(value)), groupBy=[step, cluster]]
+ *
+ * PromQL: avg(ceil(sum by (cluster) (rate(http_requests[5m]))))
+ * Result: Aggregate[avg(ceil_result), groupBy=[step]]
+ *           \_ Eval[ceil(sum_result)]
+ *                 \_ TimeSeriesAggregate[sum(rate(value)), groupBy=[step, cluster]]
+ *
+ * PromQL: time() - avg(sum by (cluster) (rate(http_requests[5m])))
+ * Result: Eval[time() - avg_result]
+ *           \_ Aggregate[avg(sum_result), groupBy=[step]]
+ *                 \_ TimeSeriesAggregate[sum(rate(value)), groupBy=[step, cluster]]
  * </pre>
  */
 public final class TranslatePromqlToEsqlPlan extends OptimizerRules.ParameterizedOptimizerRule<PromqlCommand, LogicalOptimizerContext> {
@@ -99,137 +106,284 @@ public final class TranslatePromqlToEsqlPlan extends OptimizerRules.Parameterize
         super(OptimizerRules.TransformDirection.UP);
     }
 
+    /**
+     * Holds ESQL plan built so far and an expression representing the node value.
+     */
+    private record TranslationResult(LogicalPlan plan, Expression expression) {}
+
+    /**
+     * Holds context passed through the recursive translation.
+     */
+    private record TranslationContext(
+        PromqlCommand promqlCommand,
+        LogicalOptimizerContext optimizerContext,
+        Alias stepBucketAlias,
+        List<Expression> labelFilterConditions
+    ) {
+        Attribute stepAttr() {
+            return stepBucketAlias.toAttribute();
+        }
+    }
+
     @Override
     protected LogicalPlan rule(PromqlCommand promqlCommand, LogicalOptimizerContext context) {
         Alias stepBucketAlias = createStepBucketAlias(promqlCommand);
-        Attribute stepAttr = stepBucketAlias.toAttribute();
-        LogicalPlan promqlPlan = promqlCommand.promqlPlan();
         List<Expression> labelFilterConditions = new ArrayList<>();
 
-        // Blank plan EsRelation with timestamp filter
-        LogicalPlan plan = withTimestampFilter(promqlCommand, promqlCommand.child());
+        // Base plan EsRelation with timestamp filter
+        LogicalPlan basePlan = withTimestampFilter(promqlCommand, promqlCommand.child());
 
-        // Collect PromQL aggregates
-        List<AcrossSeriesAggregate> aggregateChain = new ArrayList<>();
-        if (promqlPlan instanceof AcrossSeriesAggregate) {
-            promqlPlan.forEachDown(AcrossSeriesAggregate.class, aggregateChain::add);
-        }
+        // Create translation context
+        TranslationContext ctx = new TranslationContext(promqlCommand, context, stepBucketAlias, labelFilterConditions);
 
-        // For each PromQL aggregate build ESQL aggregate node
-        LogicalPlan aggregatePlan;
-        if (aggregateChain.isEmpty()) {
-            // No nested aggregations: single TimeSeriesAggregate node with expression is enough
-            // See: org/elasticsearch/xpack/esql/optimizer/rules/logical/TranslateTimeSeriesAggregate.java
-            Expression value = mapNode(promqlCommand, promqlPlan, labelFilterConditions, context, stepAttr);
-            plan = addLabelFilters(promqlCommand, labelFilterConditions, plan);
-            aggregatePlan = createEsqlTimeSeriesAggregate(promqlCommand, plan, stepBucketAlias, promqlPlan.output(), value);
-            // Should we handle binary operations with nested aggregations?
-            if (promqlPlan instanceof VectorBinaryComparison binaryComparison) {
-                aggregatePlan = addFilter(aggregatePlan, binaryComparison, context);
-            }
-        } else {
-            // Nested aggregations: wrap innermost to TimeSeriesAggregate then each outer in Aggregate node
-            AcrossSeriesAggregate innermost = aggregateChain.getLast();
-            // TimeSeriesAggregate[expression]
-            Expression innerValue = mapNode(promqlCommand, innermost.child(), labelFilterConditions, context, stepAttr);
-            plan = addLabelFilters(promqlCommand, labelFilterConditions, plan);
-            // Function call
-            Expression aggExpr = mapAggregateExpression(innermost, innerValue, stepAttr, promqlCommand);
-            aggregatePlan = createEsqlTimeSeriesAggregate(promqlCommand, plan, stepBucketAlias, innermost.groupings(), aggExpr);
+        TranslationResult result = translateNode(promqlCommand.promqlPlan(), basePlan, ctx);
 
-            // Build outer Aggregate stages
-            for (int i = aggregateChain.size() - 2; i >= 0; i--) {
-                AcrossSeriesAggregate outer = aggregateChain.get(i);
-                aggregatePlan = createEsqlAggregate(promqlCommand, aggregatePlan, outer, stepAttr);
-            }
-        }
-
-        aggregatePlan = convertValueToDouble(promqlCommand, aggregatePlan);
-        // ensure we're returning exactly the same columns (including ids) and in the same order before and after optimization
-        aggregatePlan = new Project(promqlCommand.source(), aggregatePlan, promqlCommand.output());
-        aggregatePlan = filterNulls(promqlCommand, aggregatePlan);
-        return aggregatePlan;
-    }
-
-    /**
-     * Adds a Filter node on top of the given plan to restrict data to the specified time range.
-     * The time range is defined by the start and end expressions in the PromqlCommand.
-     */
-    private static LogicalPlan withTimestampFilter(PromqlCommand promqlCommand, LogicalPlan plan) {
-        // start and end are either both set or both null
-        if (promqlCommand.start().value() != null && promqlCommand.end().value() != null) {
-            Source promqlSource = promqlCommand.source();
-            Expression timestamp = promqlCommand.timestamp();
-            plan = new Filter(
-                promqlSource,
-                plan,
-                new And(
-                    promqlSource,
-                    new GreaterThanOrEqual(promqlSource, timestamp, promqlCommand.start()),
-                    new LessThanOrEqual(promqlSource, timestamp, promqlCommand.end())
-                )
-            );
-        }
-        return plan;
-    }
-
-    /**
-     * Adds label filter conditions (such as {job="prometheus"}) as a Filter node on top of the given plan.
-     * Combines multiple conditions with AND.
-     * This is consistent with PromQL semantics where non-matching series are dropped.
-     * Therefore, it's both easier to implement and more efficient to filter out non-matching series early.
-     */
-    private static LogicalPlan addLabelFilters(PromqlCommand promqlCommand, List<Expression> labelFilterConditions, LogicalPlan plan) {
+        LogicalPlan plan = result.plan();
+        Expression valueExpr = result.expression();
         if (labelFilterConditions.isEmpty() == false) {
-            plan = new Filter(promqlCommand.source(), plan, Predicates.combineAnd(labelFilterConditions));
+            plan = applyLabelFilters(plan, labelFilterConditions, promqlCommand);
         }
+
+        // TimeSeriesAggregate always applies because InstantSelectors adds implicit last_over_time().
+        // TODO: If we ever support metric references without last_over_time, we could
+        // skip TimeSeriesAggregate and use plain Aggregate instead (see #141501 discussion).
+        if (containsAggregation(plan) == false) {
+            plan = createInnerAggregate(ctx, plan, promqlCommand.promqlPlan().output(), valueExpr);
+            valueExpr = plan.output().getFirst().toAttribute();
+        }
+
+        if (promqlCommand.promqlPlan() instanceof VectorBinaryComparison binaryComparison && binaryComparison.filterMode()) {
+            // for comparison with filtering mode, return left operand and apply filter later
+            plan = addComparisonFilter(plan, binaryComparison, context);
+        }
+
+        plan = convertValueToDouble(promqlCommand, plan, valueExpr);
+        // ensure we're returning exactly the same columns (including ids) and in the same order before and after optimization
+        plan = new Project(promqlCommand.source(), plan, promqlCommand.output());
+        plan = filterNulls(promqlCommand, plan);
         return plan;
     }
 
-    private static Expression mapAggregateExpression(
-        AcrossSeriesAggregate agg,
-        Expression inputValue,
-        Attribute stepAttr,
-        PromqlCommand promqlCommand
-    ) {
-        PromqlFunctionRegistry.PromqlContext ctx = new PromqlFunctionRegistry.PromqlContext(
-            promqlCommand.timestamp(),
-            AggregateFunction.NO_WINDOW,  // Across-series aggregates don't use time windows
-            stepAttr
-        );
-        return PromqlFunctionRegistry.INSTANCE.buildEsqlFunction(agg.functionName(), agg.source(), inputValue, ctx, agg.parameters());
+    /**
+     * Recursively translates a PromQL plan node into an ESQL plan node.
+     */
+    private TranslationResult translateNode(LogicalPlan node, LogicalPlan currentPlan, TranslationContext ctx) {
+        return switch (node) {
+            case AcrossSeriesAggregate agg -> translateAcrossSeriesAggregate(agg, currentPlan, ctx);
+            case WithinSeriesAggregate withinAgg -> translateFunctionCall(withinAgg, currentPlan, ctx);
+            case PromqlFunctionCall functionCall -> translateFunctionCall(functionCall, currentPlan, ctx);
+            case ScalarFunction scalarFunction -> translateScalarFunction(scalarFunction, currentPlan, ctx);
+            case VectorBinaryOperator binaryOp -> translateBinaryOperator(binaryOp, currentPlan, ctx);
+            case Selector selector -> translateSelector(selector, currentPlan, ctx);
+            default -> throw new QlIllegalArgumentException("Unsupported PromQL plan node: {}", node);
+        };
     }
 
     /**
-     * Creates a TimeSeriesAggregate node with the given value expression and groupings.
-     *
-     * <p>Translation example:</p>
-     * <pre>
-     * PromQL: sum by (cluster) (rate(http_requests[5m]))
-     *
-     * Translated to:
-     *   TimeSeriesAggregate(groupBy=[step, cluster], aggs=[sum(rate(value)), step, cluster])
-     *     └── child plan
-     * </pre>
+     * Translates an AcrossSeriesAggregate (sum, avg, max, min, count, etc.).
+     * Creates TimeSeriesAggregate if child has no aggregation or Aggregate if child already aggregated.
+     * NOTE: Only AcrossSeriesAggregate nodes create plan-level aggregation nodes.
+     * WithinSeriesAggregate and other PromqlFunctionCall nodes produce
+     * expressions embedded inside the aggregation, but do not create Aggregate plan nodes themselves.
      */
-    private static LogicalPlan createEsqlTimeSeriesAggregate(
-        PromqlCommand promqlCommand,
+    private TranslationResult translateAcrossSeriesAggregate(AcrossSeriesAggregate agg, LogicalPlan currentPlan, TranslationContext ctx) {
+        TranslationResult childResult = translateNode(agg.child(), currentPlan, ctx);
+        Expression aggExpr = buildAggregateExpression(agg, childResult.expression(), ctx);
+        if (containsAggregation(childResult.plan())) {
+            // Child already has an aggregate: create outer Aggregate
+            LogicalPlan aggregatePlan = createOuterAggregate(ctx, childResult.plan(), agg, aggExpr);
+            Expression outputRef = getValueOutput(aggregatePlan);
+            return new TranslationResult(aggregatePlan, outputRef);
+        } else {
+            // No aggregate yet: create the innermost TimeSeriesAggregate, folding within-series
+            // function expressions into the aggregation.
+            LogicalPlan timeSeriesAgg = createInnerAggregate(ctx, childResult.plan(), agg.output(), aggExpr);
+            Expression outputRef = getValueOutput(timeSeriesAgg);
+            return new TranslationResult(timeSeriesAgg, outputRef);
+        }
+    }
+
+    /**
+     * Gets the value output from an aggregate plan.
+     */
+    private static Expression getValueOutput(LogicalPlan plan) {
+        // The value column is always the first output attribute
+        return plan.output().getFirst().toAttribute();
+    }
+
+    /**
+     * Translates a generic PromQL function call (ceil, abs, floor, etc.).
+     */
+    private TranslationResult translateFunctionCall(PromqlFunctionCall functionCall, LogicalPlan currentPlan, TranslationContext ctx) {
+        TranslationResult childResult = translateNode(functionCall.child(), currentPlan, ctx);
+
+        Expression window = (functionCall.child() instanceof RangeSelector rangeSelector)
+            ? rangeSelector.range()
+            : AggregateFunction.NO_WINDOW;
+
+        PromqlFunctionRegistry.PromqlContext promqlCtx = new PromqlFunctionRegistry.PromqlContext(
+            ctx.promqlCommand().timestamp(),
+            window,
+            ctx.stepAttr()
+        );
+
+        Expression function = PromqlFunctionRegistry.INSTANCE.buildEsqlFunction(
+            functionCall.functionName(),
+            functionCall.source(),
+            childResult.expression(),
+            promqlCtx,
+            functionCall.parameters()
+        );
+
+        // This can happen when trying to provide a counter to a function that doesn't support it e.g. avg_over_time on a counter
+        // This is essentially a bug since this limitation doesn't exist in PromQL itself.
+        // Throwing an error here to avoid generating invalid plans with obscure errors downstream.
+        Expression.TypeResolution typeResolution = function.typeResolved();
+        if (typeResolution.unresolved()) {
+            throw new QlIllegalArgumentException("Could not resolve type for function [{}]: {}", function, typeResolution.message());
+        }
+
+        // If child is aggregate, add Eval to compute function.
+        //
+        // Example: ceil(sum by (cluster) (foo)) becomes:
+        // Eval[ceil(sum_result)]
+        // \_ TimeSeriesAggregate[sum_result = sum(x), groupBy=[step, cluster]]
+        //
+        // This handles both cases when aggregate is TimeSeriesAggregate or more generic Aggregate.
+        if (containsAggregation(childResult.plan())) {
+            Alias evalAlias = new Alias(function.source(), ctx.promqlCommand().valueColumnName(), function);
+            LogicalPlan evalPlan = new Eval(ctx.promqlCommand().source(), childResult.plan(), List.of(evalAlias));
+            return new TranslationResult(evalPlan, evalAlias.toAttribute());
+        }
+
+        return new TranslationResult(childResult.plan(), function);
+    }
+
+    /**
+     * Translates a scalar function (time(), etc.).
+     * These produce expressions without modifying the plan.
+     */
+    private TranslationResult translateScalarFunction(ScalarFunction scalarFunction, LogicalPlan currentPlan, TranslationContext ctx) {
+        PromqlFunctionRegistry.PromqlContext promqlCtx = new PromqlFunctionRegistry.PromqlContext(
+            ctx.promqlCommand().timestamp(),
+            null,
+            ctx.stepAttr()
+        );
+        Expression function = PromqlFunctionRegistry.INSTANCE.buildEsqlFunction(
+            scalarFunction.functionName(),
+            scalarFunction.source(),
+            null,
+            promqlCtx,
+            List.of()
+        );
+        return new TranslationResult(currentPlan, function);
+    }
+
+    /**
+     * Translates a binary operator (+, -, *, /, comparisons).
+     * If either side contains aggregation, adds Eval on top to compute the binary operation.
+     */
+    private TranslationResult translateBinaryOperator(VectorBinaryOperator binaryOp, LogicalPlan currentPlan, TranslationContext ctx) {
+        TranslationResult leftResult = translateNode(binaryOp.left(), currentPlan, ctx);
+        Expression leftExpr = new ToDouble(leftResult.expression().source(), leftResult.expression());
+
+        if (binaryOp instanceof VectorBinaryComparison comp && comp.filterMode()) {
+            return new TranslationResult(leftResult.plan(), leftExpr);
+        }
+
+        // The right operand is translated using leftResult.plan() as its base.
+        // This assumes at most one side produces an aggregate (e.g. agg + scalar).
+        // TODO: Binary ops between two independent aggregates require join operation.
+        TranslationResult rightResult = translateNode(binaryOp.right(), leftResult.plan(), ctx);
+        Expression rightExpr = new ToDouble(rightResult.expression().source(), rightResult.expression());
+
+        Expression binaryExpr = binaryOp.binaryOp()
+            .asFunction()
+            .create(binaryOp.source(), leftExpr, rightExpr, ctx.optimizerContext().configuration());
+
+        // If either side has aggregation, we need to add Eval on top
+        LogicalPlan resultPlan = rightResult.plan();
+        if (containsAggregation(resultPlan)) {
+            Alias evalAlias = new Alias(binaryExpr.source(), ctx.promqlCommand().valueColumnName(), binaryExpr);
+            LogicalPlan evalPlan = new Eval(ctx.promqlCommand().source(), resultPlan, List.of(evalAlias));
+            return new TranslationResult(evalPlan, evalAlias.toAttribute());
+        }
+
+        return new TranslationResult(resultPlan, binaryExpr);
+    }
+
+    /**
+     * Translates a selector (instant, range, or literal).
+     * Adds label filter conditions to the context.
+     */
+    private TranslationResult translateSelector(Selector selector, LogicalPlan currentPlan, TranslationContext ctx) {
+        Expression matcherCondition = translateLabelMatchers(selector.source(), selector.labels(), selector.labelMatchers());
+        if (matcherCondition != null) {
+            ctx.labelFilterConditions().add(matcherCondition);
+        }
+
+        Expression expr;
+        if (selector instanceof LiteralSelector literalSelector) {
+            expr = literalSelector.literal();
+        } else if (selector instanceof InstantSelector) {
+            // InstantSelector maps to LastOverTime to get latest sample per time series
+            expr = new LastOverTime(selector.source(), selector.series(), AggregateFunction.NO_WINDOW, ctx.promqlCommand().timestamp());
+        } else {
+            expr = selector.series();
+        }
+
+        return new TranslationResult(currentPlan, expr);
+    }
+
+    /**
+     * Checks if the plan already contains an aggregation stage.
+     */
+    private static boolean containsAggregation(LogicalPlan plan) {
+        if (plan instanceof Aggregate) {
+            return true;
+        }
+        if (plan instanceof Eval eval) {
+            // Eval may be on top of an aggregate
+            return containsAggregation(eval.child());
+        }
+        return false;
+    }
+
+    /**
+     * Builds the aggregate function expression for an AcrossSeriesAggregate.
+     */
+    private static Expression buildAggregateExpression(AcrossSeriesAggregate agg, Expression inputValue, TranslationContext ctx) {
+        PromqlFunctionRegistry.PromqlContext promqlCtx = new PromqlFunctionRegistry.PromqlContext(
+            ctx.promqlCommand().timestamp(),
+            AggregateFunction.NO_WINDOW,
+            ctx.stepAttr()
+        );
+        return PromqlFunctionRegistry.INSTANCE.buildEsqlFunction(agg.functionName(), agg.source(), inputValue, promqlCtx, agg.parameters());
+    }
+
+    /**
+     * Creates a TimeSeriesAggregate node for the innermost aggregation.
+     */
+    private static LogicalPlan createInnerAggregate(
+        TranslationContext ctx,
         LogicalPlan basePlan,
-        Alias stepBucketAlias,
         List<Attribute> labelGroupings,
-        Expression value
+        Expression aggExpr
     ) {
+        PromqlCommand promqlCommand = ctx.promqlCommand();
         List<NamedExpression> aggs = new ArrayList<>();
         List<Expression> groupings = new ArrayList<>();
 
+        // Check for time series grouping (special handling for _tsid)
         FieldAttribute timeSeriesGrouping = getTimeSeriesGrouping(labelGroupings);
         if (timeSeriesGrouping != null) {
-            value = new Values(value.source(), value);
+            aggExpr = new Values(aggExpr.source(), aggExpr);
             basePlan = basePlan.transformDown(EsRelation.class, r -> r.withAdditionalAttribute(timeSeriesGrouping));
         }
-        // value aggregation
-        aggs.add(new Alias(value.source(), promqlCommand.valueColumnName(), value));
-        Attribute stepAttr = stepBucketAlias.toAttribute();
+
+        // Value aggregation
+        aggs.add(new Alias(aggExpr.source(), promqlCommand.valueColumnName(), aggExpr));
+        Attribute stepAttr = ctx.stepAttr();
         aggs.add(stepAttr);
         for (Attribute grouping : labelGroupings) {
             if (grouping != timeSeriesGrouping) {
@@ -237,46 +391,36 @@ public final class TranslatePromqlToEsqlPlan extends OptimizerRules.Parameterize
             }
         }
 
-        // timestamp/step
-        groupings.add(stepBucketAlias);
-        // additional groupings (by)
+        // Groupings: step + label groupings
+        groupings.add(ctx.stepBucketAlias());
         groupings.addAll(labelGroupings);
 
         return new TimeSeriesAggregate(promqlCommand.promqlPlan().source(), basePlan, groupings, aggs, null, promqlCommand.timestamp());
     }
 
     /**
-     * Creates an Aggregate node for an outer across-series aggregate.
-     * Takes the first output attribute of the child plan as input value.
-     *
-     * <p>For nested aggregates like "avg(sum by (cluster) (...))":</p>
-     * <pre>
-     *   Aggregate(groupBy=[step], aggs=[avg(result), step])  // this stage
-     *     └── TimeSeriesAggregate(...)                       // child plan
-     * </pre>
+     * Creates an Aggregate node for outer aggregation stages.
+     * The aggExpr contains reference to the child's output.
      */
-    private static LogicalPlan createEsqlAggregate(
-        PromqlCommand promqlCommand,
+    private static LogicalPlan createOuterAggregate(
+        TranslationContext ctx,
         LogicalPlan childPlan,
         AcrossSeriesAggregate agg,
-        Attribute stepAttr
+        Expression aggExpr
     ) {
-        // Get child input
-        Attribute inputValue = childPlan.output().getFirst().toAttribute();
+        PromqlCommand promqlCommand = ctx.promqlCommand();
+        Attribute stepAttr = ctx.stepAttr();
 
-        // Only use groupings that exist in child output.
-        //
-        // If outer aggregate requests a grouping the inner doesn't produce fill with nulls,
-        // TODO: Is there a better approach?
-        // E.g. "max by (cluster) (min by (pod) (...))" the inner outputs "pod" but outer wants "cluster".
         List<Alias> missingGroupingAliases = new ArrayList<>();
         List<Attribute> resolvedGroupings = new ArrayList<>();
         List<Attribute> childOutput = childPlan.output();
 
-        for (Attribute grouping : agg.groupings()) {
+        for (Attribute grouping : agg.output()) {
             if (childOutput.contains(grouping)) {
                 resolvedGroupings.add(grouping);
             } else {
+                // If outer aggregate requests a grouping the inner doesn't produce we fill with null
+                // E.g., "max by (cluster) (min by (pod) (...))" inner outputs "pod" but outer wants "cluster"
                 Alias nullAlias = new Alias(grouping.source(), grouping.name(), new Literal(grouping.source(), null, grouping.dataType()));
                 missingGroupingAliases.add(nullAlias);
                 resolvedGroupings.add(nullAlias.toAttribute());
@@ -287,7 +431,6 @@ public final class TranslatePromqlToEsqlPlan extends OptimizerRules.Parameterize
             ? childPlan
             : new Eval(promqlCommand.source(), childPlan, missingGroupingAliases);
 
-        Expression aggExpr = mapAggregateExpression(agg, inputValue, stepAttr, promqlCommand);
         Alias aggAlias = new Alias(aggExpr.source(), promqlCommand.valueColumnName(), aggExpr);
 
         List<Expression> groupings = new ArrayList<>();
@@ -300,6 +443,23 @@ public final class TranslatePromqlToEsqlPlan extends OptimizerRules.Parameterize
         aggs.addAll(resolvedGroupings);
 
         return new Aggregate(promqlCommand.source(), plan, groupings, aggs);
+    }
+
+    /**
+     * Applies label filters to the plan at the appropriate level.
+     * Finds the base EsRelation and adds a Filter on top of it.
+     */
+    private static LogicalPlan applyLabelFilters(LogicalPlan plan, List<Expression> labelFilterConditions, PromqlCommand promqlCommand) {
+        Expression filterCondition = Predicates.combineAnd(labelFilterConditions);
+        return plan.transformUp(LogicalPlan.class, p -> {
+            if (p instanceof Filter f && f.child() instanceof EsRelation) {
+                // Already has a filter on EsRelation, combine conditions
+                return new Filter(f.source(), f.child(), new And(f.source(), f.condition(), filterCondition));
+            } else if (p instanceof EsRelation) {
+                return new Filter(promqlCommand.source(), p, filterCondition);
+            }
+            return p;
+        });
     }
 
     /**
@@ -324,82 +484,29 @@ public final class TranslatePromqlToEsqlPlan extends OptimizerRules.Parameterize
     }
 
     /**
-     * Ensures the value column is of type double by adding an Eval node with ToDouble conversion.
+     * Adds a Filter node for specified time range.
      */
-    private static LogicalPlan convertValueToDouble(PromqlCommand promqlCommand, LogicalPlan plan) {
-        Alias convertedValue = new Alias(
-            promqlCommand.source(),
-            promqlCommand.valueColumnName(),
-            new ToDouble(promqlCommand.source(), plan.output().getFirst().toAttribute()),
-            promqlCommand.valueId()
-        );
-        return new Eval(promqlCommand.source(), plan, List.of(convertedValue));
-    }
-
-    /**
-     * Recursively maps PromQL plan nodes to ESQL expressions to compute the value for the time series aggregation.
-     * Collects label filter conditions into the provided list.
-     */
-    private static Expression mapNode(
-        PromqlCommand promqlCommand,
-        LogicalPlan p,
-        List<Expression> labelFilterConditions,
-        LogicalOptimizerContext context,
-        Attribute stepAttribute
-    ) {
-        return switch (p) {
-            case Selector selector -> mapSelector(promqlCommand, selector, labelFilterConditions);
-            case AcrossSeriesAggregate agg -> mapAcrossSeriesAggregate(promqlCommand, agg, labelFilterConditions, context, stepAttribute);
-            case PromqlFunctionCall functionCall -> mapFunction(promqlCommand, functionCall, labelFilterConditions, context, stepAttribute);
-            case ScalarFunction functionCall -> mapScalarFunction(promqlCommand, functionCall, stepAttribute);
-            case VectorBinaryOperator binaryOperator -> mapBinaryOperator(
-                promqlCommand,
-                binaryOperator,
-                labelFilterConditions,
-                context,
-                stepAttribute
+    private static LogicalPlan withTimestampFilter(PromqlCommand promqlCommand, LogicalPlan plan) {
+        if (promqlCommand.start().value() != null && promqlCommand.end().value() != null) {
+            Source promqlSource = promqlCommand.source();
+            Expression timestamp = promqlCommand.timestamp();
+            plan = new Filter(
+                promqlSource,
+                plan,
+                new And(
+                    promqlSource,
+                    new GreaterThanOrEqual(promqlSource, timestamp, promqlCommand.start()),
+                    new LessThanOrEqual(promqlSource, timestamp, promqlCommand.end())
+                )
             );
-            default -> throw new QlIllegalArgumentException("Unsupported PromQL plan node: {}", p);
-        };
-    }
-
-    /**
-     * Maps a PromQL VectorBinaryArithmetic node to an ESQL expression.
-     * Recursively maps the left and right operands and applies the binary operation.
-     * Both operands are converted to double to ensure semantic consistency with PromQL.
-     */
-    private static Expression mapBinaryOperator(
-        PromqlCommand promqlCommand,
-        VectorBinaryOperator binaryOperator,
-        List<Expression> labelFilterConditions,
-        LogicalOptimizerContext context,
-        Attribute stepAttribute
-    ) {
-        Expression left = mapNode(promqlCommand, binaryOperator.left(), labelFilterConditions, context, stepAttribute);
-        left = new ToDouble(left.source(), left);
-
-        if (binaryOperator instanceof VectorBinaryComparison comp && comp.filterMode()) {
-            // for comparison with filtering mode, return left operand and apply filter later
-            return left;
-        } else {
-            Expression right = mapNode(promqlCommand, binaryOperator.right(), labelFilterConditions, context, stepAttribute);
-            right = new ToDouble(right.source(), right);
-            return binaryOperator.binaryOp().asFunction().create(binaryOperator.source(), left, right, context.configuration());
         }
+        return plan;
     }
 
     /**
-     * Adds a Filter node on top of the given plan for the binary comparison condition.
-     * At this time, we only support a single top-level binary comparison in filtering mode where the right operand is a literal.
-     * Therefore, we can simply filter the result of the plan.
-     * The left operand is assumed to be the value column of the plan's output.
-     * The right operand is expected to be a LiteralSelector, which we're validating during analysis.
-     * <p>
-     * To support more complex expressions in the future, we would need to individually evaluate both sides as aggregations (STATS)
-     * and account for nested comparisons where groupings may differ.
-     * Example: sum(max by (job) (foo > bar)) > avg(baz)
+     * Adds a Filter node for comparison filtering.
      */
-    private LogicalPlan addFilter(LogicalPlan plan, VectorBinaryComparison binaryComparison, LogicalOptimizerContext context) {
+    private LogicalPlan addComparisonFilter(LogicalPlan plan, VectorBinaryComparison binaryComparison, LogicalOptimizerContext context) {
         Attribute left = plan.output().getFirst().toAttribute();
         ToDouble right = new ToDouble(binaryComparison.right().source(), ((LiteralSelector) binaryComparison.right()).literal());
         Function condition = binaryComparison.op().asFunction().create(binaryComparison.source(), left, right, context.configuration());
@@ -407,90 +514,16 @@ public final class TranslatePromqlToEsqlPlan extends OptimizerRules.Parameterize
     }
 
     /**
-     * Maps a PromQL Selector node to an ESQL expression.
-     * <ul>
-     *     <li>InstantSelector: maps to LastOverTime aggregation to get the latest sample per time series and step.</li>
-     *     <li>
-     *         RangeSelector: maps to the field expression,
-     *         yielding all samples per time series and step,
-     *         to be aggregated by the enclosing {@link WithinSeriesAggregate}.
-     *     </li>
-     *     <li>LiteralSelector: maps to its literal value.</li>
-     * </ul>
-     * The label matchers of the selector are translated into filter conditions and added to the provided list.
-     * We're not creating a filter for the {@code __name__} label here, as that's handled by {@link IgnoreNullMetrics}.
+     * Ensures the value column is of type double.
      */
-    private static Expression mapSelector(PromqlCommand promqlCommand, Selector selector, List<Expression> labelFilterConditions) {
-        Expression matcherCondition = translateLabelMatchers(selector.source(), selector.labels(), selector.labelMatchers());
-        if (matcherCondition != null) {
-            labelFilterConditions.add(matcherCondition);
-        }
-
-        if (selector instanceof InstantSelector) {
-            // TODO wire lookback delta from PromqlCommand once we support window sizes independent from the step/tbucket duration
-            return new LastOverTime(selector.source(), selector.series(), AggregateFunction.NO_WINDOW, promqlCommand.timestamp());
-        }
-        return selector.series();
-    }
-
-    private static Expression mapAcrossSeriesAggregate(
-        PromqlCommand promqlCommand,
-        AcrossSeriesAggregate agg,
-        List<Expression> labelFilterConditions,
-        LogicalOptimizerContext context,
-        Attribute stepAttribute
-    ) {
-        Expression childValue = mapNode(promqlCommand, agg.child(), labelFilterConditions, context, stepAttribute);
-        return mapAggregateExpression(agg, childValue, stepAttribute, promqlCommand);
-    }
-
-    private static Expression mapFunction(
-        PromqlCommand promqlCommand,
-        PromqlFunctionCall functionCall,
-        List<Expression> labelFilterConditions,
-        LogicalOptimizerContext context,
-        Attribute stepAttribute
-    ) {
-        Expression target = mapNode(promqlCommand, functionCall.child(), labelFilterConditions, context, stepAttribute);
-
-        final Expression window;
-        if (functionCall.child() instanceof RangeSelector rangeSelector) {
-            window = rangeSelector.range();
-        } else {
-            window = AggregateFunction.NO_WINDOW;
-        }
-
-        PromqlFunctionRegistry.PromqlContext ctx = new PromqlFunctionRegistry.PromqlContext(
-            promqlCommand.timestamp(),
-            window,
-            stepAttribute
+    private static LogicalPlan convertValueToDouble(PromqlCommand promqlCommand, LogicalPlan plan, Expression valueExpr) {
+        Alias convertedValue = new Alias(
+            promqlCommand.source(),
+            promqlCommand.valueColumnName(),
+            new ToDouble(promqlCommand.source(), valueExpr),
+            promqlCommand.valueId()
         );
-
-        List<Expression> extraParams = functionCall.parameters();
-        Expression function = PromqlFunctionRegistry.INSTANCE.buildEsqlFunction(
-            functionCall.functionName(),
-            functionCall.source(),
-            target,
-            ctx,
-            extraParams
-        );
-        // This can happen when trying to provide a counter to a function that doesn't support it e.g. avg_over_time on a counter
-        // This is essentially a bug since this limitation doesn't exist in PromQL itself.
-        // Throwing an error here to avoid generating invalid plans with obscure errors downstream.
-        Expression.TypeResolution typeResolution = function.typeResolved();
-        if (typeResolution.unresolved()) {
-            throw new QlIllegalArgumentException("Could not resolve type for function [{}]: {}", function, typeResolution.message());
-        }
-        return function;
-    }
-
-    private static Expression mapScalarFunction(PromqlCommand promqlCommand, ScalarFunction function, Attribute stepAttribute) {
-        PromqlFunctionRegistry.PromqlContext ctx = new PromqlFunctionRegistry.PromqlContext(
-            promqlCommand.timestamp(),
-            /* window= */null,
-            stepAttribute
-        );
-        return PromqlFunctionRegistry.INSTANCE.buildEsqlFunction(function.functionName(), function.source(), null, ctx, List.of());
+        return new Eval(promqlCommand.source(), plan, List.of(convertedValue));
     }
 
     private static Alias createStepBucketAlias(PromqlCommand promqlCommand) {
@@ -626,7 +659,7 @@ public final class TranslatePromqlToEsqlPlan extends OptimizerRules.Parameterize
         sortedFragments.sort(Comparator.comparingInt(a -> a.type().ordinal()));
 
         // Check if all fragments are of the same type
-        AutomatonUtils.PatternFragment.Type firstType = sortedFragments.get(0).type();
+        AutomatonUtils.PatternFragment.Type firstType = sortedFragments.getFirst().type();
         boolean homogeneous = true;
         for (AutomatonUtils.PatternFragment fragment : sortedFragments) {
             if (fragment.type() != firstType) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslatePromqlToTimeSeriesAggregate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/promql/TranslatePromqlToTimeSeriesAggregate.java
@@ -42,12 +42,14 @@ import org.elasticsearch.xpack.esql.optimizer.LogicalOptimizerContext;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.OptimizerRules;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.TranslateTimeSeriesAggregate;
 import org.elasticsearch.xpack.esql.optimizer.rules.logical.local.IgnoreNullMetrics;
+import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.Filter;
 import org.elasticsearch.xpack.esql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
 import org.elasticsearch.xpack.esql.plan.logical.TimeSeriesAggregate;
+import org.elasticsearch.xpack.esql.plan.logical.promql.AcrossSeriesAggregate;
 import org.elasticsearch.xpack.esql.plan.logical.promql.PromqlCommand;
 import org.elasticsearch.xpack.esql.plan.logical.promql.PromqlFunctionCall;
 import org.elasticsearch.xpack.esql.plan.logical.promql.ScalarFunction;
@@ -102,25 +104,51 @@ public final class TranslatePromqlToTimeSeriesAggregate extends OptimizerRules.P
     @Override
     protected LogicalPlan rule(PromqlCommand promqlCommand, LogicalOptimizerContext context) {
         Alias stepBucketAlias = createStepBucketAlias(promqlCommand);
+        Attribute stepAttr = stepBucketAlias.toAttribute();
+        LogicalPlan promqlPlan = promqlCommand.promqlPlan();
         List<Expression> labelFilterConditions = new ArrayList<>();
-        Expression value = mapNode(
-            promqlCommand,
-            promqlCommand.promqlPlan(),
-            labelFilterConditions,
-            context,
-            stepBucketAlias.toAttribute()
-        );
+
+        // Blank plan EsRelation with timestamp filter
         LogicalPlan plan = withTimestampFilter(promqlCommand, promqlCommand.child());
-        plan = addLabelFilters(promqlCommand, labelFilterConditions, plan);
-        plan = createTimeSeriesAggregate(promqlCommand, value, plan, stepBucketAlias);
-        if (promqlCommand.promqlPlan() instanceof VectorBinaryComparison binaryComparison) {
-            plan = addFilter(plan, binaryComparison, context);
+
+        // Collect PromQL aggregates
+        List<AcrossSeriesAggregate> aggregateChain = new ArrayList<>();
+        if (promqlPlan instanceof AcrossSeriesAggregate) {
+            promqlPlan.forEachDown(AcrossSeriesAggregate.class, aggregateChain::add);
         }
-        plan = convertValueToDouble(promqlCommand, plan);
+
+        // For each PromQL aggregate build ESQL aggregate node
+        LogicalPlan aggregatePlan;
+        if (aggregateChain.isEmpty()) {
+            // No nested aggregations: single TimeSeriesAggregate node with expression is enough
+            // See: org/elasticsearch/xpack/esql/optimizer/rules/logical/TranslateTimeSeriesAggregate.java
+            Expression value = mapNode(promqlCommand, promqlPlan, labelFilterConditions, context, stepAttr);
+            plan = addLabelFilters(promqlCommand, labelFilterConditions, plan);
+            aggregatePlan = createEsqlTimeSeriesAggregate(promqlCommand, plan, stepBucketAlias, promqlPlan.output(), value);
+            // Should we handle binary operations with nested aggregations?
+            if (promqlPlan instanceof VectorBinaryComparison binaryComparison) {
+                aggregatePlan = addFilter(aggregatePlan, binaryComparison, context);
+            }
+        } else {
+            // Nested aggregations: wrap innermost to TimeSeriesAggregate then each outer in Aggregate node
+            AcrossSeriesAggregate innermost = aggregateChain.getLast();
+            Expression innerValue = mapNode(promqlCommand, innermost.child(), labelFilterConditions, context, stepAttr);
+            plan = addLabelFilters(promqlCommand, labelFilterConditions, plan);
+            Expression aggExpr = mapAggregateExpression(innermost, innerValue, stepAttr, promqlCommand);
+            aggregatePlan = createEsqlTimeSeriesAggregate(promqlCommand, plan, stepBucketAlias, innermost.groupings(), aggExpr);
+
+            // Build outer Aggregate stages
+            for (int i = aggregateChain.size() - 2; i >= 0; i--) {
+                AcrossSeriesAggregate outer = aggregateChain.get(i);
+                aggregatePlan = createEsqlAggregate(promqlCommand, aggregatePlan, outer, stepAttr);
+            }
+        }
+
+        aggregatePlan = convertValueToDouble(promqlCommand, aggregatePlan);
         // ensure we're returning exactly the same columns (including ids) and in the same order before and after optimization
-        plan = new Project(promqlCommand.source(), plan, promqlCommand.output());
-        plan = filterNulls(promqlCommand, plan);
-        return plan;
+        aggregatePlan = new Project(promqlCommand.source(), aggregatePlan, promqlCommand.output());
+        aggregatePlan = filterNulls(promqlCommand, aggregatePlan);
+        return aggregatePlan;
     }
 
     /**
@@ -158,40 +186,120 @@ public final class TranslatePromqlToTimeSeriesAggregate extends OptimizerRules.P
         return plan;
     }
 
+    private static Expression mapAggregateExpression(
+        AcrossSeriesAggregate agg,
+        Expression inputValue,
+        Attribute stepAttr,
+        PromqlCommand promqlCommand
+    ) {
+        PromqlFunctionRegistry.PromqlContext ctx = new PromqlFunctionRegistry.PromqlContext(
+            promqlCommand.timestamp(),
+            AggregateFunction.NO_WINDOW,  // Across-series aggregates don't use time windows
+            stepAttr
+        );
+        return PromqlFunctionRegistry.INSTANCE.buildEsqlFunction(agg.functionName(), agg.source(), inputValue, ctx, agg.parameters());
+    }
+
     /**
-     * Creates a TimeSeriesAggregate node wrapping the given child plan.
-     * The aggregation groups by step (time bucket) and additional groupings depending on the PromQL plan root.
+     * Creates a TimeSeriesAggregate node with the given value expression and groupings.
+     *
+     * <p>Translation example:</p>
+     * <pre>
+     * PromQL: sum by (cluster) (rate(http_requests[5m]))
+     *
+     * Translated to:
+     *   TimeSeriesAggregate(groupBy=[step, cluster, _tsid], aggs=[sum(rate(value)), step, cluster])
+     *     └── child plan
+     * </pre>
      */
-    private static TimeSeriesAggregate createTimeSeriesAggregate(
+    private static LogicalPlan createEsqlTimeSeriesAggregate(
         PromqlCommand promqlCommand,
-        Expression value,
-        LogicalPlan plan,
-        Alias stepBucket
+        LogicalPlan basePlan,
+        Alias stepBucketAlias,
+        List<Attribute> labelGroupings,
+        Expression value
     ) {
         List<NamedExpression> aggs = new ArrayList<>();
         List<Expression> groupings = new ArrayList<>();
 
-        List<Attribute> additionalGroupings = promqlCommand.promqlPlan().output();
-        FieldAttribute timeSeriesGrouping = getTimeSeriesGrouping(additionalGroupings);
+        FieldAttribute timeSeriesGrouping = getTimeSeriesGrouping(labelGroupings);
         if (timeSeriesGrouping != null) {
             value = new Values(value.source(), value);
-            plan = plan.transformDown(EsRelation.class, r -> r.withAdditionalAttribute(timeSeriesGrouping));
+            basePlan = basePlan.transformDown(EsRelation.class, r -> r.withAdditionalAttribute(timeSeriesGrouping));
         }
         // value aggregation
         aggs.add(new Alias(value.source(), promqlCommand.valueColumnName(), value));
-
-        // timestamp/step
-        aggs.add(stepBucket.toAttribute());
-        groupings.add(stepBucket);
-
-        // additional groupings (by)
-        for (Attribute grouping : additionalGroupings) {
+        Attribute stepAttr = stepBucketAlias.toAttribute();
+        aggs.add(stepAttr);
+        for (Attribute grouping : labelGroupings) {
             if (grouping != timeSeriesGrouping) {
                 aggs.add(grouping);
             }
-            groupings.add(grouping);
         }
-        return new TimeSeriesAggregate(promqlCommand.promqlPlan().source(), plan, groupings, aggs, null, promqlCommand.timestamp());
+
+        // timestamp/step
+        groupings.add(stepBucketAlias);
+        // additional groupings (by)
+        groupings.addAll(labelGroupings);
+
+        return new TimeSeriesAggregate(promqlCommand.promqlPlan().source(), basePlan, groupings, aggs, null, promqlCommand.timestamp());
+    }
+
+    /**
+     * Creates an Aggregate node for an outer across-series aggregate.
+     * Takes the first output attribute of the child plan as input value.
+     *
+     * <p>For nested aggregates like "avg(sum by (cluster) (...))":</p>
+     * <pre>
+     *   Aggregate(groupBy=[step], aggs=[avg(result), step])  // this stage
+     *     └── TimeSeriesAggregate(...)                       // child plan
+     * </pre>
+     */
+    private static LogicalPlan createEsqlAggregate(
+        PromqlCommand promqlCommand,
+        LogicalPlan childPlan,
+        AcrossSeriesAggregate agg,
+        Attribute stepAttr
+    ) {
+        // Get child input
+        Attribute inputValue = childPlan.output().getFirst().toAttribute();
+
+        // Only use groupings that exist in child output.
+        //
+        // If outer aggregate requests a grouping the inner doesn't produce fill with nulls,
+        // TODO: Is there a better approach?
+        // E.g. "max by (cluster) (min by (pod) (...))" the inner outputs "pod" but outer wants "cluster".
+        List<Alias> missingGroupingAliases = new ArrayList<>();
+        List<Attribute> resolvedGroupings = new ArrayList<>();
+        List<Attribute> childOutput = childPlan.output();
+
+        for (Attribute grouping : agg.groupings()) {
+            if (childOutput.contains(grouping)) {
+                resolvedGroupings.add(grouping);
+            } else {
+                Alias nullAlias = new Alias(grouping.source(), grouping.name(), new Literal(grouping.source(), null, grouping.dataType()));
+                missingGroupingAliases.add(nullAlias);
+                resolvedGroupings.add(nullAlias.toAttribute());
+            }
+        }
+
+        LogicalPlan plan = missingGroupingAliases.isEmpty()
+            ? childPlan
+            : new Eval(promqlCommand.source(), childPlan, missingGroupingAliases);
+
+        Expression aggExpr = mapAggregateExpression(agg, inputValue, stepAttr, promqlCommand);
+        Alias aggAlias = new Alias(aggExpr.source(), promqlCommand.valueColumnName(), aggExpr);
+
+        List<Expression> groupings = new ArrayList<>();
+        groupings.add(stepAttr);
+        groupings.addAll(resolvedGroupings);
+
+        List<NamedExpression> aggs = new ArrayList<>();
+        aggs.add(aggAlias);
+        aggs.add(stepAttr);
+        aggs.addAll(resolvedGroupings);
+
+        return new Aggregate(promqlCommand.source(), plan, groupings, aggs);
     }
 
     /**
@@ -241,6 +349,7 @@ public final class TranslatePromqlToTimeSeriesAggregate extends OptimizerRules.P
     ) {
         return switch (p) {
             case Selector selector -> mapSelector(promqlCommand, selector, labelFilterConditions);
+            case AcrossSeriesAggregate agg -> mapAcrossSeriesAggregate(promqlCommand, agg, labelFilterConditions, context, stepAttribute);
             case PromqlFunctionCall functionCall -> mapFunction(promqlCommand, functionCall, labelFilterConditions, context, stepAttribute);
             case ScalarFunction functionCall -> mapScalarFunction(promqlCommand, functionCall, stepAttribute);
             case VectorBinaryOperator binaryOperator -> mapBinaryOperator(
@@ -322,6 +431,17 @@ public final class TranslatePromqlToTimeSeriesAggregate extends OptimizerRules.P
             return new LastOverTime(selector.source(), selector.series(), AggregateFunction.NO_WINDOW, promqlCommand.timestamp());
         }
         return selector.series();
+    }
+
+    private static Expression mapAcrossSeriesAggregate(
+        PromqlCommand promqlCommand,
+        AcrossSeriesAggregate agg,
+        List<Expression> labelFilterConditions,
+        LogicalOptimizerContext context,
+        Attribute stepAttribute
+    ) {
+        Expression childValue = mapNode(promqlCommand, agg.child(), labelFilterConditions, context, stepAttribute);
+        return mapAggregateExpression(agg, childValue, stepAttribute, promqlCommand);
     }
 
     private static Expression mapFunction(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlCommand.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/promql/PromqlCommand.java
@@ -16,7 +16,6 @@ import org.elasticsearch.xpack.esql.core.expression.AttributeSet;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.NameId;
-import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.ReferenceAttribute;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
@@ -284,7 +283,6 @@ public class PromqlCommand extends UnaryPlan implements TelemetryAware, PostAnal
         }
 
         // Validate entire plan
-        Holder<List<String>> groupingAttributes = new Holder<>();
         Holder<Boolean> root = new Holder<>(true);
         p.forEachDown(lp -> {
             switch (lp) {
@@ -306,18 +304,6 @@ public class PromqlCommand extends UnaryPlan implements TelemetryAware, PostAnal
                 }
                 case PromqlFunctionCall functionCall -> {
                     if (functionCall instanceof AcrossSeriesAggregate asa) {
-                        var groupings = asa.groupings().stream().map(NamedExpression::name).toList();
-                        if (groupingAttributes.get() == null) {
-                            groupingAttributes.set(groupings);
-                        } else if (groupingAttributes.get().equals(groupings) == false) {
-                            failures.add(
-                                fail(
-                                    asa,
-                                    "all across-series aggregations must have the same grouping attributes at this time [{}]",
-                                    asa.sourceText()
-                                )
-                            );
-                        }
                         if (asa.grouping() == AcrossSeriesAggregate.Grouping.WITHOUT) {
                             failures.add(fail(asa, "'without' grouping is not supported at this time [{}]", asa.sourceText()));
                         }


### PR DESCRIPTION
PromQL allows queries like `avg(sum by (cluster) (rate(foo[5m])))` with nested across-series aggregates. 

Such queries cannot be represented by a single `TimeSeriesAggregate` node. So our PromQL implementation supports only [limited nesting options](https://github.com/elastic/elasticsearch/blob/05828d2494e26862b9e79c196b0878d0f625510d/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/TranslateTimeSeriesAggregate.java#L156-L155). 

This diff is a poor man rewrite of the PromQL translator to extend support to nested aggregates.


Idea:

1. If current node is `AcrossSeriesAggregate` and child is not aggregated wrap child with `TimeSeriesAggregate`. It already performs the two pass aggregation (first by _tsid + step, then by labels) so cheap to reuse.

2. If current node is `AcrossSeriesAggregate` and child is aggregated wrap child with `Aggregate` (plus `Eval` for dummy groupings if outer references labels not in child output).  We cannot nest `TimeSeriesAggregate`, so outer aggregations become regular `Aggregate` nodes on already aggregated output.

3. If current node is function call (including value transformation) and child is aggregated wrap child with `Eval` to materialize the function result. This way function has a stable reference and further operations can compose on top of that result.

4. If current node is `VectorBinaryOperator` and either operand is aggregated wrap with `Eval`. The rationale is similar to above.

5. If no aggregate in the plan wrap entire plan with `TimeSeriesAggregate`. 
