### PR TITLE
[9.3] [ML] Evict old models from the cache before loading new (#140844)

### DIFF
--- a/docs/changelog/140844.yaml
+++ b/docs/changelog/140844.yaml
@@ -1,0 +1,5 @@
+pr: 140844
+summary: Evict old models from the cache before loading new
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingServiceTests.java
@@ -67,11 +67,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.ml.MachineLearning.UTILITY_THREAD_POOL_NAME;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -500,6 +502,52 @@ public class ModelLoadingServiceTests extends ESTestCase {
         modelLoadingService.clusterChanged(ingestChangedEvent(model1));
 
         assertBusy(() -> assertThat(circuitBreaker.getUsed(), equalTo(5L)));
+    }
+
+    public void testExpiredModelsAreEvictedBeforeLoading() throws Exception {
+        String smallModel1 = "small-model-1";
+        String smallModel2 = "small-model-2";
+        String justSmallEnoughModel = "just-small-enough-model";
+        long cbBytes = 13;
+        withTrainedModel(smallModel1, cbBytes / 2);
+        withTrainedModel(smallModel1, cbBytes / 2);
+        long justSmallEnoughModelBytes = cbBytes - 1;
+        withTrainedModel(justSmallEnoughModel, justSmallEnoughModelBytes);
+        CircuitBreaker circuitBreaker = new CustomCircuitBreaker(cbBytes);
+
+        // Create cache with a low TTL value so models can be evicted quickly
+        ModelLoadingService modelLoadingService = new ModelLoadingService(
+            trainedModelProvider,
+            auditor,
+            threadPool,
+            clusterService,
+            trainedModelStatsService,
+            Settings.EMPTY,
+            "test-node",
+            circuitBreaker,
+            mock(XPackLicenseState.class),
+            TimeValue.timeValueMillis(200)
+        );
+
+        // These 2 models will be loaded as the circuit breaker has enough free memory
+        modelLoadingService.clusterChanged(ingestChangedEvent(smallModel1, smallModel2));
+
+        assertBusy(() -> {
+            assertThat(circuitBreaker.getUsed(), greaterThan(0L));
+            assertThat(circuitBreaker.getTrippedCount(), equalTo(0L));
+        }, 2, TimeUnit.SECONDS);
+
+        AtomicBoolean modelLoaded = new AtomicBoolean(false);
+
+        // This model can only be loaded if the first 2 are evicted from the cache
+        // and space freed in the circuit breaker.
+        modelLoadingService.addModelLoadedListener(justSmallEnoughModel, ActionListener.wrap(r -> {
+            modelLoaded.set(true);
+            assertThat(circuitBreaker.getUsed(), equalTo(justSmallEnoughModelBytes));
+        }, ESTestCase::fail));
+        modelLoadingService.clusterChanged(ingestChangedEvent(justSmallEnoughModel));
+
+        assertBusy(() -> assertTrue(modelLoaded.get()), 2, TimeUnit.SECONDS);
     }
 
     public void testReferenceCounting() throws Exception {


### PR DESCRIPTION
Backports the following commits to 9.3:
 - [ML] Evict old models from the cache before loading new (#140844)