### PR TITLE
[TEST] Use the last value from lower window for rate evaluation

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -324,9 +324,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT
   method: test {csv-spec:spatial_shapes.CartesianPolygonEnvelopeXYMinMax}
   issue: https://github.com/elastic/elasticsearch/issues/141425
-- class: org.elasticsearch.xpack.esql.action.RandomizedTimeSeriesIT
-  method: testRateGroupBySubset
-  issue: https://github.com/elastic/elasticsearch/issues/141455
 - class: org.elasticsearch.search.query.VectorIT
   method: testFilteredQueryStrategy
   issue: https://github.com/elastic/elasticsearch/issues/141469

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/RandomizedTimeSeriesIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/RandomizedTimeSeriesIT.java
@@ -326,7 +326,7 @@ public class RandomizedTimeSeriesIT extends AbstractEsqlIntegTestCase {
                     && timeseries.getFirst().v2().v1().toEpochMilli() % (secondsInWindow * 1000L) == 0
                     && offset > 0
                     && allTimeseries.get(offset - 1).isEmpty() == false) {
-                    // Value at lower boundary is present, check if there's one in the lower boundary to use.
+                    // Value at lower boundary is present, check if there's one in the previous window to use.
                     addLastTupleFromLowerWindow(timeseries, allTimeseries.get(offset - 1), secondsInWindow);
                 }
                 if (timeseries.size() < 2) {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/RandomizedTimeSeriesIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/RandomizedTimeSeriesIT.java
@@ -322,7 +322,16 @@ public class RandomizedTimeSeriesIT extends AbstractEsqlIntegTestCase {
                 }
             }
             if (timeseries.size() < 2) {
-                return null;
+                if (timeseries.size() == 1
+                    && timeseries.getFirst().v2().v1().toEpochMilli() % (secondsInWindow * 1000L) == 0
+                    && offset > 0
+                    && allTimeseries.get(offset - 1).isEmpty() == false) {
+                    // Value at lower boundary is present, check if there's one in the lower boundary to use.
+                    addLastTupleFromLowerWindow(timeseries, allTimeseries.get(offset - 1), secondsInWindow);
+                }
+                if (timeseries.size() < 2) {
+                    return null;
+                }
             }
             var firstTs = timeseries.getFirst().v2().v1();
             var lastTs = timeseries.getLast().v2().v1();
@@ -452,6 +461,35 @@ public class RandomizedTimeSeriesIT extends AbstractEsqlIntegTestCase {
             return true;
         }
         return false;
+    }
+
+    private static void addLastTupleFromLowerWindow(
+        List<Tuple<String, Tuple<Instant, Double>>> timeseries,
+        Collection<List<Tuple<String, Tuple<Instant, Double>>>> lowerWindow,
+        int secondsInWindow
+    ) {
+        String timeseriesId = timeseries.getFirst().v1();
+        var referenceTuple = timeseries.getFirst().v2();
+        Tuple<String, Tuple<Instant, Double>> lowerTuple = null;
+        long lowerTimestamp = 0;
+        for (var doc : lowerWindow) {
+            for (var tuple : doc) {
+                if (instantsInAdjacentWindows(tuple.v2().v1(), referenceTuple.v1(), secondsInWindow) == false) {
+                    return;
+                }
+                String id = tuple.v1();
+                if (timeseriesId.equals(id)) {
+                    long timestamp = tuple.v2().v1().toEpochMilli();
+                    if (lowerTuple == null || (timestamp > lowerTimestamp)) {
+                        lowerTimestamp = timestamp;
+                        lowerTuple = tuple;
+                    }
+                }
+            }
+        }
+        if (lowerTuple != null) {
+            timeseries.addFirst(lowerTuple);
+        }
     }
 
     private static boolean instantsInAdjacentWindows(Instant first, Instant second, int secondsInWindow) {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/RandomizedTimeSeriesIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/RandomizedTimeSeriesIT.java
@@ -322,7 +322,7 @@ public class RandomizedTimeSeriesIT extends AbstractEsqlIntegTestCase {
                 }
             }
             if (timeseries.size() < 2) {
-                if (deltaAgg.equals(DeltaAgg.RATE) || deltaAgg.equals(DeltaAgg.INCREASE)
+                if ((deltaAgg.equals(DeltaAgg.RATE) || deltaAgg.equals(DeltaAgg.INCREASE))
                     && timeseries.size() == 1
                     && timeseries.getFirst().v2().v1().toEpochMilli() % (secondsInWindow * 1000L) == 0
                     && offset > 0) {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/RandomizedTimeSeriesIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/RandomizedTimeSeriesIT.java
@@ -322,10 +322,11 @@ public class RandomizedTimeSeriesIT extends AbstractEsqlIntegTestCase {
                 }
             }
             if (timeseries.size() < 2) {
-                if (deltaAgg.equals(DeltaAgg.RATE) || deltaAgg.equals(DeltaAgg.INCREASE)
-                    && timeseries.size() == 1
-                    && timeseries.getFirst().v2().v1().toEpochMilli() % (secondsInWindow * 1000L) == 0
-                    && offset > 0) {
+                if (deltaAgg.equals(DeltaAgg.RATE)
+                    || deltaAgg.equals(DeltaAgg.INCREASE)
+                        && timeseries.size() == 1
+                        && timeseries.getFirst().v2().v1().toEpochMilli() % (secondsInWindow * 1000L) == 0
+                        && offset > 0) {
                     // Value at lower boundary is present, check if there's one in the previous window to use.
                     addLastTupleFromLowerWindow(timeseries, allTimeseries.get(offset - 1), secondsInWindow);
                 }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/RandomizedTimeSeriesIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/RandomizedTimeSeriesIT.java
@@ -324,8 +324,7 @@ public class RandomizedTimeSeriesIT extends AbstractEsqlIntegTestCase {
             if (timeseries.size() < 2) {
                 if (timeseries.size() == 1
                     && timeseries.getFirst().v2().v1().toEpochMilli() % (secondsInWindow * 1000L) == 0
-                    && offset > 0
-                    && allTimeseries.get(offset - 1).isEmpty() == false) {
+                    && offset > 0) {
                     // Value at lower boundary is present, check if there's one in the previous window to use.
                     addLastTupleFromLowerWindow(timeseries, allTimeseries.get(offset - 1), secondsInWindow);
                 }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/RandomizedTimeSeriesIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/RandomizedTimeSeriesIT.java
@@ -322,7 +322,8 @@ public class RandomizedTimeSeriesIT extends AbstractEsqlIntegTestCase {
                 }
             }
             if (timeseries.size() < 2) {
-                if (timeseries.size() == 1
+                if (deltaAgg.equals(DeltaAgg.RATE) || deltaAgg.equals(DeltaAgg.INCREASE)
+                    && timeseries.size() == 1
                     && timeseries.getFirst().v2().v1().toEpochMilli() % (secondsInWindow * 1000L) == 0
                     && offset > 0) {
                     // Value at lower boundary is present, check if there's one in the previous window to use.


### PR DESCRIPTION
When there is a single value in a window at the lower boundary, we use the last value from the previous window (if not empty) to calculate rate.

Fixes #141455