### PR TITLE
Fix partial flush for stats without aggregation

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/AggregatorBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/AggregatorBenchmark.java
@@ -199,6 +199,7 @@ public class AggregatorBenchmark {
             default -> throw new IllegalArgumentException("unsupported grouping [" + grouping + "]");
         };
         return new HashAggregationOperator(
+            AggregatorMode.SINGLE,
             List.of(supplier(op, dataType, filter).groupingAggregatorFactory(AggregatorMode.SINGLE, List.of(groups.size()))),
             () -> BlockHash.build(groups, driverContext.blockFactory(), 16 * 1024, false),
             Integer.MAX_VALUE,

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/ValuesAggregatorBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/ValuesAggregatorBenchmark.java
@@ -122,6 +122,7 @@ public class ValuesAggregatorBenchmark {
         }
         List<BlockHash.GroupSpec> groupSpec = List.of(new BlockHash.GroupSpec(0, ElementType.LONG));
         return new HashAggregationOperator(
+            mode,
             List.of(supplier(dataType).groupingAggregatorFactory(mode, List.of(1))),
             () -> BlockHash.build(groupSpec, driverContext.blockFactory(), 16 * 1024, false),
             Integer.MAX_VALUE,

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/GroupingAggregatorFunctionTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/GroupingAggregatorFunctionTestCase.java
@@ -960,6 +960,7 @@ public abstract class GroupingAggregatorFunctionTestCase extends ForkingOperator
             };
 
             return new HashAggregationOperator(
+                aggregatorMode,
                 aggregators,
                 blockHashSupplier,
                 partialEmitKeysThreshold,

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/RateDoubleGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/RateDoubleGroupingAggregatorFunctionTests.java
@@ -73,12 +73,14 @@ public class RateDoubleGroupingAggregatorFunctionTests extends ComputeTestCase {
             }
         }
         // values, timestamps, slice, future_timestamps
+        AggregatorMode aggregatorMode = AggregatorMode.INITIAL;
         var aggregatorFactory = new RateDoubleGroupingAggregatorFunction.FunctionSupplier(false, false).groupingAggregatorFactory(
-            AggregatorMode.INITIAL,
+            aggregatorMode,
             List.of(1, 2, 3, 4)
         );
         final List<BlockHash.GroupSpec> groupSpecs = List.of(new BlockHash.GroupSpec(0, ElementType.INT));
         HashAggregationOperator hashAggregationOperator = new HashAggregationOperator(
+            aggregatorMode,
             List.of(aggregatorFactory),
             () -> BlockHash.build(groupSpecs, driverContext.blockFactory(), randomIntBetween(1, 1024), randomBoolean()),
             Integer.MAX_VALUE,

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -994,6 +994,22 @@ M
 null
 ;
 
+
+aggsByFirstNameWithoutStats
+from employees | stats by f=first_name | stats c = count(f);
+
+c:long
+90
+;
+
+aggsByLastNameWithoutStats
+from employees | stats by f=last_name | stats c = count(f);
+
+c:long
+96
+;
+
+
 aggsWithoutStatsTwo
 FROM employees | STATS BY gender, still_hired | SORT gender, still_hired;
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/DimensionValuesByteRefGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/DimensionValuesByteRefGroupingAggregatorFunctionTests.java
@@ -89,8 +89,9 @@ public class DimensionValuesByteRefGroupingAggregatorFunctionTests extends Compu
                 pages.add(new Page(blocks));
             }
         }
+        AggregatorMode aggregateMode = randomFrom(AggregatorMode.INITIAL, AggregatorMode.SINGLE, AggregatorMode.FINAL);
         var aggregatorFactory = new DimensionValuesByteRefGroupingAggregatorFunction.FunctionSupplier().groupingAggregatorFactory(
-            randomFrom(AggregatorMode.INITIAL, AggregatorMode.SINGLE, AggregatorMode.FINAL),
+            aggregateMode,
             List.of(prefixBlocks)
         );
         final List<BlockHash.GroupSpec> groupSpecs;
@@ -105,6 +106,7 @@ public class DimensionValuesByteRefGroupingAggregatorFunctionTests extends Compu
             );
         }
         HashAggregationOperator hashAggregationOperator = new HashAggregationOperator(
+            aggregateMode,
             List.of(aggregatorFactory),
             () -> BlockHash.build(groupSpecs, driverContext.blockFactory(), randomIntBetween(1, 1024), randomBoolean()),
             Integer.MAX_VALUE,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/FirstDocIdGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/FirstDocIdGroupingAggregatorFunctionTests.java
@@ -69,11 +69,13 @@ public class FirstDocIdGroupingAggregatorFunctionTests extends ComputeTestCase {
                 pages.add(new Page(docVector.asBlock(), groups.build().asBlock()));
             }
         }
+        AggregatorMode aggregatorMode = AggregatorMode.INITIAL;
         var aggregatorFactory = new FirstDocIdGroupingAggregatorFunction.FunctionSupplier().groupingAggregatorFactory(
-            AggregatorMode.INITIAL,
+            aggregatorMode,
             List.of(0)
         );
         HashAggregationOperator hashAggregationOperator = new HashAggregationOperator(
+            aggregatorMode,
             List.of(aggregatorFactory),
             () -> BlockHash.build(
                 List.of(new BlockHash.GroupSpec(1, ElementType.INT)),


### PR DESCRIPTION
We accidentally enabled periodic emitting for final aggregations when no actual aggregations are present. This bug is not present in serverless or stateful releases; therefore, it is labeled as a non-issue.

Relates #141392

