### PR TITLE
Backport RandomizedRollingUpgradeIT fixes to 9.3

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -351,9 +351,6 @@ tests:
 - class: org.elasticsearch.xpack.test.rest.XPackRestIT
   method: test {p0=esql/40_unsupported_types/unsupported with sort}
   issue: https://github.com/elastic/elasticsearch/issues/139702
-- class: org.elasticsearch.xpack.logsdb.RandomizedRollingUpgradeIT
-  method: testIndexingSyntheticSource
-  issue: https://github.com/elastic/elasticsearch/issues/139482
 - class: org.elasticsearch.persistent.PersistentTasksCustomMetadataTests
   method: testMinVersionSerialization
   issue: https://github.com/elastic/elasticsearch/issues/139740

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/Clusters.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/Clusters.java
@@ -22,6 +22,7 @@ public class Clusters {
             .setting("xpack.security.enabled", "true")
             .user(user, pass)
             .keystore("bootstrap.password", pass)
+            .jvmArg("-da:org.elasticsearch.index.translog.TranslogWriter")
             .setting("xpack.license.self_generated.type", "trial");
 
         int numNodes = Integer.parseInt(System.getProperty("tests.num_nodes", "3"));

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/RandomizedRollingUpgradeIT.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/RandomizedRollingUpgradeIT.java
@@ -122,6 +122,11 @@ public class RandomizedRollingUpgradeIT extends AbstractLogsdbRollingUpgradeTest
         testEsqlSource(indexConfig);
     }
 
+    @Override
+    public String getEnsureGreenTimeout() {
+        return "2m";
+    }
+
     private void testIndexing(String indexNameBase, Settings.Builder settings) throws IOException {
         TestIndexConfig[] indexConfigs = new TestIndexConfig[NUM_INDICES];
 

--- a/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/RandomizedRollingUpgradeIT.java
+++ b/x-pack/plugin/logsdb/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/xpack/logsdb/RandomizedRollingUpgradeIT.java
@@ -132,6 +132,7 @@ public class RandomizedRollingUpgradeIT extends AbstractLogsdbRollingUpgradeTest
 
         int numNodes = Integer.parseInt(System.getProperty("tests.num_nodes", "3"));
         for (int i = 0; i < numNodes; i++) {
+            flush(indexNameBase + "*", true);
             upgradeNode(i);
             ensureGreen(indexNameBase + "*");
             for (int j = 0; j < NUM_INDICES; j++) {


### PR DESCRIPTION
This backports #139933, #139992, and #140688 to 9.3 and unmutes the test.
