### PR TITLE
Guard exponential histogram queryDSL min/max tests with test node feature.

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/SearchFeatures.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchFeatures.java
@@ -39,6 +39,9 @@ public final class SearchFeatures implements FeatureSpecification {
     public static final NodeFeature NESTED_AGG_TOP_HITS_WITH_INNER_HITS = new NodeFeature("nested_agg_top_hits_with_inner_hits");
     public static final NodeFeature DATE_FORMAT_MISSING_AS_NULL = new NodeFeature("search.sort.date_format_missing_as_null");
     public static final NodeFeature LIMIT_MAX_IDS_FEATURE = new NodeFeature("ids_query_limit_max_ids");
+    public static final NodeFeature EXPONENTIAL_HISTOGRAM_QUERYDSL_MIN_MAX = new NodeFeature(
+        "search.exponential_histogram_querydsl_min_max"
+    );
 
     @Override
     public Set<NodeFeature> getTestFeatures() {
@@ -55,7 +58,8 @@ public final class SearchFeatures implements FeatureSpecification {
             INDICES_BOOST_REMOTE_INDEX_FIX,
             NESTED_AGG_TOP_HITS_WITH_INNER_HITS,
             DATE_FORMAT_MISSING_AS_NULL,
-            LIMIT_MAX_IDS_FEATURE
+            LIMIT_MAX_IDS_FEATURE,
+            EXPONENTIAL_HISTOGRAM_QUERYDSL_MIN_MAX
         );
     }
 }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/exponential_histogram/20_aggregations.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/exponential_histogram/20_aggregations.yml
@@ -116,6 +116,9 @@ setup:
 
 ---
 "Min aggregation":
+  - requires:
+      cluster_features: [ "search.exponential_histogram_querydsl_min_max" ]
+      reason: exponential_histogram min/max aggregations were introduced
   - do:
       search:
         index: test_exponential_histogram
@@ -131,6 +134,9 @@ setup:
 
 ---
 "Max aggregation":
+  - requires:
+      cluster_features: [ "search.exponential_histogram_querydsl_min_max" ]
+      reason: exponential_histogram min/max aggregations were introduced
   - do:
       search:
         index: test_exponential_histogram

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/exponential_histogram/30_aggregate_metric_aggregations_compatibility.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/exponential_histogram/30_aggregate_metric_aggregations_compatibility.yml
@@ -110,6 +110,9 @@ setup:
 
 ---
 "Min aggregation over aggregate_metric_double and exponential_histogram":
+  - requires:
+      cluster_features: [ "search.exponential_histogram_querydsl_min_max" ]
+      reason: exponential_histogram min/max aggregations were introduced
   - do:
       search:
         index: test-data-stream
@@ -125,6 +128,9 @@ setup:
 
 ---
 "Max aggregation over aggregate_metric_double and exponential_histogram":
+  - requires:
+      cluster_features: [ "search.exponential_histogram_querydsl_min_max" ]
+      reason: exponential_histogram min/max aggregations were introduced
   - do:
       search:
         index: test-data-stream

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/exponential_histogram/40_tdigest_histogram_aggregations_compatibility.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/exponential_histogram/40_tdigest_histogram_aggregations_compatibility.yml
@@ -106,6 +106,9 @@ setup:
 
 ---
 "Min aggregation over aggregate_metric_double and exponential_histogram":
+  - requires:
+      cluster_features: [ "search.exponential_histogram_querydsl_min_max" ]
+      reason: exponential_histogram min/max aggregations were introduced
   - do:
       search:
         index: test-data-stream
@@ -121,6 +124,9 @@ setup:
 
 ---
 "Max aggregation over aggregate_metric_double and exponential_histogram":
+  - requires:
+      cluster_features: [ "search.exponential_histogram_querydsl_min_max" ]
+      reason: exponential_histogram min/max aggregations were introduced
   - do:
       search:
         index: test-data-stream


### PR DESCRIPTION
Followup for #141415.

I forgot to guard the yaml tests with a test node feature. To my knowledge, those will be run in BWC tests and would cause breakages there when run against 9.3.
