### PR TITLE
Reindexing older indices with percolator fields clears migration assistant errors

### DIFF
--- a/docs/changelog/141539.yaml
+++ b/docs/changelog/141539.yaml
@@ -1,0 +1,6 @@
+area: Infra/Core
+issues: []
+pr: 141539
+summary: Reindexing older indices with percolator fields clears migration assistant
+  errors
+type: bug

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -588,7 +588,6 @@ public class MetadataCreateIndexService {
         final IndexMetadata.Builder tmpImdBuilder = IndexMetadata.builder(request.index());
         tmpImdBuilder.setRoutingNumShards(routingNumShards);
         tmpImdBuilder.settings(indexSettings);
-        tmpImdBuilder.transportVersion(TransportVersion.current());
         tmpImdBuilder.system(isSystem);
 
         // Set up everything, now locally create the index to see that things are ok, and apply
@@ -1366,6 +1365,7 @@ public class MetadataCreateIndexService {
     ) {
         IndexMetadata.Builder indexMetadataBuilder = createIndexMetadataBuilder(indexName, sourceMetadata, indexSettings, routingNumShards);
         indexMetadataBuilder.system(isSystem);
+        indexMetadataBuilder.transportVersion(minClusterTransportVersion);
         if (minClusterTransportVersion.before(TransportVersions.V_8_15_0)) {
             // promote to UNKNOWN for older versions since they don't know how to handle event.ingested in cluster state
             indexMetadataBuilder.eventIngestedRange(IndexLongFieldRange.UNKNOWN, minClusterTransportVersion);

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTests.java
@@ -1271,6 +1271,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
         assertThat("The source index primary term must be used", indexMetadata.primaryTerm(0), is(3L));
         assertThat(indexMetadata.getTimestampRange(), equalTo(IndexLongFieldRange.NO_SHARDS));
         assertThat(indexMetadata.getEventIngestedRange(), equalTo(IndexLongFieldRange.NO_SHARDS));
+        assertThat(indexMetadata.getTransportVersion(), equalTo(TransportVersion.current()));
     }
 
     public void testBuildIndexMetadataWithTransportVersionBeforeEventIngestedRangeAdded() {
@@ -1283,6 +1284,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
 
         Settings indexSettings = indexSettings(IndexVersion.current(), 1, 0).build();
         List<AliasMetadata> aliases = List.of(AliasMetadata.builder("alias1").build());
+        TransportVersion transportVersion = randomFrom(TransportVersions.V_7_0_0, TransportVersions.V_8_0_0);
         IndexMetadata indexMetadata = buildIndexMetadata(
             "test",
             aliases,
@@ -1291,7 +1293,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
             4,
             sourceIndexMetadata,
             false,
-            randomFrom(TransportVersions.V_7_0_0, TransportVersions.V_8_0_0)
+            transportVersion
         );
 
         assertThat(indexMetadata.getAliases().size(), is(1));
@@ -1300,6 +1302,7 @@ public class MetadataCreateIndexServiceTests extends ESTestCase {
         assertThat(indexMetadata.getTimestampRange(), equalTo(IndexLongFieldRange.NO_SHARDS));
         // on versions before event.ingested was added to cluster state, it should default to UNKNOWN, not NO_SHARDS
         assertThat(indexMetadata.getEventIngestedRange(), equalTo(IndexLongFieldRange.UNKNOWN));
+        assertThat(indexMetadata.getTransportVersion(), equalTo(transportVersion));
     }
 
     public void testGetIndexNumberOfRoutingShardsWithNullSourceIndex() {


### PR DESCRIPTION
This is a follow up to https://github.com/elastic/elasticsearch/pull/138118 which added a `TransportVersion` field to `IndexMetadata` to capture the cluster transport version at the time of index creation. This is required because for some features, like percolator fields, the transport version is used for serialization, and therefore, impacts the ability to read these older indices.

This fixes a bug where the transport version wasn't correctly being set on the index metadata prior to index creation. This had downstream effects, like certain deprecation checks thinking these were old indices, when in fact, they were not. Specifically, this caused the migration assistant warning in the linked PR to continue to persist even when the incompatible index was re-indexed.