### PR TITLE
Fix ESQL profiling bwc serialization

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlExecutionInfo.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlExecutionInfo.java
@@ -138,7 +138,7 @@ public class EsqlExecutionInfo implements ChunkedToXContentObject, Writeable {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         if (out.getTransportVersion().supports(EXECUTION_PROFILE_FORMAT_VERSION) == false) {
-            out.writeOptionalTimeValue(null);
+            out.writeOptionalTimeValue(overallTook());
         }
         if (clusterInfo != null && clusterInfoInitializing == false) {
             out.writeCollection(clusterInfo.values());


### PR DESCRIPTION
This change fix `overall` duration serialization towards nodes before https://github.com/elastic/elasticsearch/pull/140433 change.