### PR TITLE
[9.2] Allow resolveTransportVersionConflict to run on release branches (#141487)

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/AbstractTransportVersionFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/transport/AbstractTransportVersionFuncTest.groovy
@@ -167,6 +167,10 @@ class AbstractTransportVersionFuncTest extends AbstractGradleFuncTest {
         execute("git init")
         execute('git config user.email "build-tool@elastic.co"')
         execute('git config user.name "Build tool"')
+        file(".gitignore") << """
+        .gradle/
+        build/
+        """.stripIndent()
         execute("git add .")
         execute('git commit -m "Initial"')
     }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/AbstractGenerateTransportVersionDefinitionTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/AbstractGenerateTransportVersionDefinitionTask.java
@@ -55,8 +55,11 @@ public abstract class AbstractGenerateTransportVersionDefinitionTask extends Def
     @Optional
     public abstract RegularFileProperty getAlternateUpperBoundFile();
 
-    protected abstract void runGeneration(TransportVersionResourcesService resources, List<TransportVersionUpperBound> upstreamUpperBounds)
-        throws IOException;
+    protected abstract void runGeneration(
+        TransportVersionResourcesService resources,
+        List<TransportVersionUpperBound> upstreamUpperBounds,
+        boolean onReleaseBranch
+    ) throws IOException;
 
     protected abstract Set<String> getTargetUpperBoundNames(
         TransportVersionResourcesService resources,
@@ -72,11 +75,8 @@ public abstract class AbstractGenerateTransportVersionDefinitionTask extends Def
         TransportVersionResourcesService resources = getResourceService().get();
         List<TransportVersionUpperBound> upstreamUpperBounds = resources.getUpperBoundsFromGitBase();
         boolean onReleaseBranch = resources.checkIfDefinitelyOnReleaseBranch(upstreamUpperBounds, getCurrentUpperBoundName().get());
-        if (onReleaseBranch) {
-            throw new IllegalArgumentException("Transport version generation cannot run on release branches");
-        }
 
-        runGeneration(resources, upstreamUpperBounds);
+        runGeneration(resources, upstreamUpperBounds, onReleaseBranch);
     }
 
     protected void generateTransportVersionDefinition(

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/GenerateTransportVersionDefinitionTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/GenerateTransportVersionDefinitionTask.java
@@ -58,8 +58,15 @@ public abstract class GenerateTransportVersionDefinitionTask extends AbstractGen
     public abstract Property<String> getBackportBranches();
 
     @Override
-    protected void runGeneration(TransportVersionResourcesService resources, List<TransportVersionUpperBound> upstreamUpperBounds)
-        throws IOException {
+    protected void runGeneration(
+        TransportVersionResourcesService resources,
+        List<TransportVersionUpperBound> upstreamUpperBounds,
+        boolean onReleaseBranch
+    ) throws IOException {
+        if (onReleaseBranch) {
+            throw new IllegalArgumentException("Transport version generation cannot run on release branches");
+        }
+
         Set<String> referencedNames = TransportVersionReference.collectNames(getReferencesFiles());
         Set<String> changedDefinitionNames = resources.getChangedReferableDefinitionNames();
         String targetDefinitionName = getTargetDefinitionName(resources, referencedNames, changedDefinitionNames);

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/ResolveTransportVersionConflictTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/transport/ResolveTransportVersionConflictTask.java
@@ -17,17 +17,29 @@ import java.util.Set;
 public abstract class ResolveTransportVersionConflictTask extends AbstractGenerateTransportVersionDefinitionTask {
 
     @Override
-    protected void runGeneration(TransportVersionResourcesService resources, List<TransportVersionUpperBound> upstreamUpperBounds)
-        throws IOException {
+    protected void runGeneration(
+        TransportVersionResourcesService resources,
+        List<TransportVersionUpperBound> upstreamUpperBounds,
+        boolean onReleaseBranch
+    ) throws IOException {
 
-        Set<String> changedDefinitionNames = resources.getChangedReferableDefinitionNames();
-        if (changedDefinitionNames.isEmpty()) {
-            getLogger().lifecycle("No transport version changes detected, skipping transport version re-generation");
-            return;
+        if (onReleaseBranch) {
+            if (resources.hasCherryPickConflicts()) {
+                getLogger().lifecycle("Resolving transport version conflicts by accepting upstream changes...");
+                resources.checkoutOriginalChange();
+            } else {
+                getLogger().lifecycle("No transport version merge conflicts detected");
+            }
+        } else {
+            Set<String> changedDefinitionNames = resources.getChangedReferableDefinitionNames();
+            if (changedDefinitionNames.isEmpty()) {
+                getLogger().lifecycle("No transport version changes detected, skipping transport version re-generation");
+                return;
+            }
+            String targetDefinitionName = changedDefinitionNames.iterator().next();
+
+            generateTransportVersionDefinition(resources, targetDefinitionName, upstreamUpperBounds, resources.getIdsByBase());
         }
-        String targetDefinitionName = changedDefinitionNames.iterator().next();
-
-        generateTransportVersionDefinition(resources, targetDefinitionName, upstreamUpperBounds, resources.getIdsByBase());
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 9.2:
 - Allow resolveTransportVersionConflict to run on release branches (#141487)