### PR TITLE
Revise elasticsearch config reference overview

### DIFF
--- a/docs/reference/elasticsearch/configuration-reference/index.md
+++ b/docs/reference/elasticsearch/configuration-reference/index.md
@@ -1,26 +1,25 @@
 ---
 navigation_title: "Configuration"
 applies_to:
-  deployment:
-    ess:
-    ece:
-    self:
-    eck:
-  serverless:
+  stack:
 ---
 
 # Elasticsearch configuration reference
 
-:::{note}
-This section provides detailed **reference information** for Elasticsearch configuration.
+Configuration settings enable you to customize the behavior of {{es}} features.
+This reference provides details about each setting, such as its purpose, default behavior, and availability in various deployment contexts.
 
-Refer to [Elasticsearch configuration](docs-content://deploy-manage/deploy/cloud-on-k8s/elasticsearch-configuration.md) in the **Deploy and manage** section for overview, getting started and conceptual information.
+To learn how to update these settings on your cluster, including on ECH, ECE, ECK, and self-managed deployments, refer to [Elastic Stack settings](docs-content://deploy-manage/stack-settings.md).
+
+This section provides detailed **reference information** for Elasticsearch configuration. Refer to the [Deploy and manage](docs-content://deploy-manage/index.md) to get started with deploying and configuring {{es}}, and to learn when and how to use some of these settings.
+
+:::{admonition} Serverless manages these settings for you
+In {{serverless-full}}, cluster-level settings and node-level settings are not required by end users, and are fully managed by Elastic.
+
+Certain [project settings](docs-content://deploy-manage/deploy/elastic-cloud/project-settings.md) allow you to customize your project’s performance and general data retention, and enable or disable project features.
 :::
 
-Configuration settings enable you to customize the behavior of Elasticsearch features.
-This reference provides details about each setting, such as its purpose, default behavior, and availability in Elastic Cloud environments.
-
-For details on updating user settings, see [Edit Elastic Stack settings](docs-content://deploy-manage/deploy/elastic-cloud/edit-stack-settings.md) for {{ech}} deployments, [Add Elasticsearch user settings](docs-content://deploy-manage/deploy/cloud-enterprise/edit-stack-settings-elasticsearch.md) for {{ece}} deployments and [Differences from other Elasticsearch offerings](docs-content://deploy-manage/deploy/elastic-cloud/differences-from-other-elasticsearch-offerings.md) for {{serverless-short}}.
+For information about index-level settings, refer to [](/reference/elasticsearch/index-settings.md).
 
 The settings are grouped by feature or purpose, for example:
 

--- a/docs/reference/elasticsearch/configuration-reference/index.md
+++ b/docs/reference/elasticsearch/configuration-reference/index.md
@@ -11,7 +11,7 @@ This reference provides details about each setting, such as its purpose, default
 
 To learn how to update these settings on your cluster, including on ECH, ECE, ECK, and self-managed deployments, refer to [Elastic Stack settings](docs-content://deploy-manage/stack-settings.md).
 
-This section provides detailed **reference information** for Elasticsearch configuration. Refer to the [Deploy and manage](docs-content://deploy-manage/index.md) section to get started with deploying and configuring {{es}}, and to learn when and how to use some of these settings.
+This section provides detailed **reference information** for {{es}} configuration. Refer to the [Deploy and manage](docs-content://deploy-manage/index.md) section to get started with deploying and configuring {{es}}, and to learn when and how to use some of these settings.
 
 :::{admonition} Serverless manages these settings for you
 In {{serverless-full}}, cluster-level settings and node-level settings are not required by end users, and are fully managed by Elastic.

--- a/docs/reference/elasticsearch/configuration-reference/index.md
+++ b/docs/reference/elasticsearch/configuration-reference/index.md
@@ -11,7 +11,7 @@ This reference provides details about each setting, such as its purpose, default
 
 To learn how to update these settings on your cluster, including on ECH, ECE, ECK, and self-managed deployments, refer to [Elastic Stack settings](docs-content://deploy-manage/stack-settings.md).
 
-This section provides detailed **reference information** for Elasticsearch configuration. Refer to the [Deploy and manage](docs-content://deploy-manage/index.md) to get started with deploying and configuring {{es}}, and to learn when and how to use some of these settings.
+This section provides detailed **reference information** for Elasticsearch configuration. Refer to the [Deploy and manage](docs-content://deploy-manage/index.md) section to get started with deploying and configuring {{es}}, and to learn when and how to use some of these settings.
 
 :::{admonition} Serverless manages these settings for you
 In {{serverless-full}}, cluster-level settings and node-level settings are not required by end users, and are fully managed by Elastic.

--- a/docs/reference/elasticsearch/configuration-reference/index.md
+++ b/docs/reference/elasticsearch/configuration-reference/index.md
@@ -19,7 +19,7 @@ In {{serverless-full}}, cluster-level settings and node-level settings are not r
 Certain [project settings](docs-content://deploy-manage/deploy/elastic-cloud/project-settings.md) allow you to customize your project’s performance and general data retention, and enable or disable project features.
 :::
 
-For information about index-level settings, refer to [](/reference/elasticsearch/index-settings.md).
+For information about index-level settings, refer to [](/reference/elasticsearch/index-settings/index.md).
 
 The settings are grouped by feature or purpose, for example:
 


### PR DESCRIPTION
* link to better central resource for editing stack settings
* link to top-level resource for configuring elasticsearch rather than a kubernetes-specific page
* provide serverless compatibility info up-front, rather than relying on an unclear link
* connection to other key setting surface: index settings.

also fixes https://github.com/elastic/docs-content/issues/4883
