### PR TITLE
Update flaky timeout in AsyncSearchConcurrentStatusIT

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -234,9 +234,6 @@ tests:
 - class: org.elasticsearch.xpack.ml.integration.DatafeedJobsIT
   method: testStopLookback_closeJobFalse
   issue: https://github.com/elastic/elasticsearch/issues/139024
-- class: org.elasticsearch.xpack.search.AsyncSearchConcurrentStatusIT
-  method: testConcurrentStatusFetchWhileTaskCloses
-  issue: https://github.com/elastic/elasticsearch/issues/138543
 - class: org.elasticsearch.smoketest.MlWithSecurityIT
   method: test {yaml=ml/sparse_vector_search/Test sparse_vector search with query vector and pruning config}
   issue: https://github.com/elastic/elasticsearch/issues/139196

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchConcurrentStatusIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchConcurrentStatusIT.java
@@ -76,7 +76,7 @@ public class AsyncSearchConcurrentStatusIT extends AsyncSearchIntegTestCase {
      * is closing and some status calls may return {@code 410 GONE}.
      */
     public void testConcurrentStatusFetchWhileTaskCloses() throws Exception {
-        final TimeValue timeout = TimeValue.timeValueSeconds(3);
+        final TimeValue timeout = TimeValue.timeValueSeconds(30);
         final String aggName = "terms";
         final SearchSourceBuilder source = new SearchSourceBuilder().aggregation(
             AggregationBuilders.terms(aggName).field("terms.keyword").size(Math.max(1, numKeywords))


### PR DESCRIPTION
The test `testConcurrentStatusFetchWhileTaskCloses` was failing intermittently with a `TimeoutException` because the 3-second timeout is too short for the randomized workload (up to 20 shards, 1000 docs, and 80 poller threads).

Increases the timeout to 30 seconds to accommodate worst-case scenarios.