### PR TITLE
[Docs] Minor update for brief-painless-walkthrough.md

### DIFF
--- a/docs/reference/scripting-languages/painless/brief-painless-walkthrough.md
+++ b/docs/reference/scripting-languages/painless/brief-painless-walkthrough.md
@@ -17,7 +17,7 @@ If you're new to Painless scripting or need step-by-step guidance, start with [H
 
 :::
 
-# A brief painless walkthrough [painless-walkthrough]
+# A brief Painless walkthrough [painless-walkthrough]
 
 To illustrate how Painless works, let’s load some hockey stats into an {{es}} index:
 


### PR DESCRIPTION
Fixing typo to capitalise Painless in the title.

Noticed it [here](https://github.com/elastic/docs-content/pull/4784#discussion_r2742737678)
