### PR TITLE
[9.3] Fix native array integration tests (#139577)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -306,9 +306,6 @@ tests:
 - class: org.elasticsearch.smoketest.SmokeTestMultiNodeClientYamlTestSuiteIT
   method: test {yaml=index/100_field_name_length_limit/Test field name length limit array synthetic source}
   issue: https://github.com/elastic/elasticsearch/issues/139300
-- class: org.elasticsearch.xpack.unsignedlong.UnsignedLongSyntheticSourceNativeArrayIntegrationTests
-  method: testSynthesizeArrayRandom
-  issue: https://github.com/elastic/elasticsearch/issues/139376
 - class: org.elasticsearch.xpack.esql.optimizer.LocalLogicalPlanOptimizerTests
   method: testReductionPlanForTopNWithPushedDownFunctionsInOrder
   issue: https://github.com/elastic/elasticsearch/issues/139490
@@ -324,9 +321,6 @@ tests:
 - class: org.elasticsearch.repositories.gcs.GoogleCloudStorageBlobStoreRepositoryTests
   method: testMultipleSnapshotAndRollback
   issue: https://github.com/elastic/elasticsearch/issues/139556
-- class: org.elasticsearch.index.mapper.LongSyntheticSourceNativeArrayIntegrationTests
-  method: testSynthesizeArrayRandom
-  issue: https://github.com/elastic/elasticsearch/issues/139562
 - class: org.elasticsearch.repositories.gcs.GoogleCloudStorageBlobStoreRepositoryTests
   method: testDeleteBlobs
   issue: https://github.com/elastic/elasticsearch/issues/139646
@@ -336,9 +330,6 @@ tests:
 - class: org.elasticsearch.xpack.core.action.XPackUsageResponseTests
   method: testVersionDependentSerializationWriteToOldStream
   issue: https://github.com/elastic/elasticsearch/issues/139576
-- class: org.elasticsearch.index.mapper.HalfFloatSyntheticSourceNativeArrayIntegrationTests
-  method: testSynthesizeArrayRandom
-  issue: https://github.com/elastic/elasticsearch/issues/139658
 - class: org.elasticsearch.smoketest.WatcherYamlRestIT
   method: test {p0=mustache/10_webhook/Test webhook action with mustache integration}
   issue: https://github.com/elastic/elasticsearch/issues/139663

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordSyntheticSourceNativeArrayIntegrationTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordSyntheticSourceNativeArrayIntegrationTests.java
@@ -63,9 +63,9 @@ public class KeywordSyntheticSourceNativeArrayIntegrationTests extends NativeArr
             new Object[] { "1", "2", "3", "blabla" } };
 
         // values in the original array should be deduplicated
-        var expectedArrayValues = new Object[][] {
+        var expectedArrayValues = new Object[] {
             new Object[] { null, "a", "ab", "abc", "abcd", null, "abcde" },
-            new Object[] { "12345" },
+            "12345",
             new Object[] { "123", "1234", "12345" },
             new Object[] { null, null, null, "blabla" },
             new Object[] { "1", "2", "3", "blabla" } };

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/NativeArrayIntegrationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/NativeArrayIntegrationTestCase.java
@@ -257,20 +257,10 @@ public abstract class NativeArrayIntegrationTestCase extends ESSingleNodeTestCas
         verifySyntheticArray(arrays, arrays, mapping, expectedStoredFields);
     }
 
-    private XContentBuilder arrayToSource(Object[] array) throws IOException {
+    private XContentBuilder arrayToSource(Object obj) throws IOException {
         var source = jsonBuilder().startObject();
-        if (array != null) {
-            // collapse array if it only consists of one element
-            // if the only element is null, then we'll skip synthesizing source for that field
-            if (array.length == 1 && array[0] != null) {
-                source.field("field", array[0]);
-            } else {
-                source.startArray("field");
-                for (Object arrayValue : array) {
-                    source.value(arrayValue);
-                }
-                source.endArray();
-            }
+        if (obj != null) {
+            source.field("field", obj);
         } else {
             source.field("field").nullValue();
         }
@@ -279,7 +269,7 @@ public abstract class NativeArrayIntegrationTestCase extends ESSingleNodeTestCas
 
     protected void verifySyntheticArray(
         Object[][] inputArrays,
-        Object[][] expectedArrays,
+        Object[] expectedArrays,
         XContentBuilder mapping,
         String... expectedStoredFields
     ) throws IOException {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.3`:
 - [Fix native array integration tests (#139577)](https://github.com/elastic/elasticsearch/pull/139577)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

Fixes #139562.