### PR TITLE
[8.19] Increase EIS sparse max_batch_size upper bound to 1024 (#141516)

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceSettingsUtils.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elastic/ElasticInferenceServiceSettingsUtils.java
@@ -16,7 +16,7 @@ import java.util.Map;
 
 public final class ElasticInferenceServiceSettingsUtils {
 
-    public static final int MAX_BATCH_SIZE_UPPER_BOUND = 512;
+    public static final int MAX_BATCH_SIZE_UPPER_BOUND = 1024;
     public static final String MAX_BATCH_SIZE = "max_batch_size";
     public static final TransportVersion INFERENCE_API_EIS_MAX_BATCH_SIZE = TransportVersion.fromName("inference_api_eis_max_batch_size");
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Increase EIS sparse max_batch_size upper bound to 1024 (#141516)](https://github.com/elastic/elasticsearch/pull/141516)

<!--- Backport version: 10.2.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)