### PR TITLE
Increase OSQ vector scorer benchmark/test coverage

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerOSQBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerOSQBenchmark.java
@@ -78,6 +78,9 @@ public class VectorScorerOSQBenchmark {
     @Param
     public DirectoryType directoryType;
 
+    @Param
+    public VectorSimilarityFunction similarityFunction;
+
     public int numVectors = ESNextOSQVectorsScorer.BULK_SIZE * 10;
     int numQueries = 10;
 
@@ -221,7 +224,7 @@ public class VectorScorerOSQBenchmark {
                     result.upperInterval(),
                     result.quantizedComponentSum(),
                     result.additionalCorrection(),
-                    VectorSimilarityFunction.EUCLIDEAN,
+                    similarityFunction,
                     centroidDp,
                     scratchScores
                 );

--- a/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerOSQBenchmarkTests.java
+++ b/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerOSQBenchmarkTests.java
@@ -11,13 +11,16 @@ package org.elasticsearch.benchmark.vector.scorer;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.BeforeClass;
 import org.openjdk.jmh.annotations.Param;
 
-import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Random;
+import java.util.stream.Stream;
 
 public class VectorScorerOSQBenchmarkTests extends ESTestCase {
 
@@ -25,11 +28,18 @@ public class VectorScorerOSQBenchmarkTests extends ESTestCase {
     private final int dims;
     private final int bits;
     private final VectorScorerOSQBenchmark.DirectoryType directoryType;
+    private final VectorSimilarityFunction similarityFunction;
 
-    public VectorScorerOSQBenchmarkTests(int dims, int bits, VectorScorerOSQBenchmark.DirectoryType directoryType) {
+    public VectorScorerOSQBenchmarkTests(
+        int dims,
+        int bits,
+        VectorScorerOSQBenchmark.DirectoryType directoryType,
+        VectorSimilarityFunction similarityFunction
+    ) {
         this.dims = dims;
         this.bits = bits;
         this.directoryType = directoryType;
+        this.similarityFunction = similarityFunction;
     }
 
     @BeforeClass
@@ -48,6 +58,7 @@ public class VectorScorerOSQBenchmarkTests extends ESTestCase {
                 scalar.dims = dims;
                 scalar.bits = bits;
                 scalar.directoryType = directoryType;
+                scalar.similarityFunction = similarityFunction;
                 scalar.setup(new Random(seed));
 
                 float[] expected = scalar.score();
@@ -56,6 +67,7 @@ public class VectorScorerOSQBenchmarkTests extends ESTestCase {
                 vectorized.dims = dims;
                 vectorized.bits = bits;
                 vectorized.directoryType = directoryType;
+                vectorized.similarityFunction = similarityFunction;
                 vectorized.setup(new Random(seed));
 
                 float[] result = vectorized.score();
@@ -105,19 +117,19 @@ public class VectorScorerOSQBenchmarkTests extends ESTestCase {
         try {
             String[] dims = VectorScorerOSQBenchmark.class.getField("dims").getAnnotationsByType(Param.class)[0].value();
             String[] bits = VectorScorerOSQBenchmark.class.getField("bits").getAnnotationsByType(Param.class)[0].value();
-            var combinations = new ArrayList<Object[]>();
-            for (var dim : dims) {
-                var d = Integer.parseInt(dim);
-                for (var bit : bits) {
-                    var b = Integer.parseInt(bit);
-                    for (var directoryType : VectorScorerOSQBenchmark.DirectoryType.values()) {
-                        combinations.add(new Object[] { d, b, directoryType });
-                    }
-                }
-            }
-            return combinations;
+
+            return () -> Arrays.stream(dims)
+                .map(Integer::parseInt)
+                .flatMap(d -> Arrays.stream(bits).map(Integer::parseInt).map(b -> List.of(d, b)))
+                .flatMap(params -> Arrays.stream(VectorScorerOSQBenchmark.DirectoryType.values()).map(dir -> concat(params, dir)))
+                .flatMap(params -> Arrays.stream(VectorSimilarityFunction.values()).map(f -> concat(params, f).toArray()))
+                .iterator();
         } catch (NoSuchFieldException e) {
             throw new AssertionError(e);
         }
+    }
+
+    private static <T> List<Object> concat(List<T> params, Object another) {
+        return Stream.concat(params.stream(), Stream.of(another)).toList();
     }
 }

--- a/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerOSQBenchmarkTests.java
+++ b/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerOSQBenchmarkTests.java
@@ -13,6 +13,7 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.util.Constants;
+import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.BeforeClass;
 import org.openjdk.jmh.annotations.Param;
@@ -21,6 +22,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Stream;
+
+import static org.elasticsearch.common.util.CollectionUtils.appendToCopy;
 
 public class VectorScorerOSQBenchmarkTests extends ESTestCase {
 
@@ -120,16 +123,12 @@ public class VectorScorerOSQBenchmarkTests extends ESTestCase {
 
             return () -> Arrays.stream(dims)
                 .map(Integer::parseInt)
-                .flatMap(d -> Arrays.stream(bits).map(Integer::parseInt).map(b -> List.of(d, b)))
-                .flatMap(params -> Arrays.stream(VectorScorerOSQBenchmark.DirectoryType.values()).map(dir -> concat(params, dir)))
-                .flatMap(params -> Arrays.stream(VectorSimilarityFunction.values()).map(f -> concat(params, f).toArray()))
+                .flatMap(d -> Arrays.stream(bits).map(Integer::parseInt).map(b -> List.<Object>of(d, b)))
+                .flatMap(params -> Arrays.stream(VectorScorerOSQBenchmark.DirectoryType.values()).map(dir -> appendToCopy(params, dir)))
+                .flatMap(params -> Arrays.stream(VectorSimilarityFunction.values()).map(f -> appendToCopy(params, f).toArray()))
                 .iterator();
         } catch (NoSuchFieldException e) {
             throw new AssertionError(e);
         }
-    }
-
-    private static <T> List<Object> concat(List<T> params, Object another) {
-        return Stream.concat(params.stream(), Stream.of(another)).toList();
     }
 }

--- a/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerOSQBenchmarkTests.java
+++ b/benchmarks/src/test/java/org/elasticsearch/benchmark/vector/scorer/VectorScorerOSQBenchmarkTests.java
@@ -13,7 +13,6 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.util.Constants;
-import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.BeforeClass;
 import org.openjdk.jmh.annotations.Param;
@@ -21,7 +20,6 @@ import org.openjdk.jmh.annotations.Param;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
-import java.util.stream.Stream;
 
 import static org.elasticsearch.common.util.CollectionUtils.appendToCopy;
 

--- a/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/MemorySegmentESNextOSQVectorsScorer.java
+++ b/libs/simdvec/src/main21/java/org/elasticsearch/simdvec/internal/vectorization/MemorySegmentESNextOSQVectorsScorer.java
@@ -25,7 +25,6 @@ import java.lang.foreign.MemorySegment;
 /** Panamized scorer for quantized vectors stored as a {@link MemorySegment}. */
 public final class MemorySegmentESNextOSQVectorsScorer extends ESNextOSQVectorsScorer {
 
-    private final MemorySegment memorySegment;
     private final MemorySegmentScorer scorer;
 
     public MemorySegmentESNextOSQVectorsScorer(
@@ -38,7 +37,6 @@ public final class MemorySegmentESNextOSQVectorsScorer extends ESNextOSQVectorsS
         MemorySegment memorySegment
     ) {
         super(in, queryBits, indexBits, dimensions, dataLength);
-        this.memorySegment = memorySegment;
         if (queryBits == 4 && indexBits == 1) {
             this.scorer = new MSBitToInt4ESNextOSQVectorsScorer(in, dimensions, dataLength, bulkSize, memorySegment);
         } else if (queryBits == 4 && indexBits == 4) {
@@ -106,7 +104,9 @@ public final class MemorySegmentESNextOSQVectorsScorer extends ESNextOSQVectorsS
     abstract static sealed class MemorySegmentScorer permits MSBitToInt4ESNextOSQVectorsScorer, MSDibitToInt4ESNextOSQVectorsScorer,
         MSInt4SymmetricESNextOSQVectorsScorer {
 
-        static final float FOUR_BIT_SCALE = 1f / ((1 << 4) - 1);
+        static final float ONE_BIT_SCALE = ESNextOSQVectorsScorer.BIT_SCALES[0];
+        static final float FOUR_BIT_SCALE = ESNextOSQVectorsScorer.BIT_SCALES[3];
+
         static final VectorSpecies<Integer> INT_SPECIES_128 = IntVector.SPECIES_128;
 
         static final VectorSpecies<Long> LONG_SPECIES_128 = LongVector.SPECIES_128;


### PR DESCRIPTION
Extracted from https://github.com/elastic/elasticsearch/pull/141332

Make `similarityFunction` a parameter in both benchmarks and tests. 
This ensures better coverage in benchmarks and tests of the OSQ vector scorer scoring functions.
