### PR TITLE
[8.19] Reduce locking when persisting ML job statistics. (#141519)

### DIFF
--- a/docs/changelog/141519.yaml
+++ b/docs/changelog/141519.yaml
@@ -1,0 +1,6 @@
+area: Machine Learning
+issues:
+ - 140511
+pr: 141519
+summary: Reduce locking when persisting ML job statistics
+type: bug


### PR DESCRIPTION
Backports the following commits to 8.19:
 - Reduce locking when persisting ML job statistics. (#141519)